### PR TITLE
Add draw modifiers, graphics layers, and animated demo

### DIFF
--- a/compose-ui/src/lib.rs
+++ b/compose-ui/src/lib.rs
@@ -8,7 +8,8 @@ mod modifier;
 mod primitives;
 
 pub use modifier::{
-    Color, CornerRadii, Modifier, Point, PointerEvent, PointerEventKind, RoundedCornerShape, Size,
+    Brush, Color, CornerRadii, DrawCommand, DrawPrimitive, GraphicsLayer, Modifier, Point,
+    PointerEvent, PointerEventKind, Rect, RoundedCornerShape, Size,
 };
 pub use primitives::{
     Button, ButtonNode, Column, ColumnNode, Row, RowNode, Spacer, SpacerNode, Text, TextNode,

--- a/desktop-app/src/main.rs
+++ b/desktop-app/src/main.rs
@@ -1,10 +1,12 @@
+use std::cell::RefCell;
 use std::rc::Rc;
+use std::time::Instant;
 
 use compose_core::{self, location_key, Composition, Key, MemoryApplier, NodeId};
 use compose_ui::{
-    composable, Button, ButtonNode, Color, Column, ColumnNode, CornerRadii, Modifier, Point,
-    PointerEvent, PointerEventKind, RoundedCornerShape, RowNode, Size, Spacer, SpacerNode, Text,
-    TextNode,
+    composable, Brush, Button, ButtonNode, Color, Column, ColumnNode, CornerRadii, DrawCommand,
+    DrawPrimitive, GraphicsLayer, Modifier, Point, PointerEvent, PointerEventKind, Rect,
+    RoundedCornerShape, Row, RowNode, Size, Spacer, SpacerNode, Text, TextNode,
 };
 use once_cell::sync::Lazy;
 use pixels::{Pixels, SurfaceTexture};
@@ -17,11 +19,35 @@ use winit::window::WindowBuilder;
 const INITIAL_WIDTH: u32 = 800;
 const INITIAL_HEIGHT: u32 = 600;
 const TEXT_SIZE: f32 = 24.0;
+const TWO_PI: f32 = std::f32::consts::PI * 2.0;
 
 static FONT: Lazy<Font<'static>> = Lazy::new(|| {
     let f = Font::try_from_bytes(include_bytes!("../assets/Roboto-Light.ttf") as &[u8]);
     f.expect("font")
 });
