### PR TITLE
Refactor snapshot state to use Arc-managed records

### DIFF
--- a/crates/compose-core/src/snapshot.rs
+++ b/crates/compose-core/src/snapshot.rs
@@ -168,19 +168,9 @@ impl Snapshot {
         let modified = self.modified.borrow();
         for (_id, state) in modified.iter() {
             let parent_head = state.first_record();
-            assert!(
-                !parent_head.is_null(),
-                "Snapshot::apply missing parent head for state {:?} (child_id={}, base_parent_id={})",
-                state.object_id(),
-                self.id.get(),
-                self.base_parent_id,
-            );
-
             let parent_readable = state.readable_record(parent.clone());
 
-            if !parent_readable.is_null()
-                && unsafe { (*parent_readable).snapshot_id() } > self.base_parent_id
-            {
+            if parent_readable.snapshot_id() > self.base_parent_id {
                 if !state.try_merge(
                     parent_head,
                     parent_readable,


### PR DESCRIPTION
## Summary
- replace the raw-pointer snapshot state list with Arc/RwLock-backed records and integrity assertions
- update snapshot application logic to use the safe merge/promote APIs
- make the runtime's UI pending check tolerate outstanding RefCell borrows

## Testing
- cargo fmt
- cargo test -p compose-core
- cargo clippy -p compose-core --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68f4cc15b63883289f05663f4421a732