### PR TITLE
Add Minesweeper tab to desktop demo

### DIFF
--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -11,6 +11,8 @@ use compose_ui::{
 };
 use std::cell::RefCell;
 
+mod mineswapper2;
+
 thread_local! {
     pub static TEST_COMPOSITION_LOCAL_COUNTER: RefCell<Option<MutableState<i32>>> = RefCell::new(None);
     pub static TEST_ACTIVE_TAB_STATE: RefCell<Option<MutableState<DemoTab>>> = RefCell::new(None);
@@ -23,7 +25,7 @@ pub enum DemoTab {
     Async,
     Layout,
     ModifierShowcase,
-    Minesweeper,
+    Mineswapper2,
 }
 
 impl DemoTab {
@@ -34,7 +36,7 @@ impl DemoTab {
             DemoTab::Async => "Async Runtime",
             DemoTab::Layout => "Recursive Layout",
             DemoTab::ModifierShowcase => "Modifiers Showcase",
-            DemoTab::Minesweeper => "Minesweeper",
+            DemoTab::Mineswapper2 => "Mineswapper2",
         }
     }
 }
@@ -96,14 +98,6 @@ fn random() -> i32 {
     (nanos % 10000) as i32
 }
 
-fn random_seed() -> u64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64
-}
-
 #[composable]
 pub fn combined_app() {
     let active_tab = compose_core::useState(|| DemoTab::Counter);
@@ -162,7 +156,7 @@ pub fn combined_app() {
                     render_tab_button(DemoTab::Async);
                     render_tab_button(DemoTab::Layout);
                     render_tab_button(DemoTab::ModifierShowcase);
-                    render_tab_button(DemoTab::Minesweeper);
+                    render_tab_button(DemoTab::Mineswapper2);
                 },
             );
 
@@ -178,7 +172,7 @@ pub fn combined_app() {
                 DemoTab::Async => async_runtime_example(),
                 DemoTab::Layout => recursive_layout_example(),
                 DemoTab::ModifierShowcase => modifier_showcase_tab(),
-                DemoTab::Minesweeper => minesweeper_tab(),
+                DemoTab::Mineswapper2 => mineswapper2::mineswapper2_tab(),
             });
         },
     );
@@ -1890,427 +1884,6 @@ pub fn long_list_showcase() {
             },
         );
     });
