### PR TITLE
Add modifier offset support to layout

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -514,8 +514,8 @@ pub fn animateColorAsState(
 
 Add most commonly used modifiers:
 
-- [ ] Modifier.offset (x, y)
-- [ ] Modifier.absoluteOffset
+- [x] Modifier.offset (x, y)
+- [x] Modifier.absoluteOffset
 - [ ] Modifier.clip(shape)
 - [ ] Modifier.border (width, brush, shape)
 - [ ] Modifier.alpha

--- a/compose-ui/src/layout/mod.rs
+++ b/compose-ui/src/layout/mod.rs
@@ -5,7 +5,9 @@ use taffy::prelude::*;
 use taffy::style::{AlignItems, JustifyContent};
 
 use self::core::{HorizontalAlignment, LinearArrangement, VerticalAlignment};
-use crate::modifier::{DimensionConstraint, EdgeInsets, Modifier, Rect as GeometryRect, Size};
+use crate::modifier::{
+    DimensionConstraint, EdgeInsets, Modifier, Point, Rect as GeometryRect, Size,
+};
 use crate::primitives::{ButtonNode, ColumnNode, RowNode, SpacerNode, TextNode};
 
 /// Result of running layout for a Compose tree.
@@ -76,6 +78,7 @@ struct LayoutHandle {
     node_id: NodeId,
     taffy_node: taffy::node::Node,
     children: Vec<LayoutHandle>,
+    offset: Point,
 }
 
 impl<'a> LayoutBuilder<'a> {
@@ -110,6 +113,7 @@ impl<'a> LayoutBuilder<'a> {
             node_id,
             taffy_node,
             children: Vec::new(),
+            offset: Point { x: 0.0, y: 0.0 },
         })
     }
 
@@ -131,6 +135,7 @@ impl<'a> LayoutBuilder<'a> {
             node_id,
             taffy_node,
             children: child_handles,
+            offset: node.modifier.total_offset(),
         })
     }
 
@@ -148,6 +153,7 @@ impl<'a> LayoutBuilder<'a> {
             node_id,
             taffy_node,
             children: child_handles,
+            offset: node.modifier.total_offset(),
         })
     }
 
@@ -161,6 +167,7 @@ impl<'a> LayoutBuilder<'a> {
             node_id,
             taffy_node,
             children: Vec::new(),
+            offset: node.modifier.total_offset(),
         })
     }
 
@@ -180,6 +187,7 @@ impl<'a> LayoutBuilder<'a> {
             node_id,
             taffy_node,
             children: Vec::new(),
+            offset: Point { x: 0.0, y: 0.0 },
         })
     }
 
@@ -199,6 +207,7 @@ impl<'a> LayoutBuilder<'a> {
             node_id,
             taffy_node,
             children: child_handles,
+            offset: node.modifier.total_offset(),
         })
     }
 
@@ -214,8 +223,8 @@ impl<'a> LayoutBuilder<'a> {
             .taffy
             .layout(handle.taffy_node)
             .expect("layout computed");
-        let x = origin.0 + layout.location.x;
-        let y = origin.1 + layout.location.y;
+        let x = origin.0 + layout.location.x + handle.offset.x;
+        let y = origin.1 + layout.location.y + handle.offset.y;
         let rect = GeometryRect {
             x,
             y,

--- a/compose-ui/src/primitives.rs
+++ b/compose-ui/src/primitives.rs
@@ -905,6 +905,40 @@ mod tests {
     }
 
     #[test]
+    fn modifier_offset_translates_layout() {
+        let mut composition = Composition::new(MemoryApplier::new());
+        let key = location_key(file!(), line!(), column!());
+        let mut text_id = None;
+
+        composition
+            .render(key, || {
+                Column(Modifier::padding(10.0), || {
+                    text_id = Some(Text("Hello", Modifier::offset(5.0, 7.5)));
+                });
+            })
+            .expect("initial render");
+
+        let root = composition.root().expect("root node");
+        let layout_tree = composition
+            .applier_mut()
+            .compute_layout(
+                root,
+                Size {
+                    width: 200.0,
+                    height: 200.0,
+                },
+            )
+            .expect("compute layout");
+
+        let root_layout = layout_tree.root().clone();
+        assert_eq!(root_layout.children.len(), 1);
+        let text_layout = &root_layout.children[0];
+        assert_eq!(text_layout.node_id, text_id.expect("text node id"));
+        assert!((text_layout.rect.x - 15.0).abs() < 1e-3);
+        assert!((text_layout.rect.y - 17.5).abs() < 1e-3);
+    }
+
+    #[test]
     fn box_with_constraints_composes_different_content() {
         let mut composition = Composition::new(MemoryApplier::new());
         let record = Rc::new(RefCell::new(Vec::new()));


### PR DESCRIPTION
## Summary
- add `Modifier::offset` and `Modifier::absolute_offset` operations that accumulate offset values
- teach the layout builder to apply modifier offsets when extracting layout boxes and cover with a regression test
- mark the roadmap items for offset modifiers as complete

## Testing
- cargo test -p compose-ui
- cargo clippy --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68ee29530d3083289586e7c847c4e3c6