+
+thread_local! {
+    static CURRENT_ANIMATION_STATE: RefCell<Option<compose_core::State<f32>>> =
+        RefCell::new(None);
+}
+
+fn with_animation_state<R>(state: &compose_core::State<f32>, f: impl FnOnce() -> R) -> R {
+    CURRENT_ANIMATION_STATE.with(|cell| {
+        let previous = cell.replace(Some(state.clone()));
+        let result = f();
+        cell.replace(previous);
+        result
+    })
+}
+
+fn animation_state() -> compose_core::State<f32> {
+    CURRENT_ANIMATION_STATE.with(|cell| {
+        cell.borrow()
+            .as_ref()
+            .expect("animation state missing")
+            .clone()
+    })
+}
 
 fn main() {
     env_logger::init();
@@ -117,12 +143,19 @@ struct ComposeDesktopApp {
     cursor: (f32, f32),
     viewport: (f32, f32),
     buffer_size: (u32, u32),
+    animation_state: compose_core::State<f32>,
+    animation_phase: f32,
+    last_frame: Instant,
 }
 
 impl ComposeDesktopApp {
     fn new(root_key: Key) -> Self {
         let mut composition = Composition::new(MemoryApplier::new());
-        composition.render(root_key, || counter_app());
+        let runtime = composition.runtime_handle();
+        let animation_state = compose_core::State::new(0.0, runtime.clone());
+        composition.render(root_key, || {
+            with_animation_state(&animation_state, || counter_app())
+        });
         let scene = Scene::new();
         let mut app = Self {
             composition,
@@ -131,6 +164,9 @@ impl ComposeDesktopApp {
             cursor: (0.0, 0.0),
             viewport: (INITIAL_WIDTH as f32, INITIAL_HEIGHT as f32),
             buffer_size: (INITIAL_WIDTH, INITIAL_HEIGHT),
+            animation_state,
+            animation_phase: 0.0,
+            last_frame: Instant::now(),
         };
         app.rebuild_scene();
         app
@@ -173,8 +209,21 @@ impl ComposeDesktopApp {
     }
 
     fn update(&mut self) {
+        let now = Instant::now();
+        let delta = now - self.last_frame;
+        self.last_frame = now;
+        let mut phase = self.animation_phase + delta.as_secs_f32();
+        if phase > TWO_PI {
+            phase = phase % TWO_PI;
+        }
+        self.animation_phase = phase;
+        let animation_value = (phase.sin() * 0.5) + 0.5;
+        self.animation_state.set(animation_value);
         if self.composition.should_render() {
-            self.composition.render(self.root_key, || counter_app());
+            let state = self.animation_state.clone();
+            self.composition.render(self.root_key, || {
+                with_animation_state(&state, || counter_app())
+            });
             self.rebuild_scene();
         }
     }
@@ -187,7 +236,15 @@ impl ComposeDesktopApp {
                 height: self.viewport.1,
             };
             let applier = self.composition.applier_mut();
-            layout_node(applier, root, 0.0, 0.0, viewport_size, 0, &mut self.scene);
+            layout_node(
+                applier,
+                root,
+                0.0,
+                0.0,
+                viewport_size,
+                GraphicsLayer::default(),
+                &mut self.scene,
+            );
         }
     }
 }
@@ -195,73 +252,209 @@ impl ComposeDesktopApp {
 #[composable]
 fn counter_app() {
     let counter = compose_core::use_state(|| 0);
+    let pointer_position = compose_core::use_state(|| Point { x: 0.0, y: 0.0 });
+    let pointer_down = compose_core::use_state(|| false);
+    let wave_state = animation_state();
+    let wave = wave_state.get();
+
     Column(
         Modifier::padding(32.0)
             .then(Modifier::rounded_corners(24.0))
-            .then(Modifier::background(Color(0.12, 0.12, 0.16, 1.0))),
+            .then(Modifier::draw_behind({
+                let phase = wave;
+                move |scope| {
+                    scope.draw_round_rect(
+                        Brush::linear_gradient(vec![
+                            Color(0.12 + phase * 0.2, 0.10, 0.24 + (1.0 - phase) * 0.3, 1.0),
+                            Color(0.08, 0.16 + (1.0 - phase) * 0.3, 0.26 + phase * 0.2, 1.0),
+                        ]),
+                        CornerRadii::uniform(24.0),
+                    );
+                }
+            }))
+            .then(Modifier::padding(20.0)),
         || {
-            Text(format!("COUNT: {}", counter.get()), Modifier::padding(12.0));
-            Text(format!("COUNT: {}", counter.get()), Modifier::padding(12.0));
-            Text(format!("COUNT: {}", counter.get()), Modifier::padding(12.0));
             Text(
-                format!("COUNT: {}", counter.get()),
-                Modifier::padding(12.0).then(Modifier::size(Size {
-                    width: 100.0,
-                    height: 40.0,
-                })),
+                "Compose-RS Playground",
+                Modifier::padding(12.0)
+                    .then(Modifier::rounded_corner_shape(RoundedCornerShape::new(
+                        16.0, 24.0, 16.0, 24.0,
+                    )))
+                    .then(Modifier::draw_with_content(|scope| {
+                        scope.draw_round_rect(
+                            Brush::solid(Color(1.0, 1.0, 1.0, 0.1)),
+                            CornerRadii::uniform(20.0),
+                        );
+                    })),
             );
+
+            Spacer(Size {
+                width: 0.0,
+                height: 12.0,
+            });
+
+            Row(Modifier::padding(8.0), || {
+                Text(
+                    format!("Counter: {}", counter.get()),
+                    Modifier::padding(8.0)
+                        .then(Modifier::background(Color(0.0, 0.0, 0.0, 0.35)))
+                        .then(Modifier::rounded_corners(12.0)),
+                );
+                Spacer(Size {
+                    width: 16.0,
+                    height: 0.0,
+                });
+                Text(
+                    format!("Wave {:.2}", wave),
+                    Modifier::padding(8.0)
+                        .then(Modifier::background(Color(0.35, 0.55, 0.9, 0.5)))
+                        .then(Modifier::rounded_corners(12.0))
+                        .then(Modifier::graphics_layer(GraphicsLayer {
+                            alpha: 0.7 + wave * 0.3,
+                            scale: 0.85 + wave * 0.3,
+                            translation_x: 0.0,
+                            translation_y: (wave - 0.5) * 12.0,
+                        })),
+                );
+            });
+
             Spacer(Size {
                 width: 0.0,
                 height: 16.0,
             });
-            Button(
-                Modifier::rounded_corners(16.0)
-                    .then(Modifier::background(Color(0.22, 0.45, 0.85, 1.0)))
-                    .then(Modifier::padding(12.0)),
-                {
-                    let counter = counter.clone();
-                    move || counter.set(counter.get() + 1)
-                },
+
+            Column(
+                Modifier::size(Size {
+                    width: 360.0,
+                    height: 180.0,
+                })
+                .then(Modifier::rounded_corners(20.0))
+                .then(Modifier::draw_with_cache(|cache| {
+                    cache.on_draw_behind(|scope| {
+                        scope.draw_round_rect(
+                            Brush::solid(Color(0.16, 0.18, 0.26, 0.95)),
+                            CornerRadii::uniform(20.0),
+                        );
+                    });
+                }))
+                .then(Modifier::draw_with_content({
+                    let position = pointer_position.get();
+                    let pressed = pointer_down.get();
+                    move |scope| {
+                        let intensity = if pressed { 0.45 } else { 0.25 };
+                        scope.draw_round_rect(
+                            Brush::radial_gradient(
+                                vec![Color(0.4, 0.6, 1.0, intensity), Color(0.2, 0.3, 0.6, 0.0)],
+                                position,
+                                120.0,
+                            ),
+                            CornerRadii::uniform(20.0),
+                        );
+                    }
+                }))
+                .then(Modifier::pointer_input({
+                    let pointer_position = pointer_position.clone();
+                    let pointer_down = pointer_down.clone();
+                    move |event: PointerEvent| {
+                        pointer_position.set(event.position);
+                        match event.kind {
+                            PointerEventKind::Down => pointer_down.set(true),
+                            PointerEventKind::Up => pointer_down.set(false),
+                            _ => {}
+                        }
+                    }
+                }))
+                .then(Modifier::clickable({
+                    let pointer_down = pointer_down.clone();
+                    move |_| pointer_down.set(!pointer_down.get())
+                }))
+                .then(Modifier::padding(12.0)),
                 || {
-                    Text("INCREMENT", Modifier::padding(6.0));
+                    Text(
+                        "Pointer playground",
+                        Modifier::padding(6.0)
+                            .then(Modifier::background(Color(0.0, 0.0, 0.0, 0.25)))
+                            .then(Modifier::rounded_corners(12.0)),
+                    );
+                    Spacer(Size {
+                        width: 0.0,
+                        height: 8.0,
+                    });
+                    Text(
+                        format!(
+                            "Local pointer: ({:.0}, {:.0})",
+                            pointer_position.get().x,
+                            pointer_position.get().y
+                        ),
+                        Modifier::padding(6.0),
+                    );
+                    Text(
+                        format!("Pressed: {}", pointer_down.get()),
+                        Modifier::padding(6.0),
+                    );
                 },
             );
-            Button(
-                Modifier::rounded_corners(16.0)
-                    .then(Modifier::background(Color(0.22, 0.45, 0.85, 1.0)))
-                    .then(Modifier::padding(12.0)),
-                {
-                    let counter = counter.clone();
-                    move || counter.set(counter.get() - 1)
-                },
-                || {
-                    Text("DEC", Modifier::padding(3.0));
-                },
-            );
+
+            Spacer(Size {
+                width: 0.0,
+                height: 16.0,
+            });
+
+            Row(Modifier::padding(8.0), || {
+                Button(
+                    Modifier::rounded_corners(16.0)
+                        .then(Modifier::draw_with_cache(|cache| {
+                            cache.on_draw_behind(|scope| {
+                                scope.draw_round_rect(
+                                    Brush::linear_gradient(vec![
+                                        Color(0.2, 0.45, 0.9, 1.0),
+                                        Color(0.15, 0.3, 0.65, 1.0),
+                                    ]),
+                                    CornerRadii::uniform(16.0),
+                                );
+                            });
+                        }))
+                        .then(Modifier::padding(12.0)),
+                    {
+                        let counter = counter.clone();
+                        move || counter.set(counter.get() + 1)
+                    },
+                    || {
+                        Text("Increment", Modifier::padding(6.0));
+                    },
+                );
+                Spacer(Size {
+                    width: 12.0,
+                    height: 0.0,
+                });
+                Button(
+                    Modifier::rounded_corners(16.0)
+                        .then(Modifier::draw_behind(|scope| {
+                            scope.draw_round_rect(
+                                Brush::solid(Color(0.4, 0.18, 0.3, 1.0)),
+                                CornerRadii::uniform(16.0),
+                            );
+                        }))
+                        .then(Modifier::padding(12.0)),
+                    {
+                        let counter = counter.clone();
+                        move || counter.set(counter.get() - 1)
+                    },
+                    || {
+                        Text("Decrement", Modifier::padding(6.0));
+                    },
+                );
+            });
         },
     );
 }
 
-#[derive(Clone, Copy)]
-struct Rect {
-    x: f32,
-    y: f32,
-    width: f32,
-    height: f32,
-}
-
-impl Rect {
-    fn contains(&self, x: f32, y: f32) -> bool {
-        x >= self.x && y >= self.y && x <= self.x + self.width && y <= self.y + self.height
-    }
-}
-
 #[derive(Clone)]
-struct DrawRect {
+struct DrawShape {
     rect: Rect,
-    color: Color,
-    depth: usize,
+    brush: Brush,
     shape: Option<RoundedCornerShape>,
+    z_index: usize,
 }
 
 #[derive(Clone)]
@@ -269,7 +462,8 @@ struct TextDraw {
     rect: Rect,
     text: String,
     color: Color,
-    depth: usize,
+    scale: f32,
+    z_index: usize,
 }
 
 #[derive(Clone)]
@@ -296,7 +490,7 @@ struct HitRegion {
     shape: Option<RoundedCornerShape>,
     click_actions: Vec<ClickAction>,
     pointer_inputs: Vec<Rc<dyn Fn(PointerEvent)>>,
-    depth: usize,
+    z_index: usize,
 }
 
 impl HitRegion {
@@ -331,32 +525,79 @@ impl HitRegion {
 }
 
 struct Scene {
-    rects: Vec<DrawRect>,
+    shapes: Vec<DrawShape>,
     texts: Vec<TextDraw>,
     hits: Vec<HitRegion>,
+    next_z: usize,
 }
 
 impl Scene {
     fn new() -> Self {
         Self {
-            rects: Vec::new(),
+            shapes: Vec::new(),
             texts: Vec::new(),
             hits: Vec::new(),
+            next_z: 0,
         }
     }
 
     fn clear(&mut self) {
-        self.rects.clear();
+        self.shapes.clear();
         self.texts.clear();
         self.hits.clear();
+        self.next_z = 0;
     }
 
     fn hit_test(&self, x: f32, y: f32) -> Option<HitRegion> {
         self.hits
             .iter()
             .filter(|hit| hit.contains(x, y))
-            .max_by(|a, b| a.depth.cmp(&b.depth))
+            .max_by(|a, b| a.z_index.cmp(&b.z_index))
             .cloned()
+    }
+
+    fn push_shape(&mut self, rect: Rect, brush: Brush, shape: Option<RoundedCornerShape>) {
+        let z_index = self.next_z;
+        self.next_z += 1;
+        self.shapes.push(DrawShape {
+            rect,
+            brush,
+            shape,
+            z_index,
+        });
+    }
+
+    fn push_text(&mut self, rect: Rect, text: String, color: Color, scale: f32) {
+        let z_index = self.next_z;
+        self.next_z += 1;
+        self.texts.push(TextDraw {
+            rect,
+            text,
+            color,
+            scale,
+            z_index,
+        });
+    }
+
+    fn push_hit(
+        &mut self,
+        rect: Rect,
+        shape: Option<RoundedCornerShape>,
+        click_actions: Vec<ClickAction>,
+        pointer_inputs: Vec<Rc<dyn Fn(PointerEvent)>>,
+    ) {
+        if click_actions.is_empty() && pointer_inputs.is_empty() {
+            return;
+        }
+        let z_index = self.next_z;
+        self.next_z += 1;
+        self.hits.push(HitRegion {
+            rect,
+            shape,
+            click_actions,
+            pointer_inputs,
+            z_index,
+        });
     }
 }
 
@@ -367,6 +608,8 @@ struct NodeStyle {
     clickable: Option<Rc<dyn Fn(Point)>>,
     shape: Option<RoundedCornerShape>,
     pointer_inputs: Vec<Rc<dyn Fn(PointerEvent)>>,
+    draw_commands: Vec<DrawCommand>,
+    graphics_layer: Option<GraphicsLayer>,
 }
 
 impl NodeStyle {
@@ -378,6 +621,128 @@ impl NodeStyle {
             clickable: modifier.click_handler(),
             shape: modifier.corner_shape(),
             pointer_inputs: modifier.pointer_inputs(),
+            draw_commands: modifier.draw_commands(),
+            graphics_layer: modifier.graphics_layer_values(),
+        }
+    }
+}
+
+fn combine_layers(current: GraphicsLayer, modifier_layer: Option<GraphicsLayer>) -> GraphicsLayer {
+    if let Some(layer) = modifier_layer {
+        GraphicsLayer {
+            alpha: (current.alpha * layer.alpha).clamp(0.0, 1.0),
+            scale: current.scale * layer.scale,
+            translation_x: current.translation_x + layer.translation_x,
+            translation_y: current.translation_y + layer.translation_y,
+        }
+    } else {
+        current
+    }
+}
+
+fn apply_layer_to_rect(rect: Rect, origin: (f32, f32), layer: GraphicsLayer) -> Rect {
+    let offset_x = rect.x - origin.0;
+    let offset_y = rect.y - origin.1;
+    Rect {
+        x: origin.0 + offset_x * layer.scale + layer.translation_x,
+        y: origin.1 + offset_y * layer.scale + layer.translation_y,
+        width: rect.width * layer.scale,
+        height: rect.height * layer.scale,
+    }
+}
+
+fn apply_layer_to_color(color: Color, layer: GraphicsLayer) -> Color {
+    Color(
+        color.0,
+        color.1,
+        color.2,
+        (color.3 * layer.alpha).clamp(0.0, 1.0),
+    )
+}
+
+fn apply_layer_to_brush(brush: Brush, layer: GraphicsLayer) -> Brush {
+    match brush {
+        Brush::Solid(color) => Brush::solid(apply_layer_to_color(color, layer)),
+        Brush::LinearGradient(colors) => Brush::LinearGradient(
+            colors
+                .into_iter()
+                .map(|c| apply_layer_to_color(c, layer))
+                .collect(),
+        ),
+        Brush::RadialGradient {
+            colors,
+            mut center,
+            mut radius,
+        } => {
+            center.x *= layer.scale;
+            center.y *= layer.scale;
+            radius *= layer.scale;
+            Brush::RadialGradient {
+                colors: colors
+                    .into_iter()
+                    .map(|c| apply_layer_to_color(c, layer))
+                    .collect(),
+                center,
+                radius,
+            }
+        }
+    }
+}
+
+fn scale_corner_radii(radii: CornerRadii, scale: f32) -> CornerRadii {
+    CornerRadii {
+        top_left: radii.top_left * scale,
+        top_right: radii.top_right * scale,
+        bottom_right: radii.bottom_right * scale,
+        bottom_left: radii.bottom_left * scale,
+    }
+}
+
+#[derive(Clone, Copy)]
+enum DrawPlacement {
+    Behind,
+    Overlay,
+}
+
+fn apply_draw_commands(
+    commands: &[DrawCommand],
+    placement: DrawPlacement,
+    rect: Rect,
+    origin: (f32, f32),
+    size: Size,
+    layer: GraphicsLayer,
+    scene: &mut Scene,
+) {
+    for command in commands {
+        let primitives = match (placement, command) {
+            (DrawPlacement::Behind, DrawCommand::Behind(func)) => func(size),
+            (DrawPlacement::Overlay, DrawCommand::Overlay(func)) => func(size),
+            _ => continue,
+        };
+        for primitive in primitives {
+            match primitive {
+                DrawPrimitive::Rect {
+                    rect: local_rect,
+                    brush,
+                } => {
+                    let draw_rect = local_rect.translate(rect.x, rect.y);
+                    let transformed = apply_layer_to_rect(draw_rect, origin, layer);
+                    let brush = apply_layer_to_brush(brush, layer);
+                    scene.push_shape(transformed, brush, None);
+                }
+                DrawPrimitive::RoundRect {
+                    rect: local_rect,
+                    brush,
+                    radii,
+                } => {
+                    let draw_rect = local_rect.translate(rect.x, rect.y);
+                    let transformed = apply_layer_to_rect(draw_rect, origin, layer);
+                    let scaled_radii = scale_corner_radii(radii, layer.scale);
+                    let shape = RoundedCornerShape::with_radii(scaled_radii);
+                    let brush = apply_layer_to_brush(brush, layer);
+                    scene.push_shape(transformed, brush, Some(shape));
+                }
+            }
         }
     }
 }
@@ -388,23 +753,23 @@ fn layout_node(
     origin_x: f32,
     origin_y: f32,
     max_size: Size,
-    depth: usize,
+    layer: GraphicsLayer,
     scene: &mut Scene,
 ) -> Size {
     if let Some(column) = applier.with_node(node_id, |node: &mut ColumnNode| node.clone()) {
-        return layout_column(applier, column, origin_x, origin_y, max_size, depth, scene);
+        return layout_column(applier, column, origin_x, origin_y, max_size, layer, scene);
     }
     if let Some(row) = applier.with_node(node_id, |node: &mut RowNode| node.clone()) {
-        return layout_row(applier, row, origin_x, origin_y, max_size, depth, scene);
+        return layout_row(applier, row, origin_x, origin_y, max_size, layer, scene);
     }
     if let Some(text) = applier.with_node(node_id, |node: &mut TextNode| node.clone()) {
-        return layout_text(text, origin_x, origin_y, depth, scene);
+        return layout_text(text, origin_x, origin_y, layer, scene);
     }
     if let Some(spacer) = applier.with_node(node_id, |node: &mut SpacerNode| node.clone()) {
-        return layout_spacer(spacer, origin_x, origin_y, depth, scene);
+        return layout_spacer(spacer, origin_x, origin_y, layer, scene);
     }
     if let Some(button) = applier.with_node(node_id, |node: &mut ButtonNode| node.clone()) {
-        return layout_button(applier, button, origin_x, origin_y, max_size, depth, scene);
+        return layout_button(applier, button, origin_x, origin_y, max_size, layer, scene);
     }
     Size {
         width: 0.0,
@@ -418,10 +783,11 @@ fn layout_column(
     origin_x: f32,
     origin_y: f32,
     max_size: Size,
-    depth: usize,
+    layer: GraphicsLayer,
     scene: &mut Scene,
 ) -> Size {
     let style = NodeStyle::from_modifier(&node.modifier);
+    let node_layer = combine_layers(layer, style.graphics_layer);
     let inner_x = origin_x + style.padding;
     let inner_y = origin_y + style.padding;
     let mut total_height: f32 = 0.0;
@@ -440,7 +806,7 @@ fn layout_column(
                 width: available_width,
                 height: available_height,
             },
-            depth + 1,
+            node_layer,
             scene,
         );
         total_height += size.height;
@@ -462,27 +828,45 @@ fn layout_column(
         width,
         height,
     };
+    let size = Size { width, height };
+    let origin = (origin_x, origin_y);
+    apply_draw_commands(
+        &style.draw_commands,
+        DrawPlacement::Behind,
+        rect,
+        origin,
+        size,
+        node_layer,
+        scene,
+    );
+    let scaled_shape = style.shape.map(|shape| {
+        let resolved = shape.resolve(width, height);
+        RoundedCornerShape::with_radii(scale_corner_radii(resolved, node_layer.scale))
+    });
+    let transformed_rect = apply_layer_to_rect(rect, origin, node_layer);
     if let Some(color) = style.background {
-        scene.rects.push(DrawRect {
-            rect,
-            color,
-            depth,
-            shape: style.shape,
-        });
+        let brush = apply_layer_to_brush(Brush::solid(color), node_layer);
+        scene.push_shape(transformed_rect, brush, scaled_shape.clone());
     }
     let mut click_actions = Vec::new();
     if let Some(handler) = style.clickable {
         click_actions.push(ClickAction::WithPoint(handler));
     }
-    if !click_actions.is_empty() || !style.pointer_inputs.is_empty() {
-        scene.hits.push(HitRegion {
-            rect,
-            shape: style.shape,
-            click_actions,
-            pointer_inputs: style.pointer_inputs.clone(),
-            depth,
-        });
-    }
+    scene.push_hit(
+        transformed_rect,
+        scaled_shape.clone(),
+        click_actions,
+        style.pointer_inputs.clone(),
+    );
+    apply_draw_commands(
+        &style.draw_commands,
+        DrawPlacement::Overlay,
+        rect,
+        origin,
+        size,
+        node_layer,
+        scene,
+    );
     Size { width, height }
 }
 
@@ -492,10 +876,11 @@ fn layout_row(
     origin_x: f32,
     origin_y: f32,
     max_size: Size,
-    depth: usize,
+    layer: GraphicsLayer,
     scene: &mut Scene,
 ) -> Size {
     let style = NodeStyle::from_modifier(&node.modifier);
+    let node_layer = combine_layers(layer, style.graphics_layer);
     let mut total_width: f32 = 0.0;
     let mut max_child_height: f32 = 0.0;
     let inner_x = origin_x + style.padding;
@@ -514,7 +899,7 @@ fn layout_row(
                 width: available_width,
                 height: available_height,
             },
-            depth + 1,
+            node_layer,
             scene,
         );
         total_width += size.width;
@@ -536,27 +921,45 @@ fn layout_row(
         width,
         height,
     };
+    let size = Size { width, height };
+    let origin = (origin_x, origin_y);
+    apply_draw_commands(
+        &style.draw_commands,
+        DrawPlacement::Behind,
+        rect,
+        origin,
+        size,
+        node_layer,
+        scene,
+    );
+    let scaled_shape = style.shape.map(|shape| {
+        let resolved = shape.resolve(width, height);
+        RoundedCornerShape::with_radii(scale_corner_radii(resolved, node_layer.scale))
+    });
+    let transformed_rect = apply_layer_to_rect(rect, origin, node_layer);
     if let Some(color) = style.background {
-        scene.rects.push(DrawRect {
-            rect,
-            color,
-            depth,
-            shape: style.shape,
-        });
+        let brush = apply_layer_to_brush(Brush::solid(color), node_layer);
+        scene.push_shape(transformed_rect, brush, scaled_shape.clone());
     }
     let mut click_actions = Vec::new();
     if let Some(handler) = style.clickable {
         click_actions.push(ClickAction::WithPoint(handler));
     }
-    if !click_actions.is_empty() || !style.pointer_inputs.is_empty() {
-        scene.hits.push(HitRegion {
-            rect,
-            shape: style.shape,
-            click_actions,
-            pointer_inputs: style.pointer_inputs.clone(),
-            depth,
-        });
-    }
+    scene.push_hit(
+        transformed_rect,
+        scaled_shape.clone(),
+        click_actions,
+        style.pointer_inputs.clone(),
+    );
+    apply_draw_commands(
+        &style.draw_commands,
+        DrawPlacement::Overlay,
+        rect,
+        origin,
+        size,
+        node_layer,
+        scene,
+    );
     Size { width, height }
 }
 
@@ -564,10 +967,11 @@ fn layout_text(
     node: TextNode,
     origin_x: f32,
     origin_y: f32,
-    depth: usize,
+    layer: GraphicsLayer,
     scene: &mut Scene,
 ) -> Size {
     let style = NodeStyle::from_modifier(&node.modifier);
+    let node_layer = combine_layers(layer, style.graphics_layer);
     let metrics = measure_text(&node.text);
     let mut width = metrics.width + style.padding * 2.0;
     let mut height = metrics.height + style.padding * 2.0;
@@ -585,38 +989,58 @@ fn layout_text(
         width,
         height,
     };
-    if let Some(color) = style.background {
-        scene.rects.push(DrawRect {
-            rect,
-            color,
-            depth,
-            shape: style.shape,
-        });
-    }
-    scene.texts.push(TextDraw {
-        rect: Rect {
-            x: origin_x + style.padding,
-            y: origin_y + style.padding,
-            width: metrics.width,
-            height: metrics.height,
-        },
-        text: node.text,
-        color: Color(1.0, 1.0, 1.0, 1.0),
-        depth,
+    let size = Size { width, height };
+    let origin = (origin_x, origin_y);
+    apply_draw_commands(
+        &style.draw_commands,
+        DrawPlacement::Behind,
+        rect,
+        origin,
+        size,
+        node_layer,
+        scene,
+    );
+    let scaled_shape = style.shape.map(|shape| {
+        let resolved = shape.resolve(width, height);
+        RoundedCornerShape::with_radii(scale_corner_radii(resolved, node_layer.scale))
     });
+    let transformed_rect = apply_layer_to_rect(rect, origin, node_layer);
+    if let Some(color) = style.background {
+        let brush = apply_layer_to_brush(Brush::solid(color), node_layer);
+        scene.push_shape(transformed_rect, brush, scaled_shape.clone());
+    }
+    let text_rect = Rect {
+        x: origin_x + style.padding,
+        y: origin_y + style.padding,
+        width: metrics.width,
+        height: metrics.height,
+    };
+    let transformed_text_rect = apply_layer_to_rect(text_rect, origin, node_layer);
+    scene.push_text(
+        transformed_text_rect,
+        node.text,
+        apply_layer_to_color(Color(1.0, 1.0, 1.0, 1.0), node_layer),
+        node_layer.scale,
+    );
     let mut click_actions = Vec::new();
     if let Some(handler) = style.clickable {
         click_actions.push(ClickAction::WithPoint(handler));
     }
-    if !click_actions.is_empty() || !style.pointer_inputs.is_empty() {
-        scene.hits.push(HitRegion {
-            rect,
-            shape: style.shape,
-            click_actions,
-            pointer_inputs: style.pointer_inputs.clone(),
-            depth,
-        });
-    }
+    scene.push_hit(
+        transformed_rect,
+        scaled_shape.clone(),
+        click_actions,
+        style.pointer_inputs.clone(),
+    );
+    apply_draw_commands(
+        &style.draw_commands,
+        DrawPlacement::Overlay,
+        rect,
+        origin,
+        size,
+        node_layer,
+        scene,
+    );
     Size { width, height }
 }
 
@@ -624,7 +1048,7 @@ fn layout_spacer(
     node: SpacerNode,
     origin_x: f32,
     origin_y: f32,
-    _depth: usize,
+    _layer: GraphicsLayer,
     _scene: &mut Scene,
 ) -> Size {
     let _ = (origin_x, origin_y);
@@ -640,10 +1064,11 @@ fn layout_button(
     origin_x: f32,
     origin_y: f32,
     max_size: Size,
-    depth: usize,
+    layer: GraphicsLayer,
     scene: &mut Scene,
 ) -> Size {
     let style = NodeStyle::from_modifier(&node.modifier);
+    let node_layer = combine_layers(layer, style.graphics_layer);
     let inner_x = origin_x + style.padding;
     let inner_y = origin_y + style.padding;
     let available_width =
@@ -662,7 +1087,7 @@ fn layout_button(
                 width: available_width,
                 height: available_height,
             },
-            depth + 1,
+            node_layer,
             scene,
         );
         total_height += size.height;
@@ -684,27 +1109,45 @@ fn layout_button(
         width,
         height,
     };
+    let size = Size { width, height };
+    let origin = (origin_x, origin_y);
+    apply_draw_commands(
+        &style.draw_commands,
+        DrawPlacement::Behind,
+        rect,
+        origin,
+        size,
+        node_layer,
+        scene,
+    );
+    let scaled_shape = style.shape.map(|shape| {
+        let resolved = shape.resolve(width, height);
+        RoundedCornerShape::with_radii(scale_corner_radii(resolved, node_layer.scale))
+    });
+    let transformed_rect = apply_layer_to_rect(rect, origin, node_layer);
     if let Some(color) = style.background {
-        scene.rects.push(DrawRect {
-            rect,
-            color,
-            depth,
-            shape: style.shape,
-        });
+        let brush = apply_layer_to_brush(Brush::solid(color), node_layer);
+        scene.push_shape(transformed_rect, brush, scaled_shape.clone());
     }
     let mut click_actions = vec![ClickAction::Simple(node.on_click.clone())];
     if let Some(handler) = style.clickable {
         click_actions.push(ClickAction::WithPoint(handler));
     }
-    if !click_actions.is_empty() || !style.pointer_inputs.is_empty() {
-        scene.hits.push(HitRegion {
-            rect,
-            shape: style.shape,
-            click_actions,
-            pointer_inputs: style.pointer_inputs.clone(),
-            depth,
-        });
-    }
+    scene.push_hit(
+        transformed_rect,
+        scaled_shape.clone(),
+        click_actions,
+        style.pointer_inputs.clone(),
+    );
+    apply_draw_commands(
+        &style.draw_commands,
+        DrawPlacement::Overlay,
+        rect,
+        origin,
+        size,
+        node_layer,
+        scene,
+    );
     Size { width, height }
 }
 
@@ -742,31 +1185,30 @@ fn draw_scene(frame: &mut [u8], width: u32, height: u32, scene: &Scene) {
         chunk.copy_from_slice(&[18, 18, 24, 255]);
     }
 
-    let mut rects = scene.rects.clone();
-    rects.sort_by(|a, b| a.depth.cmp(&b.depth));
-    for rect in rects {
-        fill_rect(frame, width, height, rect);
+    let mut shapes = scene.shapes.clone();
+    shapes.sort_by(|a, b| a.z_index.cmp(&b.z_index));
+    for shape in shapes {
+        draw_shape(frame, width, height, shape);
     }
 
     let mut texts = scene.texts.clone();
-    texts.sort_by(|a, b| a.depth.cmp(&b.depth));
+    texts.sort_by(|a, b| a.z_index.cmp(&b.z_index));
     for text in texts {
         draw_text(frame, width, height, text);
     }
 }
 
-fn fill_rect(frame: &mut [u8], width: u32, height: u32, draw: DrawRect) {
+fn draw_shape(frame: &mut [u8], width: u32, height: u32, draw: DrawShape) {
     let Rect {
         x,
         y,
         width: rect_width,
         height: rect_height,
     } = draw.rect;
-    let start_x = x.max(0.0) as i32;
-    let start_y = y.max(0.0) as i32;
-    let end_x = (x + rect_width).min(width as f32) as i32;
-    let end_y = (y + rect_height).min(height as f32) as i32;
-    let rgba = color_to_rgba(draw.color);
+    let start_x = x.floor().max(0.0) as i32;
+    let start_y = y.floor().max(0.0) as i32;
+    let end_x = (x + rect_width).ceil().min(width as f32) as i32;
+    let end_y = (y + rect_height).ceil().min(height as f32) as i32;
     let resolved_shape = draw
         .shape
         .map(|shape| shape.resolve(rect_width, rect_height));
@@ -778,22 +1220,43 @@ fn fill_rect(frame: &mut [u8], width: u32, height: u32, draw: DrawRect) {
             if px < 0 || px >= width as i32 {
                 continue;
             }
+            let center_x = px as f32 + 0.5;
+            let center_y = py as f32 + 0.5;
             if let Some(ref radii) = resolved_shape {
-                let px_center = px as f32 + 0.5;
-                let py_center = py as f32 + 0.5;
-                if !point_in_resolved_rounded_rect(px_center, py_center, draw.rect, radii) {
+                if !point_in_resolved_rounded_rect(center_x, center_y, draw.rect, radii) {
                     continue;
                 }
             }
+            let sample = sample_brush(&draw.brush, draw.rect, center_x, center_y);
+            let alpha = sample[3];
+            if alpha <= 0.0 {
+                continue;
+            }
             let idx = ((py as u32 * width + px as u32) * 4) as usize;
-            frame[idx..idx + 4].copy_from_slice(&rgba);
+            let existing = &mut frame[idx..idx + 4];
+            let dst_r = existing[0] as f32 / 255.0;
+            let dst_g = existing[1] as f32 / 255.0;
+            let dst_b = existing[2] as f32 / 255.0;
+            let dst_a = existing[3] as f32 / 255.0;
+            let out_r = sample[0] * alpha + dst_r * (1.0 - alpha);
+            let out_g = sample[1] * alpha + dst_g * (1.0 - alpha);
+            let out_b = sample[2] * alpha + dst_b * (1.0 - alpha);
+            let out_a = alpha + dst_a * (1.0 - alpha);
+            existing[0] = (out_r.clamp(0.0, 1.0) * 255.0).round() as u8;
+            existing[1] = (out_g.clamp(0.0, 1.0) * 255.0).round() as u8;
+            existing[2] = (out_b.clamp(0.0, 1.0) * 255.0).round() as u8;
+            existing[3] = (out_a.clamp(0.0, 1.0) * 255.0).round() as u8;
         }
     }
 }
 
 fn draw_text(frame: &mut [u8], width: u32, height: u32, draw: TextDraw) {
     let color = color_to_rgba(draw.color);
-    let scale = Scale::uniform(TEXT_SIZE);
+    let text_scale = (draw.scale).max(0.0);
+    if text_scale == 0.0 {
+        return;
+    }
+    let scale = Scale::uniform(TEXT_SIZE * text_scale);
     let font = &*FONT;
     let v_metrics = font.v_metrics(scale);
     let offset = point(draw.rect.x, draw.rect.y + v_metrics.ascent);
@@ -810,23 +1273,80 @@ fn draw_text(frame: &mut [u8], width: u32, height: u32, draw: TextDraw) {
                 let existing = &mut frame[idx..idx + 4];
                 for i in 0..3 {
                     let dst = existing[i] as f32 / 255.0;
-                    let src = color[i] as f32 / 255.0;
-                    let blended = (src * alpha) + dst * (1.0 - alpha);
+                    let blended = (color[i] * alpha) + dst * (1.0 - alpha);
                     existing[i] = (blended.clamp(0.0, 1.0) * 255.0).round() as u8;
                 }
-                existing[3] = 255;
+                let dst_alpha = existing[3] as f32 / 255.0;
+                let out_alpha = alpha + dst_alpha * (1.0 - alpha);
+                existing[3] = (out_alpha.clamp(0.0, 1.0) * 255.0).round() as u8;
             });
         }
     }
 }
 
-fn color_to_rgba(color: Color) -> [u8; 4] {
+fn color_to_rgba(color: Color) -> [f32; 4] {
     [
-        (color.0.clamp(0.0, 1.0) * 255.0) as u8,
-        (color.1.clamp(0.0, 1.0) * 255.0) as u8,
-        (color.2.clamp(0.0, 1.0) * 255.0) as u8,
-        (color.3.clamp(0.0, 1.0) * 255.0) as u8,
+        color.0.clamp(0.0, 1.0),
+        color.1.clamp(0.0, 1.0),
+        color.2.clamp(0.0, 1.0),
+        color.3.clamp(0.0, 1.0),
     ]
+}
+
+fn sample_brush(brush: &Brush, rect: Rect, x: f32, y: f32) -> [f32; 4] {
+    match brush {
+        Brush::Solid(color) => color_to_rgba(*color),
+        Brush::LinearGradient(colors) => {
+            let t = if rect.height.abs() <= f32::EPSILON {
+                0.0
+            } else {
+                ((y - rect.y) / rect.height).clamp(0.0, 1.0)
+            };
+            color_to_rgba(interpolate_colors(colors, t))
+        }
+        Brush::RadialGradient {
+            colors,
+            center,
+            radius,
+        } => {
+            let cx = rect.x + center.x;
+            let cy = rect.y + center.y;
+            let radius = (*radius).max(f32::EPSILON);
+            let dx = x - cx;
+            let dy = y - cy;
+            let distance = (dx * dx + dy * dy).sqrt();
+            let t = (distance / radius).clamp(0.0, 1.0);
+            color_to_rgba(interpolate_colors(colors, t))
+        }
+    }
+}
+
+fn interpolate_colors(colors: &[Color], t: f32) -> Color {
+    if colors.is_empty() {
+        return Color(0.0, 0.0, 0.0, 0.0);
+    }
+    if colors.len() == 1 {
+        return colors[0];
+    }
+    let clamped = t.clamp(0.0, 1.0);
+    let segments = (colors.len() - 1) as f32;
+    let scaled = clamped * segments;
+    let index = scaled.floor() as usize;
+    if index >= colors.len() - 1 {
+        return *colors.last().unwrap();
+    }
+    let frac = scaled - index as f32;
+    lerp_color(colors[index], colors[index + 1], frac)
+}
+
+fn lerp_color(a: Color, b: Color, t: f32) -> Color {
+    let lerp = |start: f32, end: f32| start + (end - start) * t;
+    Color(
+        lerp(a.0, b.0),
+        lerp(a.1, b.1),
+        lerp(a.2, b.2),
+        lerp(a.3, b.3),
+    )
 }
 
 fn point_in_rounded_rect(x: f32, y: f32, rect: Rect, shape: RoundedCornerShape) -> bool {


### PR DESCRIPTION
## Summary
- extend Modifier with reusable draw infrastructure, graphics layers, and cache helpers for custom rendering primitives
- re-export the new drawing types from compose-ui so applications can apply gradient and cached drawing modifiers
- overhaul the desktop demo to use the new drawing pipeline with z-index ordering, gradient sampling, pointer input, and an animated showcase of all modifiers

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e9490560a88328ab251bb1238210c1