### PR TITLE
Add initial README for Compose-RS proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Compose-RS Proposal
+
+Compose-RS is an experimental Rust workspace that sketches out a Jetpack Compose–inspired declarative UI framework. The repository accompanies the architectural proposal documented in [`proposal.md`](proposal.md) and provides crate scaffolding for the core runtime, procedural macros, UI primitives, and example applications.
+
+## Workspace layout
+
+- **`compose-core/`** – core runtime pieces such as the slot table, composer, state management, and effect system.
+- **`compose-macros/`** – the procedural macro crate that will host the `#[composable]` attribute and related code generation utilities.
+- **`compose-ui/`** – declarative UI primitives, layout system, and modifier infrastructure.
+- **`desktop-app/`** – a future native desktop demo integrating the framework with `winit` and a rendering backend.
+
+## Roadmap
+
+See [`proposal.md`](proposal.md) for background, design goals, and a phased implementation plan that covers rendering backends, recomposition semantics, modifiers, and platform integration milestones.
+
+## Contributing
+
+This repository is currently a design playground; issues and pull requests are welcome for discussions, experiments, and early prototypes that move the Jetpack Compose–style experience forward in Rust.


### PR DESCRIPTION
## Summary
- add a repository-level README that introduces the Compose-RS workspace
- document the crate layout and point contributors to the proposal for roadmap details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7f142f86c83289be3f284f7825c94