-}
-
-#[derive(Clone, Debug)]
-struct MinesweeperCell {
-    is_mine: bool,
-    is_revealed: bool,
-    is_flagged: bool,
-    adjacent: u8,
-}
-
-#[derive(Clone, Debug)]
-struct MinesweeperGame {
-    width: usize,
-    height: usize,
-    mines: usize,
-    cells: Vec<MinesweeperCell>,
-    is_lost: bool,
-    is_won: bool,
-    revealed_count: usize,
-    seed: u64,
-}
-
-impl MinesweeperGame {
-    fn new(width: usize, height: usize, mines: usize, seed: u64) -> Self {
-        let mut game = Self {
-            width,
-            height,
-            mines,
-            cells: vec![
-                MinesweeperCell {
-                    is_mine: false,
-                    is_revealed: false,
-                    is_flagged: false,
-                    adjacent: 0,
-                };
-                width * height
-            ],
-            is_lost: false,
-            is_won: false,
-            revealed_count: 0,
-            seed,
-        };
-        game.reset(seed);
-        game
-    }
-
-    fn reset(&mut self, seed: u64) {
-        self.seed = seed;
-        self.is_lost = false;
-        self.is_won = false;
-        self.revealed_count = 0;
-        for cell in &mut self.cells {
-            *cell = MinesweeperCell {
-                is_mine: false,
-                is_revealed: false,
-                is_flagged: false,
-                adjacent: 0,
-            };
-        }
-
-        let mut rng = seed | 1;
-        let mut placed = 0;
-        while placed < self.mines {
-            rng ^= rng << 7;
-            rng ^= rng >> 9;
-            rng ^= rng << 8;
-            let idx = (rng as usize) % self.cells.len();
-            if !self.cells[idx].is_mine {
-                self.cells[idx].is_mine = true;
-                placed += 1;
-            }
-        }
-
-        for y in 0..self.height {
-            for x in 0..self.width {
-                let adjacent = self
-                    .neighbors(x, y)
-                    .filter(|&(nx, ny)| self.cell_at(nx, ny).is_mine)
-                    .count() as u8;
-                self.cell_at_mut(x, y).adjacent = adjacent;
-            }
-        }
-    }
-
-    fn idx(&self, x: usize, y: usize) -> usize {
-        y * self.width + x
-    }
-
-    fn cell_at(&self, x: usize, y: usize) -> &MinesweeperCell {
-        &self.cells[self.idx(x, y)]
-    }
-
-    fn cell_at_mut(&mut self, x: usize, y: usize) -> &mut MinesweeperCell {
-        let idx = self.idx(x, y);
-        &mut self.cells[idx]
-    }
-
-    fn neighbors(&self, x: usize, y: usize) -> impl Iterator<Item = (usize, usize)> {
-        let width = self.width as isize;
-        let height = self.height as isize;
-        let x = x as isize;
-        let y = y as isize;
-
-        (-1..=1).flat_map(move |dy| {
-            (-1..=1).filter_map(move |dx| {
-                if dx == 0 && dy == 0 {
-                    return None;
-                }
-                let nx = x + dx;
-                let ny = y + dy;
-                if nx >= 0 && nx < width && ny >= 0 && ny < height {
-                    Some((nx as usize, ny as usize))
-                } else {
-                    None
-                }
-            })
-        })
-    }
-
-    fn reveal(&mut self, x: usize, y: usize) {
-        if self.is_lost || self.is_won {
-            return;
-        }
-        if x >= self.width || y >= self.height {
-            return;
-        }
-        if self.cell_at(x, y).is_flagged || self.cell_at(x, y).is_revealed {
-            return;
-        }
-
-        if self.cell_at(x, y).is_mine {
-            self.is_lost = true;
-            for cell in &mut self.cells {
-                if cell.is_mine {
-                    cell.is_revealed = true;
-                }
-            }
-            return;
-        }
-
-        let mut stack = vec![(x, y)];
-        while let Some((cx, cy)) = stack.pop() {
-            let idx = self.idx(cx, cy);
-            if self.cells[idx].is_revealed || self.cells[idx].is_flagged {
-                continue;
-            }
-
-            let adjacent = self.cells[idx].adjacent;
-            self.cells[idx].is_revealed = true;
-            self.revealed_count += 1;
-
-            if adjacent == 0 {
-                for (nx, ny) in self.neighbors(cx, cy) {
-                    let neighbor = self.cell_at(nx, ny);
-                    if !neighbor.is_revealed && !neighbor.is_flagged && !neighbor.is_mine {
-                        stack.push((nx, ny));
-                    }
-                }
-            }
-        }
-
-        if self.revealed_count + self.mines == self.width * self.height {
-            self.is_won = true;
-            for cell in &mut self.cells {
-                if cell.is_mine {
-                    cell.is_flagged = true;
-                }
-            }
-        }
-    }
-
-    fn toggle_flag(&mut self, x: usize, y: usize) {
-        if self.is_lost || self.is_won {
-            return;
-        }
-        if x >= self.width || y >= self.height {
-            return;
-        }
-        let cell = self.cell_at_mut(x, y);
-        if cell.is_revealed {
-            return;
-        }
-        cell.is_flagged = !cell.is_flagged;
-    }
-
-    fn flags_placed(&self) -> usize {
-        self.cells.iter().filter(|cell| cell.is_flagged).count()
-    }
-}
-
-#[composable]
-fn minesweeper_tab() {
-    let game_state = compose_core::useState(|| MinesweeperGame::new(8, 8, 10, random_seed()));
-    let flag_mode = compose_core::useState(|| false);
-
-    Column(
-        Modifier::empty()
-            .padding(24.0)
-            .background(Color(0.08, 0.10, 0.18, 1.0))
-            .rounded_corners(24.0)
-            .padding(20.0),
-        ColumnSpec::default(),
-        {
-            let header_game_state = game_state.clone();
-            let header_flag_mode = flag_mode.clone();
-            let content_game_state = game_state.clone();
-            let content_flag_mode = flag_mode.clone();
-            move || {
-                Row(
-                    Modifier::empty().fill_max_width().padding(8.0),
-                    RowSpec::new()
-                        .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
-                        .vertical_alignment(VerticalAlignment::CenterVertically),
-                    {
-                        let game_state = header_game_state.clone();
-                        let flag_mode = header_flag_mode.clone();
-                        move || {
-                            Text(
-                                "Minesweeper",
-                                Modifier::empty()
-                                    .padding(10.0)
-                                    .background(Color(1.0, 1.0, 1.0, 0.08))
-                                    .rounded_corners(14.0),
-                            );
-
-                            Spacer(Size {
-                                width: 0.0,
-                                height: 0.0,
-                            });
-
-                            Button(
-                                Modifier::empty()
-                                    .rounded_corners(14.0)
-                                    .draw_behind(|scope| {
-                                        scope.draw_round_rect(
-                                            Brush::solid(Color(0.2, 0.45, 0.9, 1.0)),
-                                            CornerRadii::uniform(14.0),
-                                        );
-                                    })
-                                    .padding(10.0),
-                                {
-                                    let game_state = game_state.clone();
-                                    move || {
-                                        game_state.set(MinesweeperGame::new(
-                                            8,
-                                            8,
-                                            10,
-                                            random_seed(),
-                                        ))
-                                    }
-                                },
-                                || {
-                                    Text("New Game", Modifier::empty().padding(4.0));
-                                },
-                            );
-
-                            let mode_toggle = flag_mode.clone();
-                            Button(
-                                Modifier::empty()
-                                    .rounded_corners(14.0)
-                                    .draw_behind(|scope| {
-                                        scope.draw_round_rect(
-                                            Brush::solid(Color(0.45, 0.25, 0.45, 1.0)),
-                                            CornerRadii::uniform(14.0),
-                                        );
-                                    })
-                                    .padding(10.0),
-                                move || mode_toggle.set(!mode_toggle.get()),
-                                {
-                                    let mode_label = flag_mode.clone();
-                                    move || {
-                                        let label = if mode_label.get() {
-                                            "Flag mode"
-                                        } else {
-                                            "Reveal mode"
-                                        };
-                                        Text(label, Modifier::empty().padding(4.0));
-                                    }
-                                },
-                            );
-                        }
-                    },
-                );
-
-                Spacer(Size {
-                    width: 0.0,
-                    height: 12.0,
-                });
-
-                let game = content_game_state.get();
-                let flag_mode_value = content_flag_mode.get();
-                let status_text = if game.is_lost {
-                    "You hit a mine!"
-                } else if game.is_won {
-                    "You cleared the field!"
-                } else if flag_mode_value {
-                    "Flag cells you suspect contain mines"
-                } else {
-                    "Reveal safe cells to clear the board"
-                };
-
-                Text(
-                    format!(
-                        "Mines: {} | Flags: {} | Seed: {}",
-                        game.mines,
-                        game.flags_placed(),
-                        game.seed % 100000
-                    ),
-                    Modifier::empty()
-                        .padding(8.0)
-                        .background(Color(0.15, 0.22, 0.34, 0.7))
-                        .rounded_corners(12.0),
-                );
-
-                Spacer(Size {
-                    width: 0.0,
-                    height: 8.0,
-                });
-
-                Text(
-                    status_text,
-                    Modifier::empty()
-                        .padding(8.0)
-                        .background(Color(0.12, 0.16, 0.28, 0.6))
-                        .rounded_corners(12.0),
-                );
-
-                Spacer(Size {
-                    width: 0.0,
-                    height: 16.0,
-                });
-
-                let grid_width = game.width;
-                let grid_height = game.height;
-                let grid_state = content_game_state.clone();
-                let grid_flag_mode = content_flag_mode.clone();
-
-                Column(
-                    Modifier::empty()
-                        .background(Color(0.06, 0.08, 0.16, 0.9))
-                        .rounded_corners(18.0)
-                        .padding(12.0),
-                    ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(6.0)),
-                    move || {
-                        for y in 0..grid_height {
-                            let game_state = grid_state.clone();
-                            let flag_mode = grid_flag_mode.clone();
-                            Row(
-                                Modifier::empty().fill_max_width().padding(2.0),
-                                RowSpec::new()
-                                    .horizontal_arrangement(LinearArrangement::SpacedBy(6.0))
-                                    .vertical_alignment(VerticalAlignment::CenterVertically),
-                                move || {
-                                    for x in 0..grid_width {
-                                        let game_snapshot = game_state.get();
-                                        let cell = game_snapshot.cell_at(x, y).clone();
-                                        let display = if cell.is_revealed {
-                                            if cell.is_mine {
-                                                "💣".to_string()
-                                            } else if cell.adjacent == 0 {
-                                                "".to_string()
-                                            } else {
-                                                cell.adjacent.to_string()
-                                            }
-                                        } else if cell.is_flagged {
-                                            "🚩".to_string()
-                                        } else {
-                                            "".to_string()
-                                        };
-
-                                        let background = if cell.is_revealed {
-                                            if cell.is_mine {
-                                                Color(0.6, 0.18, 0.2, 0.9)
-                                            } else {
-                                                Color(0.18, 0.26, 0.34, 0.9)
-                                            }
-                                        } else if cell.is_flagged {
-                                            Color(0.26, 0.20, 0.32, 0.9)
-                                        } else {
-                                            Color(0.12, 0.14, 0.22, 0.9)
-                                        };
-
-                                        let game_action = game_state.clone();
-                                        let mode_state = flag_mode.clone();
-                                        Button(
-                                            Modifier::empty()
-                                                .size_points(36.0, 36.0)
-                                                .rounded_corners(8.0)
-                                                .draw_behind(move |scope| {
-                                                    scope.draw_round_rect(
-                                                        Brush::solid(background),
-                                                        CornerRadii::uniform(8.0),
-                                                    );
-                                                }),
-                                            move || {
-                                                if mode_state.get() {
-                                                    game_action
-                                                        .update(|game| game.toggle_flag(x, y));
-                                                } else {
-                                                    game_action.update(|game| game.reveal(x, y));
-                                                }
-                                            },
-                                            {
-                                                let display = display.clone();
-                                                move || {
-                                                    Text(
-                                                        display.clone(),
-                                                        Modifier::empty().padding(4.0),
-                                                    );
-                                                }
-                                            },
-                                        );
-                                    }
-                                },
-                            );
-                        }
-                    },
-                );
-            }
-        },
-    );
 }
 
 #[cfg(test)]

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -23,6 +23,7 @@ pub enum DemoTab {
     Async,
     Layout,
     ModifierShowcase,
+    Minesweeper,
 }
 
 impl DemoTab {
@@ -33,6 +34,7 @@ impl DemoTab {
             DemoTab::Async => "Async Runtime",
             DemoTab::Layout => "Recursive Layout",
             DemoTab::ModifierShowcase => "Modifiers Showcase",
+            DemoTab::Minesweeper => "Minesweeper",
         }
     }
 }
@@ -94,6 +96,14 @@ fn random() -> i32 {
     (nanos % 10000) as i32
 }
 
