### PR TITLE
Introduce snapshot-backed state system

### DIFF
--- a/apps/desktop-demo/src/main.rs
+++ b/apps/desktop-demo/src/main.rs
@@ -797,3 +797,51 @@ fn composition_local_observer() {
         DisposableEffectResult::default()
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use compose_app_shell::{default_root_key, AppShell};
+    use compose_render_pixels::PixelsRenderer;
+
+    #[test]
+    fn fast_pointer_simulation() {
+        let mut app = AppShell::new(PixelsRenderer::new(), default_root_key(), combined_app);
+        app.set_viewport(800.0, 600.0);
+        for _ in 0..5 {
+            app.update();
+        }
+
+        let scene = app.scene();
+        let show_button = scene
+            .hits
+            .iter()
+            .find(|hit| !hit.click_actions.is_empty())
+            .expect("show counter button");
+        let bx = show_button.rect.x + show_button.rect.width * 0.5;
+        let by = show_button.rect.y + show_button.rect.height * 0.5;
+        app.set_cursor(bx, by);
+        app.pointer_pressed();
+        app.update();
+        app.pointer_released();
+        app.update();
+
+        let scene = app.scene();
+        let hit = scene
+            .hits
+            .iter()
+            .find(|hit| !hit.pointer_inputs.is_empty())
+            .expect("pointer input region");
+        let x = hit.rect.x + hit.rect.width * 0.5;
+        let y = hit.rect.y + hit.rect.height * 0.5;
+
+        for i in 0..200 {
+            let offset = (i % 40) as f32;
+            app.set_cursor(x + offset, y + offset * 0.5);
+            app.pointer_pressed();
+            app.update();
+            app.pointer_released();
+            app.update();
+        }
+    }
+}

--- a/crates/compose-animation/src/animation.rs
+++ b/crates/compose-animation/src/animation.rs
@@ -285,7 +285,7 @@ pub struct Animatable<T: SpringScalar + 'static> {
     inner: Rc<RefCell<AnimatableInner<T>>>,
 }
 
-struct AnimatableInner<T: SpringScalar> {
+struct AnimatableInner<T: SpringScalar + 'static> {
     state: MutableState<T>,
     runtime: RuntimeHandle,
     current: T,

--- a/crates/compose-core/src/derived_state.rs
+++ b/crates/compose-core/src/derived_state.rs
@@ -1,0 +1,28 @@
+use std::rc::Rc;
+
+use crate::mutable_state::MutableState;
+use crate::runtime::RuntimeHandle;
+
+pub(crate) struct DerivedState<T: Clone + 'static> {
+    pub(crate) compute: Rc<dyn Fn() -> T>,
+    pub(crate) state: MutableState<T>,
+}
+
+impl<T: Clone + 'static> DerivedState<T> {
+    pub(crate) fn new(runtime: RuntimeHandle, compute: Rc<dyn Fn() -> T>) -> Self {
+        let initial = compute();
+        Self {
+            compute,
+            state: MutableState::with_runtime(initial, runtime),
+        }
+    }
+
+    pub(crate) fn set_compute(&mut self, compute: Rc<dyn Fn() -> T>) {
+        self.compute = compute;
+    }
+
+    pub(crate) fn recompute(&self) {
+        let value = (self.compute)();
+        self.state.set_value(value);
+    }
+}

--- a/crates/compose-core/src/lib.rs
+++ b/crates/compose-core/src/lib.rs
@@ -1542,7 +1542,8 @@ impl<'a> Composer<'a> {
             }
         }
         let guard = Guard;
-        let result = f(self);
+        let snapshot = crate::snapshot::current_snapshot();
+        let result = crate::snapshot::with_snapshot(snapshot, || f(self));
         drop(guard);
         result
     }

