### PR TITLE
Update modifier documentation to reflect current state

### DIFF
--- a/NEXT_TASK.md
+++ b/NEXT_TASK.md
@@ -1,4 +1,5 @@
 # RS-Compose Development Roadmap
+# (Main branch snapshot reconciled with work-branch findings)
 
 **Last Updated**: April 2026  
 **Modifier System Status**: `main` reports parity; the work branch is validating and fixing remaining gaps.  

--- a/NEXT_TASK.md
+++ b/NEXT_TASK.md
@@ -1,222 +1,89 @@
 # RS-Compose Development Roadmap
 
-**Last Updated**: April 2026
-**Modifier System Status**: ⚠️ Parity verification in progress (origin/main claims parity; see "Modifier System Reality Check")
+**Last Updated**: April 2026  
+**Modifier System Status**: Upstream main claims parity; work branch has active parity fixes in flight.  
 **Documentation Status**: ✅ Comprehensive internals documented
 
 ---
 
-## ✅ Completed Milestones (per origin/main)
+## 🔎 Upstream Main Snapshot (Nov 2025)
+These items mirror the roadmap that already shipped on `main` so they remain visible after rebasing.
 
-### Modifier System (Nov 2025)
+### Modifier System Parity Claims
 - ✅ `ModifierNodeEntry` stores `Rc<RefCell<Box<dyn ModifierNode>>>`
 - ✅ `LayoutModifierNode::measure` returns `LayoutModifierMeasureResult` with placement control
 - ✅ `LayoutModifierCoordinator` holds live node references (no proxy bypass)
-- ✅ Chain preservation intended — currently **under re-validation** because `ResolvedModifiers` still flattens padding/size/offset
+- ✅ Chain preservation intended — flattening marked as removed in `main`
 - ✅ Node lifecycle: `on_attach()`, `on_detach()`, `on_reset()`
 - ✅ Capability-based dispatch with bitflags
 - ✅ Core modifiers implemented: Padding, Size, Offset, Background, Clickable, etc.
 
-### Documentation (Nov 2025)
-- ✅ **MODIFIERS.md** (37KB) - Complete modifier system internals
-- ✅ **SNAPSHOTS_AND_SLOTS.md** (54KB) - Snapshot and slot table internals
-- ✅ **modifier_match_with_jc.md** - Parity status tracking
-- ✅ GitHub Actions workflow for CI
+### Completion Milestones (main)
+- **Phase 1: Shared Ownership & Protocol** — live node references, direct coordinator calls
+- **Phase 2: Eliminating Flattening** — single measurement path, padding/offset/size handled by nodes
+- **Jetpack Compose Parity Achieved** — ordering preserved, placement control, no panicking APIs
+- **Production Ready** — 460+ workspace tests reported green in main
 
-### Test Coverage
-- ✅ 460+ workspace tests passing
-- ✅ Modifier chain composition and reuse
-- ✅ Layout measurement and placement protocols
-- ✅ Capability-based dispatch validation
-- ✅ Integration with draw, pointer input, semantics
-
-### Upstream main roadmap (Nov 2025 snapshot)
-These items reflect the priorities already present on the upstream main branch so they do not get lost while reconciling the modifier findings on this work branch.
-
-- **Performance Optimization**: benchmark modifier traversal, cache aggregated capabilities, pool allocations in `update_from_slice`, and establish a reusable benchmark suite.
-- **API Ergonomics**: builder patterns for modifiers, common helpers, clearer RefCell error messages, and richer documentation/examples.
-- **Advanced Features**: animated and conditional modifiers, modifier scopes, and custom coordinator hooks.
-- **Testing & Validation**: property-based tests, integration scenarios, stress tests for deep chains, and performance regression tracking.
+### Other Main-Branch Priorities
+- **Performance Optimization**: benchmark modifier traversal, cache aggregated capabilities, pool allocations in `update_from_slice`, reusable benchmark suite
+- **API Ergonomics**: builder patterns, common helpers, clearer RefCell errors, richer documentation/examples
+- **Advanced Features**: animated/conditional modifiers, modifier scopes, custom coordinator hooks
+- **Testing & Validation**: property-based tests, integration scenarios, stress tests for deep chains, performance regression tracking
 
 ---
 
-## ⚠️ Modifier System Reality Check (work branch)
+## ⚠️ Reality Checks (work branch)
+Observed divergences that must be addressed before the parity claim is trustworthy after rebasing.
 
 - `ResolvedModifiers` still flattens padding/size/offset, losing modifier ordering (e.g., `padding.background.padding`).
 - `ModifierNodeSlices` coalesces text and graphics layers to the last writer instead of composing them.
 - `MeasurementProxy` remains in the public API even though coordinators measure nodes directly.
 
-These gaps must be closed to reconcile the parity claim from origin/main with observed runtime behavior.
+---
+
+## 🧭 Reconciliation Plan (merge-friendly)
+These steps combine the upstream claims with the work-branch findings so rebasing on `main` keeps both perspectives.
+
+1. **Eliminate layout flattening**  
+   Route padding/size/offset/intrinsics through live nodes and coordinators; add regression tests for mixed chains.
+2. **Make draw/text slices composable**  
+   Stack graphics layers and allow multiple text entries in chain order; keep pointer handlers ordered.
+3. **Resolve the measurement proxy story**  
+   Remove the unused surface or integrate it meaningfully (e.g., borrow-safe async measurement) and update docs/tests.
+4. **Resume upstream priorities once parity is validated**  
+   Continue performance, ergonomics, advanced features, and testing work from the main snapshot.
 
 ---
 
-## 🎯 Current Priorities (merged)
+## 🎯 Active Focus Areas (post-rebase)
 
-### A) Modifier System Corrections (prevents merge conflicts with origin/main)
-- Remove layout flattening: route padding/size/offset/intrinsics through live nodes and coordinators.
-- Make draw/text slices composable: allow stacking graphics layers and multiple text entries in chain order.
-- Decide the measurement proxy story: remove unused surface or integrate it meaningfully (e.g., borrow-safe async measurement).
-- Add regression tests for mixed chains and slice composition to lock in ordering semantics.
+### A) Modifier System Corrections
+- Remove layout flattening and keep ordering semantics.
+- Compose draw/text slices instead of last-write-wins.
+- Decide and implement the measurement proxy direction.
+- Add regression tests for mixed chains and slice composition.
 
 ### B) Real-World Application Development
-**Goal**: Build production-quality example apps to validate the framework
-
-- [ ] **Complex Desktop Application** - Multi-window IDE/editor-style app
-  - State management across windows
-  - Complex nested layouts with performance testing
-  - Drag-and-drop, keyboard shortcuts
-  - Custom rendering for code editor
-
-- [ ] **Dashboard/Data Visualization App**
-  - Charts, graphs, real-time data updates
-  - LazyColumn/LazyRow with large datasets
-  - Scrolling performance optimization
-
-- [ ] **Form-Heavy Application**
-  - Text input validation
-  - Focus management
-  - Tab navigation
-  - Error states and accessibility
-
-**Why**: Real applications expose edge cases and inform API improvements
+- **Complex Desktop Application**: multi-window, nested layouts, drag-and-drop, keyboard shortcuts, custom rendering.
+- **Dashboard/Data Visualization App**: charts/graphs, large-data LazyColumn/LazyRow, scrolling performance.
+- **Form-Heavy Application**: text validation, focus management, tab navigation, error/accessibility states.
 
 ### C) Performance Optimization & Benchmarking
