### PR TITLE
Remove clone usage in demo by copying state handles

### DIFF
--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -116,7 +116,6 @@ pub fn combined_app() {
                 RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
                 move || {
                     let render_tab_button = {
-                        let tab_state_for_row = tab_state_for_row;
                         move |tab: DemoTab| {
                             let tab_state_for_tab = tab_state_for_row;
                             let is_active = tab_state_for_tab.get() == tab;
@@ -212,7 +211,6 @@ fn recursive_layout_example() {
                     .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
                     .vertical_alignment(VerticalAlignment::CenterVertically),
                 {
-                    let depth_state = depth_state;
                     move || {
                         let depth = depth_state.get();
                         Button(
@@ -226,7 +224,6 @@ fn recursive_layout_example() {
                                 })
                                 .padding(10.0),
                             {
-                                let depth_state = depth_state;
                                 move || {
                                     let next = (depth_state.get() + 1).min(96);
                                     if next != depth_state.get() {
@@ -250,7 +247,6 @@ fn recursive_layout_example() {
                                 })
                                 .padding(10.0),
                             {
-                                let depth_state = depth_state;
                                 move || {
                                     let next = depth_state.get().saturating_sub(1).max(1);
                                     if next != depth_state.get() {
@@ -411,7 +407,6 @@ pub fn composition_local_example() {
                     })
                     .padding(12.0),
                 {
-                    let counter = counter;
                     move || {
                         let new_val = counter.get() + 1;
                         println!("Incrementing counter to {}", new_val);
@@ -712,10 +707,7 @@ fn async_runtime_example() {
                                         }
                                     })
                                     .padding(12.0),
-                                {
-                                    let toggle_state = toggle_state;
-                                    move || toggle_state.set(!toggle_state.get())
-                                },
+                                move || toggle_state.set(!toggle_state.get()),
                                 {
                                     let label = if running {
                                         "Pause animation"
@@ -731,7 +723,6 @@ fn async_runtime_example() {
                             let reset_animation = animation_state;
                             let reset_stats = stats_state;
                             let reset_tick_state = reset_state;
-                            let toggle_state = toggle_state;
                             Button(
                                 Modifier::empty()
                                     .rounded_corners(16.0)
@@ -884,8 +875,6 @@ fn counter_app() {
                 let pointer_position_main = pointer_position;
                 let pointer_down_main = pointer_down;
                 let wave_main = wave_state;
-                let async_message = async_message;
-                let fetch_request = fetch_request;
                 move || {
                     let counter = counter_main;
                     let pointer_position = pointer_position_main;
@@ -992,47 +981,40 @@ fn counter_app() {
                             .pointer_input((), {
                                 let pointer_position_state = pointer_position;
                                 let pointer_down_state = pointer_down;
-                                move |scope: PointerInputScope| {
-                                    let pointer_position_state = pointer_position_state;
-                                    let pointer_down_state = pointer_down_state;
-                                    async move {
-                                        scope
-                                            .await_pointer_event_scope(|await_scope| async move {
-                                                loop {
-                                                    let event =
-                                                        await_scope.await_pointer_event().await;
-                                                    println!(
+                                move |scope: PointerInputScope| async move {
+                                    scope
+                                        .await_pointer_event_scope(|await_scope| async move {
+                                            loop {
+                                                let event = await_scope.await_pointer_event().await;
+                                                println!(
                                                     "Pointer event: kind={:?} pos=({:.1}, {:.1})",
                                                     event.kind, event.position.x, event.position.y
                                                 );
-                                                    match event.kind {
-                                                        PointerEventKind::Down => {
-                                                            pointer_down_state.set(true)
-                                                        }
-                                                        PointerEventKind::Up => {
-                                                            pointer_down_state.set(false)
-                                                        }
-                                                        PointerEventKind::Move => {
-                                                            pointer_position_state.set(Point {
-                                                                x: event.position.x,
-                                                                y: event.position.y,
-                                                            });
-                                                        }
-                                                        PointerEventKind::Cancel => {
-                                                            pointer_down_state.set(false)
-                                                        }
+                                                match event.kind {
+                                                    PointerEventKind::Down => {
+                                                        pointer_down_state.set(true)
+                                                    }
+                                                    PointerEventKind::Up => {
+                                                        pointer_down_state.set(false)
+                                                    }
+                                                    PointerEventKind::Move => {
+                                                        pointer_position_state.set(Point {
+                                                            x: event.position.x,
+                                                            y: event.position.y,
+                                                        });
+                                                    }
+                                                    PointerEventKind::Cancel => {
+                                                        pointer_down_state.set(false)
                                                     }
                                                 }
-                                            })
-                                            .await;
-                                    }
+                                            }
+                                        })
+                                        .await;
                                 }
                             })
                             .padding(16.0),
                         ColumnSpec::default(),
                         move || {
-                            let async_message_state = async_message_state;
-                            let fetch_request_state = fetch_request_state;
                             Text(
                                 format!("Pointer: ({:.1}, {:.1})", pointer.x, pointer.y),
                                 Modifier::empty()
@@ -1330,7 +1312,6 @@ fn modifier_showcase_tab() {
                                     })
                                     .padding(10.0),
                                 {
-                                    let showcase_state = showcase_state;
                                     move || {
                                         if showcase_state.get() != showcase_type {
                                             showcase_state.set(showcase_type);

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -102,22 +102,22 @@ fn random() -> i32 {
 pub fn combined_app() {
     let active_tab = compose_core::useState(|| DemoTab::Counter);
     TEST_ACTIVE_TAB_STATE.with(|cell| {
-        *cell.borrow_mut() = Some(active_tab.clone());
+        *cell.borrow_mut() = Some(active_tab);
     });
 
     Column(
         Modifier::empty().padding(20.0),
         ColumnSpec::default(),
         move || {
-            let tab_state_for_row = active_tab.clone();
-            let tab_state_for_content = active_tab.clone();
+            let tab_state_for_row = active_tab;
+            let tab_state_for_content = active_tab;
             Row(
                 Modifier::empty().fill_max_width().padding(8.0),
                 RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
                 move || {
-                    let tab_state = tab_state_for_row.clone();
+                    let tab_state = tab_state_for_row;
                     let render_tab_button = move |tab: DemoTab| {
-                        let tab_state = tab_state.clone();
+                        let tab_state = tab_state;
                         let is_active = tab_state.get() == tab;
                         Button(
                             Modifier::empty()
@@ -134,7 +134,7 @@ pub fn combined_app() {
                                 })
                                 .padding(10.0),
                             {
-                                let tab_state = tab_state.clone();
+                                let tab_state = tab_state;
                                 move || {
                                     if tab_state.get() != tab {
                                         println!("{} button clicked", tab.label());
@@ -209,7 +209,7 @@ fn recursive_layout_example() {
                     .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
                     .vertical_alignment(VerticalAlignment::CenterVertically),
                 {
-                    let depth_state = depth_state.clone();
+                    let depth_state = depth_state;
                     move || {
                         let depth = depth_state.get();
                         Button(
@@ -223,7 +223,7 @@ fn recursive_layout_example() {
                                 })
                                 .padding(10.0),
                             {
-                                let depth_state = depth_state.clone();
+                                let depth_state = depth_state;
                                 move || {
                                     let next = (depth_state.get() + 1).min(96);
                                     if next != depth_state.get() {
@@ -247,7 +247,7 @@ fn recursive_layout_example() {
                                 })
                                 .padding(10.0),
                             {
-                                let depth_state = depth_state.clone();
+                                let depth_state = depth_state;
                                 move || {
                                     let next = depth_state.get().saturating_sub(1).max(1);
                                     if next != depth_state.get() {
@@ -360,7 +360,7 @@ pub fn composition_local_example() {
     let counter = compose_core::useState(|| 0);
 
     TEST_COMPOSITION_LOCAL_COUNTER.with(|cell| {
-        *cell.borrow_mut() = Some(counter.clone());
+        *cell.borrow_mut() = Some(counter);
     });
 
     Column(
@@ -408,7 +408,7 @@ pub fn composition_local_example() {
                     })
                     .padding(12.0),
                 {
-                    let counter = counter.clone();
+                    let counter = counter;
                     move || {
                         let new_val = counter.get() + 1;
                         println!("Incrementing counter to {}", new_val);
@@ -487,15 +487,15 @@ fn async_runtime_example() {
     let reset_signal = compose_core::useState(|| 0u64);
 
     {
-        let animation_state = animation.clone();
-        let stats_state = stats.clone();
-        let running_state = is_running.clone();
-        let reset_state = reset_signal.clone();
+        let animation_state = animation;
+        let stats_state = stats;
+        let running_state = is_running;
+        let reset_state = reset_signal;
         LaunchedEffectAsync!((), move |scope| {
-            let animation = animation_state.clone();
-            let stats = stats_state.clone();
-            let running = running_state.clone();
-            let reset = reset_state.clone();
+            let animation = animation_state;
+            let stats = stats_state;
+            let running = running_state;
+            let reset = reset_state;
             Box::pin(async move {
                 let clock = scope.runtime().frame_clock();
                 let mut last_time: Option<u64> = None;
@@ -565,7 +565,7 @@ fn async_runtime_example() {
             .padding(20.0),
         ColumnSpec::default(),
         {
-            let is_running_state = is_running.clone();
+            let is_running_state = is_running;
             move || {
                 Text(
                     "Async Runtime Demo",
@@ -685,10 +685,10 @@ fn async_runtime_example() {
                         .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
                         .vertical_alignment(VerticalAlignment::CenterVertically),
                     {
-                        let toggle_state = is_running_state.clone();
-                        let animation_state = animation.clone();
-                        let stats_state = stats.clone();
-                        let reset_state = reset_signal.clone();
+                        let toggle_state = is_running_state;
+                        let animation_state = animation;
+                        let stats_state = stats;
+                        let reset_state = reset_signal;
                         move || {
                             let running = toggle_state.get();
                             let button_color = if running {
@@ -710,7 +710,7 @@ fn async_runtime_example() {
                                     })
                                     .padding(12.0),
                                 {
-                                    let toggle_state = toggle_state.clone();
+                                    let toggle_state = toggle_state;
                                     move || toggle_state.set(!toggle_state.get())
                                 },
                                 {
@@ -725,10 +725,10 @@ fn async_runtime_example() {
                                 },
                             );
 
-                            let reset_animation = animation_state.clone();
-                            let reset_stats = stats_state.clone();
-                            let reset_tick_state = reset_state.clone();
-                            let toggle_state = toggle_state.clone();
+                            let reset_animation = animation_state;
+                            let reset_stats = stats_state;
+                            let reset_tick_state = reset_state;
+                            let toggle_state = toggle_state;
                             Button(
                                 Modifier::empty()
                                     .rounded_corners(16.0)
@@ -777,12 +777,12 @@ fn counter_app() {
     let wave_state = animateFloatAsState(target_wave, "wave");
     let fetch_key = fetch_request.get();
     {
-        let async_message = async_message.clone();
+        let async_message = async_message;
         LaunchedEffect!(fetch_key, move |scope| {
             if fetch_key == 0 {
                 return;
             }
-            let message_for_ui = async_message.clone();
+            let message_for_ui = async_message;
             scope.launch_background(
                 move |token| {
                     use std::thread;
@@ -877,17 +877,17 @@ fn counter_app() {
                 .padding(20.0),
             ColumnSpec::default(),
             {
-                let counter_main = counter.clone();
-                let pointer_position_main = pointer_position.clone();
-                let pointer_down_main = pointer_down.clone();
-                let wave_main = wave_state.clone();
-                let async_message = async_message.clone();
-                let fetch_request = fetch_request.clone();
+                let counter_main = counter;
+                let pointer_position_main = pointer_position;
+                let pointer_down_main = pointer_down;
+                let wave_main = wave_state;
+                let async_message = async_message;
+                let fetch_request = fetch_request;
                 move || {
-                    let counter = counter_main.clone();
-                    let pointer_position = pointer_position_main.clone();
-                    let pointer_down = pointer_down_main.clone();
-                    let wave = wave_main.clone();
+                    let counter = counter_main;
+                    let pointer_position = pointer_position_main;
+                    let pointer_down = pointer_down_main;
+                    let wave = wave_main;
                     Text(
                         "Compose-RS Playground",
                         Modifier::empty()
@@ -916,7 +916,7 @@ fn counter_app() {
                             .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
                             .vertical_alignment(VerticalAlignment::CenterVertically),
                         {
-                            let counter_display = counter.clone();
+                            let counter_display = counter;
                             let wave_value = wave;
                             move || {
                                 let wave_value = wave_value.value();
@@ -955,8 +955,8 @@ fn counter_app() {
                         height: 16.0,
                     });
 
-                    let async_message_state = async_message.clone();
-                    let fetch_request_state = fetch_request.clone();
+                    let async_message_state = async_message;
+                    let fetch_request_state = fetch_request;
                     Column(
                         Modifier::empty()
                             .rounded_corners(20.0)
@@ -987,11 +987,11 @@ fn counter_app() {
                                 }
                             })
                             .pointer_input((), {
-                                let pointer_position = pointer_position.clone();
-                                let pointer_down = pointer_down.clone();
+                                let pointer_position = pointer_position;
+                                let pointer_down = pointer_down;
                                 move |scope: PointerInputScope| {
-                                    let pointer_position = pointer_position.clone();
-                                    let pointer_down = pointer_down.clone();
+                                    let pointer_position = pointer_position;
+                                    let pointer_down = pointer_down;
                                     async move {
                                         scope
                                             .await_pointer_event_scope(|await_scope| async move {
@@ -1028,8 +1028,8 @@ fn counter_app() {
                             .padding(16.0),
                         ColumnSpec::default(),
                         move || {
-                            let async_message_state = async_message_state.clone();
-                            let fetch_request_state = fetch_request_state.clone();
+                            let async_message_state = async_message_state;
+                            let fetch_request_state = fetch_request_state;
                             Text(
                                 format!("Pointer: ({:.1}, {:.1})", pointer.x, pointer.y),
                                 Modifier::empty()
@@ -1121,8 +1121,8 @@ fn counter_app() {
                                 height: 16.0,
                             });
 
-                            let counter_inc = counter.clone();
-                            let counter_dec = counter.clone();
+                            let counter_inc = counter;
+                            let counter_dec = counter;
                             Row(
                                 Modifier::empty().fill_max_width().padding(8.0),
                                 RowSpec::new()
@@ -1144,7 +1144,7 @@ fn counter_app() {
                                             })
                                             .padding(12.0),
                                         {
-                                            let counter = counter_inc.clone();
+                                            let counter = counter_inc;
                                             move || {
                                                 println!(
                                                     "Incrementing counter to {}",
@@ -1168,7 +1168,7 @@ fn counter_app() {
                                             })
                                             .padding(12.0),
                                         {
-                                            let counter = counter_dec.clone();
+                                            let counter = counter_dec;
                                             move || counter.set(counter.get() - 1)
                                         },
                                         || {
@@ -1183,7 +1183,7 @@ fn counter_app() {
                                 height: 20.0,
                             });
 
-                            let async_message_text = async_message_state.clone();
+                            let async_message_text = async_message_state;
                             Text(
                                 async_message_text.get(),
                                 Modifier::empty()
@@ -1197,8 +1197,8 @@ fn counter_app() {
                                 height: 12.0,
                             });
 
-                            let async_message_button = async_message_state.clone();
-                            let fetch_request_button = fetch_request_state.clone();
+                            let async_message_button = async_message_state;
+                            let fetch_request_button = fetch_request_state;
                             Button(
                                 Modifier::empty()
                                     .rounded_corners(16.0)
@@ -1285,7 +1285,7 @@ fn modifier_showcase_tab() {
                     .rounded_corners(20.0),
                 ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
                 {
-                    let showcase_state = selected_showcase.clone();
+                    let showcase_state = selected_showcase;
                     move || {
                         Text(
                             "Select Showcase",
@@ -1327,7 +1327,7 @@ fn modifier_showcase_tab() {
                                     })
                                     .padding(10.0),
                                 {
-                                    let showcase_state = showcase_state.clone();
+                                    let showcase_state = showcase_state;
                                     move || {
                                         if showcase_state.get() != showcase_type {
                                             showcase_state.set(showcase_type);
@@ -1356,7 +1356,7 @@ fn modifier_showcase_tab() {
                     .padding(16.0),
                 ColumnSpec::default(),
                 {
-                    let selected_showcase_inner = selected_showcase.clone();
+                    let selected_showcase_inner = selected_showcase;
                     move || {
                         let showcase_to_render = selected_showcase_inner.get();
                         compose_core::with_key(&showcase_to_render, || match showcase_to_render {
@@ -1816,7 +1816,7 @@ pub fn dynamic_modifiers_showcase() {
                 })
                 .padding(10.0),
             {
-                let frame_state = frame.clone();
+                let frame_state = frame;
                 move || {
                     frame_state.set(frame_state.get() + 1);
                 }

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -115,40 +115,43 @@ pub fn combined_app() {
                 Modifier::empty().fill_max_width().padding(8.0),
                 RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
                 move || {
-                    let tab_state = tab_state_for_row;
-                    let render_tab_button = move |tab: DemoTab| {
-                        let tab_state = tab_state;
-                        let is_active = tab_state.get() == tab;
-                        Button(
-                            Modifier::empty()
-                                .rounded_corners(12.0)
-                                .draw_behind(move |scope| {
-                                    scope.draw_round_rect(
-                                        Brush::solid(if is_active {
-                                            Color(0.2, 0.45, 0.9, 1.0)
-                                        } else {
-                                            Color(0.3, 0.3, 0.3, 0.5)
-                                        }),
-                                        CornerRadii::uniform(12.0),
-                                    );
-                                })
-                                .padding(10.0),
-                            {
-                                let tab_state = tab_state;
-                                move || {
-                                    if tab_state.get() != tab {
-                                        println!("{} button clicked", tab.label());
-                                        tab_state.set(tab);
+                    let render_tab_button = {
+                        let tab_state_for_row = tab_state_for_row;
+                        move |tab: DemoTab| {
+                            let tab_state_for_tab = tab_state_for_row;
+                            let is_active = tab_state_for_tab.get() == tab;
+
+                            Button(
+                                Modifier::empty()
+                                    .rounded_corners(12.0)
+                                    .draw_behind(move |scope| {
+                                        scope.draw_round_rect(
+                                            Brush::solid(if is_active {
+                                                Color(0.2, 0.45, 0.9, 1.0)
+                                            } else {
+                                                Color(0.3, 0.3, 0.3, 0.5)
+                                            }),
+                                            CornerRadii::uniform(12.0),
+                                        );
+                                    })
+                                    .padding(10.0),
+                                {
+                                    let tab_state = tab_state_for_tab;
+                                    move || {
+                                        if tab_state.get() != tab {
+                                            println!("{} button clicked", tab.label());
+                                            tab_state.set(tab);
+                                        }
                                     }
-                                }
-                            },
-                            {
-                                let label = tab.label();
-                                move || {
-                                    Text(label, Modifier::empty().padding(4.0));
-                                }
-                            },
-                        );
+                                },
+                                {
+                                    let label = tab.label();
+                                    move || {
+                                        Text(label, Modifier::empty().padding(4.0));
+                                    }
+                                },
+                            );
+                        }
                     };
 
                     render_tab_button(DemoTab::Counter);
@@ -777,12 +780,12 @@ fn counter_app() {
     let wave_state = animateFloatAsState(target_wave, "wave");
     let fetch_key = fetch_request.get();
     {
-        let async_message = async_message;
+        let async_message_state = async_message;
         LaunchedEffect!(fetch_key, move |scope| {
             if fetch_key == 0 {
                 return;
             }
-            let message_for_ui = async_message;
+            let message_for_ui = async_message_state;
             scope.launch_background(
                 move |token| {
                     use std::thread;
@@ -987,11 +990,11 @@ fn counter_app() {
                                 }
                             })
                             .pointer_input((), {
-                                let pointer_position = pointer_position;
-                                let pointer_down = pointer_down;
+                                let pointer_position_state = pointer_position;
+                                let pointer_down_state = pointer_down;
                                 move |scope: PointerInputScope| {
-                                    let pointer_position = pointer_position;
-                                    let pointer_down = pointer_down;
+                                    let pointer_position_state = pointer_position_state;
+                                    let pointer_down_state = pointer_down_state;
                                     async move {
                                         scope
                                             .await_pointer_event_scope(|await_scope| async move {
@@ -1004,19 +1007,19 @@ fn counter_app() {
                                                 );
                                                     match event.kind {
                                                         PointerEventKind::Down => {
-                                                            pointer_down.set(true)
+                                                            pointer_down_state.set(true)
                                                         }
                                                         PointerEventKind::Up => {
-                                                            pointer_down.set(false)
+                                                            pointer_down_state.set(false)
                                                         }
                                                         PointerEventKind::Move => {
-                                                            pointer_position.set(Point {
+                                                            pointer_position_state.set(Point {
                                                                 x: event.position.x,
                                                                 y: event.position.y,
                                                             });
                                                         }
                                                         PointerEventKind::Cancel => {
-                                                            pointer_down.set(false)
+                                                            pointer_down_state.set(false)
                                                         }
                                                     }
                                                 }

--- a/apps/desktop-demo/src/app/mineswapper2.rs
+++ b/apps/desktop-demo/src/app/mineswapper2.rs
@@ -284,13 +284,9 @@ pub fn mineswapper2_tab() {
                                     .horizontal_arrangement(LinearArrangement::SpacedBy(8.0))
                                     .vertical_alignment(VerticalAlignment::CenterVertically),
                                 {
-                                    let game_state = game_state;
-                                    let preset_state = preset_state;
                                     move || {
                                         for preset in GRID_PRESETS {
                                             let is_active = preset_state.get() == preset;
-                                            let game_state = game_state;
-                                            let preset_state = preset_state;
                                             Button(
                                                 Modifier::empty()
                                                     .rounded_corners(12.0)
@@ -337,8 +333,6 @@ pub fn mineswapper2_tab() {
                                     })
                                     .padding(10.0),
                                 {
-                                    let game_state = game_state;
-                                    let preset_state = preset_state;
                                     move || {
                                         let preset = preset_state.get();
                                         game_state.set(MineswapperGame::new_from_preset(

--- a/apps/desktop-demo/src/app/mineswapper2.rs
+++ b/apps/desktop-demo/src/app/mineswapper2.rs
@@ -40,7 +40,7 @@ const GRID_PRESETS: [GridPreset; 3] = [
     },
 ];
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 struct MineswapperCell {
     is_mine: bool,
     is_revealed: bool,
@@ -249,11 +249,11 @@ pub fn mineswapper2_tab() {
             .padding(20.0),
         ColumnSpec::default(),
         {
-            let header_game_state = game_state.clone();
-            let header_flag_mode = flag_mode.clone();
-            let header_preset_state = preset_state.clone();
-            let content_game_state = game_state.clone();
-            let content_flag_mode = flag_mode.clone();
+            let header_game_state = game_state;
+            let header_flag_mode = flag_mode;
+            let header_preset_state = preset_state;
+            let content_game_state = game_state;
+            let content_flag_mode = flag_mode;
             move || {
                 Row(
                     Modifier::empty().fill_max_width().padding(8.0),
@@ -261,9 +261,9 @@ pub fn mineswapper2_tab() {
                         .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
                         .vertical_alignment(VerticalAlignment::CenterVertically),
                     {
-                        let game_state = header_game_state.clone();
-                        let flag_mode = header_flag_mode.clone();
-                        let preset_state = header_preset_state.clone();
+                        let game_state = header_game_state;
+                        let flag_mode = header_flag_mode;
+                        let preset_state = header_preset_state;
                         move || {
                             Text(
                                 "Mineswapper 2",
@@ -284,13 +284,13 @@ pub fn mineswapper2_tab() {
                                     .horizontal_arrangement(LinearArrangement::SpacedBy(8.0))
                                     .vertical_alignment(VerticalAlignment::CenterVertically),
                                 {
-                                    let game_state = game_state.clone();
-                                    let preset_state = preset_state.clone();
+                                    let game_state = game_state;
+                                    let preset_state = preset_state;
                                     move || {
                                         for preset in GRID_PRESETS {
                                             let is_active = preset_state.get() == preset;
-                                            let game_state = game_state.clone();
-                                            let preset_state = preset_state.clone();
+                                            let game_state = game_state;
+                                            let preset_state = preset_state;
                                             Button(
                                                 Modifier::empty()
                                                     .rounded_corners(12.0)
@@ -337,8 +337,8 @@ pub fn mineswapper2_tab() {
                                     })
                                     .padding(10.0),
                                 {
-                                    let game_state = game_state.clone();
-                                    let preset_state = preset_state.clone();
+                                    let game_state = game_state;
+                                    let preset_state = preset_state;
                                     move || {
                                         let preset = preset_state.get();
                                         game_state.set(MineswapperGame::new_from_preset(
@@ -352,7 +352,7 @@ pub fn mineswapper2_tab() {
                                 },
                             );
 
-                            let mode_toggle = flag_mode.clone();
+                            let mode_toggle = flag_mode;
                             Button(
                                 Modifier::empty()
                                     .rounded_corners(14.0)
@@ -371,7 +371,7 @@ pub fn mineswapper2_tab() {
                                     mode_toggle.set(next_mode);
                                 },
                                 {
-                                    let mode_label = flag_mode.clone();
+                                    let mode_label = flag_mode;
                                     move || {
                                         let label = match mode_label.get() {
                                             MineswapperTool::Flag => "Flag mode",
@@ -436,8 +436,8 @@ pub fn mineswapper2_tab() {
 
                 let grid_width = game.width;
                 let grid_height = game.height;
-                let grid_state = content_game_state.clone();
-                let grid_flag_mode = content_flag_mode.clone();
+                let grid_state = content_game_state;
+                let grid_flag_mode = content_flag_mode;
 
                 Column(
                     Modifier::empty()
@@ -447,8 +447,8 @@ pub fn mineswapper2_tab() {
                     ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(6.0)),
                     move || {
                         for y in 0..grid_height {
-                            let game_state = grid_state.clone();
-                            let flag_mode = grid_flag_mode.clone();
+                            let game_state = grid_state;
+                            let flag_mode = grid_flag_mode;
                             Row(
                                 Modifier::empty().fill_max_width().padding(2.0),
                                 RowSpec::new()
@@ -457,7 +457,7 @@ pub fn mineswapper2_tab() {
                                 move || {
                                     for x in 0..grid_width {
                                         let game_snapshot = game_state.get();
-                                        let cell = game_snapshot.cell_at(x, y).clone();
+                                        let cell = *game_snapshot.cell_at(x, y);
                                         let display = if cell.is_revealed {
                                             if cell.is_mine {
                                                 "💣".to_string()
@@ -484,8 +484,8 @@ pub fn mineswapper2_tab() {
                                             Color(0.12, 0.14, 0.22, 0.9)
                                         };
 
-                                        let game_action = game_state.clone();
-                                        let mode_state = flag_mode.clone();
+                                        let game_action = game_state;
+                                        let mode_state = flag_mode;
                                         Button(
                                             Modifier::empty()
                                                 .size_points(36.0, 36.0)
@@ -506,7 +506,7 @@ pub fn mineswapper2_tab() {
                                                 }
                                             },
                                             {
-                                                let display = display.clone();
+                                                let display = display;
                                                 move || {
                                                     Text(
                                                         display.clone(),

--- a/apps/desktop-demo/src/app/mineswapper2.rs
+++ b/apps/desktop-demo/src/app/mineswapper2.rs
@@ -506,10 +506,10 @@ pub fn mineswapper2_tab() {
                                                 }
                                             },
                                             {
-                                                let display = display;
+                                                let display_text = display;
                                                 move || {
                                                     Text(
-                                                        display.clone(),
+                                                        display_text.clone(),
                                                         Modifier::empty().padding(4.0),
                                                     );
                                                 }

--- a/apps/desktop-demo/src/tests/conditional_text_test.rs
+++ b/apps/desktop-demo/src/tests/conditional_text_test.rs
@@ -28,7 +28,7 @@ fn test_conditional_text_reactivity() {
     use std::cell::RefCell;
 
     thread_local! {
-        static TEST_COUNTER: RefCell<Option<MutableState<i32>>> = RefCell::new(None);
+        static TEST_COUNTER: RefCell<Option<MutableState<i32>>> = const { RefCell::new(None) };
     }
 
     // Helper function to drain recompositions

--- a/apps/desktop-demo/src/tests/conditional_text_test.rs
+++ b/apps/desktop-demo/src/tests/conditional_text_test.rs
@@ -45,7 +45,7 @@ fn test_conditional_text_reactivity() {
     let mut composition = run_test_composition(|| {
         let counter = compose_core::useState(|| 0);
         TEST_COUNTER.with(|cell| {
-            *cell.borrow_mut() = Some(counter.clone());
+            *cell.borrow_mut() = Some(counter);
         });
         conditional_text_with_external_state(counter);
     });
@@ -56,7 +56,9 @@ fn test_conditional_text_reactivity() {
     println!("Initial node count: {}", initial_node_count);
 
     // Get the counter state and increment it
-    let counter = TEST_COUNTER.with(|cell| cell.borrow().clone().expect("counter state not set"));
+    let counter = TEST_COUNTER
+        .with(|cell| *cell.borrow())
+        .expect("counter state not set");
 
     // Increment the counter to 1 (odd)
     counter.set(1);

--- a/apps/desktop-demo/src/tests/main_tests.rs
+++ b/apps/desktop-demo/src/tests/main_tests.rs
@@ -178,13 +178,7 @@ fn async_runtime_freezes_without_conditional_key() {
     let is_running = MutableState::with_runtime(true, runtime.clone());
     let reset_signal = MutableState::with_runtime(0u64, runtime.clone());
 
-    let mut render = {
-        let animation = animation;
-        let stats = stats;
-        let is_running = is_running;
-        let reset_signal = reset_signal;
-        move || async_runtime_test_content(animation, stats, is_running, reset_signal)
-    };
+    let mut render = move || async_runtime_test_content(animation, stats, is_running, reset_signal);
 
     composition
         .render(location_key(file!(), line!(), column!()), &mut render)

--- a/apps/desktop-demo/src/tests/main_tests.rs
+++ b/apps/desktop-demo/src/tests/main_tests.rs
@@ -11,15 +11,15 @@ fn async_runtime_test_content(
     reset_signal: MutableState<u64>,
 ) {
     {
-        let animation_state = animation.clone();
-        let stats_state = stats.clone();
-        let running_state = is_running.clone();
-        let reset_state = reset_signal.clone();
+        let animation_state = animation;
+        let stats_state = stats;
+        let running_state = is_running;
+        let reset_state = reset_signal;
         LaunchedEffectAsync!((), move |scope| {
-            let animation = animation_state.clone();
-            let stats = stats_state.clone();
-            let running = running_state.clone();
-            let reset = reset_state.clone();
+            let animation = animation_state;
+            let stats = stats_state;
+            let running = running_state;
+            let reset = reset_state;
             Box::pin(async move {
                 let clock = scope.runtime().frame_clock();
                 let mut last_time: Option<u64> = None;
@@ -179,18 +179,11 @@ fn async_runtime_freezes_without_conditional_key() {
     let reset_signal = MutableState::with_runtime(0u64, runtime.clone());
 
     let mut render = {
-        let animation = animation.clone();
-        let stats = stats.clone();
-        let is_running = is_running.clone();
-        let reset_signal = reset_signal.clone();
-        move || {
-            async_runtime_test_content(
-                animation.clone(),
-                stats.clone(),
-                is_running.clone(),
-                reset_signal.clone(),
-            )
-        }
+        let animation = animation;
+        let stats = stats;
+        let is_running = is_running;
+        let reset_signal = reset_signal;
+        move || async_runtime_test_content(animation, stats, is_running, reset_signal)
     };
 
     composition

--- a/apps/desktop-demo/tests/composition_local_dup_test.rs
+++ b/apps/desktop-demo/tests/composition_local_dup_test.rs
@@ -50,7 +50,7 @@ fn composition_local_view_duplicates_regression() {
     TEST_COMPOSITION_LOCAL_COUNTER.with(|cell| cell.borrow_mut().take());
 
     let mut rule = ComposeTestRule::new();
-    rule.set_content(|| combined_app())
+    rule.set_content(combined_app)
         .expect("install combined app content");
     rule.pump_until_idle()
         .expect("initial idle after counter view");

--- a/apps/desktop-demo/tests/composition_local_dup_test.rs
+++ b/apps/desktop-demo/tests/composition_local_dup_test.rs
@@ -9,11 +9,7 @@ where
     F: FnOnce(&MutableState<DemoTab>),
 {
     TEST_ACTIVE_TAB_STATE.with(|cell| {
-        let state = cell
-            .borrow()
-            .as_ref()
-            .expect("active tab state registered")
-            .clone();
+        let state = *cell.borrow().as_ref().expect("active tab state registered");
         f(&state);
     });
 }
@@ -24,11 +20,10 @@ fn set_active_tab(tab: DemoTab) {
 
 fn increment_composition_local_counter() {
     TEST_COMPOSITION_LOCAL_COUNTER.with(|cell| {
-        let state = cell
+        let state = *cell
             .borrow()
             .as_ref()
-            .expect("composition local counter state not registered")
-            .clone();
+            .expect("composition local counter state not registered");
         state.set(state.get() + 1);
     });
 }

--- a/apps/desktop-demo/tests/modifier_showcase_layout_tests.rs
+++ b/apps/desktop-demo/tests/modifier_showcase_layout_tests.rs
@@ -446,7 +446,6 @@ fn test_dynamic_modifiers_frame_advancement() {
     let frame = MutableState::with_runtime(0i32, rule.runtime_handle());
 
     rule.set_content({
-        let frame = frame;
         move || {
             let frame_inner = frame;
             dynamic_modifiers_showcase_with_frame(frame_inner);
@@ -580,14 +579,14 @@ fn test_all_showcases_have_valid_layouts() {
 
         let mut rule = ComposeTestRule::new();
         rule.set_content(showcase_fn)
-            .expect(&format!("{} should render", name));
+            .unwrap_or_else(|_| panic!("{} should render", name));
 
         let layout = compute_layout_from_rule(&mut rule, 800.0, 600.0)
-            .expect(&format!("{} should compute layout", name));
+            .unwrap_or_else(|_| panic!("{} should compute layout", name));
 
         // Validate hierarchy - all showcases should now have valid hierarchies
         validate_layout_hierarchy(layout.root())
-            .expect(&format!("{} layout hierarchy should be valid", name));
+            .unwrap_or_else(|_| panic!("{} layout hierarchy should be valid", name));
 
         // Ensure root has non-zero size
         assert!(

--- a/apps/desktop-demo/tests/modifier_showcase_layout_tests.rs
+++ b/apps/desktop-demo/tests/modifier_showcase_layout_tests.rs
@@ -443,13 +443,12 @@ fn test_dynamic_modifiers_size_changes() {
 #[test]
 fn test_dynamic_modifiers_frame_advancement() {
     let mut rule = ComposeTestRule::new();
-    let runtime = rule.runtime_handle();
-    let frame = MutableState::with_runtime(0i32, runtime.clone());
+    let frame = MutableState::with_runtime(0i32, rule.runtime_handle());
 
     rule.set_content({
-        let frame = frame.clone();
+        let frame = frame;
         move || {
-            let frame_inner = frame.clone();
+            let frame_inner = frame;
             dynamic_modifiers_showcase_with_frame(frame_inner);
         }
     })

--- a/apps/desktop-demo/tests/modifier_showcase_rendering_tests.rs
+++ b/apps/desktop-demo/tests/modifier_showcase_rendering_tests.rs
@@ -209,7 +209,6 @@ fn test_dynamic_modifiers_recomposition_preserves_structure() {
     let frame = MutableState::with_runtime(0, rule.runtime_handle());
 
     rule.set_content({
-        let frame = frame;
         move || {
             dynamic_modifiers_showcase(frame.get());
         }
@@ -413,7 +412,6 @@ fn test_modifier_showcase_recomposition_stability() {
     let showcase_index = MutableState::with_runtime(0, rule.runtime_handle());
 
     rule.set_content({
-        let showcase_index = showcase_index;
         move || {
             let showcase_index_inner = showcase_index;
             Column(Modifier::empty(), ColumnSpec::default(), move || {
@@ -464,7 +462,7 @@ fn test_modifier_showcase_recomposition_stability() {
         let idx = i % 3;
         showcase_index.set(idx);
         rule.pump_until_idle()
-            .expect(&format!("Rapid switch {}", i));
+            .unwrap_or_else(|_| panic!("Rapid switch {}", i));
 
         let current_count = rule.applier_mut().len();
 

--- a/apps/desktop-demo/tests/modifier_showcase_rendering_tests.rs
+++ b/apps/desktop-demo/tests/modifier_showcase_rendering_tests.rs
@@ -206,12 +206,10 @@ fn test_positioned_boxes_renders_correctly() {
 #[test]
 fn test_dynamic_modifiers_recomposition_preserves_structure() {
     let mut rule = ComposeTestRule::new();
-    let runtime = rule.runtime_handle();
-
-    let frame = MutableState::with_runtime(0, runtime.clone());
+    let frame = MutableState::with_runtime(0, rule.runtime_handle());
 
     rule.set_content({
-        let frame = frame.clone();
+        let frame = frame;
         move || {
             dynamic_modifiers_showcase(frame.get());
         }
@@ -412,14 +410,12 @@ fn test_long_list_performance_and_structure() {
 fn test_modifier_showcase_recomposition_stability() {
     // Test that changing between different showcases maintains stable node counts
     let mut rule = ComposeTestRule::new();
-    let runtime = rule.runtime_handle();
-
-    let showcase_index = MutableState::with_runtime(0, runtime.clone());
+    let showcase_index = MutableState::with_runtime(0, rule.runtime_handle());
 
     rule.set_content({
-        let showcase_index = showcase_index.clone();
+        let showcase_index = showcase_index;
         move || {
-            let showcase_index_inner = showcase_index.clone();
+            let showcase_index_inner = showcase_index;
             Column(Modifier::empty(), ColumnSpec::default(), move || {
                 let current_index = showcase_index_inner.get();
                 compose_core::with_key(&current_index, || match current_index {

--- a/apps/desktop-demo/tests/modifier_showcase_tests.rs
+++ b/apps/desktop-demo/tests/modifier_showcase_tests.rs
@@ -252,7 +252,7 @@ fn count_children(applier: &mut MemoryApplier, node_id: usize) -> Option<usize> 
 fn collect_all_nodes(applier: &mut MemoryApplier, node_id: usize) -> Vec<usize> {
     let mut nodes = vec![node_id];
     if let Ok(children) = applier.with_node(node_id, |node: &mut compose_ui::LayoutNode| {
-        node.children.clone()
+        node.children.iter().copied().collect::<Vec<_>>()
     }) {
         for child_id in children {
             nodes.extend(collect_all_nodes(applier, child_id));

--- a/crates/compose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/compose-app-shell/src/tests/app_shell_tests.rs
@@ -56,14 +56,14 @@ fn tabbed_progress_content() {
     let progress = useState(|| 0.6f32);
     let active_tab = useState(|| 0i32);
 
-    let progress_effect = progress.clone();
-    let active_effect = active_tab.clone();
+    let progress_effect = progress;
+    let active_effect = active_tab;
     launched_effect_async_impl(
         location_key(file!(), line!(), column!()),
         (),
         move |scope| {
-            let progress = progress_effect.clone();
-            let active_tab = active_effect.clone();
+            let progress = progress_effect;
+            let active_tab = active_effect;
             Box::pin(async move {
                 let clock = scope.runtime().frame_clock();
                 let mut phase: u32 = 0;
@@ -98,8 +98,8 @@ fn tabbed_progress_content() {
                 format!("Progress {:.2}", progress.value()),
                 Modifier::empty().padding(2.0),
             );
-            let progress_for_branch = progress.clone();
-            let active_for_branch = active_tab.clone();
+            let progress_for_branch = progress;
+            let active_for_branch = active_tab;
             Row(
                 Modifier::empty()
                     .padding(2.0)
@@ -107,7 +107,7 @@ fn tabbed_progress_content() {
                 RowSpec::default(),
                 move || {
                     if active_for_branch.value() == 0 && progress_for_branch.value() > 0.0 {
-                        let progress_for_bar = progress_for_branch.clone();
+                        let progress_for_bar = progress_for_branch;
                         Row(
                             Modifier::empty()
                                 .width(160.0 * progress_for_bar.value())

--- a/crates/compose-core/src/lib.rs
+++ b/crates/compose-core/src/lib.rs
@@ -390,7 +390,7 @@ where
 
 #[allow(non_snake_case)]
 pub fn useState<T: Clone + 'static>(init: impl FnOnce() -> T) -> MutableState<T> {
-    remember(|| mutableStateOf(init())).with(|state| state.clone())
+    remember(|| mutableStateOf(init())).with(|state| *state)
 }
 
 #[allow(deprecated)]
@@ -1742,7 +1742,7 @@ impl Composer {
         let state = self
             .slots_mut()
             .remember(|| MutableState::with_runtime(init(), runtime.clone()));
-        state.with(|state| state.clone())
+        state.with(|state| *state)
     }
 
     pub fn emit_node<N: Node + 'static>(&self, init: impl FnOnce() -> N) -> NodeId {
@@ -2299,10 +2299,6 @@ impl<T: Clone + 'static> MutableState<T> {
         self.value()
     }
 
-    fn schedule_invalidation(&self) {
-        self.with_inner(|inner| inner.invalidate_watchers());
-    }
-
     #[cfg(test)]
     pub(crate) fn watcher_count(&self) -> usize {
         self.with_inner(|inner| inner.watchers.borrow().len())
@@ -2342,7 +2338,7 @@ impl<T: Clone + 'static> SnapshotStateList<T> {
     }
 
     pub fn as_mutable_state(&self) -> MutableState<Vec<T>> {
-        self.state.clone()
+        self.state
     }
 
     pub fn len(&self) -> usize {
@@ -2463,7 +2459,7 @@ where
     }
 
     pub fn as_mutable_state(&self) -> MutableState<HashMap<K, V>> {
-        self.state.clone()
+        self.state
     }
 
     pub fn len(&self) -> usize {

--- a/crates/compose-core/src/runtime.rs
+++ b/crates/compose-core/src/runtime.rs
@@ -578,10 +578,17 @@ pub struct TestRuntime {
 }
 
 #[cfg(test)]
+impl Default for TestRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
 impl TestRuntime {
     pub fn new() -> Self {
         Self {
-            runtime: Runtime::new(Arc::new(TestScheduler::default())),
+            runtime: Runtime::new(Arc::new(TestScheduler)),
         }
     }
 

--- a/crates/compose-core/src/runtime.rs
+++ b/crates/compose-core/src/runtime.rs
@@ -1,13 +1,14 @@
 use crate::collections::map::HashMap;
 use crate::collections::map::HashSet;
+use crate::MutableStateInner;
 use std::any::Any;
-use std::cell::{Cell, RefCell};
-use std::collections::VecDeque;
+use std::cell::{Cell, Ref, RefCell, RefMut};
+use std::collections::{HashMap as StdHashMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::{Rc, Weak};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{mpsc, Arc};
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
 use std::task::{Context, Poll, Waker};
 use std::thread::ThreadId;
 use std::thread_local;
@@ -23,6 +24,120 @@ enum UiMessage {
 
 type UiContinuation = Box<dyn Fn(Box<dyn Any>) + 'static>;
 type UiContinuationMap = HashMap<u64, UiContinuation>;
+
+trait AnyStateCell {
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+struct TypedStateCell<T: Clone + 'static> {
+    inner: MutableStateInner<T>,
+}
+
+impl<T: Clone + 'static> AnyStateCell for TypedStateCell<T> {
+    fn as_any(&self) -> &dyn Any {
+        &self.inner
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.inner
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct StateArena {
+    cells: RefCell<Vec<Option<Box<dyn AnyStateCell>>>>,
+}
+
+impl StateArena {
+    pub(crate) fn alloc<T: Clone + 'static>(&self, value: T, runtime: RuntimeHandle) -> StateId {
+        let mut cells = self.cells.borrow_mut();
+        let id = StateId(cells.len() as u32);
+        let inner = MutableStateInner::new(value, runtime.clone());
+        inner.install_snapshot_observer(id);
+        let cell: Box<dyn AnyStateCell> = Box::new(TypedStateCell { inner });
+        cells.push(Some(cell));
+        id
+    }
+
+    fn get_cell(&self, id: StateId) -> Ref<'_, Box<dyn AnyStateCell>> {
+        Ref::map(self.cells.borrow(), |cells| {
+            cells
+                .get(id.0 as usize)
+                .and_then(|cell| cell.as_ref())
+                .expect("state cell missing")
+        })
+    }
+
+    fn get_cell_mut(&self, id: StateId) -> RefMut<'_, Box<dyn AnyStateCell>> {
+        RefMut::map(self.cells.borrow_mut(), |cells| {
+            cells
+                .get_mut(id.0 as usize)
+                .and_then(|cell| cell.as_mut())
+                .expect("state cell missing")
+        })
+    }
+
+    pub(crate) fn get_typed<T: Clone + 'static>(
+        &self,
+        id: StateId,
+    ) -> Ref<'_, MutableStateInner<T>> {
+        Ref::map(self.get_cell(id), |cell| {
+            cell.as_any()
+                .downcast_ref::<MutableStateInner<T>>()
+                .expect("state cell type mismatch")
+        })
+    }
+
+    pub(crate) fn get_typed_opt<T: Clone + 'static>(
+        &self,
+        id: StateId,
+    ) -> Option<Ref<'_, MutableStateInner<T>>> {
+        Ref::filter_map(self.get_cell(id), |cell| {
+            cell.as_any().downcast_ref::<MutableStateInner<T>>()
+        })
+        .ok()
+    }
+
+    pub(crate) fn get_typed_mut<T: Clone + 'static>(
+        &self,
+        id: StateId,
+    ) -> RefMut<'_, MutableStateInner<T>> {
+        RefMut::map(self.get_cell_mut(id), |cell| {
+            cell.as_any_mut()
+                .downcast_mut::<MutableStateInner<T>>()
+                .expect("state cell type mismatch")
+        })
+    }
+}
+
+thread_local! {
+    static RUNTIME_HANDLES: RefCell<StdHashMap<RuntimeId, RuntimeHandle>> =
+        RefCell::new(StdHashMap::new());
+}
+
+fn register_runtime_handle(handle: &RuntimeHandle) {
+    RUNTIME_HANDLES.with(|registry| {
+        registry.borrow_mut().insert(handle.id, handle.clone());
+    });
+}
+
+pub(crate) fn runtime_handle_for(id: RuntimeId) -> Option<RuntimeHandle> {
+    RUNTIME_HANDLES.with(|registry| registry.borrow().get(&id).cloned())
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct StateId(pub(crate) u32);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct RuntimeId(u32);
+
+impl RuntimeId {
+    fn next() -> Self {
+        static NEXT_RUNTIME_ID: AtomicU32 = AtomicU32::new(1);
+        Self(NEXT_RUNTIME_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
 
 struct UiDispatcherInner {
     scheduler: Arc<dyn RuntimeScheduler>,
@@ -116,6 +231,8 @@ struct RuntimeInner {
     tasks: RefCell<Vec<TaskEntry>>, // FUTURE(no_std): migrate to smallvec-backed storage.
     next_task_id: Cell<u64>,
     task_waker: RefCell<Option<Waker>>,
+    state_arena: StateArena,
+    runtime_id: RuntimeId,
 }
 
 struct TaskEntry {
@@ -144,6 +261,8 @@ impl RuntimeInner {
             tasks: RefCell::new(Vec::new()),
             next_task_id: Cell::new(1),
             task_waker: RefCell::new(None),
+            state_arena: StateArena::default(),
+            runtime_id: RuntimeId::next(),
         }
     }
 
@@ -431,7 +550,9 @@ impl Runtime {
     pub fn new(scheduler: Arc<dyn RuntimeScheduler>) -> Self {
         let inner = Rc::new(RuntimeInner::new(scheduler));
         RuntimeInner::init_task_waker(&inner);
-        Self { inner }
+        let runtime = Self { inner };
+        register_runtime_handle(&runtime.handle());
+        runtime
     }
 
     pub fn handle(&self) -> RuntimeHandle {
@@ -439,6 +560,7 @@ impl Runtime {
             inner: Rc::downgrade(&self.inner),
             dispatcher: UiDispatcher::new(self.inner.ui_dispatcher.clone()),
             ui_thread_id: self.inner.ui_thread_id,
+            id: self.inner.runtime_id,
         }
     }
 
@@ -498,6 +620,7 @@ pub struct RuntimeHandle {
     inner: Weak<RuntimeInner>,
     dispatcher: UiDispatcher,
     ui_thread_id: ThreadId,
+    id: RuntimeId,
 }
 
 pub struct TaskHandle {
@@ -506,6 +629,21 @@ pub struct TaskHandle {
 }
 
 impl RuntimeHandle {
+    pub fn id(&self) -> RuntimeId {
+        self.id
+    }
+
+    pub(crate) fn alloc_state<T: Clone + 'static>(&self, value: T) -> StateId {
+        self.with_state_arena(|arena| arena.alloc(value, self.clone()))
+    }
+
+    pub(crate) fn with_state_arena<R>(&self, f: impl FnOnce(&StateArena) -> R) -> R {
+        self.inner
+            .upgrade()
+            .map(|inner| f(&inner.state_arena))
+            .unwrap_or_else(|| panic!("runtime dropped"))
+    }
+
     pub fn schedule(&self) {
         if let Some(inner) = self.inner.upgrade() {
             inner.schedule();

--- a/crates/compose-core/src/snapshot_state_observer.rs
+++ b/crates/compose-core/src/snapshot_state_observer.rs
@@ -7,7 +7,6 @@
 use crate::collections::map::HashSet;
 use crate::snapshot_v2::{register_apply_observer, ReadObserver, StateObjectId};
 use crate::state::StateObject;
-use ahash::HashSetExt;
 use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::rc::{Rc, Weak};
@@ -386,7 +385,8 @@ impl ObservedIds {
                 if small.len() < MAX_OBSERVED_STATES {
                     small.push(id);
                 } else {
-                    let mut large = HashSet::with_capacity(small.len() + 1);
+                    let mut large =
+                        HashSet::with_capacity_and_hasher(small.len() + 1, Default::default());
                     for existing in small.iter() {
                         large.insert(*existing);
                     }

--- a/crates/compose-core/src/snapshot_weak_set.rs
+++ b/crates/compose-core/src/snapshot_weak_set.rs
@@ -126,6 +126,7 @@ impl Default for SnapshotWeakSet {
 }
 
 #[cfg(test)]
+#[allow(clippy::arc_with_non_send_sync)]
 mod tests {
     use super::*;
     use crate::snapshot_id_set::{SnapshotId, SnapshotIdSet};
@@ -220,7 +221,7 @@ mod tests {
     #[test]
     fn test_weak_set_maintains_sort_order() {
         let mut set = SnapshotWeakSet::new();
-        let states: Vec<_> = (0..10).map(|i| MockState::new(i)).collect();
+        let states: Vec<_> = (0..10).map(MockState::new).collect();
 
         // Add in random order
         for state in &states {
@@ -308,7 +309,7 @@ mod tests {
         let initial_capacity = set.entries.capacity();
 
         // Add more than initial capacity
-        let states: Vec<_> = (0..20).map(|i| MockState::new(i)).collect();
+        let states: Vec<_> = (0..20).map(MockState::new).collect();
         for state in &states {
             set.add(state);
         }
@@ -343,7 +344,7 @@ mod tests {
     #[test]
     fn test_weak_set_remove_all() {
         let mut set = SnapshotWeakSet::new();
-        let states: Vec<_> = (0..5).map(|i| MockState::new(i)).collect();
+        let states: Vec<_> = (0..5).map(MockState::new).collect();
 
         for state in &states {
             set.add(state);

--- a/crates/compose-core/src/tests/recursive_decrease_increase_test.rs
+++ b/crates/compose-core/src/tests/recursive_decrease_increase_test.rs
@@ -67,7 +67,7 @@ fn recursive_decrease_increase_preserves_structure() {
     println!("\n=== Initial render at depth 3 ===");
     composition
         .render(key, &mut || {
-            recursive_root(depth_state.clone());
+            recursive_root(depth_state);
         })
         .expect("initial render");
 
@@ -176,7 +176,7 @@ fn recursive_decrease_increase_multiple_cycles() {
     // Initial render at depth 3
     composition
         .render(key, &mut || {
-            recursive_root(depth_state.clone());
+            recursive_root(depth_state);
         })
         .expect("initial render");
 

--- a/crates/compose-core/src/tests/slot_backend_tests.rs
+++ b/crates/compose-core/src/tests/slot_backend_tests.rs
@@ -862,7 +862,7 @@ fn test_chunked_anchor_rebuild_after_shift() {
     let _g = storage.begin_group(1400);
     let mut ids = Vec::new();
     for i in 0..8 {
-        let s = storage.alloc_value_slot(|| i as i32);
+        let s = storage.alloc_value_slot(|| i);
         ids.push(s);
     }
     storage.end_group();

--- a/crates/compose-core/src/tests/subcompose_tests.rs
+++ b/crates/compose-core/src/tests/subcompose_tests.rs
@@ -114,8 +114,8 @@ fn removing_slots_deactivates_scopes() {
     let scope_b = RecomposeScope::new_for_test(runtime.handle());
 
     let mut state = SubcomposeState::default();
-    state.register_active(SlotId::new(1), &[10], &[scope_a.clone()]);
-    state.register_active(SlotId::new(2), &[20], &[scope_b.clone()]);
+    state.register_active(SlotId::new(1), &[10], std::slice::from_ref(&scope_a));
+    state.register_active(SlotId::new(2), &[20], std::slice::from_ref(&scope_b));
 
     let moved = state.dispose_or_reuse_starting_from_index(1);
     assert_eq!(moved, vec![20]);

--- a/crates/compose-foundation/src/tests/modifier_tests.rs
+++ b/crates/compose-foundation/src/tests/modifier_tests.rs
@@ -503,17 +503,9 @@ impl Hash for InvalidationElement {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct InvalidationNode {
     state: NodeState,
-}
-
-impl Default for InvalidationNode {
-    fn default() -> Self {
-        Self {
-            state: NodeState::new(),
-        }
-    }
 }
 
 impl DelegatableNode for InvalidationNode {
@@ -717,7 +709,7 @@ impl ModifierNodeElement for TestDrawElement {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct MaskOnlyNode {
     state: NodeState,
 }
@@ -729,14 +721,6 @@ impl DelegatableNode for MaskOnlyNode {
 }
 
 impl ModifierNode for MaskOnlyNode {}
-
-impl Default for MaskOnlyNode {
-    fn default() -> Self {
-        Self {
-            state: NodeState::new(),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct MaskOnlyElement;

--- a/crates/compose-runtime-std/src/tests/std_runtime_tests.rs
+++ b/crates/compose-runtime-std/src/tests/std_runtime_tests.rs
@@ -11,7 +11,7 @@ fn std_runtime_requests_frame_and_recomposes_on_state_change() {
     ) {
         recompositions.set(recompositions.get() + 1);
         let state = compose_core::useState(|| 0);
-        state_slot.borrow_mut().replace(state.clone());
+        state_slot.borrow_mut().replace(state);
         let _ = state.value();
     }
 

--- a/crates/compose-testing/src/tests/recomposition_tests.rs
+++ b/crates/compose-testing/src/tests/recomposition_tests.rs
@@ -58,7 +58,6 @@ fn test_child_recomposition_preserves_parent() {
         let text_state = MutableState::with_runtime("Hello".to_string(), runtime.clone());
 
         rule.set_content({
-            let text_state = text_state.clone();
             move || {
                 Column(|| {
                     let value = text_state.value();
@@ -89,7 +88,6 @@ fn test_conditional_composable_preserves_siblings() {
         let show_middle = MutableState::with_runtime(true, runtime.clone());
 
         rule.set_content({
-            let show_middle = show_middle.clone();
             move || {
                 Column(|| {
                     Text("A".to_string());

--- a/crates/compose-testing/src/tests/testing_tests.rs
+++ b/crates/compose-testing/src/tests/testing_tests.rs
@@ -18,12 +18,10 @@ fn compose_test_rule_reports_content_and_root() {
         let recompositions = Rc::new(Cell::new(0));
 
         rule.set_content({
-            let state = state.clone();
             let recompositions = Rc::clone(&recompositions);
             move || {
                 recompositions.set(recompositions.get() + 1);
-                let id =
-                    with_current_composer(|composer| composer.emit_node(|| TestNode::default()));
+                let id = with_current_composer(|composer| composer.emit_node(TestNode::default));
                 let value = state.value();
                 with_node_mut(id, |node: &mut TestNode| {
                     node.value = value;

--- a/crates/compose-ui/benches/skip_recomposition.rs
+++ b/crates/compose-ui/benches/skip_recomposition.rs
@@ -3,7 +3,7 @@ use compose_ui::{composable, Composition, Modifier, Text};
 use criterion::{criterion_group, criterion_main, Criterion};
 
 #[composable]
-fn StaticLabel(label: &'static str) {
+fn static_label(label: &'static str) {
     Text(label.to_string(), Modifier::empty());
 }
 
@@ -12,13 +12,13 @@ fn skip_recomposition_static_label(c: &mut Criterion) {
     let key = location_key(file!(), line!(), column!());
 
     composition
-        .render(key, || StaticLabel("Hello"))
+        .render(key, || static_label("Hello"))
         .expect("initial render");
 
     c.bench_function("skip_recomposition_static_label", |b| {
         b.iter(|| {
             composition
-                .render(key, || StaticLabel("Hello"))
+                .render(key, || static_label("Hello"))
                 .expect("render");
         });
     });

--- a/crates/compose-ui/src/tests/anchor_async_tests.rs
+++ b/crates/compose-ui/src/tests/anchor_async_tests.rs
@@ -43,14 +43,14 @@ impl Node for DummyNode {}
 #[composable]
 fn async_runtime_demo(animation: MutableState<AnimationState>, stats: MutableState<FrameStats>) {
     {
-        let animation_state = animation.clone();
-        let stats_state = stats.clone();
+        let animation_state = animation;
+        let stats_state = stats;
         launched_effect_async_impl(
             location_key(file!(), line!(), column!()),
             (),
             move |scope| {
-                let animation = animation_state.clone();
-                let stats = stats_state.clone();
+                let animation = animation_state;
+                let stats = stats_state;
                 Box::pin(async move {
                     let clock = scope.runtime().frame_clock();
                     let mut last_time: Option<u64> = None;
@@ -102,7 +102,7 @@ fn async_runtime_demo(animation: MutableState<AnimationState>, stats: MutableSta
                         composer.with_group(
                             location_key(file!(), line!(), column!()),
                             |composer| {
-                                composer.emit_node(|| DummyNode::default());
+                                composer.emit_node(|| DummyNode);
                             },
                         );
                     }
@@ -142,11 +142,7 @@ fn async_runtime_freezes_without_conditional_key() {
     let animation = MutableState::with_runtime(AnimationState::default(), runtime.clone());
     let stats = MutableState::with_runtime(FrameStats::default(), runtime.clone());
 
-    let mut render = {
-        let animation = animation.clone();
-        let stats = stats.clone();
-        move || async_runtime_demo(animation.clone(), stats.clone())
-    };
+    let mut render = { move || async_runtime_demo(animation, stats) };
 
     composition
         .render(location_key(file!(), line!(), column!()), &mut render)
@@ -264,11 +260,7 @@ fn stats_state_invalidates_after_direction_flip() {
 
     animation.update(|anim| anim.progress = 0.5);
 
-    let mut render = {
-        let animation = animation.clone();
-        let stats = stats.clone();
-        move || progress_demo(animation.clone(), stats.clone())
-    };
+    let mut render = { move || progress_demo(animation, stats) };
 
     let key = location_key(file!(), line!(), column!());
     composition

--- a/crates/compose-ui/src/tests/async_runtime_full_layout_test.rs
+++ b/crates/compose-ui/src/tests/async_runtime_full_layout_test.rs
@@ -69,16 +69,16 @@ fn async_runtime_full_layout(
 ) {
     // LaunchedEffectAsync - exactly like the demo
     {
-        let animation_state = animation.clone();
-        let stats_state = stats.clone();
-        let running_state = is_running.clone();
+        let animation_state = animation;
+        let stats_state = stats;
+        let running_state = is_running;
         launched_effect_async_impl(
             location_key(file!(), line!(), column!()),
             (),
             move |scope| {
-                let animation = animation_state.clone();
-                let stats = stats_state.clone();
-                let running = running_state.clone();
+                let animation = animation_state;
+                let stats = stats_state;
+                let running = running_state;
                 Box::pin(async move {
                     let clock = scope.runtime().frame_clock();
                     let mut last_time: Option<u64> = None;
@@ -226,7 +226,7 @@ fn async_runtime_full_layout(
 
             // Button Row
             {
-                let is_running_for_button = is_running.clone();
+                let is_running_for_button = is_running;
                 Row(
                     Modifier::empty().padding(4.0),
                     RowSpec::default(),
@@ -242,7 +242,7 @@ fn async_runtime_full_layout(
                         Button(
                             Modifier::empty().padding(12.0),
                             {
-                                let toggle_state = is_running_for_button.clone();
+                                let toggle_state = is_running_for_button;
                                 move || toggle_state.set(!toggle_state.get())
                             },
                             move || {
@@ -294,7 +294,7 @@ fn async_runtime_full_layout_freezes_after_forward_flip() {
     // Initial render
     composition
         .render(location_key(file!(), line!(), column!()), &mut || {
-            async_runtime_full_layout(is_running.clone(), animation.clone(), stats.clone());
+            async_runtime_full_layout(is_running, animation, stats);
         })
         .expect("initial render");
     drain_all(&mut composition).expect("initial drain");

--- a/crates/compose-ui/src/tests/primitives_tests.rs
+++ b/crates/compose-ui/src/tests/primitives_tests.rs
@@ -17,8 +17,8 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 thread_local! {
-    static COUNTER_ROW_INVOCATIONS: Cell<usize> = Cell::new(0);
-    static COUNTER_TEXT_ID: RefCell<Option<NodeId>> = RefCell::new(None);
+    static COUNTER_ROW_INVOCATIONS: Cell<usize> = const { Cell::new(0) };
+    static COUNTER_TEXT_ID: RefCell<Option<NodeId>> = const { RefCell::new(None) };
 }
 
 fn prepare_measure_composer(
@@ -145,7 +145,7 @@ fn CounterRow(label: &'static str, count: State<i32>) -> NodeId {
     COUNTER_ROW_INVOCATIONS.with(|calls| calls.set(calls.get() + 1));
     Column(Modifier::empty(), ColumnSpec::default(), move || {
         Text(label, Modifier::empty());
-        let count_for_text = count.clone();
+        let count_for_text = count;
         let text_id = Text(
             DynamicTextSource::new(move || format!("Count = {}", count_for_text.value())),
             Modifier::empty(),
@@ -386,7 +386,7 @@ fn test_fill_max_width_respects_parent_bounds() {
 
     let root_layout = layout_tree.root();
 
-    fn find_layout<'a>(node: &'a LayoutBox, target: NodeId) -> Option<&'a LayoutBox> {
+    fn find_layout(node: &LayoutBox, target: NodeId) -> Option<&LayoutBox> {
         if node.node_id == target {
             return Some(node);
         }
@@ -402,8 +402,8 @@ fn test_fill_max_width_respects_parent_bounds() {
         .expect("column node id");
     let row_node_id = row_id.borrow().as_ref().copied().expect("row node id");
 
-    let column_layout = find_layout(&root_layout, column_node_id).expect("column layout");
-    let row_layout = find_layout(&root_layout, row_node_id).expect("row layout");
+    let column_layout = find_layout(root_layout, column_node_id).expect("column layout");
+    let row_layout = find_layout(root_layout, row_node_id).expect("row layout");
 
     // Debug output
     println!("\n=== Layout Debug ===");
@@ -535,7 +535,7 @@ fn test_fill_max_width_with_background_and_double_padding() {
 
     let root_layout = layout_tree.root();
 
-    fn find_layout<'a>(node: &'a LayoutBox, target: NodeId) -> Option<&'a LayoutBox> {
+    fn find_layout(node: &LayoutBox, target: NodeId) -> Option<&LayoutBox> {
         if node.node_id == target {
             return Some(node);
         }
@@ -556,9 +556,9 @@ fn test_fill_max_width_with_background_and_double_padding() {
         .expect("inner column");
     let row_node = row_id.borrow().as_ref().copied().expect("row");
 
-    let outer_layout = find_layout(&root_layout, outer_column_node).expect("outer column layout");
-    let inner_layout = find_layout(&root_layout, inner_column_node).expect("inner column layout");
-    let row_layout = find_layout(&root_layout, row_node).expect("row layout");
+    let outer_layout = find_layout(root_layout, outer_column_node).expect("outer column layout");
+    let inner_layout = find_layout(root_layout, inner_column_node).expect("inner column layout");
+    let row_layout = find_layout(root_layout, row_node).expect("row layout");
 
     println!("\n=== Counter App Structure Test ===");
     println!("Window: 800px");
@@ -683,7 +683,7 @@ fn test_fill_max_width_should_not_propagate_to_wrapping_parent() {
 
     let root_layout = layout_tree.root();
 
-    fn find_layout<'a>(node: &'a LayoutBox, target: NodeId) -> Option<&'a LayoutBox> {
+    fn find_layout(node: &LayoutBox, target: NodeId) -> Option<&LayoutBox> {
         if node.node_id == target {
             return Some(node);
         }
@@ -696,9 +696,9 @@ fn test_fill_max_width_should_not_propagate_to_wrapping_parent() {
     let inner_node = inner_column_id.borrow().as_ref().copied().expect("inner");
     let row_node = row_id.borrow().as_ref().copied().expect("row");
 
-    let outer_layout = find_layout(&root_layout, outer_node).expect("outer layout");
-    let inner_layout = find_layout(&root_layout, inner_node).expect("inner layout");
-    let row_layout = find_layout(&root_layout, row_node).expect("row layout");
+    let outer_layout = find_layout(root_layout, outer_node).expect("outer layout");
+    let inner_layout = find_layout(root_layout, inner_node).expect("inner layout");
+    let row_layout = find_layout(root_layout, row_node).expect("row layout");
 
     println!("\n=== Fill Propagation Test ===");
     println!("Window: 800px");
@@ -801,7 +801,7 @@ fn wrap_column_with_fill_child_uses_content_width() {
         )
         .expect("compute layout");
 
-    fn find_layout<'a>(node: &'a LayoutBox, target: NodeId) -> Option<&'a LayoutBox> {
+    fn find_layout(node: &LayoutBox, target: NodeId) -> Option<&LayoutBox> {
         if node.node_id == target {
             return Some(node);
         }
@@ -923,7 +923,7 @@ fn fill_child_respects_explicit_parent_width() {
         )
         .expect("compute layout");
 
-    fn find_layout<'a>(node: &'a LayoutBox, target: NodeId) -> Option<&'a LayoutBox> {
+    fn find_layout(node: &LayoutBox, target: NodeId) -> Option<&LayoutBox> {
         if node.node_id == target {
             return Some(node);
         }
@@ -1017,7 +1017,7 @@ fn fill_max_height_child_clamps_to_parent() {
         )
         .expect("compute layout");
 
-    fn find_layout<'a>(node: &'a LayoutBox, target: NodeId) -> Option<&'a LayoutBox> {
+    fn find_layout(node: &LayoutBox, target: NodeId) -> Option<&LayoutBox> {
         if node.node_id == target {
             return Some(node);
         }

--- a/crates/compose-ui/src/tests/subcompose_layout_tests.rs
+++ b/crates/compose-ui/src/tests/subcompose_layout_tests.rs
@@ -99,7 +99,7 @@ fn measure_subcomposes_content() {
         assert_eq!(constraints, Constraints::tight(0.0, 0.0));
         let measurables = scope.subcompose(SlotId::new(1), || {
             compose_core::with_current_composer(|composer| {
-                composer.emit_node(|| DummyNode::default());
+                composer.emit_node(|| DummyNode);
             });
         });
         for measurable in measurables {
@@ -140,7 +140,7 @@ fn subcompose_reuses_nodes_across_measures() {
     let policy: Rc<MeasurePolicy> = Rc::new(move |scope, _constraints| {
         let measurables = scope.subcompose(SlotId::new(99), || {
             compose_core::with_current_composer(|composer| {
-                composer.emit_node(|| DummyNode::default());
+                composer.emit_node(|| DummyNode);
             });
         });
         for measurable in measurables {
@@ -206,12 +206,12 @@ fn inactive_slots_move_to_reusable_pool() {
     let mut slots = SlotBackend::default();
     let mut applier = compose_core::MemoryApplier::new();
     let toggle = MutableState::with_runtime(true, handle.clone());
-    let toggle_capture = toggle.clone();
+    let toggle_capture = toggle;
     let policy: Rc<MeasurePolicy> = Rc::new(move |scope, _constraints| {
         if toggle_capture.value() {
             scope.subcompose(SlotId::new(1), || {
                 compose_core::with_current_composer(|composer| {
-                    composer.emit_node(|| DummyNode::default());
+                    composer.emit_node(|| DummyNode);
                 });
             });
         }

--- a/crates/compose-ui/src/widgets/text.rs
+++ b/crates/compose-ui/src/widgets/text.rs
@@ -76,7 +76,7 @@ where
     T: ToString + Clone + 'static,
 {
     fn into_text_source(self) -> TextSource {
-        let state = self.clone();
+        let state = self;
         TextSource::Dynamic(DynamicTextSource::new(move || state.value().to_string()))
     }
 }
@@ -86,7 +86,7 @@ where
     T: ToString + Clone + 'static,
 {
     fn into_text_source(self) -> TextSource {
-        let state = self.clone();
+        let state = self;
         TextSource::Dynamic(DynamicTextSource::new(move || state.value().to_string()))
     }
 }

--- a/crates/compose-ui/tests/button_clickable_test.rs
+++ b/crates/compose-ui/tests/button_clickable_test.rs
@@ -22,7 +22,7 @@ fn simple_button_app(clicked_count: MutableState<i32>) {
             Button(
                 Modifier::empty().padding(10.0),
                 {
-                    let count = clicked_count.clone();
+                    let count = clicked_count;
                     move || {
                         count.set(count.get() + 1);
                     }
@@ -48,9 +48,9 @@ fn test_button_creates_valid_composition() {
 
     // Set content with a button
     rule.set_content({
-        let count = clicked_count.clone();
+        let count = clicked_count;
         move || {
-            simple_button_app(count.clone());
+            simple_button_app(count);
         }
     })
     .expect("initial render succeeds");
@@ -97,7 +97,7 @@ fn multi_button_app(button1_clicks: MutableState<i32>, button2_clicks: MutableSt
             Button(
                 Modifier::empty().padding(10.0),
                 {
-                    let clicks = button1_clicks.clone();
+                    let clicks = button1_clicks;
                     move || {
                         clicks.set(clicks.get() + 1);
                     }
@@ -115,7 +115,7 @@ fn multi_button_app(button1_clicks: MutableState<i32>, button2_clicks: MutableSt
             Button(
                 Modifier::empty().padding(10.0),
                 {
-                    let clicks = button2_clicks.clone();
+                    let clicks = button2_clicks;
                     move || {
                         clicks.set(clicks.get() + 10);
                     }
@@ -139,10 +139,10 @@ fn test_multiple_buttons_in_composition() {
     let button2_clicks = MutableState::with_runtime(0, runtime.clone());
 
     rule.set_content({
-        let clicks1 = button1_clicks.clone();
-        let clicks2 = button2_clicks.clone();
+        let clicks1 = button1_clicks;
+        let clicks2 = button2_clicks;
         move || {
-            multi_button_app(clicks1.clone(), clicks2.clone());
+            multi_button_app(clicks1, clicks2);
         }
     })
     .expect("initial render succeeds");

--- a/crates/compose-ui/tests/composition_switching_test.rs
+++ b/crates/compose-ui/tests/composition_switching_test.rs
@@ -26,7 +26,6 @@ fn counter_view(counter: MutableState<i32>, render_count: MutableState<i32>) {
             Button(
                 Modifier::empty().padding(10.0),
                 {
-                    let counter = counter.clone();
                     move || {
                         counter.set(counter.get() + 1);
                     }
@@ -57,7 +56,6 @@ fn alternative_view(counter: MutableState<i32>, render_count: MutableState<i32>)
             Button(
                 Modifier::empty().padding(10.0),
                 {
-                    let counter = counter.clone();
                     move || {
                         counter.set(counter.get() + 1);
                     }
@@ -83,13 +81,13 @@ fn combined_switching_app(
         Modifier::empty().padding(20.0),
         ColumnSpec::default(),
         move || {
-            let show_counter_inner = show_counter.clone();
-            let show_counter_for_button1 = show_counter.clone();
-            let show_counter_for_button2 = show_counter.clone();
-            let counter1_inner = counter1.clone();
-            let counter2_inner = counter2.clone();
-            let render_count1_inner = render_count1.clone();
-            let render_count2_inner = render_count2.clone();
+            let show_counter_inner = show_counter;
+            let show_counter_for_button1 = show_counter;
+            let show_counter_for_button2 = show_counter;
+            let counter1_inner = counter1;
+            let counter2_inner = counter2;
+            let render_count1_inner = render_count1;
+            let render_count2_inner = render_count2;
 
             // Switch buttons
             Row(
@@ -99,7 +97,7 @@ fn combined_switching_app(
                     Button(
                         Modifier::empty().padding(10.0),
                         {
-                            let show_counter = show_counter_for_button1.clone();
+                            let show_counter = show_counter_for_button1;
                             move || {
                                 show_counter.set(true);
                             }
@@ -117,7 +115,7 @@ fn combined_switching_app(
                     Button(
                         Modifier::empty().padding(10.0),
                         {
-                            let show_counter = show_counter_for_button2.clone();
+                            let show_counter = show_counter_for_button2;
                             move || {
                                 show_counter.set(false);
                             }
@@ -136,9 +134,9 @@ fn combined_switching_app(
 
             // Conditionally show one view or the other
             if show_counter_inner.get() {
-                counter_view(counter1_inner.clone(), render_count1_inner.clone());
+                counter_view(counter1_inner, render_count1_inner);
             } else {
-                alternative_view(counter2_inner.clone(), render_count2_inner.clone());
+                alternative_view(counter2_inner, render_count2_inner);
             }
         },
     );
@@ -157,18 +155,13 @@ fn test_switching_between_views_doesnt_duplicate_content() {
 
     // Initial render - show counter view
     rule.set_content({
-        let show_counter = show_counter.clone();
-        let counter1 = counter1.clone();
-        let counter2 = counter2.clone();
-        let render_count1 = render_count1.clone();
-        let render_count2 = render_count2.clone();
         move || {
             combined_switching_app(
-                show_counter.clone(),
-                counter1.clone(),
-                counter2.clone(),
-                render_count1.clone(),
-                render_count2.clone(),
+                show_counter,
+                counter1,
+                counter2,
+                render_count1,
+                render_count2,
             );
         }
     })
@@ -303,9 +296,8 @@ fn test_node_cleanup_on_view_switch() {
     let show_first = MutableState::with_runtime(true, runtime.clone());
 
     rule.set_content({
-        let show_first = show_first.clone();
         move || {
-            let show_first_inner = show_first.clone();
+            let show_first_inner = show_first;
             Column(
                 Modifier::empty().padding(20.0),
                 ColumnSpec::default(),
@@ -358,7 +350,7 @@ fn test_node_cleanup_on_view_switch() {
     for i in 0..5 {
         show_first.set(i % 2 == 0);
         rule.pump_until_idle()
-            .expect(&format!("recompose on switch {}", i));
+            .unwrap_or_else(|_| panic!("recompose on switch {}", i));
         let count = rule.applier_mut().len();
         let expected = if i % 2 == 0 { 4 } else { 3 };
         assert_eq!(
@@ -379,13 +371,10 @@ fn test_multiple_switches_with_state_changes() {
     let counter_b = MutableState::with_runtime(0, runtime.clone());
 
     rule.set_content({
-        let show_view_a = show_view_a.clone();
-        let counter_a = counter_a.clone();
-        let counter_b = counter_b.clone();
         move || {
-            let show_view_a_inner = show_view_a.clone();
-            let counter_a_inner = counter_a.clone();
-            let counter_b_inner = counter_b.clone();
+            let show_view_a_inner = show_view_a;
+            let counter_a_inner = counter_a;
+            let counter_b_inner = counter_b;
             Column(Modifier::empty(), ColumnSpec::default(), move || {
                 if show_view_a_inner.get() {
                     Text(
@@ -395,7 +384,7 @@ fn test_multiple_switches_with_state_changes() {
                     Button(
                         Modifier::empty(),
                         {
-                            let counter_a = counter_a_inner.clone();
+                            let counter_a = counter_a_inner;
                             move || counter_a.set(counter_a.get() + 1)
                         },
                         || {
@@ -410,7 +399,7 @@ fn test_multiple_switches_with_state_changes() {
                     Button(
                         Modifier::empty(),
                         {
-                            let counter_b = counter_b_inner.clone();
+                            let counter_b = counter_b_inner;
                             move || counter_b.set(counter_b.get() + 1)
                         },
                         || {
@@ -505,14 +494,12 @@ fn test_deeply_nested_conditional_switching() {
     let show_inner = MutableState::with_runtime(true, runtime.clone());
 
     rule.set_content({
-        let show_outer = show_outer.clone();
-        let show_inner = show_inner.clone();
         move || {
-            let show_outer_inner = show_outer.clone();
-            let show_inner_inner = show_inner.clone();
+            let show_outer_inner = show_outer;
+            let show_inner_inner = show_inner;
             Column(Modifier::empty(), ColumnSpec::default(), move || {
                 if show_outer_inner.get() {
-                    let show_inner_for_column = show_inner_inner.clone();
+                    let show_inner_for_column = show_inner_inner;
                     Column(Modifier::empty(), ColumnSpec::default(), move || {
                         if show_inner_for_column.get() {
                             Text("Outer A, Inner A", Modifier::empty());
@@ -564,9 +551,8 @@ fn test_switching_with_different_node_counts() {
     let view_type = MutableState::with_runtime(0, runtime.clone());
 
     rule.set_content({
-        let view_type = view_type.clone();
         move || {
-            let view_type_inner = view_type.clone();
+            let view_type_inner = view_type;
             Column(Modifier::empty(), ColumnSpec::default(), move || {
                 match view_type_inner.get() {
                     0 => {
@@ -641,34 +627,26 @@ fn test_conditional_with_complex_button_structure() {
     let counter = MutableState::with_runtime(0, runtime.clone());
 
     rule.set_content({
-        let show_first = show_first.clone();
-        let counter = counter.clone();
         move || {
-            let show_first_inner = show_first.clone();
-            let counter_inner = counter.clone();
+            let show_first_inner = show_first;
+            let counter_inner = counter;
             Column(Modifier::empty(), ColumnSpec::default(), move || {
                 if show_first_inner.get() {
                     // Complex structure with nested buttons
                     Column(Modifier::empty(), ColumnSpec::default(), {
-                        let counter = counter_inner.clone();
+                        let counter = counter_inner;
                         move || {
                             Text("First View", Modifier::empty());
                             Button(
                                 Modifier::empty(),
-                                {
-                                    let counter = counter.clone();
-                                    move || counter.set(counter.get() + 1)
-                                },
+                                move || counter.set(counter.get() + 1),
                                 || {
                                     Text("Button 1", Modifier::empty());
                                 },
                             );
                             Button(
                                 Modifier::empty(),
-                                {
-                                    let counter = counter.clone();
-                                    move || counter.set(counter.get() + 10)
-                                },
+                                move || counter.set(counter.get() + 10),
                                 || {
                                     Text("Button 2", Modifier::empty());
                                 },
@@ -681,7 +659,7 @@ fn test_conditional_with_complex_button_structure() {
                     Button(
                         Modifier::empty(),
                         {
-                            let counter = counter_inner.clone();
+                            let counter = counter_inner;
                             move || counter.set(counter.get() - 1)
                         },
                         || {
@@ -745,17 +723,16 @@ fn test_clicking_same_switch_button_twice_no_duplication() {
     let show_counter = MutableState::with_runtime(true, runtime.clone());
 
     rule.set_content({
-        let show_counter = show_counter.clone();
         move || {
-            let show_counter_copy = show_counter.clone();
-            let show_counter_for_button = show_counter.clone();
+            let show_counter_copy = show_counter;
+            let show_counter_for_button = show_counter;
             Column(Modifier::empty(), ColumnSpec::default(), move || {
                 // Row with switching buttons
                 Row(Modifier::empty(), RowSpec::default(), {
-                    let show_counter = show_counter_for_button.clone();
+                    let show_counter = show_counter_for_button;
                     move || {
-                        let show_counter_for_btn1 = show_counter.clone();
-                        let show_counter_for_btn2 = show_counter.clone();
+                        let show_counter_for_btn1 = show_counter;
+                        let show_counter_for_btn2 = show_counter;
 
                         Button(
                             Modifier::empty(),
@@ -918,7 +895,6 @@ fn test_composition_local_demo(
             Button(
                 Modifier::empty().padding(10.0),
                 {
-                    let counter = counter.clone();
                     move || {
                         counter.set(counter.get() + 1);
                     }
@@ -953,10 +929,9 @@ fn composition_local_increment_keeps_node_count_stable() {
     let local_holder = compositionLocalOf(|| 0);
 
     rule.set_content({
-        let counter = counter.clone();
         let local_holder = local_holder.clone();
         move || {
-            test_composition_local_demo(counter.clone(), local_holder.clone());
+            test_composition_local_demo(counter, local_holder.clone());
         }
     })
     .expect("initial render succeeds");
@@ -1025,9 +1000,8 @@ fn test_switching_between_composable_functions() {
     let show_a = MutableState::with_runtime(true, runtime.clone());
 
     rule.set_content({
-        let show_a = show_a.clone();
         move || {
-            let show_a_inner = show_a.clone();
+            let show_a_inner = show_a;
             Column(Modifier::empty(), ColumnSpec::default(), move || {
                 if show_a_inner.get() {
                     composable_view_a();
@@ -1083,7 +1057,7 @@ fn test_switching_between_composable_functions() {
     for i in 0..5 {
         show_a.set(i % 2 == 0);
         rule.pump_until_idle()
-            .expect(&format!("rapid switch {}", i));
+            .unwrap_or_else(|_| panic!("rapid switch {}", i));
         let count = rule.applier_mut().len();
         let expected = if i % 2 == 0 { 6 } else { 7 };
         assert_eq!(

--- a/crates/compose-ui/tests/pointer_hover_gradient_test.rs
+++ b/crates/compose-ui/tests/pointer_hover_gradient_test.rs
@@ -38,28 +38,24 @@ fn gradient_follows_state_app(pointer_position: MutableState<Point>) {
                 }
             }))
             .then(Modifier::empty().pointer_input((), {
-                let pointer_position = pointer_position.clone();
-                move |scope: PointerInputScope| {
-                    let pointer_position = pointer_position.clone();
-                    async move {
-                        scope
-                            .await_pointer_event_scope(|await_scope| async move {
-                                loop {
-                                    let event = await_scope.await_pointer_event().await;
-                                    if let PointerEventKind::Move = event.kind {
-                                        eprintln!(
-                                            "Pointer event: setting position to {:?}",
-                                            event.position
-                                        );
-                                        pointer_position.set(Point {
-                                            x: event.position.x,
-                                            y: event.position.y,
-                                        });
-                                    }
+                move |scope: PointerInputScope| async move {
+                    scope
+                        .await_pointer_event_scope(|await_scope| async move {
+                            loop {
+                                let event = await_scope.await_pointer_event().await;
+                                if let PointerEventKind::Move = event.kind {
+                                    eprintln!(
+                                        "Pointer event: setting position to {:?}",
+                                        event.position
+                                    );
+                                    pointer_position.set(Point {
+                                        x: event.position.x,
+                                        y: event.position.y,
+                                    });
                                 }
-                            })
-                            .await;
-                    }
+                            }
+                        })
+                        .await;
                 }
             })),
         ColumnSpec::default(),
@@ -81,9 +77,9 @@ fn test_manual_state_change_triggers_recomposition() {
 
     eprintln!("\n=== Initial composition ===");
     rule.set_content({
-        let pos = pointer_position.clone();
+        let pos = pointer_position;
         move || {
-            gradient_follows_state_app(pos.clone());
+            gradient_follows_state_app(pos);
         }
     })
     .expect("initial render succeeds");
@@ -117,7 +113,6 @@ fn working_gradient_app(pointer_position: MutableState<Point>) {
             })
             .then(Modifier::empty().draw_with_content({
                 // Clone the state handle, not the value
-                let pointer_position = pointer_position.clone();
                 move |scope| {
                     // Read state at draw time, not composition time
                     let position = pointer_position.get();
@@ -130,25 +125,21 @@ fn working_gradient_app(pointer_position: MutableState<Point>) {
                 }
             }))
             .then(Modifier::empty().pointer_input((), {
-                let pointer_position = pointer_position.clone();
-                move |scope: PointerInputScope| {
-                    let pointer_position = pointer_position.clone();
-                    async move {
-                        scope
-                            .await_pointer_event_scope(|await_scope| async move {
-                                loop {
-                                    let event = await_scope.await_pointer_event().await;
-                                    if let PointerEventKind::Move = event.kind {
-                                        eprintln!("Setting position to {:?}", event.position);
-                                        pointer_position.set(Point {
-                                            x: event.position.x,
-                                            y: event.position.y,
-                                        });
-                                    }
+                move |scope: PointerInputScope| async move {
+                    scope
+                        .await_pointer_event_scope(|await_scope| async move {
+                            loop {
+                                let event = await_scope.await_pointer_event().await;
+                                if let PointerEventKind::Move = event.kind {
+                                    eprintln!("Setting position to {:?}", event.position);
+                                    pointer_position.set(Point {
+                                        x: event.position.x,
+                                        y: event.position.y,
+                                    });
                                 }
-                            })
-                            .await;
-                    }
+                            }
+                        })
+                        .await;
                 }
             })),
         ColumnSpec::default(),
@@ -171,9 +162,9 @@ fn test_correct_pattern_reads_state_at_draw_time() {
 
     eprintln!("\n=== Initial composition (correct pattern) ===");
     rule.set_content({
-        let pos = pointer_position.clone();
+        let pos = pointer_position;
         move || {
-            working_gradient_app(pos.clone());
+            working_gradient_app(pos);
         }
     })
     .expect("initial render succeeds");

--- a/crates/compose-ui/tests/render_invalidation_test.rs
+++ b/crates/compose-ui/tests/render_invalidation_test.rs
@@ -33,9 +33,9 @@ fn test_render_invalidation_on_conditional_change() {
 
     eprintln!("=== Initial composition ===");
     rule.set_content({
-        let c = counter.clone();
+        let c = counter;
         move || {
-            conditional_text_app(c.clone());
+            conditional_text_app(c);
         }
     })
     .expect("initial render succeeds");


### PR DESCRIPTION
## Summary
- make `State` and `MutableState` handles `Copy` without requiring `T: Copy`
- update the desktop demo UI and tests to pass state handles by value instead of cloning
- simplify the Mineswapper grid rendering to work with copyable cells while keeping closures owning their display text

## Testing
- cargo fmt
- cargo clippy > 2.tmp 2>&1
- cargo test > 1.tmp 2>&1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a8d5074c8328a4a8433e1d2d2620)