### PR TITLE
Simplify copyable state usage

### DIFF
--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -98,24 +98,22 @@ fn random() -> i32 {
 pub fn combined_app() {
     let active_tab = compose_core::useState(|| DemoTab::Counter);
     TEST_ACTIVE_TAB_STATE.with(|cell| {
-        *cell.borrow_mut() = Some(active_tab.clone());
+        *cell.borrow_mut() = Some(active_tab);
     });
 
     Column(
         Modifier::empty().padding(20.0),
         ColumnSpec::default(),
         move || {
-            let tab_state_for_row = active_tab.clone();
-            let tab_state_for_content = active_tab.clone();
+            let tab_state_for_row = active_tab;
+            let tab_state_for_content = active_tab;
             Row(
-                Modifier::empty()
-                    .fill_max_width()
-                    .padding(8.0),
+                Modifier::empty().fill_max_width().padding(8.0),
                 RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
                 move || {
-                    let tab_state = tab_state_for_row.clone();
+                    let tab_state = tab_state_for_row;
                     let render_tab_button = move |tab: DemoTab| {
-                        let tab_state = tab_state.clone();
+                        let tab_state = tab_state;
                         let is_active = tab_state.get() == tab;
                         Button(
                             Modifier::empty()
@@ -132,7 +130,7 @@ pub fn combined_app() {
                                 })
                                 .padding(10.0),
                             {
-                                let tab_state = tab_state.clone();
+                                let tab_state = tab_state;
                                 move || {
                                     if tab_state.get() != tab {
                                         println!("{} button clicked", tab.label());
@@ -200,9 +198,7 @@ fn recursive_layout_example() {
             });
 
             Row(
-                Modifier::empty()
-                    .fill_max_width()
-                    .padding(8.0),
+                Modifier::empty().fill_max_width().padding(8.0),
                 RowSpec::new()
                     .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
                     .vertical_alignment(VerticalAlignment::CenterVertically),
@@ -629,21 +625,15 @@ fn async_runtime_example() {
                                                         .then(
                                                             Modifier::empty().rounded_corners(13.0),
                                                         )
-                                                        .draw_behind(
-                                                            |scope| {
-                                                                scope.draw_round_rect(
-                                                                    Brush::linear_gradient(vec![
-                                                                        Color(
-                                                                            0.25, 0.55, 0.95, 1.0,
-                                                                        ),
-                                                                        Color(
-                                                                            0.15, 0.35, 0.80, 1.0,
-                                                                        ),
-                                                                    ]),
-                                                                    CornerRadii::uniform(13.0),
-                                                                );
-                                                            },
-                                                        ),
+                                                        .draw_behind(|scope| {
+                                                            scope.draw_round_rect(
+                                                                Brush::linear_gradient(vec![
+                                                                    Color(0.25, 0.55, 0.95, 1.0),
+                                                                    Color(0.15, 0.35, 0.80, 1.0),
+                                                                ]),
+                                                                CornerRadii::uniform(13.0),
+                                                            );
+                                                        }),
                                                     RowSpec::default(),
                                                     || {},
                                                 );
@@ -684,9 +674,7 @@ fn async_runtime_example() {
                 });
 
                 Row(
-                    Modifier::empty()
-                        .fill_max_width()
-                        .padding(4.0),
+                    Modifier::empty().fill_max_width().padding(4.0),
                     RowSpec::new()
                         .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
                         .vertical_alignment(VerticalAlignment::CenterVertically),
@@ -917,9 +905,7 @@ fn counter_app() {
                     });
 
                     Row(
-                        Modifier::empty()
-                            .fill_max_width()
-                            .padding(8.0),
+                        Modifier::empty().fill_max_width().padding(8.0),
                         RowSpec::new()
                             .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
                             .vertical_alignment(VerticalAlignment::CenterVertically),
@@ -1132,9 +1118,7 @@ fn counter_app() {
                             let counter_inc = counter.clone();
                             let counter_dec = counter.clone();
                             Row(
-                                Modifier::empty()
-                                    .fill_max_width()
-                                    .padding(8.0),
+                                Modifier::empty().fill_max_width().padding(8.0),
                                 RowSpec::new()
                                     .horizontal_arrangement(LinearArrangement::SpacedBy(12.0)),
                                 move || {
@@ -1281,9 +1265,7 @@ fn modifier_showcase_tab() {
     let selected_showcase = compose_core::useState(|| ShowcaseType::SimpleCard);
 
     Row(
-        Modifier::empty()
-            .fill_max_width()
-            .padding(8.0),
+        Modifier::empty().fill_max_width().padding(8.0),
         RowSpec::new()
             .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
             .vertical_alignment(VerticalAlignment::Top),
@@ -1371,15 +1353,13 @@ fn modifier_showcase_tab() {
                     let selected_showcase_inner = selected_showcase.clone();
                     move || {
                         let showcase_to_render = selected_showcase_inner.get();
-                        compose_core::with_key(&showcase_to_render, || {
-                            match showcase_to_render {
-                                ShowcaseType::SimpleCard => simple_card_showcase(),
-                                ShowcaseType::PositionedBoxes => positioned_boxes_showcase(),
-                                ShowcaseType::ItemList => item_list_showcase(),
-                                ShowcaseType::ComplexChain => complex_chain_showcase(),
-                                ShowcaseType::DynamicModifiers => dynamic_modifiers_showcase(),
-                                ShowcaseType::LongList => long_list_showcase(),
-                            }
+                        compose_core::with_key(&showcase_to_render, || match showcase_to_render {
+                            ShowcaseType::SimpleCard => simple_card_showcase(),
+                            ShowcaseType::PositionedBoxes => positioned_boxes_showcase(),
+                            ShowcaseType::ItemList => item_list_showcase(),
+                            ShowcaseType::ComplexChain => complex_chain_showcase(),
+                            ShowcaseType::DynamicModifiers => dynamic_modifiers_showcase(),
+                            ShowcaseType::LongList => long_list_showcase(),
                         });
                     }
                 },
@@ -1451,32 +1431,28 @@ pub fn simple_card_showcase() {
                                 });
 
                                 // Action buttons row
-                                Row(
-                                    Modifier::empty(),
-                                    RowSpec::default(),
-                                    || {
-                                        Text(
-                                            "Action 1",
-                                            Modifier::empty()
-                                                .padding(8.0)
-                                                .background(Color(0.2, 0.7, 0.4, 0.7))
-                                                .rounded_corners(6.0),
-                                        );
+                                Row(Modifier::empty(), RowSpec::default(), || {
+                                    Text(
+                                        "Action 1",
+                                        Modifier::empty()
+                                            .padding(8.0)
+                                            .background(Color(0.2, 0.7, 0.4, 0.7))
+                                            .rounded_corners(6.0),
+                                    );
 
-                                        Spacer(Size {
-                                            width: 8.0,
-                                            height: 0.0,
-                                        });
+                                    Spacer(Size {
+                                        width: 8.0,
+                                        height: 0.0,
+                                    });
 
-                                        Text(
-                                            "Action 2",
-                                            Modifier::empty()
-                                                .padding(8.0)
-                                                .background(Color(0.8, 0.3, 0.3, 0.7))
-                                                .rounded_corners(6.0),
-                                        );
-                                    },
-                                );
+                                    Text(
+                                        "Action 2",
+                                        Modifier::empty()
+                                            .padding(8.0)
+                                            .background(Color(0.8, 0.3, 0.3, 0.7))
+                                            .rounded_corners(6.0),
+                                    );
+                                });
                             },
                         );
                     },
@@ -1874,12 +1850,7 @@ pub fn long_list_showcase() {
                                 width: 400.0,
                                 height: 40.0,
                             })
-                            .background(Color(
-                                0.12 + (i as f32 * 0.005),
-                                0.15,
-                                0.25,
-                                0.7,
-                            ))
+                            .background(Color(0.12 + (i as f32 * 0.005), 0.15, 0.25, 0.7))
                             .rounded_corners(8.0),
                         RowSpec::default(),
                         move || {

--- a/crates/compose-core/src/tests/lib_tests.rs
+++ b/crates/compose-core/src/tests/lib_tests.rs
@@ -3993,3 +3993,22 @@ fn test_composition_with_backend(backend: SlotBackendKind) {
 
     assert_eq!(recompose_count.get(), 2, "Should have composed twice");
 }
+
+#[test]
+fn mutable_state_is_copy_and_capture_friendly() {
+    let mut composition = Composition::new(MemoryApplier::new());
+
+    composition.render(0, || {
+        let state = compose_core::useState(|| 0);
+
+        let mut bump: Box<dyn FnMut()> = Box::new(move || {
+            // No clone needed even though `state` is reused after being captured.
+            state.set(state.get() + 1);
+        });
+
+        bump();
+        bump();
+
+        assert_eq!(state.get(), 2);
+    });
+}


### PR DESCRIPTION
## Summary
- keep copyable state handles while removing the clone-on-capture helper APIs to minimize surface changes
- wire the desktop demo tabs directly with the copyable mutable state without explicit clones
- retain a focused regression test proving copyable state handles work when captured in callbacks

## Testing
- rustfmt --edition 2021 apps/desktop-demo/src/app.rs crates/compose-core/src/lib.rs crates/compose-core/src/tests/lib_tests.rs
- cargo clippy --all-targets --all-features
- cargo test > 1.tmp 2>&1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ec853e9348328a14d83939fe26049)