-**Goal**: Establish performance baselines and optimize hot paths
-
-- [ ] **Benchmark Suite** (Priority: High)
-  - Modifier chain traversal (various depths)
-  - Recomposition with different invalidation patterns
-  - Layout measurement with complex trees
-  - Draw command generation
-  - Memory allocation profiling
-
-- [ ] **Optimization Targets**
-  - Cache aggregated node capabilities (avoid recomputation)
-  - Pool allocations in `update_from_slice`
-  - Optimize `SnapshotIdSet` operations for common patterns
-  - Reduce `RefCell` borrow overhead where safe
-
-- [ ] **Profiling Infrastructure**
-  - Flamegraph integration for layout/draw passes
-  - Frame time tracking
-  - Memory usage tracking
-
-**Why**: Performance is critical for user experience; baselines prevent regressions
+- **Benchmark Suite**: traversal depth, recomposition patterns, complex layout measurement, draw command generation, allocation profiling.
+- **Optimization Targets**: cache aggregated node capabilities, pool allocations in `update_from_slice`, optimize `SnapshotIdSet`, reduce `RefCell` overhead where safe.
+- **Profiling Infrastructure**: flamegraphs for layout/draw, frame time tracking, memory usage tracking.
 
 ### D) Missing Core Features
-**Goal**: Fill gaps in functionality to match Jetpack Compose completeness
-
-- [ ] **Intrinsic Measurements** (High Priority)
-  - Implement `IntrinsicMeasureScope` for Row/Column
-  - `IntrinsicSize.Min`, `IntrinsicSize.Max` modifiers
-  - Baseline alignment support
-
-- [ ] **Text Editing** (High Priority)
-  - TextField/OutlinedTextField composables
-  - Cursor positioning and selection
-  - IME integration (desktop, mobile)
-  - Text selection gestures
-
-- [ ] **Lazy Layouts Performance**
-  - Viewport recycling optimization
-  - Item key stability and reuse
-  - Prefetching and smooth scrolling
-
-- [ ] **Animation System**
-  - `animate*AsState` helpers
-  - `Animatable` and `Transition` APIs
-  - Animated modifiers (size, offset, color, etc.)
-  - Spring physics
-
-**Why**: These features are essential for building real applications
-
-### E) Developer Experience Improvements
-**Goal**: Make the framework easier to learn and use
-
-- [ ] **Enhanced Error Messages**
-  - Better `RefCell` borrow panic context (which node, which operation)
-  - Layout measurement constraint violations with debugging hints
-  - Composition cycle detection with stack traces
-
-- [ ] **Developer Tools**
-  - Layout inspector (visualize layout tree)
-  - Recomposition counter/highlighter
-  - Performance overlay (frame times, skip counts)
-
-- [ ] **Examples & Guides**
-  - Getting started tutorial (counter → todo list → custom modifier)
-  - Migration guide from immediate-mode UIs
-  - Performance best practices guide
-  - Custom layout guide
-
-**Why**: Good DX accelerates adoption and reduces frustration
-
-### F) Platform Support Expansion
-**Goal**: Enable cross-platform development
-
-- [ ] **Android Support** (Medium Priority)
-  - `ndk_glue` integration
-  - Skia renderer on Android surface
-  - Touch input handling
-  - IME support
-
-- [ ] **Web Support** (Lower Priority)
-  - WebAssembly compilation
-  - Canvas/WebGL backend
-  - Web event integration
-
-- [ ] **iOS Support** (Future)
-  - UIKit integration
-  - Metal rendering
-  - Touch and gesture handling
-
-**Why**: Cross-platform is a key Rust value proposition
+- **Intrinsic Measurements**: implement `IntrinsicMeasureScope` for Row/Column, `IntrinsicSize.Min/Max`, baseline alignment.
+- **Text Editing**: TextField variants, cursor/selection, IME integration, selection gestures.
+- **Lazy Layouts Performance**: large dataset handling, viewport-aware recycling, smooth scrolling.
+- **Draw/Graphics Enhancements**: layered draw modifiers, blend modes, shaders; composition of text and graphics slices.
+- **Pointer/Input**: richer gesture recognizers, multi-pointer coordination, scroll/drag/zoom handling.
+- **Accessibility & Semantics**: semantics tree parity with Jetpack Compose, focus traversal, screen reader annotations.
 
 ---
 
-## 📊 Success Metrics
-
-- **Performance**: 60 FPS on complex desktop apps (10k+ layout nodes)
-- **Developer Satisfaction**: Positive feedback from early adopters
-- **Test Coverage**: >80% line coverage on core crates
-- **Documentation**: Every public API has doc comments with examples
-- **Ecosystem**: 3+ community-contributed crates (themes, components, etc.)
-
----
-
-## 🔄 Review Schedule
-
-This roadmap is reviewed and updated:
-- **Monthly**: Adjust priorities based on learnings
-- **After Major Milestones**: Celebrate wins, identify blockers
-- **Based on Feedback**: Community input shapes direction
-
----
-
-## 📚 Reference Documentation
-
-- [ARCHITECTURE.md](docs/ARCHITECTURE.md) - Overall framework design
-- [MODIFIERS.md](MODIFIERS.md) - Modifier system internals
-- [SNAPSHOTS_AND_SLOTS.md](SNAPSHOTS_AND_SLOTS.md) - Runtime internals
-- [modifier_match_with_jc.md](modifier_match_with_jc.md) - Jetpack Compose parity status
-
----
-
-## 💡 Immediate Next Actions
-
-**Modifier corrections (now)**
-1. Replace layout flattening with coordinator-driven measurement and placement for padding/size/offset.
-2. Allow stacking of draw/text slices; document ordering and add regression tests.
-3. Either integrate or remove `MeasurementProxy`, updating docs and examples accordingly.
-
-**Performance benchmarking (after parity validation)**
-1. Set up Criterion benchmarks for modifier chain operations.
-2. Profile the desktop-demo app to identify bottlenecks.
-3. Establish baseline metrics before optimization.
-4. Document findings in `docs/PERFORMANCE.md`.
-
-**Application validation (parallel where possible)**
-1. Choose a target app (e.g., markdown editor, kanban board).
-2. Implement core features using existing APIs.
-3. Document pain points and missing features.
-4. Feed findings back into priorities above.
+## ✅ Documentation References
+- **MODIFIERS.md** — modifier system internals (37KB)
+- **SNAPSHOTS_AND_SLOTS.md** — snapshot and slot table internals (54KB)
+- **modifier_match_with_jc.md** — parity status tracking

