### PR TITLE
Expand layout modifier support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -217,14 +217,14 @@ impl MeasurePolicy for RowMeasurePolicy {
 
 Add essential layout modifiers:
 
-- [ ] Modifier.padding (all variants: uniform, horizontal/vertical, each side)
-- [ ] Modifier.size (width, height, size)
-- [ ] Modifier.fillMaxSize (fraction parameter)
-- [ ] Modifier.fillMaxWidth (fraction parameter)
-- [ ] Modifier.fillMaxHeight (fraction parameter)
+- [x] Modifier.padding (all variants: uniform, horizontal/vertical, each side)
+- [x] Modifier.size (width, height, size)
+- [x] Modifier.fillMaxSize (fraction parameter)
+- [x] Modifier.fillMaxWidth (fraction parameter)
+- [x] Modifier.fillMaxHeight (fraction parameter)
 - [ ] Modifier.wrapContentSize (align parameter)
-- [ ] Modifier.requiredSize
-- [ ] Modifier.weight (for Row/Column children)
+- [x] Modifier.requiredSize
+- [x] Modifier.weight (for Row/Column children)
 - [ ] Modifier.align (for Box children)
 
 ### Task 1.7: Box Primitive

--- a/compose-ui/src/lib.rs
+++ b/compose-ui/src/lib.rs
@@ -18,8 +18,8 @@ pub use layout::{
     LayoutBox, LayoutEngine, LayoutTree,
 };
 pub use modifier::{
-    Brush, Color, CornerRadii, DrawCommand, DrawPrimitive, GraphicsLayer, Modifier, Point,
-    PointerEvent, PointerEventKind, Rect, RoundedCornerShape, Size,
+    Brush, Color, CornerRadii, DrawCommand, DrawPrimitive, EdgeInsets, GraphicsLayer, Modifier,
+    Point, PointerEvent, PointerEventKind, Rect, RoundedCornerShape, Size,
 };
 pub use primitives::{
     BoxScope, BoxWithConstraints, BoxWithConstraintsScope, BoxWithConstraintsScopeImpl, Button,

--- a/desktop-app/src/main.rs
+++ b/desktop-app/src/main.rs
@@ -8,9 +8,9 @@ use compose_core::{
 use compose_runtime_std::StdRuntime;
 use compose_ui::{
     composable, Brush, Button, ButtonNode, Color, Column, ColumnNode, CornerRadii, DrawCommand,
-    DrawPrimitive, GraphicsLayer, LayoutBox, LayoutEngine, LinearArrangement, Modifier, Point,
-    PointerEvent, PointerEventKind, Rect, RoundedCornerShape, Row, RowNode, RowWithAlignment, Size,
-    Spacer, SpacerNode, Text, TextNode, VerticalAlignment,
+    DrawPrimitive, EdgeInsets, GraphicsLayer, LayoutBox, LayoutEngine, LinearArrangement, Modifier,
+    Point, PointerEvent, PointerEventKind, Rect, RoundedCornerShape, Row, RowNode,
+    RowWithAlignment, Size, Spacer, SpacerNode, Text, TextNode, VerticalAlignment,
 };
 use once_cell::sync::Lazy;
 use pixels::{Pixels, SurfaceTexture};
@@ -616,7 +616,7 @@ impl Scene {
 }
 
 struct NodeStyle {
-    padding: f32,
+    padding: EdgeInsets,
     background: Option<Color>,
     clickable: Option<Rc<dyn Fn(Point)>>,
     shape: Option<RoundedCornerShape>,
@@ -628,7 +628,7 @@ struct NodeStyle {
 impl NodeStyle {
     fn from_modifier(modifier: &Modifier) -> Self {
         Self {
-            padding: modifier.total_padding(),
+            padding: modifier.padding_values(),
             background: modifier.background_color(),
             clickable: modifier.click_handler(),
             shape: modifier.corner_shape(),
@@ -952,8 +952,8 @@ fn render_text(node: TextNode, layout: &LayoutBox, layer: GraphicsLayer, scene: 
     }
     let metrics = measure_text(&node.text);
     let text_rect = Rect {
-        x: rect.x + style.padding,
-        y: rect.y + style.padding,
+        x: rect.x + style.padding.left,
+        y: rect.y + style.padding.top,
         width: metrics.width,
         height: metrics.height,
     };


### PR DESCRIPTION
## Summary
- add EdgeInsets-based padding storage and new modifier helpers for sizing, fill, required size, and weight
- update the layout engine to apply the richer modifier properties and re-export EdgeInsets for downstream consumers
- adjust the desktop renderer and roadmap to reflect the per-edge padding support and completed modifier tasks

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ee20ad5cb48328b97d8d32ca5c5515