### PR TITLE
Implement layout measurement caching

### DIFF
--- a/crates/compose-ui/src/widgets/nodes/layout_node.rs
+++ b/crates/compose-ui/src/widgets/nodes/layout_node.rs
@@ -28,6 +28,7 @@ struct IntrinsicCacheEntry {
 
 #[derive(Default)]
 struct NodeCacheState {
+    epoch: u64,
     measurements: Vec<MeasurementCacheEntry>,
     intrinsics: Vec<IntrinsicCacheEntry>,
 }
@@ -42,6 +43,16 @@ impl LayoutNodeCacheHandles {
         let mut state = self.state.borrow_mut();
         state.measurements.clear();
         state.intrinsics.clear();
+        state.epoch = 0;
+    }
+
+    pub(crate) fn activate(&self, epoch: u64) {
+        let mut state = self.state.borrow_mut();
+        if state.epoch != epoch {
+            state.measurements.clear();
+            state.intrinsics.clear();
+            state.epoch = epoch;
+        }
     }
 
     pub(crate) fn get_measurement(&self, constraints: Constraints) -> Option<MeasuredNode> {

--- a/crates/compose-ui/src/widgets/nodes/layout_node.rs
+++ b/crates/compose-ui/src/widgets/nodes/layout_node.rs
@@ -16,7 +16,7 @@ pub(crate) enum IntrinsicDimension {
 #[derive(Clone)]
 struct MeasurementCacheEntry {
     constraints: Constraints,
-    measured: MeasuredNode,
+    measured: Rc<MeasuredNode>,
 }
 
 #[derive(Clone)]
@@ -55,16 +55,16 @@ impl LayoutNodeCacheHandles {
         }
     }
 
-    pub(crate) fn get_measurement(&self, constraints: Constraints) -> Option<MeasuredNode> {
+    pub(crate) fn get_measurement(&self, constraints: Constraints) -> Option<Rc<MeasuredNode>> {
         let state = self.state.borrow();
         state
             .measurements
             .iter()
             .find(|entry| entry.constraints == constraints)
-            .map(|entry| entry.measured.clone())
+            .map(|entry| Rc::clone(&entry.measured))
     }
 
-    pub(crate) fn store_measurement(&self, constraints: Constraints, measured: MeasuredNode) {
+    pub(crate) fn store_measurement(&self, constraints: Constraints, measured: Rc<MeasuredNode>) {
         let mut state = self.state.borrow_mut();
         if let Some(entry) = state
             .measurements

--- a/crates/compose-ui/src/widgets/nodes/layout_node.rs
+++ b/crates/compose-ui/src/widgets/nodes/layout_node.rs
@@ -1,9 +1,109 @@
-use crate::modifier::Modifier;
+use crate::{layout::MeasuredNode, modifier::Modifier};
 use compose_core::{Node, NodeId};
 use compose_foundation::{BasicModifierNodeContext, ModifierNodeChain};
-use compose_ui_layout::MeasurePolicy;
+use compose_ui_layout::{Constraints, MeasurePolicy};
 use indexmap::IndexSet;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum IntrinsicDimension {
+    MinWidth,
+    MaxWidth,
+    MinHeight,
+    MaxHeight,
+}
+
+#[derive(Clone)]
+struct MeasurementCacheEntry {
+    constraints: Constraints,
+    measured: MeasuredNode,
+}
+
+#[derive(Clone)]
+struct IntrinsicCacheEntry {
+    dimension: IntrinsicDimension,
+    cross_axis: f32,
+    value: f32,
+}
+
+#[derive(Default)]
+struct NodeCacheState {
+    measurements: Vec<MeasurementCacheEntry>,
+    intrinsics: Vec<IntrinsicCacheEntry>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct LayoutNodeCacheHandles {
+    state: Rc<RefCell<NodeCacheState>>,
+}
+
+impl LayoutNodeCacheHandles {
+    pub(crate) fn clear(&self) {
+        let mut state = self.state.borrow_mut();
+        state.measurements.clear();
+        state.intrinsics.clear();
+    }
+
+    pub(crate) fn get_measurement(&self, constraints: Constraints) -> Option<MeasuredNode> {
+        let state = self.state.borrow();
+        state
+            .measurements
+            .iter()
+            .find(|entry| entry.constraints == constraints)
+            .map(|entry| entry.measured.clone())
+    }
+
+    pub(crate) fn store_measurement(&self, constraints: Constraints, measured: MeasuredNode) {
+        let mut state = self.state.borrow_mut();
+        if let Some(entry) = state
+            .measurements
+            .iter_mut()
+            .find(|entry| entry.constraints == constraints)
+        {
+            entry.measured = measured;
+        } else {
+            state.measurements.push(MeasurementCacheEntry {
+                constraints,
+                measured,
+            });
+        }
+    }
+
+    pub(crate) fn get_intrinsic(
+        &self,
+        dimension: IntrinsicDimension,
+        cross_axis: f32,
+    ) -> Option<f32> {
+        let state = self.state.borrow();
+        state
+            .intrinsics
+            .iter()
+            .find(|entry| entry.dimension == dimension && entry.cross_axis == cross_axis)
+            .map(|entry| entry.value)
+    }
+
+    pub(crate) fn store_intrinsic(
+        &self,
+        dimension: IntrinsicDimension,
+        cross_axis: f32,
+        value: f32,
+    ) {
+        let mut state = self.state.borrow_mut();
+        if let Some(entry) = state
+            .intrinsics
+            .iter_mut()
+            .find(|entry| entry.dimension == dimension && entry.cross_axis == cross_axis)
+        {
+            entry.value = value;
+        } else {
+            state.intrinsics.push(IntrinsicCacheEntry {
+                dimension,
+                cross_axis,
+                value,
+            });
+        }
+    }
+}
 
 pub struct LayoutNode {
     pub modifier: Modifier,
@@ -11,6 +111,7 @@ pub struct LayoutNode {
     modifier_context: BasicModifierNodeContext,
     pub measure_policy: Rc<dyn MeasurePolicy>,
     pub children: IndexSet<NodeId>,
+    cache: LayoutNodeCacheHandles,
 }
 
 impl LayoutNode {
@@ -21,6 +122,7 @@ impl LayoutNode {
             modifier_context: BasicModifierNodeContext::new(),
             measure_policy,
             children: IndexSet::new(),
+            cache: LayoutNodeCacheHandles::default(),
         };
         node.set_modifier(modifier);
         node
@@ -30,10 +132,16 @@ impl LayoutNode {
         self.modifier = modifier;
         self.mods
             .update_from_slice(self.modifier.elements(), &mut self.modifier_context);
+        self.cache.clear();
     }
 
     pub fn set_measure_policy(&mut self, policy: Rc<dyn MeasurePolicy>) {
         self.measure_policy = policy;
+        self.cache.clear();
+    }
+
+    pub(crate) fn cache_handles(&self) -> LayoutNodeCacheHandles {
+        self.cache.clone()
     }
 }
 
@@ -45,6 +153,7 @@ impl Clone for LayoutNode {
             modifier_context: BasicModifierNodeContext::new(),
             measure_policy: self.measure_policy.clone(),
             children: self.children.clone(),
+            cache: self.cache.clone(),
         }
     }
 }
@@ -52,10 +161,12 @@ impl Clone for LayoutNode {
 impl Node for LayoutNode {
     fn insert_child(&mut self, child: NodeId) {
         self.children.insert(child);
+        self.cache.clear();
     }
 
     fn remove_child(&mut self, child: NodeId) {
         self.children.shift_remove(&child);
+        self.cache.clear();
     }
 
     fn move_child(&mut self, from: usize, to: usize) {
@@ -70,6 +181,7 @@ impl Node for LayoutNode {
         for id in ordered {
             self.children.insert(id);
         }
+        self.cache.clear();
     }
 
     fn update_children(&mut self, children: &[NodeId]) {
@@ -77,6 +189,7 @@ impl Node for LayoutNode {
         for &child in children {
             self.children.insert(child);
         }
+        self.cache.clear();
     }
 
     fn children(&self) -> Vec<NodeId> {

--- a/crates/compose-ui/src/widgets/nodes/mod.rs
+++ b/crates/compose-ui/src/widgets/nodes/mod.rs
@@ -7,6 +7,7 @@ mod text_node;
 
 pub use button_node::ButtonNode;
 pub use layout_node::LayoutNode;
+pub(crate) use layout_node::{IntrinsicDimension, LayoutNodeCacheHandles};
 pub use spacer_node::SpacerNode;
 pub use text_node::TextNode;
 


### PR DESCRIPTION
## Summary
- add per-node measurement and intrinsic caches so layout nodes can reuse results across repeated passes
- update layout measurement plumbing to consult the caches before re-measuring children and to memoize intrinsic lookups
- expose cache handles through the widget node module for internal reuse

## Testing
- cargo clippy --all-targets --all-features
- cargo test -p compose-ui

------
https://chatgpt.com/codex/tasks/task_e_68fc973765bc832890a664a8d3a77741