--- a/NEXT_TASK.md
+++ b/NEXT_TASK.md
@@ -1,24 +1,214 @@
-# Modifier System Status - In Progress
+# RS-Compose Development Roadmap
 
-## ✅ What is done
-- `LayoutModifierNode::measure` returns `LayoutModifierMeasureResult` with placement offsets, enabling padding/offset implementations to drive placement.
-- `LayoutModifierCoordinator` measures nodes directly via `Rc<RefCell<Box<dyn ModifierNode>>>` and applies the captured placement offset during `place`.
+**Last Updated**: April 2026
+**Modifier System Status**: ⚠️ Parity verification in progress (origin/main claims parity; see "Modifier System Reality Check")
+**Documentation Status**: ✅ Comprehensive internals documented
 
-## ⚠️ Gaps to close
-- `ResolvedModifiers` flatten padding/size/offset into aggregated values, losing modifier ordering.
-- `ModifierNodeSlices` coalesces text and graphics layers to the rightmost entry instead of composing multiple layers.
-- `MeasurementProxy` remains in the public API even though the coordinator never uses it, leaving dead surface area to maintain.
+---
 
-## Next Tasks
+## ✅ Completed Milestones (per origin/main)
 
-### 1) Remove layout flattening
-- Route padding/size/offset/intrinsic behavior through layout nodes (and their coordinators) rather than the `ResolvedModifiers` accumulator.
-- Add regression tests for mixed chains (`padding.background.padding`, overlapping offsets, etc.) to lock in ordering semantics.
+### Modifier System (Nov 2025)
+- ✅ `ModifierNodeEntry` stores `Rc<RefCell<Box<dyn ModifierNode>>>`
+- ✅ `LayoutModifierNode::measure` returns `LayoutModifierMeasureResult` with placement control
+- ✅ `LayoutModifierCoordinator` holds live node references (no proxy bypass)
+- ✅ Chain preservation intended — currently **under re-validation** because `ResolvedModifiers` still flattens padding/size/offset
+- ✅ Node lifecycle: `on_attach()`, `on_detach()`, `on_reset()`
+- ✅ Capability-based dispatch with bitflags
+- ✅ Core modifiers implemented: Padding, Size, Offset, Background, Clickable, etc.
 
-### 2) Make draw/text slices composable
-- Allow multiple text nodes and graphics layers to stack instead of overwriting each other.
-- Preserve chain order when emitting draw commands and pointer handlers.
+### Documentation (Nov 2025)
+- ✅ **MODIFIERS.md** (37KB) - Complete modifier system internals
+- ✅ **SNAPSHOTS_AND_SLOTS.md** (54KB) - Snapshot and slot table internals
+- ✅ **modifier_match_with_jc.md** - Parity status tracking
+- ✅ GitHub Actions workflow for CI
 
-### 3) Decide the measurement proxy story
-- Either remove `MeasurementProxy` and proxy implementations or integrate them meaningfully (e.g., to support borrow-safe async measurement).
-- Update documentation and tests once the direction is chosen so the API surface matches runtime behavior.
+### Test Coverage
+- ✅ 460+ workspace tests passing
+- ✅ Modifier chain composition and reuse
+- ✅ Layout measurement and placement protocols
+- ✅ Capability-based dispatch validation
+- ✅ Integration with draw, pointer input, semantics
+
+---
+
+## ⚠️ Modifier System Reality Check (work branch)
+
+- `ResolvedModifiers` still flattens padding/size/offset, losing modifier ordering (e.g., `padding.background.padding`).
+- `ModifierNodeSlices` coalesces text and graphics layers to the last writer instead of composing them.
+- `MeasurementProxy` remains in the public API even though coordinators measure nodes directly.
+
+These gaps must be closed to reconcile the parity claim from origin/main with observed runtime behavior.
+
+---
+
+## 🎯 Current Priorities (merged)
+
+### A) Modifier System Corrections (prevents merge conflicts with origin/main)
+- Remove layout flattening: route padding/size/offset/intrinsics through live nodes and coordinators.
+- Make draw/text slices composable: allow stacking graphics layers and multiple text entries in chain order.
+- Decide the measurement proxy story: remove unused surface or integrate it meaningfully (e.g., borrow-safe async measurement).
+- Add regression tests for mixed chains and slice composition to lock in ordering semantics.
+
+### B) Real-World Application Development
+**Goal**: Build production-quality example apps to validate the framework
+
+- [ ] **Complex Desktop Application** - Multi-window IDE/editor-style app
+  - State management across windows
+  - Complex nested layouts with performance testing
+  - Drag-and-drop, keyboard shortcuts
+  - Custom rendering for code editor
+
+- [ ] **Dashboard/Data Visualization App**
+  - Charts, graphs, real-time data updates
+  - LazyColumn/LazyRow with large datasets
+  - Scrolling performance optimization
+
+- [ ] **Form-Heavy Application**
+  - Text input validation
+  - Focus management
+  - Tab navigation
+  - Error states and accessibility
+
+**Why**: Real applications expose edge cases and inform API improvements
+
+### C) Performance Optimization & Benchmarking
+**Goal**: Establish performance baselines and optimize hot paths
+
+- [ ] **Benchmark Suite** (Priority: High)
+  - Modifier chain traversal (various depths)
+  - Recomposition with different invalidation patterns
+  - Layout measurement with complex trees
+  - Draw command generation
+  - Memory allocation profiling
+
+- [ ] **Optimization Targets**
+  - Cache aggregated node capabilities (avoid recomputation)
+  - Pool allocations in `update_from_slice`
+  - Optimize `SnapshotIdSet` operations for common patterns
+  - Reduce `RefCell` borrow overhead where safe
+
+- [ ] **Profiling Infrastructure**
+  - Flamegraph integration for layout/draw passes
+  - Frame time tracking
+  - Memory usage tracking
+
+**Why**: Performance is critical for user experience; baselines prevent regressions
+
+### D) Missing Core Features
+**Goal**: Fill gaps in functionality to match Jetpack Compose completeness
+
+- [ ] **Intrinsic Measurements** (High Priority)
+  - Implement `IntrinsicMeasureScope` for Row/Column
+  - `IntrinsicSize.Min`, `IntrinsicSize.Max` modifiers
+  - Baseline alignment support
+
+- [ ] **Text Editing** (High Priority)
+  - TextField/OutlinedTextField composables
+  - Cursor positioning and selection
+  - IME integration (desktop, mobile)
+  - Text selection gestures
+
+- [ ] **Lazy Layouts Performance**
+  - Viewport recycling optimization
+  - Item key stability and reuse
+  - Prefetching and smooth scrolling
+
+- [ ] **Animation System**
+  - `animate*AsState` helpers
+  - `Animatable` and `Transition` APIs
+  - Animated modifiers (size, offset, color, etc.)
+  - Spring physics
+
+**Why**: These features are essential for building real applications
+
+### E) Developer Experience Improvements
+**Goal**: Make the framework easier to learn and use
+
+- [ ] **Enhanced Error Messages**
+  - Better `RefCell` borrow panic context (which node, which operation)
+  - Layout measurement constraint violations with debugging hints
+  - Composition cycle detection with stack traces
+
+- [ ] **Developer Tools**
+  - Layout inspector (visualize layout tree)
+  - Recomposition counter/highlighter
+  - Performance overlay (frame times, skip counts)
+
+- [ ] **Examples & Guides**
+  - Getting started tutorial (counter → todo list → custom modifier)
+  - Migration guide from immediate-mode UIs
+  - Performance best practices guide
+  - Custom layout guide
+
+**Why**: Good DX accelerates adoption and reduces frustration
+
+### F) Platform Support Expansion
+**Goal**: Enable cross-platform development
+
+- [ ] **Android Support** (Medium Priority)
+  - `ndk_glue` integration
+  - Skia renderer on Android surface
+  - Touch input handling
+  - IME support
+
+- [ ] **Web Support** (Lower Priority)
+  - WebAssembly compilation
+  - Canvas/WebGL backend
+  - Web event integration
+
+- [ ] **iOS Support** (Future)
+  - UIKit integration
+  - Metal rendering
+  - Touch and gesture handling
+
+**Why**: Cross-platform is a key Rust value proposition
+
+---
+
+## 📊 Success Metrics
+
+- **Performance**: 60 FPS on complex desktop apps (10k+ layout nodes)
+- **Developer Satisfaction**: Positive feedback from early adopters
+- **Test Coverage**: >80% line coverage on core crates
+- **Documentation**: Every public API has doc comments with examples
+- **Ecosystem**: 3+ community-contributed crates (themes, components, etc.)
+
+---
+
+## 🔄 Review Schedule
+
+This roadmap is reviewed and updated:
+- **Monthly**: Adjust priorities based on learnings
+- **After Major Milestones**: Celebrate wins, identify blockers
+- **Based on Feedback**: Community input shapes direction
+
+---
+
+## 📚 Reference Documentation
+
+- [ARCHITECTURE.md](docs/ARCHITECTURE.md) - Overall framework design
+- [MODIFIERS.md](MODIFIERS.md) - Modifier system internals
+- [SNAPSHOTS_AND_SLOTS.md](SNAPSHOTS_AND_SLOTS.md) - Runtime internals
+- [modifier_match_with_jc.md](modifier_match_with_jc.md) - Jetpack Compose parity status
+
+---
+
+## 💡 Immediate Next Actions
+
+**Modifier corrections (now)**
+1. Replace layout flattening with coordinator-driven measurement and placement for padding/size/offset.
+2. Allow stacking of draw/text slices; document ordering and add regression tests.
+3. Either integrate or remove `MeasurementProxy`, updating docs and examples accordingly.
+
+**Performance benchmarking (after parity validation)**
+1. Set up Criterion benchmarks for modifier chain operations.
+2. Profile the desktop-demo app to identify bottlenecks.
+3. Establish baseline metrics before optimization.
+4. Document findings in `docs/PERFORMANCE.md`.
+
+**Application validation (parallel where possible)**
+1. Choose a target app (e.g., markdown editor, kanban board).
+2. Implement core features using existing APIs.
+3. Document pain points and missing features.
+4. Feed findings back into priorities above.

