### PR TITLE
Fix async launched effect cancellation race

### DIFF
--- a/crates/compose-core/src/runtime.rs
+++ b/crates/compose-core/src/runtime.rs
@@ -210,8 +210,10 @@ impl RuntimeInner {
 
     fn cancel_task(&self, id: u64) {
         let mut tasks = self.tasks.borrow_mut();
-        if tasks.iter().any(|entry| entry.id == id) {
-            tasks.retain(|entry| entry.id != id);
+        if let Some(index) = tasks.iter().position(|entry| entry.id == id) {
+            let entry = tasks.remove(index);
+            drop(tasks);
+            drop(entry);
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure LaunchedEffectAsync cancellation marks the scope inactive before dropping the previous task
- adjust cancellation cleanup to drop async tasks after releasing runtime borrows to avoid RefCell panics

## Testing
- cargo test -p compose-core

------
https://chatgpt.com/codex/tasks/task_e_68f4de1b87f08328bd7653934fbe92a5