### PR TITLE
Refactor remember to return owned state handles

### DIFF
--- a/compose-core/src/owned.rs
+++ b/compose-core/src/owned.rs
@@ -1,0 +1,53 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// Single-threaded owner for values remembered by the Composer.
+///
+/// This type stores `T` inside an `Rc<RefCell<...>>`, allowing cheap cloning of the
+/// handle while keeping ownership of `T` within the composition.
+pub struct Owned<T> {
+    inner: Rc<RefCell<T>>,
+}
+
+impl<T> Clone for Owned<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Rc::clone(&self.inner),
+        }
+    }
+}
+
+impl<T> Owned<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            inner: Rc::new(RefCell::new(value)),
+        }
+    }
+
+    /// Run `f` with an immutable reference to the stored value.
+    pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        let borrow = self.inner.borrow();
+        f(&*borrow)
+    }
+
+    /// Run `f` with a mutable reference to the stored value.
+    pub fn update<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+        let mut borrow = self.inner.borrow_mut();
+        f(&mut *borrow)
+    }
+
+    /// Replace the stored value entirely.
+    pub fn replace(&self, new_value: T) {
+        *self.inner.borrow_mut() = new_value;
+    }
+
+    /// Return a raw pointer to the stored value.
+    ///
+    /// This is primarily used by code generation helpers that need to interact with
+    /// legacy APIs expecting raw pointers. The caller must ensure the pointer does not
+    /// outlive the underlying value and that mutable aliasing rules are upheld.
+    pub fn as_ptr(&self) -> *mut T {
+        let cell_ptr = Rc::as_ptr(&self.inner);
+        unsafe { (*cell_ptr).as_ptr() }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor the top-level `remember` API and the slot table to return `Owned<T>` handles and update composer helpers to borrow or mutate state through those handles
- update effects, parent tracking, and state helpers to operate on clonable handles instead of raw pointers while preserving existing semantics
- extend `Owned<T>` with a raw pointer accessor and teach the composable macro to use owned parameter handles when wiring recompose callbacks

## Testing
- cargo test -p compose-core

------
https://chatgpt.com/codex/tasks/task_e_68f10e8f41ec8328b6cd6523db71552c