--- a/NEXT_TASK.md
+++ b/NEXT_TASK.md
@@ -25,7 +25,7 @@
 
 ## Current Status: Production Ready 🚀
 
-All 460+ workspace tests passing. The modifier system has achieved true 1:1 parity with Jetpack Compose's architecture.
+All 460+ workspace tests passing. The modifier system has achieved true 1:1 parity with Jetpack Compose's architecture. The milestone text above stays identical to `main` so future rebases remain conflict-free while we reconcile the branch-specific gaps listed below.
 
 ---
 

--- a/NEXT_TASK.md
+++ b/NEXT_TASK.md
@@ -1,92 +1,87 @@
-# RS-Compose Development Roadmap
-# (Main branch snapshot reconciled with work-branch findings)
+# Modifier System Status - COMPLETE ✅
 
-**Last Updated**: April 2026  
-**Modifier System Status**: `main` reports parity; the work branch is validating and fixing remaining gaps.  
-**Documentation Status**: ✅ Comprehensive internals documented
+## ✅ Phase 1: Shared Ownership & Protocol (DONE)
+- ✅ `ModifierNodeEntry` stores `Rc<RefCell<Box<dyn ModifierNode>>>`
+- ✅ `LayoutModifierNode::measure` returns `LayoutModifierMeasureResult` with placement
+- ✅ `LayoutModifierCoordinator` holds `Rc<RefCell<dyn ModifierNode>>`
+- ✅ Direct `node.measure()` calls without proxy bypass
+- ✅ All chain traversal properly handles RefCell borrows
 
----
+## ✅ Phase 2: Eliminating Flattening (DONE)
+- ✅ Removed `ResolvedModifiers` fallback path entirely
+- ✅ All nodes measured through coordinator chain
+- ✅ `PaddingNode` implements measure with placement offsets
+- ✅ `OffsetNode` implements measure with placement offsets
+- ✅ `SizeNode` implements measure protocol
+- ✅ Single measurement path for ALL nodes
 
-## 🗺️ Main-Branch Milestone Snapshot (Nov 2025)
-These items mirror what shipped on `main` so they stay visible after rebasing.
+## ✅ Jetpack Compose Parity Achieved
+- ✅ Rc<RefCell<>> shared ownership (mirrors Kotlin references)
+- ✅ Direct node access in coordinators (no proxies)
+- ✅ Placement control through MeasureResult
+- ✅ Proper delegate chain traversal
+- ✅ No modifier flattening - order preserved
+- ✅ Clean API - removed panicking methods
 
-### ✅ Phase 1: Shared Ownership & Protocol (DONE)
-- `ModifierNodeEntry` stores `Rc<RefCell<Box<dyn ModifierNode>>>`
-- `LayoutModifierNode::measure` returns `LayoutModifierMeasureResult` with placement
-- `LayoutModifierCoordinator` holds `Rc<RefCell<dyn ModifierNode>>`
-- Direct `node.measure()` calls without proxy bypass
-- Chain traversal handles RefCell borrows correctly
+## Current Status: Production Ready 🚀
 
-### ✅ Phase 2: Eliminating Flattening (DONE, per main)
-- Flattening marked as removed; live node references drive layout
-- Node lifecycle hooks implemented: `on_attach()`, `on_detach()`, `on_reset()`
-- Capability-based dispatch via bitflags
-- Core modifiers implemented: Padding, Size, Offset, Background, Clickable, etc.
-
-### 📌 Other Main-Branch Priorities
-- **Performance**: benchmark modifier traversal, cache aggregated capabilities, pool allocations in `update_from_slice`, reusable benchmark suite
-- **API Ergonomics**: builder patterns, clearer RefCell errors, richer examples
-- **Advanced Features**: animated/conditional modifiers, modifier scopes, custom coordinator hooks
-- **Testing & Validation**: property-based tests, integration scenarios, deep-chain stress tests, performance regression tracking
+All 460+ workspace tests passing. The modifier system has achieved true 1:1 parity with Jetpack Compose's architecture.
 
 ---
 
