### PR TITLE
Add rounded corner shape support

### DIFF
--- a/compose-ui/src/lib.rs
+++ b/compose-ui/src/lib.rs
@@ -7,7 +7,7 @@ pub use compose_macros::composable;
 mod modifier;
 mod primitives;
 
-pub use modifier::{Color, Modifier, Point, Size};
+pub use modifier::{Color, CornerRadii, Modifier, Point, RoundedCornerShape, Size};
 pub use primitives::{
     Button, ButtonNode, Column, ColumnNode, Row, RowNode, Spacer, SpacerNode, Text, TextNode,
 };


### PR DESCRIPTION
## Summary
- add rounded corner shape primitives to the modifier API and re-export them from compose-ui
- render rounded backgrounds and respect shapes during hit testing in the desktop app
- update the counter demo to showcase the new rounded corner styling

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e7f95c07388328adcfde9d3934f187