### PR TITLE
Add robot testing harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,10 +561,13 @@ dependencies = [
 name = "compose-testing"
 version = "0.1.0"
 dependencies = [
+ "compose-app-shell",
  "compose-core",
  "compose-foundation",
  "compose-macros",
+ "compose-render-pixels",
  "compose-ui",
+ "compose-ui-graphics",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,8 +566,12 @@ dependencies = [
  "compose-foundation",
  "compose-macros",
  "compose-render-pixels",
+ "compose-render-wgpu",
  "compose-ui",
  "compose-ui-graphics",
+ "pollster",
+ "thiserror 1.0.69",
+ "wgpu",
 ]
 
 [[package]]
@@ -2083,7 +2087,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,10 +435,12 @@ dependencies = [
  "compose-platform-desktop-winit",
  "compose-render-pixels",
  "compose-render-wgpu",
+ "compose-ui-graphics",
  "log",
  "pixels",
  "pollster",
  "raw-window-handle",
+ "thiserror 1.0.69",
  "wgpu",
  "winit",
 ]
@@ -561,6 +563,7 @@ dependencies = [
 name = "compose-testing"
 version = "0.1.0"
 dependencies = [
+ "compose-app",
  "compose-app-shell",
  "compose-core",
  "compose-foundation",

--- a/apps/desktop-demo/tests/robot_combined_app_tests.rs
+++ b/apps/desktop-demo/tests/robot_combined_app_tests.rs
@@ -1,0 +1,47 @@
+use compose_testing::robot::{rect_center, RobotApp};
+use desktop_app::app::combined_app;
+
+#[test]
+fn robot_can_wrap_real_app_and_drive_counter() {
+    let mut robot = RobotApp::launch(|| {
+        combined_app();
+    });
+
+    robot.set_viewport(1024.0, 768.0);
+    robot.pump_until_idle(20);
+
+    let snapshot = robot.snapshot();
+    assert!(
+        snapshot
+            .text_values()
+            .any(|text| text.contains("Counter: 0")),
+        "counter tab should start at zero",
+    );
+
+    let increment_rect = snapshot
+        .text_rects("Increment")
+        .first()
+        .cloned()
+        .expect("increment button text should be visible");
+    let (x, y) = rect_center(&increment_rect);
+
+    assert!(
+        robot.move_pointer(x, y),
+        "pointer should land on increment button"
+    );
+    assert!(
+        robot.click(x, y),
+        "click should dispatch to increment button"
+    );
+
+    robot.pump_until_idle(20);
+    let updated = robot.snapshot();
+    assert!(
+        updated
+            .text_values()
+            .any(|text| text.contains("Counter: 1")),
+        "counter text should update after click",
+    );
+
+    robot.close();
+}

--- a/crates/compose-app/Cargo.toml
+++ b/crates/compose-app/Cargo.toml
@@ -16,6 +16,7 @@ compose-platform-desktop-winit = { path = "../compose-platform/desktop-winit", o
 compose-platform-android = { path = "../compose-platform/android", optional = true }
 compose-render-pixels = { path = "../compose-render/pixels", optional = true }
 compose-render-wgpu = { path = "../compose-render/wgpu", optional = true }
+compose-ui-graphics = { path = "../compose-ui-graphics" }
 pixels = { version = "0.15", optional = true }
 wgpu = { version = "0.19", optional = true }
 pollster = { version = "0.3", optional = true }
@@ -24,3 +25,4 @@ android-activity = { workspace = true, optional = true }
 android_logger = { version = "0.14", optional = true }
 raw-window-handle = { version = "0.6", optional = true }
 log = "0.4"
+thiserror = "1"

--- a/crates/compose-app/src/android.rs
+++ b/crates/compose-app/src/android.rs
@@ -188,13 +188,13 @@ pub fn run(
                             // Create surface using raw window handle from NativeWindow
                             let surface = unsafe {
                                 use raw_window_handle::{
-                                    AndroidNdkWindowHandle, RawWindowHandle, RawDisplayHandle,
-                                    AndroidDisplayHandle,
+                                    AndroidDisplayHandle, AndroidNdkWindowHandle, RawDisplayHandle,
+                                    RawWindowHandle,
                                 };
 
                                 let mut window_handle = AndroidNdkWindowHandle::new(
                                     std::ptr::NonNull::new(native_window.ptr().as_ptr() as *mut _)
-                                        .expect("NativeWindow pointer is null")
+                                        .expect("NativeWindow pointer is null"),
                                 );
                                 let raw_window_handle = RawWindowHandle::AndroidNdk(window_handle);
 

--- a/crates/compose-app/src/desktop.rs
+++ b/crates/compose-app/src/desktop.rs
@@ -5,11 +5,15 @@
 use crate::launcher::AppSettings;
 use compose_app_shell::{default_root_key, AppShell};
 use compose_platform_desktop_winit::DesktopWinitPlatform;
-use compose_render_wgpu::WgpuRenderer;
-use std::sync::Arc;
-use winit::dpi::LogicalSize;
+use compose_render_wgpu::{DrawShape, TextDraw, WgpuRenderer};
+use compose_ui_graphics::{Rect, RoundedCornerShape};
+use std::sync::{mpsc, Arc};
+use std::thread;
+use thiserror::Error;
+use winit::dpi::{LogicalSize, PhysicalSize};
+use winit::error::EventLoopError;
 use winit::event::{ElementState, Event, MouseButton, WindowEvent};
-use winit::event_loop::{ControlFlow, EventLoopBuilder};
+use winit::event_loop::{ControlFlow, EventLoopBuilder, EventLoopProxy};
 use winit::window::WindowBuilder;
 
 /// Runs a desktop Compose application with wgpu rendering.
@@ -237,4 +241,681 @@ pub fn run(settings: AppSettings, content: impl FnMut() + 'static) -> ! {
     });
 
     std::process::exit(0)
+}
+
+/// Resulting handle for a robot-controlled desktop application running with the
+/// real renderer, event loop, and surface.
+pub struct DesktopRobotApp {
+    proxy: EventLoopProxy<RobotCommand>,
+    join_handle: Option<thread::JoinHandle<()>>,
+}
+
+impl DesktopRobotApp {
+    /// Move the virtual pointer to the provided logical coordinates.
+    pub fn move_pointer(&self, x: f32, y: f32) -> Result<bool, DesktopRobotError> {
+        self.send_command(|respond_to| RobotCommand::MovePointer { x, y, respond_to })
+    }
+
+    /// Press the virtual pointer at the provided logical coordinates.
+    pub fn press(&self, x: f32, y: f32) -> Result<bool, DesktopRobotError> {
+        self.send_command(|respond_to| RobotCommand::Press { x, y, respond_to })
+    }
+
+    /// Release the virtual pointer at the provided logical coordinates.
+    pub fn release(&self, x: f32, y: f32) -> Result<bool, DesktopRobotError> {
+        self.send_command(|respond_to| RobotCommand::Release { x, y, respond_to })
+    }
+
+    /// Click (press + release) at the provided logical coordinates.
+    pub fn click(&self, x: f32, y: f32) -> Result<bool, DesktopRobotError> {
+        self.send_command(|respond_to| RobotCommand::Click { x, y, respond_to })
+    }
+
+    /// Resize the viewport to the provided logical size.
+    pub fn set_viewport(&self, width: f32, height: f32) -> Result<(), DesktopRobotError> {
+        self.send_command(|respond_to| RobotCommand::SetViewport {
+            width,
+            height,
+            respond_to,
+        })
+    }
+
+    /// Drive the app until it no longer requests redraws or the iteration limit is reached.
+    pub fn pump_until_idle(&self, max_iterations: usize) -> Result<(), DesktopRobotError> {
+        self.send_command(|respond_to| RobotCommand::PumpUntilIdle {
+            max_iterations,
+            respond_to,
+        })
+    }
+
+    /// Snapshot the current render scene (texts, shapes, and hit regions).
+    pub fn snapshot(&self) -> Result<RobotSceneSnapshot, DesktopRobotError> {
+        self.send_command(RobotCommand::Snapshot)
+    }
+
+    /// Capture the latest rendered frame into RGBA bytes.
+    pub fn capture_frame(&self) -> Result<RobotFrameCapture, DesktopRobotError> {
+        self.send_command(RobotCommand::CaptureFrame)?
+    }
+
+    /// Shut down the application and block until the event loop exits.
+    pub fn close(mut self) -> Result<(), DesktopRobotError> {
+        let _ = self.send_command(|respond_to| RobotCommand::Close { respond_to });
+        if let Some(handle) = self.join_handle.take() {
+            handle.join().map_err(|_| DesktopRobotError::Join)?;
+        }
+        Ok(())
+    }
+
+    fn send_command<R: Send + 'static>(
+        &self,
+        build: impl FnOnce(mpsc::Sender<R>) -> RobotCommand,
+    ) -> Result<R, DesktopRobotError> {
+        let (tx, rx) = mpsc::channel();
+        self.proxy
+            .send_event(build(tx))
+            .map_err(|_| DesktopRobotError::EventLoopClosed)?;
+        rx.recv().map_err(|_| DesktopRobotError::EventLoopClosed)
+    }
+}
+
+impl Drop for DesktopRobotApp {
+    fn drop(&mut self) {
+        if let Some(handle) = self.join_handle.take() {
+            let (tx, _rx) = mpsc::channel();
+            let _ = self
+                .proxy
+                .send_event(RobotCommand::Close { respond_to: tx });
+            let _ = handle.join();
+        }
+    }
+}
+
+/// In-memory screenshot of a rendered frame.
+#[derive(Clone, Debug)]
+pub struct RobotFrameCapture {
+    /// Render width in physical pixels.
+    pub width: u32,
+    /// Render height in physical pixels.
+    pub height: u32,
+    /// RGBA pixel data.
+    pub pixels: Vec<u8>,
+}
+
+/// Simplified snapshot of the render scene suitable for assertions.
+#[derive(Clone)]
+pub struct RobotSceneSnapshot {
+    /// Visible texts in the scene.
+    pub texts: Vec<TextDraw>,
+    /// Drawn shapes in the scene.
+    pub shapes: Vec<DrawShape>,
+    /// Hit regions without closures.
+    pub hits: Vec<RobotHitRegion>,
+}
+
+/// Hit region stripped of callbacks for safe cross-thread transfer.
+#[derive(Clone)]
+pub struct RobotHitRegion {
+    /// Rectangle for the hit target.
+    pub rect: Rect,
+    /// Optional rounded shape for the hit target.
+    pub shape: Option<RoundedCornerShape>,
+    /// Z-depth used when selecting the deepest hit.
+    pub z_index: usize,
+    /// Optional clipping rectangle for the hit region.
+    pub hit_clip: Option<Rect>,
+}
+
+/// Errors surfaced while running a robot-controlled desktop app.
+#[derive(Debug, Error)]
+pub enum DesktopRobotError {
+    /// Creating the winit event loop failed.
+    #[error("failed to create event loop: {0}")]
+    EventLoop(#[from] EventLoopError),
+    /// The offscreen window could not be created.
+    #[error("failed to build window")]
+    Window,
+    /// No compatible GPU adapter is available.
+    #[error("no WGPU adapter available for desktop robot")]
+    NoAdapter,
+    /// Creating the WGPU device failed.
+    #[error("failed to create device: {0}")]
+    RequestDevice(#[from] wgpu::RequestDeviceError),
+    /// The render surface was lost and needs to be recreated.
+    #[error("render surface lost")]
+    SurfaceLost,
+    /// GPU ran out of memory when rendering.
+    #[error("render surface out of memory")]
+    OutOfMemory,
+    /// GPU timed out while producing a frame.
+    #[error("render surface timed out")]
+    SurfaceTimeout,
+    /// Rendering failed within the WGPU renderer.
+    #[error("rendering failed: {0}")]
+    Render(String),
+    /// Mapping the readback buffer failed.
+    #[error("readback mapping failed: {0}")]
+    Map(wgpu::BufferAsyncError),
+    /// The render thread shut down unexpectedly.
+    #[error("render thread exited")]
+    EventLoopClosed,
+    /// The render thread panicked.
+    #[error("render thread panicked")]
+    Join,
+}
+
+enum RobotCommand {
+    MovePointer {
+        x: f32,
+        y: f32,
+        respond_to: mpsc::Sender<bool>,
+    },
+    Press {
+        x: f32,
+        y: f32,
+        respond_to: mpsc::Sender<bool>,
+    },
+    Release {
+        x: f32,
+        y: f32,
+        respond_to: mpsc::Sender<bool>,
+    },
+    Click {
+        x: f32,
+        y: f32,
+        respond_to: mpsc::Sender<bool>,
+    },
+    SetViewport {
+        width: f32,
+        height: f32,
+        respond_to: mpsc::Sender<()>,
+    },
+    PumpUntilIdle {
+        max_iterations: usize,
+        respond_to: mpsc::Sender<()>,
+    },
+    Snapshot(mpsc::Sender<RobotSceneSnapshot>),
+    CaptureFrame(mpsc::Sender<Result<RobotFrameCapture, DesktopRobotError>>),
+    Close {
+        respond_to: mpsc::Sender<()>,
+    },
+    Wake,
+}
+
+/// Launch the real desktop runtime with an embedded robot controller.
+pub fn run_with_robot(
+    settings: AppSettings,
+    content: impl FnMut() + Send + 'static,
+) -> Result<DesktopRobotApp, DesktopRobotError> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+
+    let join_handle = thread::spawn(move || {
+        let result: Result<(), DesktopRobotError> = (|| {
+            let event_loop = EventLoopBuilder::<RobotCommand>::with_user_event()
+                .build()
+                .map_err(DesktopRobotError::EventLoop)?;
+            let proxy = event_loop.create_proxy();
+
+            let window = Arc::new(
+                WindowBuilder::new()
+                    .with_title(settings.window_title)
+                    .with_visible(false)
+                    .with_inner_size(LogicalSize::new(
+                        settings.initial_width as f64,
+                        settings.initial_height as f64,
+                    ))
+                    .build(&event_loop)
+                    .map_err(|_| DesktopRobotError::Window)?,
+            );
+
+            // Initialize WGPU
+            let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+                backends: wgpu::Backends::all(),
+                ..Default::default()
+            });
+
+            let surface = instance
+                .create_surface(window.clone())
+                .map_err(|_| DesktopRobotError::Window)?;
+
+            let adapter =
+                pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::HighPerformance,
+                    compatible_surface: Some(&surface),
+                    force_fallback_adapter: false,
+                }))
+                .ok_or(DesktopRobotError::NoAdapter)?;
+
+            let (device, queue) = pollster::block_on(adapter.request_device(
+                &wgpu::DeviceDescriptor {
+                    label: Some("Robot Device"),
+                    required_features: wgpu::Features::empty(),
+                    required_limits: wgpu::Limits::default(),
+                },
+                None,
+            ))?;
+
+            let size = window.inner_size();
+            let surface_caps = surface.get_capabilities(&adapter);
+            let surface_format = surface_caps
+                .formats
+                .iter()
+                .copied()
+                .find(|f| f.is_srgb())
+                .unwrap_or(surface_caps.formats[0]);
+
+            let mut surface_config = wgpu::SurfaceConfiguration {
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                format: surface_format,
+                width: size.width,
+                height: size.height,
+                present_mode: wgpu::PresentMode::Fifo,
+                alpha_mode: surface_caps.alpha_modes[0],
+                view_formats: vec![],
+                desired_maximum_frame_latency: 2,
+            };
+
+            surface.configure(&device, &surface_config);
+
+            let mut renderer = if let Some(fonts) = settings.fonts {
+                WgpuRenderer::new_with_fonts(fonts)
+            } else {
+                WgpuRenderer::new()
+            };
+            renderer.init_gpu(Arc::new(device), Arc::new(queue), surface_format);
+
+            let scale_factor = window.scale_factor();
+            renderer.set_root_scale(scale_factor as f32);
+
+            let mut app = AppShell::new(renderer, default_root_key(), content);
+            let mut platform = DesktopWinitPlatform::default();
+            platform.set_scale_factor(scale_factor);
+
+            app.set_frame_waker({
+                let proxy = proxy.clone();
+                move || {
+                    let _ = proxy.send_event(RobotCommand::Wake);
+                }
+            });
+
+            app.set_buffer_size(size.width, size.height);
+            app.set_viewport(
+                size.width as f32 / scale_factor as f32,
+                size.height as f32 / scale_factor as f32,
+            );
+
+            ready_tx
+                .send(Ok(proxy.clone()))
+                .map_err(|_| DesktopRobotError::EventLoopClosed)?;
+
+            event_loop.run(move |event, elwt| {
+                elwt.set_control_flow(ControlFlow::Wait);
+                match event {
+                    Event::UserEvent(command) => {
+                        handle_robot_command(
+                            command,
+                            &window,
+                            &mut app,
+                            &surface,
+                            &mut surface_config,
+                            elwt,
+                        );
+                    }
+                    Event::WindowEvent { window_id, event } if window_id == window.id() => {
+                        match event {
+                            WindowEvent::CloseRequested => {
+                                elwt.exit();
+                            }
+                            WindowEvent::Resized(new_size) => {
+                                resize_surface(
+                                    &window,
+                                    &mut app,
+                                    &surface,
+                                    &mut surface_config,
+                                    new_size,
+                                );
+                            }
+                            WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                                platform.set_scale_factor(scale_factor);
+                                app.renderer().set_root_scale(scale_factor as f32);
+
+                                let new_size = window.inner_size();
+                                resize_surface(
+                                    &window,
+                                    &mut app,
+                                    &surface,
+                                    &mut surface_config,
+                                    new_size,
+                                );
+                            }
+                            WindowEvent::CursorMoved { position, .. } => {
+                                let logical = platform.pointer_position(position);
+                                app.set_cursor(logical.x, logical.y);
+                            }
+                            WindowEvent::MouseInput {
+                                state,
+                                button: MouseButton::Left,
+                                ..
+                            } => match state {
+                                ElementState::Pressed => {
+                                    app.pointer_pressed();
+                                }
+                                ElementState::Released => {
+                                    app.pointer_released();
+                                }
+                            },
+                            WindowEvent::KeyboardInput { event, .. } => {
+                                use winit::keyboard::{KeyCode, PhysicalKey};
+                                if event.state == ElementState::Pressed {
+                                    if let PhysicalKey::Code(KeyCode::KeyD) = event.physical_key {
+                                        app.log_debug_info();
+                                    }
+                                }
+                            }
+                            WindowEvent::RedrawRequested => {
+                                if let Ok(Some(frame)) = render_to_surface(
+                                    &window,
+                                    &mut app,
+                                    &surface,
+                                    &mut surface_config,
+                                ) {
+                                    frame.present();
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    Event::AboutToWait => {
+                        if app.needs_redraw() {
+                            window.request_redraw();
+                        }
+
+                        if app.has_active_animations() {
+                            elwt.set_control_flow(ControlFlow::Poll);
+                        }
+                    }
+                    _ => {}
+                }
+            })?;
+
+            Ok(())
+        })();
+
+        if let Err(err) = result {
+            let _ = ready_tx.send(Err(err));
+        }
+    });
+
+    let proxy = ready_rx
+        .recv()
+        .map_err(|_| DesktopRobotError::EventLoopClosed)??;
+
+    Ok(DesktopRobotApp {
+        proxy,
+        join_handle: Some(join_handle),
+    })
+}
+
+fn handle_robot_command(
+    command: RobotCommand,
+    window: &winit::window::Window,
+    app: &mut AppShell<WgpuRenderer>,
+    surface: &wgpu::Surface,
+    surface_config: &mut wgpu::SurfaceConfiguration,
+    elwt: &winit::event_loop::EventLoopWindowTarget<RobotCommand>,
+) {
+    match command {
+        RobotCommand::MovePointer { x, y, respond_to } => {
+            let moved = app.set_cursor(x, y);
+            app.update();
+            let _ = respond_to.send(moved);
+        }
+        RobotCommand::Press { x, y, respond_to } => {
+            app.set_cursor(x, y);
+            let pressed = app.pointer_pressed();
+            app.update();
+            let _ = respond_to.send(pressed);
+        }
+        RobotCommand::Release { x, y, respond_to } => {
+            app.set_cursor(x, y);
+            let released = app.pointer_released();
+            app.update();
+            let _ = respond_to.send(released);
+        }
+        RobotCommand::Click { x, y, respond_to } => {
+            app.set_cursor(x, y);
+            let pressed = app.pointer_pressed();
+            let released = app.pointer_released();
+            app.update();
+            let _ = respond_to.send(pressed || released);
+        }
+        RobotCommand::SetViewport {
+            width,
+            height,
+            respond_to,
+        } => {
+            let scale = window.scale_factor() as f32;
+            let physical = PhysicalSize::new(
+                (width * scale).round() as u32,
+                (height * scale).round() as u32,
+            );
+            let _ = window.request_inner_size(physical);
+            resize_surface(window, app, surface, surface_config, physical);
+            let _ = respond_to.send(());
+        }
+        RobotCommand::PumpUntilIdle {
+            max_iterations,
+            respond_to,
+        } => {
+            for _ in 0..max_iterations {
+                if !app.needs_redraw() {
+                    break;
+                }
+                app.update();
+            }
+            let _ = respond_to.send(());
+        }
+        RobotCommand::Snapshot(respond_to) => {
+            app.update();
+            let snapshot = RobotSceneSnapshot {
+                texts: app.scene().texts.clone(),
+                shapes: app.scene().shapes.clone(),
+                hits: app
+                    .scene()
+                    .hits
+                    .iter()
+                    .map(|hit| RobotHitRegion {
+                        rect: hit.rect,
+                        shape: hit.shape,
+                        z_index: hit.z_index,
+                        hit_clip: hit.hit_clip,
+                    })
+                    .collect(),
+            };
+            let _ = respond_to.send(snapshot);
+        }
+        RobotCommand::CaptureFrame(respond_to) => {
+            let result =
+                render_to_surface(window, app, surface, surface_config).and_then(|frame_opt| {
+                    match frame_opt {
+                        Some(frame) => read_back_frame(app, frame, surface_config),
+                        None => Err(DesktopRobotError::SurfaceLost),
+                    }
+                });
+            let _ = respond_to.send(result);
+        }
+        RobotCommand::Close { respond_to } => {
+            elwt.exit();
+            let _ = respond_to.send(());
+        }
+        RobotCommand::Wake => {
+            if app.needs_redraw() {
+                window.request_redraw();
+            }
+        }
+    }
+}
+
+fn render_to_surface(
+    window: &winit::window::Window,
+    app: &mut AppShell<WgpuRenderer>,
+    surface: &wgpu::Surface,
+    surface_config: &mut wgpu::SurfaceConfiguration,
+) -> Result<Option<wgpu::SurfaceTexture>, DesktopRobotError> {
+    app.update();
+
+    let output = match surface.get_current_texture() {
+        Ok(output) => output,
+        Err(wgpu::SurfaceError::Lost) | Err(wgpu::SurfaceError::Outdated) => {
+            resize_surface(window, app, surface, surface_config, window.inner_size());
+            return Ok(None);
+        }
+        Err(wgpu::SurfaceError::OutOfMemory) => {
+            return Err(DesktopRobotError::OutOfMemory);
+        }
+        Err(wgpu::SurfaceError::Timeout) => {
+            return Err(DesktopRobotError::SurfaceTimeout);
+        }
+    };
+
+    let view = output
+        .texture
+        .create_view(&wgpu::TextureViewDescriptor::default());
+
+    app.renderer()
+        .render(&view, surface_config.width, surface_config.height)
+        .map_err(|err| DesktopRobotError::Render(format!("{err:?}")))?;
+
+    Ok(Some(output))
+}
+
+fn read_back_frame(
+    app: &mut AppShell<WgpuRenderer>,
+    output: wgpu::SurfaceTexture,
+    surface_config: &wgpu::SurfaceConfiguration,
+) -> Result<RobotFrameCapture, DesktopRobotError> {
+    let texture = &output.texture;
+    let renderer = app.renderer();
+    let device = renderer.device();
+    let queue = renderer.queue();
+
+    let bytes = read_texture_rgba(
+        device,
+        queue,
+        texture,
+        surface_config.width,
+        surface_config.height,
+    )?;
+
+    output.present();
+
+    Ok(RobotFrameCapture {
+        width: surface_config.width,
+        height: surface_config.height,
+        pixels: bytes,
+    })
+}
+
+fn resize_surface(
+    window: &winit::window::Window,
+    app: &mut AppShell<WgpuRenderer>,
+    surface: &wgpu::Surface,
+    surface_config: &mut wgpu::SurfaceConfiguration,
+    new_size: PhysicalSize<u32>,
+) {
+    if new_size.width == 0 || new_size.height == 0 {
+        return;
+    }
+
+    surface_config.width = new_size.width;
+    surface_config.height = new_size.height;
+    let device = app.renderer().device();
+    surface.configure(device, surface_config);
+
+    let scale_factor = window.scale_factor();
+    let logical_width = new_size.width as f32 / scale_factor as f32;
+    let logical_height = new_size.height as f32 / scale_factor as f32;
+
+    app.set_buffer_size(new_size.width, new_size.height);
+    app.set_viewport(logical_width, logical_height);
+}
+
+fn read_texture_rgba(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    texture: &wgpu::Texture,
+    width: u32,
+    height: u32,
+) -> Result<Vec<u8>, DesktopRobotError> {
+    let bytes_per_pixel = std::mem::size_of::<[u8; 4]>();
+    let unpadded_bytes_per_row = width as usize * bytes_per_pixel;
+    let padded_bytes_per_row = wgpu::util::align_to(
+        unpadded_bytes_per_row,
+        wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize,
+    );
+    let output_buffer_size = (padded_bytes_per_row * height as usize) as wgpu::BufferAddress;
+
+    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("robot-readback"),
+        size: output_buffer_size,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("robot-copy"),
+    });
+    encoder.copy_texture_to_buffer(
+        wgpu::ImageCopyTexture {
+            texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::ImageCopyBuffer {
+            buffer: &buffer,
+            layout: wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(padded_bytes_per_row as u32),
+                rows_per_image: Some(height),
+            },
+        },
+        wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(Some(encoder.finish()));
+    device.poll(wgpu::Maintain::Wait);
+
+    let buffer_slice = buffer.slice(..);
+    let (sender, receiver) = mpsc::channel();
+    buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = sender.send(result);
+    });
+    device.poll(wgpu::Maintain::Wait);
+    match receiver.recv() {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => return Err(DesktopRobotError::Map(err)),
+        Err(_) => return Err(DesktopRobotError::EventLoopClosed),
+    }
+
+    let data = buffer_slice.get_mapped_range();
+    let mut pixels = vec![0u8; width as usize * height as usize * bytes_per_pixel];
+    for row in 0..height as usize {
+        let src_offset = row * padded_bytes_per_row;
+        let dst_offset = row * unpadded_bytes_per_row;
+        let src = &data[src_offset..src_offset + unpadded_bytes_per_row];
+        pixels[dst_offset..dst_offset + unpadded_bytes_per_row].copy_from_slice(src);
+    }
+
+    drop(data);
+    buffer.unmap();
+
+    for chunk in pixels.chunks_exact_mut(4) {
+        chunk.swap(0, 2); // BGRA → RGBA
+    }
+
+    Ok(pixels)
 }

