### PR TITLE
Add runtime abstraction traits and standard runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "compose-runtime-std"
+version = "0.1.0"
+dependencies = [
+ "compose-core",
+]
+
+[[package]]
 name = "compose-ui"
 version = "0.1.0"
 dependencies = [
@@ -490,6 +497,7 @@ name = "desktop-app"
 version = "0.1.0"
 dependencies = [
  "compose-core",
+ "compose-runtime-std",
  "compose-ui",
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "compose-core",
     "compose-macros",
+    "compose-runtime-std",
     "compose-ui",
     "desktop-app",
 ]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@
 
 ### Critical Issues
 
-- [ ] LaunchedEffect uses `std::thread::spawn` directly (needs platform abstraction)
+- [x] LaunchedEffect uses `std::thread::spawn` directly (needs platform abstraction)
 - [ ] Layout system uses Taffy (needs Compose intrinsic model)
 - [ ] Modifier is Vec-based (needs persistent node chain for performance)
 - [ ] Animation is rudimentary (just state updates, no interpolation)
@@ -71,26 +71,26 @@ pub trait Clock: Send + Sync {
 }
 ```
 
-- [ ] Define RuntimeScheduler trait
-- [ ] Define Clock trait
-- [ ] Add to compose-core public API
+- [x] Define RuntimeScheduler trait
+- [x] Define Clock trait
+- [x] Add to compose-core public API
 
 ### Task 0.2: Create Standard Runtime
 
 Create `compose-runtime-std/` crate:
 
-- [ ] Implement StdScheduler using std::thread
-- [ ] Implement StdClock using std::time
-- [ ] Document usage
+- [x] Implement StdScheduler using std::thread
+- [x] Implement StdClock using std::time
+- [x] Document usage
 
 ### Task 0.3: Refactor LaunchedEffect
 
 Update LaunchedEffect to use RuntimeScheduler:
 
-- [ ] Remove direct `thread::spawn` from LaunchedEffectState
-- [ ] Use RuntimeScheduler::spawn_task
-- [ ] Update Composition to accept runtime parameter
-- [ ] Update desktop-app to provide StdRuntime
+- [x] Remove direct `thread::spawn` from LaunchedEffectState
+- [x] Use RuntimeScheduler::spawn_task
+- [x] Update Composition to accept runtime parameter
+- [x] Update desktop-app to provide StdRuntime
 
 ### Task 0.4: Document Allocations
 
@@ -106,10 +106,10 @@ Update LaunchedEffect to use RuntimeScheduler:
 
 ### Deliverables
 
-- [ ] Platform traits defined
-- [ ] Standard runtime working
-- [ ] LaunchedEffect refactored
-- [ ] Desktop app updated
+- [x] Platform traits defined
+- [x] Standard runtime working
+- [x] LaunchedEffect refactored
+- [x] Desktop app updated
 - [ ] Signals deprecated
 - [ ] No breaking changes to user code
 

--- a/compose-core/src/platform.rs
+++ b/compose-core/src/platform.rs
@@ -1,0 +1,30 @@
+//! Platform abstraction traits for Compose runtime services.
+//!
+//! These traits allow Compose to delegate scheduling and clock
+//! responsibilities to the host platform, enabling integration with
+//! different environments without depending directly on `std` APIs.
+
+/// Schedules work for the Compose runtime.
+///
+/// Implementations are responsible for triggering frame processing and
+/// executing background tasks on behalf of Compose. They must be safe to
+/// use from multiple threads.
+pub trait RuntimeScheduler: Send + Sync {
+    /// Request that the host schedule a new frame.
+    fn schedule_frame(&self);
+
+    /// Spawn a task that will run asynchronously.
+    fn spawn_task(&self, task: Box<dyn FnOnce() + Send + 'static>);
+}
+
+/// Provides timing information for the runtime.
+pub trait Clock: Send + Sync {
+    /// Instant type produced by this clock implementation.
+    type Instant: Copy + Send + Sync;
+
+    /// Returns the current instant.
+    fn now(&self) -> Self::Instant;
+
+    /// Returns the number of milliseconds elapsed since `since`.
+    fn elapsed_millis(&self, since: Self::Instant) -> u64;
+}

--- a/compose-runtime-std/Cargo.toml
+++ b/compose-runtime-std/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "compose-runtime-std"
+version = "0.1.0"
+edition = "2021"
+description = "Standard library backed runtime services for Compose-RS"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+compose-core = { path = "../compose-core" }

--- a/compose-runtime-std/src/lib.rs
+++ b/compose-runtime-std/src/lib.rs
@@ -1,0 +1,87 @@
+//! Standard runtime services backed by Rust's `std` library.
+//!
+//! This crate provides concrete implementations of the platform
+//! abstraction traits defined in `compose-core`. Applications can
+//! construct a [`StdRuntime`] and pass it to [`compose_core::Composition`]
+//! to power the runtime with `std` primitives.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use compose_core::{Clock, Runtime, RuntimeScheduler};
+
+/// Scheduler that delegates work to Rust's threading primitives.
+#[derive(Debug, Default)]
+pub struct StdScheduler;
+
+impl RuntimeScheduler for StdScheduler {
+    fn schedule_frame(&self) {
+        // Desktop applications typically drive the render loop manually.
+        // Requesting a frame is therefore a no-op for the standard runtime.
+    }
+
+    fn spawn_task(&self, task: Box<dyn FnOnce() + Send + 'static>) {
+        std::thread::spawn(move || task());
+    }
+}
+
+/// Clock implementation backed by [`std::time`].
+#[derive(Debug, Default, Clone)]
+pub struct StdClock;
+
+impl Clock for StdClock {
+    type Instant = Instant;
+
+    fn now(&self) -> Self::Instant {
+        Instant::now()
+    }
+
+    fn elapsed_millis(&self, since: Self::Instant) -> u64 {
+        since.elapsed().as_millis() as u64
+    }
+}
+
+impl StdClock {
+    /// Returns the elapsed time as a [`Duration`] for convenience.
+    pub fn elapsed(&self, since: Instant) -> Duration {
+        since.elapsed()
+    }
+}
+
+/// Convenience container bundling the standard scheduler and clock.
+#[derive(Debug, Clone)]
+pub struct StdRuntime {
+    scheduler: Arc<StdScheduler>,
+    clock: Arc<StdClock>,
+}
+
+impl StdRuntime {
+    /// Creates a new standard runtime instance.
+    pub fn new() -> Self {
+        Self {
+            scheduler: Arc::new(StdScheduler::default()),
+            clock: Arc::new(StdClock::default()),
+        }
+    }
+
+    /// Returns a [`compose_core::Runtime`] configured with the standard scheduler.
+    pub fn runtime(&self) -> Runtime {
+        Runtime::new(self.scheduler.clone())
+    }
+
+    /// Returns the scheduler implementation.
+    pub fn scheduler(&self) -> Arc<StdScheduler> {
+        Arc::clone(&self.scheduler)
+    }
+
+    /// Returns the clock implementation.
+    pub fn clock(&self) -> Arc<StdClock> {
+        Arc::clone(&self.clock)
+    }
+}
+
+impl Default for StdRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/desktop-app/Cargo.toml
+++ b/desktop-app/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 compose-core = { path = "../compose-core" }
+compose-runtime-std = { path = "../compose-runtime-std" }
 compose-ui = { path = "../compose-ui" }
 pixels = "0.13"
 winit = "0.28"

--- a/desktop-app/src/main.rs
+++ b/desktop-app/src/main.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 use compose_core::{
     self, location_key, Composition, Key, LaunchedEffect, MemoryApplier, Node, NodeError, NodeId,
 };
+use compose_runtime_std::StdRuntime;
 use compose_ui::{
     composable, Brush, Button, ButtonNode, Color, Column, ColumnNode, CornerRadii, DrawCommand,
     DrawPrimitive, GraphicsLayer, LayoutBox, LayoutEngine, Modifier, Point, PointerEvent,
@@ -152,9 +153,10 @@ struct ComposeDesktopApp {
 
 impl ComposeDesktopApp {
     fn new(root_key: Key) -> Self {
-        let mut composition = Composition::new(MemoryApplier::new());
-        let runtime = composition.runtime_handle();
-        let animation_state = compose_core::MutableState::with_runtime(0.0, runtime.clone());
+        let mut composition =
+            Composition::with_runtime(MemoryApplier::new(), StdRuntime::new().runtime());
+        let runtime_handle = composition.runtime_handle();
+        let animation_state = compose_core::MutableState::with_runtime(0.0, runtime_handle.clone());
         if let Err(err) = composition.render(root_key, || {
             with_animation_state(&animation_state, || counter_app())
         }) {


### PR DESCRIPTION
## Summary
- add platform runtime traits to compose-core and rework Composition to accept injected runtimes
- create the compose-runtime-std crate with std-backed scheduler/clock helpers
- update the desktop app and roadmap to use the new runtime infrastructure

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68edfb3f3adc832887558fa16b0cb59a