### PR TITLE
Align layout text measurement with renderer

### DIFF
--- a/crates/compose-render/common/src/lib.rs
+++ b/crates/compose-render/common/src/lib.rs
@@ -7,6 +7,8 @@ use compose_ui_graphics::{DrawPrimitive, DrawScope, DrawScopeDefault, Rect, Size
 
 pub use compose_ui_graphics::Brush;
 
+pub mod text;
+
 /// Trait implemented by hit-test targets stored inside a [`RenderScene`].
 pub trait HitTestTarget {
     fn dispatch(&self, kind: PointerEventKind, x: f32, y: f32);

--- a/crates/compose-render/common/src/text.rs
+++ b/crates/compose-render/common/src/text.rs
@@ -1,0 +1,45 @@
+use std::sync::{OnceLock, RwLock};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TextMetrics {
+    pub width: f32,
+    pub height: f32,
+}
+
+pub trait TextMeasurer: Send + Sync + 'static {
+    fn measure(&self, text: &str) -> TextMetrics;
+}
+
+#[derive(Default)]
+struct MonospacedTextMeasurer;
+
+impl TextMeasurer for MonospacedTextMeasurer {
+    fn measure(&self, text: &str) -> TextMetrics {
+        const CHAR_WIDTH: f32 = 8.0;
+        const HEIGHT: f32 = 20.0;
+        let width = text.chars().count() as f32 * CHAR_WIDTH;
+        TextMetrics {
+            width,
+            height: HEIGHT,
+        }
+    }
+}
+
+fn global_text_measurer() -> &'static RwLock<Box<dyn TextMeasurer>> {
+    static TEXT_MEASURER: OnceLock<RwLock<Box<dyn TextMeasurer>>> = OnceLock::new();
+    TEXT_MEASURER.get_or_init(|| RwLock::new(Box::new(MonospacedTextMeasurer::default())))
+}
+
+pub fn set_text_measurer<M: TextMeasurer>(measurer: M) {
+    let mut guard = global_text_measurer()
+        .write()
+        .expect("text measurer lock poisoned");
+    *guard = Box::new(measurer);
+}
+
+pub fn measure_text(text: &str) -> TextMetrics {
+    global_text_measurer()
+        .read()
+        .expect("text measurer lock poisoned")
+        .measure(text)
+}

--- a/crates/compose-render/pixels/src/draw.rs
+++ b/crates/compose-render/pixels/src/draw.rs
@@ -1,7 +1,10 @@
 use once_cell::sync::Lazy;
 use rusttype::{point, Font, Scale};
 
-use compose_render_common::Brush;
+use compose_render_common::{
+    text::{TextMeasurer, TextMetrics},
+    Brush,
+};
 use compose_ui_graphics::{Color, Rect};
 
 use crate::scene::{Scene, TextDraw};
@@ -16,12 +19,15 @@ static FONT: Lazy<Font<'static>> = Lazy::new(|| {
     f
 });
 
-pub struct TextMetrics {
-    pub width: f32,
-    pub height: f32,
+pub(crate) struct RusttypeTextMeasurer;
+
+impl TextMeasurer for RusttypeTextMeasurer {
+    fn measure(&self, text: &str) -> TextMetrics {
+        measure_text_impl(text)
+    }
 }
 
-pub fn measure_text(text: &str) -> TextMetrics {
+fn measure_text_impl(text: &str) -> TextMetrics {
     let scale = Scale::uniform(TEXT_SIZE);
     let font = &*FONT;
     let v_metrics = font.v_metrics(scale);

--- a/crates/compose-render/pixels/src/lib.rs
+++ b/crates/compose-render/pixels/src/lib.rs
@@ -4,7 +4,7 @@ pub mod scene;
 pub mod style;
 
 use compose_core::MemoryApplier;
-use compose_render_common::{RenderScene, Renderer};
+use compose_render_common::{text::set_text_measurer, RenderScene, Renderer};
 use compose_ui::LayoutBox;
 use compose_ui_graphics::{GraphicsLayer, Size};
 
@@ -22,6 +22,7 @@ pub struct PixelsRenderer {
 
 impl PixelsRenderer {
     pub fn new() -> Self {
+        set_text_measurer(draw::RusttypeTextMeasurer);
         Self {
             scene: Scene::new(),
         }

--- a/crates/compose-render/pixels/src/pipeline.rs
+++ b/crates/compose-render/pixels/src/pipeline.rs
@@ -214,7 +214,7 @@ fn render_text(node: TextNode, layout: &LayoutBox, layer: GraphicsLayer, scene: 
         let brush = apply_layer_to_brush(Brush::solid(color), node_layer);
         scene.push_shape(transformed_rect, brush, scaled_shape.clone());
     }
-    let metrics = crate::draw::measure_text(&node.text);
+    let metrics = compose_render_common::text::measure_text(&node.text);
     let padding = style.padding;
     let text_rect = Rect {
         x: rect.x + padding.left,

--- a/crates/compose-ui/src/layout/mod.rs
+++ b/crates/compose-ui/src/layout/mod.rs
@@ -653,10 +653,10 @@ fn measure_leaf(
 }
 
 fn measure_text_content(text: &str) -> Size {
-    let width = (text.chars().count() as f32) * 8.0;
+    let metrics = compose_render_common::text::measure_text(text);
     Size {
-        width,
-        height: 20.0,
+        width: metrics.width,
+        height: metrics.height,
     }
 }
 


### PR DESCRIPTION
## Summary
- add a shared text measurer API to compose-render-common with a monospaced fallback
- register the rusttype-based measurer from the pixels renderer and reuse it for layout sizing
- switch layout text measurement to the shared API so rendering and layout agree on bounds

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f35005302c83288e4457694d9cc1c9