### PR TITLE
Handle closure parameters in composable skip path

### DIFF
--- a/compose-core/src/lib.rs
+++ b/compose-core/src/lib.rs
@@ -5,12 +5,10 @@ pub mod modifier;
 pub mod platform;
 pub mod testing;
 
-pub use animation::{
-    Animatable, AnimationSpec, AnimationType, Easing, Lerp, SpringSpec,
-};
+pub use animation::{Animatable, AnimationSpec, AnimationType, Easing, Lerp, SpringSpec};
 pub use modifier::{
     modifier_element, AnyModifierElement, Constraints, DrawModifierNode, DrawScope,
-    DynModifierElement, InvalidationKind, LayoutModifierNode, MeasureResult, Measurable,
+    DynModifierElement, InvalidationKind, LayoutModifierNode, Measurable, MeasureResult,
     ModifierElement, ModifierNode, ModifierNodeChain, ModifierNodeContext, NodeCapabilities,
     PointerEvent, PointerInputNode, SemanticsConfiguration, SemanticsNode,
 };
@@ -1983,6 +1981,22 @@ impl<T> ParamState<T> {
     }
 }
 
+pub struct ParamSlot<T> {
+    value: Option<T>,
+}
+
+impl<T> ParamSlot<T> {
+    pub fn set(&mut self, value: T) {
+        self.value = Some(value);
+    }
+
+    pub fn take(&mut self) -> T {
+        self.value
+            .take()
+            .expect("composable parameter missing during recomposition")
+    }
+}
+
 pub struct ReturnSlot<T> {
     value: Option<T>,
 }
