### PR TITLE
Add compose-style state helpers and roadmap updates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,8 @@ Goal
 
 Naming and API normalization
 - Public API uses lowerCamelCase names that mirror Kotlin closely.
-- Provide remember, mutableStateOf, derivedStateOf, State<T>, MutableState<T>.
-- Replace use_state with remember { mutableStateOf(...) } (keep a temporary alias useState for migration if desired).
+- Provide remember, mutableStateOf, derivedStateOf, State<T>, MutableState<T>. (Implemented)
+- Replace use_state with remember { mutableStateOf(...) } (keep a temporary alias useState for migration if desired). (Implemented)
 - Replace emit_node and similar internals from the public surface. Node creation happens inside composables; any remaining low-level helpers are internal-only.
 - Functions like with_key -> withKey; with_current_composer -> withCurrentComposer kept internal; public API is composables and Modifiers.
 - Prefer Rust ergonomics where it doesn’t change behavior, but match Kotlin naming and call shapes for public API.
@@ -45,6 +45,7 @@ Deliverables
   - interface State<T> { val value: T }
   - interface MutableState<T> : State<T> { override var value: T }
   - derivedStateOf { … }: recomputes lazily, invalidates readers when source states change.
+  (remember/mutableStateOf/derivedStateOf now available in compose-core; derivedStateOf currently recomputes eagerly.)
 - Skip logic: when parameters are stable and equal and no local invalidations exist, skip the scope and reuse prior result. The macro should generate changed bit masks (ints) like Compose instead of per-param heap allocations. Keep a pragmatic stability model:
   - Provide a Stable marker/derive for pure data types; default to equality for non-stable types.
   - Allow a @stable marker in the macro until stability inference matures.

--- a/compose-ui/src/lib.rs
+++ b/compose-ui/src/lib.rs
@@ -32,4 +32,5 @@ pub fn run_test_composition(mut build: impl FnMut()) -> TestComposition {
     composition
 }
 
-pub use compose_core::State as SnapshotState;
+pub use compose_core::{MutableState, State};
+pub type SnapshotState<T> = compose_core::MutableState<T>;

--- a/compose-ui/src/primitives.rs
+++ b/compose-ui/src/primitives.rs
@@ -318,7 +318,7 @@ mod tests {
         let mut button_id = None;
         composition
             .render(location_key(file!(), line!(), column!()), || {
-                let counter = compose_core::use_state(|| 0);
+                let counter = compose_core::remember(|| compose_core::mutableStateOf(0));
                 if button_state.is_none() {
                     button_state = Some(counter.clone());
                 }


### PR DESCRIPTION
## Summary
- add `remember`, `mutableStateOf`, `derivedStateOf`, and a dedicated `MutableState` handle in `compose-core`, including an alias `useState`
- convert the desktop demo and UI primitives to the new state API and re-export the updated handles
- mark the roadmap items as implemented and document the current derivedStateOf behavior

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ebc7ba8d9c8328bf4688fdca4d9431