### PR TITLE
Clean up desktop demo wasm build warnings

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -e
           cd apps/desktop-demo
-          wasm-pack build --target web --features web,renderer-wgpu --out-dir pkg -- -Z unstable-options
+          wasm-pack build --target web --features web,renderer-wgpu
 
       - name: Create deployment directory
         run: |

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -100,7 +100,6 @@ fn local_holder() -> CompositionLocal<Holder> {
 }
 
 fn random() -> i32 {
-    use instant::{SystemTime, Duration};
     // For WASM compatibility, use a simple counter-based seed
     #[cfg(target_arch = "wasm32")]
     {
@@ -110,6 +109,8 @@ fn random() -> i32 {
     }
     #[cfg(not(target_arch = "wasm32"))]
     {
+        use instant::SystemTime;
+
         let nanos = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
@@ -796,16 +797,16 @@ fn counter_app() {
     let fetch_key = fetch_request.get();
     {
         let async_message_state = async_message;
-        LaunchedEffect!(fetch_key, move |scope| {
+        LaunchedEffect!(fetch_key, move |_scope| {
             if fetch_key == 0 {
                 return;
             }
             let message_for_ui = async_message_state;
             #[cfg(not(target_arch = "wasm32"))]
-            scope.launch_background(
+            _scope.launch_background(
                 move |token| {
-                    use std::thread;
                     use instant::{Duration, SystemTime};
+                    use std::thread;
 
                     for _ in 0..5 {
                         if token.is_cancelled() {
@@ -829,7 +830,10 @@ fn counter_app() {
             );
             // On WASM, immediately set a message since we can't use background threads
             #[cfg(target_arch = "wasm32")]
-            message_for_ui.set(format!("WASM: Background threads not supported (fetch #{})", fetch_key));
+            message_for_ui.set(format!(
+                "WASM: Background threads not supported (fetch #{})",
+                fetch_key
+            ));
         });
     }
     LaunchedEffect!(counter.get(), |_| println!("effect call"));


### PR DESCRIPTION
## Summary
- gate the random seed helper's `SystemTime` import to non-wasm builds to avoid unused warnings
- mark the fetch effect scope parameter unused on wasm while still using it for desktop background work, and tidy the wasm message formatting

## Testing
- wasm-pack build --target web --features web,renderer-wgpu


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c0e19ba6083288a6bdcc45014b58b)