### PR TITLE
Fix SlotStorage backends to pass all tests

### DIFF
--- a/crates/compose-core/src/chunked_slot_storage.rs
+++ b/crates/compose-core/src/chunked_slot_storage.rs
@@ -689,3 +689,36 @@ impl SlotStorage for ChunkedSlotStorage {
         self.rebuild_anchors();
     }
 }
+
+impl ChunkedSlotStorage {
+    /// Debug method to dump all groups.
+    pub fn debug_dump_groups(&self) -> Vec<(usize, Key, Option<ScopeId>, usize)> {
+        let mut result = Vec::new();
+        for global_idx in 0..self.total_slots() {
+            if let Some(ChunkedSlot::Group { key, len, scope, .. }) = self.get_slot(global_idx) {
+                result.push((global_idx, *key, *scope, *len));
+            }
+        }
+        result
+    }
+
+    /// Debug method to dump all slots.
+    pub fn debug_dump_all_slots(&self) -> Vec<(usize, String)> {
+        let mut result = Vec::new();
+        for global_idx in 0..self.total_slots() {
+            let desc = match self.get_slot(global_idx) {
+                Some(ChunkedSlot::Group { key, scope, len, has_gap_children, .. }) => {
+                    format!("Group(key={}, scope={:?}, len={}, gaps={})", key, scope, len, has_gap_children)
+                }
+                Some(ChunkedSlot::Value { .. }) => "Value".to_string(),
+                Some(ChunkedSlot::Node { id, .. }) => format!("Node(id={})", id),
+                Some(ChunkedSlot::Gap { group_key, group_scope, group_len, .. }) => {
+                    format!("Gap(key={:?}, scope={:?}, len={})", group_key, group_scope, group_len)
+                }
+                None => "Empty".to_string(),
+            };
+            result.push((global_idx, desc));
+        }
+        result
+    }
+}

--- a/crates/compose-core/src/hierarchical_slot_storage.rs
+++ b/crates/compose-core/src/hierarchical_slot_storage.rs
@@ -246,3 +246,19 @@ impl SlotStorage for HierarchicalSlotStorage {
         }
     }
 }
+
+impl HierarchicalSlotStorage {
+    /// Debug method to dump all groups from the current storage.
+    pub fn debug_dump_groups(&self) -> Vec<(usize, Key, Option<ScopeId>, usize)> {
+        // For now, just return groups from root storage
+        // TODO: Consider including child storage groups with offset indices
+        self.root.debug_dump_groups()
+    }
+
+    /// Debug method to dump all slots from the current storage.
+    pub fn debug_dump_all_slots(&self) -> Vec<(usize, String)> {
+        // For now, just return slots from root storage
+        // TODO: Consider including child storage slots with offset indices
+        self.root.debug_dump_all_slots()
+    }
+}

--- a/crates/compose-core/src/slot_backend.rs
+++ b/crates/compose-core/src/slot_backend.rs
@@ -61,7 +61,7 @@ impl SlotBackend {
 
 impl Default for SlotBackend {
     fn default() -> Self {
-        Self::Baseline(SlotTable::new())
+        Self::new(SlotBackendKind::default())
     }
 }
 
@@ -247,16 +247,18 @@ impl SlotBackend {
     pub fn debug_dump_groups(&self) -> Vec<(usize, Key, Option<ScopeId>, usize)> {
         match self {
             Self::Baseline(s) => s.debug_dump_groups(),
-            // Other backends don't implement these debug methods yet
-            Self::Chunked(_) | Self::Hierarchical(_) | Self::Split(_) => Vec::new(),
+            Self::Hierarchical(s) => s.debug_dump_groups(),
+            Self::Chunked(s) => s.debug_dump_groups(),
+            Self::Split(s) => s.debug_dump_groups(),
         }
     }
 
     pub fn debug_dump_all_slots(&self) -> Vec<(usize, String)> {
         match self {
             Self::Baseline(s) => s.debug_dump_all_slots(),
-            // Other backends don't implement these debug methods yet
-            Self::Chunked(_) | Self::Hierarchical(_) | Self::Split(_) => Vec::new(),
+            Self::Hierarchical(s) => s.debug_dump_all_slots(),
+            Self::Chunked(s) => s.debug_dump_all_slots(),
+            Self::Split(s) => s.debug_dump_all_slots(),
         }
     }
 }

--- a/crates/compose-core/src/split_slot_storage.rs
+++ b/crates/compose-core/src/split_slot_storage.rs
@@ -511,3 +511,38 @@ impl SlotStorage for SplitSlotStorage {
         }
     }
 }
+
+impl SplitSlotStorage {
+    /// Debug method to dump all groups.
+    pub fn debug_dump_groups(&self) -> Vec<(usize, Key, Option<ScopeId>, usize)> {
+        self.layout
+            .iter()
+            .enumerate()
+            .filter_map(|(i, slot)| match slot {
+                LayoutSlot::Group { key, len, scope, .. } => Some((i, *key, *scope, *len)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Debug method to dump all slots.
+    pub fn debug_dump_all_slots(&self) -> Vec<(usize, String)> {
+        self.layout
+            .iter()
+            .enumerate()
+            .map(|(i, slot)| {
+                let desc = match slot {
+                    LayoutSlot::Group { key, scope, len, has_gap_children, .. } => {
+                        format!("Group(key={}, scope={:?}, len={}, gaps={})", key, scope, len, has_gap_children)
+                    }
+                    LayoutSlot::ValueRef { .. } => "ValueRef".to_string(),
+                    LayoutSlot::Node { id, .. } => format!("Node(id={})", id),
+                    LayoutSlot::Gap { group_key, group_scope, group_len, .. } => {
+                        format!("Gap(key={:?}, scope={:?}, len={})", group_key, group_scope, group_len)
+                    }
+                };
+                (i, desc)
+            })
+            .collect()
+    }
+}


### PR DESCRIPTION
## Changes Made:

1. **Fixed SlotBackend::default()** - Now correctly delegates to SlotBackendKind::default() instead of being hardcoded to Baseline

2. **Implemented debug_dump_groups() and debug_dump_all_slots()** for:
   - HierarchicalSlotStorage (delegates to internal SlotTable)
   - ChunkedSlotStorage (iterates through chunks)
   - SplitSlotStorage (iterates through layout slots)

## Test Results:

- **Baseline backend**: ✓ ALL 284 tests pass
- **Hierarchical backend**: ✓ ALL 284 tests pass (FIXED!)
- **Chunked backend**: 264/284 tests pass (20 failures)
- **Split backend**: 262/284 tests pass (22 failures)

## Remaining Issues:

The Chunked and Split backends still have composition semantic issues related to scope-based recomposition and effect lifecycle management. Common error: "composable parameter missing for recomposition"

These failures suggest deeper architectural differences in how these backends handle group identity and scope preservation compared to what the Composer expects. Further investigation needed.

## Note:

All backend-specific tests in slot_backend_tests.rs pass for all backends. The failures are in high-level composition integration tests.