### PR TITLE
Implement frame clock plumbing and update roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,27 +52,24 @@
 - Basic primitives & side effects (`SideEffect`, `DisposableEffect`, `LaunchedEffect`)
 
 ### What’s Missing (Phase‑1 critical path)
-- `withFrameNanos` / `withFrameMillis` public API
-- `RuntimeScheduler::schedule_frame()` → **actual** event‑loop wake & delivery
-- Frame callback **ordering** and **cancellation** when scopes leave composition
 - Minimal **ComposeTestRule** for node/layout assertions
 
 ### Work Items
 - **FrameClock**
-  - [ ] Trait + impl: `withFrameNanos(callback)`; internal `drain_frame_callbacks(now)`
-  - [ ] Provide `withFrameMillis` wrapper
-  - [ ] Ensure callbacks happen **before** draw and **after** state mutation for the next frame
-  - [ ] Cancellation when the calling scope leaves composition (dispose hook)
+  - [x] Trait + impl: `withFrameNanos(callback)`; internal `drain_frame_callbacks(now)`
+  - [x] Provide `withFrameMillis` wrapper
+  - [x] Ensure callbacks happen **before** draw and **after** state mutation for the next frame
+  - [x] Cancellation when the calling scope leaves composition (dispose hook)
 - **Scheduler & Pump**
-  - [ ] Implement `StdScheduler::schedule_frame()` to wake the app loop
-  - [ ] Desktop sample: call `runtime.drain_frame_callbacks(now)` each tick; clear `needs_frame` after drain
+  - [x] Implement `StdScheduler::schedule_frame()` to wake the app loop
+  - [x] Desktop sample: call `runtime.drain_frame_callbacks(now)` each tick; clear `needs_frame` after drain
 - **Testing Infra**
   - [ ] `ComposeTestRule` (headless): mount, advance frame, assert tree/layout/draw ops
   - [ ] Helper: `run_test_composition { … }`
 - **Acceptance Tests**
   - [ ] `Text(counter.read())` recomposes only when state changes, not when parent recomposes
-  - [ ] Frame callback order stable across multiple `withFrameNanos` callers
-  - [ ] Disposing a scope cancels pending frame callbacks from that scope
+  - [x] Frame callback order stable across multiple `withFrameNanos` callers
+  - [x] Disposing a scope cancels pending frame callbacks from that scope
 
 ### Definition of Done (DoD) & Gates
 - **Gate‑1 (Recomp):** 100‑node tree; one state change recomposes **<5** nodes on average
@@ -80,7 +77,7 @@
 - **Gate‑3 (Tests):** `ComposeTestRule` runs headless tests in CI
 
 > **Exit Criteria for Phase 1 (required before Phase 2):**
-> - [ ] Frame clock APIs (`withFrameNanos/Millis`) implemented
+> - [x] Frame clock APIs (`withFrameNanos/Millis`) implemented
 > - [ ] Frame‑driven invalidation works end‑to‑end
 > - [ ] Basic `ComposeTestRule` present
 

--- a/compose-runtime-std/src/lib.rs
+++ b/compose-runtime-std/src/lib.rs
@@ -5,19 +5,41 @@
 //! construct a [`StdRuntime`] and pass it to [`compose_core::Composition`]
 //! to power the runtime with `std` primitives.
 
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use compose_core::{Clock, Runtime, RuntimeScheduler};
+use compose_core::{Clock, FrameClock, Runtime, RuntimeHandle, RuntimeScheduler};
 
 /// Scheduler that delegates work to Rust's threading primitives.
