### PR TITLE
Use safe slot access in composable macro skip path

### DIFF
--- a/crates/compose-core/src/owned.rs
+++ b/crates/compose-core/src/owned.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell, RefMut};
 use std::rc::Rc;
 
 /// Single-threaded owner for values remembered by the Composer.
@@ -34,6 +34,16 @@ impl<T> Owned<T> {
     pub fn update<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
         let mut borrow = self.inner.borrow_mut();
         f(&mut *borrow)
+    }
+
+    /// Borrow the stored value immutably.
+    pub fn borrow(&self) -> Ref<'_, T> {
+        self.inner.borrow()
+    }
+
+    /// Borrow the stored value mutably.
+    pub fn borrow_mut(&self) -> RefMut<'_, T> {
+        self.inner.borrow_mut()
     }
 
     /// Replace the stored value entirely.


### PR DESCRIPTION
## Summary
- expose safe borrow helpers on `Owned` so remembered values can be accessed without raw pointers
- update the `#[composable]` macro skip path to borrow slot state safely for parameters and return values

## Testing
- cargo fmt
- cargo check -p compose-macros

------
https://chatgpt.com/codex/tasks/task_e_68f34fa04274832885a45b29b2055663