--- a/crates/compose-render/wgpu/src/lib.rs
+++ b/crates/compose-render/wgpu/src/lib.rs
@@ -301,6 +301,14 @@ impl WgpuRenderer {
             .map(|r| &*r.device)
             .expect("GPU renderer not initialized")
     }
+
+    /// Get access to the WGPU queue (for readbacks and uploads).
+    pub fn queue(&self) -> &wgpu::Queue {
+        self.gpu_renderer
+            .as_ref()
+            .map(|r| &*r.queue)
+            .expect("GPU renderer not initialized")
+    }
 }
 
 impl Default for WgpuRenderer {

--- a/crates/compose-testing/Cargo.toml
+++ b/crates/compose-testing/Cargo.toml
@@ -6,9 +6,12 @@ license = "Apache-2.0"
 description = "Testing utilities and harness for Compose-RS"
 
 [dependencies]
+compose-app-shell = { version = "0.1.0", path = "../compose-app-shell" }
 compose-core = { path = "../compose-core" }
 compose-foundation = { path = "../compose-foundation" }
+compose-render-pixels = { version = "0.1.0", path = "../compose-render/pixels" }
 compose-ui = { path = "../compose-ui" }
+compose-ui-graphics = { version = "0.1.0", path = "../compose-ui-graphics" }
 
 [dev-dependencies]
 compose-macros = { path = "../compose-macros" }

--- a/crates/compose-testing/Cargo.toml
+++ b/crates/compose-testing/Cargo.toml
@@ -10,8 +10,12 @@ compose-app-shell = { version = "0.1.0", path = "../compose-app-shell" }
 compose-core = { path = "../compose-core" }
 compose-foundation = { path = "../compose-foundation" }
 compose-render-pixels = { version = "0.1.0", path = "../compose-render/pixels" }
+compose-render-wgpu = { version = "0.1.0", path = "../compose-render/wgpu" }
 compose-ui = { path = "../compose-ui" }
 compose-ui-graphics = { version = "0.1.0", path = "../compose-ui-graphics" }
+pollster = "0.3"
+thiserror = "1"
+wgpu = "0.19"
 
 [dev-dependencies]
 compose-macros = { path = "../compose-macros" }

--- a/crates/compose-testing/Cargo.toml
+++ b/crates/compose-testing/Cargo.toml
@@ -7,6 +7,7 @@ description = "Testing utilities and harness for Compose-RS"
 
 [dependencies]
 compose-app-shell = { version = "0.1.0", path = "../compose-app-shell" }
+compose-app = { path = "../compose-app" }
 compose-core = { path = "../compose-core" }
 compose-foundation = { path = "../compose-foundation" }
 compose-render-pixels = { version = "0.1.0", path = "../compose-render/pixels" }

--- a/crates/compose-testing/README.md
+++ b/crates/compose-testing/README.md
@@ -1,3 +1,40 @@
 # compose-testing
 
 Testing utilities and harnesses for validating Compose-RS behaviour.
+
+## Robot testing
+
+`RobotApp` wraps a real Compose-RS application inside an `AppShell` that
+uses the headless pixels renderer. It lets integration tests launch a
+composable tree, drive pointer input (move/press/release/click), and read
+the rendered scene to assert on text or geometry.
+
+Example usage against the `desktop-app` demo:
+
+```rust
+use compose_testing::robot::{rect_center, RobotApp};
+use desktop_app::app::combined_app;
+
+let mut robot = RobotApp::launch(|| {
+    combined_app();
+});
+robot.set_viewport(1024.0, 768.0);
+robot.pump_until_idle(20);
+
+let button_rect = robot
+    .snapshot()
+    .text_rects("Increment")
+    .first()
+    .cloned()
+    .expect("increment text should exist");
+let (x, y) = rect_center(&button_rect);
+robot.click(x, y);
+robot.pump_until_idle(20);
+
+assert!(
+    robot
+        .snapshot()
+        .text_values()
+        .any(|text| text.contains("Counter: 1"))
+);
+```

--- a/crates/compose-testing/README.md
+++ b/crates/compose-testing/README.md
@@ -9,6 +9,11 @@ uses the headless pixels renderer. It lets integration tests launch a
 composable tree, drive pointer input (move/press/release/click), and read
 the rendered scene to assert on text or geometry.
 
+`WgpuRobotApp` drives the same WGPU renderer used in production desktop
+applications while rendering into an offscreen texture. It supports the
+same pointer automation and scene access as `RobotApp`, and it can also
+capture rendered frames for future screenshot-style tests.
+
 Example usage against the `desktop-app` demo:
 
 ```rust
@@ -37,4 +42,28 @@ assert!(
         .text_values()
         .any(|text| text.contains("Counter: 1"))
 );
+```
+
+Example using the WGPU-backed robot and capturing a frame:
+
+```rust
+use compose_testing::robot::rect_center;
+use compose_testing::wgpu_robot::WgpuRobotApp;
+use desktop_app::app::combined_app;
+
+static ROBOTO_REGULAR: &[u8] = include_bytes!("../../../assets/Roboto-Regular.ttf");
+
+let mut robot = WgpuRobotApp::launch_with_fonts(1024, 768, &[ROBOTO_REGULAR], || {
+    combined_app();
+})?;
+robot.pump_until_idle(30)?;
+
+let snapshot = robot.snapshot();
+let button_rect = snapshot.text_rects("Increment")[0].clone();
+let (x, y) = rect_center(&button_rect);
+robot.click(x, y)?;
+robot.pump_until_idle(30)?;
+
+let capture = robot.capture_frame()?;
+assert_eq!(capture.rgba().len(), (capture.width * capture.height * 4) as usize);
 ```

--- a/crates/compose-testing/src/lib.rs
+++ b/crates/compose-testing/src/lib.rs
@@ -4,12 +4,15 @@
 
 pub mod robot;
 pub mod testing;
+pub mod wgpu_robot;
 
 // Re-export testing utilities
 pub use robot::{rect_center, RobotApp, SceneSnapshot};
 pub use testing::*;
+pub use wgpu_robot::{FrameCapture, WgpuRobotApp, WgpuRobotError};
 
 pub mod prelude {
     pub use crate::robot::{rect_center, RobotApp, SceneSnapshot};
     pub use crate::testing::*;
+    pub use crate::wgpu_robot::{FrameCapture, WgpuRobotApp, WgpuRobotError};
 }

--- a/crates/compose-testing/src/lib.rs
+++ b/crates/compose-testing/src/lib.rs
@@ -2,11 +2,14 @@
 
 #![allow(non_snake_case)]
 
+pub mod robot;
 pub mod testing;
 
 // Re-export testing utilities
+pub use robot::{rect_center, RobotApp, SceneSnapshot};
 pub use testing::*;
 
 pub mod prelude {
+    pub use crate::robot::{rect_center, RobotApp, SceneSnapshot};
     pub use crate::testing::*;
 }

--- a/crates/compose-testing/src/robot.rs
+++ b/crates/compose-testing/src/robot.rs
@@ -101,11 +101,51 @@ pub struct SceneSnapshot {
 }
 
 impl SceneSnapshot {
-    fn from_scene(scene: &compose_render_pixels::Scene) -> Self {
+    pub(crate) fn from_scene(scene: &compose_render_pixels::Scene) -> Self {
         Self {
             texts: scene.texts.clone(),
             shapes: scene.shapes.clone(),
             hits: scene.hits.clone(),
+        }
+    }
+
+    pub(crate) fn from_wgpu_scene(scene: &compose_render_wgpu::Scene) -> Self {
+        Self {
+            texts: scene
+                .texts
+                .iter()
+                .map(|text| TextDraw {
+                    rect: text.rect,
+                    text: text.text.clone(),
+                    color: text.color,
+                    scale: text.scale,
+                    z_index: text.z_index,
+                    clip: text.clip,
+                })
+                .collect(),
+            shapes: scene
+                .shapes
+                .iter()
+                .map(|shape| DrawShape {
+                    rect: shape.rect,
+                    brush: shape.brush.clone(),
+                    shape: shape.shape,
+                    z_index: shape.z_index,
+                    clip: shape.clip,
+                })
+                .collect(),
+            hits: scene
+                .hits
+                .iter()
+                .map(|hit| HitRegion {
+                    rect: hit.rect,
+                    shape: hit.shape,
+                    click_actions: Vec::new(),
+                    pointer_inputs: Vec::new(),
+                    z_index: hit.z_index,
+                    hit_clip: hit.hit_clip,
+                })
+                .collect(),
         }
     }
 

--- a/crates/compose-testing/src/robot.rs
+++ b/crates/compose-testing/src/robot.rs
@@ -1,0 +1,173 @@
+use compose_app_shell::{default_root_key, AppShell};
+use compose_core::Key;
+use compose_render_pixels::scene::{DrawShape, HitRegion, TextDraw};
+use compose_render_pixels::PixelsRenderer;
+use compose_ui_graphics::Rect;
+
+/// Headless harness that wraps an [`AppShell`] with the pixels renderer to enable
+/// black-box robot style tests against real applications.
+///
+/// The robot exposes pointer interactions (move, press, release, click), frame
+/// stepping, and snapshotting utilities that let tests assert on the rendered
+/// scene (visible texts, rectangles, and hit regions).
+pub struct RobotApp {
+    shell: AppShell<PixelsRenderer>,
+}
+
+impl RobotApp {
+    /// Launch a new robot-controlled application using the default root key.
+    pub fn launch(content: impl FnMut() + 'static) -> Self {
+        Self::launch_with_key(default_root_key(), content)
+    }
+
+    /// Launch a new robot-controlled application with an explicit root key.
+    pub fn launch_with_key(root_key: Key, content: impl FnMut() + 'static) -> Self {
+        let renderer = PixelsRenderer::new();
+        let shell = AppShell::new(renderer, root_key, content);
+        Self { shell }
+    }
+
+    /// Update the viewport used for layout.
+    pub fn set_viewport(&mut self, width: f32, height: f32) {
+        self.shell.set_viewport(width, height);
+    }
+
+    /// Run a single frame update, processing recompositions, layout, and scene rebuilds.
+    pub fn step(&mut self) {
+        self.shell.update();
+    }
+
+    /// Drive the application until no further redraws are requested or the iteration
+    /// limit is reached.
+    pub fn pump_until_idle(&mut self, max_iterations: usize) {
+        for _ in 0..max_iterations {
+            if !self.shell.needs_redraw() {
+                break;
+            }
+            self.shell.update();
+        }
+    }
+
+    /// Move the virtual pointer to the provided coordinates, dispatching pointer move
+    /// events to any hit targets.
+    pub fn move_pointer(&mut self, x: f32, y: f32) -> bool {
+        let moved = self.shell.set_cursor(x, y);
+        self.shell.update();
+        moved
+    }
+
+    /// Press the virtual pointer at the provided coordinates.
+    pub fn press(&mut self, x: f32, y: f32) -> bool {
+        self.shell.set_cursor(x, y);
+        let pressed = self.shell.pointer_pressed();
+        self.shell.update();
+        pressed
+    }
+
+    /// Release the virtual pointer at the provided coordinates.
+    pub fn release(&mut self, x: f32, y: f32) -> bool {
+        self.shell.set_cursor(x, y);
+        let released = self.shell.pointer_released();
+        self.shell.update();
+        released
+    }
+
+    /// Convenience helper that presses and then releases the pointer at the provided
+    /// coordinates.
+    pub fn click(&mut self, x: f32, y: f32) -> bool {
+        self.shell.set_cursor(x, y);
+        let pressed = self.shell.pointer_pressed();
+        let released = self.shell.pointer_released();
+        self.shell.update();
+        pressed || released
+    }
+
+    /// Capture a snapshot of the current render scene for assertions.
+    pub fn snapshot(&mut self) -> SceneSnapshot {
+        SceneSnapshot::from_scene(self.shell.scene())
+    }
+
+    /// Shut down the robot-controlled application. Dropping the instance will
+    /// clean up the underlying shell; this is provided for clarity in tests.
+    pub fn close(self) {}
+}
+
+/// Immutable snapshot of a rendered scene containing draw operations and hit regions.
+#[derive(Clone)]
+pub struct SceneSnapshot {
+    texts: Vec<TextDraw>,
+    shapes: Vec<DrawShape>,
+    hits: Vec<HitRegion>,
+}
+
+impl SceneSnapshot {
+    fn from_scene(scene: &compose_render_pixels::Scene) -> Self {
+        Self {
+            texts: scene.texts.clone(),
+            shapes: scene.shapes.clone(),
+            hits: scene.hits.clone(),
+        }
+    }
+
+    /// Visible texts recorded in the scene.
+    pub fn texts(&self) -> &[TextDraw] {
+        &self.texts
+    }
+
+    /// Rectangles produced by draw primitives in the scene.
+    pub fn shapes(&self) -> &[DrawShape] {
+        &self.shapes
+    }
+
+    /// Hit regions that accept pointer interaction.
+    pub fn hits(&self) -> &[HitRegion] {
+        &self.hits
+    }
+
+    /// Iterator over the string contents of all visible texts.
+    pub fn text_values(&self) -> impl Iterator<Item = &str> {
+        self.texts.iter().map(|text| text.text.as_str())
+    }
+
+    /// Rectangles for texts that exactly match the provided value.
+    pub fn text_rects(&self, value: &str) -> Vec<Rect> {
+        self.texts
+            .iter()
+            .filter(move |text| text.text == value)
+            .map(|text| Rect {
+                x: text.rect.x,
+                y: text.rect.y,
+                width: text.rect.width,
+                height: text.rect.height,
+            })
+            .collect()
+    }
+
+    /// Returns the deepest hit region that contains the provided point, if any.
+    pub fn hit_at(&self, x: f32, y: f32) -> Option<HitRegion> {
+        self.hits
+            .iter()
+            .filter(|hit| hit.contains(x, y))
+            .max_by(|a, b| a.z_index.cmp(&b.z_index))
+            .cloned()
+    }
+}
+
+impl std::fmt::Debug for SceneSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SceneSnapshot")
+            .field("texts", &self.texts.len())
+            .field("shapes", &self.shapes.len())
+            .field("hits", &self.hits.len())
+            .finish()
+    }
+}
+
+/// Compute the center point for a rectangle.
+pub fn rect_center(rect: &Rect) -> (f32, f32) {
+    (rect.x + rect.width / 2.0, rect.y + rect.height / 2.0)
+}
+
+#[cfg(test)]
+#[path = "tests/robot_tests.rs"]
+mod tests;

--- a/crates/compose-testing/src/robot.rs
+++ b/crates/compose-testing/src/robot.rs
@@ -109,6 +109,7 @@ impl SceneSnapshot {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn from_wgpu_scene(scene: &compose_render_wgpu::Scene) -> Self {
         Self {
             texts: scene
@@ -135,6 +136,46 @@ impl SceneSnapshot {
                 })
                 .collect(),
             hits: scene
+                .hits
+                .iter()
+                .map(|hit| HitRegion {
+                    rect: hit.rect,
+                    shape: hit.shape,
+                    click_actions: Vec::new(),
+                    pointer_inputs: Vec::new(),
+                    z_index: hit.z_index,
+                    hit_clip: hit.hit_clip,
+                })
+                .collect(),
+        }
+    }
+
+    pub(crate) fn from_robot_snapshot(snapshot: &compose_app::desktop::RobotSceneSnapshot) -> Self {
+        Self {
+            texts: snapshot
+                .texts
+                .iter()
+                .map(|text| TextDraw {
+                    rect: text.rect,
+                    text: text.text.clone(),
+                    color: text.color,
+                    scale: text.scale,
+                    z_index: text.z_index,
+                    clip: text.clip,
+                })
+                .collect(),
+            shapes: snapshot
+                .shapes
+                .iter()
+                .map(|shape| DrawShape {
+                    rect: shape.rect,
+                    brush: shape.brush.clone(),
+                    shape: shape.shape,
+                    z_index: shape.z_index,
+                    clip: shape.clip,
+                })
+                .collect(),
+            hits: snapshot
                 .hits
                 .iter()
                 .map(|hit| HitRegion {

--- a/crates/compose-testing/src/tests/robot_tests.rs
+++ b/crates/compose-testing/src/tests/robot_tests.rs
@@ -1,0 +1,79 @@
+use crate::robot::{rect_center, RobotApp};
+use compose_core::useState;
+use compose_macros::composable;
+use compose_ui::widgets::Button;
+use compose_ui::{Column, ColumnSpec, Modifier, Text};
+
+#[composable]
+fn CounterApp() {
+    let count = useState(|| 0i32);
+    Column(Modifier::empty(), ColumnSpec::default(), move || {
+        Text(
+            format!("Count: {}", count.value()),
+            Modifier::empty().padding(4.0),
+        );
+        let on_click = count;
+        Button(
+            Modifier::empty().padding(4.0),
+            move || {
+                let current = on_click.value();
+                on_click.set_value(current + 1);
+            },
+            || {
+                Text("Tap".to_string(), Modifier::empty().padding(2.0));
+            },
+        );
+    });
+}
+
+#[test]
+fn robot_can_click_and_read_scene() {
+    let mut robot = RobotApp::launch(|| {
+        CounterApp();
+    });
+
+    robot.pump_until_idle(10);
+    let snapshot = robot.snapshot();
+    assert!(snapshot.text_values().any(|text| text == "Count: 0"));
+
+    let button_rect = snapshot
+        .text_rects("Tap")
+        .first()
+        .cloned()
+        .expect("button text rect should exist");
+    let (x, y) = rect_center(&button_rect);
+
+    assert!(robot.move_pointer(x, y), "pointer should hit button");
+    assert!(robot.click(x, y), "click dispatch should succeed");
+
+    robot.pump_until_idle(10);
+    let updated = robot.snapshot();
+    assert!(updated.text_values().any(|text| text == "Count: 1"));
+    assert!(!updated.text_rects("Count: 1").is_empty());
+
+    robot.close();
+}
+
+#[test]
+fn robot_can_press_and_release_individually() {
+    let mut robot = RobotApp::launch(|| {
+        CounterApp();
+    });
+    robot.pump_until_idle(5);
+
+    let snapshot = robot.snapshot();
+    let tap_rect = snapshot
+        .text_rects("Tap")
+        .first()
+        .cloned()
+        .expect("button text rect should exist");
+    let (x, y) = rect_center(&tap_rect);
+
+    assert!(robot.press(x, y));
+    robot.pump_until_idle(5);
+    assert!(robot.release(x, y));
+    robot.pump_until_idle(5);
+
+    let updated = robot.snapshot();
+    assert!(updated.text_values().any(|text| text == "Count: 1"));
+}

--- a/crates/compose-testing/src/tests/wgpu_robot_tests.rs
+++ b/crates/compose-testing/src/tests/wgpu_robot_tests.rs
@@ -1,0 +1,72 @@
+use crate::robot::rect_center;
+use crate::wgpu_robot::WgpuRobotApp;
+use crate::WgpuRobotError;
+use compose_core::useState;
+use compose_macros::composable;
+use compose_ui::widgets::Button;
+use compose_ui::{Column, ColumnSpec, Modifier, Text};
+
+static ROBOTO_REGULAR: &[u8] = include_bytes!("../../../../assets/Roboto-Regular.ttf");
+static ROBOTO_FONTS: [&[u8]; 1] = [ROBOTO_REGULAR];
+
+#[composable]
+fn CounterApp() {
+    let count = useState(|| 0i32);
+    Column(Modifier::empty(), ColumnSpec::default(), move || {
+        Text(
+            format!("Count: {}", count.value()),
+            Modifier::empty().padding(4.0),
+        );
+        let on_click = count;
+        Button(
+            Modifier::empty().padding(4.0),
+            move || {
+                let current = on_click.value();
+                on_click.set_value(current + 1);
+            },
+            || {
+                Text("Tap".to_string(), Modifier::empty().padding(2.0));
+            },
+        );
+    });
+}
+
+#[test]
+fn wgpu_robot_drives_real_renderer_and_captures_frames() -> Result<(), WgpuRobotError> {
+    let mut robot = match WgpuRobotApp::launch_with_fonts(640, 480, &ROBOTO_FONTS, || {
+        CounterApp();
+    }) {
+        Ok(robot) => robot,
+        Err(WgpuRobotError::NoAdapter) => {
+            eprintln!("skipping WGPU robot test: no adapter available");
+            return Ok(());
+        }
+        Err(err) => return Err(err),
+    };
+
+    robot.pump_until_idle(20)?;
+    let snapshot = robot.snapshot();
+    assert!(snapshot.text_values().any(|text| text == "Count: 0"));
+
+    let button_rect = snapshot
+        .text_rects("Tap")
+        .first()
+        .cloned()
+        .expect("button text rect should exist");
+    let (x, y) = rect_center(&button_rect);
+
+    assert!(robot.move_pointer(x, y)?);
+    assert!(robot.click(x, y)?);
+
+    robot.pump_until_idle(20)?;
+    let updated = robot.snapshot();
+    assert!(updated.text_values().any(|text| text == "Count: 1"));
+
+    let capture = robot.capture_frame()?;
+    assert_eq!(capture.width, 640);
+    assert_eq!(capture.height, 480);
+    assert!(!capture.rgba().is_empty());
+
+    robot.close();
+    Ok(())
+}

--- a/crates/compose-testing/src/tests/wgpu_robot_tests.rs
+++ b/crates/compose-testing/src/tests/wgpu_robot_tests.rs
@@ -33,7 +33,7 @@ fn CounterApp() {
 
 #[test]
 fn wgpu_robot_drives_real_renderer_and_captures_frames() -> Result<(), WgpuRobotError> {
-    let mut robot = match WgpuRobotApp::launch_with_fonts(640, 480, &ROBOTO_FONTS, || {
+    let robot = match WgpuRobotApp::launch_with_fonts(640, 480, &ROBOTO_FONTS, || {
         CounterApp();
     }) {
         Ok(robot) => robot,
@@ -45,7 +45,7 @@ fn wgpu_robot_drives_real_renderer_and_captures_frames() -> Result<(), WgpuRobot
     };
 
     robot.pump_until_idle(20)?;
-    let snapshot = robot.snapshot();
+    let snapshot = robot.snapshot()?;
     assert!(snapshot.text_values().any(|text| text == "Count: 0"));
 
     let button_rect = snapshot
@@ -59,7 +59,7 @@ fn wgpu_robot_drives_real_renderer_and_captures_frames() -> Result<(), WgpuRobot
     assert!(robot.click(x, y)?);
 
     robot.pump_until_idle(20)?;
-    let updated = robot.snapshot();
+    let updated = robot.snapshot()?;
     assert!(updated.text_values().any(|text| text == "Count: 1"));
 
     let capture = robot.capture_frame()?;
@@ -67,6 +67,6 @@ fn wgpu_robot_drives_real_renderer_and_captures_frames() -> Result<(), WgpuRobot
     assert_eq!(capture.height, 480);
     assert!(!capture.rgba().is_empty());
 
-    robot.close();
+    robot.close()?;
     Ok(())
 }

--- a/crates/compose-testing/src/wgpu_robot.rs
+++ b/crates/compose-testing/src/wgpu_robot.rs
@@ -1,0 +1,332 @@
+use compose_app_shell::{default_root_key, AppShell};
+use compose_render_wgpu::WgpuRenderer;
+use std::sync::{mpsc, Arc};
+
+use crate::robot::SceneSnapshot;
+
+/// Offscreen robot harness that drives a full WGPU renderer, mirroring how
+/// applications run in production while remaining fully programmatic for
+/// testing (pointer moves, presses, releases, and frame captures).
+pub struct WgpuRobotApp {
+    shell: AppShell<WgpuRenderer>,
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    texture: wgpu::Texture,
+    view: wgpu::TextureView,
+    surface_format: wgpu::TextureFormat,
+    width: u32,
+    height: u32,
+}
+
+impl WgpuRobotApp {
+    /// Launch a robot-controlled application using the provided viewport size
+    /// and renderer fonts.
+    pub fn launch_with_fonts(
+        width: u32,
+        height: u32,
+        fonts: &'static [&'static [u8]],
+        content: impl FnMut() + 'static,
+    ) -> Result<Self, WgpuRobotError> {
+        Self::launch_internal(width, height, Some(fonts), content)
+    }
+
+    /// Launch a robot-controlled application using the provided viewport size
+    /// without bundled fonts. Text rendering will fail unless your UI draws
+    /// only shapes.
+    pub fn launch(
+        width: u32,
+        height: u32,
+        content: impl FnMut() + 'static,
+    ) -> Result<Self, WgpuRobotError> {
+        Self::launch_internal(width, height, None, content)
+    }
+
+    fn launch_internal(
+        width: u32,
+        height: u32,
+        fonts: Option<&'static [&'static [u8]]>,
+        content: impl FnMut() + 'static,
+    ) -> Result<Self, WgpuRobotError> {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        }))
+        .ok_or(WgpuRobotError::NoAdapter)?;
+
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                label: Some("robot-device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::default(),
+            },
+            None,
+        ))?;
+
+        let device = Arc::new(device);
+        let queue = Arc::new(queue);
+        let surface_format = wgpu::TextureFormat::Bgra8UnormSrgb;
+
+        let mut renderer = match fonts {
+            Some(fonts) => WgpuRenderer::new_with_fonts(fonts),
+            None => WgpuRenderer::new(),
+        };
+        renderer.init_gpu(device.clone(), queue.clone(), surface_format);
+        renderer.set_root_scale(1.0);
+
+        let mut shell = AppShell::new(renderer, default_root_key(), content);
+        shell.set_buffer_size(width, height);
+        shell.set_viewport(width as f32, height as f32);
+        shell.set_frame_waker(|| {});
+
+        let (texture, view) = create_render_target(&device, surface_format, width, height);
+
+        Ok(Self {
+            shell,
+            device,
+            queue,
+            texture,
+            view,
+            surface_format,
+            width,
+            height,
+        })
+    }
+
+    /// Resize the viewport and backing texture.
+    pub fn set_viewport(&mut self, width: u32, height: u32) {
+        if width == self.width && height == self.height {
+            return;
+        }
+
+        self.width = width;
+        self.height = height;
+        self.shell.set_buffer_size(width, height);
+        self.shell.set_viewport(width as f32, height as f32);
+        let (texture, view) =
+            create_render_target(&self.device, self.surface_format, width, height);
+        self.texture = texture;
+        self.view = view;
+    }
+
+    /// Run a single frame update and render into the offscreen texture.
+    pub fn render_frame(&mut self) -> Result<(), WgpuRobotError> {
+        self.shell.update();
+        self.shell
+            .renderer()
+            .render(&self.view, self.width, self.height)
+            .map_err(|err| WgpuRobotError::Render(format!("{err:?}")))?;
+        Ok(())
+    }
+
+    /// Drive the application until no redraw is requested or the iteration limit
+    /// is reached.
+    pub fn pump_until_idle(&mut self, max_iterations: usize) -> Result<(), WgpuRobotError> {
+        for _ in 0..max_iterations {
+            if !self.shell.needs_redraw() {
+                break;
+            }
+            self.render_frame()?;
+        }
+        Ok(())
+    }
+
+    /// Move the virtual pointer to the provided coordinates, dispatching pointer
+    /// move events to any hit targets.
+    pub fn move_pointer(&mut self, x: f32, y: f32) -> Result<bool, WgpuRobotError> {
+        let moved = self.shell.set_cursor(x, y);
+        self.render_frame()?;
+        Ok(moved)
+    }
+
+    /// Press the virtual pointer at the provided coordinates.
+    pub fn press(&mut self, x: f32, y: f32) -> Result<bool, WgpuRobotError> {
+        self.shell.set_cursor(x, y);
+        let pressed = self.shell.pointer_pressed();
+        self.render_frame()?;
+        Ok(pressed)
+    }
+
+    /// Release the virtual pointer at the provided coordinates.
+    pub fn release(&mut self, x: f32, y: f32) -> Result<bool, WgpuRobotError> {
+        self.shell.set_cursor(x, y);
+        let released = self.shell.pointer_released();
+        self.render_frame()?;
+        Ok(released)
+    }
+
+    /// Convenience helper that presses and releases the pointer at the provided
+    /// coordinates.
+    pub fn click(&mut self, x: f32, y: f32) -> Result<bool, WgpuRobotError> {
+        self.shell.set_cursor(x, y);
+        let pressed = self.shell.pointer_pressed();
+        let released = self.shell.pointer_released();
+        self.render_frame()?;
+        Ok(pressed || released)
+    }
+
+    /// Snapshot the current render scene for assertions.
+    pub fn snapshot(&mut self) -> SceneSnapshot {
+        SceneSnapshot::from_wgpu_scene(self.shell.scene())
+    }
+
+    /// Capture the currently rendered frame into RGBA bytes suitable for
+    /// screenshot comparisons.
+    pub fn capture_frame(&mut self) -> Result<FrameCapture, WgpuRobotError> {
+        self.render_frame()?;
+        let bytes = read_texture_rgba(
+            &self.device,
+            &self.queue,
+            &self.texture,
+            self.width,
+            self.height,
+        )?;
+        Ok(FrameCapture {
+            width: self.width,
+            height: self.height,
+            pixels: bytes,
+        })
+    }
+
+    /// Shut down the robot-controlled application. Dropping the instance will
+    /// clean up the underlying shell; this is provided for clarity in tests.
+    pub fn close(self) {}
+}
+
+/// In-memory screenshot of a rendered frame.
+pub struct FrameCapture {
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Vec<u8>,
+}
+
+impl FrameCapture {
+    /// Raw RGBA pixels for the captured frame.
+    pub fn rgba(&self) -> &[u8] {
+        &self.pixels
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WgpuRobotError {
+    #[error("no WGPU adapter available for headless robot run")]
+    NoAdapter,
+    #[error("failed to create device: {0}")]
+    RequestDevice(#[from] wgpu::RequestDeviceError),
+    #[error("rendering failed: {0}")]
+    Render(String),
+    #[error("buffer mapping failed: {0}")]
+    Map(wgpu::BufferAsyncError),
+    #[error("buffer mapping channel dropped before completion")]
+    MapChannel,
+}
+
+fn create_render_target(
+    device: &wgpu::Device,
+    format: wgpu::TextureFormat,
+    width: u32,
+    height: u32,
+) -> (wgpu::Texture, wgpu::TextureView) {
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("robot-framebuffer"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[format],
+    });
+
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    (texture, view)
+}
+
+fn read_texture_rgba(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    texture: &wgpu::Texture,
+    width: u32,
+    height: u32,
+) -> Result<Vec<u8>, WgpuRobotError> {
+    let bytes_per_pixel = std::mem::size_of::<[u8; 4]>();
+    let unpadded_bytes_per_row = width as usize * bytes_per_pixel;
+    let padded_bytes_per_row = wgpu::util::align_to(
+        unpadded_bytes_per_row,
+        wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize,
+    );
+    let output_buffer_size = (padded_bytes_per_row * height as usize) as wgpu::BufferAddress;
+
+    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("robot-readback"),
+        size: output_buffer_size,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("robot-copy"),
+    });
+    encoder.copy_texture_to_buffer(
+        wgpu::ImageCopyTexture {
+            texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::ImageCopyBuffer {
+            buffer: &buffer,
+            layout: wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(padded_bytes_per_row as u32),
+                rows_per_image: Some(height),
+            },
+        },
+        wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(Some(encoder.finish()));
+    device.poll(wgpu::Maintain::Wait);
+
+    let buffer_slice = buffer.slice(..);
+    let (sender, receiver) = mpsc::channel();
+    buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = sender.send(result);
+    });
+    device.poll(wgpu::Maintain::Wait);
+    match receiver.recv() {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => return Err(WgpuRobotError::Map(err)),
+        Err(_) => return Err(WgpuRobotError::MapChannel),
+    }
+
+    let data = buffer_slice.get_mapped_range();
+    let mut pixels = vec![0u8; width as usize * height as usize * bytes_per_pixel];
+    for row in 0..height as usize {
+        let src_offset = row * padded_bytes_per_row;
+        let dst_offset = row * unpadded_bytes_per_row;
+        let src = &data[src_offset..src_offset + unpadded_bytes_per_row];
+        pixels[dst_offset..dst_offset + unpadded_bytes_per_row].copy_from_slice(src);
+    }
+
+    drop(data);
+    buffer.unmap();
+
+    for chunk in pixels.chunks_exact_mut(4) {
+        chunk.swap(0, 2); // BGRA → RGBA
+    }
+
+    Ok(pixels)
+}
+
+#[cfg(test)]
+#[path = "tests/wgpu_robot_tests.rs"]
+mod tests;

