### PR TITLE
Add layout node support with measure policies

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -175,11 +175,11 @@ pub fn Layout(
 ) -> NodeId
 ```
 
-- [ ] Create LayoutNode type
-- [ ] Implement measure pass
-- [ ] Implement place pass
-- [ ] Integrate with existing Composer
-- [ ] Handle modifier chain in layout
+- [x] Create LayoutNode type
+- [x] Implement measure pass
+- [x] Implement place pass
+- [x] Integrate with existing Composer
+- [x] Handle modifier chain in layout
 
 ### Task 1.4: Alignment and Arrangement
 

--- a/compose-ui/src/layout/core.rs
+++ b/compose-ui/src/layout/core.rs
@@ -1,3 +1,5 @@
+use compose_core::NodeId;
+
 use crate::subcompose_layout::{Constraints, MeasureResult};
 
 /// Object capable of measuring a layout child and exposing intrinsic sizes.
@@ -28,6 +30,9 @@ pub trait Placeable {
 
     /// Returns the measured height of the child.
     fn height(&self) -> f32;
+
+    /// Returns the identifier of the underlying layout node.
+    fn node_id(&self) -> NodeId;
 }
 
 /// Policy responsible for measuring and placing children.

--- a/compose-ui/src/lib.rs
+++ b/compose-ui/src/lib.rs
@@ -23,8 +23,8 @@ pub use modifier::{
 };
 pub use primitives::{
     BoxScope, BoxWithConstraints, BoxWithConstraintsScope, BoxWithConstraintsScopeImpl, Button,
-    ButtonNode, Column, ColumnNode, ColumnWithAlignment, ForEach, Row, RowNode, RowWithAlignment,
-    Spacer, SpacerNode, SubcomposeLayout, Text, TextNode,
+    ButtonNode, Column, ColumnNode, ColumnWithAlignment, ForEach, Layout, LayoutNode, Row, RowNode,
+    RowWithAlignment, Spacer, SpacerNode, SubcomposeLayout, Text, TextNode,
 };
 pub use renderer::{HeadlessRenderer, PaintLayer, RenderOp, RenderScene};
 pub use subcompose_layout::{

--- a/compose-ui/src/renderer.rs
+++ b/compose-ui/src/renderer.rs
@@ -5,7 +5,7 @@ use crate::modifier::{
     Brush, DrawCommand as ModifierDrawCommand, DrawPrimitive, Modifier, Rect, RoundedCornerShape,
     Size,
 };
-use crate::primitives::{ButtonNode, ColumnNode, RowNode, TextNode};
+use crate::primitives::{ButtonNode, ColumnNode, LayoutNode, RowNode, TextNode};
 
 /// Layer that a paint operation targets within the rendering pipeline.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -123,6 +123,11 @@ impl<'a> HeadlessRenderer<'a> {
         }
         if let Some(modifier) =
             self.read_node::<RowNode, _>(node_id, |node| node.modifier.clone())?
+        {
+            return Ok(Some(modifier));
+        }
+        if let Some(modifier) =
+            self.read_node::<LayoutNode, _>(node_id, |node| node.modifier.clone())?
         {
             return Ok(Some(modifier));
         }


### PR DESCRIPTION
## Summary
- add a reusable LayoutNode primitive and public Layout composable that carry MeasurePolicy implementations
- teach the layout engine to evaluate MeasurePolicy-driven nodes, including child measurables/placeables and intrinsic queries, and cover it with a unit test
- expose node identifiers on Placeable, handle LayoutNode modifiers in the renderer, and mark the roadmap items complete

## Testing
- cargo test -p compose-ui

------
https://chatgpt.com/codex/tasks/task_e_68ee426bda348328bf0eccb9cd82f95e