### PR TITLE
Support per-child alignment overrides in columns

### DIFF
--- a/crates/compose-ui-layout/src/core.rs
+++ b/crates/compose-ui-layout/src/core.rs
@@ -1,5 +1,6 @@
 //! Core layout traits and types shared by Compose UI widgets.
 
+use crate::alignment::HorizontalAlignment;
 use crate::constraints::Constraints;
 use compose_core::NodeId;
 use compose_ui_graphics::Size;
@@ -35,6 +36,16 @@ pub trait Placeable {
 
     /// Returns the identifier for the underlying layout node.
     fn node_id(&self) -> NodeId;
+
+    /// Returns a per-child horizontal alignment override when placed in a column layout.
+    ///
+    /// Layout primitives such as Compose UI's `Column` honour the parent's
+    /// [`HorizontalAlignment`] by default. Children can override this behaviour via
+    /// modifier data (e.g. `Modifier::alignInColumn`). When present the override is used
+    /// instead of the parent's alignment during placement.
+    fn column_alignment_override(&self) -> Option<HorizontalAlignment> {
+        None
+    }
 }
 
 /// Scope for measurement operations.

--- a/crates/compose-ui/src/layout/mod.rs
+++ b/crates/compose-ui/src/layout/mod.rs
@@ -395,6 +395,7 @@ impl<'a> LayoutBuilder<'a> {
             Rc::new(ColumnMeasurePolicy::new(
                 LinearArrangement::Start,
                 HorizontalAlignment::Start,
+                node.modifier.layout_properties(),
             )),
         );
         layout.children = node.children.clone();
@@ -613,6 +614,17 @@ impl Placeable for LayoutChildPlaceable {
 
     fn node_id(&self) -> NodeId {
         self.node_id
+    }
+
+    fn column_alignment_override(&self) -> Option<HorizontalAlignment> {
+        self.measured.borrow().as_ref().and_then(|node| {
+            let modifier = &node.data.modifier;
+            modifier.column_alignment().or_else(|| {
+                modifier
+                    .box_alignment()
+                    .map(|alignment| alignment.horizontal)
+            })
+        })
     }
 }
 
@@ -860,7 +872,7 @@ fn resolve_dimension_with_intrinsics(
     size.max(0.0)
 }
 
-fn resolve_dimension(
+pub(super) fn resolve_dimension(
     base: f32,
     explicit: DimensionConstraint,
     min_override: Option<f32>,

--- a/crates/compose-ui/src/layout/tests/policies_tests.rs
+++ b/crates/compose-ui/src/layout/tests/policies_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::layout::core::Placeable;
+use crate::modifier::LayoutProperties;
 
 struct MockMeasurable {
     width: f32,
@@ -87,7 +88,11 @@ fn box_measure_policy_takes_max_size() {
 
 #[test]
 fn column_measure_policy_sums_heights() {
-    let policy = ColumnMeasurePolicy::new(LinearArrangement::Start, HorizontalAlignment::Start);
+    let policy = ColumnMeasurePolicy::new(
+        LinearArrangement::Start,
+        HorizontalAlignment::Start,
+        LayoutProperties::default(),
+    );
     let measurables: Vec<Box<dyn Measurable>> = vec![
         Box::new(MockMeasurable::new(40.0, 20.0, 1)),
         Box::new(MockMeasurable::new(60.0, 30.0, 2)),

--- a/crates/compose-ui/src/widgets/column.rs
+++ b/crates/compose-ui/src/widgets/column.rs
@@ -46,6 +46,11 @@ pub fn Column<F>(modifier: Modifier, spec: ColumnSpec, content: F) -> NodeId
 where
     F: FnMut() + 'static,
 {
-    let policy = ColumnMeasurePolicy::new(spec.vertical_arrangement, spec.horizontal_alignment);
+    let layout_properties = modifier.layout_properties();
+    let policy = ColumnMeasurePolicy::new(
+        spec.vertical_arrangement,
+        spec.horizontal_alignment,
+        layout_properties,
+    );
     Layout(modifier, policy, content)
 }


### PR DESCRIPTION
## Summary
- pass layout properties to `ColumnMeasurePolicy` so padding and explicit width constraints influence horizontal placement
- allow `Placeable` implementations to expose per-child column alignment overrides and wire the data through layout measurement
- add a dedicated column alignment test and resize the desktop counter fixture to keep content within the container

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test -p compose-ui

------
https://chatgpt.com/codex/tasks/task_e_68f7d1e71e8c8328a0f6b6f2a34e687e