--- a/crates/compose-core/src/mutable_state.rs
+++ b/crates/compose-core/src/mutable_state.rs
@@ -1,0 +1,212 @@
+use std::cell::RefCell;
+use std::fmt;
+use std::rc::Weak;
+use std::sync::{Arc, RwLock};
+
+use crate::runtime::RuntimeHandle;
+use crate::snapshot::{self, StateRecord};
+use crate::{with_current_composer_opt, RecomposeScope, RecomposeScopeInner};
+
+pub(crate) struct MutableStateInner<T: Clone + 'static> {
+    head: RwLock<Arc<StateRecord<T>>>,
+    watchers: RefCell<Vec<Weak<RecomposeScopeInner>>>,
+    runtime: RuntimeHandle,
+}
+
+impl<T: Clone + 'static> MutableStateInner<T> {
+    pub(crate) fn new(value: T, runtime: RuntimeHandle) -> Self {
+        let snapshot = snapshot::current_snapshot();
+        let record = Arc::new(StateRecord::new(snapshot.id(), value));
+        Self {
+            head: RwLock::new(record),
+            watchers: RefCell::new(Vec::new()),
+            runtime,
+        }
+    }
+
+    fn first_state_record(&self) -> Arc<StateRecord<T>> {
+        self.head.read().unwrap().clone()
+    }
+
+    fn set_first_state_record(&self, record: Arc<StateRecord<T>>) {
+        *self.head.write().unwrap() = record;
+    }
+
+    fn object_id(&self) -> usize {
+        self as *const _ as usize
+    }
+}
+
+pub struct State<T: Clone + 'static> {
+    inner: Arc<MutableStateInner<T>>,
+}
+
+pub struct MutableState<T: Clone + 'static> {
+    inner: Arc<MutableStateInner<T>>,
+}
+
+impl<T: Clone + 'static> PartialEq for State<T> {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+impl<T: Clone + 'static> Eq for State<T> {}
+
+impl<T: Clone + 'static> Clone for State<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<T: Clone + 'static> PartialEq for MutableState<T> {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+impl<T: Clone + 'static> Eq for MutableState<T> {}
+
+impl<T: Clone + 'static> Clone for MutableState<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<T: Clone + 'static> MutableState<T> {
+    pub fn with_runtime(value: T, runtime: RuntimeHandle) -> Self {
+        Self {
+            inner: Arc::new(MutableStateInner::new(value, runtime)),
+        }
+    }
+
+    pub fn as_state(&self) -> State<T> {
+        State {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
+    pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        self.as_state().with(f)
+    }
+
+    pub fn update<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+        self.inner.runtime.assert_ui_thread();
+        let snapshot = snapshot::current_snapshot();
+        let head = self.inner.first_state_record();
+        let record = snapshot::writable_record(&head, &*snapshot);
+        let mut current = record.value();
+        let result = f(&mut current);
+        record.set_value(current);
+        if !Arc::ptr_eq(&record, &head) {
+            record.set_next(Some(head));
+            self.inner.set_first_state_record(record.clone());
+        }
+        snapshot.record_modified(self.inner.object_id());
+        self.notify_watchers();
+        result
+    }
+
+    pub fn replace(&self, value: T) {
+        self.inner.runtime.assert_ui_thread();
+        let snapshot = snapshot::current_snapshot();
+        let head = self.inner.first_state_record();
+        let record = snapshot::writable_record(&head, &*snapshot);
+        record.set_value(value);
+        if !Arc::ptr_eq(&record, &head) {
+            record.set_next(Some(head));
+            self.inner.set_first_state_record(record.clone());
+        }
+        snapshot.record_modified(self.inner.object_id());
+        self.notify_watchers();
+    }
+
+    pub fn set_value(&self, value: T) {
+        self.replace(value);
+    }
+
+    pub fn set(&self, value: T) {
+        self.replace(value);
+    }
+
+    fn notify_watchers(&self) {
+        let watchers: Vec<RecomposeScope> = {
+            let mut watchers = self.inner.watchers.borrow_mut();
+            watchers.retain(|w| w.strong_count() > 0);
+            watchers
+                .iter()
+                .filter_map(|w| w.upgrade())
+                .map(|inner| RecomposeScope { inner })
+                .collect()
+        };
+
+        for watcher in watchers {
+            watcher.invalidate();
+        }
+    }
+
+    pub fn value(&self) -> T {
+        self.as_state().value()
+    }
+
+    pub fn get(&self) -> T {
+        self.value()
+    }
+}
+
+impl<T: fmt::Debug + Clone + 'static> fmt::Debug for MutableState<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MutableState")
+            .field("value", &self.value())
+            .finish()
+    }
+}
+
+impl<T: Clone + 'static> State<T> {
+    fn subscribe_current_scope(&self) {
+        if let Some(Some(scope)) =
+            with_current_composer_opt(|composer| composer.current_recompose_scope())
+        {
+            let mut watchers = self.inner.watchers.borrow_mut();
+            watchers.retain(|w| w.strong_count() > 0);
+            let id = scope.id();
+            let already_registered = watchers
+                .iter()
+                .any(|w| w.upgrade().map(|inner| inner.id == id).unwrap_or(false));
+            if !already_registered {
+                watchers.push(scope.downgrade());
+            }
+        }
+    }
+
+    pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        self.subscribe_current_scope();
+        let snapshot = snapshot::current_snapshot();
+        let record = snapshot::readable(&self.inner.first_state_record(), &*snapshot);
+        let value = record.value();
+        f(&value)
+    }
+
+    pub fn value(&self) -> T {
+        self.subscribe_current_scope();
+        let snapshot = snapshot::current_snapshot();
+        let record = snapshot::readable(&self.inner.first_state_record(), &*snapshot);
+        record.value()
+    }
+
+    pub fn get(&self) -> T {
+        self.value()
+    }
+}
+
+impl<T: fmt::Debug + Clone + 'static> fmt::Debug for State<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("State")
+            .field("value", &self.value())
+            .finish()
+    }
+}

