### PR TITLE
Add high-level compose app runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "compose-app"
+version = "0.1.0"
+dependencies = [
+ "compose-app-shell",
+ "compose-platform-desktop-winit",
+ "compose-render-pixels",
+ "compose-render-wgpu",
+ "log",
+ "pixels",
+ "winit",
+]
+
+[[package]]
 name = "compose-app-shell"
 version = "0.1.0"
 dependencies = [
@@ -598,20 +611,13 @@ name = "desktop-app"
 version = "0.1.0"
 dependencies = [
  "compose-animation",
- "compose-app-shell",
+ "compose-app",
  "compose-core",
  "compose-foundation",
- "compose-platform-desktop-winit",
- "compose-render-pixels",
- "compose-render-wgpu",
- "compose-runtime-std",
  "compose-ui",
  "compose-ui-graphics",
  "compose-ui-layout",
  "env_logger",
- "log",
- "pixels",
- "winit",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/compose-app-shell",
+    "crates/compose-app",
     "crates/compose-assets",
     "crates/compose-core",
     "crates/compose-macros",

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -5,23 +5,16 @@ edition = "2021"
 
 [features]
 default = ["renderer-pixels", "desktop"]
-renderer-pixels = ["compose-render-pixels", "dep:pixels"]
-renderer-wgpu = ["compose-render-wgpu"]
-desktop = ["compose-platform-desktop-winit", "dep:winit"]
+renderer-pixels = ["compose-app/renderer-pixels"]
+renderer-wgpu = ["compose-app/renderer-wgpu"]
+desktop = ["compose-app/desktop"]
 
 [dependencies]
-compose-app-shell = { path = "../../crates/compose-app-shell" }
+compose-app = { path = "../../crates/compose-app", default-features = false }
 compose-animation = { path = "../../crates/compose-animation" }
 compose-core = { path = "../../crates/compose-core" }
 compose-foundation = { path = "../../crates/compose-foundation" }
-compose-render-pixels = { path = "../../crates/compose-render/pixels", optional = true }
-compose-render-wgpu = { path = "../../crates/compose-render/wgpu", optional = true }
-compose-runtime-std = { path = "../../crates/compose-runtime-std" }
 compose-ui = { path = "../../crates/compose-ui" }
 compose-ui-graphics = { path = "../../crates/compose-ui-graphics" }
 compose-ui-layout = { path = "../../crates/compose-ui-layout" }
-compose-platform-desktop-winit = { path = "../../crates/compose-platform/desktop-winit", optional = true }
-pixels = { version = "0.13", optional = true }
-winit = { version = "0.28", optional = true }
-log = "0.4"
 env_logger = "0.10"

--- a/apps/desktop-demo/src/main.rs
+++ b/apps/desktop-demo/src/main.rs
@@ -1,34 +1,15 @@
 use compose_animation::animateFloatAsState;
-use compose_app_shell::{default_root_key, AppShell};
+use compose_app::ComposeAppOptions;
 use compose_core::{
     self, compositionLocalOf, CompositionLocal, CompositionLocalProvider, DisposableEffect,
     DisposableEffectResult, LaunchedEffect, LaunchedEffectAsync,
 };
 use compose_foundation::{PointerEvent, PointerEventKind};
-use compose_platform_desktop_winit::DesktopWinitPlatform;
-#[cfg(feature = "renderer-pixels")]
-use compose_render_pixels::{draw_scene, PixelsRenderer};
-#[cfg(feature = "renderer-pixels")]
-use pixels::{Pixels, SurfaceTexture};
-
-#[cfg(not(feature = "renderer-pixels"))]
-compile_error!("The desktop demo currently requires the `renderer-pixels` feature.");
-
-#[cfg(not(feature = "desktop"))]
-compile_error!("The desktop demo must be built with the `desktop` feature enabled.");
-
 use compose_ui::{
     composable, Brush, Button, Color, Column, ColumnSpec, CornerRadii, GraphicsLayer,
     IntrinsicSize, LinearArrangement, Modifier, Point, RoundedCornerShape, Row, RowSpec, Size,
     Spacer, Text, VerticalAlignment,
 };
-use winit::dpi::LogicalSize;
-use winit::event::{ElementState, Event, MouseButton, VirtualKeyCode, WindowEvent};
-use winit::event_loop::{ControlFlow, EventLoopBuilder};
-use winit::window::WindowBuilder;
-
-const INITIAL_WIDTH: u32 = 800;
-const INITIAL_HEIGHT: u32 = 600;
 
 fn main() {
     env_logger::init();
@@ -43,120 +24,14 @@ fn main() {
     println!("Press 'D' key to dump debug info about what's on screen");
     println!();
 
-    let event_loop = EventLoopBuilder::new().build();
-    let frame_proxy = event_loop.create_proxy();
-    let window = WindowBuilder::new()
-        .with_title("Compose Counter")
-        .with_inner_size(LogicalSize::new(
-            INITIAL_WIDTH as f64,
-            INITIAL_HEIGHT as f64,
-        ))
-        .build(&event_loop)
-        .expect("window");
-    let size = window.inner_size();
-    let surface_texture = SurfaceTexture::new(size.width, size.height, &window);
-    let mut pixels = Pixels::new(INITIAL_WIDTH, INITIAL_HEIGHT, surface_texture).expect("pixels");
-
-    let renderer = PixelsRenderer::new();
-    let mut app = AppShell::new(renderer, default_root_key(), combined_app);
-    let mut platform = DesktopWinitPlatform::default();
-    app.set_frame_waker({
-        let proxy = frame_proxy.clone();
-        move || {
-            let _ = proxy.send_event(());
+    compose_app::composeApp!(
+        options: ComposeAppOptions::default()
+            .with_title("Compose Counter")
+            .with_size(800, 600),
+        {
+            combined_app();
         }
-    });
-    app.set_viewport(size.width as f32, size.height as f32);
-
-    event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
-        match event {
-            Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => {
-                    *control_flow = ControlFlow::Exit;
-                }
-                WindowEvent::Resized(new_size) => {
-                    if let Err(err) = pixels.resize_surface(new_size.width, new_size.height) {
-                        log::error!("failed to resize surface: {err}");
-                        *control_flow = ControlFlow::Exit;
-                        return;
-                    }
-                    if let Err(err) = pixels.resize_buffer(new_size.width, new_size.height) {
-                        log::error!("failed to resize buffer: {err}");
-                        *control_flow = ControlFlow::Exit;
-                        return;
-                    }
-                    app.set_buffer_size(new_size.width, new_size.height);
-                    app.set_viewport(new_size.width as f32, new_size.height as f32);
-                }
-                WindowEvent::ScaleFactorChanged {
-                    scale_factor,
-                    new_inner_size,
-                    ..
-                } => {
-                    platform.set_scale_factor(scale_factor);
-                    if let Err(err) =
-                        pixels.resize_surface(new_inner_size.width, new_inner_size.height)
-                    {
-                        log::error!("failed to resize surface: {err}");
-                        *control_flow = ControlFlow::Exit;
-                        return;
-                    }
-                    if let Err(err) =
-                        pixels.resize_buffer(new_inner_size.width, new_inner_size.height)
-                    {
-                        log::error!("failed to resize buffer: {err}");
-                        *control_flow = ControlFlow::Exit;
-                        return;
-                    }
-                    app.set_buffer_size(new_inner_size.width, new_inner_size.height);
-                    app.set_viewport(new_inner_size.width as f32, new_inner_size.height as f32);
-                }
-                WindowEvent::CursorMoved { position, .. } => {
-                    let logical = platform.pointer_position(position);
-                    app.set_cursor(logical.x, logical.y);
-                    if app.should_render() {
-                        app.update();
-                        window.request_redraw();
-                    }
-                }
-                WindowEvent::MouseInput {
-                    state,
-                    button: MouseButton::Left,
-                    ..
-                } => match state {
-                    ElementState::Pressed => app.pointer_pressed(),
-                    ElementState::Released => app.pointer_released(),
-                },
-                WindowEvent::KeyboardInput { input, .. } => {
-                    if let Some(keycode) = input.virtual_keycode {
-                        if input.state == ElementState::Pressed && keycode == VirtualKeyCode::D {
-                            app.log_debug_info();
-                        }
-                    }
-                }
-                _ => {}
-            },
-            Event::MainEventsCleared | Event::RedrawEventsCleared | Event::UserEvent(()) => {
-                if app.should_render() {
-                    window.request_redraw();
-                    *control_flow = ControlFlow::Poll;
-                }
-            }
-            Event::RedrawRequested(_) => {
-                app.update();
-
-                let frame = pixels.frame_mut();
-                let (buffer_width, buffer_height) = app.buffer_size();
-                draw_scene(frame, buffer_width, buffer_height, app.scene());
-                if let Err(err) = pixels.render() {
-                    log::error!("pixels render failed: {err}");
-                    *control_flow = ControlFlow::Exit;
-                }
-            }
-            _ => {}
-        }
-    });
+    );
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/apps/desktop-demo/src/main.rs
+++ b/apps/desktop-demo/src/main.rs
@@ -24,10 +24,10 @@ fn main() {
     println!("Press 'D' key to dump debug info about what's on screen");
     println!();
 
-    compose_app::composeApp!(
+    compose_app::ComposeApp!(
         options: ComposeAppOptions::default()
-            .with_title("Compose Counter")
-            .with_size(800, 600),
+            .WithTitle("Compose Counter")
+            .WithSize(800, 600),
         {
             combined_app();
         }

--- a/crates/compose-app/Cargo.toml
+++ b/crates/compose-app/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "compose-app"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = ["desktop", "renderer-pixels"]
+desktop = ["compose-platform-desktop-winit", "dep:winit"]
+renderer-pixels = ["compose-render-pixels", "dep:pixels"]
+renderer-wgpu = ["compose-render-wgpu"]
+
+[dependencies]
+compose-app-shell = { path = "../compose-app-shell" }
+compose-platform-desktop-winit = { path = "../compose-platform/desktop-winit", optional = true }
+compose-render-pixels = { path = "../compose-render/pixels", optional = true }
+compose-render-wgpu = { path = "../compose-render/wgpu", optional = true }
+pixels = { version = "0.13", optional = true }
+winit = { version = "0.28", optional = true }
+log = "0.4"

--- a/crates/compose-app/src/lib.rs
+++ b/crates/compose-app/src/lib.rs
@@ -25,25 +25,49 @@ pub struct ComposeAppBuilder {
 
 impl ComposeAppBuilder {
     /// Creates a new builder with default configuration.
-    pub fn new() -> Self {
+    #[allow(non_snake_case)]
+    pub fn New() -> Self {
         Self::default()
     }
 
     /// Sets the window title for the application.
-    pub fn title(mut self, title: impl Into<String>) -> Self {
+    #[allow(non_snake_case)]
+    pub fn Title(mut self, title: impl Into<String>) -> Self {
         self.options.title = title.into();
         self
     }
 
     /// Sets the initial logical size of the application window.
-    pub fn size(mut self, width: u32, height: u32) -> Self {
+    #[allow(non_snake_case)]
+    pub fn Size(mut self, width: u32, height: u32) -> Self {
         self.options.initial_size = (width, height);
         self
     }
 
     /// Runs the application using the configured options and provided Compose content.
-    pub fn run(self, content: impl FnMut() + 'static) -> ! {
+    #[allow(non_snake_case)]
+    pub fn Run(self, content: impl FnMut() + 'static) -> ! {
         run_app(self.options, content)
+    }
+
+    #[doc(hidden)]
+    pub fn new() -> Self {
+        Self::New()
+    }
+
+    #[doc(hidden)]
+    pub fn title(self, title: impl Into<String>) -> Self {
+        self.Title(title)
+    }
+
+    #[doc(hidden)]
+    pub fn size(self, width: u32, height: u32) -> Self {
+        self.Size(width, height)
+    }
+
+    #[doc(hidden)]
+    pub fn run(self, content: impl FnMut() + 'static) -> ! {
+        self.Run(content)
     }
 }
 
@@ -65,51 +89,84 @@ impl Default for ComposeAppOptions {
 
 impl ComposeAppOptions {
     /// Sets the title used for the application window.
-    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+    #[allow(non_snake_case)]
+    pub fn WithTitle(mut self, title: impl Into<String>) -> Self {
         self.title = title.into();
         self
     }
 
     /// Sets the initial window size in logical pixels.
-    pub fn with_size(mut self, width: u32, height: u32) -> Self {
+    #[allow(non_snake_case)]
+    pub fn WithSize(mut self, width: u32, height: u32) -> Self {
         self.initial_size = (width, height);
         self
+    }
+
+    #[doc(hidden)]
+    pub fn with_title(self, title: impl Into<String>) -> Self {
+        self.WithTitle(title)
+    }
+
+    #[doc(hidden)]
+    pub fn with_size(self, width: u32, height: u32) -> Self {
+        self.WithSize(width, height)
     }
 }
 
 /// Launches a Compose application using the default options.
-pub fn compose_app(content: impl FnMut() + 'static) -> ! {
-    ComposeAppBuilder::default().run(content)
+#[allow(non_snake_case)]
+pub fn ComposeApp(content: impl FnMut() + 'static) -> ! {
+    ComposeAppBuilder::New().Run(content)
 }
 
 /// Launches a Compose application using the provided options.
-pub fn compose_app_with_options(options: ComposeAppOptions, content: impl FnMut() + 'static) -> ! {
+#[allow(non_snake_case)]
+pub fn ComposeAppWithOptions(options: ComposeAppOptions, content: impl FnMut() + 'static) -> ! {
     run_app(options, content)
 }
 
 /// Alias with Kotlin-inspired casing for use in DSL-like code.
 #[allow(non_snake_case)]
+#[doc(hidden)]
 pub fn composeApp(content: impl FnMut() + 'static) -> ! {
-    compose_app(content)
+    ComposeApp(content)
 }
 
-/// Macro helper that allows calling [`compose_app`] using a block without a closure wrapper.
+#[doc(hidden)]
+pub fn compose_app(content: impl FnMut() + 'static) -> ! {
+    ComposeApp(content)
+}
+
+#[doc(hidden)]
+pub fn compose_app_with_options(options: ComposeAppOptions, content: impl FnMut() + 'static) -> ! {
+    ComposeAppWithOptions(options, content)
+}
+
+/// Macro helper that allows calling [`ComposeApp`] using a block without a closure wrapper.
 #[macro_export]
-macro_rules! composeApp {
+macro_rules! ComposeApp {
     (options: $options:expr, { $($body:tt)* }) => {
-        $crate::compose_app_with_options($options, || { $($body)* })
+        $crate::ComposeAppWithOptions($options, || { $($body)* })
     };
     (options: $options:expr, $body:block) => {
-        $crate::compose_app_with_options($options, || $body)
+        $crate::ComposeAppWithOptions($options, || $body)
     };
     ({ $($body:tt)* }) => {
-        $crate::compose_app(|| { $($body)* })
+        $crate::ComposeApp(|| { $($body)* })
     };
     ($body:block) => {
-        $crate::compose_app(|| $body)
+        $crate::ComposeApp(|| $body)
     };
     ($($body:tt)*) => {
-        $crate::compose_app(|| { $($body)* })
+        $crate::ComposeApp(|| { $($body)* })
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! composeApp {
+    ($($body:tt)*) => {
+        $crate::ComposeApp!($($body)*)
     };
 }
 
@@ -118,7 +175,7 @@ fn run_app(options: ComposeAppOptions, content: impl FnMut() + 'static) -> ! {
 }
 
 fn run_pixels_app(options: &ComposeAppOptions, content: impl FnMut() + 'static) -> ! {
-    let event_loop = EventLoopBuilder::<()>::with_user_event().build();
+    let event_loop = EventLoopBuilder::new().build();
     let frame_proxy = event_loop.create_proxy();
 
     let initial_width = options.initial_size.0;
@@ -135,7 +192,7 @@ fn run_pixels_app(options: &ComposeAppOptions, content: impl FnMut() + 'static) 
 
     let size = window.inner_size();
     let surface_texture = SurfaceTexture::new(size.width, size.height, &window);
-    let mut pixels = Pixels::new(size.width, size.height, surface_texture)
+    let mut pixels = Pixels::new(initial_width, initial_height, surface_texture)
         .expect("failed to create pixel buffer");
 
     let renderer = PixelsRenderer::new();
@@ -150,7 +207,7 @@ fn run_pixels_app(options: &ComposeAppOptions, content: impl FnMut() + 'static) 
         }
     });
 
-    app.set_buffer_size(size.width, size.height);
+    app.set_buffer_size(initial_width, initial_height);
     app.set_viewport(size.width as f32, size.height as f32);
 
     event_loop.run(move |event, _, control_flow| {

--- a/crates/compose-app/src/lib.rs
+++ b/crates/compose-app/src/lib.rs
@@ -198,7 +198,11 @@ fn run_pixels_app(options: &ComposeAppOptions, content: impl FnMut() + 'static) 
     let renderer = PixelsRenderer::new();
     let mut app = AppShell::new(renderer, default_root_key(), content);
     let mut platform = DesktopWinitPlatform::default();
-    platform.set_scale_factor(window.scale_factor());
+    // Defer updating the platform scale factor until winit notifies us of a
+    // change. Using the window's current scale factor here causes pointer
+    // coordinates to be scaled twice on high-DPI setups, which breaks
+    // hit-testing. The `ScaleFactorChanged` event below keeps the platform in
+    // sync instead.
 
     app.set_frame_waker({
         let proxy = frame_proxy.clone();

--- a/crates/compose-app/src/lib.rs
+++ b/crates/compose-app/src/lib.rs
@@ -1,0 +1,245 @@
+#![deny(missing_docs)]
+
+//! High level utilities for running Compose applications with minimal boilerplate.
+
+#[cfg(not(feature = "desktop"))]
+compile_error!("compose-app must be built with the `desktop` feature enabled.");
+
+#[cfg(not(feature = "renderer-pixels"))]
+compile_error!("compose-app currently requires the `renderer-pixels` feature.");
+
+use compose_app_shell::{default_root_key, AppShell};
+use compose_platform_desktop_winit::DesktopWinitPlatform;
+use compose_render_pixels::{draw_scene, PixelsRenderer};
+use pixels::{Pixels, SurfaceTexture};
+use winit::dpi::LogicalSize;
+use winit::event::{ElementState, Event, MouseButton, VirtualKeyCode, WindowEvent};
+use winit::event_loop::{ControlFlow, EventLoopBuilder};
+use winit::window::WindowBuilder;
+
+/// Builder used to configure and launch a Compose application.
+#[derive(Debug, Clone, Default)]
+pub struct ComposeAppBuilder {
+    options: ComposeAppOptions,
+}
+
+impl ComposeAppBuilder {
+    /// Creates a new builder with default configuration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the window title for the application.
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.options.title = title.into();
+        self
+    }
+
+    /// Sets the initial logical size of the application window.
+    pub fn size(mut self, width: u32, height: u32) -> Self {
+        self.options.initial_size = (width, height);
+        self
+    }
+
+    /// Runs the application using the configured options and provided Compose content.
+    pub fn run(self, content: impl FnMut() + 'static) -> ! {
+        run_app(self.options, content)
+    }
+}
+
+/// Options used to configure the Compose application window.
+#[derive(Debug, Clone)]
+pub struct ComposeAppOptions {
+    title: String,
+    initial_size: (u32, u32),
+}
+
+impl Default for ComposeAppOptions {
+    fn default() -> Self {
+        Self {
+            title: "Compose App".to_string(),
+            initial_size: (800, 600),
+        }
+    }
+}
+
+impl ComposeAppOptions {
+    /// Sets the title used for the application window.
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = title.into();
+        self
+    }
+
+    /// Sets the initial window size in logical pixels.
+    pub fn with_size(mut self, width: u32, height: u32) -> Self {
+        self.initial_size = (width, height);
+        self
+    }
+}
+
+/// Launches a Compose application using the default options.
+pub fn compose_app(content: impl FnMut() + 'static) -> ! {
+    ComposeAppBuilder::default().run(content)
+}
+
+/// Launches a Compose application using the provided options.
+pub fn compose_app_with_options(options: ComposeAppOptions, content: impl FnMut() + 'static) -> ! {
+    run_app(options, content)
+}
+
+/// Alias with Kotlin-inspired casing for use in DSL-like code.
+#[allow(non_snake_case)]
+pub fn composeApp(content: impl FnMut() + 'static) -> ! {
+    compose_app(content)
+}
+
+/// Macro helper that allows calling [`compose_app`] using a block without a closure wrapper.
+#[macro_export]
+macro_rules! composeApp {
+    (options: $options:expr, { $($body:tt)* }) => {
+        $crate::compose_app_with_options($options, || { $($body)* })
+    };
+    (options: $options:expr, $body:block) => {
+        $crate::compose_app_with_options($options, || $body)
+    };
+    ({ $($body:tt)* }) => {
+        $crate::compose_app(|| { $($body)* })
+    };
+    ($body:block) => {
+        $crate::compose_app(|| $body)
+    };
+    ($($body:tt)*) => {
+        $crate::compose_app(|| { $($body)* })
+    };
+}
+
+fn run_app(options: ComposeAppOptions, content: impl FnMut() + 'static) -> ! {
+    run_pixels_app(&options, content)
+}
+
+fn run_pixels_app(options: &ComposeAppOptions, content: impl FnMut() + 'static) -> ! {
+    let event_loop = EventLoopBuilder::<()>::with_user_event().build();
+    let frame_proxy = event_loop.create_proxy();
+
+    let initial_width = options.initial_size.0;
+    let initial_height = options.initial_size.1;
+
+    let window = WindowBuilder::new()
+        .with_title(options.title.clone())
+        .with_inner_size(LogicalSize::new(
+            initial_width as f64,
+            initial_height as f64,
+        ))
+        .build(&event_loop)
+        .expect("failed to create window");
+
+    let size = window.inner_size();
+    let surface_texture = SurfaceTexture::new(size.width, size.height, &window);
+    let mut pixels = Pixels::new(size.width, size.height, surface_texture)
+        .expect("failed to create pixel buffer");
+
+    let renderer = PixelsRenderer::new();
+    let mut app = AppShell::new(renderer, default_root_key(), content);
+    let mut platform = DesktopWinitPlatform::default();
+    platform.set_scale_factor(window.scale_factor());
+
+    app.set_frame_waker({
+        let proxy = frame_proxy.clone();
+        move || {
+            let _ = proxy.send_event(());
+        }
+    });
+
+    app.set_buffer_size(size.width, size.height);
+    app.set_viewport(size.width as f32, size.height as f32);
+
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+        match event {
+            Event::WindowEvent { event, .. } => match event {
+                WindowEvent::CloseRequested => {
+                    *control_flow = ControlFlow::Exit;
+                }
+                WindowEvent::Resized(new_size) => {
+                    if let Err(err) = pixels.resize_surface(new_size.width, new_size.height) {
+                        log::error!("failed to resize surface: {err}");
+                        *control_flow = ControlFlow::Exit;
+                        return;
+                    }
+                    if let Err(err) = pixels.resize_buffer(new_size.width, new_size.height) {
+                        log::error!("failed to resize buffer: {err}");
+                        *control_flow = ControlFlow::Exit;
+                        return;
+                    }
+                    app.set_buffer_size(new_size.width, new_size.height);
+                    app.set_viewport(new_size.width as f32, new_size.height as f32);
+                }
+                WindowEvent::ScaleFactorChanged {
+                    scale_factor,
+                    new_inner_size,
+                    ..
+                } => {
+                    platform.set_scale_factor(scale_factor);
+                    if let Err(err) =
+                        pixels.resize_surface(new_inner_size.width, new_inner_size.height)
+                    {
+                        log::error!("failed to resize surface: {err}");
+                        *control_flow = ControlFlow::Exit;
+                        return;
+                    }
+                    if let Err(err) =
+                        pixels.resize_buffer(new_inner_size.width, new_inner_size.height)
+                    {
+                        log::error!("failed to resize buffer: {err}");
+                        *control_flow = ControlFlow::Exit;
+                        return;
+                    }
+                    app.set_buffer_size(new_inner_size.width, new_inner_size.height);
+                    app.set_viewport(new_inner_size.width as f32, new_inner_size.height as f32);
+                }
+                WindowEvent::CursorMoved { position, .. } => {
+                    let logical = platform.pointer_position(position);
+                    app.set_cursor(logical.x, logical.y);
+                    if app.should_render() {
+                        app.update();
+                        window.request_redraw();
+                    }
+                }
+                WindowEvent::MouseInput {
+                    state,
+                    button: MouseButton::Left,
+                    ..
+                } => match state {
+                    ElementState::Pressed => app.pointer_pressed(),
+                    ElementState::Released => app.pointer_released(),
+                },
+                WindowEvent::KeyboardInput { input, .. } => {
+                    if let Some(keycode) = input.virtual_keycode {
+                        if input.state == ElementState::Pressed && keycode == VirtualKeyCode::D {
+                            app.log_debug_info();
+                        }
+                    }
+                }
+                _ => {}
+            },
+            Event::MainEventsCleared | Event::RedrawEventsCleared | Event::UserEvent(()) => {
+                if app.should_render() {
+                    window.request_redraw();
+                    *control_flow = ControlFlow::Poll;
+                }
+            }
+            Event::RedrawRequested(_) => {
+                app.update();
+
+                let frame = pixels.frame_mut();
+                let (buffer_width, buffer_height) = app.buffer_size();
+                draw_scene(frame, buffer_width, buffer_height, app.scene());
+                if let Err(err) = pixels.render() {
+                    log::error!("pixels render failed: {err}");
+                    *control_flow = ControlFlow::Exit;
+                }
+            }
+            _ => {}
+        }
+    });
+}


### PR DESCRIPTION
## Summary
- add a new `compose-app` crate that wraps the winit/pixels event loop behind a builder, options, and `composeApp!` macro for running Compose content
- switch the desktop demo to depend on the new crate and launch the UI via `composeApp!`

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68f716fbb5788328a259b4989128e00a