### PR TITLE
Add basic modifier node context tracking

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -137,7 +137,8 @@ Converted `LaunchedEffect` and `DisposableEffect` from functions to macros that 
 
 #### Status
 - ✅ Core modifier node traits (`ModifierNode`, `ModifierElement`) and chain reconciliation scaffolding implemented in `compose-core`
-- ⏳ Specialized layout/draw/input/semantics nodes and runtime invalidation plumbing
+- ✅ Basic modifier-node invalidation plumbing via `BasicModifierNodeContext`
+- ⏳ Specialized layout/draw/input/semantics nodes
 
 #### Deliverables
 - ✅ Node trait scaffolding: `ModifierNode` + generic `ModifierElement`


### PR DESCRIPTION
## Summary
- add a reusable `BasicModifierNodeContext` that records modifier invalidations and update requests
- extend modifier unit tests to cover the new context lifecycle and detaching behaviour
- mark the roadmap item for modifier invalidation plumbing as complete

## Testing
- cargo clippy --all-targets --all-features
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ef84b074ac832881fa8c8a5de287b7