-## ⚠️ Reality Checks on the Work Branch
-Observed divergences that must be addressed before the parity claim is trustworthy after rebasing.
+# Next Major Tasks
+
+## 1. Performance Optimization
+- **Benchmark hot paths**: Measure performance of modifier chain traversal
+- **Cache aggregated capabilities**: Avoid recomputing on every traversal
+- **Pool allocations**: Reuse Vec/Box allocations in update_from_slice
+- **Lazy evaluation**: Defer work until actually needed
+
+## 2. API Ergonomics
+- **Builder patterns**: Make modifier construction more ergonomic
+- **Common modifier helpers**: Provide convenient wrappers for common cases
+- **Better error messages**: Add context to RefCell borrow failures
+- **Documentation**: Add comprehensive examples and guides
+
+## 3. Advanced Features
+- **Animated modifiers**: Support transitions between modifier states
+- **Conditional modifiers**: Better patterns for dynamic modifier lists
+- **Modifier scopes**: Provide contextual APIs for specific modifier types
+- **Custom coordinators**: Allow users to implement custom layout strategies
+
+## 4. Testing & Validation
+- **Property-based tests**: Use proptest for modifier chain behavior
+- **Benchmark suite**: Track performance regressions
+- **Integration tests**: Real-world usage scenarios
+- **Stress tests**: Large modifier chains, deep nesting
+
+## Immediate Next Task Recommendation
+
+Start with **Performance Optimization** - specifically:
+1. Add benchmarks to measure current performance baseline
+2. Profile modifier chain traversal and update operations
+3. Identify and optimize hot spots
+4. Measure improvements
+
+This ensures the system is not just correct but also fast.
+
+---
+
+## April 2026 Reality Check (work branch)
+These items reconcile the "parity achieved" claims above with the current work-branch gaps that still need to be merged back.
 
 - `ResolvedModifiers` still flattens padding/size/offset, losing modifier ordering (e.g., `padding.background.padding`).
 - `ModifierNodeSlices` coalesces text and graphics layers to the last writer instead of composing them.
 - `LayoutModifierCoordinator::measure` treats the absence of a measurement proxy as "skip the node" rather than measuring the live node.
-- `MeasurementProxy` remains in the public API even though coordinators measure nodes directly.
-- Placement is pass-through: `LayoutModifierNode::measure` returns only `Size`, blocking placement-aware modifiers (offset/alignment).
+- `MeasurementProxy` remains exposed even though coordinators measure nodes directly.
 
----
+## Merge Readiness Checklist
+- Fetch the latest `main` (auth required) and replay these reality-check items to spot regressions early.
+- Keep the main-branch milestone text above intact so the PR diff stays merge-friendly.
+- When rebasing, prefer additive edits (notes/sections) over rewrites of existing bullet lists to minimize future conflicts.
 
-## 🤝 Merge-Friendly Reconciliation Plan
-These steps combine `main`'s parity claims with the work-branch findings so rebasing keeps both perspectives.
-
-1. **Fix layout modifier protocol**  
-   Measure live nodes (or meaningful proxies) and return placement-aware results; remove the "no proxy = skip" behavior.
-2. **Eliminate layout flattening**  
-   Route padding/size/offset/intrinsics through live nodes and coordinators; add regression tests for mixed chains.
-3. **Make draw/text slices composable**  
-   Stack graphics layers and allow multiple text entries in chain order; keep pointer handlers ordered.
-4. **Resolve the measurement proxy story**  
-   Remove the unused surface or integrate it meaningfully (e.g., borrow-safe async measurement) and update docs/tests.
-5. **Resume upstream priorities once parity is validated**  
-   Continue performance, ergonomics, advanced features, and testing work from the main snapshot.
-
----
-
-## 🎯 Active Focus Areas (post-rebase)
-
-### A) Modifier System Corrections
-- Remove layout flattening and keep ordering semantics.
-- Compose draw/text slices instead of last-write-wins.
-- Decide and implement the measurement proxy direction.
-- Add regression tests for mixed chains and slice composition.
-
-### B) Real-World Application Development
-- **Complex Desktop Application**: multi-window, nested layouts, drag-and-drop, keyboard shortcuts, custom rendering.
-- **Dashboard/Data Visualization App**: charts/graphs, large-data LazyColumn/LazyRow, scrolling performance.
-- **Form-Heavy Application**: text validation, focus management, tab navigation, error/accessibility states.
-
-### C) Performance Optimization & Benchmarking
-- **Benchmark Suite**: traversal depth, recomposition patterns, complex layout measurement, draw command generation, allocation profiling.
-- **Optimization Targets**: cache aggregated node capabilities, pool allocations in `update_from_slice`, optimize `SnapshotIdSet`, reduce `RefCell` overhead where safe.
-- **Profiling Infrastructure**: flamegraphs for layout/draw, frame time tracking, memory usage tracking.
-
-### D) Missing Core Features
-- **Intrinsic Measurements**: implement `IntrinsicMeasureScope` for Row/Column, `IntrinsicSize.Min/Max`, baseline alignment.
-- **Text Editing**: TextField variants, cursor/selection, IME integration, selection gestures.
-- **Lazy Layouts Performance**: large dataset handling, viewport-aware recycling, smooth scrolling.
-- **Draw/Graphics Enhancements**: layered draw modifiers, blend modes, shaders; composition of text and graphics slices.
-- **Pointer/Input**: richer gesture recognizers, multi-pointer coordination, scroll/drag/zoom handling.
-- **Accessibility & Semantics**: semantics tree parity with Jetpack Compose, focus traversal, screen reader annotations.
-
----
-
-## ✅ Documentation References
-- **MODIFIERS.md** — modifier system internals (37KB)
-- **SNAPSHOTS_AND_SLOTS.md** — snapshot and slot table internals (54KB)
-- **modifier_match_with_jc.md** — parity status tracking
+## Near-Term Tasks After Rebasing
+- Fix flattening: remove `ResolvedModifiers` aggregation and keep ordered node traversal for layout/draw.
+- Compose slices: accumulate text/graphics layers instead of overwriting.
+- Align measurement: ensure `LayoutModifierCoordinator::measure` always exercises the node when no proxy is present, and make placement part of the result type.
+- Simplify API: retire the public `MeasurementProxy` type once direct measurement is stable.

--- a/NEXT_TASK.md
+++ b/NEXT_TASK.md
@@ -30,6 +30,14 @@
 - ✅ Capability-based dispatch validation
 - ✅ Integration with draw, pointer input, semantics
 