@@ -1998,6 +2012,12 @@ impl<T: Clone> ReturnSlot<T> {
 }
 
 impl<T> Default for ParamState<T> {
+    fn default() -> Self {
+        Self { value: None }
+    }
+}
+
+impl<T> Default for ParamSlot<T> {
     fn default() -> Self {
         Self { value: None }
     }

--- a/compose-ui/src/primitives.rs
+++ b/compose-ui/src/primitives.rs
@@ -442,7 +442,7 @@ impl Node for ButtonNode {
 #[composable(no_skip)]
 pub fn Column<F>(modifier: Modifier, content: F) -> NodeId
 where
-    F: FnMut(),
+    F: FnMut() + 'static,
 {
     ColumnWithAlignment(
         modifier,
@@ -455,12 +455,12 @@ where
 #[composable(no_skip)]
 pub fn Box<F>(modifier: Modifier, content: F) -> NodeId
 where
-    F: FnMut(),
+    F: FnMut() + 'static,
 {
     BoxWithOptions(modifier, Alignment::TOP_START, false, content)
 }
 
-#[composable(no_skip)]
+#[composable]
 pub fn BoxWithOptions<F>(
     modifier: Modifier,
     content_alignment: Alignment,
@@ -468,7 +468,7 @@ pub fn BoxWithOptions<F>(
     mut content: F,
 ) -> NodeId
 where
-    F: FnMut(),
+    F: FnMut() + 'static,
 {
     let id = compose_node(|| BoxNode {
         modifier: modifier.clone(),
@@ -489,7 +489,7 @@ where
     id
 }
 
-#[composable(no_skip)]
+#[composable]
 pub fn ColumnWithAlignment<F>(
     modifier: Modifier,
     vertical_arrangement: LinearArrangement,
@@ -497,7 +497,7 @@ pub fn ColumnWithAlignment<F>(
     mut content: F,
 ) -> NodeId
 where
-    F: FnMut(),
+    F: FnMut() + 'static,
 {
     let id = compose_node(|| ColumnNode {
         modifier: modifier.clone(),
@@ -521,7 +521,7 @@ where
 #[composable(no_skip)]
 pub fn Row<F>(modifier: Modifier, content: F) -> NodeId
 where
-    F: FnMut(),
+    F: FnMut() + 'static,
 {
     RowWithAlignment(
         modifier,
@@ -531,7 +531,7 @@ where
     )
 }
 
-#[composable(no_skip)]
+#[composable]
 pub fn RowWithAlignment<F>(
     modifier: Modifier,
     horizontal_arrangement: LinearArrangement,
@@ -539,7 +539,7 @@ pub fn RowWithAlignment<F>(
     mut content: F,
 ) -> NodeId
 where
-    F: FnMut(),
+    F: FnMut() + 'static,
 {
     let id = compose_node(|| RowNode {
         modifier: modifier.clone(),
@@ -563,7 +563,7 @@ where
 #[composable(no_skip)]
 pub fn Layout<F, P>(modifier: Modifier, measure_policy: P, mut content: F) -> NodeId
 where
-    F: FnMut(),
+    F: FnMut() + 'static,
     P: MeasurePolicy + 'static,
 {
     let policy: Rc<dyn MeasurePolicy> = Rc::new(measure_policy);
@@ -765,7 +765,7 @@ pub fn Spacer(size: Size) -> NodeId {
 pub fn Button<F, G>(modifier: Modifier, on_click: F, mut content: G) -> NodeId
 where
     F: FnMut() + 'static,
-    G: FnMut(),
+    G: FnMut() + 'static,
 {
     let on_click_rc: Rc<RefCell<dyn FnMut()>> = Rc::new(RefCell::new(on_click));
     let id = compose_node(|| ButtonNode {
@@ -789,7 +789,7 @@ where
 pub fn ForEach<T, F>(items: &[T], mut row: F)
 where
     T: Hash,
-    F: FnMut(&T),
+    F: FnMut(&T) + 'static,
 {
     for item in items {
         compose_core::with_key(item, || row(item));

--- a/desktop-app/src/main.rs
+++ b/desktop-app/src/main.rs
@@ -274,6 +274,10 @@ fn counter_app() {
     let wave = compose_core::animateFloatAsState(target_wave, "wave").value();
     LaunchedEffect!(counter.get(), |_| println!("effect call")); // todo: provide a way to use mutablestate from lambda
 
+    let counter_for_content = counter.clone();
+    let pointer_position_for_content = pointer_position.clone();
+    let pointer_down_for_content = pointer_down.clone();
+
     Column(
         Modifier::padding(32.0)
             .then(Modifier::rounded_corners(24.0))
@@ -290,7 +294,10 @@ fn counter_app() {
                 }
             }))
             .then(Modifier::padding(20.0)),
-        || {
+        move || {
+            let counter = counter_for_content.clone();
+            let pointer_position = pointer_position_for_content.clone();
+            let pointer_down = pointer_down_for_content.clone();
             Text(
                 "Compose-RS Playground",
                 Modifier::padding(12.0)
@@ -310,13 +317,14 @@ fn counter_app() {
                 height: 12.0,
             });
 
+            let counter_for_row = counter.clone();
             RowWithAlignment(
                 Modifier::padding(8.0),
                 LinearArrangement::SpacedBy(12.0),
                 VerticalAlignment::CenterVertically,
-                || {
+                move || {
                     Text(
-                        format!("Counter: {}", counter.get()),
+                        format!("Counter: {}", counter_for_row.get()),
                         Modifier::padding(8.0)
                             .then(Modifier::background(Color(0.0, 0.0, 0.0, 0.35)))
                             .then(Modifier::rounded_corners(12.0)),
@@ -341,6 +349,9 @@ fn counter_app() {
                 height: 16.0,
             });
 
+            let counter_for_inner = counter.clone();
+            let pointer_position_for_inner = pointer_position.clone();
+            let pointer_down_for_inner = pointer_down.clone();
             Column(
                 Modifier::size(Size {
                     width: 360.0,
@@ -387,8 +398,11 @@ fn counter_app() {
                     move |_| pointer_down.set(!pointer_down.get())
                 }))
                 .then(Modifier::padding(12.0)),
-                || {
-                    if counter.get() % 2 == 0 {
+                move || {
+                    let counter = counter_for_inner.clone();
+                    let pointer_position = pointer_position_for_inner.clone();
+                    let pointer_down = pointer_down_for_inner.clone();
+                    if counter.clone().get() % 2 == 0 {
                         LaunchedEffect!("", |_| { println!("launch playground") });
                         DisposableEffect!("", |x| {
                             println!("dispose effect playground");
@@ -469,7 +483,13 @@ fn counter_app() {
                             .then(Modifier::padding(10.0)),
                         || {},
                         || {
-                            Text("OK", Modifier::padding(4.0).then(Modifier::size(Size { width: 50.0, height:50.0})));
+                            Text(
+                                "OK",
+                                Modifier::padding(4.0).then(Modifier::size(Size {
+                                    width: 50.0,
+                                    height: 50.0,
+                                })),
+                            );
                         },
                     );
                     Spacer(Size {
@@ -518,7 +538,7 @@ fn counter_app() {
                 height: 16.0,
             });
 
-            Row(Modifier::padding(8.0), || {
+            Row(Modifier::padding(8.0), move || {
                 Button(
                     Modifier::rounded_corners(16.0)
                         .then(Modifier::draw_with_cache(|cache| {


### PR DESCRIPTION
## Summary
- add a ParamSlot helper in compose-core so closures can be stored without relying on PartialEq/Clone
- update the composable macro to route function-like parameters through ParamSlot, avoiding skip comparisons and capturing
- require 'static for composable closures in primitives and adjust the desktop demo to move state into the new closures

## Testing
- cargo check -p compose-ui --lib

------
https://chatgpt.com/codex/tasks/task_e_68f09d4b3c148328abda3524cb09da78