### PR TITLE
Expose layout modifier nodes for runtime traversal

### DIFF
--- a/crates/compose-foundation/src/modifier.rs
+++ b/crates/compose-foundation/src/modifier.rs
@@ -371,6 +371,16 @@ pub trait ModifierNode: Any + DelegatableNode {
         None
     }
 
+    /// Returns this node as a layout modifier if it implements the trait.
+    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
+        None
+    }
+
+    /// Returns this node as a mutable layout modifier if it implements the trait.
+    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
+        None
+    }
+
     /// Visits every delegate node owned by this modifier.
     fn for_each_delegate<'b>(&'b self, _visitor: &mut dyn FnMut(&'b dyn ModifierNode)) {}
 

--- a/crates/compose-foundation/src/tests/modifier_tests.rs
+++ b/crates/compose-foundation/src/tests/modifier_tests.rs
@@ -600,7 +600,15 @@ impl DelegatableNode for TestLayoutNode {
     }
 }
 
-impl ModifierNode for TestLayoutNode {}
+impl ModifierNode for TestLayoutNode {
+    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
+        Some(self)
+    }
+
+    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
+        Some(self)
+    }
+}
 
 impl LayoutModifierNode for TestLayoutNode {
     fn measure(

--- a/crates/compose-ui/src/modifier_nodes.rs
+++ b/crates/compose-ui/src/modifier_nodes.rs
@@ -150,6 +150,14 @@ impl ModifierNode for PaddingNode {
     fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
         context.invalidate(compose_foundation::InvalidationKind::Layout);
     }
+
+    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
+        Some(self)
+    }
+
+    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
+        Some(self)
+    }
 }
 
 impl LayoutModifierNode for PaddingNode {
@@ -613,6 +621,14 @@ impl DelegatableNode for SizeNode {
 impl ModifierNode for SizeNode {
     fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
         context.invalidate(compose_foundation::InvalidationKind::Layout);
+    }
+
+    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
+        Some(self)
+    }
+
+    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
+        Some(self)
     }
 }
 
@@ -1455,6 +1471,14 @@ impl ModifierNode for OffsetNode {
     fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
         context.invalidate(compose_foundation::InvalidationKind::Layout);
     }
+
+    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
+        Some(self)
+    }
+
+    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
+        Some(self)
+    }
 }
 
 impl LayoutModifierNode for OffsetNode {
@@ -1582,6 +1606,14 @@ impl DelegatableNode for FillNode {
 impl ModifierNode for FillNode {
     fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
         context.invalidate(compose_foundation::InvalidationKind::Layout);
+    }
+
+    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
+        Some(self)
+    }
+
+    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
+        Some(self)
     }
 }
 

--- a/crates/compose-ui/src/text_modifier_node.rs
+++ b/crates/compose-ui/src/text_modifier_node.rs
@@ -92,6 +92,14 @@ impl ModifierNode for TextModifierNode {
     fn as_semantics_node_mut(&mut self) -> Option<&mut dyn SemanticsNode> {
         Some(self)
     }
+
+    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
+        Some(self)
+    }
+
+    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
+        Some(self)
+    }
 }
 
 impl LayoutModifierNode for TextModifierNode {


### PR DESCRIPTION
## Summary
- add `as_layout_node` / `as_layout_node_mut` hooks to `ModifierNode`
- update built-in layout nodes (padding/size/offset/fill/text + test helpers) to advertise their layout capability through the new hooks

## Testing
- `cargo test > 1.tmp 2>&1`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1338908883288356ef796c06efe1)