### PR TITLE
Implement smart recomposition pipeline

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,19 +37,19 @@ Context and why
 - Jetpack Compose invalidates and recomposes only scopes that read a changing State. Parents that pass state down without reading do not recompose. This is the crux of Compose performance and must match exactly.
 
 Deliverables
-- RecomposeScope per composed group. Composer maintains a current scope stack.
-- Tracked reads: State<T>.value getter records the current RecomposeScope; writer invalidates only its readers. Passing state through without reading does not register the parent.
-- State and remember APIs:
-  - remember { T }
-  - mutableStateOf(initial): MutableState<T>
-  - interface State<T> { val value: T }
-  - interface MutableState<T> : State<T> { override var value: T }
-  - derivedStateOf { … }: recomputes lazily, invalidates readers when source states change.
-- Skip logic: when parameters are stable and equal and no local invalidations exist, skip the scope and reuse prior result. The macro should generate changed bit masks (ints) like Compose instead of per-param heap allocations. Keep a pragmatic stability model:
-  - Provide a Stable marker/derive for pure data types; default to equality for non-stable types.
-  - Allow a @stable marker in the macro until stability inference matures.
+- RecomposeScope per composed group. Composer maintains a current scope stack. (Implemented)
+- Tracked reads: State<T>.value getter records the current RecomposeScope; writer invalidates only its readers. Passing state through without reading does not register the parent. (Implemented)
+- State and remember APIs: (Implemented)
+  - remember { T } (Implemented)
+  - mutableStateOf(initial): MutableState<T> (Implemented)
+  - interface State<T> { val value: T } (Implemented)
+  - interface MutableState<T> : State<T> { override var value: T } (Implemented)
+  - derivedStateOf { … }: recomputes lazily, invalidates readers when source states change. (Implemented)
+- Skip logic: when parameters are stable and equal and no local invalidations exist, skip the scope and reuse prior result. The macro should generate changed bit masks (ints) like Compose instead of per-param heap allocations. Keep a pragmatic stability model: (Implemented - stability annotations pending)
+  - Provide a Stable marker/derive for pure data types; default to equality for non-stable types. (Planned)
+  - Allow a @stable marker in the macro until stability inference matures. (Planned)
 - ApplyChanges loop: apply change ops (Phase 0), then run SideEffect queue (Phase 3 later) in the same frame.
-- Migrate signal-based updates in Text to tracked State reads (no out-of-band patching).
+- Migrate signal-based updates in Text to tracked State reads (no out-of-band patching). (Implemented)
 
 Tests / definition of done
 - Changing one leaf MutableState in a 100-node tree recomposes only the readers (and their ancestors needed to reach them), not the whole tree.