+### Upstream main roadmap (Nov 2025 snapshot)
+These items reflect the priorities already present on the upstream main branch so they do not get lost while reconciling the modifier findings on this work branch.
+
+- **Performance Optimization**: benchmark modifier traversal, cache aggregated capabilities, pool allocations in `update_from_slice`, and establish a reusable benchmark suite.
+- **API Ergonomics**: builder patterns for modifiers, common helpers, clearer RefCell error messages, and richer documentation/examples.
+- **Advanced Features**: animated and conditional modifiers, modifier scopes, and custom coordinator hooks.
+- **Testing & Validation**: property-based tests, integration scenarios, stress tests for deep chains, and performance regression tracking.
+
 ---
 
 ## ⚠️ Modifier System Reality Check (work branch)

--- a/modifier_match_with_jc.md
+++ b/modifier_match_with_jc.md
@@ -1,4 +1,5 @@
 # Modifier System: Jetpack Compose Parity Checkpoint
+# (Main-branch reality snapshot merged with work-branch gaps)
 
 **Status**: `main` advertises parity; the work branch is validating and fixing remaining gaps.
 

--- a/modifier_match_with_jc.md
+++ b/modifier_match_with_jc.md
@@ -1,46 +1,38 @@
 # Modifier System: Jetpack Compose Parity Checkpoint
 
-**Status**: ⚠️ Parity claim from origin/main is under validation; outstanding gaps remain on the work branch.
+**Status**: Upstream `main` advertises parity; the work branch is validating and fixing remaining gaps.
 
-This document merges the parity narrative from origin/main with the current reality checks discovered while exercising the modifier runtime.
+This version reconciles `main`'s parity claims with the outstanding correctness issues discovered locally so the rebase keeps both sets of facts.
 
-## What origin/main reports as complete (Nov 2025)
+## ✅ What `main` reports as complete (Nov 2025)
+- **Live Node References**: Coordinators hold `Rc<RefCell<Box<dyn ModifierNode>>>` directly, matching Kotlin's object references.
+- **Placement Control**: `LayoutModifierNode::measure` returns `LayoutModifierMeasureResult` with size and placement offsets.
+- **Node Lifecycle**: Proper `on_attach()`, `on_detach()`, `on_reset()` callbacks.
+- **Capability Dispatch**: Bitflag-based capability system for traversal.
+- **Node Reuse**: Zero allocations when modifier chains remain stable across recompositions.
 
-- ✅ **Live Node References**: Coordinators hold `Rc<RefCell<Box<dyn ModifierNode>>>` directly, matching Kotlin's object references.
-- ✅ **Placement Control**: `LayoutModifierNode::measure` returns `LayoutModifierMeasureResult` with size and placement offsets.
-- ✅ **Node Lifecycle**: Proper `on_attach()`, `on_detach()`, `on_reset()` callbacks.
-- ✅ **Capability Dispatch**: Bitflag-based capability system for traversal.
-- ✅ **Node Reuse**: Zero allocations when modifier chains remain stable across recompositions.
+Broader `main` follow-ups (performance, ergonomics, advanced modifiers, and deep testing) resume once the gaps below are closed.
 
-Upstream main also tracks broader follow-ups once parity is stable: performance benchmarking of traversal, ergonomic builder helpers, animated/conditional modifiers, and richer testing (property-based, stress, and integration coverage). Those priorities remain valid and should resume after the correctness gaps below are closed.
+## ⚠️ Reality checks on the work branch
+- **Coordinator bypass**: `LayoutModifierCoordinator::measure` still treats the absence of a measurement proxy as "skip the node" rather than measuring the live node.
+- **Missing placement API**: `LayoutModifierNode::measure` returns only `Size` in practice; placement is pass-through, preventing modifiers from affecting child placement (e.g., offset/alignment).
+- **Flattened resolution**: `ModifierChainHandle::compute_resolved` aggregates padding/size/offset into a single `ResolvedModifiers`, losing ordering (e.g., `padding.background.padding`).
+- **Slice coalescing**: `ModifierNodeSlices` collapses text content and graphics layers to last-write-wins, blocking composition of multiple layers.
+- **Proxy dependency**: `MeasurementProxy` stays public even though coordinators aim to measure nodes directly, leaving an unused surface area.
 
-## Reality checks on the work branch
-
-- **Flattened resolution**: `ModifierChainHandle::compute_resolved` still aggregates padding/size/offset into a single `ResolvedModifiers`, losing ordering (e.g., `padding.background.padding`).
-- **Slice coalescing**: `ModifierNodeSlices` collects draw commands and pointer inputs but collapses text content and graphics layers to "last write wins", blocking composition of multiple layers.
-- **Unused measurement proxy**: The `MeasurementProxy` API remains in the public surface even though `LayoutModifierCoordinator` measures nodes directly. Keeping it without integration adds maintenance overhead.
-
-## Reconciliation plan (merge of origin/main and work-branch needs)
-
-1. **Eliminate layout flattening**
-   - Route padding/size/offset/intrinsic behavior through live nodes and coordinators instead of `ResolvedModifiers`.
-   - Add coverage for mixed chains (e.g., `padding.background.padding`) to ensure ordering is preserved.
-
-2. **Make draw/text slices composable**
-   - Allow multiple text entries and graphics layers to stack instead of last-write-wins semantics.
-   - Preserve chain order when emitting draw commands and pointer handlers.
-
-3. **Decide the measurement proxy story**
-   - Either remove `MeasurementProxy` and related implementations or integrate it meaningfully (e.g., borrow-safe async measurement).
-   - Update documentation and tests so the public API matches runtime behavior.
-
-4. **Continue origin/main focus areas once parity is re-validated**
-   - Performance optimization of modifier traversal and capability caching.
-   - Advanced features such as animated/conditional modifiers and custom coordinators.
-   - Developer experience: clearer errors, guides, and examples.
+## 🛠️ Reconciliation plan
+1. **Fix layout modifier protocol**  
+   Measure live nodes (or meaningful proxies) and return placement-aware results; remove the "no proxy = skip" behavior.
+2. **Remove flattening**  
+   Route padding/size/offset/intrinsics through the node chain and add coverage for interleaved modifier ordering.
+3. **Make draw/text slices composable**  
+   Allow stacking of graphics layers and multiple text entries; preserve chain order for draw and pointer handlers.
+4. **Decide the proxy story**  
+   Either remove `MeasurementProxy` or integrate it for a real use case (e.g., borrow-safe async measurement), then align docs/tests.
+5. **Continue `main` priorities after parity is validated**  
+   Resume performance/ergonomics/advanced feature work once the above correctness items are landed.
 
 ## Reference documentation
-
-- **[MODIFIERS.md](./MODIFIERS.md)** - Complete modifier system internals (37KB, Nov 2025)
-- **[SNAPSHOTS_AND_SLOTS.md](./SNAPSHOTS_AND_SLOTS.md)** - Snapshot and slot table system (54KB, Nov 2025)
-- **[NEXT_TASK.md](./NEXT_TASK.md)** - Broader project roadmap with modifier corrections highlighted
+- **[MODIFIERS.md](./MODIFIERS.md)** — modifier system internals (37KB, Nov 2025)
+- **[SNAPSHOTS_AND_SLOTS.md](./SNAPSHOTS_AND_SLOTS.md)** — snapshot and slot table system (54KB, Nov 2025)
+- **[NEXT_TASK.md](./NEXT_TASK.md)** — roadmap with merged `main` snapshot and local parity fixes

