### PR TITLE
Fix GitHub Pages publishing for WASM build

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -e
           cd apps/desktop-demo
-          wasm-pack build --target web --features web,renderer-wgpu --out-dir pkg .
+          wasm-pack build --target web --features web,renderer-wgpu --out-dir pkg
 
       - name: Create deployment directory
         run: |


### PR DESCRIPTION
The cargo build command doesn't accept positional arguments. The trailing '.' in the wasm-pack build command was being passed to cargo, causing the build to fail.