+fn random_seed() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64
+}
+
 #[composable]
 pub fn combined_app() {
     let active_tab = compose_core::useState(|| DemoTab::Counter);
@@ -108,9 +118,7 @@ pub fn combined_app() {
             let tab_state_for_row = active_tab.clone();
             let tab_state_for_content = active_tab.clone();
             Row(
-                Modifier::empty()
-                    .fill_max_width()
-                    .padding(8.0),
+                Modifier::empty().fill_max_width().padding(8.0),
                 RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
                 move || {
                     let tab_state = tab_state_for_row.clone();
@@ -154,6 +162,7 @@ pub fn combined_app() {
                     render_tab_button(DemoTab::Async);
                     render_tab_button(DemoTab::Layout);
                     render_tab_button(DemoTab::ModifierShowcase);
+                    render_tab_button(DemoTab::Minesweeper);
                 },
             );
 
@@ -169,6 +178,7 @@ pub fn combined_app() {
                 DemoTab::Async => async_runtime_example(),
                 DemoTab::Layout => recursive_layout_example(),
                 DemoTab::ModifierShowcase => modifier_showcase_tab(),
+                DemoTab::Minesweeper => minesweeper_tab(),
             });
         },
     );
@@ -200,9 +210,7 @@ fn recursive_layout_example() {
             });
 
             Row(
-                Modifier::empty()
-                    .fill_max_width()
-                    .padding(8.0),
+                Modifier::empty().fill_max_width().padding(8.0),
                 RowSpec::new()
                     .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
                     .vertical_alignment(VerticalAlignment::CenterVertically),
@@ -629,21 +637,15 @@ fn async_runtime_example() {
                                                         .then(
                                                             Modifier::empty().rounded_corners(13.0),
                                                         )
-                                                        .draw_behind(
-                                                            |scope| {
-                                                                scope.draw_round_rect(
-                                                                    Brush::linear_gradient(vec![
-                                                                        Color(
-                                                                            0.25, 0.55, 0.95, 1.0,
-                                                                        ),
-                                                                        Color(
-                                                                            0.15, 0.35, 0.80, 1.0,
-                                                                        ),
-                                                                    ]),
-                                                                    CornerRadii::uniform(13.0),
-                                                                );
-                                                            },
-                                                        ),
+                                                        .draw_behind(|scope| {
+                                                            scope.draw_round_rect(
+                                                                Brush::linear_gradient(vec![
+                                                                    Color(0.25, 0.55, 0.95, 1.0),
+                                                                    Color(0.15, 0.35, 0.80, 1.0),
+                                                                ]),
+                                                                CornerRadii::uniform(13.0),
+                                                            );
+                                                        }),
                                                     RowSpec::default(),
                                                     || {},
                                                 );
@@ -684,9 +686,7 @@ fn async_runtime_example() {
                 });
 
                 Row(
-                    Modifier::empty()
-                        .fill_max_width()
-                        .padding(4.0),
+                    Modifier::empty().fill_max_width().padding(4.0),
                     RowSpec::new()
                         .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
                         .vertical_alignment(VerticalAlignment::CenterVertically),
@@ -917,9 +917,7 @@ fn counter_app() {
                     });
 
                     Row(
-                        Modifier::empty()
-                            .fill_max_width()
-                            .padding(8.0),
+                        Modifier::empty().fill_max_width().padding(8.0),
                         RowSpec::new()
                             .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
                             .vertical_alignment(VerticalAlignment::CenterVertically),
@@ -1132,9 +1130,7 @@ fn counter_app() {
                             let counter_inc = counter.clone();
                             let counter_dec = counter.clone();
                             Row(
-                                Modifier::empty()
-                                    .fill_max_width()
-                                    .padding(8.0),
+                                Modifier::empty().fill_max_width().padding(8.0),
                                 RowSpec::new()
                                     .horizontal_arrangement(LinearArrangement::SpacedBy(12.0)),
                                 move || {
@@ -1281,9 +1277,7 @@ fn modifier_showcase_tab() {
     let selected_showcase = compose_core::useState(|| ShowcaseType::SimpleCard);
 
     Row(
-        Modifier::empty()
-            .fill_max_width()
-            .padding(8.0),
+        Modifier::empty().fill_max_width().padding(8.0),
         RowSpec::new()
             .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
             .vertical_alignment(VerticalAlignment::Top),
@@ -1371,15 +1365,13 @@ fn modifier_showcase_tab() {
                     let selected_showcase_inner = selected_showcase.clone();
                     move || {
                         let showcase_to_render = selected_showcase_inner.get();
-                        compose_core::with_key(&showcase_to_render, || {
-                            match showcase_to_render {
-                                ShowcaseType::SimpleCard => simple_card_showcase(),
-                                ShowcaseType::PositionedBoxes => positioned_boxes_showcase(),
-                                ShowcaseType::ItemList => item_list_showcase(),
-                                ShowcaseType::ComplexChain => complex_chain_showcase(),
-                                ShowcaseType::DynamicModifiers => dynamic_modifiers_showcase(),
-                                ShowcaseType::LongList => long_list_showcase(),
-                            }
+                        compose_core::with_key(&showcase_to_render, || match showcase_to_render {
+                            ShowcaseType::SimpleCard => simple_card_showcase(),
+                            ShowcaseType::PositionedBoxes => positioned_boxes_showcase(),
+                            ShowcaseType::ItemList => item_list_showcase(),
+                            ShowcaseType::ComplexChain => complex_chain_showcase(),
+                            ShowcaseType::DynamicModifiers => dynamic_modifiers_showcase(),
+                            ShowcaseType::LongList => long_list_showcase(),
                         });
                     }
                 },
@@ -1451,32 +1443,28 @@ pub fn simple_card_showcase() {
                                 });
 
                                 // Action buttons row
-                                Row(
-                                    Modifier::empty(),
-                                    RowSpec::default(),
-                                    || {
-                                        Text(
-                                            "Action 1",
-                                            Modifier::empty()
-                                                .padding(8.0)
-                                                .background(Color(0.2, 0.7, 0.4, 0.7))
-                                                .rounded_corners(6.0),
-                                        );
+                                Row(Modifier::empty(), RowSpec::default(), || {
+                                    Text(
+                                        "Action 1",
+                                        Modifier::empty()
+                                            .padding(8.0)
+                                            .background(Color(0.2, 0.7, 0.4, 0.7))
+                                            .rounded_corners(6.0),
+                                    );
 
-                                        Spacer(Size {
-                                            width: 8.0,
-                                            height: 0.0,
-                                        });
+                                    Spacer(Size {
+                                        width: 8.0,
+                                        height: 0.0,
+                                    });
 
-                                        Text(
-                                            "Action 2",
-                                            Modifier::empty()
-                                                .padding(8.0)
-                                                .background(Color(0.8, 0.3, 0.3, 0.7))
-                                                .rounded_corners(6.0),
-                                        );
-                                    },
-                                );
+                                    Text(
+                                        "Action 2",
+                                        Modifier::empty()
+                                            .padding(8.0)
+                                            .background(Color(0.8, 0.3, 0.3, 0.7))
+                                            .rounded_corners(6.0),
+                                    );
+                                });
                             },
                         );
                     },
@@ -1874,12 +1862,7 @@ pub fn long_list_showcase() {
                                 width: 400.0,
                                 height: 40.0,
                             })
-                            .background(Color(
-                                0.12 + (i as f32 * 0.005),
-                                0.15,
-                                0.25,
-                                0.7,
-                            ))
+                            .background(Color(0.12 + (i as f32 * 0.005), 0.15, 0.25, 0.7))
                             .rounded_corners(8.0),
                         RowSpec::default(),
                         move || {
@@ -1907,6 +1890,427 @@ pub fn long_list_showcase() {
             },
         );
     });
+}
+
+#[derive(Clone, Debug)]
+struct MinesweeperCell {
+    is_mine: bool,
+    is_revealed: bool,
+    is_flagged: bool,
+    adjacent: u8,
+}
+
+#[derive(Clone, Debug)]
+struct MinesweeperGame {
+    width: usize,
+    height: usize,
+    mines: usize,
+    cells: Vec<MinesweeperCell>,
+    is_lost: bool,
+    is_won: bool,
+    revealed_count: usize,
+    seed: u64,
+}
+
+impl MinesweeperGame {
+    fn new(width: usize, height: usize, mines: usize, seed: u64) -> Self {
+        let mut game = Self {
+            width,
+            height,
+            mines,
+            cells: vec![
+                MinesweeperCell {
+                    is_mine: false,
+                    is_revealed: false,
+                    is_flagged: false,
+                    adjacent: 0,
+                };
+                width * height
+            ],
+            is_lost: false,
+            is_won: false,
+            revealed_count: 0,
+            seed,
+        };
+        game.reset(seed);
+        game
+    }
+
+    fn reset(&mut self, seed: u64) {
+        self.seed = seed;
+        self.is_lost = false;
+        self.is_won = false;
+        self.revealed_count = 0;
+        for cell in &mut self.cells {
+            *cell = MinesweeperCell {
+                is_mine: false,
+                is_revealed: false,
+                is_flagged: false,
+                adjacent: 0,
+            };
+        }
+
+        let mut rng = seed | 1;
+        let mut placed = 0;
+        while placed < self.mines {
+            rng ^= rng << 7;
+            rng ^= rng >> 9;
+            rng ^= rng << 8;
+            let idx = (rng as usize) % self.cells.len();
+            if !self.cells[idx].is_mine {
+                self.cells[idx].is_mine = true;
+                placed += 1;
+            }
+        }
+
+        for y in 0..self.height {
+            for x in 0..self.width {
+                let adjacent = self
+                    .neighbors(x, y)
+                    .filter(|&(nx, ny)| self.cell_at(nx, ny).is_mine)
+                    .count() as u8;
+                self.cell_at_mut(x, y).adjacent = adjacent;
+            }
+        }
+    }
+
+    fn idx(&self, x: usize, y: usize) -> usize {
+        y * self.width + x
+    }
+
+    fn cell_at(&self, x: usize, y: usize) -> &MinesweeperCell {
+        &self.cells[self.idx(x, y)]
+    }
+
+    fn cell_at_mut(&mut self, x: usize, y: usize) -> &mut MinesweeperCell {
+        let idx = self.idx(x, y);
+        &mut self.cells[idx]
+    }
+
+    fn neighbors(&self, x: usize, y: usize) -> impl Iterator<Item = (usize, usize)> {
+        let width = self.width as isize;
+        let height = self.height as isize;
+        let x = x as isize;
+        let y = y as isize;
+
+        (-1..=1).flat_map(move |dy| {
+            (-1..=1).filter_map(move |dx| {
+                if dx == 0 && dy == 0 {
+                    return None;
+                }
+                let nx = x + dx;
+                let ny = y + dy;
+                if nx >= 0 && nx < width && ny >= 0 && ny < height {
+                    Some((nx as usize, ny as usize))
+                } else {
+                    None
+                }
+            })
+        })
+    }
+
+    fn reveal(&mut self, x: usize, y: usize) {
+        if self.is_lost || self.is_won {
+            return;
+        }
+        if x >= self.width || y >= self.height {
+            return;
+        }
+        if self.cell_at(x, y).is_flagged || self.cell_at(x, y).is_revealed {
+            return;
+        }
+
+        if self.cell_at(x, y).is_mine {
+            self.is_lost = true;
+            for cell in &mut self.cells {
+                if cell.is_mine {
+                    cell.is_revealed = true;
+                }
+            }
+            return;
+        }
+
+        let mut stack = vec![(x, y)];
+        while let Some((cx, cy)) = stack.pop() {
+            let idx = self.idx(cx, cy);
+            if self.cells[idx].is_revealed || self.cells[idx].is_flagged {
+                continue;
+            }
+
+            let adjacent = self.cells[idx].adjacent;
+            self.cells[idx].is_revealed = true;
+            self.revealed_count += 1;
+
+            if adjacent == 0 {
+                for (nx, ny) in self.neighbors(cx, cy) {
+                    let neighbor = self.cell_at(nx, ny);
+                    if !neighbor.is_revealed && !neighbor.is_flagged && !neighbor.is_mine {
+                        stack.push((nx, ny));
+                    }
+                }
+            }
+        }
+
+        if self.revealed_count + self.mines == self.width * self.height {
+            self.is_won = true;
+            for cell in &mut self.cells {
+                if cell.is_mine {
+                    cell.is_flagged = true;
+                }
+            }
+        }
+    }
+
+    fn toggle_flag(&mut self, x: usize, y: usize) {
+        if self.is_lost || self.is_won {
+            return;
+        }
+        if x >= self.width || y >= self.height {
+            return;
+        }
+        let cell = self.cell_at_mut(x, y);
+        if cell.is_revealed {
+            return;
+        }
+        cell.is_flagged = !cell.is_flagged;
+    }
+
+    fn flags_placed(&self) -> usize {
+        self.cells.iter().filter(|cell| cell.is_flagged).count()
+    }
+}
+
+#[composable]
+fn minesweeper_tab() {
+    let game_state = compose_core::useState(|| MinesweeperGame::new(8, 8, 10, random_seed()));
+    let flag_mode = compose_core::useState(|| false);
+
+    Column(
+        Modifier::empty()
+            .padding(24.0)
+            .background(Color(0.08, 0.10, 0.18, 1.0))
+            .rounded_corners(24.0)
+            .padding(20.0),
+        ColumnSpec::default(),
+        {
+            let header_game_state = game_state.clone();
+            let header_flag_mode = flag_mode.clone();
+            let content_game_state = game_state.clone();
+            let content_flag_mode = flag_mode.clone();
+            move || {
+                Row(
+                    Modifier::empty().fill_max_width().padding(8.0),
+                    RowSpec::new()
+                        .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
+                        .vertical_alignment(VerticalAlignment::CenterVertically),
+                    {
+                        let game_state = header_game_state.clone();
+                        let flag_mode = header_flag_mode.clone();
+                        move || {
+                            Text(
+                                "Minesweeper",
+                                Modifier::empty()
+                                    .padding(10.0)
+                                    .background(Color(1.0, 1.0, 1.0, 0.08))
+                                    .rounded_corners(14.0),
+                            );
+
+                            Spacer(Size {
+                                width: 0.0,
+                                height: 0.0,
+                            });
+
+                            Button(
+                                Modifier::empty()
+                                    .rounded_corners(14.0)
+                                    .draw_behind(|scope| {
+                                        scope.draw_round_rect(
+                                            Brush::solid(Color(0.2, 0.45, 0.9, 1.0)),
+                                            CornerRadii::uniform(14.0),
+                                        );
+                                    })
+                                    .padding(10.0),
+                                {
+                                    let game_state = game_state.clone();
+                                    move || {
+                                        game_state.set(MinesweeperGame::new(
+                                            8,
+                                            8,
+                                            10,
+                                            random_seed(),
+                                        ))
+                                    }
+                                },
+                                || {
+                                    Text("New Game", Modifier::empty().padding(4.0));
+                                },
+                            );
+
+                            let mode_toggle = flag_mode.clone();
+                            Button(
+                                Modifier::empty()
+                                    .rounded_corners(14.0)
+                                    .draw_behind(|scope| {
+                                        scope.draw_round_rect(
+                                            Brush::solid(Color(0.45, 0.25, 0.45, 1.0)),
+                                            CornerRadii::uniform(14.0),
+                                        );
+                                    })
+                                    .padding(10.0),
+                                move || mode_toggle.set(!mode_toggle.get()),
+                                {
+                                    let mode_label = flag_mode.clone();
+                                    move || {
+                                        let label = if mode_label.get() {
+                                            "Flag mode"
+                                        } else {
+                                            "Reveal mode"
+                                        };
+                                        Text(label, Modifier::empty().padding(4.0));
+                                    }
+                                },
+                            );
+                        }
+                    },
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 12.0,
+                });
+
+                let game = content_game_state.get();
+                let flag_mode_value = content_flag_mode.get();
+                let status_text = if game.is_lost {
+                    "You hit a mine!"
+                } else if game.is_won {
+                    "You cleared the field!"
+                } else if flag_mode_value {
+                    "Flag cells you suspect contain mines"
+                } else {
+                    "Reveal safe cells to clear the board"
+                };
+
+                Text(
+                    format!(
+                        "Mines: {} | Flags: {} | Seed: {}",
+                        game.mines,
+                        game.flags_placed(),
+                        game.seed % 100000
+                    ),
+                    Modifier::empty()
+                        .padding(8.0)
+                        .background(Color(0.15, 0.22, 0.34, 0.7))
+                        .rounded_corners(12.0),
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 8.0,
+                });
+
+                Text(
+                    status_text,
+                    Modifier::empty()
+                        .padding(8.0)
+                        .background(Color(0.12, 0.16, 0.28, 0.6))
+                        .rounded_corners(12.0),
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 16.0,
+                });
+
+                let grid_width = game.width;
+                let grid_height = game.height;
+                let grid_state = content_game_state.clone();
+                let grid_flag_mode = content_flag_mode.clone();
+
+                Column(
+                    Modifier::empty()
+                        .background(Color(0.06, 0.08, 0.16, 0.9))
+                        .rounded_corners(18.0)
+                        .padding(12.0),
+                    ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(6.0)),
+                    move || {
+                        for y in 0..grid_height {
+                            let game_state = grid_state.clone();
+                            let flag_mode = grid_flag_mode.clone();
+                            Row(
+                                Modifier::empty().fill_max_width().padding(2.0),
+                                RowSpec::new()
+                                    .horizontal_arrangement(LinearArrangement::SpacedBy(6.0))
+                                    .vertical_alignment(VerticalAlignment::CenterVertically),
+                                move || {
+                                    for x in 0..grid_width {
+                                        let game_snapshot = game_state.get();
+                                        let cell = game_snapshot.cell_at(x, y).clone();
+                                        let display = if cell.is_revealed {
+                                            if cell.is_mine {
+                                                "💣".to_string()
+                                            } else if cell.adjacent == 0 {
+                                                "".to_string()
+                                            } else {
+                                                cell.adjacent.to_string()
+                                            }
+                                        } else if cell.is_flagged {
+                                            "🚩".to_string()
+                                        } else {
+                                            "".to_string()
+                                        };
+
+                                        let background = if cell.is_revealed {
+                                            if cell.is_mine {
+                                                Color(0.6, 0.18, 0.2, 0.9)
+                                            } else {
+                                                Color(0.18, 0.26, 0.34, 0.9)
+                                            }
+                                        } else if cell.is_flagged {
+                                            Color(0.26, 0.20, 0.32, 0.9)
+                                        } else {
+                                            Color(0.12, 0.14, 0.22, 0.9)
+                                        };
+
+                                        let game_action = game_state.clone();
+                                        let mode_state = flag_mode.clone();
+                                        Button(
+                                            Modifier::empty()
+                                                .size_points(36.0, 36.0)
+                                                .rounded_corners(8.0)
+                                                .draw_behind(move |scope| {
+                                                    scope.draw_round_rect(
+                                                        Brush::solid(background),
+                                                        CornerRadii::uniform(8.0),
+                                                    );
+                                                }),
+                                            move || {
+                                                if mode_state.get() {
+                                                    game_action
+                                                        .update(|game| game.toggle_flag(x, y));
+                                                } else {
+                                                    game_action.update(|game| game.reveal(x, y));
+                                                }
+                                            },
+                                            {
+                                                let display = display.clone();
+                                                move || {
+                                                    Text(
+                                                        display.clone(),
+                                                        Modifier::empty().padding(4.0),
+                                                    );
+                                                }
+                                            },
+                                        );
+                                    }
+                                },
+                            );
+                        }
+                    },
+                );
+            }
+        },
+    );
 }
 
 #[cfg(test)]

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -12,7 +12,6 @@ use compose_ui::{
 use std::cell::RefCell;
 
 mod mineswapper2;
-use mineswapper2::MineswapperTool;
 
 thread_local! {
     pub static TEST_COMPOSITION_LOCAL_COUNTER: RefCell<Option<MutableState<i32>>> = RefCell::new(None);
@@ -102,8 +101,6 @@ fn random() -> i32 {
 #[composable]
 pub fn combined_app() {
     let active_tab = compose_core::useState(|| DemoTab::Counter);
-    let mineswapper_tool_state = compose_core::useState(|| MineswapperTool::Reveal);
-    mineswapper2::set_shared_tool_state(&mineswapper_tool_state);
     TEST_ACTIVE_TAB_STATE.with(|cell| {
         *cell.borrow_mut() = Some(active_tab.clone());
     });
@@ -175,10 +172,7 @@ pub fn combined_app() {
                 DemoTab::Async => async_runtime_example(),
                 DemoTab::Layout => recursive_layout_example(),
                 DemoTab::ModifierShowcase => modifier_showcase_tab(),
-                DemoTab::Mineswapper2 => {
-                    mineswapper2::set_shared_tool_state(&mineswapper_tool_state);
-                    mineswapper2::mineswapper2_tab()
-                }
+                DemoTab::Mineswapper2 => mineswapper2::mineswapper2_tab(),
             });
         },
     );
@@ -894,7 +888,6 @@ fn counter_app() {
                     let pointer_position = pointer_position_main.clone();
                     let pointer_down = pointer_down_main.clone();
                     let wave = wave_main.clone();
-                    let mineswapper_tool_state = mineswapper2::shared_tool_state();
                     Text(
                         "Compose-RS Playground",
                         Modifier::empty()
@@ -1235,42 +1228,6 @@ fn counter_app() {
                             );
                         },
                     );
-
-                    if let Some(tool_state) = mineswapper_tool_state.clone() {
-                        let indicator_tool_state = tool_state.clone();
-                        compose_ui::Box(
-                            Modifier::empty()
-                                .size(Size {
-                                    width: 36.0,
-                                    height: 36.0,
-                                })
-                                .graphics_layer(GraphicsLayer {
-                                    translation_x: pointer_position.get().x - 18.0,
-                                    translation_y: pointer_position.get().y - 18.0,
-                                    ..GraphicsLayer::default()
-                                })
-                                .draw_behind(move |scope| {
-                                    let mode = indicator_tool_state.get();
-                                    let color = match mode {
-                                        MineswapperTool::Reveal => Color(0.18, 0.45, 0.78, 0.9),
-                                        MineswapperTool::Flag => Color(0.70, 0.25, 0.32, 0.9),
-                                    };
-                                    scope.draw_round_rect(
-                                        Brush::solid(color),
-                                        CornerRadii::uniform(12.0),
-                                    );
-                                }),
-                            BoxSpec::default(),
-                            move || {
-                                let mode = tool_state.get();
-                                let label = match mode {
-                                    MineswapperTool::Reveal => "⛏️",
-                                    MineswapperTool::Flag => "🚩",
-                                };
-                                Text(label, Modifier::empty().padding(6.0));
-                            },
-                        );
-                    }
                 }
             },
         );

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -112,7 +112,9 @@ pub fn combined_app() {
             let tab_state_for_row = active_tab.clone();
             let tab_state_for_content = active_tab.clone();
             Row(
-                Modifier::empty().fill_max_width().padding(8.0),
+                Modifier::empty()
+                    .fill_max_width()
+                    .padding(8.0),
                 RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
                 move || {
                     let tab_state = tab_state_for_row.clone();
@@ -204,7 +206,9 @@ fn recursive_layout_example() {
             });
 
             Row(
-                Modifier::empty().fill_max_width().padding(8.0),
+                Modifier::empty()
+                    .fill_max_width()
+                    .padding(8.0),
                 RowSpec::new()
                     .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
                     .vertical_alignment(VerticalAlignment::CenterVertically),
@@ -631,15 +635,21 @@ fn async_runtime_example() {
                                                         .then(
                                                             Modifier::empty().rounded_corners(13.0),
                                                         )
-                                                        .draw_behind(|scope| {
-                                                            scope.draw_round_rect(
-                                                                Brush::linear_gradient(vec![
-                                                                    Color(0.25, 0.55, 0.95, 1.0),
-                                                                    Color(0.15, 0.35, 0.80, 1.0),
-                                                                ]),
-                                                                CornerRadii::uniform(13.0),
-                                                            );
-                                                        }),
+                                                        .draw_behind(
+                                                            |scope| {
+                                                                scope.draw_round_rect(
+                                                                    Brush::linear_gradient(vec![
+                                                                        Color(
+                                                                            0.25, 0.55, 0.95, 1.0,
+                                                                        ),
+                                                                        Color(
+                                                                            0.15, 0.35, 0.80, 1.0,
+                                                                        ),
+                                                                    ]),
+                                                                    CornerRadii::uniform(13.0),
+                                                                );
+                                                            },
+                                                        ),
                                                     RowSpec::default(),
                                                     || {},
                                                 );
@@ -680,7 +690,9 @@ fn async_runtime_example() {
                 });
 
                 Row(
-                    Modifier::empty().fill_max_width().padding(4.0),
+                    Modifier::empty()
+                        .fill_max_width()
+                        .padding(4.0),
                     RowSpec::new()
                         .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
                         .vertical_alignment(VerticalAlignment::CenterVertically),
@@ -911,7 +923,9 @@ fn counter_app() {
                     });
 
                     Row(
-                        Modifier::empty().fill_max_width().padding(8.0),
+                        Modifier::empty()
+                            .fill_max_width()
+                            .padding(8.0),
                         RowSpec::new()
                             .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
                             .vertical_alignment(VerticalAlignment::CenterVertically),
@@ -1124,7 +1138,9 @@ fn counter_app() {
                             let counter_inc = counter.clone();
                             let counter_dec = counter.clone();
                             Row(
-                                Modifier::empty().fill_max_width().padding(8.0),
+                                Modifier::empty()
+                                    .fill_max_width()
+                                    .padding(8.0),
                                 RowSpec::new()
                                     .horizontal_arrangement(LinearArrangement::SpacedBy(12.0)),
                                 move || {
@@ -1271,7 +1287,9 @@ fn modifier_showcase_tab() {
     let selected_showcase = compose_core::useState(|| ShowcaseType::SimpleCard);
 
     Row(
-        Modifier::empty().fill_max_width().padding(8.0),
+        Modifier::empty()
+            .fill_max_width()
+            .padding(8.0),
         RowSpec::new()
             .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
             .vertical_alignment(VerticalAlignment::Top),
@@ -1359,13 +1377,15 @@ fn modifier_showcase_tab() {
                     let selected_showcase_inner = selected_showcase.clone();
                     move || {
                         let showcase_to_render = selected_showcase_inner.get();
-                        compose_core::with_key(&showcase_to_render, || match showcase_to_render {
-                            ShowcaseType::SimpleCard => simple_card_showcase(),
-                            ShowcaseType::PositionedBoxes => positioned_boxes_showcase(),
-                            ShowcaseType::ItemList => item_list_showcase(),
-                            ShowcaseType::ComplexChain => complex_chain_showcase(),
-                            ShowcaseType::DynamicModifiers => dynamic_modifiers_showcase(),
-                            ShowcaseType::LongList => long_list_showcase(),
+                        compose_core::with_key(&showcase_to_render, || {
+                            match showcase_to_render {
+                                ShowcaseType::SimpleCard => simple_card_showcase(),
+                                ShowcaseType::PositionedBoxes => positioned_boxes_showcase(),
+                                ShowcaseType::ItemList => item_list_showcase(),
+                                ShowcaseType::ComplexChain => complex_chain_showcase(),
+                                ShowcaseType::DynamicModifiers => dynamic_modifiers_showcase(),
+                                ShowcaseType::LongList => long_list_showcase(),
+                            }
                         });
                     }
                 },
@@ -1437,28 +1457,32 @@ pub fn simple_card_showcase() {
                                 });
 
                                 // Action buttons row
-                                Row(Modifier::empty(), RowSpec::default(), || {
-                                    Text(
-                                        "Action 1",
-                                        Modifier::empty()
-                                            .padding(8.0)
-                                            .background(Color(0.2, 0.7, 0.4, 0.7))
-                                            .rounded_corners(6.0),
-                                    );
+                                Row(
+                                    Modifier::empty(),
+                                    RowSpec::default(),
+                                    || {
+                                        Text(
+                                            "Action 1",
+                                            Modifier::empty()
+                                                .padding(8.0)
+                                                .background(Color(0.2, 0.7, 0.4, 0.7))
+                                                .rounded_corners(6.0),
+                                        );
 
-                                    Spacer(Size {
-                                        width: 8.0,
-                                        height: 0.0,
-                                    });
+                                        Spacer(Size {
+                                            width: 8.0,
+                                            height: 0.0,
+                                        });
 
-                                    Text(
-                                        "Action 2",
-                                        Modifier::empty()
-                                            .padding(8.0)
-                                            .background(Color(0.8, 0.3, 0.3, 0.7))
-                                            .rounded_corners(6.0),
-                                    );
-                                });
+                                        Text(
+                                            "Action 2",
+                                            Modifier::empty()
+                                                .padding(8.0)
+                                                .background(Color(0.8, 0.3, 0.3, 0.7))
+                                                .rounded_corners(6.0),
+                                        );
+                                    },
+                                );
                             },
                         );
                     },
@@ -1856,7 +1880,12 @@ pub fn long_list_showcase() {
                                 width: 400.0,
                                 height: 40.0,
                             })
-                            .background(Color(0.12 + (i as f32 * 0.005), 0.15, 0.25, 0.7))
+                            .background(Color(
+                                0.12 + (i as f32 * 0.005),
+                                0.15,
+                                0.25,
+                                0.7,
+                            ))
                             .rounded_corners(8.0),
                         RowSpec::default(),
                         move || {

--- a/apps/desktop-demo/src/app/mineswapper2.rs
+++ b/apps/desktop-demo/src/app/mineswapper2.rs
@@ -4,7 +4,6 @@ use compose_ui::{
     Row, RowSpec, Size, Spacer, Text, VerticalAlignment,
 };
 use std::time::{SystemTime, UNIX_EPOCH};
-use crate::app::mineswapper2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MineswapperTool {

--- a/apps/desktop-demo/src/app/mineswapper2.rs
+++ b/apps/desktop-demo/src/app/mineswapper2.rs
@@ -1,0 +1,515 @@
+use compose_core::useState;
+use compose_ui::{
+    composable, Brush, Button, Color, Column, ColumnSpec, CornerRadii, LinearArrangement, Modifier,
+    Row, RowSpec, Size, Spacer, Text, VerticalAlignment,
+};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GridPreset {
+    pub name: &'static str,
+    pub width: usize,
+    pub height: usize,
+    pub mines: usize,
+}
+
+const GRID_PRESETS: [GridPreset; 3] = [
+    GridPreset {
+        name: "Compact (8x8)",
+        width: 8,
+        height: 8,
+        mines: 10,
+    },
+    GridPreset {
+        name: "Roomy (12x12)",
+        width: 12,
+        height: 12,
+        mines: 22,
+    },
+    GridPreset {
+        name: "Spacious (16x16)",
+        width: 16,
+        height: 16,
+        mines: 40,
+    },
+];
+
+#[derive(Clone, Debug)]
+struct MineswapperCell {
+    is_mine: bool,
+    is_revealed: bool,
+    is_flagged: bool,
+    adjacent: u8,
+}
+
+#[derive(Clone, Debug)]
+struct MineswapperGame {
+    width: usize,
+    height: usize,
+    mines: usize,
+    cells: Vec<MineswapperCell>,
+    is_lost: bool,
+    is_won: bool,
+    revealed_count: usize,
+    seed: u64,
+}
+
+impl MineswapperGame {
+    fn new_from_preset(preset: GridPreset, seed: u64) -> Self {
+        let mut game = Self {
+            width: preset.width,
+            height: preset.height,
+            mines: preset.mines,
+            cells: vec![
+                MineswapperCell {
+                    is_mine: false,
+                    is_revealed: false,
+                    is_flagged: false,
+                    adjacent: 0,
+                };
+                preset.width * preset.height
+            ],
+            is_lost: false,
+            is_won: false,
+            revealed_count: 0,
+            seed,
+        };
+        game.reset(seed);
+        game
+    }
+
+    fn reset(&mut self, seed: u64) {
+        self.seed = seed;
+        self.is_lost = false;
+        self.is_won = false;
+        self.revealed_count = 0;
+        for cell in &mut self.cells {
+            *cell = MineswapperCell {
+                is_mine: false,
+                is_revealed: false,
+                is_flagged: false,
+                adjacent: 0,
+            };
+        }
+
+        let mut rng = seed | 1;
+        let mut placed = 0;
+        while placed < self.mines {
+            rng ^= rng << 7;
+            rng ^= rng >> 9;
+            rng ^= rng << 8;
+            let idx = (rng as usize) % self.cells.len();
+            if !self.cells[idx].is_mine {
+                self.cells[idx].is_mine = true;
+                placed += 1;
+            }
+        }
+
+        for y in 0..self.height {
+            for x in 0..self.width {
+                let adjacent = self
+                    .neighbors(x, y)
+                    .filter(|&(nx, ny)| self.cell_at(nx, ny).is_mine)
+                    .count() as u8;
+                self.cell_at_mut(x, y).adjacent = adjacent;
+            }
+        }
+    }
+
+    fn idx(&self, x: usize, y: usize) -> usize {
+        y * self.width + x
+    }
+
+    fn cell_at(&self, x: usize, y: usize) -> &MineswapperCell {
+        &self.cells[self.idx(x, y)]
+    }
+
+    fn cell_at_mut(&mut self, x: usize, y: usize) -> &mut MineswapperCell {
+        let idx = self.idx(x, y);
+        &mut self.cells[idx]
+    }
+
+    fn neighbors(&self, x: usize, y: usize) -> impl Iterator<Item = (usize, usize)> {
+        let width = self.width as isize;
+        let height = self.height as isize;
+        let x = x as isize;
+        let y = y as isize;
+
+        (-1..=1).flat_map(move |dy| {
+            (-1..=1).filter_map(move |dx| {
+                if dx == 0 && dy == 0 {
+                    return None;
+                }
+                let nx = x + dx;
+                let ny = y + dy;
+                if nx >= 0 && nx < width && ny >= 0 && ny < height {
+                    Some((nx as usize, ny as usize))
+                } else {
+                    None
+                }
+            })
+        })
+    }
+
+    fn reveal(&mut self, x: usize, y: usize) {
+        if self.is_lost || self.is_won {
+            return;
+        }
+        if x >= self.width || y >= self.height {
+            return;
+        }
+        if self.cell_at(x, y).is_flagged || self.cell_at(x, y).is_revealed {
+            return;
+        }
+
+        if self.cell_at(x, y).is_mine {
+            self.is_lost = true;
+            for cell in &mut self.cells {
+                if cell.is_mine {
+                    cell.is_revealed = true;
+                }
+            }
+            return;
+        }
+
+        let mut stack = vec![(x, y)];
+        while let Some((cx, cy)) = stack.pop() {
+            let idx = self.idx(cx, cy);
+            if self.cells[idx].is_revealed || self.cells[idx].is_flagged {
+                continue;
+            }
+
+            let adjacent = self.cells[idx].adjacent;
+            self.cells[idx].is_revealed = true;
+            self.revealed_count += 1;
+
+            if adjacent == 0 {
+                for (nx, ny) in self.neighbors(cx, cy) {
+                    let neighbor = self.cell_at(nx, ny);
+                    if !neighbor.is_revealed && !neighbor.is_flagged && !neighbor.is_mine {
+                        stack.push((nx, ny));
+                    }
+                }
+            }
+        }
+
+        if self.revealed_count + self.mines == self.width * self.height {
+            self.is_won = true;
+            for cell in &mut self.cells {
+                if cell.is_mine {
+                    cell.is_flagged = true;
+                }
+            }
+        }
+    }
+
+    fn toggle_flag(&mut self, x: usize, y: usize) {
+        if self.is_lost || self.is_won {
+            return;
+        }
+        if x >= self.width || y >= self.height {
+            return;
+        }
+        let cell = self.cell_at_mut(x, y);
+        if cell.is_revealed {
+            return;
+        }
+        cell.is_flagged = !cell.is_flagged;
+    }
+
+    fn flags_placed(&self) -> usize {
+        self.cells.iter().filter(|cell| cell.is_flagged).count()
+    }
+}
+
+fn random_seed() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64
+}
+
+#[composable]
+pub fn mineswapper2_tab() {
+    let preset_state = useState(|| GRID_PRESETS[0]);
+    let game_state = useState(|| MineswapperGame::new_from_preset(GRID_PRESETS[0], random_seed()));
+    let flag_mode = useState(|| false);
+
+    Column(
+        Modifier::empty()
+            .padding(24.0)
+            .background(Color(0.08, 0.10, 0.18, 1.0))
+            .rounded_corners(24.0)
+            .padding(20.0),
+        ColumnSpec::default(),
+        {
+            let header_game_state = game_state.clone();
+            let header_flag_mode = flag_mode.clone();
+            let header_preset_state = preset_state.clone();
+            let content_game_state = game_state.clone();
+            let content_flag_mode = flag_mode.clone();
+            move || {
+                Row(
+                    Modifier::empty().fill_max_width().padding(8.0),
+                    RowSpec::new()
+                        .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
+                        .vertical_alignment(VerticalAlignment::CenterVertically),
+                    {
+                        let game_state = header_game_state.clone();
+                        let flag_mode = header_flag_mode.clone();
+                        let preset_state = header_preset_state.clone();
+                        move || {
+                            Text(
+                                "Mineswapper 2",
+                                Modifier::empty()
+                                    .padding(10.0)
+                                    .background(Color(1.0, 1.0, 1.0, 0.08))
+                                    .rounded_corners(14.0),
+                            );
+
+                            Spacer(Size {
+                                width: 0.0,
+                                height: 0.0,
+                            });
+
+                            Row(
+                                Modifier::empty(),
+                                RowSpec::new()
+                                    .horizontal_arrangement(LinearArrangement::SpacedBy(8.0))
+                                    .vertical_alignment(VerticalAlignment::CenterVertically),
+                                {
+                                    let game_state = game_state.clone();
+                                    let preset_state = preset_state.clone();
+                                    move || {
+                                        for preset in GRID_PRESETS {
+                                            let is_active = preset_state.get() == preset;
+                                            let game_state = game_state.clone();
+                                            let preset_state = preset_state.clone();
+                                            Button(
+                                                Modifier::empty()
+                                                    .rounded_corners(12.0)
+                                                    .draw_behind(move |scope| {
+                                                        scope.draw_round_rect(
+                                                            Brush::solid(if is_active {
+                                                                Color(0.28, 0.48, 0.88, 1.0)
+                                                            } else {
+                                                                Color(0.20, 0.24, 0.34, 0.8)
+                                                            }),
+                                                            CornerRadii::uniform(12.0),
+                                                        );
+                                                    })
+                                                    .padding(8.0),
+                                                move || {
+                                                    preset_state.set(preset);
+                                                    game_state.set(
+                                                        MineswapperGame::new_from_preset(
+                                                            preset,
+                                                            random_seed(),
+                                                        ),
+                                                    );
+                                                },
+                                                {
+                                                    let label = preset.name;
+                                                    move || {
+                                                        Text(label, Modifier::empty().padding(4.0));
+                                                    }
+                                                },
+                                            );
+                                        }
+                                    }
+                                },
+                            );
+
+                            Button(
+                                Modifier::empty()
+                                    .rounded_corners(14.0)
+                                    .draw_behind(|scope| {
+                                        scope.draw_round_rect(
+                                            Brush::solid(Color(0.2, 0.45, 0.9, 1.0)),
+                                            CornerRadii::uniform(14.0),
+                                        );
+                                    })
+                                    .padding(10.0),
+                                {
+                                    let game_state = game_state.clone();
+                                    let preset_state = preset_state.clone();
+                                    move || {
+                                        let preset = preset_state.get();
+                                        game_state.set(MineswapperGame::new_from_preset(
+                                            preset,
+                                            random_seed(),
+                                        ))
+                                    }
+                                },
+                                || {
+                                    Text("New Game", Modifier::empty().padding(4.0));
+                                },
+                            );
+
+                            let mode_toggle = flag_mode.clone();
+                            Button(
+                                Modifier::empty()
+                                    .rounded_corners(14.0)
+                                    .draw_behind(|scope| {
+                                        scope.draw_round_rect(
+                                            Brush::solid(Color(0.45, 0.25, 0.45, 1.0)),
+                                            CornerRadii::uniform(14.0),
+                                        );
+                                    })
+                                    .padding(10.0),
+                                move || mode_toggle.set(!mode_toggle.get()),
+                                {
+                                    let mode_label = flag_mode.clone();
+                                    move || {
+                                        let label = if mode_label.get() {
+                                            "Flag mode"
+                                        } else {
+                                            "Reveal mode"
+                                        };
+                                        Text(label, Modifier::empty().padding(4.0));
+                                    }
+                                },
+                            );
+                        }
+                    },
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 12.0,
+                });
+
+                let game = content_game_state.get();
+                let flag_mode_value = content_flag_mode.get();
+                let status_text = if game.is_lost {
+                    "You hit a mine!"
+                } else if game.is_won {
+                    "You cleared the field!"
+                } else if flag_mode_value {
+                    "Flag cells you suspect contain mines"
+                } else {
+                    "Reveal safe cells to clear the board"
+                };
+
+                Text(
+                    format!(
+                        "{} — Mines: {} | Flags: {} | Seed: {}",
+                        preset_state.get().name,
+                        game.mines,
+                        game.flags_placed(),
+                        game.seed % 100000
+                    ),
+                    Modifier::empty()
+                        .padding(8.0)
+                        .background(Color(0.15, 0.22, 0.34, 0.7))
+                        .rounded_corners(12.0),
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 8.0,
+                });
+
+                Text(
+                    status_text,
+                    Modifier::empty()
+                        .padding(8.0)
+                        .background(Color(0.12, 0.16, 0.28, 0.6))
+                        .rounded_corners(12.0),
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 16.0,
+                });
+
+                let grid_width = game.width;
+                let grid_height = game.height;
+                let grid_state = content_game_state.clone();
+                let grid_flag_mode = content_flag_mode.clone();
+
+                Column(
+                    Modifier::empty()
+                        .background(Color(0.06, 0.08, 0.16, 0.9))
+                        .rounded_corners(18.0)
+                        .padding(12.0),
+                    ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(6.0)),
+                    move || {
+                        for y in 0..grid_height {
+                            let game_state = grid_state.clone();
+                            let flag_mode = grid_flag_mode.clone();
+                            Row(
+                                Modifier::empty().fill_max_width().padding(2.0),
+                                RowSpec::new()
+                                    .horizontal_arrangement(LinearArrangement::SpacedBy(6.0))
+                                    .vertical_alignment(VerticalAlignment::CenterVertically),
+                                move || {
+                                    for x in 0..grid_width {
+                                        let game_snapshot = game_state.get();
+                                        let cell = game_snapshot.cell_at(x, y).clone();
+                                        let display = if cell.is_revealed {
+                                            if cell.is_mine {
+                                                "💣".to_string()
+                                            } else if cell.adjacent == 0 {
+                                                "".to_string()
+                                            } else {
+                                                cell.adjacent.to_string()
+                                            }
+                                        } else if cell.is_flagged {
+                                            "🚩".to_string()
+                                        } else {
+                                            "".to_string()
+                                        };
+
+                                        let background = if cell.is_revealed {
+                                            if cell.is_mine {
+                                                Color(0.6, 0.18, 0.2, 0.9)
+                                            } else {
+                                                Color(0.18, 0.26, 0.34, 0.9)
+                                            }
+                                        } else if cell.is_flagged {
+                                            Color(0.26, 0.20, 0.32, 0.9)
+                                        } else {
+                                            Color(0.12, 0.14, 0.22, 0.9)
+                                        };
+
+                                        let game_action = game_state.clone();
+                                        let mode_state = flag_mode.clone();
+                                        Button(
+                                            Modifier::empty()
+                                                .size_points(36.0, 36.0)
+                                                .rounded_corners(8.0)
+                                                .draw_behind(move |scope| {
+                                                    scope.draw_round_rect(
+                                                        Brush::solid(background),
+                                                        CornerRadii::uniform(8.0),
+                                                    );
+                                                }),
+                                            move || {
+                                                if mode_state.get() {
+                                                    game_action
+                                                        .update(|game| game.toggle_flag(x, y));
+                                                } else {
+                                                    game_action.update(|game| game.reveal(x, y));
+                                                }
+                                            },
+                                            {
+                                                let display = display.clone();
+                                                move || {
+                                                    Text(
+                                                        display.clone(),
+                                                        Modifier::empty().padding(4.0),
+                                                    );
+                                                }
+                                            },
+                                        );
+                                    }
+                                },
+                            );
+                        }
+                    },
+                );
+            }
+        },
+    );
+}

--- a/apps/desktop-demo/src/app/mineswapper2.rs
+++ b/apps/desktop-demo/src/app/mineswapper2.rs
@@ -1,29 +1,14 @@
-use compose_core::{useState, MutableState};
+use compose_core::useState;
 use compose_ui::{
     composable, Brush, Button, Color, Column, ColumnSpec, CornerRadii, LinearArrangement, Modifier,
     Row, RowSpec, Size, Spacer, Text, VerticalAlignment,
 };
-use std::{
-    cell::RefCell,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MineswapperTool {
     Reveal,
     Flag,
-}
-
-thread_local! {
-    static SHARED_TOOL_STATE: RefCell<Option<MutableState<MineswapperTool>>> = RefCell::new(None);
-}
-
-pub fn set_shared_tool_state(state: &MutableState<MineswapperTool>) {
-    SHARED_TOOL_STATE.with(|cell| *cell.borrow_mut() = Some(state.clone()));
-}
-
-pub fn shared_tool_state() -> Option<MutableState<MineswapperTool>> {
-    SHARED_TOOL_STATE.with(|cell| cell.borrow().clone())
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -254,11 +239,7 @@ fn random_seed() -> u64 {
 pub fn mineswapper2_tab() {
     let preset_state = useState(|| GRID_PRESETS[0]);
     let game_state = useState(|| MineswapperGame::new_from_preset(GRID_PRESETS[0], random_seed()));
-    let flag_mode = shared_tool_state().unwrap_or_else(|| {
-        let state = useState(|| MineswapperTool::Reveal);
-        set_shared_tool_state(&state);
-        state
-    });
+    let flag_mode = useState(|| MineswapperTool::Reveal);
 
     Column(
         Modifier::empty()

--- a/apps/desktop-demo/src/app/mineswapper2.rs
+++ b/apps/desktop-demo/src/app/mineswapper2.rs
@@ -4,6 +4,7 @@ use compose_ui::{
     Row, RowSpec, Size, Spacer, Text, VerticalAlignment,
 };
 use std::time::{SystemTime, UNIX_EPOCH};
+use crate::app::mineswapper2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MineswapperTool {


### PR DESCRIPTION
## Summary
- add a new Minesweeper tab to the desktop demo with interactive gameplay
- include board reset and flagging controls and status displays

## Testing
- cargo test -p desktop-app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e6b7d446083288111e46535365057)