--- a/modifier_match_with_jc.md
+++ b/modifier_match_with_jc.md
@@ -35,7 +35,7 @@ Concise snapshot of how the modifier system differs from Jetpack Compose and wha
 
 ---
 
-This edition merges `main`'s parity claims with the file-path-specific gaps previously documented so rebasing keeps both sets of facts.
+This edition merges `main`'s parity claims with the file-path-specific gaps previously documented so rebasing keeps both sets of facts. The "complete" claims below remain verbatim from `main`'s November 2025 snapshot; the reality checks call out what is still pending on this branch so future rebases won't drop either perspective.
 
 ## ✅ What `main` reports as complete (Nov 2025)
 - **Live Node References**: Coordinators hold `Rc<RefCell<Box<dyn ModifierNode>>>` directly, matching Kotlin's object references.

--- a/modifier_match_with_jc.md
+++ b/modifier_match_with_jc.md
@@ -12,6 +12,8 @@ This document merges the parity narrative from origin/main with the current real
 - ✅ **Capability Dispatch**: Bitflag-based capability system for traversal.
 - ✅ **Node Reuse**: Zero allocations when modifier chains remain stable across recompositions.
 
+Upstream main also tracks broader follow-ups once parity is stable: performance benchmarking of traversal, ergonomic builder helpers, animated/conditional modifiers, and richer testing (property-based, stress, and integration coverage). Those priorities remain valid and should resume after the correctness gaps below are closed.
+
 ## Reality checks on the work branch
 
 - **Flattened resolution**: `ModifierChainHandle::compute_resolved` still aggregates padding/size/offset into a single `ResolvedModifiers`, losing ordering (e.g., `padding.background.padding`).

--- a/modifier_match_with_jc.md
+++ b/modifier_match_with_jc.md
@@ -4,31 +4,26 @@ Concise snapshot of how the modifier system differs from Jetpack Compose and wha
 
 ## Current Snapshot (modifier-specific)
 
-- **Coordinator Bypass**: `LayoutModifierCoordinator::measure` (`crates/compose-ui/src/layout/coordinator.rs:120`) explicitly checks for a measurement proxy. If `create_measurement_proxy()` returns `None`, the coordinator **skips the node's measure logic entirely** and falls back to measuring the wrapped content directly. This renders the `LayoutModifierNode::measure` default implementation useless for custom modifiers that don't supply a proxy.
-- **Missing Placement API**: `LayoutModifierNode::measure` returns only `Size`. There is no mechanism to return a `MeasureResult` with a placement block (as in Kotlin). Consequently, `LayoutModifierCoordinator::place` is a hardcoded pass-through (`crates/compose-ui/src/layout/coordinator.rs:112`), preventing modifiers from affecting child placement (e.g., offset, alignment).
-- **Flattened Resolution**: `ModifierChainHandle::compute_resolved` (`crates/compose-ui/src/modifier/chain.rs:188`) iterates the chain and flattens standard modifiers (Padding, Size, Offset) into a single `ResolvedModifiers` struct. This loses the interleaving of modifiers (e.g., `padding(10).background(...).padding(20)` becomes just 30 padding and one background).
-- **Slice Coalescing**: `ModifierNodeSlices` (`crates/compose-ui/src/modifier/slices.rs`) collects draw commands and pointer inputs but reduces text content and graphics layers to "last write wins", preventing composition of these effects.
-- **Proxy Dependency**: The system relies heavily on `MeasurementProxy` to avoid borrowing the modifier chain during measure. This is a divergence from Kotlin where the coordinator holds a reference to the live node.
+- **Direct measurement with placement offsets**: `LayoutModifierNode::measure` now returns a `LayoutModifierMeasureResult` that includes placement offsets, and `LayoutModifierCoordinator` stores that offset and applies it during `place`.
+- **Unused proxy surface**: The `LayoutModifierNode` trait still exposes `create_measurement_proxy`, and built-in nodes implement proxies, but `LayoutModifierCoordinator` measures nodes directly and never consults the proxy API. The snapshot surface diverges from Kotlin without providing value today.
+- **Flattened Resolution**: `ModifierChainHandle::compute_resolved` flattens standard modifiers (Padding, Size, Offset) into a single `ResolvedModifiers` struct. This loses ordering (e.g., `padding(10).background(...).padding(20)` becomes just 30 padding and one background).
+- **Slice Coalescing**: `ModifierNodeSlices` collects draw commands and pointer inputs but reduces text content and graphics layers to "last write wins", preventing composition of these effects.
 
 ## Mismatches vs Jetpack Compose
 
-- **Live Node vs. Snapshot Proxy**: Kotlin's `LayoutModifierNodeCoordinator` calls `measure` on the live `LayoutModifierNode`. Rust's coordinator requires the node to produce a `MeasurementProxy` (a snapshot) to participate in measurement. If no proxy is produced, the node is ignored.
-- **Placement Control**: Kotlin's `measure` returns a `MeasureResult` containing a `placeChildren` lambda. Rust's `measure` returns `Size` only, and placement is handled entirely by the coordinator's pass-through logic.
-- **Chain Traversal**: Kotlin traverses the actual node chain for all operations. Rust flattens the chain into `ResolvedModifiers` for layout properties, losing the structural information necessary for correct order of operations in complex chains.
+- **Flattened layout semantics**: Kotlin traverses the node chain for layout behavior; the Rust path still aggregates padding/size/offset into `ResolvedModifiers`, discarding modifier order.
+- **Draw/text composition gaps**: Kotlin composes multiple draw/text layers; `ModifierNodeSlices` coalesces text and graphics layers to the rightmost entry instead of composing them.
+- **Stray proxy API**: Kotlin coordinators call nodes directly. Rust now measures nodes directly too, but the exposed `MeasurementProxy` API remains unused noise.
 
 ## Roadmap (integrates “open protocol” proposal)
 
-1.  **Fix Layout Modifier Protocol**:
-    - Change `LayoutModifierNode::measure` to return a `MeasureResult` (containing Size and a Placement trait/closure).
-    - Update `LayoutModifierCoordinator` to execute this placement logic.
-    - Remove the "no proxy = skip" behavior; the coordinator should call `measure` on the node (or a proxy of it) and respect the result.
+1. **Eliminate layout flattening**
+   - Route padding/size/offset/intrinsic behavior through layout nodes instead of `ResolvedModifiers`.
+   - Add coverage for mixed chains (e.g., `padding.background.padding`) to ensure ordering is preserved.
 
-2.  **Generic Extensibility**:
-    - Ensure all built-in modifiers (Padding, Size, etc.) implement `LayoutModifierNode` correctly.
-    - Deprecate/Remove `ResolvedModifiers` flattening in favor of the coordinator chain handling these properties via the `measure`/`place` protocol.
+2. **Make draw/text slices composable**
+   - Allow multiple text and graphics-layer entries to stack instead of last-write-wins semantics.
+   - Preserve chain order when emitting draw commands and pointer handlers.
 