--- a/crates/compose-core/src/mutable_state.rs
+++ b/crates/compose-core/src/mutable_state.rs
@@ -1,14 +1,14 @@
 use std::cell::RefCell;
 use std::fmt;
 use std::rc::Weak;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use crate::runtime::RuntimeHandle;
 use crate::snapshot::{self, StateRecord};
 use crate::{with_current_composer_opt, RecomposeScope, RecomposeScopeInner};
 
 pub(crate) struct MutableStateInner<T: Clone + 'static> {
-    head: RwLock<Arc<StateRecord<T>>>,
+    head: RefCell<Arc<StateRecord<T>>>,
     watchers: RefCell<Vec<Weak<RecomposeScopeInner>>>,
     runtime: RuntimeHandle,
 }
@@ -18,18 +18,18 @@ impl<T: Clone + 'static> MutableStateInner<T> {
         let snapshot = snapshot::current_snapshot();
         let record = Arc::new(StateRecord::new(snapshot.id(), value));
         Self {
-            head: RwLock::new(record),
+            head: RefCell::new(record),
             watchers: RefCell::new(Vec::new()),
             runtime,
         }
     }
 
     fn first_state_record(&self) -> Arc<StateRecord<T>> {
-        self.head.read().unwrap().clone()
+        self.head.borrow().clone()
     }
 
     fn set_first_state_record(&self, record: Arc<StateRecord<T>>) {
-        *self.head.write().unwrap() = record;
+        *self.head.borrow_mut() = record;
     }
 
     fn object_id(&self) -> usize {

--- a/crates/compose-core/src/mutable_state.rs
+++ b/crates/compose-core/src/mutable_state.rs
@@ -25,12 +25,24 @@ impl<T: Clone + 'static> MutableStateInner<T> {
     }
 
     fn first_state_record(&self) -> Arc<StateRecord<T>> {
-        let guard = self.head.read().unwrap_or_else(|e| e.into_inner());
+        let guard = self.head.read().unwrap_or_else(|err| {
+            panic!(
+                "MutableStateInner::first_state_record poisoned RwLock (object_id={:#x}): {}",
+                self.object_id(),
+                err
+            )
+        });
         Arc::clone(&*guard)
     }
 
     fn set_first_state_record(&self, record: Arc<StateRecord<T>>) {
-        let mut guard = self.head.write().unwrap_or_else(|e| e.into_inner());
+        let mut guard = self.head.write().unwrap_or_else(|err| {
+            panic!(
+                "MutableStateInner::set_first_state_record poisoned RwLock (object_id={:#x}): {}",
+                self.object_id(),
+                err
+            )
+        });
         *guard = record;
     }
 

--- a/crates/compose-core/src/snapshot.rs
+++ b/crates/compose-core/src/snapshot.rs
@@ -38,6 +38,10 @@ pub fn current_snapshot() -> Arc<dyn Snapshot> {
     })
 }
 
