### PR TITLE
Fix double click invocations on single button click

### DIFF
--- a/crates/compose-ui/src/modifier/slices.rs
+++ b/crates/compose-ui/src/modifier/slices.rs
@@ -114,9 +114,11 @@ pub fn collect_modifier_slices(chain: &ModifierNodeChain) -> ModifierNodeSlices 
         // Collect click handlers from ClickableNode
         if let Some(clickable) = any.downcast_ref::<ClickableNode>() {
             slices.click_handlers.push(clickable.handler());
+            // Skip adding to pointer_inputs to avoid duplicate invocation
+            return;
         }
 
-        // Collect general pointer input handlers
+        // Collect general pointer input handlers (non-clickable)
         if let Some(handler) = node
             .as_pointer_input_node()
             .and_then(|n| n.pointer_input_handler())


### PR DESCRIPTION
Problem:
- Single mouse clicks were causing click handlers to be invoked multiple times
- Counter was incrementing by 2 instead of 1 on each click

Root Cause:
In collect_modifier_slices(), ClickableNode was being added to BOTH:
1. click_handlers list (via clickable.handler())
2. pointer_inputs list (via pointer_input_handler())

Then in HitRegion::dispatch(), on PointerEventKind::Down:
1. All pointer_inputs handlers were invoked
2. All click_actions were invoked

This caused the same handler to be called twice per click.

Solution:
- Skip adding ClickableNode to pointer_inputs after adding to click_handlers
- Added early return after collecting click handler to prevent duplicate registration
- Only non-clickable pointer input handlers are now added to pointer_inputs

Location: crates/compose-ui/src/modifier/slices.rs:111-128