### PR TITLE
Add pointer input modifier and dispatching

### DIFF
--- a/compose-ui/src/lib.rs
+++ b/compose-ui/src/lib.rs
@@ -7,7 +7,9 @@ pub use compose_macros::composable;
 mod modifier;
 mod primitives;
 
-pub use modifier::{Color, CornerRadii, Modifier, Point, RoundedCornerShape, Size};
+pub use modifier::{
+    Color, CornerRadii, Modifier, Point, PointerEvent, PointerEventKind, RoundedCornerShape, Size,
+};
 pub use primitives::{
     Button, ButtonNode, Column, ColumnNode, Row, RowNode, Spacer, SpacerNode, Text, TextNode,
 };


### PR DESCRIPTION
## Summary
- add pointer event types and a `pointer_input` modifier to the Compose UI crate
- re-export the pointer input types for consumers of the UI facade
- update the desktop scene graph to dispatch pointer move/down/up events to pointer handlers alongside click actions

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e7fdb1d5ac8328be70fdb9a594df65