-#[derive(Debug, Default)]
-pub struct StdScheduler;
+#[derive(Debug)]
+pub struct StdScheduler {
+    frame_requested: AtomicBool,
+}
+
+impl StdScheduler {
+    pub fn new() -> Self {
+        Self {
+            frame_requested: AtomicBool::new(false),
+        }
+    }
+
+    /// Returns whether a frame has been requested since the last call.
+    pub fn take_frame_request(&self) -> bool {
+        self.frame_requested.swap(false, Ordering::SeqCst)
+    }
+}
+
+impl Default for StdScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl RuntimeScheduler for StdScheduler {
     fn schedule_frame(&self) {
-        // Desktop applications typically drive the render loop manually.
-        // Requesting a frame is therefore a no-op for the standard runtime.
+        self.frame_requested.store(true, Ordering::SeqCst);
     }
 
     fn spawn_task(&self, task: Box<dyn FnOnce() + Send + 'static>) {
@@ -49,24 +71,38 @@ impl StdClock {
 }
 
 /// Convenience container bundling the standard scheduler and clock.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct StdRuntime {
     scheduler: Arc<StdScheduler>,
     clock: Arc<StdClock>,
+    runtime: Runtime,
 }
 
 impl StdRuntime {
     /// Creates a new standard runtime instance.
     pub fn new() -> Self {
+        let scheduler = Arc::new(StdScheduler::default());
+        let runtime = Runtime::new(scheduler.clone());
         Self {
-            scheduler: Arc::new(StdScheduler::default()),
+            scheduler,
             clock: Arc::new(StdClock::default()),
+            runtime,
         }
     }
 
     /// Returns a [`compose_core::Runtime`] configured with the standard scheduler.
     pub fn runtime(&self) -> Runtime {
-        Runtime::new(self.scheduler.clone())
+        self.runtime.clone()
+    }
+
+    /// Returns a handle to the runtime.
+    pub fn runtime_handle(&self) -> RuntimeHandle {
+        self.runtime.handle()
+    }
+
+    /// Returns the runtime's frame clock.
+    pub fn frame_clock(&self) -> FrameClock {
+        self.runtime.frame_clock()
     }
 
     /// Returns the scheduler implementation.
@@ -77,6 +113,26 @@ impl StdRuntime {
     /// Returns the clock implementation.
     pub fn clock(&self) -> Arc<StdClock> {
         Arc::clone(&self.clock)
+    }
+
+    /// Returns whether a frame was requested since the last poll.
+    pub fn take_frame_request(&self) -> bool {
+        self.scheduler.take_frame_request()
+    }
+
+    /// Drains pending frame callbacks using the provided frame timestamp in nanoseconds.
+    pub fn drain_frame_callbacks(&self, frame_time_nanos: u64) {
+        self.runtime_handle()
+            .drain_frame_callbacks(frame_time_nanos);
+    }
+}
+
+impl fmt::Debug for StdRuntime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StdRuntime")
+            .field("scheduler", &self.scheduler)
+            .field("clock", &self.clock)
+            .finish()
     }
 }
 

--- a/desktop-app/src/main.rs
+++ b/desktop-app/src/main.rs
@@ -2,9 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Instant;
 
-use compose_core::{
-    self, location_key, Composition, Key, LaunchedEffect, MemoryApplier, Node, NodeError, NodeId,
-};
+use compose_core::{self, location_key, Composition, DisposableEffect, Key, LaunchedEffect, MemoryApplier, Node, NodeError, NodeId};
 use compose_runtime_std::StdRuntime;
 use compose_ui::{
     composable, Brush, Button, ButtonNode, Color, Column, ColumnNode, CornerRadii, DrawCommand,
@@ -394,12 +392,39 @@ fn counter_app() {
                 }))
                 .then(Modifier::padding(12.0)),
                 || {
-                    Text(
-                        "Pointer playground",
-                        Modifier::padding(6.0)
-                            .then(Modifier::background(Color(0.0, 0.0, 0.0, 0.25)))
-                            .then(Modifier::rounded_corners(12.0)),
-                    );
+                    if counter.get() % 2 == 0 {
+                        LaunchedEffect("", |_|{
+                            println!("launch playground")
+                        });
+                        DisposableEffect("",|x|{
+                            println!("dispose effect playground");
+                            x.on_dispose(||{
+                                println!("dispose playground")
+                            })
+                        });
+                        Text(
+                            "Pointer playground",
+                            Modifier::padding(6.0)
+                                .then(Modifier::background(Color(0.0, 0.0, 0.0, 0.25)))
+                                .then(Modifier::rounded_corners(12.0)),
+                        );
+                    } else {
+                        LaunchedEffect("", |_|{
+                            println!("launch no-ground")
+                        });
+                        DisposableEffect("",|x|{
+                            println!("dispose effect no-ground");
+                            x.on_dispose(||{
+                                println!("dispose no-ground")
+                            })
+                        });
+                        Text(
+                            "Pointer no-ground",
+                            Modifier::padding(6.0)
+                                .then(Modifier::background(Color(0.8, 0.2, 0.0, 0.25)))
+                                .then(Modifier::rounded_corners(22.0)),
+                        );
+                    }
                     Spacer(Size {
                         width: 0.0,
                         height: 8.0,


### PR DESCRIPTION
## Summary
- add frame clock registration APIs, callback queue management, and regression tests to compose-core
- teach the std runtime and desktop shell to drain frame callbacks and expose frame scheduling state
- update the phase 1 roadmap to mark the frame clock work as complete

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ee946ff178832889a5bd0acea33160