### PR TITLE
Add regression test for desktop counter layout bounds

### DIFF
--- a/crates/compose-ui/src/tests/primitives_tests.rs
+++ b/crates/compose-ui/src/tests/primitives_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::composable;
+use crate::layout::LayoutBox;
 use crate::modifier::{Modifier, Size};
 use crate::subcompose_layout::{Constraints, SubcomposeLayoutNode};
 use crate::widgets::nodes::{ButtonNode, LayoutNode, TextNode};
@@ -396,6 +397,464 @@ fn modifier_offset_translates_layout() {
     );
     assert!((text_layout.rect.x - 15.0).abs() < 1e-3);
     assert!((text_layout.rect.y - 17.5).abs() < 1e-3);
+}
+
+#[test]
+fn desktop_counter_layout_respects_container_bounds() {
+    const EPSILON: f32 = 1e-3;
+
+    fn assert_approx_eq(value: f32, expected: f32, label: &str) {
+        assert!(
+            (value - expected).abs() <= EPSILON,
+            "{} expected {:.3} got {:.3}",
+            label,
+            expected,
+            value
+        );
+    }
+
+    fn assert_within(parent: &LayoutBox, child: &LayoutBox, label: &str) {
+        assert!(
+            child.rect.x >= parent.rect.x - EPSILON,
+            "{} starts before parent: child_x={:.3} parent_x={:.3}",
+            label,
+            child.rect.x,
+            parent.rect.x
+        );
+        assert!(
+            child.rect.y >= parent.rect.y - EPSILON,
+            "{} starts above parent: child_y={:.3} parent_y={:.3}",
+            label,
+            child.rect.y,
+            parent.rect.y
+        );
+        assert!(
+            child.rect.x + child.rect.width <= parent.rect.x + parent.rect.width + EPSILON,
+            "{} overflows horizontally: child_right={:.3} parent_right={:.3}",
+            label,
+            child.rect.x + child.rect.width,
+            parent.rect.x + parent.rect.width
+        );
+        assert!(
+            child.rect.y + child.rect.height <= parent.rect.y + parent.rect.height + EPSILON,
+            "{} overflows vertically: child_bottom={:.3} parent_bottom={:.3}",
+            label,
+            child.rect.y + child.rect.height,
+            parent.rect.y + parent.rect.height
+        );
+    }
+
+    fn find_layout<'a>(node: &'a LayoutBox, target: NodeId) -> Option<&'a LayoutBox> {
+        if node.node_id == target {
+            return Some(node);
+        }
+        node.children
+            .iter()
+            .find_map(|child| find_layout(child, target))
+    }
+
+    let mut composition = Composition::new(MemoryApplier::new());
+    let key = location_key(file!(), line!(), column!());
+
+    let header_box_id: Rc<RefCell<Option<NodeId>>> = Rc::new(RefCell::new(None));
+    let info_row_id: Rc<RefCell<Option<NodeId>>> = Rc::new(RefCell::new(None));
+    let row_chip_primary_id: Rc<RefCell<Option<NodeId>>> = Rc::new(RefCell::new(None));
+    let row_chip_secondary_id: Rc<RefCell<Option<NodeId>>> = Rc::new(RefCell::new(None));
+    let row_chip_tertiary_id: Rc<RefCell<Option<NodeId>>> = Rc::new(RefCell::new(None));
+    let panel_column_id: Rc<RefCell<Option<NodeId>>> = Rc::new(RefCell::new(None));
+    let pointer_panel_id: Rc<RefCell<Option<NodeId>>> = Rc::new(RefCell::new(None));
+    let action_row_id: Rc<RefCell<Option<NodeId>>> = Rc::new(RefCell::new(None));
+    let action_primary_id: Rc<RefCell<Option<NodeId>>> = Rc::new(RefCell::new(None));
+    let action_secondary_id: Rc<RefCell<Option<NodeId>>> = Rc::new(RefCell::new(None));
+    let footer_row_id: Rc<RefCell<Option<NodeId>>> = Rc::new(RefCell::new(None));
+    let footer_status_id: Rc<RefCell<Option<NodeId>>> = Rc::new(RefCell::new(None));
+    let footer_extra_id: Rc<RefCell<Option<NodeId>>> = Rc::new(RefCell::new(None));
+
+    let header_box_id_render = Rc::clone(&header_box_id);
+    let info_row_id_render = Rc::clone(&info_row_id);
+    let row_chip_primary_render = Rc::clone(&row_chip_primary_id);
+    let row_chip_secondary_render = Rc::clone(&row_chip_secondary_id);
+    let row_chip_tertiary_render = Rc::clone(&row_chip_tertiary_id);
+    let panel_column_render = Rc::clone(&panel_column_id);
+    let pointer_panel_render = Rc::clone(&pointer_panel_id);
+    let action_row_render = Rc::clone(&action_row_id);
+    let action_primary_render = Rc::clone(&action_primary_id);
+    let action_secondary_render = Rc::clone(&action_secondary_id);
+    let footer_row_render = Rc::clone(&footer_row_id);
+    let footer_status_render = Rc::clone(&footer_status_id);
+    let footer_extra_render = Rc::clone(&footer_extra_id);
+
+    composition
+        .render(key, move || {
+            let header_box_capture = Rc::clone(&header_box_id_render);
+            let info_row_capture = Rc::clone(&info_row_id_render);
+            let row_chip_primary_capture = Rc::clone(&row_chip_primary_render);
+            let row_chip_secondary_capture = Rc::clone(&row_chip_secondary_render);
+            let row_chip_tertiary_capture = Rc::clone(&row_chip_tertiary_render);
+            let panel_column_capture = Rc::clone(&panel_column_render);
+            let pointer_panel_capture = Rc::clone(&pointer_panel_render);
+            let action_row_capture = Rc::clone(&action_row_render);
+            let action_primary_capture = Rc::clone(&action_primary_render);
+            let action_secondary_capture = Rc::clone(&action_secondary_render);
+            let footer_row_capture = Rc::clone(&footer_row_render);
+            let footer_status_capture = Rc::clone(&footer_status_render);
+            let footer_extra_capture = Rc::clone(&footer_extra_render);
+
+            Column(Modifier::padding(16.0), ColumnSpec::default(), move || {
+                *header_box_capture.borrow_mut() = Some(Spacer(Size {
+                    width: 280.0,
+                    height: 40.0,
+                }));
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 12.0,
+                });
+
+                let row_chip_primary_inner = Rc::clone(&row_chip_primary_capture);
+                let row_chip_secondary_inner = Rc::clone(&row_chip_secondary_capture);
+                let row_chip_tertiary_inner = Rc::clone(&row_chip_tertiary_capture);
+                *info_row_capture.borrow_mut() = Some(Row(
+                    Modifier::padding(8.0),
+                    RowSpec::new()
+                        .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
+                        .vertical_alignment(VerticalAlignment::CenterVertically),
+                    move || {
+                        *row_chip_primary_inner.borrow_mut() = Some(Spacer(Size {
+                            width: 120.0,
+                            height: 48.0,
+                        }));
+                        *row_chip_secondary_inner.borrow_mut() = Some(Spacer(Size {
+                            width: 96.0,
+                            height: 48.0,
+                        }));
+                        *row_chip_tertiary_inner.borrow_mut() = Some(Spacer(Size {
+                            width: 84.0,
+                            height: 48.0,
+                        }));
+                    },
+                ));
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 16.0,
+                });
+
+                let pointer_panel_inner = Rc::clone(&pointer_panel_capture);
+                let action_row_inner = Rc::clone(&action_row_capture);
+                let action_primary_inner = Rc::clone(&action_primary_capture);
+                let action_secondary_inner = Rc::clone(&action_secondary_capture);
+                let footer_row_inner = Rc::clone(&footer_row_capture);
+                let footer_status_inner = Rc::clone(&footer_status_capture);
+                let footer_extra_inner = Rc::clone(&footer_extra_capture);
+
+                *panel_column_capture.borrow_mut() = Some(Column(
+                    Modifier::padding(12.0).then(Modifier::size(Size {
+                        width: 360.0,
+                        height: 180.0,
+                    })),
+                    ColumnSpec::default(),
+                    move || {
+                        *pointer_panel_inner.borrow_mut() = Some(Spacer(Size {
+                            width: 260.0,
+                            height: 60.0,
+                        }));
+
+                        Spacer(Size {
+                            width: 0.0,
+                            height: 16.0,
+                        });
+
+                        let action_primary_leaf = Rc::clone(&action_primary_inner);
+                        let action_secondary_leaf = Rc::clone(&action_secondary_inner);
+                        *action_row_inner.borrow_mut() = Some(Row(
+                            Modifier::padding(8.0),
+                            RowSpec::new()
+                                .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
+                                .vertical_alignment(VerticalAlignment::CenterVertically),
+                            move || {
+                                *action_primary_leaf.borrow_mut() = Some(Spacer(Size {
+                                    width: 140.0,
+                                    height: 48.0,
+                                }));
+                                *action_secondary_leaf.borrow_mut() = Some(Spacer(Size {
+                                    width: 132.0,
+                                    height: 48.0,
+                                }));
+                            },
+                        ));
+
+                        Spacer(Size {
+                            width: 0.0,
+                            height: 12.0,
+                        });
+
+                        let footer_status_leaf = Rc::clone(&footer_status_inner);
+                        let footer_extra_leaf = Rc::clone(&footer_extra_inner);
+                        *footer_row_inner.borrow_mut() = Some(Row(
+                            Modifier::padding(8.0),
+                            RowSpec::new()
+                                .horizontal_arrangement(LinearArrangement::SpacedBy(16.0))
+                                .vertical_alignment(VerticalAlignment::CenterVertically),
+                            move || {
+                                *footer_status_leaf.borrow_mut() = Some(Spacer(Size {
+                                    width: 220.0,
+                                    height: 52.0,
+                                }));
+                                *footer_extra_leaf.borrow_mut() = Some(Spacer(Size {
+                                    width: 80.0,
+                                    height: 52.0,
+                                }));
+                            },
+                        ));
+                    },
+                ));
+            });
+        })
+        .expect("initial render");
+
+    let root = composition.root().expect("root node");
+    let layout_tree = composition
+        .applier_mut()
+        .compute_layout(
+            root,
+            Size {
+                width: 320.0,
+                height: 220.0,
+            },
+        )
+        .expect("compute layout");
+
+    let root_layout = layout_tree.root().clone();
+
+    let header_box_id = header_box_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("header node id");
+    let info_row_id = info_row_id.borrow().as_ref().copied().expect("info row id");
+    let row_chip_primary_id = row_chip_primary_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("primary chip id");
+    let row_chip_secondary_id = row_chip_secondary_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("secondary chip id");
+    let row_chip_tertiary_id = row_chip_tertiary_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("tertiary chip id");
+    let panel_column_id = panel_column_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("panel column id");
+    let pointer_panel_id = pointer_panel_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("pointer panel id");
+    let action_row_id = action_row_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("action row id");
+    let action_primary_id = action_primary_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("primary action id");
+    let action_secondary_id = action_secondary_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("secondary action id");
+    let footer_row_id = footer_row_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("footer row id");
+    let footer_status_id = footer_status_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("footer status id");
+    let footer_extra_id = footer_extra_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("footer extra id");
+
+    let header_layout = find_layout(&root_layout, header_box_id).expect("header layout");
+    let info_row_layout = find_layout(&root_layout, info_row_id).expect("info row layout");
+    let primary_chip_layout =
+        find_layout(&root_layout, row_chip_primary_id).expect("primary chip layout");
+    let secondary_chip_layout =
+        find_layout(&root_layout, row_chip_secondary_id).expect("secondary chip layout");
+    let tertiary_chip_layout =
+        find_layout(&root_layout, row_chip_tertiary_id).expect("tertiary chip layout");
+    let panel_layout = find_layout(&root_layout, panel_column_id).expect("panel layout");
+    let pointer_layout = find_layout(&root_layout, pointer_panel_id).expect("pointer layout");
+    let action_row_layout = find_layout(&root_layout, action_row_id).expect("action row layout");
+    let action_primary_layout =
+        find_layout(&root_layout, action_primary_id).expect("primary action layout");
+    let action_secondary_layout =
+        find_layout(&root_layout, action_secondary_id).expect("secondary action layout");
+    let footer_row_layout = find_layout(&root_layout, footer_row_id).expect("footer row layout");
+    let footer_status_layout =
+        find_layout(&root_layout, footer_status_id).expect("footer status layout");
+    let footer_extra_layout =
+        find_layout(&root_layout, footer_extra_id).expect("footer extra layout");
+
+    assert_approx_eq(root_layout.rect.width, 320.0, "root width");
+    assert_approx_eq(root_layout.rect.height, 220.0, "root height");
+
+    assert_approx_eq(header_layout.rect.x, 16.0, "header x");
+    assert_approx_eq(header_layout.rect.y, 16.0, "header y");
+    assert_approx_eq(header_layout.rect.width, 280.0, "header width");
+    assert_approx_eq(header_layout.rect.height, 40.0, "header height");
+
+    assert_approx_eq(info_row_layout.rect.x, 16.0, "info row x");
+    assert_approx_eq(info_row_layout.rect.y, 68.0, "info row y");
+    assert_approx_eq(info_row_layout.rect.width, 288.0, "info row width");
+    assert_approx_eq(info_row_layout.rect.height, 64.0, "info row height");
+
+    assert_approx_eq(primary_chip_layout.rect.x, 24.0, "primary chip x");
+    assert_approx_eq(primary_chip_layout.rect.y, 76.0, "primary chip y");
+    assert_approx_eq(primary_chip_layout.rect.width, 120.0, "primary chip width");
+    assert_approx_eq(primary_chip_layout.rect.height, 48.0, "primary chip height");
+
+    assert_approx_eq(secondary_chip_layout.rect.x, 156.0, "secondary chip x");
+    assert_approx_eq(secondary_chip_layout.rect.y, 76.0, "secondary chip y");
+    assert_approx_eq(
+        secondary_chip_layout.rect.width,
+        96.0,
+        "secondary chip width",
+    );
+    assert_approx_eq(
+        secondary_chip_layout.rect.height,
+        48.0,
+        "secondary chip height",
+    );
+
+    assert_approx_eq(tertiary_chip_layout.rect.x, 264.0, "tertiary chip x");
+    assert_approx_eq(tertiary_chip_layout.rect.y, 76.0, "tertiary chip y");
+    assert_approx_eq(tertiary_chip_layout.rect.width, 84.0, "tertiary chip width");
+    assert_approx_eq(
+        tertiary_chip_layout.rect.height,
+        48.0,
+        "tertiary chip height",
+    );
+
+    assert_approx_eq(panel_layout.rect.x, 16.0, "panel x");
+    assert_approx_eq(panel_layout.rect.y, 148.0, "panel y");
+    assert_approx_eq(panel_layout.rect.width, 288.0, "panel width");
+    assert_approx_eq(panel_layout.rect.height, 180.0, "panel height");
+
+    assert_approx_eq(pointer_layout.rect.x, 28.0, "pointer panel x");
+    assert_approx_eq(pointer_layout.rect.y, 160.0, "pointer panel y");
+    assert_approx_eq(pointer_layout.rect.width, 260.0, "pointer panel width");
+    assert_approx_eq(pointer_layout.rect.height, 60.0, "pointer panel height");
+
+    assert_approx_eq(action_row_layout.rect.x, 28.0, "action row x");
+    assert_approx_eq(action_row_layout.rect.y, 236.0, "action row y");
+    assert_approx_eq(action_row_layout.rect.width, 264.0, "action row width");
+    assert_approx_eq(action_row_layout.rect.height, 64.0, "action row height");
+
+    assert_approx_eq(action_primary_layout.rect.x, 36.0, "action primary x");
+    assert_approx_eq(action_primary_layout.rect.y, 244.0, "action primary y");
+    assert_approx_eq(
+        action_primary_layout.rect.width,
+        140.0,
+        "action primary width",
+    );
+    assert_approx_eq(
+        action_primary_layout.rect.height,
+        48.0,
+        "action primary height",
+    );
+
+    assert_approx_eq(action_secondary_layout.rect.x, 188.0, "action secondary x");
+    assert_approx_eq(action_secondary_layout.rect.y, 244.0, "action secondary y");
+    assert_approx_eq(
+        action_secondary_layout.rect.width,
+        132.0,
+        "action secondary width",
+    );
+    assert_approx_eq(
+        action_secondary_layout.rect.height,
+        48.0,
+        "action secondary height",
+    );
+
+    assert_approx_eq(footer_row_layout.rect.x, 28.0, "footer row x");
+    assert_approx_eq(footer_row_layout.rect.y, 312.0, "footer row y");
+    assert_approx_eq(footer_row_layout.rect.width, 264.0, "footer row width");
+    assert_approx_eq(footer_row_layout.rect.height, 68.0, "footer row height");
+
+    assert_approx_eq(footer_status_layout.rect.x, 36.0, "footer status x");
+    assert_approx_eq(footer_status_layout.rect.y, 320.0, "footer status y");
+    assert_approx_eq(
+        footer_status_layout.rect.width,
+        220.0,
+        "footer status width",
+    );
+    assert_approx_eq(
+        footer_status_layout.rect.height,
+        52.0,
+        "footer status height",
+    );
+
+    assert_approx_eq(footer_extra_layout.rect.x, 272.0, "footer extra x");
+    assert_approx_eq(footer_extra_layout.rect.y, 320.0, "footer extra y");
+    assert_approx_eq(footer_extra_layout.rect.width, 80.0, "footer extra width");
+    assert_approx_eq(footer_extra_layout.rect.height, 52.0, "footer extra height");
+
+    assert_within(&root_layout, header_layout, "header panel");
+    assert_within(&root_layout, info_row_layout, "info row");
+    assert_within(
+        info_row_layout,
+        primary_chip_layout,
+        "info row primary chip",
+    );
+    assert_within(
+        info_row_layout,
+        secondary_chip_layout,
+        "info row secondary chip",
+    );
+    assert_within(
+        info_row_layout,
+        tertiary_chip_layout,
+        "info row tertiary chip",
+    );
+    assert_within(&root_layout, panel_layout, "interaction panel");
+    assert_within(panel_layout, pointer_layout, "pointer readout");
+    assert_within(panel_layout, action_row_layout, "action row");
+    assert_within(
+        action_row_layout,
+        action_primary_layout,
+        "primary action button",
+    );
+    assert_within(
+        action_row_layout,
+        action_secondary_layout,
+        "secondary action button",
+    );
+    assert_within(panel_layout, footer_row_layout, "footer row");
+    assert_within(
+        footer_row_layout,
+        footer_status_layout,
+        "footer status label",
+    );
+    assert_within(
+        footer_row_layout,
+        footer_extra_layout,
+        "footer extra action",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a primitives test that mimics the desktop counter layout using fixed-size spacers
- validate expected positions and assert children stay within their container bounds to expose the overflow bug

## Testing
- cargo test -p compose-ui --no-run

------
https://chatgpt.com/codex/tasks/task_e_68f704c090688328975d999f99e9ddd6