### PR TITLE
Introduce structured node error handling

### DIFF
--- a/compose-ui/src/lib.rs
+++ b/compose-ui/src/lib.rs
@@ -21,7 +21,9 @@ pub type TestComposition = Composition<MemoryApplier>;
 /// Build a composition with a simple in-memory applier and run the provided closure once.
 pub fn run_test_composition(mut build: impl FnMut()) -> TestComposition {
     let mut composition = Composition::new(MemoryApplier::new());
-    composition.render(location_key(file!(), line!(), column!()), || build());
+    composition
+        .render(location_key(file!(), line!(), column!()), || build())
+        .expect("initial render succeeds");
     composition
 }
 


### PR DESCRIPTION
## Summary
- add a `NodeError` enum and convert core runtime and applier APIs to return `Result`
- update UI primitives, tests, and the desktop demo to gracefully handle node access failures
- mark the roadmap error handling milestone as complete

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ea72d8b1f0832881878e7397573c74