### PR TITLE
Improve ComposeTestRule coverage and utilities

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,7 +81,7 @@ See examples:
 ### Gates
 - **Gate-1 (Recomp):** 100-node tree; one state change recomposes **<5** nodes - DONE (skip logic working)
 - **Gate-2 (Frame):** Toggle state schedules **one** frame; callbacks fire; `needs_frame` cleared - DONE
-- **Gate-3 (Tests):** `ComposeTestRule` runs headless tests in CI - IN PROGRESS
+- **Gate-3 (Tests):** `ComposeTestRule` runs headless tests in CI - DONE
 
 ### Exit Criteria
 - [x] Frame clock APIs implemented

--- a/compose-core/src/testing.rs
+++ b/compose-core/src/testing.rs
@@ -1,4 +1,11 @@
-use crate::{location_key, Composition, Key, MemoryApplier, NodeError, RuntimeHandle};
+use crate::{location_key, Composition, Key, MemoryApplier, NodeError, NodeId, RuntimeHandle};
+
+#[cfg(test)]
+use crate::{with_current_composer, with_node_mut, MutableState, Node};
+#[cfg(test)]
+use std::cell::Cell;
+#[cfg(test)]
+use std::rc::Rc;
 
 /// Headless harness for exercising compositions in tests.
 ///
@@ -83,6 +90,16 @@ impl ComposeTestRule {
         self.composition.applier_mut()
     }
 
+    /// Returns whether user content has been installed in this rule.
+    pub fn has_content(&self) -> bool {
+        self.content.is_some()
+    }
+
+    /// Returns the id of the root node produced by the current composition.
+    pub fn root_id(&self) -> Option<NodeId> {
+        self.composition.root()
+    }
+
     /// Gain mutable access to the raw composition for advanced scenarios.
     pub fn composition(&mut self) -> &mut Composition<MemoryApplier> {
         &mut self.composition
@@ -107,4 +124,67 @@ impl Default for ComposeTestRule {
 pub fn run_test_composition<R>(f: impl FnOnce(&mut ComposeTestRule) -> R) -> R {
     let mut rule = ComposeTestRule::new();
     f(&mut rule)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct TestNode {
+        value: i32,
+    }
+
+    impl Node for TestNode {}
+
+    #[test]
+    fn compose_test_rule_reports_content_and_root() {
+        run_test_composition(|rule| {
+            assert!(!rule.has_content());
+            assert!(rule.root_id().is_none());
+
+            let runtime = rule.runtime_handle();
+            let state = MutableState::with_runtime(0, runtime.clone());
+            let recompositions = Rc::new(Cell::new(0));
+
+            rule.set_content({
+                let state = state.clone();
+                let recompositions = Rc::clone(&recompositions);
+                move || {
+                    recompositions.set(recompositions.get() + 1);
+                    let id = with_current_composer(|composer| {
+                        composer.emit_node(|| TestNode::default())
+                    });
+                    let value = state.value();
+                    with_node_mut(id, |node: &mut TestNode| {
+                        node.value = value;
+                    })
+                    .expect("update node text");
+                }
+            })
+            .expect("install content");
+
+            assert!(rule.has_content());
+            assert_eq!(recompositions.get(), 1);
+
+            let root = rule.root_id().expect("root id available");
+            let stored_value = {
+                rule.applier_mut()
+                    .with_node(root, |node: &mut TestNode| node.value)
+                    .expect("read node")
+            };
+            assert_eq!(stored_value, 0);
+
+            state.set_value(5);
+            rule.pump_until_idle().expect("process invalidation");
+
+            assert_eq!(recompositions.get(), 2);
+            let updated_value = {
+                rule.applier_mut()
+                    .with_node(root, |node: &mut TestNode| node.value)
+                    .expect("read updated node")
+            };
+            assert_eq!(updated_value, 5);
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- expose helper accessors on `ComposeTestRule` for interrogating mounted content
- add regression coverage that exercises root node reuse and state-driven updates
- update the roadmap to reflect the completed ComposeTestRule gate

## Testing
- cargo fmt
- cargo test -p compose-core

------
https://chatgpt.com/codex/tasks/task_e_68ef8065cdd48328843034cec7017f9e