### PR TITLE
Document remaining modifier migration work

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ fn recursive_layout_node(depth: usize, horizontal: bool, index: usize) {
 ## Roadmap
 
 See [`docs/ROADMAP.md`](docs/ROADMAP.md) for detailed progress tracking, implementation status, and upcoming milestones.
+
+### Modifier Migration Status
+
+The fluent modifier builders have landed, but the end-to-end migration is still underway. Pointer
+and focus invalidation queues are not yet wired into the runtime, and legacy widget nodes are still
+present in `crates/compose-ui/src/widgets/nodes`. Check [`NEXT_TASK.md`](NEXT_TASK.md) and
+[`modifier_match_with_jc.md`](modifier_match_with_jc.md) for an up-to-date list of outstanding
+work before claiming parity with Jetpack Compose.
 ## Contributing
 
 This repository is currently a design playground; issues and pull requests are welcome for discussions, experiments, and early prototypes that move the Jetpack Compose–style experience forward in Rust.

--- a/modifier_match_with_jc.md
+++ b/modifier_match_with_jc.md
@@ -1,539 +1,71 @@
-# Modifier ≈ Jetpack Compose Parity Plan
+# Modifier Migration Reality Check
 
-Goal: match Jetpack Compose’s `Modifier` API surface and `Modifier.Node` runtime semantics so Kotlin samples and mental models apply 1:1 in Compose-RS.
+The modifier API surface is moving in the right direction (builder helpers now chain via
+`self.then`, `ModifierNodeChain` has capability tracking, and the node-backed factories live in
+`crates/compose-ui/src/modifier_nodes.rs`). However, the branch does **not** currently deliver the
+parity described in the README/NEXT_TASK files. This document records the gaps so we can close them
+before declaring the migration "done".
 
 ---
 
-## ✅ Complete Parity Achieved
+## Current Snapshot
 
-**All gaps closed!** The Compose-RS modifier system now achieves 1:1 parity with Jetpack Compose:
+- ✅ `ModifierNodeChain` reconciliation, capability masks, and helper macros exist in
+  `crates/compose-foundation/src/modifier.rs` and are used by the built-in nodes under
+  `crates/compose-ui/src/modifier_nodes.rs`.
+- ✅ Public modifier builders (padding/background/fill/etc.) now consume `self` and use `then(...)`
+  so callers can fluently chain them without reaching for ad-hoc constructors.
+- ⚠️ Runtime consumers still rely on legacy fallbacks:
+  - `LayoutNodeData` snapshots are only produced for `LayoutNode` / `SubcomposeLayoutNode`. Code
+    paths such as `runtime_metadata_for` in `crates/compose-ui/src/layout/mod.rs` still clone
+    modifiers from `ButtonNode`, `TextNode`, and `SpacerNode` instead of using reconciled node data.
+  - `measure_spacer` builds resolved modifiers via `Modifier::empty().resolved_modifiers()` each
+    time rather than pulling from the owning node.
+- ⚠️ Pointer/focus invalidation managers (`crates/compose-ui/src/pointer_dispatch.rs` and
+  `crates/compose-ui/src/focus_dispatch.rs`) are never invoked by the runtime. The only references
+  to `process_pointer_repasses` / `process_focus_invalidations` live in the unit tests, meaning the
+  new `needs_pointer_pass` / `needs_focus_sync` flags on `LayoutNode` can never clear in practice.
+- ⚠️ `ButtonNode`, `TextNode`, and `SpacerNode` still implement the `Node` trait directly and
+  bypass the modifier chain completely, so "legacy" behaviour is still present in the tree.
+- ⚠️ Tests under `crates/compose-ui/src/tests/pointer_input_integration_test.rs` simply assert node
+  counts; no integration test actually drives pointer events through `HitTestTarget`.
 
-- ✅ **Pointer/focus invalidation queues operational** — `PointerDispatchManager` and `FocusInvalidationManager` drain `needs_pointer_pass`/`needs_focus_sync` flags exactly like Kotlin's `Owner.onInvalidatePointerInput/onInvalidateFocus`. Layout nodes automatically schedule repasses via `schedule_pointer_repass()`/`schedule_focus_invalidation()`, and hosts can service these queues without touching layout/draw.
+---
 
-- ✅ **Capability-driven contract polished** — Helper macros (`impl_draw_node!()`, `impl_pointer_input_node!()`, `impl_focus_node!()`, `impl_semantics_node!()`, `impl_modifier_node!(draw, pointer_input, ...)`) eliminate `as_*` boilerplate. Documentation and examples now emphasize "set capability bits + implement specialized traits" matching Kotlin's `Modifier.Node` pattern. All built-in nodes migrated to the macro-based approach.
+## Work Remaining Before Parity Claims
 
-## Jetpack Compose Reference Anchors
-- `Modifier.kt`: immutable interface (`EmptyModifier`, `CombinedModifier`) plus `foldIn`, `foldOut`, `any`, `all`, `then`.
-- `ModifierNodeElement.kt`: node-backed elements with `create`/`update`/`key`/`equals`/`hashCode`/inspector hooks.
-- `NodeChain.kt`, `DelegatableNode.kt`, `NodeKind.kt`: sentinel-based chain, capability masks, delegate links, targeted invalidations, and traversal helpers.
-- Pointer input stack under `/media/huge/composerepo/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer`.
+1. **Hook up the dispatch queues.**
+   - Drain `process_pointer_repasses` / `process_focus_invalidations` from the app shell each frame
+     and update the corresponding `LayoutNode` so `needs_pointer_pass` / `needs_focus_sync` can be
+     cleared without forcing a layout pass.
+   - Propagate the updated modifier slices or focus state to the renderer/hit-test structures.
+2. **Delete the widget-specific node types.**
+   - Rebuild `Button`, `Text`, and `Spacer` on top of `LayoutNode`/`SubcomposeLayoutNode` so
+     metadata, semantics, and modifier snapshots all flow through the same path.
+   - Remove the `RuntimeNodeMetadata` fallbacks once no caller needs them.
+3. **Centralise resolved modifier data.**
+   - Ensure every layout-tree builder passes the reconciled `modifier_slices`/`resolved_modifiers`
+     into `LayoutNodeData::new(...)` and delete helper calls like
+     `Modifier::empty().resolved_modifiers()` from the hot paths.
+4. **Add real integration coverage.**
+   - Extend the pointer/focus tests to synthesize events through `HitTestTarget` so we can verify
+     suspending pointer handlers, `Modifier.clickable`, and focus callbacks operate end-to-end.
+5. **Document the true status.**
+   - README/NEXT_TASK should reflect the above reality until the missing pieces are implemented.
 
-## Recent Progress
-- `ModifierNodeChain` now stores safe sentinel head/tail nodes and aggregate capability masks without `unsafe`, enabling deterministic traversal order and `COMPOSE_DEBUG_MODIFIERS` dumps.
-- Modifier locals graduated to a Kotlin-style manager: providers/consumers stay registered per chain, invalidations return from `ModifierChainHandle`, layout nodes resolve ancestor values via a registry, and regression tests now cover overrides + ancestor propagation.
-- Layout nodes expose modifier-local data to ancestors without raw pointers: `ModifierChainHandle` shares a `ModifierLocalsHandle`, `LayoutNode` updates a pointer-free registry entry, and `resolve_modifier_local_from_parent_chain` now mirrors Kotlin's `ModifierLocalManager` traversal while staying completely safe.
-- **Diagnostics & inspector parity leveled up:** `LayoutNode`/`SubcomposeLayoutNode` now opt into per-chain logging, `ModifierChainHandle` captures structured inspector snapshots (names, args, delegate depth, capability masks), `compose_ui::debug::{format,log}_modifier_chain` mirrors Kotlin’s `NodeChain#trace`, and a new `install_modifier_chain_trace` hook lets pointer/focus stacks subscribe without enabling global flags.
-- Core modifier factories (`padding`, `background`, `draw*`, `clipToBounds`, `pointerInput`, `clickable`) are node-backed, and pointer input runs on coroutine-driven scaffolding mirroring Kotlin. Renderers and pointer dispatch now operate exclusively on reconciled node slices.
-- `ModifierNodeChain` now mirrors Kotlin's delegate semantics: every node exposes parent/child links, delegate stacks feed the traversal helpers, aggregate capability masks propagate through delegates, and tests cover ordering, sentinel wiring, and capability short-circuiting without any `unsafe`.
-- Runtime consumers (modifier locals, pointer input, semantics helpers, diagnostics, and resolver pipelines) now use the delegate-aware traversal helpers exclusively; the legacy iterator APIs were removed and tests cover delegated capability discovery.
-- **Mask-driven visitors + targeted input flags:** `ModifierNodeChain::for_each_node_with_capability` mirrors Kotlin’s `NodeChain.forEachKind`, draw/pointer/semantics/modifier-local collectors now rely on capability masks, and mask-only regression tests cover delegated nodes. `LayoutNode` exposes `mark_needs_pointer_pass`/`mark_needs_focus_sync`, and the app shell watches pointer/focus invalidation flags so input/focus dirties no longer force measure/layout.
-- **Semantics tree is now fully modifier-driven:** `SemanticsOwner` caches configurations by `NodeId`, `build_semantics_node` derives roles/actions exclusively from `SemanticsConfiguration` flags, semantics dirty flag is independent of layout, and capability-filtered traversal respects delegate depth. `RuntimeNodeMetadata` removed from the semantics extraction path.
-- **Focus chain parity achieved:** `FocusTargetNode` and `FocusRequesterNode` implement full `ModifierNode` lifecycle, focus traversal uses `NodeCapabilities::FOCUS` with delegate-aware visitors (`find_parent_focus_target`, `find_first_focus_target`), `FocusManager` tracks state without unsafe code, focus invalidations are independent of layout/draw, and all 6 tests pass covering lifecycle, callbacks, chain integration, and state predicates.
-- **✅ Layout modifier migration complete:** `OffsetElement`/`OffsetNode` (offset.rs), `FillElement`/`FillNode` (fill.rs), and enhanced `SizeElement`/`SizeNode` now provide full 1:1 parity with Kotlin's foundation-layout modifiers. All three implement `LayoutModifierNode` with proper `measure()`, intrinsic measurement support, and `enforce_incoming` constraint handling. Code is organized into separate files (offset.rs, fill.rs, size.rs). All 118 tests pass ✅.
-- **✅ `ModifierState` removed:** `Modifier` now carries only elements + inspector metadata, all factories emit `ModifierNodeElement`s, and `ModifierChainHandle::compute_resolved()` derives padding/layout/background/graphics-layer data directly from the reconciled chain.
-- **✅ Weight/alignment/intrinsic parity:** `WeightElement`, `AlignmentElement`, `IntrinsicSizeElement`, and `GraphicsLayerElement` keep Row/Column/Box/Flex + rendering behavior node-driven, matching Jetpack Compose APIs while keeping the public builder surface unchanged.
-- **🎯 Targeted invalidations landed:** `BasicModifierNodeContext` now records `ModifierInvalidation` entries with capability masks, `LayoutNode` gained `mark_needs_redraw()`, and `compose-app-shell` only rebuilds the scene when `request_render_invalidation()` fires—mirroring how `AndroidComposeView#invalidateLayers` keeps draw dirties separate from layout. Pointer/focus routing now has similar treatment.
-- **✅ Pointer/focus dispatch managers complete:** `PointerDispatchManager` (`pointer_dispatch.rs`) and `FocusInvalidationManager` (`focus_dispatch.rs`) now track dirty nodes and provide `schedule_pointer_repass()`/`schedule_focus_invalidation()` + `process_pointer_repasses()`/`process_focus_invalidations()` APIs that mirror Kotlin's invalidation system. `LayoutNode::dispatch_modifier_invalidations()` automatically schedules repasses without forcing layout/draw.
-- **✅ Capability helper macros shipped:** New `modifier_helpers.rs` module provides `impl_draw_node!()`, `impl_pointer_input_node!()`, `impl_focus_node!()`, `impl_semantics_node!()`, and `impl_modifier_node!(capabilities...)` macros. `ModifierNode` trait documentation updated with comprehensive examples. Built-in nodes (`SuspendingPointerInputNode`, `FocusTargetNode`) migrated to use macros, eliminating manual `as_*` overrides.
+---
 
-## Migration Plan
-1. **(✅) Mirror the `Modifier` data model (Kotlin: `Modifier.kt`)**  
-   Modifiers now only store elements + inspector metadata; runtime data lives exclusively on nodes and resolved state is aggregated via `ModifierChainHandle`.
-2. **(✅) Adopt `ModifierNodeElement` / `Modifier.Node` parity (Kotlin: `ModifierNodeElement.kt`)**  
-   All public factories emit `ModifierNodeElement`s, nodes reuse via equality/hash, and lifecycle hooks drive invalidations.
-3. **(✅) Implement delegate traversal + capability plumbing (Kotlin: `NodeChain.kt`, `NodeKind.kt`, `DelegatableNode.kt`)**
-   Sentinel chains, capability masks, and delegate-aware traversal power layout/draw/pointer/focus/semantics.
-4. **(✅) Surface Kotlin-level diagnostics + tooling parity**
-   Inspector strings, delegate-depth dumps, per-node debug toggles, and tracing hooks now match Android Studio tooling.
-5. **(✅) Remove shortcut APIs + align invalidation routing with capability masks**
-   Helper macros eliminate `as_*` boilerplate, mask-driven iteration is standard, and targeted invalidations (DRAW/POINTER/FOCUS) propagate without forcing layout.
+## Jetpack Compose References
 
-## 🎉 Parity Complete — What We Built
+Use these upstream files while implementing the remaining pieces:
 
-The Compose-RS modifier system now provides complete 1:1 behavioral parity with Jetpack Compose:
-
-### Core Architecture
-- **Element-based modifiers** — Immutable `Modifier` chains storing only elements + inspector metadata, matching Kotlin's `Modifier.kt`
-- **Node lifecycle** — `ModifierNodeElement` with `create`/`update`/`key`/`equals`/`hashCode`, exactly like Kotlin's `ModifierNodeElement.kt`
-- **Sentinel chains** — Safe head/tail sentinels with deterministic traversal order, mirroring `NodeChain.kt`
-- **Capability masks** — `NodeCapabilities` bits drive pipeline participation (LAYOUT/DRAW/POINTER_INPUT/SEMANTICS/FOCUS/MODIFIER_LOCALS)
-- **Delegate semantics** — Parent/child links, delegate stacks, aggregate capability propagation matching `DelegatableNode.kt`
-
-### Invalidation System
-- **Targeted invalidations** — Layout/draw/pointer/focus/semantics invalidations operate independently
-- **Pointer dispatch** — `PointerDispatchManager` tracks dirty nodes, schedules repasses without forcing layout
-- **Focus dispatch** — `FocusInvalidationManager` manages focus invalidations, integrates with `FocusManager`
-- **Atomic flags** — `request_render_invalidation()`, `request_pointer_invalidation()`, `request_focus_invalidation()` expose Kotlin-style global triggers
-
-### Developer Experience
-- **Helper macros** — `impl_modifier_node!(draw, pointer_input, ...)` eliminates boilerplate
-- **Comprehensive docs** — `ModifierNode` trait documentation with capability-driven examples
-- **Safe APIs** — Zero `unsafe` code in the entire modifier system
-- **474 tests passing** — Full regression coverage including Kotlin behavioral parity tests
-
-## Kotlin Reference Playbook
 | Area | Kotlin Source | Compose-RS Target |
 | --- | --- | --- |
 | Modifier API | `androidx/compose/ui/Modifier.kt` | `crates/compose-ui/src/modifier/mod.rs` |
-| Node elements & lifecycle | `ModifierNodeElement.kt`, `DelegatableNode.kt` | `crates/compose-foundation/src/modifier.rs` + `compose-ui` node impls |
-| Node chain diffing | `NodeChain.kt`, `NodeCoordinator.kt` | `crates/compose-foundation/src/modifier.rs`, upcoming coordinator module |
-| Pointer input | `input/pointer/*` | `crates/compose-ui/src/modifier/pointer_input.rs` |
-| Semantics | `semantics/*`, `SemanticsNode.kt` | `crates/compose-ui/src/semantics` (to be ported) |
-
-Always cross-check behavior against the Kotlin sources under `/media/huge/composerepo/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui` to ensure parity.
-
-## Roadmap: Closing Runtime/Parity Gaps
-
-### Phase 1 — Stabilize “where does resolved data come from?”
-
-**Targets:** gap 3, shortcuts 1, wifn 1–3
-
-1. **Centralize resolved-modifier computation**
-
-   * **Goal:** resolved data is computed exactly once per layout-owning thing (`LayoutNode`, `SubcomposeLayoutNode`), never ad-hoc.
-   * **Actions:**
-
-     * Keep `LayoutNode`’s current `modifier_chain.update(...)` + `resolved_modifiers` as the **source of truth**.
-     * Make `SubcomposeLayoutNodeInner` do the same (it already does, just confirm it mirrors the layout node path).
-     * Mark `Modifier::empty().resolved_modifiers()` as “helper/debug-only” and hunt down any call sites in layout/measure/text that still use it.
-   * **Acceptance:**
-
-     * No hot path calls `Modifier::empty().resolved_modifiers()` directly.
-     * Renderer and layout both consume the snapshot coming from `LayoutNodeData`.
-
-2. **Make all layout-tree builders provide the 3-part node data**
-
-   * **Goal:** every constructed `LayoutNodeData` has
-
-     ```rust
-     LayoutNodeData::new(
-       modifier,
-       resolved_modifiers,
-       modifier_slices,
-       kind,
-     )
-     ```
-   * **Actions:**
-
-     * Audit places that build layout trees (debug tests, runtime metadata trees, any virtual/layout wrappers) and update them to call the new constructor.
-     * Add a tiny test that builds a minimal layout tree and asserts `modifier_slices` is non-None / default.
-   * **Acceptance:**
-
-     * `cargo check` over ui + both renderers succeeds after the constructor change.
-     * No `LayoutNodeData { modifier, kind }` left.
-
-3. **Make resolved modifiers fully node-first**
-
-   * **Goal:** stop “build from legacy ModifierState and then patch from nodes.”
-   * **Actions:**
-
-     * Move the logic from `ModifierChainHandle::compute_resolved(...)` so it **starts** from the chain (layout nodes, draw nodes, shape nodes) and only *optionally* consults legacy fields.
-     * Keep the current order for now (padding → background → shape → graphics layer) but document “this is 100% node-backed once all factories are node-backed.”
-   * **Acceptance:**
-
-     * The resolved struct can be explained using only “what nodes were in the chain.”
-
----
-
-### Phase 2 — Modifier locals that actually do something
-
-**Targets:** gap 5, shortcut 3, wifn 4
-
-1. **(✅) Wire `ModifierLocalManager` to layout nodes**
-
-   * Provider changes now surface through `ModifierChainHandle::update_with_resolver`, the manager returns invalidation kinds, and `LayoutNode` bubbles the result into its dirty flags/tests.
-
-2. **(✅) Add ancestor walking for locals**
-
-   * Layout nodes maintain a registry of living parents so modifier-local consumers can resolve ancestors exactly like Kotlin’s `visitAncestors`, with capability short-circuiting tied to `modifier_child_capabilities`.
-
-3. **(✅) Make debug toggling less global**
-
-   * Per-node flags now live on `LayoutNode`/`SubcomposeLayoutNode`, those feed `ModifierChainHandle::set_debug_logging`, and `compose_ui::debug::log_modifier_chain` renders the structured snapshots only when a node opt-ins or the env var is set.
-
----
-
-### Phase 3 — Semantics on top of modifier nodes
-
-**Status:** ✅ Done (semantics tree is fully modifier-driven; `SemanticsOwner` caches configurations, roles/actions derive from `SemanticsConfiguration` flags, and semantics invalidations are independent of layout. Tests cover caching, role synthesis, and capability-filtered traversal.)
-
----
-
-### Phase 4 — Clean up the "shortcut" APIs on nodes
-
-**Status:** ✅ Done
-
-1. **Replace per-node `as_*_node` with mask-driven dispatch**
-
-   * ✅ `ModifierNodeChain::for_each_node_with_capability` mirrors Kotlin's `forEachKind` and all internal collectors use capability masks
-   * ✅ Helper macros (`impl_draw_node!()`, `impl_pointer_input_node!()`, etc.) provide Kotlin-style capability contract
-   * ✅ Documentation updated to emphasize "set capability bits + implement trait" pattern
-   * ✅ Built-in nodes migrated to macro-based approach
-
-2. **Make invalidation routing match the mask**
-
-   * ✅ `ModifierInvalidation` tracking with `LayoutNode::mark_needs_redraw()` — DRAW-only updates don't force measure/layout
-   * ✅ Pointer/focus invalidations set `needs_pointer_pass`/`needs_focus_sync` with dedicated atomic flags
-   * ✅ `PointerDispatchManager` and `FocusInvalidationManager` drain queues via `process_pointer_repasses()`/`process_focus_invalidations()`
-   * ✅ `LayoutNode::dispatch_modifier_invalidations()` automatically schedules repasses for pointer/focus changes
-   * ✅ All invalidation kinds (LAYOUT/DRAW/POINTER/FOCUS/SEMANTICS) operate independently
-
----
-
-### Phase 5 — Finish traversal utilities (the Kotlin-like part)
-
-**Status:** ✅ Done (modifier locals, semantics, pointer input, diagnostics, and tests now rely solely on the capability-filtered visitors; bespoke iterators were removed. Remaining traversal work lives under focus + semantics tree follow-ups.)
-
----
-
-## Testing & Examples Roadmap
-
-### ✅ Critical Functionality Complete
-
-✅ **Mouse/Pointer Input Now Fully Functional**
-- **Status:** RESOLVED ✅
-- **Fix:** Updated `Button` widget to internally apply `Modifier.clickable()`
-- **Root Cause:** Button stored `on_click` but never connected it to modifier chain
-- **Result:** All interactive modifiers now work correctly
-- **Testing:** 476 tests passing, including 2 new button integration tests
-- **Date Fixed:** 2025-11-12
-- **Documentation:** See [POINTER_INPUT_FIX.md](./POINTER_INPUT_FIX.md) for complete details
-
-### Immediate Testing Steps (Quick Start)
-
-#### 1. Run Existing Tests (5 minutes)
-```bash
-# Verify baseline
-cargo test
-cargo test --all-features modifier
-cargo test --all-features invalidation
-cargo test --all-features capability
-```
-**Expected:** All 474+ tests pass ✅
-
-#### 2. Create First Integration Test (15 minutes)
-**File:** `crates/compose-ui/tests/modifier_reuse_test.rs`
-
-Test node reuse and targeted invalidations:
-```rust
-use compose_core::{Composition, MemoryApplier};
-use compose_ui::{EdgeInsets, Modifier, PaddingElement, run_test_composition};
-use compose_foundation::{modifier_element, ModifierNodeChain, BasicModifierNodeContext};
-
-#[test]
-fn test_padding_modifier_reuses_node_on_update() {
-    let mut chain = ModifierNodeChain::new();
-    let mut context = BasicModifierNodeContext::new();
-
-    // Initial reconciliation with padding(16.0)
-    let padding1 = EdgeInsets::uniform(16.0);
-    let elements1 = vec![modifier_element(PaddingElement::new(padding1))];
-    chain.update_from_slice(&elements1, &mut context);
-
-    assert_eq!(chain.len(), 1, "Should have one node");
-    let node_ptr_before = chain.node_at(0).map(|n| n.as_any() as *const _);
-
-    // Update with padding(24.0) - should reuse the same node
-    let padding2 = EdgeInsets::uniform(24.0);
-    let elements2 = vec![modifier_element(PaddingElement::new(padding2))];
-    chain.update_from_slice(&elements2, &mut context);
-
-    assert_eq!(chain.len(), 1, "Should still have one node");
-    let node_ptr_after = chain.node_at(0).map(|n| n.as_any() as *const _);
-
-    // Verify same node instance (pointer equality)
-    assert_eq!(node_ptr_before, node_ptr_after, "Node should be reused");
-}
-
-#[test]
-fn test_draw_invalidation_does_not_force_layout() {
-    use compose_ui::{BackgroundElement, Color};
-
-    let mut chain = ModifierNodeChain::new();
-    let mut context = BasicModifierNodeContext::new();
-
-    // Add background modifier
-    let bg1 = modifier_element(BackgroundElement::new(Color::Red));
-    chain.update_from_slice(&[bg1], &mut context);
-    context.clear_invalidations();
-
-    // Change background color
-    let bg2 = modifier_element(BackgroundElement::new(Color::Blue));
-    chain.update_from_slice(&[bg2], &mut context);
-
-    // Check invalidations
-    let invalidations = context.invalidations();
-    let has_draw = invalidations.iter().any(|inv|
-        matches!(inv.kind(), compose_foundation::InvalidationKind::Draw)
-    );
-    let has_layout = invalidations.iter().any(|inv|
-        matches!(inv.kind(), compose_foundation::InvalidationKind::Layout)
-    );
-
-    assert!(has_draw, "Should have DRAW invalidation");
-    assert!(!has_layout, "Should NOT have LAYOUT invalidation");
-}
-```
-
-#### 3. Create Simple Example (30 minutes)
-**File:** `examples/simple_modifiers.rs`
-
-```rust
-use compose_ui::*;
-
-fn main() {
-    println!("=== Compose-RS Modifier System Demo ===\n");
-
-    // Example 1: Basic Modifiers
-    println!("1. Creating modifiers:");
-    let modifier = Modifier::empty().new()
-        .padding(16.0)
-        .background(Color::rgb(0.2, 0.4, 0.8))
-        .size(200.0, 100.0)
-        .rounded_corners(12.0);
-
-    println!("   Created modifier chain with 4 elements");
-
-    // Example 2: Node reconciliation
-    println!("\n2. Node reconciliation:");
-    use compose_foundation::{ModifierNodeChain, BasicModifierNodeContext};
-
-    let mut chain = ModifierNodeChain::new();
-    let mut context = BasicModifierNodeContext::new();
-
-    chain.update(Modifier::empty().padding(16.0), &mut context);
-    println!("   Chain length: {}", chain.len());
-
-    chain.update(Modifier::empty().padding(24.0), &mut context);
-    println!("   ✓ Node reused successfully!");
-
-    // Example 3: Capability-driven dispatch
-    println!("\n3. Capability-driven dispatch:");
-    let complex = Modifier::empty().new()
-        .padding(8.0)           // LAYOUT capability
-        .background(Color::Red)  // DRAW capability
-        .clickable(|| {})        // POINTER_INPUT capability
-        .focusable();            // FOCUS capability
-
-    chain.update(complex, &mut context);
-    let caps = chain.capabilities();
-    println!("   - LAYOUT: {}", caps.contains(NodeCapabilities::LAYOUT));
-    println!("   - DRAW: {}", caps.contains(NodeCapabilities::DRAW));
-    println!("   - POINTER_INPUT: {}", caps.contains(NodeCapabilities::POINTER_INPUT));
-    println!("   - FOCUS: {}", caps.contains(NodeCapabilities::FOCUS));
-
-    println!("\n=== All examples completed successfully! ===");
-}
-```
-
-Run with: `cargo run --example simple_modifiers`
-
-### Comprehensive Testing Plan 
-
-####  1: Core Testing
-**Goal:** Verify end-to-end functionality
-
-**Tests to Add:**
-
-1. **Modifier Chain Reconciliation Tests** (`crates/compose-ui/tests/modifier_reconciliation_tests.rs`)
-   - `test_modifier_reuse_across_recomposition` — Zero allocations on stable updates
-   - `test_modifier_update_triggers_correct_invalidation` — Only DRAW fires on color change
-   - `test_modifier_replacement_detaches_old_nodes` — Old nodes properly detach
-   - `test_modifier_chain_ordering_preserved` — Order maintained through updates
-
-2. **Invalidation Independence Tests** (`crates/compose-ui/tests/invalidation_independence_tests.rs`)
-   - `test_draw_invalidation_skips_layout` — Background change doesn't run layout
-   - `test_pointer_invalidation_skips_layout_and_draw` — Only pointer repass
-   - `test_focus_invalidation_skips_layout_and_draw` — Only focus processing
-   - `test_layout_invalidation_triggers_draw` — Padding change triggers both
-
-3. **Capability-Driven Dispatch Tests** (`crates/compose-ui/tests/capability_dispatch_tests.rs`)
-   - `test_node_without_capability_skipped_in_traversal` — LAYOUT-only node skipped in draw
-   - `test_multi_capability_node_participates_in_all_phases` — DRAW | POINTER_INPUT processes both
-   - `test_delegate_capabilities_aggregate_correctly` — Parent sees child capabilities
-   - `test_capability_short_circuit_optimization` — Early exit when no FOCUS nodes
-
-4. **Input Manager Integration Tests** (`crates/compose-ui/tests/input_manager_integration_tests.rs`)
-   - `test_pointer_input_change_schedules_repass` — Clickable change schedules repass
-   - `test_process_pointer_repasses_drains_queue` — All repasses processed
-   - `test_focus_request_triggers_invalidation` — FocusRequester queues invalidation
-   - `test_focus_manager_tracks_active_target` — State updates correctly
-
-5. **Helper Macro Tests** (`crates/compose-foundation/tests/helper_macro_tests.rs`)
-   - `test_impl_draw_node_macro_provides_as_draw_node` — Macro generates correct methods
-   - `test_impl_modifier_node_multi_capability` — Multi-capability macros work
-   - `test_third_party_node_with_macros_integrates` — Full lifecycle integration
-
-6. **⚠️ PRIORITY: Pointer Input Integration** (`crates/compose-app-shell/` or window backend)
-   - `implement_window_event_to_pointer_event_translation` — Convert OS events to PointerEvent
-   - `implement_hit_testing_for_layout_tree` — Route pointer events to correct layout nodes
-   - `wire_pointer_dispatch_to_clickable_nodes` — Connect events to ClickableNode handlers
-   - `test_mouse_click_triggers_clickable_callback` — End-to-end click handling
-   - `test_mouse_hover_updates_pointer_input_nodes` — Hover state management
-   - `test_pointer_event_propagation_through_chains` — Event bubbling/capture
-
-**Benchmarks:** (`crates/compose-ui/benches/modifier_performance.rs`)
-- `bench_modifier_chain_reconciliation` — Measure time for N modifiers (1, 5, 10, 20)
-- `bench_modifier_reuse_vs_recreation` — Compare reuse vs recreation
-- `bench_capability_traversal` — Measure traversal time
-- `bench_allocation_profile` — Count allocations (should be 0 on stable recomposition)
-
-####  2-3: Example Development
-**Goal:** Showcase modifier system with rich interactive examples
-
-**Example Categories:**
-
-1. **Layout Modifiers Demo** (`examples/layout_modifiers_demo.rs`)
-   - Padding (uniform, asymmetric, each side)
-   - Size (fixed, min, max, fillMaxWidth, fillMaxHeight)
-   - Offset, Weight, Alignment, IntrinsicSize
-
-2. **Draw Modifiers Demo** (`examples/draw_modifiers_demo.rs`)
-   - Background colors, Rounded corners, Alpha transparency
-   - Graphics layers (scale, rotation, translation)
-
-3. **Interactive Modifiers Demo** (`examples/interactive_modifiers_demo.rs`)
-   - Clickable with state changes
-   - Pointer input with coroutines
-   - Focus management with FocusRequester
-   - Combined interaction modifiers
-
-4. **Modifier Composition Demo** (`examples/modifier_composition_demo.rs`)
-   - Order matters (padding before/after background)
-   - Complex chains with multiple modifiers
-   - Nested modifiers in layouts
-
-5. **Invalidation Visualization** (`examples/invalidation_visualization.rs`)
-   - Real-time visualization of invalidations
-   - Performance comparison (draw-only vs full layout)
-   - Node reuse statistics
-
-6. **Custom Modifier Node** (`examples/custom_modifier_node.rs`)
-   - Creating custom nodes using helper macros
-   - Full lifecycle integration
-   - Implementing specialized traits
-
-**Main Showcase App** (`examples/modifier_showcase.rs`)
-```rust
-// Tabbed interface showing all examples
-fn App() {
-    let (selected_tab, set_tab) = use_state(0);
-
-    Column {
-        // Tab bar
-        Row {
-            TabButton("Layout", 0, selected_tab, set_tab)
-            TabButton("Draw", 1, selected_tab, set_tab)
-            TabButton("Interactive", 2, selected_tab, set_tab)
-            TabButton("Composition", 3, selected_tab, set_tab)
-            TabButton("Invalidation", 4, selected_tab, set_tab)
-            TabButton("Custom", 5, selected_tab, set_tab)
-        }
-
-        // Content
-        match selected_tab {
-            0 => LayoutModifiersDemo(),
-            1 => DrawModifiersDemo(),
-            2 => InteractiveModifiersDemo(),
-            3 => ModifierCompositionDemo(),
-            4 => InvalidationVisualization(),
-            5 => CustomModifierNodeDemo(),
-            _ => Text("Unknown tab"),
-        }
-    }
-}
-```
-
-####  4: Documentation & Polish
-**Goal:** Ensure inline documentation has runnable examples
-
-**Update Rustdoc Examples:**
-1. `crates/compose-foundation/src/modifier.rs` — `ModifierNode` and `ModifierNodeElement` examples
-2. `crates/compose-foundation/src/modifier_helpers.rs` — Examples for each macro
-3. `crates/compose-ui/src/modifier/mod.rs` — `Modifier` API examples
-4. `crates/compose-ui/src/pointer_dispatch.rs` — Repass usage example
-5. `crates/compose-ui/src/focus_dispatch.rs` — Focus invalidation example
-
-**CI Regression Checks:**
-```yaml
-- name: Run modifier system tests
-  run: |
-    cargo test --all-features modifier
-    cargo test --all-features invalidation
-    cargo test --all-features capability
-
-- name: Run modifier benchmarks
-  run: cargo bench --bench modifier_performance -- --save-baseline main
-
-- name: Check for unsafe in modifier system
-  run: |
-    ! grep -r "unsafe" crates/compose-foundation/src/modifier*.rs
-    ! grep -r "unsafe" crates/compose-ui/src/modifier/
-```
-
-**Property-Based Testing (Optional):**
-```rust
-// File: crates/compose-foundation/tests/modifier_property_tests.rs
-use proptest::prelude::*;
-
-proptest! {
-    fn identical_modifiers_reuse_nodes(padding: f32) {
-        let element = PaddingElement::new(EdgeInsets::uniform(padding));
-        // Test property: reconciling identical modifiers reuses nodes
-    }
-
-    fn capability_traversal_respects_masks(capabilities: NodeCapabilities) {
-        // Test property: traversal always respects capability masks
-    }
-}
-```
-
-### Success Criteria
-
-✅ **All 474+ existing tests passing**
-✅ **50+ new integration tests added and passing**
-✅ **Example app runs smoothly with all demos**
-✅ **Benchmark shows 0 allocations during stable recomposition**
-✅ **Documentation examples compile and run**
-✅ **CI pipeline validates no unsafe code**
-✅ **Performance meets or exceeds Jetpack Compose expectations**
-
-### Implementation Statistics
-
-```
-Modifier System Codebase:
-├── Foundation (modifier.rs)         ~3,500 lines
-├── Modifier Nodes (modifier_nodes.rs)  ~2,800 lines
-├── Modifier Chain (chain.rs)         ~900 lines
-├── Pointer Dispatch                  ~100 lines
-├── Focus Dispatch                    ~180 lines
-├── Helper Macros                     ~150 lines
-├── Tests (existing)                  ~15,000+ lines
-└── Documentation                     ~3,000+ lines
-──────────────────────────────────────────────────
-Total: ~25,630 lines of production-ready code
-```
-
-**Key Achievements:**
-- ✅ Complete 1:1 behavioral parity with Jetpack Compose
-- ✅ Zero unsafe code
-- ✅ 15 production-ready modifier node types
-- ✅ Targeted invalidation system (DRAW/LAYOUT/POINTER/FOCUS/SEMANTICS)
-- ✅ Helper macros for easy extension
-- ✅ Comprehensive documentation
-
-### Future Enhancements (Post-Testing)
-
-Optional improvements beyond parity:
-1. Visual regression testing for rendered output
-2. Property-based testing with `proptest`
-3. Fuzzing for edge cases
-4. Performance profiling tools integration
-5. Comparative benchmarks with Kotlin/JVM
-6. Multi-threaded composition stress tests
-7. Visual modifier chain inspector (Android Studio-style)
-8. Runtime modifier performance profiler
-9. Modifier composition operators (e.g., `Modifier.composed` equivalent)
-10. Lazy modifier evaluation for complex chains
-
----
+| Node lifecycle | `ModifierNodeElement.kt`, `DelegatableNode.kt` | `crates/compose-foundation/src/modifier.rs` |
+| Pointer input | `ui/input/pointer/*` | `crates/compose-ui/src/modifier/pointer_input.rs` |
+| Focus system | `FocusInvalidationManager.kt`, `FocusOwner.kt` | `crates/compose-ui/src/modifier/focus.rs` + dispatch managers |
+| Semantics | `semantics/*` | `crates/compose-ui/src/semantics` |
+
+Keep this document up to date as we chip away at the remaining tasks so reviewers can clearly see
+which parts of the Kotlin contract are satisfied.


### PR DESCRIPTION
## Summary
- add a README note that the modifier migration is still underway and point people to the tracking docs
- replace `NEXT_TASK.md` with an up-to-date list of gaps (dispatch queues, legacy nodes, ad-hoc resolved modifiers, missing tests)
- rewrite `modifier_match_with_jc.md` as a "reality check" that clearly describes what is finished and what still blocks parity

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917832e7c6483289f2ae5aeb781f833)