### PR TITLE
Deduplicate layout constraints and measurement types

### DIFF
--- a/crates/compose-ui/src/lib.rs
+++ b/crates/compose-ui/src/lib.rs
@@ -13,6 +13,7 @@ mod renderer;
 mod subcompose_layout;
 pub mod widgets;
 
+pub use compose_ui_graphics::Dp;
 pub use layout::{
     core::{
         Alignment, Arrangement, HorizontalAlignment, LinearArrangement, Measurable, MeasurePolicy,
@@ -35,7 +36,7 @@ pub use primitives::{
 };
 pub use renderer::{HeadlessRenderer, PaintLayer, RenderOp, RenderScene};
 pub use subcompose_layout::{
-    Constraints, Dp, MeasureResult, Placement, SubcomposeLayoutNode, SubcomposeMeasureScope,
+    Constraints, MeasureResult, Placement, SubcomposeLayoutNode, SubcomposeMeasureScope,
     SubcomposeMeasureScopeImpl,
 };
 

--- a/crates/compose-ui/src/primitives.rs
+++ b/crates/compose-ui/src/primitives.rs
@@ -424,7 +424,7 @@ mod tests {
                 BoxWithConstraints(Modifier::empty(), {
                     let record_capture = Rc::clone(&record_capture);
                     move |scope| {
-                        let label = if scope.max_width().value() > 100.0 {
+                        let label = if scope.max_width().0 > 100.0 {
                             "wide"
                         } else {
                             "narrow"
@@ -445,10 +445,7 @@ mod tests {
             &mut slots,
             &handle,
             root,
-            Constraints::tight(Size {
-                width: 200.0,
-                height: 100.0,
-            }),
+            Constraints::tight(200.0, 100.0),
         );
 
         assert_eq!(record.borrow().as_slice(), ["wide"]);
@@ -460,10 +457,7 @@ mod tests {
             &mut slots,
             &handle,
             root,
-            Constraints::tight(Size {
-                width: 80.0,
-                height: 50.0,
-            }),
+            Constraints::tight(80.0, 50.0),
         );
 
         assert_eq!(record.borrow().as_slice(), ["wide", "narrow"]);
@@ -492,10 +486,7 @@ mod tests {
         let mut slots = SlotTable::new();
 
         for width in [120.0, 60.0] {
-            let constraints = Constraints::tight(Size {
-                width,
-                height: 40.0,
-            });
+            let constraints = Constraints::tight(width, 40.0);
             measure_subcompose_node(&mut composition, &mut slots, &handle, root, constraints);
             slots.reset();
         }

--- a/crates/compose-ui/src/widgets/layout.rs
+++ b/crates/compose-ui/src/widgets/layout.rs
@@ -5,13 +5,14 @@
 use super::nodes::LayoutNode;
 use super::scopes::{BoxWithConstraintsScope, BoxWithConstraintsScopeImpl};
 use crate::composable;
-use crate::modifier::{Modifier, Point};
+use crate::modifier::Modifier;
 use crate::subcompose_layout::{
-    Constraints, MeasurePolicy as SubcomposeMeasurePolicy, MeasureResult, MeasureScope, Placement,
+    Constraints, MeasurePolicy as SubcomposeMeasurePolicy, MeasureResult, MeasureScope,
     SubcomposeLayoutNode, SubcomposeMeasureScope, SubcomposeMeasureScopeImpl,
 };
 use compose_core::{NodeId, SlotId};
 use compose_ui_layout::MeasurePolicy;
+use compose_ui_layout::Placement;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -72,12 +73,12 @@ where
                 content(scope_for_content.clone());
             })
         };
-        let width_dp = if scope_impl.max_width().is_finite() {
+        let width_dp = if scope_impl.max_width().0.is_finite() {
             scope_impl.max_width()
         } else {
             scope_impl.min_width()
         };
-        let height_dp = if scope_impl.max_height().is_finite() {
+        let height_dp = if scope_impl.max_height().0.is_finite() {
             scope_impl.max_height()
         } else {
             scope_impl.min_height()
@@ -86,7 +87,7 @@ where
         let height = scope_impl.to_px(height_dp);
         let placements: Vec<Placement> = measurables
             .into_iter()
-            .map(|measurable| Placement::new(measurable.node_id(), Point { x: 0.0, y: 0.0 }, 0))
+            .map(|measurable| Placement::new(measurable.node_id(), 0.0, 0.0, 0))
             .collect();
         scope.layout(width, height, placements)
     })

--- a/crates/compose-ui/src/widgets/scopes.rs
+++ b/crates/compose-ui/src/widgets/scopes.rs
@@ -1,26 +1,8 @@
 //! Scope traits and implementations for Box, Column, and Row
 
 use crate::modifier::Modifier;
-use crate::subcompose_layout::Constraints;
-use compose_ui_layout::{Alignment, HorizontalAlignment, VerticalAlignment};
-
-/// Unit type for density-independent pixels
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
-pub struct Dp(f32);
-
-impl Dp {
-    pub fn new(value: f32) -> Self {
-        Dp(value)
-    }
-
-    pub fn value(&self) -> f32 {
-        self.0
-    }
-
-    pub fn is_finite(&self) -> bool {
-        self.0.is_finite()
-    }
-}
+use compose_ui_graphics::Dp;
+use compose_ui_layout::{Alignment, Constraints, HorizontalAlignment, VerticalAlignment};
 
 /// Marker trait matching Jetpack Compose's `BoxScope` API.
 #[allow(dead_code)]
@@ -79,11 +61,11 @@ impl BoxWithConstraintsScopeImpl {
     }
 
     fn to_dp(&self, raw: f32) -> Dp {
-        Dp::new(raw / self.density)
+        Dp::from_px(raw, self.density)
     }
 
     pub fn to_px(&self, dp: Dp) -> f32 {
-        dp.value() * self.density
+        dp.to_px(self.density)
     }
 
     pub fn density(&self) -> f32 {


### PR DESCRIPTION
## Summary
- reuse the shared compose_ui_layout Constraints, MeasureResult, and Placement types inside subcompose_layout instead of duplicate definitions
- align BoxWithConstraints scope helpers with the canonical Dp unit type and update layout widgets to use the shared placement constructor
- adjust tests that exercised BoxWithConstraints to call the new constraint constructors

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f2829128cc832881991f4fbb86239f