### PR TITLE
Add pipeline benchmark suite

### DIFF
--- a/crates/compose-ui/Cargo.toml
+++ b/crates/compose-ui/Cargo.toml
@@ -20,3 +20,7 @@ default = []
 [dev-dependencies]
 criterion = "0.5"
 compose-testing = { path = "../compose-testing" }
+
+[[bench]]
+name = "pipeline"
+harness = false

--- a/crates/compose-ui/benches/pipeline.rs
+++ b/crates/compose-ui/benches/pipeline.rs
@@ -1,0 +1,149 @@
+use compose_core::{location_key, Composition, Key, MemoryApplier};
+use compose_ui::{
+    composable, measure_layout, Column, ColumnSpec, HeadlessRenderer, LayoutMeasurements, Modifier,
+    Row, RowSpec, Size, Text,
+};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+const SECTION_COUNT: usize = 4;
+const ROWS_PER_SECTION: usize = 32;
+const ROOT_SIZE: Size = Size {
+    width: 1080.0,
+    height: 1920.0,
+};
+
+#[composable]
+fn pipeline_content(sections: usize, rows_per_section: usize) {
+    Column(
+        Modifier::fill_max_size(),
+        ColumnSpec::default(),
+        move || {
+            for section in 0..sections {
+                Column(
+                    Modifier::fill_max_width(),
+                    ColumnSpec::default(),
+                    move || {
+                        Text(format!("Section {section}"), Modifier::empty());
+                        for row in 0..rows_per_section {
+                            Row(Modifier::fill_max_width(), RowSpec::default(), move || {
+                                Text(format!("Item {section}-{row} title"), Modifier::weight(1.0));
+                                Text(format!("Detail {section}-{row}"), Modifier::empty());
+                            });
+                        }
+                    },
+                );
+            }
+        },
+    );
+}
+
+struct PipelineFixture {
+    composition: Composition<MemoryApplier>,
+    key: Key,
+    sections: usize,
+    rows: usize,
+    root_size: Size,
+}
+
+impl PipelineFixture {
+    fn new(sections: usize, rows: usize, root_size: Size) -> Self {
+        let key = location_key(file!(), line!(), column!());
+        Self {
+            composition: Composition::new(MemoryApplier::new()),
+            key,
+            sections,
+            rows,
+            root_size,
+        }
+    }
+
+    fn compose(&mut self) {
+        let sections = self.sections;
+        let rows = self.rows;
+        self.composition
+            .render(self.key, || pipeline_content(sections, rows))
+            .expect("composition");
+    }
+
+    fn measure(&mut self) -> LayoutMeasurements {
+        let root = self.composition.root().expect("composition root");
+        measure_layout(self.composition.applier_mut(), root, self.root_size).expect("measure")
+    }
+}
+
+fn bench_composition(c: &mut Criterion) {
+    let mut fixture = PipelineFixture::new(SECTION_COUNT, ROWS_PER_SECTION, ROOT_SIZE);
+    // Warm up the composition so steady-state recomposition is measured.
+    fixture.compose();
+
+    c.bench_function("pipeline_composition", |b| {
+        b.iter(|| {
+            fixture.compose();
+        });
+    });
+}
+
+fn bench_measure(c: &mut Criterion) {
+    let mut fixture = PipelineFixture::new(SECTION_COUNT, ROWS_PER_SECTION, ROOT_SIZE);
+    fixture.compose();
+
+    c.bench_function("pipeline_measure", |b| {
+        b.iter(|| {
+            let measurements = fixture.measure();
+            black_box(measurements);
+        });
+    });
+}
+
+fn bench_layout(c: &mut Criterion) {
+    let mut fixture = PipelineFixture::new(SECTION_COUNT, ROWS_PER_SECTION, ROOT_SIZE);
+    fixture.compose();
+    let measurements = fixture.measure();
+
+    c.bench_function("pipeline_layout", |b| {
+        b.iter(|| {
+            let tree = measurements.layout_tree();
+            black_box(tree);
+        });
+    });
+}
+
+fn bench_render(c: &mut Criterion) {
+    let mut fixture = PipelineFixture::new(SECTION_COUNT, ROWS_PER_SECTION, ROOT_SIZE);
+    fixture.compose();
+    let measurements = fixture.measure();
+    let layout_tree = measurements.layout_tree();
+    let renderer = HeadlessRenderer::new();
+
+    c.bench_function("pipeline_render", |b| {
+        b.iter(|| {
+            let scene = renderer.render(&layout_tree);
+            black_box(scene);
+        });
+    });
+}
+
+fn bench_full_pipeline(c: &mut Criterion) {
+    let mut fixture = PipelineFixture::new(SECTION_COUNT, ROWS_PER_SECTION, ROOT_SIZE);
+    let renderer = HeadlessRenderer::new();
+
+    c.bench_function("pipeline_full", |b| {
+        b.iter(|| {
+            fixture.compose();
+            let measurements = fixture.measure();
+            let layout_tree = measurements.layout_tree();
+            let scene = renderer.render(&layout_tree);
+            black_box(scene);
+        });
+    });
+}
+
+criterion_group!(
+    pipeline,
+    bench_composition,
+    bench_measure,
+    bench_layout,
+    bench_render,
+    bench_full_pipeline
+);
+criterion_main!(pipeline);

--- a/crates/compose-ui/benches/pipeline.rs
+++ b/crates/compose-ui/benches/pipeline.rs
@@ -6,10 +6,11 @@ use compose_ui::{
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
 const SECTION_COUNT: usize = 4;
-const ROWS_PER_SECTION: usize = 32;
-const ROWS_PER_SECTION_SAMPLES: &[usize] = &[8, 16, 24, 32, 40, 48, 56, 64];
+const ROWS_PER_SECTION: usize = 64;
+const ROWS_PER_SECTION_SAMPLES: &[usize] = &[ROWS_PER_SECTION];
 const RECURSIVE_ROWS_PER_LEVEL: usize = 8;
-const RECURSIVE_DEPTH_SAMPLES: &[usize] = &[1, 2, 3, 4, 5, 6, 7, 8];
+const RECURSIVE_DEPTH: usize = 8;
+const RECURSIVE_DEPTH_SAMPLES: &[usize] = &[RECURSIVE_DEPTH];
 const ROOT_SIZE: Size = Size {
     width: 1080.0,
     height: 1920.0,

--- a/crates/compose-ui/src/lib.rs
+++ b/crates/compose-ui/src/lib.rs
@@ -23,7 +23,7 @@ pub use layout::{
         Alignment, Arrangement, HorizontalAlignment, LinearArrangement, Measurable, Placeable,
         VerticalAlignment,
     },
-    LayoutBox, LayoutEngine, LayoutNodeKind, LayoutTree,
+    measure_layout, LayoutBox, LayoutEngine, LayoutMeasurements, LayoutNodeKind, LayoutTree,
 };
 pub use modifier::{
     Brush, Color, CornerRadii, EdgeInsets, GraphicsLayer, Modifier, Point, PointerEvent,


### PR DESCRIPTION
## Summary
- expose a reusable `measure_layout` helper that returns `LayoutMeasurements` so the measure and layout passes can be timed independently
- add a Criterion-based `pipeline` benchmark covering composition, measure, layout, render, and end-to-end stages
- register the benchmark target in `compose-ui`'s manifest

## Testing
- `cargo bench -p compose-ui --bench pipeline`


------
https://chatgpt.com/codex/tasks/task_e_68fba76d6564832898a6eefcad5bea7b