### PR TITLE
Add layout core traits and document intrinsic measurement

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,10 +120,10 @@ Update LaunchedEffect to use RuntimeScheduler:
 ### Task 1.1: Study and Design
 
 - [ ] Read Jetpack Compose layout documentation thoroughly
-- [ ] Document Constraints → Measure → Place flow
-- [ ] Document intrinsic measurement contract
-- [ ] Design Rust API matching Compose
-- [ ] Write detailed design document
+- [x] Document Constraints → Measure → Place flow
+- [x] Document intrinsic measurement contract
+- [x] Design Rust API matching Compose
+- [x] Write detailed design document
 
 ### Task 1.2: Core Layout Traits
 
@@ -158,11 +158,11 @@ pub trait MeasurePolicy {
 }
 ```
 
-- [ ] Define Measurable trait with intrinsics
-- [ ] Define Placeable trait
-- [ ] Define MeasurePolicy trait
-- [ ] Add Alignment enum (Start, Center, End, Top, Bottom, etc.)
-- [ ] Add Arrangement trait (spacedBy, SpaceBetween, SpaceAround, SpaceEvenly)
+- [x] Define Measurable trait with intrinsics
+- [x] Define Placeable trait
+- [x] Define MeasurePolicy trait
+- [x] Add Alignment enum (Start, Center, End, Top, Bottom, etc.)
+- [x] Add Arrangement trait (spacedBy, SpaceBetween, SpaceAround, SpaceEvenly)
 
 ### Task 1.3: Layout Composable
 

--- a/compose-ui/src/layout/core.rs
+++ b/compose-ui/src/layout/core.rs
@@ -1,0 +1,191 @@
+use crate::subcompose_layout::{Constraints, MeasureResult};
+
+/// Object capable of measuring a layout child and exposing intrinsic sizes.
+pub trait Measurable {
+    /// Measures the child with the provided constraints, returning a [`Placeable`].
+    fn measure(&self, constraints: Constraints) -> Box<dyn Placeable>;
+
+    /// Returns the minimum width achievable for the given height.
+    fn min_intrinsic_width(&self, height: f32) -> f32;
+
+    /// Returns the maximum width achievable for the given height.
+    fn max_intrinsic_width(&self, height: f32) -> f32;
+
+    /// Returns the minimum height achievable for the given width.
+    fn min_intrinsic_height(&self, width: f32) -> f32;
+
+    /// Returns the maximum height achievable for the given width.
+    fn max_intrinsic_height(&self, width: f32) -> f32;
+}
+
+/// Result of running a measurement pass for a single child.
+pub trait Placeable {
+    /// Places the child at the provided coordinates relative to its parent.
+    fn place(&self, x: f32, y: f32);
+
+    /// Returns the measured width of the child.
+    fn width(&self) -> f32;
+
+    /// Returns the measured height of the child.
+    fn height(&self) -> f32;
+}
+
+/// Policy responsible for measuring and placing children.
+pub trait MeasurePolicy {
+    /// Runs the measurement pass with the provided children and constraints.
+    fn measure(
+        &self,
+        measurables: &[Box<dyn Measurable>],
+        constraints: Constraints,
+    ) -> MeasureResult;
+
+    /// Computes the minimum intrinsic width of this policy.
+    fn min_intrinsic_width(&self, measurables: &[Box<dyn Measurable>], height: f32) -> f32;
+
+    /// Computes the maximum intrinsic width of this policy.
+    fn max_intrinsic_width(&self, measurables: &[Box<dyn Measurable>], height: f32) -> f32;
+
+    /// Computes the minimum intrinsic height of this policy.
+    fn min_intrinsic_height(&self, measurables: &[Box<dyn Measurable>], width: f32) -> f32;
+
+    /// Computes the maximum intrinsic height of this policy.
+    fn max_intrinsic_height(&self, measurables: &[Box<dyn Measurable>], width: f32) -> f32;
+}
+
+/// Alignment along the horizontal axis.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HorizontalAlignment {
+    /// Align children to the leading edge.
+    Start,
+    /// Align children to the horizontal center.
+    Center,
+    /// Align children to the trailing edge.
+    End,
+}
+
+/// Alignment along the vertical axis.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VerticalAlignment {
+    /// Align children to the top edge.
+    Top,
+    /// Align children to the vertical center.
+    Center,
+    /// Align children to the bottom edge.
+    Bottom,
+}
+
+/// Trait implemented by alignment strategies that distribute children on an axis.
+pub trait Arrangement {
+    /// Computes the position for each child given the available space and their sizes.
+    fn arrange(&self, total_size: f32, sizes: &[f32], out_positions: &mut [f32]);
+}
+
+/// Arrangement strategy matching Jetpack Compose's linear arrangements.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LinearArrangement {
+    /// Place children consecutively starting from the leading edge.
+    Start,
+    /// Place children so the last child touches the trailing edge.
+    End,
+    /// Place children so they are centered as a block.
+    Center,
+    /// Distribute the remaining space evenly between children.
+    SpaceBetween,
+    /// Distribute the remaining space before, after, and between children.
+    SpaceAround,
+    /// Distribute the remaining space before the first child, between children, and after the last child.
+    SpaceEvenly,
+    /// Insert a fixed amount of space between children.
+    SpacedBy(f32),
+}
+
+impl LinearArrangement {
+    /// Creates an arrangement that inserts a fixed spacing between children.
+    pub fn spaced_by(spacing: f32) -> Self {
+        Self::SpacedBy(spacing)
+    }
+
+    fn total_children_size(sizes: &[f32]) -> f32 {
+        sizes.iter().copied().sum()
+    }
+
+    fn fill_positions(start: f32, gap: f32, sizes: &[f32], out_positions: &mut [f32]) {
+        debug_assert_eq!(sizes.len(), out_positions.len());
+        let mut cursor = start;
+        for (index, (size, position)) in sizes.iter().zip(out_positions.iter_mut()).enumerate() {
+            *position = cursor;
+            cursor += size;
+            if index + 1 < sizes.len() {
+                cursor += gap;
+            }
+        }
+    }
+}
+
+impl Arrangement for LinearArrangement {
+    fn arrange(&self, total_size: f32, sizes: &[f32], out_positions: &mut [f32]) {
+        debug_assert_eq!(sizes.len(), out_positions.len());
+        if sizes.is_empty() {
+            return;
+        }
+
+        let children_total = Self::total_children_size(sizes);
+        let remaining = total_size - children_total;
+
+        match *self {
+            LinearArrangement::Start => Self::fill_positions(0.0, 0.0, sizes, out_positions),
+            LinearArrangement::End => {
+                let start = remaining;
+                Self::fill_positions(start, 0.0, sizes, out_positions);
+            }
+            LinearArrangement::Center => {
+                let start = remaining / 2.0;
+                Self::fill_positions(start, 0.0, sizes, out_positions);
+            }
+            LinearArrangement::SpaceBetween => {
+                let gap = if sizes.len() <= 1 {
+                    0.0
+                } else {
+                    remaining / (sizes.len() as f32 - 1.0)
+                };
+                Self::fill_positions(0.0, gap, sizes, out_positions);
+            }
+            LinearArrangement::SpaceAround => {
+                let gap = remaining / sizes.len() as f32;
+                let start = gap / 2.0;
+                Self::fill_positions(start, gap, sizes, out_positions);
+            }
+            LinearArrangement::SpaceEvenly => {
+                let gap = remaining / (sizes.len() as f32 + 1.0);
+                let start = gap;
+                Self::fill_positions(start, gap, sizes, out_positions);
+            }
+            LinearArrangement::SpacedBy(spacing) => {
+                Self::fill_positions(0.0, spacing, sizes, out_positions);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Arrangement, LinearArrangement};
+
+    #[test]
+    fn space_evenly_distributes_gaps() {
+        let arrangement = LinearArrangement::SpaceEvenly;
+        let sizes = vec![10.0, 10.0, 10.0];
+        let mut positions = vec![0.0; sizes.len()];
+        arrangement.arrange(100.0, &sizes, &mut positions);
+        assert_eq!(positions, vec![17.5, 45.0, 72.5]);
+    }
+
+    #[test]
+    fn spaced_by_uses_fixed_spacing() {
+        let arrangement = LinearArrangement::spaced_by(5.0);
+        let sizes = vec![10.0, 10.0];
+        let mut positions = vec![0.0; sizes.len()];
+        arrangement.arrange(40.0, &sizes, &mut positions);
+        assert_eq!(positions, vec![0.0, 15.0]);
+    }
+}

--- a/compose-ui/src/layout/mod.rs
+++ b/compose-ui/src/layout/mod.rs
@@ -1,3 +1,5 @@
+pub mod core;
+
 use compose_core::{MemoryApplier, Node, NodeError, NodeId};
 use taffy::prelude::*;
 

--- a/compose-ui/src/lib.rs
+++ b/compose-ui/src/lib.rs
@@ -10,7 +10,13 @@ mod primitives;
 mod renderer;
 mod subcompose_layout;
 
-pub use layout::{LayoutBox, LayoutEngine, LayoutTree};
+pub use layout::{
+    core::{
+        Arrangement, HorizontalAlignment, LinearArrangement, Measurable, MeasurePolicy, Placeable,
+        VerticalAlignment,
+    },
+    LayoutBox, LayoutEngine, LayoutTree,
+};
 pub use modifier::{
     Brush, Color, CornerRadii, DrawCommand, DrawPrimitive, GraphicsLayer, Modifier, Point,
     PointerEvent, PointerEventKind, Rect, RoundedCornerShape, Size,

--- a/compose-ui/src/subcompose_layout.rs
+++ b/compose-ui/src/subcompose_layout.rs
@@ -95,11 +95,11 @@ impl Placement {
 
 /// Representation of a subcomposed child that can later be measured by the policy.
 #[derive(Clone, Debug, PartialEq)]
-pub struct Measurable {
+pub struct SubcomposeChild {
     node_id: usize,
 }
 
-impl Measurable {
+impl SubcomposeChild {
     pub fn new(node_id: usize) -> Self {
         Self { node_id }
     }
@@ -123,7 +123,7 @@ pub trait MeasureScope {
 
 /// Public trait exposed to measure policies for subcomposition.
 pub trait SubcomposeMeasureScope: MeasureScope {
-    fn subcompose<Content>(&mut self, slot_id: SlotId, content: Content) -> Vec<Measurable>
+    fn subcompose<Content>(&mut self, slot_id: SlotId, content: Content) -> Vec<SubcomposeChild>
     where
         Content: FnOnce();
 }
@@ -156,7 +156,7 @@ impl<'a> MeasureScope for SubcomposeMeasureScopeImpl<'a> {
 }
 
 impl<'a> SubcomposeMeasureScope for SubcomposeMeasureScopeImpl<'a> {
-    fn subcompose<Content>(&mut self, slot_id: SlotId, content: Content) -> Vec<Measurable>
+    fn subcompose<Content>(&mut self, slot_id: SlotId, content: Content) -> Vec<SubcomposeChild>
     where
         Content: FnOnce(),
     {
@@ -170,7 +170,7 @@ impl<'a> SubcomposeMeasureScope for SubcomposeMeasureScopeImpl<'a> {
             });
             nodes
         };
-        nodes.into_iter().map(Measurable::new).collect()
+        nodes.into_iter().map(SubcomposeChild::new).collect()
     }
 }
 

--- a/docs/layout_intrinsics.md
+++ b/docs/layout_intrinsics.md
@@ -1,0 +1,59 @@
+# Compose-RS Layout Measurement and Intrinsics
+
+## Constraints → Measure → Place Flow
+
+Compose's layout pipeline is structured around a deterministic flow: parents **establish constraints**, children **measure** themselves within those limits, and finally parents **place** the results. Constraints are always expressed as inclusive min/max bounds on width and height. A parent first builds the list of children to be measured, then iterates over them, invoking `Measurable::measure` with tightened constraints derived from its policy. The returned `Placeable` encapsulates both the measured size and the deferred ability to position the child. Once all children are measured, the parent decides the final container size and invokes `Placeable::place` for each child with concrete coordinates. This sequencing ensures that measurement is pure (no side-effects from placement) and that positioning decisions always have full knowledge of siblings' sizes.
+
+## Intrinsic Measurement Contract
+
+Intrinsic measurement answers "how big would you like to be?" when only one axis is constrained. Each `Measurable` exposes four queries:
+
+- `min_intrinsic_width(height)` – the minimum width that avoids overflow for a given height.
+- `max_intrinsic_width(height)` – the width preferred when horizontal space is unbounded.
+- `min_intrinsic_height(width)` – the minimum height required at a given width.
+- `max_intrinsic_height(width)` – the preferred height with unbounded vertical space.
+
+Policies must relay these queries to their children without mutating state, enabling features such as `IntrinsicSize.Min` in Jetpack Compose and making lazy layouts predictable. Intrinsic calls may be expensive, so the API keeps them explicit and side-effect free.
+
+## Rust API Surface
+
+To model the Compose semantics we introduce `compose_ui::layout::core`:
+
+```rust
+pub trait Measurable {
+    fn measure(&self, constraints: Constraints) -> Box<dyn Placeable>;
+    fn min_intrinsic_width(&self, height: f32) -> f32;
+    fn max_intrinsic_width(&self, height: f32) -> f32;
+    fn min_intrinsic_height(&self, width: f32) -> f32;
+    fn max_intrinsic_height(&self, width: f32) -> f32;
+}
+
+pub trait Placeable {
+    fn place(&self, x: f32, y: f32);
+    fn width(&self) -> f32;
+    fn height(&self) -> f32;
+}
+
+pub trait MeasurePolicy {
+    fn measure(&self, measurables: &[Box<dyn Measurable>], constraints: Constraints) -> MeasureResult;
+    fn min_intrinsic_width(&self, measurables: &[Box<dyn Measurable>], height: f32) -> f32;
+    fn max_intrinsic_width(&self, measurables: &[Box<dyn Measurable>], height: f32) -> f32;
+    fn min_intrinsic_height(&self, measurables: &[Box<dyn Measurable>], width: f32) -> f32;
+    fn max_intrinsic_height(&self, measurables: &[Box<dyn Measurable>], width: f32) -> f32;
+}
+```
+
+`Constraints` and `MeasureResult` are reused from the existing subcomposition module, keeping the API surface consistent across layout implementations.
+
+## Alignment and Arrangement
+
+Horizontal and vertical alignment become strongly typed enums (`HorizontalAlignment`, `VerticalAlignment`), mirroring Jetpack Compose's `Alignment` family. Linear arrangements are represented by `LinearArrangement`, implementing a shared `Arrangement` trait with behaviors for `Start`, `End`, `Center`, `SpaceBetween`, `SpaceAround`, `SpaceEvenly`, and `SpacedBy`. The helper maintains parity with Compose's spacing rules while remaining platform-agnostic.
+
+## Detailed Design Notes
+
+- The traits are defined in a standalone `layout::core` module so future layout engines (desktop, web, embedded) can implement them without pulling in the existing Taffy-based engine.
+- Return types use trait objects to keep the API ergonomic until we can specialize on concrete layout nodes; this mirrors Jetpack Compose's reliance on interfaces such as `Placeable`.
+- Arrangement math is deterministic and handles negative remaining space, which occurs when children collectively exceed their parent constraints.
+- Subcomposition primitives have been renamed to `SubcomposeChild` to avoid collisions with the new trait names and to set the stage for trait implementations that wrap those children.
+
+These building blocks unblock Task 1 by providing a Compose-accurate contract for measurement and placement while the concrete engine is refactored away from Taffy.


### PR DESCRIPTION
## Summary
- extract the layout module into a directory and add a new layout::core module with Compose-aligned Measurable, Placeable, and MeasurePolicy traits
- introduce alignment and arrangement primitives plus tests while renaming subcompose children to avoid naming collisions
- document the Compose measurement flow and intrinsics contract and update the roadmap checklist accordingly

## Testing
- cargo fmt
- cargo test -p compose-ui

------
https://chatgpt.com/codex/tasks/task_e_68ee15a989a8832882c4bfadd410a4c4