### PR TITLE
Fix child diff to use atomic update and add regression tests

### DIFF
--- a/compose-ui/src/primitives.rs
+++ b/compose-ui/src/primitives.rs
@@ -219,6 +219,10 @@ impl Node for LayoutNode {
             self.children.insert(child);
         }
     }
+
+    fn supports_update_children(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Clone, Default)]
@@ -287,6 +291,10 @@ impl Node for ButtonNode {
         for &child in children {
             self.children.insert(child);
         }
+    }
+
+    fn supports_update_children(&self) -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
## Summary
- update `Composer::pop_parent` to batch child list changes through `update_children`
- extend the diff harness with batch-aware logging and new regression scenarios
- add an integration test that exercises the counter header/buttons through state updates

## Testing
- cargo test -p compose-core
- cargo test -p compose-ui

------
https://chatgpt.com/codex/tasks/task_e_68f129b986348328a14c19a4266ae9b3