### PR TITLE
Preserve subcomposition state during measure

### DIFF
--- a/crates/compose-ui/src/layout/mod.rs
+++ b/crates/compose-ui/src/layout/mod.rs
@@ -215,15 +215,16 @@ impl<'a> LayoutBuilder<'a> {
         let inner_constraints = normalize_constraints(subtract_padding(constraints, padding));
 
         self.slots.reset();
-        let mut composer = Composer::new(
+        let mut outer = Composer::new(
             &mut self.slots,
             unsafe { &mut *self.applier },
             runtime_handle,
             Some(node_id),
         );
-        composer.enter_phase(Phase::Measure);
+        outer.enter_phase(Phase::Measure);
 
-        let measure_result = unsafe { (&mut *node_ptr).measure(&mut composer, inner_constraints) };
+        let measure_result =
+            unsafe { (&mut *node_ptr).measure(&mut outer, node_id, inner_constraints)? };
 
         let node_ids: Vec<NodeId> = measure_result
             .placements

--- a/crates/compose-ui/src/tests/primitives_tests.rs
+++ b/crates/compose-ui/src/tests/primitives_tests.rs
@@ -77,7 +77,8 @@ fn measure_subcompose_node(
                 let applier_ref: &mut MemoryApplier = &mut *applier_ptr;
                 let mut composer = Composer::new(slots, applier_ref, handle.clone(), Some(root));
                 composer.enter_phase(Phase::Measure);
-                node.measure(&mut composer, constraints);
+                node.measure(&mut composer, root, constraints)
+                    .expect("measure subcompose node");
             })
             .expect("node available");
     }


### PR DESCRIPTION
## Summary
- add a Composer::subcompose_in helper that reuses runtime state for nested compositions and flushes side effects
- store persistent SlotTables on SubcomposeLayoutNode and use the new helper when measuring subcompositions
- update LayoutBuilder and subcompose tests to pass node identifiers and handle the Result-returning measure API

## Testing
- cargo clippy --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68f736d82b68832892980c3f035128d9