### PR TITLE
Ensure launched effects execute on the runtime thread

### DIFF
--- a/crates/compose-core/src/platform.rs
+++ b/crates/compose-core/src/platform.rs
@@ -13,7 +13,10 @@ pub trait RuntimeScheduler: Send + Sync {
     /// Request that the host schedule a new frame.
     fn schedule_frame(&self);
 
-    /// Spawn a task that will run asynchronously.
+    /// Spawn a task that will run on the runtime's execution thread.
+    ///
+    /// Implementations should ensure the task is executed on the same thread
+    /// that drives the runtime so callers can freely interact with UI state.
     fn spawn_task(&self, task: Box<dyn FnOnce() + Send + 'static>);
 }
 

--- a/crates/compose-core/src/runtime.rs
+++ b/crates/compose-core/src/runtime.rs
@@ -159,7 +159,7 @@ impl RuntimeScheduler for DefaultScheduler {
     fn schedule_frame(&self) {}
 
     fn spawn_task(&self, task: Box<dyn FnOnce() + Send + 'static>) {
-        std::thread::spawn(move || task());
+        task();
     }
 }
 
@@ -172,7 +172,7 @@ impl RuntimeScheduler for TestScheduler {
     fn schedule_frame(&self) {}
 
     fn spawn_task(&self, task: Box<dyn FnOnce() + Send + 'static>) {
-        std::thread::spawn(move || task());
+        task();
     }
 }
 

--- a/crates/compose-runtime-std/src/lib.rs
+++ b/crates/compose-runtime-std/src/lib.rs
@@ -43,7 +43,7 @@ impl RuntimeScheduler for StdScheduler {
     }
 
     fn spawn_task(&self, task: Box<dyn FnOnce() + Send + 'static>) {
-        std::thread::spawn(move || task());
+        task();
     }
 }
 


### PR DESCRIPTION
## Summary
- document that `RuntimeScheduler::spawn_task` must execute work on the runtime thread
- run default and std schedulers' tasks immediately so launched effects mutate UI state safely

## Testing
- cargo fmt
- cargo test *(hangs in headless environment; manually interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68f34f813348832894d2eb26482a3844