### PR TITLE
Implement keyed reconciliation for dynamic children

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,7 @@ version = "0.1.0"
 dependencies = [
  "compose-core",
  "compose-macros",
+ "indexmap 2.11.4",
 ]
 
 [[package]]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ This roadmap captures near-term milestones and ready-to-apply patches for evolvi
 2. ✅ **Skip recomposition when inputs unchanged**: extend `#[composable]` to persist prior parameters in slots and early-return when all implement `PartialEq` and remain unchanged.
 3. ✅ **Fine-grained updates – Signals (Phase 2)**: route signal writes through a dirty-node queue, expose `schedule_node_update`/`flush_pending_node_updates`, and let `Text` subscribe so it can patch its own node without a full recomposition.
 4. ✅ **Error handling**: replace `expect`/`unwrap` across the runtime and applier with `Result` and structured error types.
-5. **Keys & reordering**: provide stable identity for dynamic lists to avoid churn during reordering.
+5. ✅ **Keys & reordering**: provide stable identity for dynamic lists to avoid churn during reordering.
 6. **Layout with `taffy`**: map `Modifier` data into `taffy::Style` and compute layouts inside the applier.
 7. **Renderer stub**: sketch a `WgpuApplier` (or keep a headless applier plus golden layout tests).
 8. **Benchmarks & tests**: add microbenchmarks for skip/wide list scenarios, signal-targeted updates, and layout goldens.
@@ -80,11 +80,15 @@ non-fatal miss while still debug-asserting on unexpected missing nodes.
 
 ### 6. Keys & reordering
 
-Add keyed groups and keyed child management to keep dynamic lists stable.
+Status: ✅ Introduced `compose_core::with_key`, container-aware child diffing, and
+`ForEach` for collections. Parents now snapshot child order, reconcile updates
+through `Node::update_children`, and Compose UI containers store children in an
+`IndexSet` for stable ordering. A regression test confirms reordering preserves
+node identity while updating display order.
 
 ```rust
 #[composable]
-pub fn ForEach<T: Hash + Eq + Clone>(items: &[T], mut row: impl FnMut(&T)) {
+pub fn ForEach<T: Hash>(items: &[T], mut row: impl FnMut(&T)) {
     for it in items {
         compose_core::with_key(it, || row(it));
     }

--- a/compose-ui/Cargo.toml
+++ b/compose-ui/Cargo.toml
@@ -8,6 +8,7 @@ description = "UI primitives for Compose-RS"
 [dependencies]
 compose-core = { path = "../compose-core" }
 compose-macros = { path = "../compose-macros" }
+indexmap = "2"
 
 [features]
 default = []

--- a/compose-ui/src/lib.rs
+++ b/compose-ui/src/lib.rs
@@ -12,7 +12,8 @@ pub use modifier::{
     PointerEvent, PointerEventKind, Rect, RoundedCornerShape, Size,
 };
 pub use primitives::{
-    Button, ButtonNode, Column, ColumnNode, Row, RowNode, Spacer, SpacerNode, Text, TextNode,
+    Button, ButtonNode, Column, ColumnNode, ForEach, Row, RowNode, Spacer, SpacerNode, Text,
+    TextNode,
 };
 
 /// Convenience alias used in examples and tests.


### PR DESCRIPTION
## Summary
- add a `with_key` helper and parent-frame tracking so keyed groups reconcile child order without full remounts
- update container primitives to use `IndexSet`, expose a `ForEach` helper, and cover reordering with a regression test
- mark the roadmap milestone for keys and reordering as complete

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ea7b7942c08328938e980445703439