### PR TITLE
Fix GitHub Pages CI build

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,7 +35,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack --version 0.12.1
+        run: cargo install wasm-pack --version 0.13.1
 
       - name: Build WASM demo
         run: |


### PR DESCRIPTION
The previous version (0.12.1) was using the --out-dir flag which has been changed to --artifact-dir in newer Cargo versions. The --artifact-dir flag is only available on nightly Rust, causing the build to fail on stable Rust.

Upgrading to wasm-pack 0.13.1 resolves this compatibility issue with stable Rust toolchain.