### PR TITLE
Refactor layout placeables to value type

### DIFF
--- a/crates/compose-ui/src/layout/mod.rs
+++ b/crates/compose-ui/src/layout/mod.rs
@@ -354,13 +354,17 @@ impl<'a> LayoutBuilder<'a> {
         let mut measurables: Vec<Box<dyn Measurable>> = Vec::new();
 
         for child_id in node.children.iter().copied() {
-            let state = self
+            let state = match self
                 .applier_mut()
                 .with_node(node_id, |layout: &mut LayoutNode| {
                     layout.ensure_child_state(child_id)
-                })?;
+                }) {
+                Ok(state) => state,
+                Err(NodeError::TypeMismatch { .. }) => ChildLayoutState::new(),
+                Err(err) => return Err(err),
+            };
             let state_clone = state.clone();
-            child_states.push((child_id, state.clone()));
+            child_states.push((child_id, state));
             measurables.push(Box::new(LayoutChildMeasurable::new(
                 self.applier,
                 child_id,

--- a/crates/compose-ui/src/layout/policies.rs
+++ b/crates/compose-ui/src/layout/policies.rs
@@ -331,7 +331,7 @@ impl MeasurePolicy for FlexMeasurePolicy {
         // Children get loose constraints on both axes (min = 0)
         let child_constraints = self.make_constraints(0.0, max_main, 0.0, max_cross);
 
-        let mut placeables: Vec<Option<Box<dyn compose_ui_layout::Placeable>>> =
+        let mut placeables: Vec<Option<compose_ui_layout::Placeable>> =
             (0..measurables.len()).map(|_| None).collect();
         let mut fixed_main_size = 0.0_f32;
         let mut max_cross_size = 0.0_f32;
@@ -435,7 +435,9 @@ impl MeasurePolicy for FlexMeasurePolicy {
         let mut placements = Vec::with_capacity(placeables.len());
         for (placeable, main_pos) in placeables.into_iter().zip(main_positions.into_iter()) {
             let child_cross = self.get_cross_axis_size(placeable.width(), placeable.height());
-            let cross_pos = self.cross_axis_alignment.align(container_cross, child_cross);
+            let cross_pos = self
+                .cross_axis_alignment
+                .align(container_cross, child_cross);
 
             let (x, y) = match self.axis {
                 Axis::Horizontal => (main_pos, cross_pos),

--- a/crates/compose-ui/src/layout/tests/policies_tests.rs
+++ b/crates/compose-ui/src/layout/tests/policies_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::layout::core::Placeable;
+use compose_ui_graphics::Size;
 
 struct MockMeasurable {
     width: f32,
@@ -17,32 +18,16 @@ impl MockMeasurable {
     }
 }
 
-struct MockPlaceable {
-    width: f32,
-    height: f32,
-    node_id: usize,
-}
-
-impl Placeable for MockPlaceable {
-    fn place(&self, _x: f32, _y: f32) {}
-    fn width(&self) -> f32 {
-        self.width
-    }
-    fn height(&self) -> f32 {
-        self.height
-    }
-    fn node_id(&self) -> usize {
-        self.node_id
-    }
-}
-
 impl Measurable for MockMeasurable {
-    fn measure(&self, _constraints: Constraints) -> Box<dyn Placeable> {
-        Box::new(MockPlaceable {
-            width: self.width,
-            height: self.height,
-            node_id: self.node_id,
-        })
+    fn measure(&self, _constraints: Constraints) -> Placeable {
+        Placeable::new(
+            self.node_id,
+            Size {
+                width: self.width,
+                height: self.height,
+            },
+            |_x, _y| {},
+        )
     }
 
     fn min_intrinsic_width(&self, _height: f32) -> f32 {

--- a/crates/compose-ui/src/tests/modifier_nodes_tests.rs
+++ b/crates/compose-ui/src/tests/modifier_nodes_tests.rs
@@ -1,33 +1,11 @@
 use super::*;
-use compose_core::NodeId;
 use compose_foundation::{
     modifier_element, BasicModifierNodeContext, ModifierNodeChain, PointerButton, PointerButtons,
     PointerPhase,
 };
+use compose_ui_graphics::Size;
 use compose_ui_layout::Placeable;
 use std::cell::Cell;
-
-struct TestPlaceable {
-    width: f32,
-    height: f32,
-    node_id: NodeId,
-}
-
-impl Placeable for TestPlaceable {
-    fn place(&self, _x: f32, _y: f32) {}
-
-    fn width(&self) -> f32 {
-        self.width
-    }
-
-    fn height(&self) -> f32 {
-        self.height
-    }
-
-    fn node_id(&self) -> NodeId {
-        self.node_id
-    }
-}
 
 struct TestMeasurable {
     intrinsic_width: f32,
@@ -35,12 +13,15 @@ struct TestMeasurable {
 }
 
 impl Measurable for TestMeasurable {
-    fn measure(&self, constraints: Constraints) -> Box<dyn Placeable> {
-        Box::new(TestPlaceable {
-            width: constraints.max_width.min(self.intrinsic_width),
-            height: constraints.max_height.min(self.intrinsic_height),
-            node_id: 0,
-        })
+    fn measure(&self, constraints: Constraints) -> Placeable {
+        Placeable::new(
+            0,
+            Size {
+                width: constraints.max_width.min(self.intrinsic_width),
+                height: constraints.max_height.min(self.intrinsic_height),
+            },
+            |_x, _y| {},
+        )
     }
 
     fn min_intrinsic_width(&self, _height: f32) -> f32 {

--- a/docs/layout_intrinsics.md
+++ b/docs/layout_intrinsics.md
@@ -21,17 +21,20 @@ To model the Compose semantics we introduce `compose_ui::layout::core`:
 
 ```rust
 pub trait Measurable {
-    fn measure(&self, constraints: Constraints) -> Box<dyn Placeable>;
+    fn measure(&self, constraints: Constraints) -> Placeable;
     fn min_intrinsic_width(&self, height: f32) -> f32;
     fn max_intrinsic_width(&self, height: f32) -> f32;
     fn min_intrinsic_height(&self, width: f32) -> f32;
     fn max_intrinsic_height(&self, width: f32) -> f32;
 }
 
-pub trait Placeable {
+pub struct Placeable { /* internal fields elided */ }
+
+impl Placeable {
     fn place(&self, x: f32, y: f32);
     fn width(&self) -> f32;
     fn height(&self) -> f32;
+    fn node_id(&self) -> NodeId;
 }
 
 pub trait MeasurePolicy {


### PR DESCRIPTION
## Summary
- return `Placeable` values from `Measurable::measure` and implement the struct with placement callbacks
- persist child measurement state on `LayoutNode` and reuse it from the measure pass
- update layout policies, tests, and docs to consume the new `Placeable` API

## Testing
- cargo test -p compose-ui

------
https://chatgpt.com/codex/tasks/task_e_68fc9864cf1483288c49edd9c9702088