### PR TITLE
Route animateFloatAsState through compose-animation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,7 @@ dependencies = [
 name = "desktop-app"
 version = "0.1.0"
 dependencies = [
+ "compose-animation",
  "compose-app-shell",
  "compose-core",
  "compose-foundation",

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -11,6 +11,7 @@ desktop = ["compose-platform-desktop-winit", "dep:winit"]
 
 [dependencies]
 compose-app-shell = { path = "../../crates/compose-app-shell" }
+compose-animation = { path = "../../crates/compose-animation" }
 compose-core = { path = "../../crates/compose-core" }
 compose-foundation = { path = "../../crates/compose-foundation" }
 compose-render-pixels = { path = "../../crates/compose-render/pixels", optional = true }

--- a/apps/desktop-demo/src/main.rs
+++ b/apps/desktop-demo/src/main.rs
@@ -1,3 +1,4 @@
+use compose_animation::animateFloatAsState;
 use compose_app_shell::{default_root_key, AppShell};
 use compose_core::{
     self, compositionLocalOf, CompositionLocal, CompositionLocalProvider, DisposableEffect,
@@ -389,7 +390,7 @@ fn counter_app() {
     } else {
         pointer_wave * 0.6
     };
-    let wave = compose_core::animateFloatAsState(target_wave, "wave").value();
+    let wave = animateFloatAsState(target_wave, "wave").value();
     LaunchedEffect!(counter.get(), |_| println!("effect call"));
 
     Column(

--- a/crates/compose-animation/src/animation.rs
+++ b/crates/compose-animation/src/animation.rs
@@ -341,6 +341,16 @@ impl<T: SpringScalar + 'static> Animatable<T> {
         }
     }
 
+    /// Return the current animation target.
+    pub fn target(&self) -> T {
+        self.inner.borrow().target.clone()
+    }
+
+    /// Return the animation spec currently driving this animatable.
+    pub fn animation_type(&self) -> AnimationType {
+        self.inner.borrow().animation_type
+    }
+
     /// Get the current state.
     pub fn state(&self) -> State<T> {
         self.inner.borrow().state.as_state()
@@ -505,8 +515,9 @@ pub fn animateFloatAsStateWithSpec(
         let runtime = composer.runtime_handle();
         let anim: Owned<Animatable<f32>> = composer.remember(|| Animatable::new(target, runtime));
         anim.update(|animatable| {
-            let current = animatable.state().value();
-            if (current - target).abs() > f32::EPSILON {
+            let is_new_target = (animatable.target() - target).abs() > f32::EPSILON;
+            let is_new_animation = animatable.animation_type() != animation;
+            if is_new_target || is_new_animation {
                 animatable.animateTo(target, animation);
             }
         });

--- a/crates/compose-animation/src/lib.rs
+++ b/crates/compose-animation/src/lib.rs
@@ -11,6 +11,7 @@ pub use animation::*;
 
 pub mod prelude {
     pub use crate::animation::{
-        Animatable, AnimationSpec, AnimationType, Easing, Lerp, SpringSpec,
+        animateFloatAsState, animateFloatAsStateWithSpec, Animatable, AnimationSpec, AnimationType,
+        Easing, Lerp, SpringSpec,
     };
 }

--- a/crates/compose-animation/src/tests/animation_tests.rs
+++ b/crates/compose-animation/src/tests/animation_tests.rs
@@ -1,5 +1,94 @@
 use super::*;
 
+use compose_core::{location_key, with_current_composer, Composition, MemoryApplier, State};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[test]
+fn animate_float_as_state_interpolates_over_time() {
+    let mut composition = Composition::new(MemoryApplier::new());
+    let runtime = composition.runtime_handle();
+    let root_key = location_key(file!(), line!(), column!());
+    let group_key = location_key(file!(), line!(), column!());
+    let state_slot = Rc::new(RefCell::new(None::<State<f32>>));
+    let target = Rc::new(RefCell::new(0.0f32));
+
+    {
+        let state_slot = Rc::clone(&state_slot);
+        let target = Rc::clone(&target);
+        composition
+            .render(root_key, move || {
+                let state_slot = Rc::clone(&state_slot);
+                let target = Rc::clone(&target);
+                with_current_composer(|composer| {
+                    composer.with_group(group_key, |_| {
+                        let state = animateFloatAsState(*target.borrow(), "alpha");
+                        state_slot.borrow_mut().replace(state);
+                    });
+                });
+            })
+            .expect("render succeeds");
+    }
+
+    let mut samples = Vec::new();
+    let initial = state_slot.borrow().as_ref().expect("state available").get();
+    samples.push(initial);
+    assert_eq!(samples.as_slice(), &[0.0]);
+    assert!(!composition.should_render());
+
+    *target.borrow_mut() = 1.0;
+
+    {
+        let state_slot = Rc::clone(&state_slot);
+        let target = Rc::clone(&target);
+        composition
+            .render(root_key, move || {
+                let state_slot = Rc::clone(&state_slot);
+                let target = Rc::clone(&target);
+                with_current_composer(|composer| {
+                    composer.with_group(group_key, |_| {
+                        let state = animateFloatAsState(*target.borrow(), "alpha");
+                        state_slot.borrow_mut().replace(state);
+                    });
+                });
+            })
+            .expect("render succeeds");
+    }
+
+    let immediate = state_slot.borrow().as_ref().expect("state available").get();
+    samples.push(immediate);
+    assert_eq!(samples[1], 0.0);
+    assert!(composition.should_render());
+
+    let mut frame_time = 0u64;
+    let mut saw_midpoint = false;
+    for _ in 0..32 {
+        if !composition.should_render() {
+            break;
+        }
+        frame_time += 16_666_667; // ~60 FPS
+        runtime.drain_frame_callbacks(frame_time);
+        composition
+            .process_invalid_scopes()
+            .expect("process invalid scopes succeeds");
+        if let Some(state) = state_slot.borrow().as_ref() {
+            let value = state.get();
+            if value > 0.0 && value < 1.0 {
+                saw_midpoint = true;
+            }
+            samples.push(value);
+        }
+    }
+
+    let last = *samples.last().expect("at least one value recorded");
+    assert!(saw_midpoint, "animation should report intermediate values");
+    assert!(
+        (last - 1.0).abs() < f32::EPSILON,
+        "animation should end at target"
+    );
+    assert!(!composition.should_render());
+}
+
 #[test]
 fn easing_linear_is_identity() {
     assert_eq!(Easing::LinearEasing.transform(0.0), 0.0);
@@ -64,23 +153,4 @@ fn spring_spec_stiff_has_high_stiffness() {
     assert!(spec.stiffness > SpringSpec::default().stiffness);
 }
 
-#[test]
-fn try_as_f32_handles_f32() {
-    let value = 42.5f32;
-    assert_eq!(try_as_f32(&value), Some(42.5));
-}
 
-#[test]
-fn try_as_f32_handles_f64() {
-    let value = 42.5f64;
-    assert_eq!(try_as_f32(&value), Some(42.5));
-}
-
-#[test]
-fn try_as_f32_returns_none_for_other_types() {
-    let value = 42i32;
-    assert_eq!(try_as_f32(&value), None);
-
-    let value = "hello";
-    assert_eq!(try_as_f32(&value), None);
-}


### PR DESCRIPTION
## Summary
- remove the bespoke animateFloatAsState implementation from compose-core and delete its supporting state type
- add a composable wrapper in compose-animation that reuses Animatable and expose a helper with an optional animation spec
- update the desktop demo (and lockfile) to depend on compose-animation and migrate tests to cover the new entry point

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f34fcff32c83289a3cdc0c7a9c2151