--- a/compose-macros/src/lib.rs
+++ b/compose-macros/src/lib.rs
@@ -33,8 +33,7 @@ pub fn composable(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
-    let original_block = func.block;
-    let original_block_clone = original_block.clone();
+    let original_block = func.block.clone();
     let key_expr = quote! { compose_core::location_key(file!(), line!(), column!()) };
 
     let rebinds: Vec<_> = param_info
@@ -48,26 +47,81 @@ pub fn composable(attr: TokenStream, item: TokenStream) -> TokenStream {
         ReturnType::Default => syn::parse_quote! { () },
         ReturnType::Type(_, ty) => ty.as_ref().clone(),
     };
+    let _helper_ident = Ident::new(
+        &format!("__compose_impl_{}", func.sig.ident),
+        Span::call_site(),
+    );
+    let generics = func.sig.generics.clone();
+    let (_impl_generics, _ty_generics, _where_clause) = generics.split_for_impl();
 
-    let skip_logic = if enable_skip && !param_info.is_empty() {
-        let param_updates = param_info.iter().map(|(ident, _pat, ty)| {
-            quote! {
-                let __state = __scope.remember(|| compose_core::ParamState::<#ty>::default());
-                if __state.update(&#ident) {
-                    __changed = true;
+    let _helper_inputs: Vec<TokenStream2> = param_info
+        .iter()
+        .map(|(ident, _pat, ty)| quote! { #ident: #ty })
+        .collect();
+
+    if enable_skip {
+        let helper_ident = Ident::new(
+            &format!("__compose_impl_{}", func.sig.ident),
+            Span::call_site(),
+        );
+        let generics = func.sig.generics.clone();
+        let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
+
+        let helper_inputs: Vec<TokenStream2> = param_info
+            .iter()
+            .map(|(ident, _pat, ty)| quote! { #ident: #ty })
+            .collect();
+
+        let param_state_ptrs: Vec<Ident> = (0..param_info.len())
+            .map(|index| Ident::new(&format!("__param_state_ptr{}", index), Span::call_site()))
+            .collect();
+
+        let param_setup: Vec<TokenStream2> = param_info
+            .iter()
+            .zip(param_state_ptrs.iter())
+            .map(|((ident, _pat, ty), ptr_ident)| {
+                quote! {
+                    let #ptr_ident: *mut compose_core::ParamState<#ty> = {
+                        let __state_ref = __composer
+                            .remember(|| compose_core::ParamState::<#ty>::default());
+                        __state_ref as *mut compose_core::ParamState<#ty>
+                    };
+                    if unsafe { (&mut *#ptr_ident).update(&#ident) } {
+                        __changed = true;
+                    }
                 }
-            }
-        });
-        quote! {
-            let mut __changed = false;
-            #(#param_updates)*
+            })
+            .collect();
+
+        let recompose_args: Vec<TokenStream2> = param_state_ptrs
+            .iter()
+            .enumerate()
+            .map(|(index, ptr_ident)| {
+                let message = format!("composable parameter {} missing for recomposition", index);
+                quote! {
+                    unsafe {
+                        (&*#ptr_ident)
+                            .value()
+                            .expect(#message)
+                    }
+                }
+            })
+            .collect();
+
+        let helper_body = quote! {
+            let __current_scope = __composer
+                .current_recompose_scope()
+                .expect("missing recompose scope");
+            let mut __changed = __current_scope.is_invalid();
+            #(#param_setup)*
             let __result_slot_ptr: *mut compose_core::ReturnSlot<#return_ty> = {
-                let __slot_ref = __scope
+                let __slot_ref = __composer
                     .remember(|| compose_core::ReturnSlot::<#return_ty>::default());
                 __slot_ref as *mut compose_core::ReturnSlot<#return_ty>
             };
-            if !__changed {
-                __scope.skip_current_group();
+            let __has_previous = unsafe { (&*__result_slot_ptr).get().is_some() };
+            if !__changed && __has_previous {
+                __composer.skip_current_group();
                 let __result = unsafe {
                     (&*__result_slot_ptr)
                         .get()
@@ -80,22 +134,57 @@ pub fn composable(attr: TokenStream, item: TokenStream) -> TokenStream {
             unsafe {
                 (*__result_slot_ptr).store(__value.clone());
             }
+            {
+                let __impl_fn = #helper_ident;
+                __composer.set_recompose_callback(move |
+                    __composer: &mut compose_core::Composer<'_>|
+                {
+                    __impl_fn(
+                        __composer
+                        #(, #recompose_args)*
+                    );
+                });
+            }
             __value
-        }
-    } else {
-        quote! {
-            #(#rebinds)*
-            #original_block_clone
-        }
-    };
+        };
 
-    let wrapped = quote!({
-        compose_core::with_current_composer(|__composer: &mut compose_core::Composer<'_>| {
-            __composer.with_group(#key_expr, |__scope: &mut compose_core::Composer<'_>| {
-                #skip_logic
+        let helper_fn = quote! {
+            #[allow(non_snake_case)]
+            fn #helper_ident #impl_generics (
+                __composer: &mut compose_core::Composer<'_>
+                #(, #helper_inputs)*
+            ) -> #return_ty #where_clause {
+                #helper_body
+            }
+        };
+
+        let wrapper_args: Vec<TokenStream2> = param_info
+            .iter()
+            .map(|(ident, _pat, _)| quote! { #ident })
+            .collect();
+
+        let wrapped = quote!({
+            compose_core::with_current_composer(|__composer: &mut compose_core::Composer<'_>| {
+                __composer.with_group(#key_expr, |__composer: &mut compose_core::Composer<'_>| {
+                    #helper_ident(__composer #(, #wrapper_args)*)
+                })
             })
+        });
+        func.block = Box::new(syn::parse2(wrapped).expect("failed to build block"));
+        TokenStream::from(quote! {
+            #helper_fn
+            #func
         })
-    });
-    func.block = Box::new(syn::parse2(wrapped).expect("failed to build block"));
-    TokenStream::from(quote! { #func })
+    } else {
+        let wrapped = quote!({
+            compose_core::with_current_composer(|__composer: &mut compose_core::Composer<'_>| {
+                __composer.with_group(#key_expr, |__scope: &mut compose_core::Composer<'_>| {
+                    #(#rebinds)*
+                    #original_block
+                })
+            })
+        });
+        func.block = Box::new(syn::parse2(wrapped).expect("failed to build block"));
+        TokenStream::from(quote! { #func })
+    }
 }

--- a/compose-ui/src/lib.rs
+++ b/compose-ui/src/lib.rs
@@ -32,4 +32,4 @@ pub fn run_test_composition(mut build: impl FnMut()) -> TestComposition {
     composition
 }
 
-pub use compose_core::State as SnapshotState;
+pub use compose_core::MutableState as SnapshotState;

--- a/compose-ui/src/modifier.rs
+++ b/compose-ui/src/modifier.rs
@@ -253,6 +253,14 @@ pub enum ModOp {
 #[derive(Clone, Default)]
 pub struct Modifier(Rc<Vec<ModOp>>);
 
+impl PartialEq for Modifier {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for Modifier {}
+
 impl Modifier {
     pub fn empty() -> Self {
         Self::default()


### PR DESCRIPTION
## Summary
- add tracked state watchers, runtime invalidation queues, and targeted scope processing in the core composer
- teach the composable macro to capture parameters for skips and register per-scope recompose closures
- migrate UI primitives, tests, and the desktop demo to the new MutableState APIs while removing the signal-based Text path
- mark Phase 1 items as implemented in the roadmap

## Testing
- cargo test -q

------
https://chatgpt.com/codex/tasks/task_e_68ebb97abeac83289779419753da1fd4