-3.  **State Fidelity**:
-    - Move towards using live nodes or more robust proxies that don't require full reconstruction on every frame.
-
-4.  **Text & Input**:
-    - Align text handling with the node system (TextModifierNode should participate in layout/draw properly, not just export a string). 
+3. **Resolve the measurement proxy story**
+   - Either remove `MeasurementProxy` and related implementations or integrate it meaningfully (e.g., for borrow-safe async measurement). Right now it is unused surface area.

--- a/modifier_match_with_jc.md
+++ b/modifier_match_with_jc.md
@@ -1,7 +1,39 @@
-# Modifier System: Jetpack Compose Parity Checkpoint
-# (Main-branch reality snapshot merged with work-branch gaps)
+# Modifier Migration Reality Check
 
-**Status**: `main` advertises parity; the work branch is validating and fixing remaining gaps.
+Concise snapshot of how the modifier system differs from Jetpack Compose and what must change next.
+
+## Current Snapshot (modifier-specific)
+
+- **Coordinator Bypass**: `LayoutModifierCoordinator::measure` (`crates/compose-ui/src/layout/coordinator.rs:120`) explicitly checks for a measurement proxy. If `create_measurement_proxy()` returns `None`, the coordinator **skips the node's measure logic entirely** and falls back to measuring the wrapped content directly. This renders the `LayoutModifierNode::measure` default implementation useless for custom modifiers that don't supply a proxy.
+- **Missing Placement API**: `LayoutModifierNode::measure` returns only `Size`. There is no mechanism to return a `MeasureResult` with a placement block (as in Kotlin). Consequently, `LayoutModifierCoordinator::place` is a hardcoded pass-through (`crates/compose-ui/src/layout/coordinator.rs:112`), preventing modifiers from affecting child placement (e.g., offset, alignment).
+- **Flattened Resolution**: `ModifierChainHandle::compute_resolved` (`crates/compose-ui/src/modifier/chain.rs:188`) iterates the chain and flattens standard modifiers (Padding, Size, Offset) into a single `ResolvedModifiers` struct. This loses the interleaving of modifiers (e.g., `padding(10).background(...).padding(20)` becomes just 30 padding and one background).
+- **Slice Coalescing**: `ModifierNodeSlices` (`crates/compose-ui/src/modifier/slices.rs`) collects draw commands and pointer inputs but reduces text content and graphics layers to "last write wins", preventing composition of these effects.
+- **Proxy Dependency**: The system relies heavily on `MeasurementProxy` to avoid borrowing the modifier chain during measure. This is a divergence from Kotlin where the coordinator holds a reference to the live node.
+
+## Mismatches vs Jetpack Compose
+
+- **Live Node vs. Snapshot Proxy**: Kotlin's `LayoutModifierNodeCoordinator` calls `measure` on the live `LayoutModifierNode`. Rust's coordinator requires the node to produce a `MeasurementProxy` (a snapshot) to participate in measurement. If no proxy is produced, the node is ignored.
+- **Placement Control**: Kotlin's `measure` returns a `MeasureResult` containing a `placeChildren` lambda. Rust's `measure` returns `Size` only, and placement is handled entirely by the coordinator's pass-through logic.
+- **Chain Traversal**: Kotlin traverses the actual node chain for all operations. Rust flattens the chain into `ResolvedModifiers` for layout properties, losing the structural information necessary for correct order of operations in complex chains.
+
+## Roadmap (integrates “open protocol” proposal)
+
+1.  **Fix Layout Modifier Protocol**:
+    - Change `LayoutModifierNode::measure` to return a `MeasureResult` (containing Size and a Placement trait/closure).
+    - Update `LayoutModifierCoordinator` to execute this placement logic.
+    - Remove the "no proxy = skip" behavior; the coordinator should call `measure` on the node (or a proxy of it) and respect the result.
+
+2.  **Generic Extensibility**:
+    - Ensure all built-in modifiers (Padding, Size, etc.) implement `LayoutModifierNode` correctly.
+    - Deprecate/Remove `ResolvedModifiers` flattening in favor of the coordinator chain handling these properties via the `measure`/`place` protocol.
+
+3.  **State Fidelity**:
+    - Move towards using live nodes or more robust proxies that don't require full reconstruction on every frame.
+
+4.  **Text & Input**:
+    - Align text handling with the node system (TextModifierNode should participate in layout/draw properly, not just export a string). 
+
+---
 
 This edition merges `main`'s parity claims with the file-path-specific gaps previously documented so rebasing keeps both sets of facts.
 
@@ -21,21 +53,16 @@ Broader `main` follow-ups (performance, ergonomics, advanced modifiers, and deep
 - **Slice coalescing** (`crates/compose-ui/src/modifier/slices.rs`): `ModifierNodeSlices` collapses text content and graphics layers to last-write-wins, blocking composition of multiple layers.
 - **Proxy dependency**: `MeasurementProxy` stays public even though coordinators aim to measure nodes directly, leaving an unused surface area.
 
-## 🚧 Mismatches vs Jetpack Compose (context)
-- **Live node vs snapshot proxy**: Kotlin's `LayoutModifierNodeCoordinator` measures the live `LayoutModifierNode`. The Rust implementation relies on proxies and can ignore nodes if none are provided.
-- **Placement control**: Kotlin's `measure` returns a `MeasureResult` containing a `placeChildren` lambda. Rust currently returns `Size` only, with placement handled by pass-through coordinator logic.
-- **Chain traversal**: Kotlin traverses the actual node chain for all operations. Rust flattens layout-affecting modifiers into `ResolvedModifiers`, losing ordering in complex chains.
-
 ## 🛠️ Reconciliation plan
-1. **Fix layout modifier protocol**  
+1. **Fix layout modifier protocol**
    Measure live nodes (or meaningful proxies) and return placement-aware results; remove the "no proxy = skip" behavior.
-2. **Remove flattening**  
+2. **Remove flattening**
    Route padding/size/offset/intrinsics through the node chain and add coverage for interleaved modifier ordering.
-3. **Make draw/text slices composable**  
+3. **Make draw/text slices composable**
    Allow stacking of graphics layers and multiple text entries; preserve chain order for draw and pointer handlers.
-4. **Decide the proxy story**  
+4. **Decide the proxy story**
    Either remove `MeasurementProxy` or integrate it for a real use case (e.g., borrow-safe async measurement), then align docs/tests.
-5. **Continue `main` priorities after parity is validated**  
+5. **Continue `main` priorities after parity is validated**
    Resume performance/ergonomics/advanced feature work once the above correctness items are landed.
 
 ## Reference documentation


### PR DESCRIPTION
## Summary
- refresh modifier_match_with_jc.md to reflect current layout behavior, remaining gaps, and roadmap
- rewrite NEXT_TASK.md status to capture completed work, outstanding issues, and prioritized follow-ups

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e16215ee08328ae1928e10636b86f)