+pub fn has_thread_snapshot() -> bool {
+    THREAD_SNAPSHOT.with(|slot| slot.borrow().is_some())
+}
+
 pub fn with_snapshot<T>(snapshot: Arc<dyn Snapshot>, f: impl FnOnce() -> T) -> T {
     THREAD_SNAPSHOT.with(|slot| {
         let previous = slot.borrow_mut().replace(snapshot);

--- a/crates/compose-core/src/snapshot.rs
+++ b/crates/compose-core/src/snapshot.rs
@@ -158,10 +158,8 @@ pub fn readable<T: Clone + 'static>(
 
     let mut current: Option<Arc<StateRecord<T>>> = Some(first.clone());
     let mut candidate: Option<Arc<StateRecord<T>>> = None;
-    let mut fallback: Option<Arc<StateRecord<T>>> = None;
 
     while let Some(record) = current {
-        fallback = Some(record.clone());
         if valid(id, record.snapshot_id(), &invalid) {
             let replace = match &candidate {
                 Some(existing) => existing.snapshot_id() < record.snapshot_id(),
@@ -174,9 +172,7 @@ pub fn readable<T: Clone + 'static>(
         current = record.next();
     }
 
-    candidate
-        .or(fallback)
-        .expect("State had no records when attempting to read a snapshot")
+    candidate.unwrap_or_else(|| first.clone())
 }
 
 pub fn writable_record<T: Clone + 'static>(

--- a/crates/compose-core/src/snapshot.rs
+++ b/crates/compose-core/src/snapshot.rs
@@ -158,8 +158,10 @@ pub fn readable<T: Clone + 'static>(
 
     let mut current: Option<Arc<StateRecord<T>>> = Some(first.clone());
     let mut candidate: Option<Arc<StateRecord<T>>> = None;
+    let mut fallback: Option<Arc<StateRecord<T>>> = None;
 
     while let Some(record) = current {
+        fallback = Some(record.clone());
         if valid(id, record.snapshot_id(), &invalid) {
             let replace = match &candidate {
                 Some(existing) => existing.snapshot_id() < record.snapshot_id(),
@@ -172,7 +174,9 @@ pub fn readable<T: Clone + 'static>(
         current = record.next();
     }
 
-    candidate.expect("No readable state record for snapshot")
+    candidate
+        .or(fallback)
+        .expect("State had no records when attempting to read a snapshot")
 }
 
 pub fn writable_record<T: Clone + 'static>(

--- a/crates/compose-core/src/snapshot.rs
+++ b/crates/compose-core/src/snapshot.rs
@@ -1,0 +1,193 @@
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
+
+pub type SnapshotId = usize;
+pub const INVALID_SNAPSHOT: SnapshotId = 0;
+pub type SnapshotIdSet = HashSet<SnapshotId>;
+
+static NEXT_SNAPSHOT_ID: AtomicUsize = AtomicUsize::new(1);
+static GLOBAL_SNAPSHOT: OnceLock<RwLock<Arc<MutableSnapshot>>> = OnceLock::new();
+
+thread_local! {
+    static THREAD_SNAPSHOT: RefCell<Option<Arc<dyn Snapshot>>> = RefCell::new(None);
+}
+
+fn global_snapshot_lock() -> &'static RwLock<Arc<MutableSnapshot>> {
+    GLOBAL_SNAPSHOT.get_or_init(|| {
+        let id = NEXT_SNAPSHOT_ID.fetch_add(1, Ordering::Relaxed);
+        RwLock::new(Arc::new(MutableSnapshot::new(
+            id,
+            SnapshotIdSet::new(),
+            false,
+        )))
+    })
+}
+
+pub fn current_snapshot() -> Arc<dyn Snapshot> {
+    THREAD_SNAPSHOT.with(|slot| {
+        if let Some(snapshot) = slot.borrow().clone() {
+            snapshot
+        } else {
+            global_snapshot_lock().read().unwrap().clone()
+        }
+    })
+}
+
+pub fn with_snapshot<T>(snapshot: Arc<dyn Snapshot>, f: impl FnOnce() -> T) -> T {
+    THREAD_SNAPSHOT.with(|slot| {
+        let previous = slot.borrow_mut().replace(snapshot);
+        let result = f();
+        *slot.borrow_mut() = previous;
+        result
+    })
+}
+
+pub fn advance_global_snapshot() -> Arc<dyn Snapshot> {
+    let mut guard = global_snapshot_lock().write().unwrap();
+    let id = NEXT_SNAPSHOT_ID.fetch_add(1, Ordering::Relaxed);
+    let snapshot = Arc::new(MutableSnapshot::new(id, SnapshotIdSet::new(), false));
+    *guard = snapshot.clone();
+    snapshot
+}
+
+pub trait Snapshot: Send + Sync {
+    fn id(&self) -> SnapshotId;
+    fn invalid(&self) -> SnapshotIdSet;
+    fn read_only(&self) -> bool;
+    fn disposed(&self) -> bool;
+    fn record_modified(&self, object_id: usize);
+}
+
+pub struct MutableSnapshot {
+    id: SnapshotId,
+    invalid: SnapshotIdSet,
+    disposed: AtomicBool,
+    modified: Mutex<HashSet<usize>>,
+    read_only: bool,
+}
+
+impl MutableSnapshot {
+    fn new(id: SnapshotId, invalid: SnapshotIdSet, read_only: bool) -> Self {
+        Self {
+            id,
+            invalid,
+            disposed: AtomicBool::new(false),
+            modified: Mutex::new(HashSet::new()),
+            read_only,
+        }
+    }
+
+    pub fn has_pending_changes(&self) -> bool {
+        !self.modified.lock().unwrap().is_empty()
+    }
+}
+
+impl Snapshot for MutableSnapshot {
+    fn id(&self) -> SnapshotId {
+        self.id
+    }
+
+    fn invalid(&self) -> SnapshotIdSet {
+        self.invalid.clone()
+    }
+
+    fn read_only(&self) -> bool {
+        self.read_only
+    }
+
+    fn disposed(&self) -> bool {
+        self.disposed.load(Ordering::SeqCst)
+    }
+
+    fn record_modified(&self, object_id: usize) {
+        if self.disposed.load(Ordering::SeqCst) {
+            return;
+        }
+        self.modified.lock().unwrap().insert(object_id);
+    }
+}
+
+pub struct StateRecord<T: Clone + 'static> {
+    snapshot_id: SnapshotId,
+    next: RefCell<Option<Arc<StateRecord<T>>>>,
+    value: RefCell<T>,
+}
+
+impl<T: Clone + 'static> StateRecord<T> {
+    pub fn new(snapshot_id: SnapshotId, value: T) -> Self {
+        Self {
+            snapshot_id,
+            next: RefCell::new(None),
+            value: RefCell::new(value),
+        }
+    }
+
+    pub fn snapshot_id(&self) -> SnapshotId {
+        self.snapshot_id
+    }
+
+    pub fn next(&self) -> Option<Arc<StateRecord<T>>> {
+        self.next.borrow().clone()
+    }
+
+    pub fn set_next(&self, next: Option<Arc<StateRecord<T>>>) {
+        *self.next.borrow_mut() = next;
+    }
+
+    pub fn value(&self) -> T {
+        self.value.borrow().clone()
+    }
+
+    pub fn set_value(&self, value: T) {
+        *self.value.borrow_mut() = value;
+    }
+}
+
+fn valid(current_snapshot: SnapshotId, candidate: SnapshotId, invalid: &SnapshotIdSet) -> bool {
+    candidate != INVALID_SNAPSHOT && candidate <= current_snapshot && !invalid.contains(&candidate)
+}
+
+pub fn readable<T: Clone + 'static>(
+    first: &Arc<StateRecord<T>>,
+    snapshot: &dyn Snapshot,
+) -> Arc<StateRecord<T>> {
+    let id = snapshot.id();
+    let invalid = snapshot.invalid();
+
+    let mut current: Option<Arc<StateRecord<T>>> = Some(first.clone());
+    let mut candidate: Option<Arc<StateRecord<T>>> = None;
+
+    while let Some(record) = current {
+        if valid(id, record.snapshot_id(), &invalid) {
+            let replace = match &candidate {
+                Some(existing) => existing.snapshot_id() < record.snapshot_id(),
+                None => true,
+            };
+            if replace {
+                candidate = Some(record.clone());
+            }
+        }
+        current = record.next();
+    }
+
+    candidate.expect("No readable state record for snapshot")
+}
+
+pub fn writable_record<T: Clone + 'static>(
+    first: &Arc<StateRecord<T>>,
+    snapshot: &dyn Snapshot,
+) -> Arc<StateRecord<T>> {
+    if snapshot.read_only() {
+        panic!("Cannot modify state in a read-only snapshot");
+    }
+
+    let id = snapshot.id();
+    let record = readable(first, snapshot);
+    if record.snapshot_id() == id {
+        record
+    } else {
+        Arc::new(StateRecord::new(id, record.value()))
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `snapshot` module that maintains snapshot ids, mutable snapshots, and state record traversal helpers
- refactor `State` and `MutableState` to store snapshot-backed records and expose updated read/write behaviour
- refresh unit tests for the new semantics, dropping the pending-value specific cases and adding coverage for snapshot reads
- move the snapshot-aware mutable state implementation and derived state helper into dedicated modules for clarity

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo clippy -p compose-core --all-targets --all-features
- cargo test -p compose-core

------
https://chatgpt.com/codex/tasks/task_e_68f3ea0c27948328b130449d07967853