### PR TITLE
Use nightly toolchain for Pages wasm build

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust (nightly for wasm-pack artifact output)
+        uses: dtolnay/rust-toolchain@nightly
         with:
           targets: wasm32-unknown-unknown
 


### PR DESCRIPTION
## Summary
- switch the Pages deployment workflow to use the nightly Rust toolchain for wasm-pack
- ensure the wasm32-unknown-unknown target is installed for the nightly toolchain

## Testing
- Not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c0ab1fad0832883423d667c1055fc)