### PR TITLE
Add tab demonstrating web data fetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -932,6 +933,18 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -946,9 +959,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -2182,7 +2199,9 @@ checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -64,7 +64,7 @@ dependencies = [
  "ndk-context",
  "ndk-sys",
  "num_enum",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -93,6 +93,12 @@ name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arrayref"
@@ -132,6 +138,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
@@ -228,7 +240,7 @@ dependencies = [
  "polling",
  "rustix 0.38.44",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -278,6 +290,12 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ciborium"
@@ -708,6 +726,7 @@ dependencies = [
 name = "desktop-app"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "compose-animation",
  "compose-app",
  "compose-core",
@@ -718,6 +737,7 @@ dependencies = [
  "compose-ui-graphics",
  "compose-ui-layout",
  "env_logger",
+ "reqwest",
 ]
 
 [[package]]
@@ -725,6 +745,17 @@ name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "dlib"
@@ -802,6 +833,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,10 +910,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+]
 
 [[package]]
 name = "gethostname"
@@ -890,14 +963,29 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.7+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -971,7 +1059,7 @@ checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
 dependencies = [
  "log",
  "presser",
- "thiserror",
+ "thiserror 1.0.69",
  "winapi",
  "windows",
 ]
@@ -1049,7 +1137,7 @@ dependencies = [
  "com",
  "libc",
  "libloading 0.8.9",
- "thiserror",
+ "thiserror 1.0.69",
  "widestring",
  "winapi",
 ]
@@ -1067,10 +1155,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec 1.15.1",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "icrate"
@@ -1084,6 +1274,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec 1.15.1",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec 1.15.1",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1383,22 @@ checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1130,7 +1438,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -1147,7 +1455,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -1234,6 +1542,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,6 +1570,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "malloc_buf"
@@ -1310,6 +1630,17 @@ name = "minimal-single-file"
 version = "0.1.0"
 
 [[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "naga"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,7 +1656,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "spirv",
  "termcolor",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-xid",
 ]
 
@@ -1341,7 +1672,7 @@ dependencies = [
  "ndk-sys",
  "num_enum",
  "raw-window-handle",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1512,6 +1843,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pixels"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,7 +1857,7 @@ dependencies = [
  "bytemuck",
  "pollster",
  "raw-window-handle",
- "thiserror",
+ "thiserror 1.0.69",
  "ultraviolet",
  "wgpu",
 ]
@@ -1580,6 +1917,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1975,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time 1.1.0",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time 1.1.0",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,6 +2043,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
 
 [[package]]
 name = "range-alloc"
@@ -1736,6 +2175,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "reqwest"
+version = "0.12.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,6 +2268,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+dependencies = [
+ "web-time 1.1.0",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1911,6 +2437,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,7 +2505,7 @@ dependencies = [
  "log",
  "memmap2 0.9.9",
  "rustix 0.38.44",
- "thiserror",
+ "thiserror 1.0.69",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -1988,6 +2526,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,6 +2543,12 @@ checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
  "bitflags 2.9.4",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -2007,6 +2561,12 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svg_fmt"
@@ -2048,6 +2608,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "sys-locale"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,7 +2651,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -2079,6 +2668,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2111,6 +2711,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,6 +2746,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,6 +2785,76 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.4",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
@@ -2246,6 +2950,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,6 +2988,21 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -2480,6 +3223,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "wgpu"
 version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,7 +3249,7 @@ checksum = "cbd7311dbd2abcfebaabf1841a2824ed7c8be443a0f29166e5d3c6a53a762c01"
 dependencies = [
  "arrayvec",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "js-sys",
  "log",
  "naga",
@@ -2513,7 +3275,7 @@ dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.9.4",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "codespan-reporting",
  "indexmap",
  "log",
@@ -2524,7 +3286,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec 1.15.1",
- "thiserror",
+ "thiserror 1.0.69",
  "web-sys",
  "wgpu-hal",
  "wgpu-types",
@@ -2542,7 +3304,7 @@ dependencies = [
  "bit-set",
  "bitflags 2.9.4",
  "block",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "core-graphics-types",
  "d3d12",
  "glow",
@@ -2568,7 +3330,7 @@ dependencies = [
  "renderdoc-sys",
  "rustc-hash 1.1.0",
  "smallvec 1.15.1",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -2678,11 +3440,29 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2733,11 +3513,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2759,6 +3556,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2775,6 +3578,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2795,10 +3604,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2819,6 +3640,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,6 +3662,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2855,6 +3688,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2873,6 +3712,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "winit"
 version = "0.29.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2884,7 +3729,7 @@ dependencies = [
  "bitflags 2.9.4",
  "bytemuck",
  "calloop",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "core-foundation",
  "core-graphics",
  "cursor-icon",
@@ -2913,7 +3758,7 @@ dependencies = [
  "wayland-protocols",
  "wayland-protocols-plasma",
  "web-sys",
- "web-time",
+ "web-time 0.2.4",
  "windows-sys 0.48.0",
  "x11-dl",
  "x11rb",
@@ -2934,6 +3779,12 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "x11-dl"
@@ -3005,6 +3856,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
 
 [[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "synstructure",
+]
+
+[[package]]
 name = "zeno"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,6 +3898,66 @@ name = "zerocopy-derive"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -19,7 +19,7 @@ compose-ui-graphics = { path = "../../crates/compose-ui-graphics" }
 compose-ui-layout = { path = "../../crates/compose-ui-layout" }
 env_logger = "0.10"
 anyhow = "1.0.100"
-reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 
 [dev-dependencies]
 compose-macros = { path = "../../crates/compose-macros" }

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -18,8 +18,8 @@ compose-ui = { path = "../../crates/compose-ui" }
 compose-ui-graphics = { path = "../../crates/compose-ui-graphics" }
 compose-ui-layout = { path = "../../crates/compose-ui-layout" }
 env_logger = "0.10"
-anyhow = "1.0.100"
-reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+anyhow = "1.0"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 
 [dev-dependencies]
 compose-macros = { path = "../../crates/compose-macros" }

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -18,6 +18,8 @@ compose-ui = { path = "../../crates/compose-ui" }
 compose-ui-graphics = { path = "../../crates/compose-ui-graphics" }
 compose-ui-layout = { path = "../../crates/compose-ui-layout" }
 env_logger = "0.10"
+anyhow = "1.0.100"
+reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 compose-macros = { path = "../../crates/compose-macros" }

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -1,4 +1,3 @@
-use anyhow::{anyhow, Context};
 use compose_animation::animateFloatAsState;
 use compose_core::{
     self, compositionLocalOf, CompositionLocal, CompositionLocalProvider, DisposableEffect,
@@ -13,6 +12,9 @@ use compose_ui::{
 use std::cell::RefCell;
 
 mod mineswapper2;
+mod web_fetch;
+
+use web_fetch::web_fetch_example;
 
 thread_local! {
     pub static TEST_COMPOSITION_LOCAL_COUNTER: RefCell<Option<MutableState<i32>>> = const { RefCell::new(None) };
@@ -77,14 +79,6 @@ impl Default for FrameStats {
             last_frame_ms: 0.0,
         }
     }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-enum FetchStatus {
-    Idle,
-    Loading,
-    Success(String),
-    Error(String),
 }
 
 fn local_holder() -> CompositionLocal<Holder> {
@@ -761,210 +755,6 @@ fn async_runtime_example() {
                         }
                     },
                 );
-            }
-        },
-    );
-}
-
-#[composable]
-fn web_fetch_example() {
-    let fetch_status = compose_core::useState(|| FetchStatus::Idle);
-    let request_counter = compose_core::useState(|| 0u64);
-
-    {
-        let status_state = fetch_status;
-        let request_state = request_counter;
-        let request_key = request_state.get();
-        LaunchedEffect!(request_key, move |scope| {
-            let status = status_state;
-            status.set(FetchStatus::Loading);
-
-            scope.launch_background(
-                move |token| {
-                    if token.is_cancelled() {
-                        return Err(anyhow!("request cancelled"));
-                    }
-
-                    let client = reqwest::blocking::Client::builder()
-                        .user_agent("compose-rs-desktop-demo/0.1")
-                        .build()
-                        .context("building HTTP client")?;
-
-                    let response = client
-                        .get("https://api.github.com/zen")
-                        .send()
-                        .context("sending request")?;
-
-                    let status = response.status();
-                    let body = response.text().context("reading response body")?;
-
-                    if status.is_success() {
-                        Ok(body.trim().to_string())
-                    } else {
-                        Err(anyhow!("Request failed with status {}: {}", status, body))
-                    }
-                },
-                move |fetch_result| match fetch_result {
-                    Ok(text) => status.set(FetchStatus::Success(text)),
-                    Err(error) => status.set(FetchStatus::Error(error.to_string())),
-                },
-            );
-        });
-    }
-
-    Column(
-        Modifier::empty()
-            .padding(32.0)
-            .background(Color(0.08, 0.12, 0.22, 1.0))
-            .rounded_corners(24.0)
-            .padding(20.0),
-        ColumnSpec::default(),
-        {
-            let status_state = fetch_status;
-            let request_state = request_counter;
-            move || {
-                Text(
-                    "Fetch data from the web",
-                    Modifier::empty()
-                        .padding(12.0)
-                        .background(Color(1.0, 1.0, 1.0, 0.08))
-                        .rounded_corners(16.0),
-                );
-
-                Spacer(Size {
-                    width: 0.0,
-                    height: 12.0,
-                });
-
-                Text(
-                    concat!(
-                        "This tab uses LaunchedEffect with a background worker to ",
-                        "request a short motto from api.github.com/zen. Each click ",
-                        "spawns a request and updates the UI when the response ",
-                        "arrives.",
-                    ),
-                    Modifier::empty()
-                        .padding(12.0)
-                        .background(Color(0.12, 0.16, 0.28, 0.7))
-                        .rounded_corners(14.0),
-                );
-
-                Spacer(Size {
-                    width: 0.0,
-                    height: 16.0,
-                });
-
-                Row(
-                    Modifier::empty().fill_max_width().padding(4.0),
-                    RowSpec::new()
-                        .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
-                        .vertical_alignment(VerticalAlignment::CenterVertically),
-                    {
-                        let status_for_button = status_state;
-                        let request_for_button = request_state;
-                        move || {
-                            Button(
-                                Modifier::empty()
-                                    .rounded_corners(14.0)
-                                    .draw_behind(|scope| {
-                                        scope.draw_round_rect(
-                                            Brush::linear_gradient(vec![
-                                                Color(0.22, 0.52, 0.92, 1.0),
-                                                Color(0.14, 0.42, 0.78, 1.0),
-                                            ]),
-                                            CornerRadii::uniform(14.0),
-                                        );
-                                    })
-                                    .padding(10.0),
-                                move || {
-                                    status_for_button.set(FetchStatus::Loading);
-                                    request_for_button.update(|tick| *tick = tick.wrapping_add(1));
-                                },
-                                || {
-                                    Text(
-                                        "Fetch motto",
-                                        Modifier::empty()
-                                            .padding(6.0)
-                                            .background(Color(1.0, 1.0, 1.0, 0.05))
-                                            .rounded_corners(10.0),
-                                    );
-                                },
-                            );
-                        }
-                    },
-                );
-
-                Spacer(Size {
-                    width: 0.0,
-                    height: 12.0,
-                });
-
-                let status_snapshot = status_state.get();
-                let (status_label, banner_color) = match &status_snapshot {
-                    FetchStatus::Idle => (
-                        "Click the button to start an HTTP request",
-                        Color(0.14, 0.24, 0.36, 0.8),
-                    ),
-                    FetchStatus::Loading => {
-                        ("Contacting api.github.com...", Color(0.20, 0.30, 0.48, 0.9))
-                    }
-                    FetchStatus::Success(_) => {
-                        ("Success: received response", Color(0.16, 0.42, 0.26, 0.85))
-                    }
-                    FetchStatus::Error(_) => ("Request failed", Color(0.45, 0.18, 0.18, 0.85)),
-                };
-
-                Text(
-                    status_label,
-                    Modifier::empty()
-                        .padding(10.0)
-                        .background(banner_color)
-                        .rounded_corners(12.0),
-                );
-
-                Spacer(Size {
-                    width: 0.0,
-                    height: 8.0,
-                });
-
-                match status_snapshot {
-                    FetchStatus::Idle => {
-                        Text(
-                            "No request has been made yet.",
-                            Modifier::empty()
-                                .padding(10.0)
-                                .background(Color(0.10, 0.16, 0.28, 0.7))
-                                .rounded_corners(12.0),
-                        );
-                    }
-                    FetchStatus::Loading => {
-                        Text(
-                            "Hang tight while the response arrives...",
-                            Modifier::empty()
-                                .padding(10.0)
-                                .background(Color(0.12, 0.18, 0.32, 0.9))
-                                .rounded_corners(12.0),
-                        );
-                    }
-                    FetchStatus::Success(message) => {
-                        Text(
-                            format!("\"{}\"", message),
-                            Modifier::empty()
-                                .padding(12.0)
-                                .background(Color(0.14, 0.34, 0.26, 0.9))
-                                .rounded_corners(14.0),
-                        );
-                    }
-                    FetchStatus::Error(error) => {
-                        Text(
-                            format!("Error: {}", error),
-                            Modifier::empty()
-                                .padding(12.0)
-                                .background(Color(0.40, 0.18, 0.18, 0.9))
-                                .rounded_corners(14.0),
-                        );
-                    }
-                }
             }
         },
     );

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Context};
 use compose_animation::animateFloatAsState;
 use compose_core::{
     self, compositionLocalOf, CompositionLocal, CompositionLocalProvider, DisposableEffect,
@@ -23,6 +24,7 @@ pub enum DemoTab {
     Counter,
     CompositionLocal,
     Async,
+    WebFetch,
     Layout,
     ModifierShowcase,
     Mineswapper2,
@@ -34,6 +36,7 @@ impl DemoTab {
             DemoTab::Counter => "Counter App",
             DemoTab::CompositionLocal => "CompositionLocal Test",
             DemoTab::Async => "Async Runtime",
+            DemoTab::WebFetch => "Web Fetch",
             DemoTab::Layout => "Recursive Layout",
             DemoTab::ModifierShowcase => "Modifiers Showcase",
             DemoTab::Mineswapper2 => "Mineswapper2",
@@ -74,6 +77,14 @@ impl Default for FrameStats {
             last_frame_ms: 0.0,
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum FetchStatus {
+    Idle,
+    Loading,
+    Success(String),
+    Error(String),
 }
 
 fn local_holder() -> CompositionLocal<Holder> {
@@ -156,6 +167,7 @@ pub fn combined_app() {
                     render_tab_button(DemoTab::Counter);
                     render_tab_button(DemoTab::CompositionLocal);
                     render_tab_button(DemoTab::Async);
+                    render_tab_button(DemoTab::WebFetch);
                     render_tab_button(DemoTab::Layout);
                     render_tab_button(DemoTab::ModifierShowcase);
                     render_tab_button(DemoTab::Mineswapper2);
@@ -172,6 +184,7 @@ pub fn combined_app() {
                 DemoTab::Counter => counter_app(),
                 DemoTab::CompositionLocal => composition_local_example(),
                 DemoTab::Async => async_runtime_example(),
+                DemoTab::WebFetch => web_fetch_example(),
                 DemoTab::Layout => recursive_layout_example(),
                 DemoTab::ModifierShowcase => modifier_showcase_tab(),
                 DemoTab::Mineswapper2 => mineswapper2::mineswapper2_tab(),
@@ -748,6 +761,207 @@ fn async_runtime_example() {
                         }
                     },
                 );
+            }
+        },
+    );
+}
+
+#[composable]
+fn web_fetch_example() {
+    let fetch_status = compose_core::useState(|| FetchStatus::Idle);
+    let request_counter = compose_core::useState(|| 0u64);
+
+    {
+        let status_state = fetch_status;
+        let request_state = request_counter;
+        let request_key = request_state.get();
+        LaunchedEffectAsync!(request_key, move |_scope| {
+            let status = status_state;
+            Box::pin(async move {
+                status.set(FetchStatus::Loading);
+                let fetch_result: Result<String, anyhow::Error> = async {
+                    let client = reqwest::Client::builder()
+                        .user_agent("compose-rs-desktop-demo/0.1")
+                        .build()
+                        .context("building HTTP client")?;
+
+                    let response = client
+                        .get("https://api.github.com/zen")
+                        .send()
+                        .await
+                        .context("sending request")?;
+
+                    let status = response.status();
+                    let body = response.text().await.context("reading response body")?;
+
+                    if status.is_success() {
+                        Ok(body.trim().to_string())
+                    } else {
+                        Err(anyhow!("Request failed with status {}: {}", status, body))
+                    }
+                }
+                .await;
+
+                match fetch_result {
+                    Ok(text) => status.set(FetchStatus::Success(text)),
+                    Err(error) => status.set(FetchStatus::Error(error.to_string())),
+                }
+            })
+        });
+    }
+
+    Column(
+        Modifier::empty()
+            .padding(32.0)
+            .background(Color(0.08, 0.12, 0.22, 1.0))
+            .rounded_corners(24.0)
+            .padding(20.0),
+        ColumnSpec::default(),
+        {
+            let status_state = fetch_status;
+            let request_state = request_counter;
+            move || {
+                Text(
+                    "Fetch data from the web",
+                    Modifier::empty()
+                        .padding(12.0)
+                        .background(Color(1.0, 1.0, 1.0, 0.08))
+                        .rounded_corners(16.0),
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 12.0,
+                });
+
+                Text(
+                    concat!(
+                        "This tab uses LaunchedEffectAsync to request a short motto ",
+                        "from api.github.com/zen. Each click spawns an async fetch ",
+                        "and updates the UI when the response arrives.",
+                    ),
+                    Modifier::empty()
+                        .padding(12.0)
+                        .background(Color(0.12, 0.16, 0.28, 0.7))
+                        .rounded_corners(14.0),
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 16.0,
+                });
+
+                Row(
+                    Modifier::empty().fill_max_width().padding(4.0),
+                    RowSpec::new()
+                        .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
+                        .vertical_alignment(VerticalAlignment::CenterVertically),
+                    {
+                        let status_for_button = status_state;
+                        let request_for_button = request_state;
+                        move || {
+                            Button(
+                                Modifier::empty()
+                                    .rounded_corners(14.0)
+                                    .draw_behind(|scope| {
+                                        scope.draw_round_rect(
+                                            Brush::linear_gradient(vec![
+                                                Color(0.22, 0.52, 0.92, 1.0),
+                                                Color(0.14, 0.42, 0.78, 1.0),
+                                            ]),
+                                            CornerRadii::uniform(14.0),
+                                        );
+                                    })
+                                    .padding(10.0),
+                                move || {
+                                    status_for_button.set(FetchStatus::Loading);
+                                    request_for_button.update(|tick| *tick = tick.wrapping_add(1));
+                                },
+                                || {
+                                    Text(
+                                        "Fetch motto",
+                                        Modifier::empty()
+                                            .padding(6.0)
+                                            .background(Color(1.0, 1.0, 1.0, 0.05))
+                                            .rounded_corners(10.0),
+                                    );
+                                },
+                            );
+                        }
+                    },
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 12.0,
+                });
+
+                let status_snapshot = status_state.get();
+                let (status_label, banner_color) = match &status_snapshot {
+                    FetchStatus::Idle => (
+                        "Click the button to start an HTTP request",
+                        Color(0.14, 0.24, 0.36, 0.8),
+                    ),
+                    FetchStatus::Loading => {
+                        ("Contacting api.github.com...", Color(0.20, 0.30, 0.48, 0.9))
+                    }
+                    FetchStatus::Success(_) => {
+                        ("Success: received response", Color(0.16, 0.42, 0.26, 0.85))
+                    }
+                    FetchStatus::Error(_) => ("Request failed", Color(0.45, 0.18, 0.18, 0.85)),
+                };
+
+                Text(
+                    status_label,
+                    Modifier::empty()
+                        .padding(10.0)
+                        .background(banner_color)
+                        .rounded_corners(12.0),
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 8.0,
+                });
+
+                match status_snapshot {
+                    FetchStatus::Idle => {
+                        Text(
+                            "No request has been made yet.",
+                            Modifier::empty()
+                                .padding(10.0)
+                                .background(Color(0.10, 0.16, 0.28, 0.7))
+                                .rounded_corners(12.0),
+                        );
+                    }
+                    FetchStatus::Loading => {
+                        Text(
+                            "Hang tight while the response arrives...",
+                            Modifier::empty()
+                                .padding(10.0)
+                                .background(Color(0.12, 0.18, 0.32, 0.9))
+                                .rounded_corners(12.0),
+                        );
+                    }
+                    FetchStatus::Success(message) => {
+                        Text(
+                            format!("\"{}\"", message),
+                            Modifier::empty()
+                                .padding(12.0)
+                                .background(Color(0.14, 0.34, 0.26, 0.9))
+                                .rounded_corners(14.0),
+                        );
+                    }
+                    FetchStatus::Error(error) => {
+                        Text(
+                            format!("Error: {}", error),
+                            Modifier::empty()
+                                .padding(12.0)
+                                .background(Color(0.40, 0.18, 0.18, 0.9))
+                                .rounded_corners(14.0),
+                        );
+                    }
+                }
             }
         },
     );

--- a/apps/desktop-demo/src/app/web_fetch.rs
+++ b/apps/desktop-demo/src/app/web_fetch.rs
@@ -1,0 +1,218 @@
+use anyhow::{anyhow, Context};
+use compose_core::LaunchedEffect;
+use compose_ui::{
+    composable, Brush, Button, Color, Column, ColumnSpec, CornerRadii, LinearArrangement, Modifier,
+    Row, RowSpec, Size, Spacer, Text, VerticalAlignment,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum FetchStatus {
+    Idle,
+    Loading,
+    Success(String),
+    Error(String),
+}
+
+#[composable]
+pub(crate) fn web_fetch_example() {
+    let fetch_status = compose_core::useState(|| FetchStatus::Idle);
+    let request_counter = compose_core::useState(|| 0u64);
+
+    {
+        let status_state = fetch_status;
+        let request_state = request_counter;
+        let request_key = request_state.get();
+        LaunchedEffect!(request_key, move |scope| {
+            let status = status_state;
+            status.set(FetchStatus::Loading);
+
+            scope.launch_background(
+                move |token| {
+                    if token.is_cancelled() {
+                        return Err(anyhow!("request cancelled"));
+                    }
+
+                    let client = reqwest::blocking::Client::builder()
+                        .user_agent("compose-rs-desktop-demo/0.1")
+                        .build()
+                        .context("building HTTP client")?;
+
+                    let response = client
+                        .get("https://api.github.com/zen")
+                        .send()
+                        .context("sending request")?;
+
+                    let status = response.status();
+                    let body = response.text().context("reading response body")?;
+
+                    if status.is_success() {
+                        Ok(body.trim().to_string())
+                    } else {
+                        Err(anyhow!("Request failed with status {}: {}", status, body))
+                    }
+                },
+                move |fetch_result| match fetch_result {
+                    Ok(text) => status.set(FetchStatus::Success(text)),
+                    Err(error) => status.set(FetchStatus::Error(error.to_string())),
+                },
+            );
+        });
+    }
+
+    Column(
+        Modifier::empty()
+            .padding(32.0)
+            .background(Color(0.08, 0.12, 0.22, 1.0))
+            .rounded_corners(24.0)
+            .padding(20.0),
+        ColumnSpec::default(),
+        {
+            let status_state = fetch_status;
+            let request_state = request_counter;
+            move || {
+                Text(
+                    "Fetch data from the web",
+                    Modifier::empty()
+                        .padding(12.0)
+                        .background(Color(1.0, 1.0, 1.0, 0.08))
+                        .rounded_corners(16.0),
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 12.0,
+                });
+
+                Text(
+                    concat!(
+                        "This tab uses LaunchedEffect with a background worker to ",
+                        "request a short motto from api.github.com/zen. Each click ",
+                        "spawns a request and updates the UI when the response ",
+                        "arrives.",
+                    ),
+                    Modifier::empty()
+                        .padding(12.0)
+                        .background(Color(0.12, 0.16, 0.28, 0.7))
+                        .rounded_corners(14.0),
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 16.0,
+                });
+
+                Row(
+                    Modifier::empty().fill_max_width().padding(4.0),
+                    RowSpec::new()
+                        .horizontal_arrangement(LinearArrangement::SpacedBy(12.0))
+                        .vertical_alignment(VerticalAlignment::CenterVertically),
+                    {
+                        let status_for_button = status_state;
+                        let request_for_button = request_state;
+                        move || {
+                            Button(
+                                Modifier::empty()
+                                    .rounded_corners(14.0)
+                                    .draw_behind(|scope| {
+                                        scope.draw_round_rect(
+                                            Brush::linear_gradient(vec![
+                                                Color(0.22, 0.52, 0.92, 1.0),
+                                                Color(0.14, 0.42, 0.78, 1.0),
+                                            ]),
+                                            CornerRadii::uniform(14.0),
+                                        );
+                                    })
+                                    .padding(10.0),
+                                move || {
+                                    status_for_button.set(FetchStatus::Loading);
+                                    request_for_button.update(|tick| *tick = tick.wrapping_add(1));
+                                },
+                                || {
+                                    Text(
+                                        "Fetch motto",
+                                        Modifier::empty()
+                                            .padding(6.0)
+                                            .background(Color(1.0, 1.0, 1.0, 0.05))
+                                            .rounded_corners(10.0),
+                                    );
+                                },
+                            );
+                        }
+                    },
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 12.0,
+                });
+
+                let status_snapshot = status_state.get();
+                let (status_label, banner_color) = match &status_snapshot {
+                    FetchStatus::Idle => (
+                        "Click the button to start an HTTP request",
+                        Color(0.14, 0.24, 0.36, 0.8),
+                    ),
+                    FetchStatus::Loading => {
+                        ("Contacting api.github.com...", Color(0.20, 0.30, 0.48, 0.9))
+                    }
+                    FetchStatus::Success(_) => {
+                        ("Success: received response", Color(0.16, 0.42, 0.26, 0.85))
+                    }
+                    FetchStatus::Error(_) => ("Request failed", Color(0.45, 0.18, 0.18, 0.85)),
+                };
+
+                Text(
+                    status_label,
+                    Modifier::empty()
+                        .padding(10.0)
+                        .background(banner_color)
+                        .rounded_corners(12.0),
+                );
+
+                Spacer(Size {
+                    width: 0.0,
+                    height: 8.0,
+                });
+
+                match status_snapshot {
+                    FetchStatus::Idle => {
+                        Text(
+                            "No request has been made yet.",
+                            Modifier::empty()
+                                .padding(10.0)
+                                .background(Color(0.10, 0.16, 0.28, 0.7))
+                                .rounded_corners(12.0),
+                        );
+                    }
+                    FetchStatus::Loading => {
+                        Text(
+                            "Hang tight while the response arrives...",
+                            Modifier::empty()
+                                .padding(10.0)
+                                .background(Color(0.12, 0.18, 0.32, 0.9))
+                                .rounded_corners(12.0),
+                        );
+                    }
+                    FetchStatus::Success(message) => {
+                        Text(
+                            format!("\"{}\"", message),
+                            Modifier::empty()
+                                .padding(12.0)
+                                .background(Color(0.14, 0.34, 0.26, 0.9))
+                                .rounded_corners(14.0),
+                        );
+                    }
+                    FetchStatus::Error(error) => {
+                        Text(
+                            format!("Error: {}", error),
+                            Modifier::empty()
+                                .padding(12.0)
+                                .background(Color(0.40, 0.18, 0.18, 0.9))
+                                .rounded_corners(14.0),
+                        );
+                    }
+                }
+            }
+        },
+    );
+}

--- a/apps/desktop-demo/src/app/web_fetch.rs
+++ b/apps/desktop-demo/src/app/web_fetch.rs
@@ -20,9 +20,12 @@ pub(crate) fn web_fetch_example() {
 
     {
         let status_state = fetch_status;
-        let request_state = request_counter;
-        let request_key = request_state.get();
+        let request_key = request_counter.get();
         LaunchedEffect!(request_key, move |scope| {
+            if request_key == 0 {
+                return;
+            }
+
             let status = status_state;
             status.set(FetchStatus::Loading);
 


### PR DESCRIPTION
## Summary
- add a Web Fetch tab that requests data from api.github.com/zen using LaunchedEffectAsync
- track fetch status with new UI messaging and styling in the desktop demo
- add anyhow and reqwest (rustls) dependencies for HTTP requests

## Testing
- cargo fmt
- cargo test -p desktop-app
- cargo clippy -p desktop-app -- -D warnings


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921a1f96ca88328afc7548b86fa7827)