--- a/crates/compose-testing/src/wgpu_robot.rs
+++ b/crates/compose-testing/src/wgpu_robot.rs
@@ -1,21 +1,14 @@
-use compose_app_shell::{default_root_key, AppShell};
-use compose_render_wgpu::WgpuRenderer;
-use std::sync::{mpsc, Arc};
+use compose_app::desktop::{run_with_robot, DesktopRobotApp, DesktopRobotError, RobotFrameCapture};
+use compose_app::AppSettings;
 
 use crate::robot::SceneSnapshot;
 
-/// Offscreen robot harness that drives a full WGPU renderer, mirroring how
-/// applications run in production while remaining fully programmatic for
-/// testing (pointer moves, presses, releases, and frame captures).
+pub type WgpuRobotError = DesktopRobotError;
+
+/// Robot harness that drives the real desktop runtime, WGPU renderer, and event
+/// loop for black-box testing of full applications.
 pub struct WgpuRobotApp {
-    shell: AppShell<WgpuRenderer>,
-    device: Arc<wgpu::Device>,
-    queue: Arc<wgpu::Queue>,
-    texture: wgpu::Texture,
-    view: wgpu::TextureView,
-    surface_format: wgpu::TextureFormat,
-    width: u32,
-    height: u32,
+    inner: DesktopRobotApp,
 }
 
 impl WgpuRobotApp {
@@ -25,8 +18,8 @@ impl WgpuRobotApp {
         width: u32,
         height: u32,
         fonts: &'static [&'static [u8]],
-        content: impl FnMut() + 'static,
-    ) -> Result<Self, WgpuRobotError> {
+        content: impl FnMut() + Send + 'static,
+    ) -> Result<Self, DesktopRobotError> {
         Self::launch_internal(width, height, Some(fonts), content)
     }
 
