### PR TITLE
Queue semantics bubbling to avoid composer reentrancy

### DIFF
--- a/crates/compose-ui/src/layout/tests/layout_tests.rs
+++ b/crates/compose-ui/src/layout/tests/layout_tests.rs
@@ -259,8 +259,9 @@ fn set_modifier_marks_dirty() {
     let mut node = LayoutNode::new(Modifier::empty(), Rc::new(MaxSizePolicy));
     node.clear_needs_measure();
     node.clear_needs_layout();
+    node.clear_needs_semantics();
 
-    node.set_modifier(Modifier::empty());
+    node.set_modifier(Modifier::padding(4.0));
     assert!(
         node.needs_measure(),
         "set_modifier should mark node as needing measure"
@@ -268,6 +269,10 @@ fn set_modifier_marks_dirty() {
     assert!(
         node.needs_layout(),
         "set_modifier should mark node as needing layout"
+    );
+    assert!(
+        node.needs_semantics(),
+        "set_modifier should mark node as needing semantics"
     );
 }
 

--- a/crates/compose-ui/src/modifier/mod.rs
+++ b/crates/compose-ui/src/modifier/mod.rs
@@ -39,6 +39,7 @@ pub(crate) use local::{
 };
 #[allow(unused_imports)]
 pub use pointer_input::{AwaitPointerEventScope, PointerInputScope};
+pub use semantics::{collect_semantics_from_chain, collect_semantics_from_modifier};
 pub use slices::{collect_modifier_slices, collect_slices_from_modifier, ModifierNodeSlices};
 
 use crate::modifier_nodes::{ClipToBoundsElement, SizeElement};


### PR DESCRIPTION
## Summary
- add an applier-side semantics bubbling helper and expose a composer hook to schedule semantics invalidations without reentrant borrowing
- update layout nodes to mark semantics dirtiness once and queue bubbling through the composer command stream instead of bubbling inline during composition

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features`
- `cargo test > 1.tmp 2>&1`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69122bd0a3d88328b0796b8fcfe4fdec)