### PR TITLE
Support persistent subcomposition slots

### DIFF
--- a/crates/compose-ui/src/subcompose_layout.rs
+++ b/crates/compose-ui/src/subcompose_layout.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use compose_core::{Composer, NodeId, Phase, SlotId, SubcomposeState};
+use compose_core::{Composer, NodeError, NodeId, Phase, SlotId, SlotTable, SubcomposeState};
 use indexmap::IndexSet;
 
 use crate::modifier::{Modifier, Size};
@@ -101,6 +101,7 @@ pub struct SubcomposeLayoutNode {
     state: SubcomposeState,
     measure_policy: Rc<MeasurePolicy>,
     children: IndexSet<NodeId>,
+    slots: SlotTable,
 }
 
 impl SubcomposeLayoutNode {
@@ -112,6 +113,7 @@ impl SubcomposeLayoutNode {
             state: SubcomposeState::default(),
             measure_policy,
             children: IndexSet::new(),
+            slots: SlotTable::new(),
         };
         node.set_modifier(modifier);
         node
@@ -138,23 +140,24 @@ impl SubcomposeLayoutNode {
     pub fn measure<'a>(
         &'a mut self,
         composer: &'a mut Composer<'a>,
+        node_id: NodeId,
         constraints: Constraints,
-    ) -> MeasureResult {
+    ) -> Result<MeasureResult, NodeError> {
         let previous = composer.phase();
         if !matches!(previous, Phase::Measure | Phase::Layout) {
             composer.enter_phase(Phase::Measure);
         }
-        let state_ptr = &mut self.state as *mut _;
-        let composer_ptr = composer as *mut _;
-        let result = {
+        let result = composer.subcompose_in(&mut self.slots, Some(node_id), |inner| {
+            let state_ptr = &mut self.state as *mut _;
+            let composer_ptr = inner as *mut _;
             let mut scope = SubcomposeMeasureScopeImpl::new(composer_ptr, state_ptr, constraints);
             (self.measure_policy)(&mut scope, constraints)
-        };
+        })?;
         self.state.dispose_or_reuse_starting_from_index(0);
         if previous != composer.phase() {
             composer.enter_phase(previous);
         }
-        result
+        Ok(result)
     }
 
     pub fn set_active_children<I>(&mut self, children: I)

--- a/crates/compose-ui/src/tests/primitives_tests.rs
+++ b/crates/compose-ui/src/tests/primitives_tests.rs
@@ -77,7 +77,8 @@ fn measure_subcompose_node(
                 let applier_ref: &mut MemoryApplier = &mut *applier_ptr;
                 let mut composer = Composer::new(slots, applier_ref, handle.clone(), Some(root));
                 composer.enter_phase(Phase::Measure);
-                node.measure(&mut composer, constraints);
+                node.measure(&mut composer, root, constraints)
+                    .expect("measure succeeds");
             })
             .expect("node available");
     }


### PR DESCRIPTION
## Summary
- add a `Composer::subcompose_in` helper that preserves applier/runtime context, locals, and phase while applying commands, updates, and side effects
- give each `SubcomposeLayoutNode` a persistent `SlotTable` and route measure-time subcomposition through the new helper
- update the layout builder and tests to operate on the persistent subcomposition slots and handle the new measure signature

## Testing
- cargo test *(fails: primitives::tests::desktop_counter_layout_respects_container_bounds – pre-existing)*


------
https://chatgpt.com/codex/tasks/task_e_68f736ed67188328832a662a2781b29a