@@ -36,8 +29,8 @@ impl WgpuRobotApp {
     pub fn launch(
         width: u32,
         height: u32,
-        content: impl FnMut() + 'static,
-    ) -> Result<Self, WgpuRobotError> {
+        content: impl FnMut() + Send + 'static,
+    ) -> Result<Self, DesktopRobotError> {
         Self::launch_internal(width, height, None, content)
     }
 
@@ -45,153 +38,70 @@ impl WgpuRobotApp {
         width: u32,
         height: u32,
         fonts: Option<&'static [&'static [u8]]>,
-        content: impl FnMut() + 'static,
-    ) -> Result<Self, WgpuRobotError> {
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
-        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-            power_preference: wgpu::PowerPreference::HighPerformance,
-            compatible_surface: None,
-            force_fallback_adapter: false,
-        }))
-        .ok_or(WgpuRobotError::NoAdapter)?;
-
-        let (device, queue) = pollster::block_on(adapter.request_device(
-            &wgpu::DeviceDescriptor {
-                label: Some("robot-device"),
-                required_features: wgpu::Features::empty(),
-                required_limits: wgpu::Limits::default(),
-            },
-            None,
-        ))?;
-
-        let device = Arc::new(device);
-        let queue = Arc::new(queue);
-        let surface_format = wgpu::TextureFormat::Bgra8UnormSrgb;
-
-        let mut renderer = match fonts {
-            Some(fonts) => WgpuRenderer::new_with_fonts(fonts),
-            None => WgpuRenderer::new(),
+        content: impl FnMut() + Send + 'static,
+    ) -> Result<Self, DesktopRobotError> {
+        let settings = AppSettings {
+            initial_width: width,
+            initial_height: height,
+            fonts,
+            ..AppSettings::default()
         };
-        renderer.init_gpu(device.clone(), queue.clone(), surface_format);
-        renderer.set_root_scale(1.0);
 
-        let mut shell = AppShell::new(renderer, default_root_key(), content);
-        shell.set_buffer_size(width, height);
-        shell.set_viewport(width as f32, height as f32);
-        shell.set_frame_waker(|| {});
+        let app = run_with_robot(settings, content)?;
+        app.set_viewport(width as f32, height as f32)?;
 
-        let (texture, view) = create_render_target(&device, surface_format, width, height);
-
-        Ok(Self {
-            shell,
-            device,
-            queue,
-            texture,
-            view,
-            surface_format,
-            width,
-            height,
-        })
+        Ok(Self { inner: app })
     }
 
