### PR TITLE
Fix GitHub CI deployment to Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,7 +35,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: cargo install wasm-pack --version 0.12.1
 
       - name: Build WASM demo
         run: |


### PR DESCRIPTION
The latest wasm-pack version has a compatibility issue with stable Rust, where it tries to use cargo's --out-dir flag which has been renamed to --artifact-dir and is only available on nightly. Pinning to v0.12.1 resolves this issue.