### PR TITLE
Implement alignment controls for layout primitives

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -183,10 +183,10 @@ pub fn Layout(
 
 ### Task 1.4: Alignment and Arrangement
 
-- [ ] Implement Alignment.Horizontal (Start, CenterHorizontally, End)
-- [ ] Implement Alignment.Vertical (Top, CenterVertically, Bottom)
-- [ ] Implement Arrangement.Horizontal (Start, Center, End, SpaceBetween, SpaceAround, SpaceEvenly, spacedBy)
-- [ ] Implement Arrangement.Vertical (Top, Center, Bottom, SpaceBetween, SpaceAround, SpaceEvenly, spacedBy)
+- [x] Implement Alignment.Horizontal (Start, CenterHorizontally, End)
+- [x] Implement Alignment.Vertical (Top, CenterVertically, Bottom)
+- [x] Implement Arrangement.Horizontal (Start, Center, End, SpaceBetween, SpaceAround, SpaceEvenly, spacedBy)
+- [x] Implement Arrangement.Vertical (Top, Center, Bottom, SpaceBetween, SpaceAround, SpaceEvenly, spacedBy)
 
 ### Task 1.5: Rebuild Row/Column
 

--- a/compose-ui/src/layout/core.rs
+++ b/compose-ui/src/layout/core.rs
@@ -58,7 +58,7 @@ pub enum HorizontalAlignment {
     /// Align children to the leading edge.
     Start,
     /// Align children to the horizontal center.
-    Center,
+    CenterHorizontally,
     /// Align children to the trailing edge.
     End,
 }
@@ -69,7 +69,7 @@ pub enum VerticalAlignment {
     /// Align children to the top edge.
     Top,
     /// Align children to the vertical center.
-    Center,
+    CenterVertically,
     /// Align children to the bottom edge.
     Bottom,
 }

--- a/compose-ui/src/lib.rs
+++ b/compose-ui/src/lib.rs
@@ -23,8 +23,8 @@ pub use modifier::{
 };
 pub use primitives::{
     BoxScope, BoxWithConstraints, BoxWithConstraintsScope, BoxWithConstraintsScopeImpl, Button,
-    ButtonNode, Column, ColumnNode, ForEach, Row, RowNode, Spacer, SpacerNode, SubcomposeLayout,
-    Text, TextNode,
+    ButtonNode, Column, ColumnNode, ColumnWithAlignment, ForEach, Row, RowNode, RowWithAlignment,
+    Spacer, SpacerNode, SubcomposeLayout, Text, TextNode,
 };
 pub use renderer::{HeadlessRenderer, PaintLayer, RenderOp, RenderScene};
 pub use subcompose_layout::{

--- a/desktop-app/src/main.rs
+++ b/desktop-app/src/main.rs
@@ -8,9 +8,9 @@ use compose_core::{
 use compose_runtime_std::StdRuntime;
 use compose_ui::{
     composable, Brush, Button, ButtonNode, Color, Column, ColumnNode, CornerRadii, DrawCommand,
-    DrawPrimitive, GraphicsLayer, LayoutBox, LayoutEngine, Modifier, Point, PointerEvent,
-    PointerEventKind, Rect, RoundedCornerShape, Row, RowNode, Size, Spacer, SpacerNode, Text,
-    TextNode,
+    DrawPrimitive, GraphicsLayer, LayoutBox, LayoutEngine, LinearArrangement, Modifier, Point,
+    PointerEvent, PointerEventKind, Rect, RoundedCornerShape, Row, RowNode, RowWithAlignment, Size,
+    Spacer, SpacerNode, Text, TextNode, VerticalAlignment,
 };
 use once_cell::sync::Lazy;
 use pixels::{Pixels, SurfaceTexture};
@@ -306,30 +306,31 @@ fn counter_app() {
                 height: 12.0,
             });
 
-            Row(Modifier::padding(8.0), || {
-                Text(
-                    format!("Counter: {}", counter.get()),
-                    Modifier::padding(8.0)
-                        .then(Modifier::background(Color(0.0, 0.0, 0.0, 0.35)))
-                        .then(Modifier::rounded_corners(12.0)),
-                );
-                Spacer(Size {
-                    width: 16.0,
-                    height: 0.0,
-                });
-                Text(
-                    format!("Wave {:.2}", wave),
-                    Modifier::padding(8.0)
-                        .then(Modifier::background(Color(0.35, 0.55, 0.9, 0.5)))
-                        .then(Modifier::rounded_corners(12.0))
-                        .then(Modifier::graphics_layer(GraphicsLayer {
-                            alpha: 0.7 + wave * 0.3,
-                            scale: 0.85 + wave * 0.3,
-                            translation_x: 0.0,
-                            translation_y: (wave - 0.5) * 12.0,
-                        })),
-                );
-            });
+            RowWithAlignment(
+                Modifier::padding(8.0),
+                LinearArrangement::SpacedBy(12.0),
+                VerticalAlignment::CenterVertically,
+                || {
+                    Text(
+                        format!("Counter: {}", counter.get()),
+                        Modifier::padding(8.0)
+                            .then(Modifier::background(Color(0.0, 0.0, 0.0, 0.35)))
+                            .then(Modifier::rounded_corners(12.0)),
+                    );
+                    Text(
+                        format!("Wave {:.2}", wave),
+                        Modifier::padding(8.0)
+                            .then(Modifier::background(Color(0.35, 0.55, 0.9, 0.5)))
+                            .then(Modifier::rounded_corners(12.0))
+                            .then(Modifier::graphics_layer(GraphicsLayer {
+                                alpha: 0.7 + wave * 0.3,
+                                scale: 0.85 + wave * 0.3,
+                                translation_x: 0.0,
+                                translation_y: (wave - 0.5) * 12.0,
+                            })),
+                    );
+                },
+            );
 
             Spacer(Size {
                 width: 0.0,


### PR DESCRIPTION
## Summary
- add `RowWithAlignment` and `ColumnWithAlignment` helpers that persist arrangement data on their nodes and exercise them in tests
- teach the layout builder to translate `LinearArrangement` and alignment enums into Taffy styles and cover the mapping with unit tests
- demonstrate the new row spacing API in the desktop app and mark Task 1.4 in the roadmap as complete

## Testing
- cargo clippy --all-targets --all-features
- cargo test -p compose-ui

------
https://chatgpt.com/codex/tasks/task_e_68ee18276ad0832887b54b246f37c39f