### PR TITLE
Handle composable function parameters without PartialEq/Clone

### DIFF
--- a/compose-core/src/lib.rs
+++ b/compose-core/src/lib.rs
@@ -2070,6 +2070,22 @@ impl<T> ParamState<T> {
     }
 }
 
+pub struct ParamSlot<T> {
+    value: Option<T>,
+}
+
+impl<T> ParamSlot<T> {
+    pub fn set(&mut self, value: T) {
+        self.value = Some(value);
+    }
+
+    pub fn take(&mut self) -> T {
+        self.value
+            .take()
+            .expect("composable parameter missing during recomposition")
+    }
+}
+
 pub struct ReturnSlot<T> {
     value: Option<T>,
 }
@@ -2085,6 +2101,12 @@ impl<T: Clone> ReturnSlot<T> {
 }
 
 impl<T> Default for ParamState<T> {
+    fn default() -> Self {
+        Self { value: None }
+    }
+}
+
+impl<T> Default for ParamSlot<T> {
     fn default() -> Self {
         Self { value: None }
     }

--- a/compose-ui/src/layout/policies.rs
+++ b/compose-ui/src/layout/policies.rs
@@ -6,7 +6,7 @@ use crate::modifier::Point;
 use crate::subcompose_layout::{Constraints, MeasureResult, Placement};
 
 /// MeasurePolicy for Box layout - overlays children according to alignment.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BoxMeasurePolicy {
     pub content_alignment: Alignment,
     pub propagate_min_constraints: bool,
@@ -106,7 +106,7 @@ impl MeasurePolicy for BoxMeasurePolicy {
 }
 
 /// MeasurePolicy for Column layout - arranges children vertically.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ColumnMeasurePolicy {
     pub vertical_arrangement: LinearArrangement,
     pub horizontal_alignment: HorizontalAlignment,
@@ -237,7 +237,7 @@ impl MeasurePolicy for ColumnMeasurePolicy {
 }
 
 /// MeasurePolicy for Row layout - arranges children horizontally.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct RowMeasurePolicy {
     pub horizontal_arrangement: LinearArrangement,
     pub vertical_alignment: VerticalAlignment,
@@ -483,8 +483,10 @@ mod tests {
 
     #[test]
     fn row_measure_policy_sums_widths() {
-        let policy =
-            RowMeasurePolicy::new(LinearArrangement::Start, VerticalAlignment::CenterVertically);
+        let policy = RowMeasurePolicy::new(
+            LinearArrangement::Start,
+            VerticalAlignment::CenterVertically,
+        );
         let measurables: Vec<Box<dyn Measurable>> = vec![
             Box::new(MockMeasurable::new(40.0, 20.0, 1)),
             Box::new(MockMeasurable::new(60.0, 30.0, 2)),

--- a/compose-ui/src/primitives.rs
+++ b/compose-ui/src/primitives.rs
@@ -291,7 +291,7 @@ impl Node for ButtonNode {
 }
 
 /// Specification for Box layout behavior.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BoxSpec {
     pub content_alignment: Alignment,
     pub propagate_min_constraints: bool,
@@ -323,7 +323,7 @@ impl Default for BoxSpec {
 }
 
 /// Specification for Column layout behavior.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ColumnSpec {
     pub vertical_arrangement: LinearArrangement,
     pub horizontal_alignment: HorizontalAlignment,
@@ -355,7 +355,7 @@ impl Default for ColumnSpec {
 }
 
 /// Specification for Row layout behavior.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RowSpec {
     pub horizontal_arrangement: LinearArrangement,
     pub vertical_alignment: VerticalAlignment,

--- a/desktop-app/src/main.rs
+++ b/desktop-app/src/main.rs
@@ -3,16 +3,16 @@ use std::rc::Rc;
 use std::time::Instant;
 
 use compose_core::{
-    self, compositionLocalOf, location_key, CompositionLocal, CompositionLocalProvider,
-    Composition, DisposableEffect, Key, LaunchedEffect, MemoryApplier, Node, NodeError, NodeId,
+    self, compositionLocalOf, location_key, Composition, CompositionLocal,
+    CompositionLocalProvider, DisposableEffect, Key, LaunchedEffect, MemoryApplier, Node,
+    NodeError, NodeId,
 };
 use compose_runtime_std::StdRuntime;
 use compose_ui::{
     composable, Brush, Button, ButtonNode, Color, Column, ColumnSpec, CornerRadii, DrawCommand,
     DrawPrimitive, EdgeInsets, GraphicsLayer, LayoutBox, LayoutEngine, LayoutNode,
-    LinearArrangement, Modifier, Point, PointerEvent, PointerEventKind, Rect,
-    RoundedCornerShape, Row, RowSpec, Size, Spacer, SpacerNode, Text, TextNode,
-    VerticalAlignment,
+    LinearArrangement, Modifier, Point, PointerEvent, PointerEventKind, Rect, RoundedCornerShape,
+    Row, RowSpec, Size, Spacer, SpacerNode, Text, TextNode, VerticalAlignment,
 };
 use once_cell::sync::Lazy;
 use pixels::{Pixels, SurfaceTexture};
@@ -292,282 +292,303 @@ fn counter_app() {
             }))
             .then(Modifier::padding(20.0)),
         ColumnSpec::default(),
-        || {
-            Text(
-                "Compose-RS Playground",
-                Modifier::padding(12.0)
-                    .then(Modifier::rounded_corner_shape(RoundedCornerShape::new(
-                        16.0, 24.0, 16.0, 24.0,
-                    )))
-                    .then(Modifier::draw_with_content(|scope| {
-                        scope.draw_round_rect(
-                            Brush::solid(Color(1.0, 1.0, 1.0, 0.1)),
-                            CornerRadii::uniform(20.0),
-                        );
-                    })),
-            );
+        {
+            let counter = counter.clone();
+            let pointer_position = pointer_position.clone();
+            let pointer_down = pointer_down.clone();
+            let wave = wave;
+            move || {
+                Text(
+                    "Compose-RS Playground",
+                    Modifier::padding(12.0)
+                        .then(Modifier::rounded_corner_shape(RoundedCornerShape::new(
+                            16.0, 24.0, 16.0, 24.0,
+                        )))
+                        .then(Modifier::draw_with_content(|scope| {
+                            scope.draw_round_rect(
+                                Brush::solid(Color(1.0, 1.0, 1.0, 0.1)),
+                                CornerRadii::uniform(20.0),
+                            );
+                        })),
+                );
 
-            Spacer(Size {
-                width: 0.0,
-                height: 12.0,
-            });
+                Spacer(Size {
+                    width: 0.0,
+                    height: 12.0,
+                });
 
-            Row(
-                Modifier::padding(8.0),
-                RowSpec::new()
-                    .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
-                    .vertical_alignment(VerticalAlignment::CenterVertically),
-                || {
-                    Text(
-                        format!("Counter: {}", counter.get()),
-                        Modifier::padding(8.0)
-                            .then(Modifier::background(Color(0.0, 0.0, 0.0, 0.35)))
-                            .then(Modifier::rounded_corners(12.0)),
-                    );
-                    Text(
-                        format!("Wave {:.2}", wave),
-                        Modifier::padding(8.0)
-                            .then(Modifier::background(Color(0.35, 0.55, 0.9, 0.5)))
-                            .then(Modifier::rounded_corners(12.0))
-                            .then(Modifier::graphics_layer(GraphicsLayer {
-                                alpha: 0.7 + wave * 0.3,
-                                scale: 0.85 + wave * 0.3,
-                                translation_x: 0.0,
-                                translation_y: (wave - 0.5) * 12.0,
-                            })),
-                    );
-                },
-            );
-
-            Spacer(Size {
-                width: 0.0,
-                height: 16.0,
-            });
-
-            Column(
-                Modifier::size(Size {
-                    width: 360.0,
-                    height: 180.0,
-                })
-                .then(Modifier::rounded_corners(20.0))
-                .then(Modifier::draw_with_cache(|cache| {
-                    cache.on_draw_behind(|scope| {
-                        scope.draw_round_rect(
-                            Brush::solid(Color(0.16, 0.18, 0.26, 0.95)),
-                            CornerRadii::uniform(20.0),
-                        );
-                    });
-                }))
-                .then(Modifier::draw_with_content({
-                    let position = pointer_position.get();
-                    let pressed = pointer_down.get();
-                    move |scope| {
-                        let intensity = if pressed { 0.45 } else { 0.25 };
-                        scope.draw_round_rect(
-                            Brush::radial_gradient(
-                                vec![Color(0.4, 0.6, 1.0, intensity), Color(0.2, 0.3, 0.6, 0.0)],
-                                position,
-                                120.0,
-                            ),
-                            CornerRadii::uniform(20.0),
-                        );
-                    }
-                }))
-                .then(Modifier::pointer_input({
-                    let pointer_position = pointer_position.clone();
-                    let pointer_down = pointer_down.clone();
-                    move |event: PointerEvent| {
-                        pointer_position.set(event.position);
-                        match event.kind {
-                            PointerEventKind::Down => pointer_down.set(true),
-                            PointerEventKind::Up => pointer_down.set(false),
-                            _ => {}
-                        }
-                    }
-                }))
-                .then(Modifier::clickable({
-                    let pointer_down = pointer_down.clone();
-                    move |_| pointer_down.set(!pointer_down.get())
-                }))
-                .then(Modifier::padding(12.0)),
-                ColumnSpec::default(),
-                || {
-                    if counter.get() % 2 == 0 {
-                        LaunchedEffect!("", |_| { println!("launch playground") });
-                        DisposableEffect!("", |x| {
-                            println!("dispose effect playground");
-                            x.on_dispose(|| println!("dispose playground"))
-                        });
+                let counter_for_row = counter.clone();
+                let wave_for_row = wave;
+                Row(
+                    Modifier::padding(8.0),
+                    RowSpec::new()
+                        .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
+                        .vertical_alignment(VerticalAlignment::CenterVertically),
+                    move || {
                         Text(
-                            "Pointer playground",
-                            Modifier::padding(6.0)
-                                .then(Modifier::background(Color(0.0, 0.0, 0.0, 0.25)))
+                            format!("Counter: {}", counter_for_row.get()),
+                            Modifier::padding(8.0)
+                                .then(Modifier::background(Color(0.0, 0.0, 0.0, 0.35)))
                                 .then(Modifier::rounded_corners(12.0)),
                         );
-                    } else {
-                        LaunchedEffect!("", |_| { println!("launch no-ground") });
-                        DisposableEffect!("", |x| {
-                            println!("dispose effect no-ground");
-                            x.on_dispose(|| println!("dispose no-ground"))
+                        Text(
+                            format!("Wave {:.2}", wave_for_row),
+                            Modifier::padding(8.0)
+                                .then(Modifier::background(Color(0.35, 0.55, 0.9, 0.5)))
+                                .then(Modifier::rounded_corners(12.0))
+                                .then(Modifier::graphics_layer(GraphicsLayer {
+                                    alpha: 0.7 + wave_for_row * 0.3,
+                                    scale: 0.85 + wave_for_row * 0.3,
+                                    translation_x: 0.0,
+                                    translation_y: (wave_for_row - 0.5) * 12.0,
+                                })),
+                        );
+                    },
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 16.0,
+                });
+
+                let counter_for_column = counter.clone();
+                let pointer_position_for_column = pointer_position.clone();
+                let pointer_down_for_column = pointer_down.clone();
+                Column(
+                    Modifier::size(Size {
+                        width: 360.0,
+                        height: 180.0,
+                    })
+                    .then(Modifier::rounded_corners(20.0))
+                    .then(Modifier::draw_with_cache(|cache| {
+                        cache.on_draw_behind(|scope| {
+                            scope.draw_round_rect(
+                                Brush::solid(Color(0.16, 0.18, 0.26, 0.95)),
+                                CornerRadii::uniform(20.0),
+                            );
+                        });
+                    }))
+                    .then(Modifier::draw_with_content({
+                        let position = pointer_position.get();
+                        let pressed = pointer_down.get();
+                        move |scope| {
+                            let intensity = if pressed { 0.45 } else { 0.25 };
+                            scope.draw_round_rect(
+                                Brush::radial_gradient(
+                                    vec![
+                                        Color(0.4, 0.6, 1.0, intensity),
+                                        Color(0.2, 0.3, 0.6, 0.0),
+                                    ],
+                                    position,
+                                    120.0,
+                                ),
+                                CornerRadii::uniform(20.0),
+                            );
+                        }
+                    }))
+                    .then(Modifier::pointer_input({
+                        let pointer_position = pointer_position.clone();
+                        let pointer_down = pointer_down.clone();
+                        move |event: PointerEvent| {
+                            pointer_position.set(event.position);
+                            match event.kind {
+                                PointerEventKind::Down => pointer_down.set(true),
+                                PointerEventKind::Up => pointer_down.set(false),
+                                _ => {}
+                            }
+                        }
+                    }))
+                    .then(Modifier::clickable({
+                        let pointer_down = pointer_down.clone();
+                        move |_| pointer_down.set(!pointer_down.get())
+                    }))
+                    .then(Modifier::padding(12.0)),
+                    ColumnSpec::default(),
+                    move || {
+                        if counter_for_column.get() % 2 == 0 {
+                            LaunchedEffect!("", |_| { println!("launch playground") });
+                            DisposableEffect!("", |x| {
+                                println!("dispose effect playground");
+                                x.on_dispose(|| println!("dispose playground"))
+                            });
+                            Text(
+                                "Pointer playground",
+                                Modifier::padding(6.0)
+                                    .then(Modifier::background(Color(0.0, 0.0, 0.0, 0.25)))
+                                    .then(Modifier::rounded_corners(12.0)),
+                            );
+                        } else {
+                            LaunchedEffect!("", |_| { println!("launch no-ground") });
+                            DisposableEffect!("", |x| {
+                                println!("dispose effect no-ground");
+                                x.on_dispose(|| println!("dispose no-ground"))
+                            });
+                            Text(
+                                "Pointer no-ground",
+                                Modifier::padding(6.0)
+                                    .then(Modifier::background(Color(0.8, 0.2, 0.0, 0.25)))
+                                    .then(Modifier::rounded_corners(22.0)),
+                            );
+                        }
+                        Spacer(Size {
+                            width: 0.0,
+                            height: 8.0,
                         });
                         Text(
-                            "Pointer no-ground",
-                            Modifier::padding(6.0)
-                                .then(Modifier::background(Color(0.8, 0.2, 0.0, 0.25)))
-                                .then(Modifier::rounded_corners(22.0)),
+                            format!(
+                                "Local pointer: ({:.0}, {:.0})",
+                                pointer_position_for_column.get().x,
+                                pointer_position_for_column.get().y
+                            ),
+                            Modifier::padding(6.0),
                         );
-                    }
-                    Spacer(Size {
-                        width: 0.0,
-                        height: 8.0,
-                    });
-                    Text(
-                        format!(
-                            "Local pointer: ({:.0}, {:.0})",
-                            pointer_position.get().x,
-                            pointer_position.get().y
-                        ),
-                        Modifier::padding(6.0),
-                    );
-                    Text(
-                        format!("Pressed: {}", pointer_down.get()),
-                        Modifier::padding(6.0),
-                    );
-                },
-            );
+                        Text(
+                            format!("Pressed: {}", pointer_down_for_column.get()),
+                            Modifier::padding(6.0),
+                        );
+                    },
+                );
 
-            Spacer(Size {
-                width: 0.0,
-                height: 16.0,
-            });
+                Spacer(Size {
+                    width: 0.0,
+                    height: 16.0,
+                });
 
-            // Intrinsics demonstration: Equal-width buttons
-            Text(
-                "Intrinsic Sizing Demo (Equal Width):",
-                Modifier::padding(8.0)
-                    .then(Modifier::background(Color(0.2, 0.2, 0.2, 0.5)))
-                    .then(Modifier::rounded_corners(8.0)),
-            );
+                // Intrinsics demonstration: Equal-width buttons
+                Text(
+                    "Intrinsic Sizing Demo (Equal Width):",
+                    Modifier::padding(8.0)
+                        .then(Modifier::background(Color(0.2, 0.2, 0.2, 0.5)))
+                        .then(Modifier::rounded_corners(8.0)),
+                );
 
-            Spacer(Size {
-                width: 0.0,
-                height: 8.0,
-            });
+                Spacer(Size {
+                    width: 0.0,
+                    height: 8.0,
+                });
 
-            Row(
-                Modifier::padding(8.0)
-                    .then(Modifier::rounded_corners(12.0))
-                    .then(Modifier::background(Color(0.1, 0.1, 0.15, 0.6)))
-                    .then(Modifier::padding(8.0)),
-                RowSpec::default(),
-                || {
-                    // All buttons will have the same width as the widest one ("Long Button Text")
-                    Button(
-                        Modifier::width_intrinsic(compose_ui::IntrinsicSize::Max)
-                            .then(Modifier::rounded_corners(12.0))
-                            .then(Modifier::draw_behind(|scope| {
-                                scope.draw_round_rect(
-                                    Brush::solid(Color(0.3, 0.5, 0.2, 1.0)),
-                                    CornerRadii::uniform(12.0),
+                Row(
+                    Modifier::padding(8.0)
+                        .then(Modifier::rounded_corners(12.0))
+                        .then(Modifier::background(Color(0.1, 0.1, 0.15, 0.6)))
+                        .then(Modifier::padding(8.0)),
+                    RowSpec::default(),
+                    || {
+                        // All buttons will have the same width as the widest one ("Long Button Text")
+                        Button(
+                            Modifier::width_intrinsic(compose_ui::IntrinsicSize::Max)
+                                .then(Modifier::rounded_corners(12.0))
+                                .then(Modifier::draw_behind(|scope| {
+                                    scope.draw_round_rect(
+                                        Brush::solid(Color(0.3, 0.5, 0.2, 1.0)),
+                                        CornerRadii::uniform(12.0),
+                                    );
+                                }))
+                                .then(Modifier::padding(10.0)),
+                            || {},
+                            || {
+                                Text(
+                                    "OK",
+                                    Modifier::padding(4.0).then(Modifier::size(Size {
+                                        width: 50.0,
+                                        height: 50.0,
+                                    })),
                                 );
+                            },
+                        );
+                        Spacer(Size {
+                            width: 8.0,
+                            height: 0.0,
+                        });
+                        Button(
+                            Modifier::width_intrinsic(compose_ui::IntrinsicSize::Max)
+                                .then(Modifier::rounded_corners(12.0))
+                                .then(Modifier::draw_behind(|scope| {
+                                    scope.draw_round_rect(
+                                        Brush::solid(Color(0.5, 0.3, 0.2, 1.0)),
+                                        CornerRadii::uniform(12.0),
+                                    );
+                                }))
+                                .then(Modifier::padding(10.0)),
+                            || {},
+                            || {
+                                Text("Cancel", Modifier::padding(4.0));
+                            },
+                        );
+                        Spacer(Size {
+                            width: 8.0,
+                            height: 0.0,
+                        });
+                        Button(
+                            Modifier::width_intrinsic(compose_ui::IntrinsicSize::Max)
+                                .then(Modifier::rounded_corners(12.0))
+                                .then(Modifier::draw_behind(|scope| {
+                                    scope.draw_round_rect(
+                                        Brush::solid(Color(0.2, 0.3, 0.5, 1.0)),
+                                        CornerRadii::uniform(12.0),
+                                    );
+                                }))
+                                .then(Modifier::padding(10.0)),
+                            || {},
+                            || {
+                                Text("Long Button Text", Modifier::padding(4.0));
+                            },
+                        );
+                    },
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 16.0,
+                });
+
+                let counter_for_controls = counter.clone();
+                Row(Modifier::padding(8.0), RowSpec::default(), move || {
+                    Button(
+                        Modifier::rounded_corners(16.0)
+                            .then(Modifier::draw_with_cache(|cache| {
+                                cache.on_draw_behind(|scope| {
+                                    scope.draw_round_rect(
+                                        Brush::linear_gradient(vec![
+                                            Color(0.2, 0.45, 0.9, 1.0),
+                                            Color(0.15, 0.3, 0.65, 1.0),
+                                        ]),
+                                        CornerRadii::uniform(16.0),
+                                    );
+                                });
                             }))
-                            .then(Modifier::padding(10.0)),
-                        || {},
+                            .then(Modifier::padding(12.0)),
+                        {
+                            let counter = counter_for_controls.clone();
+                            move || counter.set(counter.get() + 1)
+                        },
                         || {
-                            Text("OK", Modifier::padding(4.0).then(Modifier::size(Size { width: 50.0, height:50.0})));
+                            Text("Increment", Modifier::padding(6.0));
                         },
                     );
                     Spacer(Size {
-                        width: 8.0,
+                        width: 12.0,
                         height: 0.0,
                     });
                     Button(
-                        Modifier::width_intrinsic(compose_ui::IntrinsicSize::Max)
-                            .then(Modifier::rounded_corners(12.0))
+                        Modifier::rounded_corners(16.0)
                             .then(Modifier::draw_behind(|scope| {
                                 scope.draw_round_rect(
-                                    Brush::solid(Color(0.5, 0.3, 0.2, 1.0)),
-                                    CornerRadii::uniform(12.0),
-                                );
-                            }))
-                            .then(Modifier::padding(10.0)),
-                        || {},
-                        || {
-                            Text("Cancel", Modifier::padding(4.0));
-                        },
-                    );
-                    Spacer(Size {
-                        width: 8.0,
-                        height: 0.0,
-                    });
-                    Button(
-                        Modifier::width_intrinsic(compose_ui::IntrinsicSize::Max)
-                            .then(Modifier::rounded_corners(12.0))
-                            .then(Modifier::draw_behind(|scope| {
-                                scope.draw_round_rect(
-                                    Brush::solid(Color(0.2, 0.3, 0.5, 1.0)),
-                                    CornerRadii::uniform(12.0),
-                                );
-                            }))
-                            .then(Modifier::padding(10.0)),
-                        || {},
-                        || {
-                            Text("Long Button Text", Modifier::padding(4.0));
-                        },
-                    );
-                },
-            );
-
-            Spacer(Size {
-                width: 0.0,
-                height: 16.0,
-            });
-
-            Row(Modifier::padding(8.0), RowSpec::default(), || {
-                Button(
-                    Modifier::rounded_corners(16.0)
-                        .then(Modifier::draw_with_cache(|cache| {
-                            cache.on_draw_behind(|scope| {
-                                scope.draw_round_rect(
-                                    Brush::linear_gradient(vec![
-                                        Color(0.2, 0.45, 0.9, 1.0),
-                                        Color(0.15, 0.3, 0.65, 1.0),
-                                    ]),
+                                    Brush::solid(Color(0.4, 0.18, 0.3, 1.0)),
                                     CornerRadii::uniform(16.0),
                                 );
-                            });
-                        }))
-                        .then(Modifier::padding(12.0)),
-                    {
-                        let counter = counter.clone();
-                        move || counter.set(counter.get() + 1)
-                    },
-                    || {
-                        Text("Increment", Modifier::padding(6.0));
-                    },
-                );
-                Spacer(Size {
-                    width: 12.0,
-                    height: 0.0,
+                            }))
+                            .then(Modifier::padding(12.0)),
+                        {
+                            let counter = counter_for_controls.clone();
+                            move || counter.set(counter.get() - 1)
+                        },
+                        || {
+                            Text("Decrement", Modifier::padding(6.0));
+                        },
+                    );
                 });
-                Button(
-                    Modifier::rounded_corners(16.0)
-                        .then(Modifier::draw_behind(|scope| {
-                            scope.draw_round_rect(
-                                Brush::solid(Color(0.4, 0.18, 0.3, 1.0)),
-                                CornerRadii::uniform(16.0),
-                            );
-                        }))
-                        .then(Modifier::padding(12.0)),
-                    {
-                        let counter = counter.clone();
-                        move || counter.set(counter.get() - 1)
-                    },
-                    || {
-                        Text("Decrement", Modifier::padding(6.0));
-                    },
-                );
-            });
+            }
         },
     );
 }
@@ -606,92 +627,94 @@ fn random() -> i32 {
 fn combined_app() {
     let show_counter = compose_core::useState(|| false);
 
-    Column(
-        Modifier::padding(20.0),
-        ColumnSpec::default(),
-        || {
-            let is_counter = show_counter.get();
-            Row(
-                Modifier::padding(8.0),
-                RowSpec::default(),
+    let show_counter = show_counter.clone();
+    Column(Modifier::padding(20.0), ColumnSpec::default(), move || {
+        let is_counter = show_counter.get();
+        let show_counter_for_row = show_counter.clone();
+        Row(Modifier::padding(8.0), RowSpec::default(), move || {
+            let show_counter = show_counter_for_row.clone();
+            Button(
+                Modifier::rounded_corners(12.0)
+                    .then(Modifier::draw_behind(move |scope| {
+                        scope.draw_round_rect(
+                            Brush::solid(if is_counter {
+                                Color(0.2, 0.45, 0.9, 1.0)
+                            } else {
+                                Color(0.3, 0.3, 0.3, 0.5)
+                            }),
+                            CornerRadii::uniform(12.0),
+                        );
+                    }))
+                    .then(Modifier::padding(10.0)),
+                {
+                    let show_counter = show_counter.clone();
+                    move || {
+                        println!("Counter App button clicked");
+                        show_counter.set(true)
+                    }
+                },
                 || {
-                    Button(
-                        Modifier::rounded_corners(12.0)
-                            .then(Modifier::draw_behind(move |scope| {
-                                scope.draw_round_rect(
-                                    Brush::solid(if is_counter {
-                                        Color(0.2, 0.45, 0.9, 1.0)
-                                    } else {
-                                        Color(0.3, 0.3, 0.3, 0.5)
-                                    }),
-                                    CornerRadii::uniform(12.0),
-                                );
-                            }))
-                            .then(Modifier::padding(10.0)),
-                        {
-                            let show_counter = show_counter.clone();
-                            move || {
-                                println!("Counter App button clicked");
-                                show_counter.set(true)
-                            }
-                        },
-                        || {
-                            Text("Counter App", Modifier::padding(4.0));
-                        },
-                    );
-                    Spacer(Size { width: 8.0, height: 0.0 });
-                    Button(
-                        Modifier::rounded_corners(12.0)
-                            .then(Modifier::draw_behind(move |scope| {
-                                scope.draw_round_rect(
-                                    Brush::solid(if !is_counter {
-                                        Color(0.2, 0.45, 0.9, 1.0)
-                                    } else {
-                                        Color(0.3, 0.3, 0.3, 0.5)
-                                    }),
-                                    CornerRadii::uniform(12.0),
-                                );
-                            }))
-                            .then(Modifier::padding(10.0)),
-                        {
-                            let show_counter = show_counter.clone();
-                            move || {
-                                println!("Composition Local button clicked");
-                                show_counter.set(false)
-                            }
-                        },
-                        || {
-                            Text("CompositionLocal Test", Modifier::padding(4.0));
-                        },
-                    );
+                    Text("Counter App", Modifier::padding(4.0));
                 },
             );
+            Spacer(Size {
+                width: 8.0,
+                height: 0.0,
+            });
+            Button(
+                Modifier::rounded_corners(12.0)
+                    .then(Modifier::draw_behind(move |scope| {
+                        scope.draw_round_rect(
+                            Brush::solid(if !is_counter {
+                                Color(0.2, 0.45, 0.9, 1.0)
+                            } else {
+                                Color(0.3, 0.3, 0.3, 0.5)
+                            }),
+                            CornerRadii::uniform(12.0),
+                        );
+                    }))
+                    .then(Modifier::padding(10.0)),
+                {
+                    let show_counter = show_counter.clone();
+                    move || {
+                        println!("Composition Local button clicked");
+                        show_counter.set(false)
+                    }
+                },
+                || {
+                    Text("CompositionLocal Test", Modifier::padding(4.0));
+                },
+            );
+        });
 
-            Spacer(Size { width: 0.0, height: 12.0 });
+        Spacer(Size {
+            width: 0.0,
+            height: 12.0,
+        });
 
-            println!("if recomposed");
-            if show_counter.get() {
-                println!("if show counter");
-                counter_app();
-            } else {
-                println!("if not show counter");
-                composition_local_example();
-            }
-        },
-    );
+        println!("if recomposed");
+        if show_counter.get() {
+            println!("if show counter");
+            counter_app();
+        } else {
+            println!("if not show counter");
+            composition_local_example();
+        }
+    });
 }
 
 #[composable]
 fn composition_local_example() {
     let counter = compose_core::useState(|| 0);
 
+    let counter = counter.clone();
     Column(
         Modifier::padding(32.0)
             .then(Modifier::background(Color(0.12, 0.10, 0.24, 1.0)))
             .then(Modifier::rounded_corners(24.0))
             .then(Modifier::padding(20.0)),
         ColumnSpec::default(),
-        || {
+        move || {
             Text(
                 "CompositionLocal Subscription Test",
                 Modifier::padding(12.0)
@@ -699,7 +722,10 @@ fn composition_local_example() {
                     .then(Modifier::rounded_corners(16.0)),
             );
 
-            Spacer(Size { width: 0.0, height: 16.0 });
+            Spacer(Size {
+                width: 0.0,
+                height: 16.0,
+            });
 
             Text(
                 format!("Counter: {}", counter.get()),
@@ -708,7 +734,10 @@ fn composition_local_example() {
                     .then(Modifier::rounded_corners(12.0)),
             );
 
-            Spacer(Size { width: 0.0, height: 12.0 });
+            Spacer(Size {
+                width: 0.0,
+                height: 12.0,
+            });
 
             Button(
                 Modifier::rounded_corners(16.0)
@@ -732,13 +761,16 @@ fn composition_local_example() {
                 },
             );
 
-            Spacer(Size { width: 0.0, height: 16.0 });
+            Spacer(Size {
+                width: 0.0,
+                height: 16.0,
+            });
 
             // Provide the composition local
             let local = local_holder();
             let count = counter.get();
 
-            CompositionLocalProvider(vec![local.provides(Holder { count })], || {
+            CompositionLocalProvider(vec![local.provides(Holder { count })], move || {
                 composition_local_content();
             });
         },
@@ -755,7 +787,10 @@ fn composition_local_content() {
             .then(Modifier::rounded_corners(12.0)),
     );
 
-    Spacer(Size { width: 0.0, height: 8.0 });
+    Spacer(Size {
+        width: 0.0,
+        height: 8.0,
+    });
 
     let local = local_holder();
     let holder = local.current(); // This establishes subscription
@@ -767,7 +802,10 @@ fn composition_local_content() {
             .then(Modifier::rounded_corners(12.0)),
     );
 
-    Spacer(Size { width: 0.0, height: 8.0 });
+    Spacer(Size {
+        width: 0.0,
+        height: 8.0,
+    });
 
     let r3 = random();
     Text(


### PR DESCRIPTION
## Summary
- add `ParamSlot` to the core runtime for storing function-like parameters across recompositions
- enhance the `#[composable]` macro to detect Fn-style inputs, remember them through `ParamSlot`, and treat them as always changed without requiring `PartialEq`/`Clone`
- derive `PartialEq` for layout specs and measure policies that are forwarded between composables so they continue to participate in skip logic

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68f09e20dea883289caa291313f15c31