### PR TITLE
Add scroll handling for tab row

### DIFF
--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -9,6 +9,7 @@ use compose_ui::{
     IntrinsicSize, LinearArrangement, Modifier, Point, PointerInputScope, RoundedCornerShape, Row,
     RowSpec, Size, Spacer, Text, VerticalAlignment,
 };
+use compose_ui::{remember_scroll_state, ScrollAxis};
 use std::cell::RefCell;
 
 mod mineswapper2;
@@ -130,10 +131,14 @@ pub fn combined_app() {
         Modifier::empty().padding(20.0),
         ColumnSpec::default(),
         move || {
+            let tabs_scroll = remember_scroll_state(0.0);
             let tab_state_for_row = active_tab;
             let tab_state_for_content = active_tab;
             Row(
-                Modifier::empty().fill_max_width().padding(8.0),
+                Modifier::empty()
+                    .fill_max_width()
+                    .padding(8.0)
+                    .scrollable(tabs_scroll, ScrollAxis::Horizontal),
                 RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
                 move || {
                     let render_tab_button = {

--- a/crates/compose-ui/src/lib.rs
+++ b/crates/compose-ui/src/lib.rs
@@ -14,6 +14,7 @@ mod pointer_dispatch;
 mod primitives;
 mod render_state;
 mod renderer;
+mod scroll;
 mod subcompose_layout;
 mod text;
 mod text_modifier_node;
@@ -62,6 +63,7 @@ pub use render_state::{
     take_focus_invalidation, take_pointer_invalidation, take_render_invalidation,
 };
 pub use renderer::{HeadlessRenderer, PaintLayer, RecordedRenderScene, RenderOp};
+pub use scroll::{remember_scroll_state, ScrollAxis, ScrollState};
 pub use subcompose_layout::{
     Constraints, MeasureResult, Placement, SubcomposeLayoutNode, SubcomposeLayoutScope,
     SubcomposeMeasureScope, SubcomposeMeasureScopeImpl,

--- a/crates/compose-ui/src/modifier/mod.rs
+++ b/crates/compose-ui/src/modifier/mod.rs
@@ -22,6 +22,7 @@ mod local;
 mod offset;
 mod padding;
 mod pointer_input;
+mod scroll;
 mod semantics;
 mod size;
 mod slices;

--- a/crates/compose-ui/src/modifier/scroll.rs
+++ b/crates/compose-ui/src/modifier/scroll.rs
@@ -1,0 +1,28 @@
+use super::{inspector_metadata, Modifier};
+use crate::modifier_nodes::ScrollElement;
+use crate::scroll::{ScrollAxis, ScrollState};
+
+impl Modifier {
+    /// Make content scrollable in the given axis using the provided [ScrollState].
+    ///
+    /// This attaches both a layout modifier that offsets the content based on the
+    /// scroll state and a pointer input handler that updates the state from drag
+    /// gestures.
+    pub fn scrollable(self, state: ScrollState, axis: ScrollAxis) -> Self {
+        let inspector_state = state.clone();
+        let modifier = Modifier::with_element(ScrollElement::new(state, axis))
+            .with_inspector_metadata(inspector_metadata("scrollable", move |info| {
+                info.add_property(
+                    "axis",
+                    match axis {
+                        ScrollAxis::Horizontal => "Horizontal",
+                        ScrollAxis::Vertical => "Vertical",
+                    },
+                );
+                info.add_property("scrollOffset", format!("{:.2}", inspector_state.value()));
+            }))
+            .clip_to_bounds();
+
+        self.then(modifier)
+    }
+}

--- a/crates/compose-ui/src/scroll.rs
+++ b/crates/compose-ui/src/scroll.rs
@@ -1,0 +1,104 @@
+use compose_core::{mutableStateOf, remember, MutableState};
+use compose_macros::composable;
+use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ScrollAxis {
+    Horizontal,
+    Vertical,
+}
+
+/// Simple scroll position holder backed by snapshot state.
+#[derive(Clone, Debug)]
+pub struct ScrollState {
+    id: u64,
+    offset: MutableState<f32>,
+    max_offset: MutableState<f32>,
+}
+
+impl ScrollState {
+    /// Create a scroll state starting at the provided offset.
+    pub fn new(initial: f32) -> Self {
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+        Self {
+            id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+            offset: mutableStateOf(initial),
+            max_offset: mutableStateOf(0.0),
+        }
+    }
+
+    pub fn value(&self) -> f32 {
+        self.offset.get()
+    }
+
+    pub fn max_value(&self) -> f32 {
+        self.max_offset.get()
+    }
+
+    /// Update the allowed scroll extent and clamp the current position.
+    pub fn update_bounds(&self, max_value: f32) {
+        let clamped = max_value.max(0.0);
+        self.max_offset.set(clamped);
+        self.offset.update(|value| {
+            if *value > clamped {
+                *value = clamped;
+            }
+        });
+    }
+
+    /// Apply a raw delta to the scroll position, returning the consumed amount.
+    pub fn dispatch_raw_delta(&self, delta: f32) -> f32 {
+        let max_value = self.max_offset.get();
+        self.offset.update(|value| {
+            let new_value = (*value + delta).clamp(0.0, max_value.max(0.0));
+            let consumed = new_value - *value;
+            *value = new_value;
+            consumed
+        })
+    }
+}
+
+#[composable]
+pub fn remember_scroll_state(initial: f32) -> ScrollState {
+    remember(move || ScrollState::new(initial)).with(|state| state.clone())
+}
+
+impl PartialEq for ScrollState {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for ScrollState {}
+
+impl Hash for ScrollState {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::run_test_composition;
+
+    #[test]
+    fn dispatch_raw_delta_clamps_to_bounds() {
+        run_test_composition(|| {
+            let state = remember_scroll_state(0.0);
+            state.update_bounds(10.0);
+
+            assert_eq!(state.dispatch_raw_delta(5.0), 5.0);
+            assert_eq!(state.value(), 5.0);
+
+            // Exceeding max clamps to the configured bound
+            assert_eq!(state.dispatch_raw_delta(10.0), 5.0);
+            assert_eq!(state.value(), 10.0);
+
+            // Negative deltas clamp at zero
+            assert_eq!(state.dispatch_raw_delta(-15.0), -10.0);
+            assert_eq!(state.value(), 0.0);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add scroll state and scrollable modifier with gesture handling
- integrate layout and pointer support for scrolling content
- apply horizontal scrolling to the desktop demo tab row

## Testing
- cargo test
- cargo clippy

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c87fc565c83288eb4bbe64a4a03c7)