-    /// Resize the viewport and backing texture.
-    pub fn set_viewport(&mut self, width: u32, height: u32) {
-        if width == self.width && height == self.height {
-            return;
-        }
-
-        self.width = width;
-        self.height = height;
-        self.shell.set_buffer_size(width, height);
-        self.shell.set_viewport(width as f32, height as f32);
-        let (texture, view) =
-            create_render_target(&self.device, self.surface_format, width, height);
-        self.texture = texture;
-        self.view = view;
+    /// Resize the viewport used for layout.
+    pub fn set_viewport(&self, width: f32, height: f32) -> Result<(), DesktopRobotError> {
+        self.inner.set_viewport(width, height)
     }
 
-    /// Run a single frame update and render into the offscreen texture.
-    pub fn render_frame(&mut self) -> Result<(), WgpuRobotError> {
-        self.shell.update();
-        self.shell
-            .renderer()
-            .render(&self.view, self.width, self.height)
-            .map_err(|err| WgpuRobotError::Render(format!("{err:?}")))?;
-        Ok(())
+    /// Drive the app until no redraws are requested or the iteration limit is reached.
+    pub fn pump_until_idle(&self, max_iterations: usize) -> Result<(), DesktopRobotError> {
+        self.inner.pump_until_idle(max_iterations)
     }
 
-    /// Drive the application until no redraw is requested or the iteration limit
-    /// is reached.
-    pub fn pump_until_idle(&mut self, max_iterations: usize) -> Result<(), WgpuRobotError> {
-        for _ in 0..max_iterations {
-            if !self.shell.needs_redraw() {
-                break;
-            }
-            self.render_frame()?;
-        }
-        Ok(())
-    }
-
-    /// Move the virtual pointer to the provided coordinates, dispatching pointer
-    /// move events to any hit targets.
-    pub fn move_pointer(&mut self, x: f32, y: f32) -> Result<bool, WgpuRobotError> {
-        let moved = self.shell.set_cursor(x, y);
-        self.render_frame()?;
-        Ok(moved)
+    /// Move the virtual pointer to the provided coordinates, dispatching pointer move
+    /// events to any hit targets.
+    pub fn move_pointer(&self, x: f32, y: f32) -> Result<bool, DesktopRobotError> {
+        self.inner.move_pointer(x, y)
     }
 
     /// Press the virtual pointer at the provided coordinates.
-    pub fn press(&mut self, x: f32, y: f32) -> Result<bool, WgpuRobotError> {
-        self.shell.set_cursor(x, y);
-        let pressed = self.shell.pointer_pressed();
-        self.render_frame()?;
-        Ok(pressed)
+    pub fn press(&self, x: f32, y: f32) -> Result<bool, DesktopRobotError> {
+        self.inner.press(x, y)
     }
 
     /// Release the virtual pointer at the provided coordinates.
-    pub fn release(&mut self, x: f32, y: f32) -> Result<bool, WgpuRobotError> {
-        self.shell.set_cursor(x, y);
-        let released = self.shell.pointer_released();
-        self.render_frame()?;
-        Ok(released)
+    pub fn release(&self, x: f32, y: f32) -> Result<bool, DesktopRobotError> {
+        self.inner.release(x, y)
     }
 
-    /// Convenience helper that presses and releases the pointer at the provided
+    /// Convenience helper that presses and then releases the pointer at the provided
     /// coordinates.
-    pub fn click(&mut self, x: f32, y: f32) -> Result<bool, WgpuRobotError> {
-        self.shell.set_cursor(x, y);
-        let pressed = self.shell.pointer_pressed();
-        let released = self.shell.pointer_released();
-        self.render_frame()?;
-        Ok(pressed || released)
+    pub fn click(&self, x: f32, y: f32) -> Result<bool, DesktopRobotError> {
+        self.inner.click(x, y)
     }
 
-    /// Snapshot the current render scene for assertions.
-    pub fn snapshot(&mut self) -> SceneSnapshot {
-        SceneSnapshot::from_wgpu_scene(self.shell.scene())
+    /// Capture a snapshot of the current render scene for assertions.
+    pub fn snapshot(&self) -> Result<SceneSnapshot, DesktopRobotError> {
+        let snapshot = self.inner.snapshot()?;
+        Ok(SceneSnapshot::from_robot_snapshot(&snapshot))
     }
 
     /// Capture the currently rendered frame into RGBA bytes suitable for
     /// screenshot comparisons.
-    pub fn capture_frame(&mut self) -> Result<FrameCapture, WgpuRobotError> {
-        self.render_frame()?;
-        let bytes = read_texture_rgba(
-            &self.device,
-            &self.queue,
-            &self.texture,
-            self.width,
-            self.height,
-        )?;
-        Ok(FrameCapture {
-            width: self.width,
-            height: self.height,
-            pixels: bytes,
-        })
+    pub fn capture_frame(&self) -> Result<FrameCapture, DesktopRobotError> {
+        let frame = self.inner.capture_frame()?;
+        Ok(FrameCapture::from_robot_capture(frame))
     }
 
-    /// Shut down the robot-controlled application. Dropping the instance will
-    /// clean up the underlying shell; this is provided for clarity in tests.
-    pub fn close(self) {}
+    /// Shut down the robot-controlled application.
+    pub fn close(self) -> Result<(), DesktopRobotError> {
+        self.inner.close()
+    }
 }
 
 /// In-memory screenshot of a rendered frame.
@@ -206,127 +116,12 @@ impl FrameCapture {
     pub fn rgba(&self) -> &[u8] {
         &self.pixels
     }
-}
 
-#[derive(Debug, thiserror::Error)]
-pub enum WgpuRobotError {
-    #[error("no WGPU adapter available for headless robot run")]
-    NoAdapter,
-    #[error("failed to create device: {0}")]
-    RequestDevice(#[from] wgpu::RequestDeviceError),
-    #[error("rendering failed: {0}")]
-    Render(String),
-    #[error("buffer mapping failed: {0}")]
-    Map(wgpu::BufferAsyncError),
-    #[error("buffer mapping channel dropped before completion")]
-    MapChannel,
-}
-
-fn create_render_target(
-    device: &wgpu::Device,
-    format: wgpu::TextureFormat,
-    width: u32,
-    height: u32,
-) -> (wgpu::Texture, wgpu::TextureView) {
-    let texture = device.create_texture(&wgpu::TextureDescriptor {
-        label: Some("robot-framebuffer"),
-        size: wgpu::Extent3d {
-            width,
-            height,
-            depth_or_array_layers: 1,
-        },
-        mip_level_count: 1,
-        sample_count: 1,
-        dimension: wgpu::TextureDimension::D2,
-        format,
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
-        view_formats: &[format],
-    });
-
-    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
-    (texture, view)
-}
-
-fn read_texture_rgba(
-    device: &wgpu::Device,
-    queue: &wgpu::Queue,
-    texture: &wgpu::Texture,
-    width: u32,
-    height: u32,
-) -> Result<Vec<u8>, WgpuRobotError> {
-    let bytes_per_pixel = std::mem::size_of::<[u8; 4]>();
-    let unpadded_bytes_per_row = width as usize * bytes_per_pixel;
-    let padded_bytes_per_row = wgpu::util::align_to(
-        unpadded_bytes_per_row,
-        wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize,
-    );
-    let output_buffer_size = (padded_bytes_per_row * height as usize) as wgpu::BufferAddress;
-
-    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
-        label: Some("robot-readback"),
-        size: output_buffer_size,
-        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
-        mapped_at_creation: false,
-    });
-
-    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-        label: Some("robot-copy"),
-    });
-    encoder.copy_texture_to_buffer(
-        wgpu::ImageCopyTexture {
-            texture,
-            mip_level: 0,
-            origin: wgpu::Origin3d::ZERO,
-            aspect: wgpu::TextureAspect::All,
-        },
-        wgpu::ImageCopyBuffer {
-            buffer: &buffer,
-            layout: wgpu::ImageDataLayout {
-                offset: 0,
-                bytes_per_row: Some(padded_bytes_per_row as u32),
-                rows_per_image: Some(height),
-            },
-        },
-        wgpu::Extent3d {
-            width,
-            height,
-            depth_or_array_layers: 1,
-        },
-    );
-    queue.submit(Some(encoder.finish()));
-    device.poll(wgpu::Maintain::Wait);
-
-    let buffer_slice = buffer.slice(..);
-    let (sender, receiver) = mpsc::channel();
-    buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
-        let _ = sender.send(result);
-    });
-    device.poll(wgpu::Maintain::Wait);
-    match receiver.recv() {
-        Ok(Ok(())) => {}
-        Ok(Err(err)) => return Err(WgpuRobotError::Map(err)),
-        Err(_) => return Err(WgpuRobotError::MapChannel),
+    fn from_robot_capture(capture: RobotFrameCapture) -> Self {
+        Self {
+            width: capture.width,
+            height: capture.height,
+            pixels: capture.pixels,
+        }
     }
-
-    let data = buffer_slice.get_mapped_range();
-    let mut pixels = vec![0u8; width as usize * height as usize * bytes_per_pixel];
-    for row in 0..height as usize {
-        let src_offset = row * padded_bytes_per_row;
-        let dst_offset = row * unpadded_bytes_per_row;
-        let src = &data[src_offset..src_offset + unpadded_bytes_per_row];
-        pixels[dst_offset..dst_offset + unpadded_bytes_per_row].copy_from_slice(src);
-    }
-
-    drop(data);
-    buffer.unmap();
-
-    for chunk in pixels.chunks_exact_mut(4) {
-        chunk.swap(0, 2); // BGRA → RGBA
-    }
-
-    Ok(pixels)
 }
-
-#[cfg(test)]
-#[path = "tests/wgpu_robot_tests.rs"]
-mod tests;


### PR DESCRIPTION
## Summary
- add a robot-style testing harness that wraps `AppShell` with the pixels renderer for pointer-driven UI automation
- expose the robot utilities through the compose-testing crate along with new dependencies
- add integration tests that drive a counter app via simulated pointer input and validate rendered text

## Testing
- cargo clippy
- cargo test -p compose-testing

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b34e2102483288d054bcde9d4f357)