### PR TITLE
Add web platform support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,10 +435,14 @@ dependencies = [
  "compose-platform-desktop-winit",
  "compose-render-pixels",
  "compose-render-wgpu",
+ "console_error_panic_hook",
+ "console_log",
  "log",
  "pixels",
  "pollster",
  "raw-window-handle",
+ "wasm-bindgen",
+ "web-sys",
  "wgpu",
  "winit",
 ]
@@ -606,6 +610,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "web-sys",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,8 +787,12 @@ dependencies = [
  "compose-macros",
  "compose-testing",
  "compose-ui",
+ "console_error_panic_hook",
+ "console_log",
  "env_logger",
+ "log",
  "reqwest",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2080,7 +2108,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -21,6 +21,7 @@ default = ["renderer-wgpu", "desktop"]
 renderer-pixels = ["compose-app/renderer-pixels"]
 renderer-wgpu = ["compose-app/renderer-wgpu"]
 desktop = ["compose-app/desktop"]
+web = ["compose-app/web"]
 android = ["compose-app/android"]
 
 [dependencies]
@@ -32,10 +33,16 @@ compose-foundation = { path = "../../crates/compose-foundation" }
 env_logger = "0.10"
 anyhow = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+log = "0.4"
 
 # Android-specific dependencies (only when building for Android)
 [target.'cfg(target_os = "android")'.dependencies]
 android-activity = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+console_error_panic_hook = "0.1"
+console_log = "1.0"
 
 [dev-dependencies]
 compose-macros = { path = "../../crates/compose-macros" }

--- a/apps/desktop-demo/src/lib.rs
+++ b/apps/desktop-demo/src/lib.rs
@@ -3,6 +3,8 @@ pub mod fonts;
 
 use crate::fonts::DEMO_FONTS;
 use compose_app::AppLauncher;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
 
 fn create_app() -> AppLauncher {
     AppLauncher::new()
@@ -23,4 +25,11 @@ pub fn entry_point() {
 #[no_mangle]
 pub fn android_main(app: android_activity::AndroidApp) {
     create_app().run(app, app::combined_app);
+}
+
+/// Web entry point
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
+#[cfg(target_arch = "wasm32")]
+pub fn wasm_entry_point() {
+    create_app().run(app::combined_app);
 }

--- a/crates/compose-app/Cargo.toml
+++ b/crates/compose-app/Cargo.toml
@@ -6,6 +6,14 @@ edition = "2021"
 [features]
 default = ["desktop", "renderer-wgpu"]
 desktop = ["compose-platform-desktop-winit", "dep:winit"]
+web = [
+    "compose-platform-desktop-winit",
+    "dep:winit",
+    "dep:wasm-bindgen",
+    "dep:web-sys",
+    "dep:console_error_panic_hook",
+    "dep:console_log",
+]
 android = ["compose-platform-android", "dep:android-activity", "dep:android_logger", "dep:raw-window-handle"]
 renderer-pixels = ["compose-render-pixels", "dep:pixels"]
 renderer-wgpu = ["compose-render-wgpu", "dep:wgpu", "dep:pollster"]
@@ -24,3 +32,7 @@ android-activity = { workspace = true, optional = true }
 android_logger = { version = "0.14", optional = true }
 raw-window-handle = { version = "0.6", optional = true }
 log = "0.4"
+console_error_panic_hook = { version = "0.1", optional = true }
+console_log = { version = "1.0", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
+web-sys = { version = "0.3", optional = true, features = ["Document", "Window", "HtmlCanvasElement", "Element", "CssStyleDeclaration"] }

--- a/crates/compose-app/src/android.rs
+++ b/crates/compose-app/src/android.rs
@@ -188,13 +188,13 @@ pub fn run(
                             // Create surface using raw window handle from NativeWindow
                             let surface = unsafe {
                                 use raw_window_handle::{
-                                    AndroidNdkWindowHandle, RawWindowHandle, RawDisplayHandle,
-                                    AndroidDisplayHandle,
+                                    AndroidDisplayHandle, AndroidNdkWindowHandle, RawDisplayHandle,
+                                    RawWindowHandle,
                                 };
 
                                 let mut window_handle = AndroidNdkWindowHandle::new(
                                     std::ptr::NonNull::new(native_window.ptr().as_ptr() as *mut _)
-                                        .expect("NativeWindow pointer is null")
+                                        .expect("NativeWindow pointer is null"),
                                 );
                                 let raw_window_handle = RawWindowHandle::AndroidNdk(window_handle);
 

--- a/crates/compose-app/src/launcher.rs
+++ b/crates/compose-app/src/launcher.rs
@@ -123,6 +123,12 @@ impl AppLauncher {
     pub fn run(self, app: android_activity::AndroidApp, content: impl FnMut() + 'static) {
         crate::android::run(app, self.settings, content)
     }
+
+    /// Run the application (web platform).
+    #[cfg(all(feature = "web", feature = "renderer-wgpu", target_arch = "wasm32"))]
+    pub fn run(self, content: impl FnMut() + 'static) -> ! {
+        crate::web::run(self.settings, content)
+    }
 }
 
 impl Default for AppLauncher {

--- a/crates/compose-app/src/lib.rs
+++ b/crates/compose-app/src/lib.rs
@@ -2,8 +2,10 @@
 
 //! High level utilities for running Compose applications with minimal boilerplate.
 
-#[cfg(not(any(feature = "desktop", feature = "android")))]
-compile_error!("compose-app must be built with at least one of `desktop` or `android` features.");
+#[cfg(not(any(feature = "desktop", feature = "android", feature = "web")))]
+compile_error!(
+    "compose-app must be built with at least one of `desktop`, `android`, or `web` features."
+);
 
 #[cfg(not(any(feature = "renderer-pixels", feature = "renderer-wgpu")))]
 compile_error!("compose-app requires either `renderer-pixels` or `renderer-wgpu` feature.");
@@ -17,3 +19,6 @@ pub mod android;
 
 #[cfg(all(feature = "desktop", feature = "renderer-wgpu"))]
 pub mod desktop;
+
+#[cfg(all(feature = "web", feature = "renderer-wgpu"))]
+pub mod web;

--- a/crates/compose-app/src/web.rs
+++ b/crates/compose-app/src/web.rs
@@ -1,0 +1,245 @@
+//! Web runtime for Compose applications.
+//!
+//! Provides a WASM-targeted event loop using `winit` and `wgpu`.
+
+use crate::launcher::AppSettings;
+use compose_app_shell::{default_root_key, AppShell};
+use compose_platform_desktop_winit::DesktopWinitPlatform;
+use compose_render_wgpu::WgpuRenderer;
+use std::sync::Arc;
+use wasm_bindgen::JsCast;
+use winit::dpi::LogicalSize;
+use winit::event::{ElementState, Event, MouseButton, WindowEvent};
+use winit::event_loop::{ControlFlow, EventLoopBuilder};
+use winit::platform::web::{EventLoopExtWebSys, WindowExtWebSys};
+use winit::window::WindowBuilder;
+
+fn attach_canvas_to_document(window: &winit::window::Window) {
+    let canvas = window
+        .canvas()
+        .expect("winit window should provide a canvas on web");
+    let document = web_sys::window()
+        .and_then(|w| w.document())
+        .expect("expected document");
+    let body = document.body().expect("expected body element");
+
+    // Ensure the canvas fills the available viewport by clearing inline sizing first.
+    if let Some(style) = canvas.dyn_ref::<web_sys::HtmlElement>() {
+        style.style().remove_property("width").ok();
+        style.style().remove_property("height").ok();
+        style
+            .style()
+            .set_property("display", "block")
+            .expect("failed to update canvas style");
+    }
+
+    let _ = body.append_child(&canvas);
+}
+
+/// Runs a web Compose application with wgpu rendering.
+#[allow(clippy::too_many_lines)]
+pub fn run(settings: AppSettings, mut content: impl FnMut() + 'static) -> ! {
+    console_error_panic_hook::set_once();
+    console_log::init_with_level(log::Level::Debug).expect("failed to initialize console logging");
+
+    let event_loop = EventLoopBuilder::new().build();
+
+    let initial_width = settings.initial_width;
+    let initial_height = settings.initial_height;
+
+    let window = Arc::new(
+        WindowBuilder::new()
+            .with_title(settings.window_title)
+            .with_inner_size(LogicalSize::new(
+                initial_width as f64,
+                initial_height as f64,
+            ))
+            .build(&event_loop)
+            .expect("failed to create window"),
+    );
+
+    attach_canvas_to_document(&window);
+
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::BROWSER_WEBGPU,
+        ..Default::default()
+    });
+
+    let surface = instance
+        .create_surface(window.clone())
+        .expect("failed to create surface");
+
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        compatible_surface: Some(&surface),
+        force_fallback_adapter: false,
+    }))
+    .expect("failed to find suitable adapter");
+
+    let (device, queue) = pollster::block_on(adapter.request_device(
+        &wgpu::DeviceDescriptor {
+            label: Some("Main Device"),
+            required_features: wgpu::Features::empty(),
+            required_limits:
+                wgpu::Limits::downlevel_webgl2_defaults().using_resolution(adapter.limits()),
+        },
+        None,
+    ))
+    .expect("failed to create device");
+
+    let size = window.inner_size();
+    let surface_caps = surface.get_capabilities(&adapter);
+    let surface_format = surface_caps
+        .formats
+        .iter()
+        .copied()
+        .find(|f| f.is_srgb())
+        .unwrap_or(surface_caps.formats[0]);
+
+    let mut surface_config = wgpu::SurfaceConfiguration {
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        format: surface_format,
+        width: size.width.max(1),
+        height: size.height.max(1),
+        present_mode: wgpu::PresentMode::Fifo,
+        alpha_mode: surface_caps.alpha_modes[0],
+        view_formats: vec![],
+        desired_maximum_frame_latency: 1,
+    };
+
+    surface.configure(&device, &surface_config);
+
+    let mut renderer = if let Some(fonts) = settings.fonts {
+        WgpuRenderer::new_with_fonts(fonts)
+    } else {
+        WgpuRenderer::new()
+    };
+    renderer.init_gpu(Arc::new(device), Arc::new(queue), surface_format);
+    let initial_scale = window.scale_factor();
+    renderer.set_root_scale(initial_scale as f32);
+
+    let mut app = AppShell::new(renderer, default_root_key(), content);
+    let mut platform = DesktopWinitPlatform::default();
+    platform.set_scale_factor(initial_scale);
+
+    let redraw_window = window.clone();
+    app.set_frame_waker(move || {
+        redraw_window.request_redraw();
+    });
+
+    app.set_buffer_size(surface_config.width, surface_config.height);
+    let logical_width = surface_config.width as f32 / initial_scale as f32;
+    let logical_height = surface_config.height as f32 / initial_scale as f32;
+    app.set_viewport(logical_width, logical_height);
+
+    window.request_redraw();
+
+    let spawn_result = event_loop.spawn(move |event_loop| {
+        event_loop.set_control_flow(ControlFlow::Poll);
+        event_loop.run(move |event, elwt| match event {
+            Event::WindowEvent { window_id, event } if window_id == window.id() => match event {
+                WindowEvent::CloseRequested => {
+                    elwt.exit();
+                }
+                WindowEvent::Resized(new_size) => {
+                    if new_size.width > 0 && new_size.height > 0 {
+                        surface_config.width = new_size.width;
+                        surface_config.height = new_size.height;
+                        let device = app.renderer().device();
+                        surface.configure(device, &surface_config);
+
+                        let scale_factor = window.scale_factor();
+                        let logical_width = new_size.width as f32 / scale_factor as f32;
+                        let logical_height = new_size.height as f32 / scale_factor as f32;
+
+                        app.set_buffer_size(new_size.width, new_size.height);
+                        app.set_viewport(logical_width, logical_height);
+                    }
+                }
+                WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                    platform.set_scale_factor(scale_factor);
+                    app.renderer().set_root_scale(scale_factor as f32);
+
+                    let new_size = window.inner_size();
+                    if new_size.width > 0 && new_size.height > 0 {
+                        surface_config.width = new_size.width;
+                        surface_config.height = new_size.height;
+                        let device = app.renderer().device();
+                        surface.configure(device, &surface_config);
+
+                        let logical_width = new_size.width as f32 / scale_factor as f32;
+                        let logical_height = new_size.height as f32 / scale_factor as f32;
+
+                        app.set_buffer_size(new_size.width, new_size.height);
+                        app.set_viewport(logical_width, logical_height);
+                    }
+                }
+                WindowEvent::CursorMoved { position, .. } => {
+                    let logical = platform.pointer_position(position);
+                    app.set_cursor(logical.x, logical.y);
+                }
+                WindowEvent::MouseInput {
+                    state,
+                    button: MouseButton::Left,
+                    ..
+                } => match state {
+                    ElementState::Pressed => {
+                        app.pointer_pressed();
+                    }
+                    ElementState::Released => {
+                        app.pointer_released();
+                    }
+                },
+                WindowEvent::RedrawRequested => {
+                    app.update();
+
+                    let output = match surface.get_current_texture() {
+                        Ok(output) => output,
+                        Err(wgpu::SurfaceError::Lost) | Err(wgpu::SurfaceError::Outdated) => {
+                            let size = window.inner_size();
+                            if size.width > 0 && size.height > 0 {
+                                surface_config.width = size.width;
+                                surface_config.height = size.height;
+                                let device = app.renderer().device();
+                                surface.configure(device, &surface_config);
+                            }
+                            return;
+                        }
+                        Err(wgpu::SurfaceError::OutOfMemory) => {
+                            log::error!("Out of memory, exiting");
+                            elwt.exit();
+                            return;
+                        }
+                        Err(wgpu::SurfaceError::Timeout) => {
+                            log::warn!("Surface timeout, skipping frame");
+                            return;
+                        }
+                    };
+
+                    let view = output
+                        .texture
+                        .create_view(&wgpu::TextureViewDescriptor::default());
+                    if let Err(err) = app.renderer().render(&view) {
+                        log::error!("render failed: {err}");
+                    }
+                    output.present();
+                }
+                _ => {}
+            },
+            Event::AboutToWait => {
+                if app.needs_redraw() {
+                    window.request_redraw();
+                }
+            }
+            Event::UserEvent(()) => {
+                window.request_redraw();
+            }
+            _ => {}
+        });
+    });
+
+    match spawn_result {
+        Ok(()) => unreachable!("event loop exited unexpectedly"),
+        Err(error) => panic!("failed to start web event loop: {error:?}"),
+    }
+}


### PR DESCRIPTION
## Summary
- add a `web` feature to compose-app with wasm/web-sys logging dependencies and update the desktop demo to opt in
- implement a winit/wgpu-based web runtime and wasm entry point so apps can launch in browsers
- keep existing android/desktop launchers while reusing the common platform support

## Testing
- cargo test > 1.tmp 2>&1
- cargo clippy > 2.tmp 2>&1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692aa2921ce4832884dfa336eebb8bd6)