### PR TITLE
Fix GitHub Pages workflow build flag

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -e
           cd apps/desktop-demo
-          wasm-pack build --target web --features web,renderer-wgpu --out-dir pkg
+          wasm-pack build --target web --features web,renderer-wgpu --out-dir pkg -- -Z unstable-options
 
       - name: Create deployment directory
         run: |


### PR DESCRIPTION
## Summary
- add `-Z unstable-options` to the wasm-pack build step so cargo accepts the `--out-dir` argument on nightly

## Testing
- not run (CI workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c0cb673608328a68cb6d77883fe29)