### PR TITLE
Implement side effect lifecycle support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,8 +82,8 @@ Context and why
 - Side effects and locals are required to write real apps and to match Compose behavior.
 
 Deliverables
-- SideEffect: runs after applyChanges in the same frame.
-- DisposableEffect(vararg keys): cleanup runs on key change and on scope disposal; effect re-runs with new keys.
+- SideEffect: runs after applyChanges in the same frame. (Implemented)
+- DisposableEffect(vararg keys): cleanup runs on key change and on scope disposal; effect re-runs with new keys. (Implemented)
 - LaunchedEffect(vararg keys): coroutine/tick scope tied to composition lifecycle; cancels and restarts on key changes.
 - CompositionLocal:
   - compositionLocalOf/staticCompositionLocalOf


### PR DESCRIPTION
## Summary
- add a composer-managed side effect queue and expose a `SideEffect` helper for composables
- implement `DisposableEffect` cleanup handling and cover the lifecycle with unit tests
- mark the roadmap items for `SideEffect` and `DisposableEffect` as implemented

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ec99c682c48328a19b8bdaef5af195