### PR TITLE
Separate layout geometry caches from semantics metadata

### DIFF
--- a/apps/desktop-demo/src/main.rs
+++ b/apps/desktop-demo/src/main.rs
@@ -223,7 +223,7 @@ fn recursive_layout_example() {
                             {
                                 let depth_state = depth_state.clone();
                                 move || {
-                                    let next = (depth_state.get() + 1).min(6);
+                                    let next = (depth_state.get() + 1).min(16);
                                     if next != depth_state.get() {
                                         depth_state.set(next);
                                     }

--- a/apps/desktop-demo/src/main.rs
+++ b/apps/desktop-demo/src/main.rs
@@ -122,46 +122,47 @@ fn combined_app() {
             Modifier::fill_max_width().then(Modifier::padding(8.0)),
             RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
             move || {
-            let tab_state = tab_state_for_row.clone();
-            let render_tab_button = move |tab: DemoTab| {
-                let tab_state = tab_state.clone();
-                let is_active = tab_state.get() == tab;
-                Button(
-                    Modifier::rounded_corners(12.0)
-                        .then(Modifier::draw_behind(move |scope| {
-                            scope.draw_round_rect(
-                                Brush::solid(if is_active {
-                                    Color(0.2, 0.45, 0.9, 1.0)
-                                } else {
-                                    Color(0.3, 0.3, 0.3, 0.5)
-                                }),
-                                CornerRadii::uniform(12.0),
-                            );
-                        }))
-                        .then(Modifier::padding(10.0)),
-                    {
-                        let tab_state = tab_state.clone();
-                        move || {
-                            if tab_state.get() != tab {
-                                println!("{} button clicked", tab.label());
-                                tab_state.set(tab);
+                let tab_state = tab_state_for_row.clone();
+                let render_tab_button = move |tab: DemoTab| {
+                    let tab_state = tab_state.clone();
+                    let is_active = tab_state.get() == tab;
+                    Button(
+                        Modifier::rounded_corners(12.0)
+                            .then(Modifier::draw_behind(move |scope| {
+                                scope.draw_round_rect(
+                                    Brush::solid(if is_active {
+                                        Color(0.2, 0.45, 0.9, 1.0)
+                                    } else {
+                                        Color(0.3, 0.3, 0.3, 0.5)
+                                    }),
+                                    CornerRadii::uniform(12.0),
+                                );
+                            }))
+                            .then(Modifier::padding(10.0)),
+                        {
+                            let tab_state = tab_state.clone();
+                            move || {
+                                if tab_state.get() != tab {
+                                    println!("{} button clicked", tab.label());
+                                    tab_state.set(tab);
+                                }
                             }
-                        }
-                    },
-                    {
-                        let label = tab.label();
-                        move || {
-                            Text(label, Modifier::padding(4.0));
-                        }
-                    },
-                );
-            };
+                        },
+                        {
+                            let label = tab.label();
+                            move || {
+                                Text(label, Modifier::padding(4.0));
+                            }
+                        },
+                    );
+                };
 
-            render_tab_button(DemoTab::Counter);
-            render_tab_button(DemoTab::CompositionLocal);
-            render_tab_button(DemoTab::Async);
+                render_tab_button(DemoTab::Counter);
+                render_tab_button(DemoTab::CompositionLocal);
+                render_tab_button(DemoTab::Async);
             render_tab_button(DemoTab::Layout);
-        });
+        },
+        );
 
         Spacer(Size {
             width: 0.0,
@@ -902,48 +903,48 @@ fn counter_app() {
                 let fetch_request_state = fetch_request.clone();
                 Column(
                     Modifier::rounded_corners(20.0)
-                    .then(Modifier::draw_with_cache(|cache| {
-                        cache.on_draw_behind(|scope| {
-                            scope.draw_round_rect(
-                                Brush::solid(Color(0.16, 0.18, 0.26, 0.95)),
-                                CornerRadii::uniform(20.0),
-                            );
-                        });
-                    }))
-                    .then(Modifier::draw_with_content({
-                        let position = pointer_position.get();
-                        let pressed = pointer_down.get();
-                        move |scope| {
-                            let intensity = if pressed { 0.45 } else { 0.25 };
-                            scope.draw_round_rect(
-                                Brush::radial_gradient(
-                                    vec![
-                                        Color(0.4, 0.6, 1.0, intensity),
-                                        Color(0.2, 0.3, 0.6, 0.0),
-                                    ],
-                                    position,
-                                    120.0,
-                                ),
-                                CornerRadii::uniform(20.0),
-                            );
-                        }
-                    }))
-                    .then(Modifier::pointer_input({
-                        let pointer_position = pointer_position.clone();
-                        let pointer_down = pointer_down.clone();
-                        move |event: PointerEvent| match event.kind {
-                            PointerEventKind::Down => pointer_down.set(true),
-                            PointerEventKind::Up => pointer_down.set(false),
-                            PointerEventKind::Move => {
-                                pointer_position.set(Point {
-                                    x: event.position.x,
-                                    y: event.position.y,
-                                });
+                        .then(Modifier::draw_with_cache(|cache| {
+                            cache.on_draw_behind(|scope| {
+                                scope.draw_round_rect(
+                                    Brush::solid(Color(0.16, 0.18, 0.26, 0.95)),
+                                    CornerRadii::uniform(20.0),
+                                );
+                            });
+                        }))
+                        .then(Modifier::draw_with_content({
+                            let position = pointer_position.get();
+                            let pressed = pointer_down.get();
+                            move |scope| {
+                                let intensity = if pressed { 0.45 } else { 0.25 };
+                                scope.draw_round_rect(
+                                    Brush::radial_gradient(
+                                        vec![
+                                            Color(0.4, 0.6, 1.0, intensity),
+                                            Color(0.2, 0.3, 0.6, 0.0),
+                                        ],
+                                        position,
+                                        120.0,
+                                    ),
+                                    CornerRadii::uniform(20.0),
+                                );
                             }
-                            PointerEventKind::Cancel => pointer_down.set(false),
-                        }
-                    }))
-                    .then(Modifier::padding(16.0)),
+                        }))
+                        .then(Modifier::pointer_input({
+                            let pointer_position = pointer_position.clone();
+                            let pointer_down = pointer_down.clone();
+                            move |event: PointerEvent| match event.kind {
+                                PointerEventKind::Down => pointer_down.set(true),
+                                PointerEventKind::Up => pointer_down.set(false),
+                                PointerEventKind::Move => {
+                                    pointer_position.set(Point {
+                                        x: event.position.x,
+                                        y: event.position.y,
+                                    });
+                                }
+                                PointerEventKind::Cancel => pointer_down.set(false),
+                            }
+                        }))
+                        .then(Modifier::padding(16.0)),
                     ColumnSpec::default(),
                     move || {
                         let async_message_state = async_message_state.clone();
@@ -1033,7 +1034,8 @@ fn counter_app() {
                         let counter_dec = counter.clone();
                         Row(
                             Modifier::fill_max_width().then(Modifier::padding(8.0)),
-                            RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(12.0)),
+                            RowSpec::new()
+                                .horizontal_arrangement(LinearArrangement::SpacedBy(12.0)),
                             move || {
                                 Button(
                                     Modifier::rounded_corners(16.0)
@@ -1058,23 +1060,24 @@ fn counter_app() {
                                     },
                                 );
                                 Button(
-                                Modifier::rounded_corners(16.0)
-                                    .then(Modifier::draw_behind(|scope| {
-                                        scope.draw_round_rect(
-                                            Brush::solid(Color(0.4, 0.18, 0.3, 1.0)),
-                                            CornerRadii::uniform(16.0),
-                                        );
-                                    }))
-                                    .then(Modifier::padding(12.0)),
-                                {
-                                    let counter = counter_dec.clone();
-                                    move || counter.set(counter.get() - 1)
-                                },
-                                || {
-                                    Text("Decrement", Modifier::padding(6.0));
-                                },
-                            );
-                        });
+                                    Modifier::rounded_corners(16.0)
+                                        .then(Modifier::draw_behind(|scope| {
+                                            scope.draw_round_rect(
+                                                Brush::solid(Color(0.4, 0.18, 0.3, 1.0)),
+                                                CornerRadii::uniform(16.0),
+                                            );
+                                        }))
+                                        .then(Modifier::padding(12.0)),
+                                    {
+                                        let counter = counter_dec.clone();
+                                        move || counter.set(counter.get() - 1)
+                                    },
+                                    || {
+                                        Text("Decrement", Modifier::padding(6.0));
+                                    },
+                                );
+                            },
+                        );
 
                         Spacer(Size {
                             width: 0.0,

--- a/crates/compose-ui/src/layout/policies.rs
+++ b/crates/compose-ui/src/layout/policies.rs
@@ -435,7 +435,9 @@ impl MeasurePolicy for FlexMeasurePolicy {
         let mut placements = Vec::with_capacity(placeables.len());
         for (placeable, main_pos) in placeables.into_iter().zip(main_positions.into_iter()) {
             let child_cross = self.get_cross_axis_size(placeable.width(), placeable.height());
-            let cross_pos = self.cross_axis_alignment.align(container_cross, child_cross);
+            let cross_pos = self
+                .cross_axis_alignment
+                .align(container_cross, child_cross);
 
             let (x, y) = match self.axis {
                 Axis::Horizontal => (main_pos, cross_pos),

--- a/crates/compose-ui/src/lib.rs
+++ b/crates/compose-ui/src/lib.rs
@@ -24,6 +24,7 @@ pub use layout::{
         VerticalAlignment,
     },
     measure_layout, LayoutBox, LayoutEngine, LayoutMeasurements, LayoutNodeKind, LayoutTree,
+    SemanticsAction, SemanticsCallback, SemanticsNode, SemanticsRole, SemanticsTree,
 };
 pub use modifier::{
     Brush, Color, CornerRadii, EdgeInsets, GraphicsLayer, Modifier, Point, PointerEvent,

--- a/crates/compose-ui/src/tests/primitives_tests.rs
+++ b/crates/compose-ui/src/tests/primitives_tests.rs
@@ -1001,7 +1001,11 @@ fn test_fill_max_width_respects_parent_bounds() {
             .find_map(|child| find_layout(child, target))
     }
 
-    let column_node_id = column_id.borrow().as_ref().copied().expect("column node id");
+    let column_node_id = column_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("column node id");
     let row_node_id = row_id.borrow().as_ref().copied().expect("row node id");
 
     let column_layout = find_layout(&root_layout, column_node_id).expect("column layout");
@@ -1009,15 +1013,33 @@ fn test_fill_max_width_respects_parent_bounds() {
 
     // Debug output
     println!("\n=== Layout Debug ===");
-    println!("Root: x={}, y={}, width={}, height={}",
-        root_layout.rect.x, root_layout.rect.y, root_layout.rect.width, root_layout.rect.height);
-    println!("Column: x={}, y={}, width={}, height={}",
-        column_layout.rect.x, column_layout.rect.y, column_layout.rect.width, column_layout.rect.height);
-    println!("Row: x={}, y={}, width={}, height={}",
-        row_layout.rect.x, row_layout.rect.y, row_layout.rect.width, row_layout.rect.height);
-    println!("Column inner width (after padding): {}", column_layout.rect.width - 40.0);
-    println!("Row right edge: {}", row_layout.rect.x + row_layout.rect.width);
-    println!("Column right inner edge: {}", column_layout.rect.x + column_layout.rect.width - 20.0);
+    println!(
+        "Root: x={}, y={}, width={}, height={}",
+        root_layout.rect.x, root_layout.rect.y, root_layout.rect.width, root_layout.rect.height
+    );
+    println!(
+        "Column: x={}, y={}, width={}, height={}",
+        column_layout.rect.x,
+        column_layout.rect.y,
+        column_layout.rect.width,
+        column_layout.rect.height
+    );
+    println!(
+        "Row: x={}, y={}, width={}, height={}",
+        row_layout.rect.x, row_layout.rect.y, row_layout.rect.width, row_layout.rect.height
+    );
+    println!(
+        "Column inner width (after padding): {}",
+        column_layout.rect.width - 40.0
+    );
+    println!(
+        "Row right edge: {}",
+        row_layout.rect.x + row_layout.rect.width
+    );
+    println!(
+        "Column right inner edge: {}",
+        column_layout.rect.x + column_layout.rect.width - 20.0
+    );
 
     // Expected:
     // Window: 800px
@@ -1124,8 +1146,16 @@ fn test_fill_max_width_with_background_and_double_padding() {
             .find_map(|child| find_layout(child, target))
     }
 
-    let outer_column_node = outer_column_id.borrow().as_ref().copied().expect("outer column");
-    let inner_column_node = inner_column_id.borrow().as_ref().copied().expect("inner column");
+    let outer_column_node = outer_column_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("outer column");
+    let inner_column_node = inner_column_id
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("inner column");
     let row_node = row_id.borrow().as_ref().copied().expect("row");
 
     let outer_layout = find_layout(&root_layout, outer_column_node).expect("outer column layout");
@@ -1134,11 +1164,26 @@ fn test_fill_max_width_with_background_and_double_padding() {
 
     println!("\n=== Counter App Structure Test ===");
     println!("Window: 800px");
-    println!("Outer Column (padding 32): x={}, width={}", outer_layout.rect.x, outer_layout.rect.width);
-    println!("Inner Column (width 360): x={}, width={}", inner_layout.rect.x, inner_layout.rect.width);
-    println!("Row (fill_max_width): x={}, width={}", row_layout.rect.x, row_layout.rect.width);
-    println!("Row right edge: {}", row_layout.rect.x + row_layout.rect.width);
-    println!("Inner Column right edge: {}", inner_layout.rect.x + inner_layout.rect.width);
+    println!(
+        "Outer Column (padding 32): x={}, width={}",
+        outer_layout.rect.x, outer_layout.rect.width
+    );
+    println!(
+        "Inner Column (width 360): x={}, width={}",
+        inner_layout.rect.x, inner_layout.rect.width
+    );
+    println!(
+        "Row (fill_max_width): x={}, width={}",
+        row_layout.rect.x, row_layout.rect.width
+    );
+    println!(
+        "Row right edge: {}",
+        row_layout.rect.x + row_layout.rect.width
+    );
+    println!(
+        "Inner Column right edge: {}",
+        inner_layout.rect.x + inner_layout.rect.width
+    );
 
     const EPSILON: f32 = 0.001;
 
@@ -1195,22 +1240,28 @@ fn test_fill_max_width_should_not_propagate_to_wrapping_parent() {
                 move || {
                     let inner_cap2 = Rc::clone(&inner_cap);
                     let row_cap2 = Rc::clone(&row_cap);
-                    
+
                     // Inner Column - no size modifier (should wrap content)
                     *inner_cap2.borrow_mut() = Some(Column(
                         Modifier::empty(),
                         ColumnSpec::default(),
                         move || {
                             let row_cap3 = Rc::clone(&row_cap2);
-                            
+
                             // Row with fill_max_width() containing fixed-width content
                             *row_cap3.borrow_mut() = Some(Row(
                                 Modifier::fill_max_width(),
                                 RowSpec::default(),
                                 move || {
                                     // Fixed width content: 100px + 100px = 200px
-                                    Spacer(Size { width: 100.0, height: 20.0 });
-                                    Spacer(Size { width: 100.0, height: 20.0 });
+                                    Spacer(Size {
+                                        width: 100.0,
+                                        height: 20.0,
+                                    });
+                                    Spacer(Size {
+                                        width: 100.0,
+                                        height: 20.0,
+                                    });
                                 },
                             ));
                         },
@@ -1238,7 +1289,9 @@ fn test_fill_max_width_should_not_propagate_to_wrapping_parent() {
         if node.node_id == target {
             return Some(node);
         }
-        node.children.iter().find_map(|child| find_layout(child, target))
+        node.children
+            .iter()
+            .find_map(|child| find_layout(child, target))
     }
 
     let outer_node = outer_column_id.borrow().as_ref().copied().expect("outer");
@@ -1252,8 +1305,14 @@ fn test_fill_max_width_should_not_propagate_to_wrapping_parent() {
     println!("\n=== Fill Propagation Test ===");
     println!("Window: 800px");
     println!("Row content: 200px (100 + 100)");
-    println!("Outer Column (should wrap): width={}", outer_layout.rect.width);
-    println!("Inner Column (should wrap): width={}", inner_layout.rect.width);
+    println!(
+        "Outer Column (should wrap): width={}",
+        outer_layout.rect.width
+    );
+    println!(
+        "Inner Column (should wrap): width={}",
+        inner_layout.rect.width
+    );
     println!("Row (fill_max_width): width={}", row_layout.rect.width);
 
     // Expected behavior (now FIXED):

--- a/crates/compose-ui/src/widgets/nodes/layout_node.rs
+++ b/crates/compose-ui/src/widgets/nodes/layout_node.rs
@@ -1,9 +1,67 @@
-use crate::modifier::Modifier;
+use crate::{layout::MeasuredNode, modifier::Modifier};
 use compose_core::{Node, NodeId};
 use compose_foundation::{BasicModifierNodeContext, ModifierNodeChain};
-use compose_ui_layout::MeasurePolicy;
+use compose_ui_layout::{Constraints, MeasurePolicy};
 use indexmap::IndexSet;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
+
+#[derive(Clone)]
+struct MeasurementCacheEntry {
+    constraints: Constraints,
+    measured: Rc<MeasuredNode>,
+}
+
+#[derive(Default)]
+struct NodeCacheState {
+    epoch: u64,
+    measurements: Vec<MeasurementCacheEntry>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct LayoutNodeCacheHandles {
+    state: Rc<RefCell<NodeCacheState>>,
+}
+
+impl LayoutNodeCacheHandles {
+    pub(crate) fn clear(&self) {
+        let mut state = self.state.borrow_mut();
+        state.measurements.clear();
+        state.epoch = 0;
+    }
+
+    pub(crate) fn activate(&self, epoch: u64) {
+        let mut state = self.state.borrow_mut();
+        if state.epoch != epoch {
+            state.measurements.clear();
+            state.epoch = epoch;
+        }
+    }
+
+    pub(crate) fn get_measurement(&self, constraints: Constraints) -> Option<Rc<MeasuredNode>> {
+        let state = self.state.borrow();
+        state
+            .measurements
+            .iter()
+            .find(|entry| entry.constraints == constraints)
+            .map(|entry| Rc::clone(&entry.measured))
+    }
+
+    pub(crate) fn store_measurement(&self, constraints: Constraints, measured: Rc<MeasuredNode>) {
+        let mut state = self.state.borrow_mut();
+        if let Some(entry) = state
+            .measurements
+            .iter_mut()
+            .find(|entry| entry.constraints == constraints)
+        {
+            entry.measured = measured;
+        } else {
+            state.measurements.push(MeasurementCacheEntry {
+                constraints,
+                measured,
+            });
+        }
+    }
+}
 
 pub struct LayoutNode {
     pub modifier: Modifier,
@@ -11,6 +69,7 @@ pub struct LayoutNode {
     modifier_context: BasicModifierNodeContext,
     pub measure_policy: Rc<dyn MeasurePolicy>,
     pub children: IndexSet<NodeId>,
+    cache: LayoutNodeCacheHandles,
 }
 
 impl LayoutNode {
@@ -21,6 +80,7 @@ impl LayoutNode {
             modifier_context: BasicModifierNodeContext::new(),
             measure_policy,
             children: IndexSet::new(),
+            cache: LayoutNodeCacheHandles::default(),
         };
         node.set_modifier(modifier);
         node
@@ -30,10 +90,16 @@ impl LayoutNode {
         self.modifier = modifier;
         self.mods
             .update_from_slice(self.modifier.elements(), &mut self.modifier_context);
+        self.cache.clear();
     }
 
     pub fn set_measure_policy(&mut self, policy: Rc<dyn MeasurePolicy>) {
         self.measure_policy = policy;
+        self.cache.clear();
+    }
+
+    pub(crate) fn cache_handles(&self) -> LayoutNodeCacheHandles {
+        self.cache.clone()
     }
 }
 
@@ -45,6 +111,7 @@ impl Clone for LayoutNode {
             modifier_context: BasicModifierNodeContext::new(),
             measure_policy: self.measure_policy.clone(),
             children: self.children.clone(),
+            cache: self.cache.clone(),
         }
     }
 }
@@ -52,10 +119,12 @@ impl Clone for LayoutNode {
 impl Node for LayoutNode {
     fn insert_child(&mut self, child: NodeId) {
         self.children.insert(child);
+        self.cache.clear();
     }
 
     fn remove_child(&mut self, child: NodeId) {
         self.children.shift_remove(&child);
+        self.cache.clear();
     }
 
     fn move_child(&mut self, from: usize, to: usize) {
@@ -70,6 +139,7 @@ impl Node for LayoutNode {
         for id in ordered {
             self.children.insert(id);
         }
+        self.cache.clear();
     }
 
     fn update_children(&mut self, children: &[NodeId]) {
@@ -77,6 +147,7 @@ impl Node for LayoutNode {
         for &child in children {
             self.children.insert(child);
         }
+        self.cache.clear();
     }
 
     fn children(&self) -> Vec<NodeId> {

--- a/crates/compose-ui/src/widgets/nodes/mod.rs
+++ b/crates/compose-ui/src/widgets/nodes/mod.rs
@@ -7,6 +7,7 @@ mod text_node;
 
 pub use button_node::ButtonNode;
 pub use layout_node::LayoutNode;
+pub(crate) use layout_node::LayoutNodeCacheHandles;
 pub use spacer_node::SpacerNode;
 pub use text_node::TextNode;
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -66,7 +66,7 @@ pub fn Column(modifier: Modifier, content: impl FnOnce()) -> NodeId {
 
 * ✅ Implement intrinsic methods for primitives (Column/Row/Box).
 * ✅ Add `IntrinsicSize` support: `Modifier.width_intrinsic(IntrinsicSize::Min/Max)` and `Modifier.height_intrinsic(IntrinsicSize::Min/Max)`.
-* ✅ Add intrinsic resolver pass in layout engine via `resolve_dimension_with_intrinsics`.
+* ✅ Add intrinsic resolver pass in layout engine that unifies intrinsic sizing with standard measurement constraints.
 * ✅ Implement `compute_*_intrinsic_width/height` for Column/Row/Box.
 
 ### Implementation Notes


### PR DESCRIPTION
## Summary
- add semantics structures, runtime metadata, and geometry-only measured nodes to the layout snapshot pipeline
- collapse layout-node caches to share entries across normal and intrinsic queries and remove unused helpers
- export semantics data, gate alignment helpers to tests, and update roadmap notes accordingly

## Testing
- cargo clippy --all-targets --all-features
- cargo test -p compose-ui

------
https://chatgpt.com/codex/tasks/task_e_68fc973765bc832890a664a8d3a77741