### PR TITLE
Clip pixel renderer output to parent bounds

### DIFF
--- a/crates/compose-render/pixels/src/scene.rs
+++ b/crates/compose-render/pixels/src/scene.rs
@@ -50,7 +50,7 @@ pub struct HitRegion {
     pub click_actions: Vec<ClickAction>,
     pub pointer_inputs: Vec<Rc<dyn Fn(PointerEvent)>>,
     pub z_index: usize,
-    pub clip: Option<Rect>,
+    pub hit_clip: Option<Rect>,
 }
 
 impl HitTestTarget for HitRegion {
@@ -103,7 +103,7 @@ impl HitTestTarget for HitRegion {
 
 impl HitRegion {
     pub fn contains(&self, x: f32, y: f32) -> bool {
-        if let Some(clip) = self.clip {
+        if let Some(clip) = self.hit_clip {
             if !clip.contains(x, y) {
                 return false;
             }
@@ -177,7 +177,7 @@ impl Scene {
         shape: Option<RoundedCornerShape>,
         click_actions: Vec<ClickAction>,
         pointer_inputs: Vec<Rc<dyn Fn(PointerEvent)>>,
-        clip: Option<Rect>,
+        hit_clip: Option<Rect>,
     ) {
         if click_actions.is_empty() && pointer_inputs.is_empty() {
             return;
@@ -190,7 +190,7 @@ impl Scene {
             click_actions,
             pointer_inputs,
             z_index,
-            clip,
+            hit_clip,
         });
     }
 }

--- a/crates/compose-render/pixels/src/scene.rs
+++ b/crates/compose-render/pixels/src/scene.rs
@@ -12,6 +12,7 @@ pub struct DrawShape {
     pub brush: Brush,
     pub shape: Option<RoundedCornerShape>,
     pub z_index: usize,
+    pub clip: Option<Rect>,
 }
 
 #[derive(Clone)]
@@ -21,6 +22,7 @@ pub struct TextDraw {
     pub color: Color,
     pub scale: f32,
     pub z_index: usize,
+    pub clip: Option<Rect>,
 }
 
 #[derive(Clone)]
@@ -48,6 +50,7 @@ pub struct HitRegion {
     pub click_actions: Vec<ClickAction>,
     pub pointer_inputs: Vec<Rc<dyn Fn(PointerEvent)>>,
     pub z_index: usize,
+    pub clip: Option<Rect>,
 }
 
 impl HitTestTarget for HitRegion {
@@ -100,6 +103,11 @@ impl HitTestTarget for HitRegion {
 
 impl HitRegion {
     pub fn contains(&self, x: f32, y: f32) -> bool {
+        if let Some(clip) = self.clip {
+            if !clip.contains(x, y) {
+                return false;
+            }
+        }
         if let Some(shape) = self.shape {
             super::style::point_in_rounded_rect(x, y, self.rect, shape)
         } else {
@@ -125,7 +133,13 @@ impl Scene {
         }
     }
 
-    pub fn push_shape(&mut self, rect: Rect, brush: Brush, shape: Option<RoundedCornerShape>) {
+    pub fn push_shape(
+        &mut self,
+        rect: Rect,
+        brush: Brush,
+        shape: Option<RoundedCornerShape>,
+        clip: Option<Rect>,
+    ) {
         let z_index = self.next_z;
         self.next_z += 1;
         self.shapes.push(DrawShape {
@@ -133,10 +147,18 @@ impl Scene {
             brush,
             shape,
             z_index,
+            clip,
         });
     }
 
-    pub fn push_text(&mut self, rect: Rect, text: String, color: Color, scale: f32) {
+    pub fn push_text(
+        &mut self,
+        rect: Rect,
+        text: String,
+        color: Color,
+        scale: f32,
+        clip: Option<Rect>,
+    ) {
         let z_index = self.next_z;
         self.next_z += 1;
         self.texts.push(TextDraw {
@@ -145,6 +167,7 @@ impl Scene {
             color,
             scale,
             z_index,
+            clip,
         });
     }
 
@@ -154,6 +177,7 @@ impl Scene {
         shape: Option<RoundedCornerShape>,
         click_actions: Vec<ClickAction>,
         pointer_inputs: Vec<Rc<dyn Fn(PointerEvent)>>,
+        clip: Option<Rect>,
     ) {
         if click_actions.is_empty() && pointer_inputs.is_empty() {
             return;
@@ -166,6 +190,7 @@ impl Scene {
             click_actions,
             pointer_inputs,
             z_index,
+            clip,
         });
     }
 }

--- a/crates/compose-render/pixels/src/style.rs
+++ b/crates/compose-render/pixels/src/style.rs
@@ -16,6 +16,7 @@ pub(crate) struct NodeStyle {
     pub pointer_inputs: Vec<Rc<dyn Fn(PointerEvent)>>,
     pub draw_commands: Vec<DrawCommand>,
     pub graphics_layer: Option<GraphicsLayer>,
+    pub clip_to_bounds: bool,
 }
 
 impl NodeStyle {
@@ -28,6 +29,7 @@ impl NodeStyle {
             pointer_inputs: modifier.pointer_inputs(),
             draw_commands: modifier.draw_commands(),
             graphics_layer: modifier.graphics_layer_values(),
+            clip_to_bounds: modifier.clips_to_bounds(),
         }
     }
 }

--- a/crates/compose-render/pixels/src/style.rs
+++ b/crates/compose-render/pixels/src/style.rs
@@ -119,6 +119,7 @@ pub(crate) fn apply_draw_commands(
     origin: (f32, f32),
     size: Size,
     layer: GraphicsLayer,
+    clip: Option<Rect>,
     scene: &mut Scene,
 ) {
     for command in commands {
@@ -136,7 +137,7 @@ pub(crate) fn apply_draw_commands(
                     let draw_rect = local_rect.translate(rect.x, rect.y);
                     let transformed = apply_layer_to_rect(draw_rect, origin, layer);
                     let brush = apply_layer_to_brush(brush, layer);
-                    scene.push_shape(transformed, brush, None);
+                    scene.push_shape(transformed, brush, None, clip);
                 }
                 DrawPrimitive::RoundRect {
                     rect: local_rect,
@@ -148,7 +149,7 @@ pub(crate) fn apply_draw_commands(
                     let scaled_radii = scale_corner_radii(radii, layer.scale);
                     let shape = RoundedCornerShape::with_radii(scaled_radii);
                     let brush = apply_layer_to_brush(brush, layer);
-                    scene.push_shape(transformed, brush, Some(shape));
+                    scene.push_shape(transformed, brush, Some(shape), clip);
                 }
             }
         }

--- a/crates/compose-ui/src/modifier/mod.rs
+++ b/crates/compose-ui/src/modifier/mod.rs
@@ -173,6 +173,12 @@ impl Modifier {
         self.then(Self::weight_with_fill(weight, fill))
     }
 
+    pub fn clip_to_bounds() -> Self {
+        Self::with_state(|state| {
+            state.clip_to_bounds = true;
+        })
+    }
+
     pub fn then(&self, next: Modifier) -> Modifier {
         if self.elements.is_empty() && self.state.is_default() {
             return next;
@@ -259,6 +265,10 @@ impl Modifier {
         self.state.graphics_layer
     }
 
+    pub fn clips_to_bounds(&self) -> bool {
+        self.state.clip_to_bounds
+    }
+
     fn with_element<E, F>(element: E, update: F) -> Self
     where
         E: ModifierElement,
@@ -309,6 +319,7 @@ struct ModifierState {
     click_handler: Option<Rc<dyn Fn(Point)>>,
     pointer_inputs: Vec<Rc<dyn Fn(PointerEvent)>>,
     graphics_layer: Option<GraphicsLayer>,
+    clip_to_bounds: bool,
 }
 
 impl ModifierState {
@@ -341,6 +352,9 @@ impl ModifierState {
         if let Some(layer) = other.graphics_layer {
             self.graphics_layer = Some(layer);
         }
+        if other.clip_to_bounds {
+            self.clip_to_bounds = true;
+        }
         self.draw_commands
             .extend(other.draw_commands.iter().cloned());
         self.pointer_inputs
@@ -354,6 +368,7 @@ impl ModifierState {
             && self.corner_shape.is_none()
             && self.click_handler.is_none()
             && self.graphics_layer.is_none()
+            && !self.clip_to_bounds
             && self.draw_commands.is_empty()
             && self.pointer_inputs.is_empty()
     }
@@ -370,6 +385,7 @@ impl Default for ModifierState {
             click_handler: None,
             pointer_inputs: Vec::new(),
             graphics_layer: None,
+            clip_to_bounds: false,
         }
     }
 }


### PR DESCRIPTION
## Summary
- propagate clip rectangles through the pixels pipeline so layouts, draw commands, and hit regions inherit parent bounds
- update the scene and renderer to store clip data and restrict shape/text rasterization to the clipped area

## Testing
- cargo test -p compose-render-pixels


------
https://chatgpt.com/codex/tasks/task_e_68f7da6007948328bc3408758ec1e97c