### PR TITLE
Refactor SlotTable start to preserve sibling state

### DIFF
--- a/apps/desktop-demo/src/main.rs
+++ b/apps/desktop-demo/src/main.rs
@@ -433,6 +433,36 @@ fn counter_app() {
     }
     LaunchedEffect!(counter.get(), |_| println!("effect call"));
 
+    if counter.get() % 2 == 0 {
+        Text(
+            "if counter % 2 == 0",
+            Modifier::padding(12.0)
+                .then(Modifier::rounded_corner_shape(RoundedCornerShape::new(
+                    16.0, 24.0, 16.0, 24.0,
+                )))
+                .then(Modifier::draw_with_content(|scope| {
+                    scope.draw_round_rect(
+                        Brush::solid(Color(1.0, 1.0, 1.0, 0.1)),
+                        CornerRadii::uniform(20.0),
+                    );
+                })),
+        );
+    } else {
+        Text(
+            "if counter % 2 != 0",
+            Modifier::padding(12.0)
+                .then(Modifier::rounded_corner_shape(RoundedCornerShape::new(
+                    16.0, 24.0, 16.0, 24.0,
+                )))
+                .then(Modifier::draw_with_content(|scope| {
+                    scope.draw_round_rect(
+                        Brush::solid(Color(1.0, 1.0, 1.0, 0.5)),
+                        CornerRadii::uniform(20.0),
+                    );
+                })),
+        );
+    }
+
     Column(
         Modifier::padding(32.0)
             .then(Modifier::rounded_corners(24.0))


### PR DESCRIPTION
## Summary
- add a helper to adjust open group indices when the slot table grows or shrinks
- update `SlotTable::start` to search for matching groups and move or insert them without truncating following state

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test -p compose-core

------
https://chatgpt.com/codex/tasks/task_e_68f3bd29c5848328a526c7033d074508