### PR TITLE
Implement dirty-node queue for targeted signal updates

### DIFF
--- a/compose-core/src/signals.rs
+++ b/compose-core/src/signals.rs
@@ -1,22 +1,79 @@
+use std::any::Any;
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
+
+struct SignalCore<T> {
+    value: RefCell<T>,
+    listeners: RefCell<Vec<Weak<dyn Fn(&T)>>>,
+    tokens: RefCell<Vec<Box<dyn Any>>>,
+}
+
+impl<T> SignalCore<T> {
+    fn new(initial: T) -> Self {
+        Self {
+            value: RefCell::new(initial),
+            listeners: RefCell::new(Vec::new()),
+            tokens: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn get(&self) -> T
+    where
+        T: Clone,
+    {
+        self.value.borrow().clone()
+    }
+
+    fn replace(&self, new_value: T) -> bool
+    where
+        T: PartialEq,
+    {
+        let mut current = self.value.borrow_mut();
+        if *current != new_value {
+            *current = new_value;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn add_listener(&self, listener: Rc<dyn Fn(&T)>) {
+        self.listeners.borrow_mut().push(Rc::downgrade(&listener));
+    }
+
+    fn notify(&self) {
+        let value_ref = self.value.borrow();
+        self.listeners.borrow_mut().retain(|weak| {
+            if let Some(listener) = weak.upgrade() {
+                listener(&value_ref);
+                true
+            } else {
+                false
+            }
+        });
+    }
+
+    fn store_token(&self, token: Box<dyn Any>) {
+        self.tokens.borrow_mut().push(token);
+    }
+}
 
 /// Read handle for a signal value.
 ///
 /// Signals are reference-counted so that UI nodes can cheaply clone handles
 /// and read the latest value during recomposition.
-pub struct ReadSignal<T>(Rc<RefCell<T>>);
+pub struct ReadSignal<T>(Rc<SignalCore<T>>);
 
 /// Write handle for a signal value.
 pub struct WriteSignal<T> {
-    inner: Rc<RefCell<T>>,
+    inner: Rc<SignalCore<T>>,
     on_write: Rc<dyn Fn()>,
 }
 
 /// Create a new signal pair with the provided initial value and callback to
 /// invoke whenever the value changes.
 pub fn create_signal<T>(initial: T, on_write: Rc<dyn Fn()>) -> (ReadSignal<T>, WriteSignal<T>) {
-    let cell = Rc::new(RefCell::new(initial));
+    let cell = Rc::new(SignalCore::new(initial));
     (
         ReadSignal(cell.clone()),
         WriteSignal {
@@ -29,7 +86,7 @@ pub fn create_signal<T>(initial: T, on_write: Rc<dyn Fn()>) -> (ReadSignal<T>, W
 impl<T: Clone> ReadSignal<T> {
     /// Get the current value by cloning it out of the signal.
     pub fn get(&self) -> T {
-        self.0.borrow().clone()
+        self.0.get()
     }
 
     /// Create a derived signal by mapping the current value through `f`.
@@ -37,9 +94,34 @@ impl<T: Clone> ReadSignal<T> {
     /// Phase 1 signals are coarse-grained – derived signals simply snapshot the
     /// mapped value and rely on writers of the source signal to schedule a
     /// follow-up frame when updates occur.
-    pub fn map<U: 'static>(&self, f: impl Fn(&T) -> U + 'static) -> ReadSignal<U> {
-        let v = f(&self.0.borrow());
-        ReadSignal(Rc::new(RefCell::new(v)))
+    pub fn map<U>(&self, f: impl Fn(&T) -> U + 'static) -> ReadSignal<U>
+    where
+        U: Clone + PartialEq + 'static,
+    {
+        let initial = {
+            let value = self.0.value.borrow();
+            f(&value)
+        };
+        let (derived_read, derived_write) = create_signal(initial, Rc::new(|| {}));
+        let listener_write = derived_write.clone();
+        let listener = Rc::new(move |value: &T| {
+            listener_write.set(f(value));
+        });
+        self.subscribe(listener.clone());
+        derived_read.0.store_token(Box::new(listener));
+        derived_read
+    }
+
+    /// Subscribe to updates from this signal.
+    ///
+    /// The returned listener must be kept alive (e.g. in a slot) for updates to
+    /// continue flowing. Dropping the listener automatically unsubscribes it.
+    pub fn subscribe(&self, listener: Rc<dyn Fn(&T)>) {
+        self.0.add_listener(listener);
+    }
+
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
     }
 }
 
@@ -47,9 +129,8 @@ impl<T: PartialEq> WriteSignal<T> {
     /// Replace the current value and trigger the supplied callback when the
     /// value actually changes.
     pub fn set(&self, new_val: T) {
-        let mut b = self.inner.borrow_mut();
-        if *b != new_val {
-            *b = new_val;
+        if self.inner.replace(new_val) {
+            self.inner.notify();
             (self.on_write)();
         }
     }
@@ -62,19 +143,19 @@ pub trait IntoSignal<T> {
 
 impl<T: Clone> IntoSignal<T> for T {
     fn into_signal(self) -> ReadSignal<T> {
-        ReadSignal(Rc::new(RefCell::new(self)))
+        ReadSignal(Rc::new(SignalCore::new(self)))
     }
 }
 
 impl IntoSignal<String> for &str {
     fn into_signal(self) -> ReadSignal<String> {
-        ReadSignal(Rc::new(RefCell::new(self.to_string())))
+        ReadSignal(Rc::new(SignalCore::new(self.to_string())))
     }
 }
 
 impl IntoSignal<String> for &String {
     fn into_signal(self) -> ReadSignal<String> {
-        ReadSignal(Rc::new(RefCell::new(self.clone())))
+        ReadSignal(Rc::new(SignalCore::new(self.clone())))
     }
 }
 


### PR DESCRIPTION
## Summary
- add a dirty-node queue to the runtime with `schedule_node_update` and a composition flush helper
- extend the signals module with subscriptions, stable mapping, and pointer comparison support
- teach `Text` to subscribe to its signal and patch nodes directly, and update the roadmap to reflect the completed milestone

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ea5277491883288bb420f14f344054