### PR TITLE
Support SubcomposeLayout in headless renderer

### DIFF
--- a/crates/compose-ui/src/renderer.rs
+++ b/crates/compose-ui/src/renderer.rs
@@ -3,6 +3,7 @@ use crate::modifier::{
     Brush, DrawCommand as ModifierDrawCommand, Modifier, Rect, RoundedCornerShape, Size,
 };
 use crate::primitives::{ButtonNode, LayoutNode, TextNode};
+use crate::SubcomposeLayoutNode;
 use compose_core::{MemoryApplier, Node, NodeError, NodeId};
 use compose_ui_graphics::DrawPrimitive;
 
@@ -118,6 +119,11 @@ impl<'a> HeadlessRenderer<'a> {
         // Box, Row, and Column all use LayoutNode now
         if let Some(modifier) =
             self.read_node::<LayoutNode, _>(node_id, |node| node.modifier.clone())?
+        {
+            return Ok(Some(modifier));
+        }
+        if let Some(modifier) =
+            self.read_node::<SubcomposeLayoutNode, _>(node_id, |node| node.modifier.clone())?
         {
             return Ok(Some(modifier));
         }


### PR DESCRIPTION
## Summary
- ensure the headless renderer treats SubcomposeLayout nodes like other containers so background/draw modifiers are applied
- exercise subcomposition in the renderer tests and install the runtime handle before computing layout so subcompose measurement succeeds

## Testing
- cargo test -p compose-ui

------
https://chatgpt.com/codex/tasks/task_e_68f370caab5c8328b1deee33dbdb8a60