### PR TITLE
Add Box primitive with alignment modifier support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -225,7 +225,7 @@ Add essential layout modifiers:
 - [ ] Modifier.wrapContentSize (align parameter)
 - [x] Modifier.requiredSize
 - [x] Modifier.weight (for Row/Column children)
-- [ ] Modifier.align (for Box children)
+- [x] Modifier.align (for Box children)
 
 ### Task 1.7: Box Primitive
 
@@ -239,11 +239,11 @@ pub fn Box(
 )
 ```
 
-- [ ] Implement BoxMeasurePolicy
-- [ ] Handle z-ordering of children
-- [ ] Handle alignment
-- [ ] Add BoxScope trait
-- [ ] Add Modifier.align for BoxScope
+- [x] Implement BoxMeasurePolicy
+- [x] Handle z-ordering of children
+- [x] Handle alignment
+- [x] Add BoxScope trait
+- [x] Add Modifier.align for BoxScope
 
 ### Task 1.8: Validation
 

--- a/compose-ui/src/layout/core.rs
+++ b/compose-ui/src/layout/core.rs
@@ -57,6 +57,37 @@ pub trait MeasurePolicy {
     fn max_intrinsic_height(&self, measurables: &[Box<dyn Measurable>], width: f32) -> f32;
 }
 
+/// Alignment across both axes used for positioning content within a box.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Alignment {
+    /// Horizontal alignment component.
+    pub horizontal: HorizontalAlignment,
+    /// Vertical alignment component.
+    pub vertical: VerticalAlignment,
+}
+
+impl Alignment {
+    /// Creates a new [`Alignment`] from explicit horizontal and vertical components.
+    pub const fn new(horizontal: HorizontalAlignment, vertical: VerticalAlignment) -> Self {
+        Self {
+            horizontal,
+            vertical,
+        }
+    }
+
+    /// Align children to the top-start corner.
+    pub const TOP_START: Self = Self::new(HorizontalAlignment::Start, VerticalAlignment::Top);
+
+    /// Align children to the center of the parent.
+    pub const CENTER: Self = Self::new(
+        HorizontalAlignment::CenterHorizontally,
+        VerticalAlignment::CenterVertically,
+    );
+
+    /// Align children to the bottom-end corner.
+    pub const BOTTOM_END: Self = Self::new(HorizontalAlignment::End, VerticalAlignment::Bottom);
+}
+
 /// Alignment along the horizontal axis.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HorizontalAlignment {

--- a/compose-ui/src/lib.rs
+++ b/compose-ui/src/lib.rs
@@ -12,8 +12,8 @@ mod subcompose_layout;
 
 pub use layout::{
     core::{
-        Arrangement, HorizontalAlignment, LinearArrangement, Measurable, MeasurePolicy, Placeable,
-        VerticalAlignment,
+        Alignment, Arrangement, HorizontalAlignment, LinearArrangement, Measurable, MeasurePolicy,
+        Placeable, VerticalAlignment,
     },
     LayoutBox, LayoutEngine, LayoutTree,
 };
@@ -22,9 +22,10 @@ pub use modifier::{
     Point, PointerEvent, PointerEventKind, Rect, RoundedCornerShape, Size,
 };
 pub use primitives::{
-    BoxScope, BoxWithConstraints, BoxWithConstraintsScope, BoxWithConstraintsScopeImpl, Button,
-    ButtonNode, Column, ColumnNode, ColumnWithAlignment, ForEach, Layout, LayoutNode, Row, RowNode,
-    RowWithAlignment, Spacer, SpacerNode, SubcomposeLayout, Text, TextNode,
+    Box, BoxNode, BoxScope, BoxWithConstraints, BoxWithConstraintsScope,
+    BoxWithConstraintsScopeImpl, BoxWithOptions, Button, ButtonNode, Column, ColumnNode,
+    ColumnWithAlignment, ForEach, Layout, LayoutNode, Row, RowNode, RowWithAlignment, Spacer,
+    SpacerNode, SubcomposeLayout, Text, TextNode,
 };
 pub use renderer::{HeadlessRenderer, PaintLayer, RenderOp, RenderScene};
 pub use subcompose_layout::{


### PR DESCRIPTION
## Summary
- introduce a reusable Alignment type for combining horizontal and vertical alignment
- add a Box node/composable with measurement logic that honors child alignment and propagate-min-constraints
- extend Modifier with align support and update layout builder/tests accordingly, marking roadmap items complete

## Testing
- cargo test -p compose-ui

------
https://chatgpt.com/codex/tasks/task_e_68ee56c859a48328b9483e4ceca49506