### PR TITLE
Fix GitHub Pages deployment workflow error

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -39,7 +39,8 @@ jobs:
 
       - name: Build WASM demo
         run: |
-          wasm-pack build --target web --out-dir apps/desktop-demo/pkg apps/desktop-demo
+          set -e
+          wasm-pack build --target web --features web,renderer-wgpu --out-dir apps/desktop-demo/pkg apps/desktop-demo
 
       - name: Create deployment directory
         run: |


### PR DESCRIPTION
The wasm-pack build was failing silently because it was using the default features (desktop) instead of the web feature. This fix:

1. Adds --features web,renderer-wgpu to enable WASM dependencies
2. Adds set -e to fail immediately on build errors

The build was running for 1m 39s and failing silently, causing the deployment step to fail when trying to copy the non-existent pkg directory.