### PR TITLE
Add layout dirty tracking for selective measurement

### DIFF
--- a/crates/compose-app-shell/src/lib.rs
+++ b/crates/compose-app-shell/src/lib.rs
@@ -6,8 +6,8 @@ use compose_foundation::PointerEventKind;
 use compose_render_common::{HitTestTarget, RenderScene, Renderer};
 use compose_runtime_std::StdRuntime;
 use compose_ui::{
-    log_layout_tree, log_render_scene, log_screen_summary, HeadlessRenderer, LayoutEngine,
-    LayoutTree,
+    has_measure_dirty_nodes, log_layout_tree, log_render_scene, log_screen_summary,
+    HeadlessRenderer, LayoutEngine, LayoutTree,
 };
 use compose_ui_graphics::Size;
 
@@ -87,7 +87,7 @@ where
     }
 
     pub fn should_render(&self) -> bool {
-        if self.layout_dirty || self.scene_dirty {
+        if self.layout_dirty || self.scene_dirty || has_measure_dirty_nodes() {
             return true;
         }
         self.runtime.take_frame_request() || self.composition.should_render()
@@ -167,7 +167,7 @@ where
     }
 
     fn run_layout_phase(&mut self) {
-        if !self.layout_dirty {
+        if !self.layout_dirty && !has_measure_dirty_nodes() {
             return;
         }
         self.layout_dirty = false;

--- a/crates/compose-core/src/chunked_slot_storage.rs
+++ b/crates/compose-core/src/chunked_slot_storage.rs
@@ -101,18 +101,18 @@ impl ChunkedSlot {
 
     fn as_value<T: 'static>(&self) -> &T {
         match self {
-            ChunkedSlot::Value { data, .. } => data
-                .downcast_ref::<T>()
-                .expect("slot value type mismatch"),
+            ChunkedSlot::Value { data, .. } => {
+                data.downcast_ref::<T>().expect("slot value type mismatch")
+            }
             _ => panic!("slot is not a value"),
         }
     }
 
     fn as_value_mut<T: 'static>(&mut self) -> &mut T {
         match self {
-            ChunkedSlot::Value { data, .. } => data
-                .downcast_mut::<T>()
-                .expect("slot value type mismatch"),
+            ChunkedSlot::Value { data, .. } => {
+                data.downcast_mut::<T>().expect("slot value type mismatch")
+            }
             _ => panic!("slot is not a value"),
         }
     }
@@ -278,7 +278,7 @@ impl ChunkedSlotStorage {
             // Use mem::replace to move without cloning
             let temp = std::mem::replace(
                 &mut self.chunks[src_chunk][src_offset],
-                ChunkedSlot::default()
+                ChunkedSlot::default(),
             );
             // Capacity is guaranteed by the loop above
             self.chunks[dst_chunk][dst_offset] = temp;
@@ -492,7 +492,9 @@ impl ChunkedSlotStorage {
                     if let Some(slot) = self.get_slot_mut(self.cursor) {
                         let anchor = slot.anchor_id();
                         let (group_key, group_scope, group_len) = match slot {
-                            ChunkedSlot::Group { key, scope, len, .. } => (Some(*key), *scope, *len),
+                            ChunkedSlot::Group {
+                                key, scope, len, ..
+                            } => (Some(*key), *scope, *len),
                             _ => (None, None, 0),
                         };
                         *slot = ChunkedSlot::Gap {
@@ -517,7 +519,9 @@ impl ChunkedSlotStorage {
                 // Convert to gap
                 let anchor = slot.anchor_id();
                 let (group_key, group_scope, group_len) = match slot {
-                    ChunkedSlot::Group { key, scope, len, .. } => (Some(*key), *scope, *len),
+                    ChunkedSlot::Group {
+                        key, scope, len, ..
+                    } => (Some(*key), *scope, *len),
                     _ => (None, None, 0),
                 };
                 *slot = ChunkedSlot::Gap {
@@ -585,10 +589,7 @@ impl SlotStorage for ChunkedSlotStorage {
     fn begin_recompose_at_scope(&mut self, scope: ScopeId) -> Option<Self::Group> {
         // Linear scan to find group with this scope
         for global_idx in 0..self.total_slots() {
-            if let Some(ChunkedSlot::Group {
-                scope: Some(s), ..
-            }) = self.get_slot(global_idx)
-            {
+            if let Some(ChunkedSlot::Group { scope: Some(s), .. }) = self.get_slot(global_idx) {
                 if *s == scope {
                     self.cursor = global_idx;
                     return Some(GroupId::new(global_idx));
@@ -695,7 +696,10 @@ impl ChunkedSlotStorage {
     pub fn debug_dump_groups(&self) -> Vec<(usize, Key, Option<ScopeId>, usize)> {
         let mut result = Vec::new();
         for global_idx in 0..self.total_slots() {
-            if let Some(ChunkedSlot::Group { key, len, scope, .. }) = self.get_slot(global_idx) {
+            if let Some(ChunkedSlot::Group {
+                key, len, scope, ..
+            }) = self.get_slot(global_idx)
+            {
                 result.push((global_idx, *key, *scope, *len));
             }
         }
@@ -707,13 +711,30 @@ impl ChunkedSlotStorage {
         let mut result = Vec::new();
         for global_idx in 0..self.total_slots() {
             let desc = match self.get_slot(global_idx) {
-                Some(ChunkedSlot::Group { key, scope, len, has_gap_children, .. }) => {
-                    format!("Group(key={}, scope={:?}, len={}, gaps={})", key, scope, len, has_gap_children)
+                Some(ChunkedSlot::Group {
+                    key,
+                    scope,
+                    len,
+                    has_gap_children,
+                    ..
+                }) => {
+                    format!(
+                        "Group(key={}, scope={:?}, len={}, gaps={})",
+                        key, scope, len, has_gap_children
+                    )
                 }
                 Some(ChunkedSlot::Value { .. }) => "Value".to_string(),
                 Some(ChunkedSlot::Node { id, .. }) => format!("Node(id={})", id),
-                Some(ChunkedSlot::Gap { group_key, group_scope, group_len, .. }) => {
-                    format!("Gap(key={:?}, scope={:?}, len={})", group_key, group_scope, group_len)
+                Some(ChunkedSlot::Gap {
+                    group_key,
+                    group_scope,
+                    group_len,
+                    ..
+                }) => {
+                    format!(
+                        "Gap(key={:?}, scope={:?}, len={})",
+                        group_key, group_scope, group_len
+                    )
                 }
                 None => "Empty".to_string(),
             };

--- a/crates/compose-core/src/slot_table.rs
+++ b/crates/compose-core/src/slot_table.rs
@@ -365,7 +365,12 @@ impl SlotTable {
     /// Mark a range of slots as gaps instead of truncating.
     /// This preserves sibling components while allowing structure changes.
     /// When encountering a Group, recursively marks the entire group structure as gaps.
-    pub fn mark_range_as_gaps(&mut self, start: usize, end: usize, owner_index: Option<usize>) -> bool {
+    pub fn mark_range_as_gaps(
+        &mut self,
+        start: usize,
+        end: usize,
+        owner_index: Option<usize>,
+    ) -> bool {
         let mut i = start;
         let end = end.min(self.slots.len());
         let mut marked_any = false;

--- a/crates/compose-core/src/split_slot_storage.rs
+++ b/crates/compose-core/src/split_slot_storage.rs
@@ -253,7 +253,9 @@ impl SplitSlotStorage {
                     let slot = &mut self.layout[self.cursor];
                     let anchor = slot.anchor_id();
                     let (group_key, group_scope, group_len) = match slot {
-                        LayoutSlot::Group { key, scope, len, .. } => (Some(*key), *scope, *len),
+                        LayoutSlot::Group {
+                            key, scope, len, ..
+                        } => (Some(*key), *scope, *len),
                         _ => (None, None, 0),
                     };
                     *slot = LayoutSlot::Gap {
@@ -276,7 +278,9 @@ impl SplitSlotStorage {
             let slot = &mut self.layout[self.cursor];
             let anchor = slot.anchor_id();
             let (group_key, group_scope, group_len) = match slot {
-                LayoutSlot::Group { key, scope, len, .. } => (Some(*key), *scope, *len),
+                LayoutSlot::Group {
+                    key, scope, len, ..
+                } => (Some(*key), *scope, *len),
                 _ => (None, None, 0),
             };
 
@@ -345,10 +349,7 @@ impl SlotStorage for SplitSlotStorage {
 
     fn begin_recompose_at_scope(&mut self, scope: ScopeId) -> Option<Self::Group> {
         for (idx, slot) in self.layout.iter().enumerate() {
-            if let LayoutSlot::Group {
-                scope: Some(s), ..
-            } = slot
-            {
+            if let LayoutSlot::Group { scope: Some(s), .. } = slot {
                 if *s == scope {
                     self.cursor = idx;
                     return Some(GroupId::new(idx));
@@ -432,21 +433,30 @@ impl SlotStorage for SplitSlotStorage {
     }
 
     fn read_value<T: 'static>(&self, slot: Self::ValueSlot) -> &T {
-        let layout_slot = self.layout.get(slot.index()).expect("layout slot not found");
+        let layout_slot = self
+            .layout
+            .get(slot.index())
+            .expect("layout slot not found");
         let anchor = layout_slot.anchor_id();
         let data = self.payload.get(&anchor.0).expect("payload not found");
         data.downcast_ref::<T>().expect("type mismatch")
     }
 
     fn read_value_mut<T: 'static>(&mut self, slot: Self::ValueSlot) -> &mut T {
-        let layout_slot = self.layout.get(slot.index()).expect("layout slot not found");
+        let layout_slot = self
+            .layout
+            .get(slot.index())
+            .expect("layout slot not found");
         let anchor = layout_slot.anchor_id();
         let data = self.payload.get_mut(&anchor.0).expect("payload not found");
         data.downcast_mut::<T>().expect("type mismatch")
     }
 
     fn write_value<T: 'static>(&mut self, slot: Self::ValueSlot, value: T) {
-        let layout_slot = self.layout.get(slot.index()).expect("layout slot not found");
+        let layout_slot = self
+            .layout
+            .get(slot.index())
+            .expect("layout slot not found");
         let anchor = layout_slot.anchor_id();
         self.payload.insert(anchor.0, Box::new(value));
     }
@@ -519,7 +529,9 @@ impl SplitSlotStorage {
             .iter()
             .enumerate()
             .filter_map(|(i, slot)| match slot {
-                LayoutSlot::Group { key, len, scope, .. } => Some((i, *key, *scope, *len)),
+                LayoutSlot::Group {
+                    key, len, scope, ..
+                } => Some((i, *key, *scope, *len)),
                 _ => None,
             })
             .collect()
@@ -532,13 +544,30 @@ impl SplitSlotStorage {
             .enumerate()
             .map(|(i, slot)| {
                 let desc = match slot {
-                    LayoutSlot::Group { key, scope, len, has_gap_children, .. } => {
-                        format!("Group(key={}, scope={:?}, len={}, gaps={})", key, scope, len, has_gap_children)
+                    LayoutSlot::Group {
+                        key,
+                        scope,
+                        len,
+                        has_gap_children,
+                        ..
+                    } => {
+                        format!(
+                            "Group(key={}, scope={:?}, len={}, gaps={})",
+                            key, scope, len, has_gap_children
+                        )
                     }
                     LayoutSlot::ValueRef { .. } => "ValueRef".to_string(),
                     LayoutSlot::Node { id, .. } => format!("Node(id={})", id),
-                    LayoutSlot::Gap { group_key, group_scope, group_len, .. } => {
-                        format!("Gap(key={:?}, scope={:?}, len={})", group_key, group_scope, group_len)
+                    LayoutSlot::Gap {
+                        group_key,
+                        group_scope,
+                        group_len,
+                        ..
+                    } => {
+                        format!(
+                            "Gap(key={:?}, scope={:?}, len={})",
+                            group_key, group_scope, group_len
+                        )
                     }
                 };
                 (i, desc)

--- a/crates/compose-core/src/tests/lib_tests.rs
+++ b/crates/compose-core/src/tests/lib_tests.rs
@@ -3982,7 +3982,9 @@ fn test_composition_with_backend(backend: SlotBackendKind) {
 
                     composer.with_group(2, |composer| {
                         let nested = composer.remember(|| "world".to_string());
-                        nested.with(|n| assert_eq!(n, "hello", "Nested remembered value should be preserved"));
+                        nested.with(|n| {
+                            assert_eq!(n, "hello", "Nested remembered value should be preserved")
+                        });
                     });
                 });
             });

--- a/crates/compose-ui/src/layout/dirty.rs
+++ b/crates/compose-ui/src/layout/dirty.rs
@@ -1,0 +1,117 @@
+use compose_core::NodeId;
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use super::MeasuredNode;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct DirtyPhase(u8);
+
+impl DirtyPhase {
+    pub(crate) const MEASURE: Self = Self(1 << 0);
+
+    fn contains(self, other: Self) -> bool {
+        self.0 & other.0 != 0
+    }
+
+    fn insert(&mut self, other: Self) {
+        self.0 |= other.0;
+    }
+
+    fn remove(&mut self, other: Self) {
+        self.0 &= !other.0;
+    }
+
+    fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+}
+
+#[derive(Default)]
+struct LayoutDirtyState {
+    parents: HashMap<NodeId, Option<NodeId>>,
+    dirty: HashMap<NodeId, DirtyPhase>,
+}
+
+impl LayoutDirtyState {
+    fn mark_dirty(&mut self, node_id: NodeId, phases: DirtyPhase) {
+        let mut current = Some(node_id);
+        while let Some(id) = current {
+            self.dirty
+                .entry(id)
+                .and_modify(|flags| flags.insert(phases))
+                .or_insert(phases);
+            current = self.parents.get(&id).and_then(|parent| *parent);
+        }
+    }
+
+    fn mark_clean(&mut self, node_id: NodeId, phases: DirtyPhase) {
+        if let Some(flags) = self.dirty.get_mut(&node_id) {
+            flags.remove(phases);
+            if flags.is_empty() {
+                self.dirty.remove(&node_id);
+            }
+        }
+    }
+
+    fn is_dirty(&self, node_id: NodeId, phases: DirtyPhase) -> bool {
+        self.dirty
+            .get(&node_id)
+            .map(|flags| flags.contains(phases))
+            .unwrap_or(false)
+    }
+
+    fn has_dirty(&self, phases: DirtyPhase) -> bool {
+        self.dirty.values().any(|flags| flags.contains(phases))
+    }
+
+    fn rebuild_parents(&mut self, root: &MeasuredNode) {
+        fn walk(
+            node: &MeasuredNode,
+            parent: Option<NodeId>,
+            map: &mut HashMap<NodeId, Option<NodeId>>,
+        ) {
+            map.insert(node.node_id, parent);
+            for child in node.children.iter() {
+                walk(&child.node, Some(node.node_id), map);
+            }
+        }
+
+        let mut new_map = HashMap::new();
+        walk(root, None, &mut new_map);
+        self.parents = new_map;
+        self.dirty
+            .retain(|node_id, _| self.parents.contains_key(node_id));
+    }
+}
+
+thread_local! {
+    static LAYOUT_DIRTY_STATE: RefCell<LayoutDirtyState> = RefCell::new(LayoutDirtyState::default());
+}
+
+fn with_state<R>(f: impl FnOnce(&mut LayoutDirtyState) -> R) -> R {
+    LAYOUT_DIRTY_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        f(&mut state)
+    })
+}
+
+pub(crate) fn mark_dirty(node_id: NodeId, phases: DirtyPhase) {
+    with_state(|state| state.mark_dirty(node_id, phases));
+}
+
+pub(crate) fn mark_clean(node_id: NodeId, phases: DirtyPhase) {
+    with_state(|state| state.mark_clean(node_id, phases));
+}
+
+pub(crate) fn is_dirty(node_id: NodeId, phases: DirtyPhase) -> bool {
+    LAYOUT_DIRTY_STATE.with(|state| state.borrow().is_dirty(node_id, phases))
+}
+
+pub(crate) fn has_dirty(phases: DirtyPhase) -> bool {
+    LAYOUT_DIRTY_STATE.with(|state| state.borrow().has_dirty(phases))
+}
+
+pub(crate) fn rebuild_parent_links(root: &MeasuredNode) {
+    with_state(|state| state.rebuild_parents(root));
+}

--- a/crates/compose-ui/src/lib.rs
+++ b/crates/compose-ui/src/lib.rs
@@ -23,8 +23,9 @@ pub use layout::{
         Alignment, Arrangement, HorizontalAlignment, LinearArrangement, Measurable, Placeable,
         VerticalAlignment,
     },
-    measure_layout, LayoutBox, LayoutEngine, LayoutMeasurements, LayoutNodeKind, LayoutTree,
-    SemanticsAction, SemanticsCallback, SemanticsNode, SemanticsRole, SemanticsTree,
+    has_measure_dirty_nodes, measure_layout, LayoutBox, LayoutEngine, LayoutMeasurements,
+    LayoutNodeKind, LayoutTree, SemanticsAction, SemanticsCallback, SemanticsNode, SemanticsRole,
+    SemanticsTree,
 };
 pub use modifier::{
     Brush, Color, CornerRadii, EdgeInsets, GraphicsLayer, Modifier, Point, PointerEvent,

--- a/crates/compose-ui/src/tests/subcompose_layout_tests.rs
+++ b/crates/compose-ui/src/tests/subcompose_layout_tests.rs
@@ -3,7 +3,8 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use compose_core::{
-    self, Applier, ConcreteApplierHost, MutableState, SlotBackend, SlotStorage, SlotsHost, SnapshotStateObserver,
+    self, Applier, ConcreteApplierHost, MutableState, SlotBackend, SlotStorage, SlotsHost,
+    SnapshotStateObserver,
 };
 
 #[derive(Default)]

--- a/crates/compose-ui/src/widgets/button.rs
+++ b/crates/compose-ui/src/widgets/button.rs
@@ -6,7 +6,6 @@ use super::nodes::ButtonNode;
 use crate::composable;
 use crate::modifier::Modifier;
 use compose_core::NodeId;
-use indexmap::IndexSet;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -17,15 +16,11 @@ where
     G: FnMut() + 'static,
 {
     let on_click_rc: Rc<RefCell<dyn FnMut()>> = Rc::new(RefCell::new(on_click));
-    let id = compose_core::with_current_composer(|composer| {
-        composer.emit_node(|| ButtonNode {
-            modifier: modifier.clone(),
-            on_click: on_click_rc.clone(),
-            children: IndexSet::new(),
-        })
-    });
+    let id =
+        compose_core::with_current_composer(|composer| composer.emit_node(ButtonNode::default));
     if let Err(err) = compose_core::with_node_mut(id, |node: &mut ButtonNode| {
-        node.modifier = modifier;
+        node.set_node_id(id);
+        node.set_modifier(modifier);
         node.on_click = on_click_rc.clone();
     }) {
         debug_assert!(false, "failed to update Button node: {err}");

--- a/crates/compose-ui/src/widgets/layout.rs
+++ b/crates/compose-ui/src/widgets/layout.rs
@@ -26,6 +26,7 @@ where
         composer.emit_node(|| LayoutNode::new(modifier.clone(), Rc::clone(&policy)))
     });
     if let Err(err) = compose_core::with_node_mut(id, |node: &mut LayoutNode| {
+        node.set_node_id(id);
         node.set_modifier(modifier.clone());
         node.set_measure_policy(Rc::clone(&policy));
     }) {
@@ -48,6 +49,7 @@ pub fn SubcomposeLayout(
         composer.emit_node(|| SubcomposeLayoutNode::new(modifier.clone(), Rc::clone(&policy)))
     });
     if let Err(err) = compose_core::with_node_mut(id, |node: &mut SubcomposeLayoutNode| {
+        node.set_node_id(id);
         node.set_modifier(modifier.clone());
         node.set_measure_policy(Rc::clone(&policy));
     }) {

--- a/crates/compose-ui/src/widgets/nodes/button_node.rs
+++ b/crates/compose-ui/src/widgets/nodes/button_node.rs
@@ -1,4 +1,4 @@
-use crate::modifier::Modifier;
+use crate::{layout::mark_measure_dirty, modifier::Modifier};
 use compose_core::{Node, NodeId};
 use indexmap::IndexSet;
 use std::cell::RefCell;
@@ -9,6 +9,7 @@ pub struct ButtonNode {
     pub modifier: Modifier,
     pub on_click: Rc<RefCell<dyn FnMut()>>,
     pub children: IndexSet<NodeId>,
+    id: Option<NodeId>,
 }
 
 impl Default for ButtonNode {
@@ -17,6 +18,7 @@ impl Default for ButtonNode {
             modifier: Modifier::empty(),
             on_click: Rc::new(RefCell::new(|| {})),
             children: IndexSet::new(),
+            id: None,
         }
     }
 }
@@ -25,15 +27,35 @@ impl ButtonNode {
     pub fn trigger(&self) {
         (self.on_click.borrow_mut())();
     }
+
+    pub fn set_node_id(&mut self, id: NodeId) {
+        self.id = Some(id);
+    }
+
+    pub fn set_modifier(&mut self, modifier: Modifier) {
+        if self.modifier == modifier {
+            return;
+        }
+        self.modifier = modifier;
+        if let Some(id) = self.id {
+            mark_measure_dirty(id);
+        }
+    }
 }
 
 impl Node for ButtonNode {
     fn insert_child(&mut self, child: NodeId) {
         self.children.insert(child);
+        if let Some(id) = self.id {
+            mark_measure_dirty(id);
+        }
     }
 
     fn remove_child(&mut self, child: NodeId) {
         self.children.shift_remove(&child);
+        if let Some(id) = self.id {
+            mark_measure_dirty(id);
+        }
     }
 
     fn move_child(&mut self, from: usize, to: usize) {
@@ -48,12 +70,18 @@ impl Node for ButtonNode {
         for id in ordered {
             self.children.insert(id);
         }
+        if let Some(id) = self.id {
+            mark_measure_dirty(id);
+        }
     }
 
     fn update_children(&mut self, children: &[NodeId]) {
         self.children.clear();
         for &child in children {
             self.children.insert(child);
+        }
+        if let Some(id) = self.id {
+            mark_measure_dirty(id);
         }
     }
 

--- a/crates/compose-ui/src/widgets/spacer.rs
+++ b/crates/compose-ui/src/widgets/spacer.rs
@@ -4,6 +4,7 @@
 
 use super::nodes::SpacerNode;
 use crate::composable;
+use crate::layout::mark_measure_dirty;
 use crate::modifier::Size;
 use compose_core::NodeId;
 
@@ -12,7 +13,10 @@ pub fn Spacer(size: Size) -> NodeId {
     let id =
         compose_core::with_current_composer(|composer| composer.emit_node(|| SpacerNode { size }));
     if let Err(err) = compose_core::with_node_mut(id, |node: &mut SpacerNode| {
-        node.size = size;
+        if node.size != size {
+            node.size = size;
+            mark_measure_dirty(id);
+        }
     }) {
         debug_assert!(false, "failed to update Spacer node: {err}");
     }

--- a/crates/compose-ui/src/widgets/text.rs
+++ b/crates/compose-ui/src/widgets/text.rs
@@ -4,6 +4,7 @@
 
 use super::nodes::TextNode;
 use crate::composable;
+use crate::layout::mark_measure_dirty;
 use crate::modifier::Modifier;
 use compose_core::{MutableState, NodeId, State};
 use std::rc::Rc;
@@ -113,8 +114,12 @@ where
     if let Err(err) = compose_core::with_node_mut(id, |node: &mut TextNode| {
         if node.text != current {
             node.text = current.clone();
+            mark_measure_dirty(id);
         }
-        node.modifier = modifier.clone();
+        if node.modifier != modifier {
+            node.modifier = modifier.clone();
+            mark_measure_dirty(id);
+        }
     }) {
         debug_assert!(false, "failed to update Text node: {err}");
     }


### PR DESCRIPTION
## Summary
- introduce a layout dirty tracker and consult it before reusing cached measurements
- mark layout, subcompose, and widget nodes dirty when their configuration changes
- surface the dirty-state query to the app shell and add a regression test for selective measurement

## Testing
- cargo test -p compose-ui selective_measure_reuses_clean_subtrees

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f25aa62a8832888c83a8edc5574b0)