### PR TITLE
Reduce binary file sizes

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,14 @@
+[build]
+# Remap source paths to shorter names in panic messages
+rustflags = [
+    "--remap-path-prefix", "/root/.cargo/registry/src/=",
+    "--remap-path-prefix", "/home/user/rs-compose/=",
+]
+
+[target.wasm32-unknown-unknown]
+rustflags = [
+    "--cfg", "web_sys_unstable_apis",
+    "--cfg", "getrandom_backend=\"wasm_js\"",
+    "--remap-path-prefix", "/root/.cargo/registry/src/=",
+    "--remap-path-prefix", "/home/user/rs-compose/=",
+]

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -34,14 +34,22 @@ jobs:
         with:
           cache-on-failure: true
 
+      - name: Install binaryen (wasm-opt) for size optimization
+        run: sudo apt-get install -y binaryen
+
       - name: Install wasm-pack
         run: cargo install wasm-pack --version 0.13.1
 
-      - name: Build WASM demo
+      - name: Build WASM demo (optimized for size)
         run: |
           set -e
           cd apps/desktop-demo
+          # wasm-pack uses release profile from Cargo.toml (LTO, strip, etc.)
+          # wasm-opt runs with -Oz for additional size optimization
           wasm-pack build --target web --features web,renderer-wgpu
+          # Report binary size
+          echo "WASM binary size:"
+          ls -lh pkg/desktop_app_bg.wasm
 
       - name: Create deployment directory
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,30 @@ dependencies = [
  "jni-sys",
  "libc",
  "log",
- "ndk",
+ "ndk 0.8.0",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "android-activity"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
+dependencies = [
+ "android-properties",
+ "bitflags 2.10.0",
+ "cc",
+ "cesu8",
+ "jni",
+ "jni-sys",
+ "libc",
+ "log",
+ "ndk 0.9.0",
+ "ndk-context",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror 1.0.69",
 ]
@@ -145,6 +166,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,7 +198,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -176,6 +215,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -188,6 +233,9 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block"
@@ -196,21 +244,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
-name = "block-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7"
-dependencies = [
- "objc-sys",
-]
-
-[[package]]
 name = "block2"
-version = "0.3.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "block-sys",
  "objc2",
 ]
 
@@ -248,9 +286,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "calloop"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
  "bitflags 2.10.0",
  "log",
@@ -262,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "calloop-wayland-source"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
  "calloop",
  "rustix 0.38.44",
@@ -377,6 +415,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "com"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,7 +477,7 @@ dependencies = [
 name = "compose-app"
 version = "0.1.0"
 dependencies = [
- "android-activity",
+ "android-activity 0.5.2",
  "android_logger",
  "compose-app-shell",
  "compose-platform-android",
@@ -440,12 +489,12 @@ dependencies = [
  "console_error_panic_hook",
  "log",
  "pixels",
- "pollster",
+ "pollster 0.4.0",
  "raw-window-handle",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu",
+ "wgpu 25.0.2",
  "winit",
 ]
 
@@ -565,7 +614,7 @@ dependencies = [
  "glyphon",
  "log",
  "lru",
- "wgpu",
+ "wgpu 25.0.2",
 ]
 
 [[package]]
@@ -679,19 +728,21 @@ dependencies = [
 
 [[package]]
 name = "cosmic-text"
-version = "0.10.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75acbfb314aeb4f5210d379af45ed1ec2c98c7f1790bf57b8a4c562ac0c51b71"
+checksum = "da46a9d5a8905cc538a4a5bceb6a4510de7a51049c5588c0114efce102bcbbe8"
 dependencies = [
+ "bitflags 2.10.0",
  "fontdb",
- "libm",
  "log",
  "rangemap",
  "rustc-hash 1.1.0",
  "rustybuzz",
  "self_cell",
+ "smol_str",
  "swash",
  "sys-locale",
+ "ttf-parser 0.21.1",
  "unicode-bidi",
  "unicode-linebreak",
  "unicode-script",
@@ -786,7 +837,7 @@ dependencies = [
 name = "desktop-app"
 version = "0.1.0"
 dependencies = [
- "android-activity",
+ "android-activity 0.5.2",
  "anyhow",
  "compose-animation",
  "compose-app",
@@ -799,11 +850,13 @@ dependencies = [
  "env_logger",
  "getrandom 0.3.4",
  "instant",
+ "js-sys",
  "log",
  "reqwest",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-logger",
+ "web-sys",
 ]
 
 [[package]]
@@ -833,10 +886,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "either"
@@ -922,9 +990,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.7.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3971f9a5ca983419cdc386941ba3b9e1feba01a0ab888adf78739feb2798492"
+checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
 dependencies = [
  "bytemuck",
 ]
@@ -940,16 +1008,16 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.15.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020e203f177c0fb250fb19455a252e838d2bbbce1f80f25ecc42402aafa8cd38"
+checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
 dependencies = [
  "fontconfig-parser",
  "log",
- "memmap2 0.8.0",
+ "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser 0.19.2",
+ "ttf-parser 0.20.0",
 ]
 
 [[package]]
@@ -1099,6 +1167,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "glow"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "glutin_wgl_sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,15 +1188,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "glyphon"
-version = "0.5.0"
+name = "glutin_wgl_sys"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a62d0338e4056db6a73221c2fb2e30619452f6ea9651bac4110f51b0f7a7581"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "glyphon"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6a289ad2a23656ccf4306fc818cef6776471a136d909123fd26c0f2ecb44ba"
 dependencies = [
  "cosmic-text",
  "etagere",
  "lru",
- "wgpu",
+ "rustc-hash 2.1.1",
+ "wgpu 25.0.2",
 ]
 
 [[package]]
@@ -1148,7 +1238,19 @@ dependencies = [
  "presser",
  "thiserror 1.0.69",
  "winapi",
- "windows",
+ "windows 0.52.0",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror 1.0.69",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1158,8 +1260,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
 dependencies = [
  "bitflags 2.10.0",
- "gpu-descriptor-types",
+ "gpu-descriptor-types 0.1.2",
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.10.0",
+ "gpu-descriptor-types 0.2.0",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1172,6 +1285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,6 +1301,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -1228,6 +1351,12 @@ dependencies = [
  "widestring",
  "winapi",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1346,17 +1475,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "icrate"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319"
-dependencies = [
- "block2",
- "dispatch",
- "objc2",
 ]
 
 [[package]]
@@ -1646,6 +1764,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,15 +1816,6 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memmap2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
@@ -1713,6 +1828,21 @@ name = "metal"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+dependencies = [
+ "bitflags 2.10.0",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
+name = "metal"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
 dependencies = [
  "bitflags 2.10.0",
  "block",
@@ -1744,9 +1874,9 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50e3524642f53d9af419ab5e8dd29d3ba155708267667c2f3f06c88c9e130843"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "bitflags 2.10.0",
- "codespan-reporting",
+ "codespan-reporting 0.11.1",
  "hexf-parse",
  "indexmap",
  "log",
@@ -1759,6 +1889,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "naga"
+version = "25.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b977c445f26e49757f9aca3631c3b8b836942cb278d69a92e7b80d3b24da632"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.8.0",
+ "bitflags 2.10.0",
+ "cfg_aliases 0.2.1",
+ "codespan-reporting 0.12.0",
+ "half",
+ "hashbrown 0.15.5",
+ "hexf-parse",
+ "indexmap",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "strum",
+ "thiserror 2.0.17",
+ "unicode-ident",
+]
+
+[[package]]
 name = "ndk"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,7 +1922,21 @@ dependencies = [
  "bitflags 2.10.0",
  "jni-sys",
  "log",
- "ndk-sys",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.10.0",
+ "jni-sys",
+ "log",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -1789,12 +1958,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1837,19 +2016,200 @@ checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 
 [[package]]
 name = "objc2"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
  "objc-sys",
  "objc2-encode",
 ]
 
 [[package]]
-name = "objc2-encode"
-version = "3.0.0"
+name = "objc2-app-kit"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-contacts",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "dispatch",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation",
+ "objc2-link-presentation",
+ "objc2-quartz-core",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
+]
 
 [[package]]
 name = "objc_exception"
@@ -1879,6 +2239,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "247ad146e19b9437f8604c21f8652423595cf710ad108af40e77d3ae6e96b827"
 dependencies = [
  "libredox",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1935,6 +2304,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,11 +2342,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518d43cd70c5381d4c7bd4bf47ee344beee99b58b0587adcb198cc713ff0dfb5"
 dependencies = [
  "bytemuck",
- "pollster",
+ "pollster 0.3.0",
  "raw-window-handle",
  "thiserror 1.0.69",
  "ultraviolet",
- "wgpu",
+ "wgpu 0.19.4",
 ]
 
 [[package]]
@@ -2013,6 +2402,18 @@ name = "pollster"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
@@ -2088,7 +2489,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
- "web-time 1.1.0",
+ "web-time",
 ]
 
 [[package]]
@@ -2109,7 +2510,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tinyvec",
  "tracing",
- "web-time 1.1.0",
+ "web-time",
 ]
 
 [[package]]
@@ -2210,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.22.7"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69aacb76b5c29acfb7f90155d39759a29496aebb49395830e928a9703d2eec2f"
+checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -2220,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -2389,7 +2790,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
- "web-time 1.1.0",
+ "web-time",
  "zeroize",
 ]
 
@@ -2422,15 +2823,15 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustybuzz"
-version = "0.11.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee8fe2a8461a0854a37101fe7a1b13998d0cfa987e43248e81d2a5f4570f6fa"
+checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.10.0",
  "bytemuck",
  "libm",
  "smallvec 1.15.1",
- "ttf-parser 0.20.0",
+ "ttf-parser 0.21.1",
  "unicode-bidi-mirroring",
  "unicode-ccc",
  "unicode-properties",
@@ -2475,13 +2876,13 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.8.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b31447ca297092c5a9916fc3b955203157b37c19ca8edde4f52e9843e602c7"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
 dependencies = [
  "ab_glyph",
  "log",
- "memmap2 0.9.9",
+ "memmap2",
  "smithay-client-toolkit",
  "tiny-skia",
 ]
@@ -2555,9 +2956,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "skrifa"
-version = "0.22.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1c44ad1f6c5bdd4eefed8326711b7dbda9ea45dfd36068c427d332aa382cbe"
+checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -2592,9 +2993,9 @@ checksum = "ef784004ca8777809dcdad6ac37629f0a97caee4c685fcea805278d81dd8b857"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.18.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
  "bitflags 2.10.0",
  "calloop",
@@ -2602,7 +3003,7 @@ dependencies = [
  "cursor-icon",
  "libc",
  "log",
- "memmap2 0.9.9",
+ "memmap2",
  "rustix 0.38.44",
  "thiserror 1.0.69",
  "wayland-backend",
@@ -2662,6 +3063,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2675,9 +3098,9 @@ checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "swash"
-version = "0.1.19"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd59f3f359ddd2c95af4758c18270eddd9c730dde98598023cdabff472c2ca2"
+checksum = "47846491253e976bdd07d0f9cc24b7daf24720d11309302ccbbc6e6b6e53550a"
 dependencies = [
  "skrifa",
  "yazi",
@@ -2976,15 +3399,15 @@ checksum = "7b3e06c9b9d80ed6b745c7159c40b311ad2916abb34a49e9be2653b90db0d8dd"
 
 [[package]]
 name = "ttf-parser"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1"
-
-[[package]]
-name = "ttf-parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+
+[[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
 name = "ttf-parser"
@@ -3009,15 +3432,15 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-bidi-mirroring"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694"
+checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
 
 [[package]]
 name = "unicode-ccc"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1"
+checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
 
 [[package]]
 name = "unicode-ident"
@@ -3244,9 +3667,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.2"
+version = "0.32.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
 dependencies = [
  "bitflags 2.10.0",
  "wayland-backend",
@@ -3256,9 +3679,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.2.0"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
+checksum = "a07a14257c077ab3279987c4f8bb987851bf57081b93710381daea94f2c2c032"
 dependencies = [
  "bitflags 2.10.0",
  "wayland-backend",
@@ -3269,9 +3692,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.2.0"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
 dependencies = [
  "bitflags 2.10.0",
  "wayland-backend",
@@ -3315,16 +3738,6 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
@@ -3353,7 +3766,7 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "js-sys",
  "log",
- "naga",
+ "naga 0.19.2",
  "parking_lot",
  "profiling",
  "raw-window-handle",
@@ -3362,9 +3775,37 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-core 0.19.4",
+ "wgpu-hal 0.19.5",
+ "wgpu-types 0.19.2",
+]
+
+[[package]]
+name = "wgpu"
+version = "25.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec8fb398f119472be4d80bc3647339f56eb63b2a331f6a3d16e25d8144197dd9"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.10.0",
+ "cfg_aliases 0.2.1",
+ "document-features",
+ "hashbrown 0.15.5",
+ "js-sys",
+ "log",
+ "naga 25.0.1",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec 1.15.1",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core 25.0.2",
+ "wgpu-hal 25.0.2",
+ "wgpu-types 25.0.0",
 ]
 
 [[package]]
@@ -3374,13 +3815,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b94525fc99ba9e5c9a9e24764f2bc29bad0911a7446c12f446a8277369bf3a"
 dependencies = [
  "arrayvec",
- "bit-vec",
+ "bit-vec 0.6.3",
  "bitflags 2.10.0",
  "cfg_aliases 0.1.1",
- "codespan-reporting",
+ "codespan-reporting 0.11.1",
  "indexmap",
  "log",
- "naga",
+ "naga 0.19.2",
  "once_cell",
  "parking_lot",
  "profiling",
@@ -3389,8 +3830,76 @@ dependencies = [
  "smallvec 1.15.1",
  "thiserror 1.0.69",
  "web-sys",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-hal 0.19.5",
+ "wgpu-types 0.19.2",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "25.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7b882196f8368511d613c6aeec80655160db6646aebddf8328879a88d54e500"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.10.0",
+ "cfg_aliases 0.2.1",
+ "document-features",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "log",
+ "naga 25.0.1",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec 1.15.1",
+ "thiserror 2.0.17",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal 25.0.2",
+ "wgpu-types 25.0.0",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd488b3239b6b7b185c3b045c39ca6bf8af34467a4c5de4e0b1a564135d093d"
+dependencies = [
+ "wgpu-hal 25.0.2",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09ad7aceb3818e52539acc679f049d3475775586f3f4e311c30165cf2c00445"
+dependencies = [
+ "wgpu-hal 25.0.2",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca8809ad123f6c7f2c5e01a2c7117c4fdfd02f70bd422ee2533f69dfa98756c"
+dependencies = [
+ "wgpu-hal 25.0.2",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba5fb5f7f9c98baa7c889d444f63ace25574833df56f5b817985f641af58e46"
+dependencies = [
+ "wgpu-hal 25.0.2",
 ]
 
 [[package]]
@@ -3401,27 +3910,27 @@ checksum = "bfabcfc55fd86611a855816326b2d54c3b2fd7972c27ce414291562650552703"
 dependencies = [
  "android_system_properties",
  "arrayvec",
- "ash",
- "bit-set",
+ "ash 0.37.3+1.3.251",
+ "bit-set 0.5.3",
  "bitflags 2.10.0",
  "block",
  "cfg_aliases 0.1.1",
  "core-graphics-types",
  "d3d12",
- "glow",
- "glutin_wgl_sys",
+ "glow 0.13.1",
+ "glutin_wgl_sys 0.5.0",
  "gpu-alloc",
- "gpu-allocator",
- "gpu-descriptor",
+ "gpu-allocator 0.25.0",
+ "gpu-descriptor 0.2.4",
  "hassle-rs",
  "js-sys",
  "khronos-egl",
  "libc",
  "libloading 0.8.9",
  "log",
- "metal",
- "naga",
- "ndk-sys",
+ "metal 0.27.0",
+ "naga 0.19.2",
+ "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
  "parking_lot",
@@ -3434,8 +3943,55 @@ dependencies = [
  "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types",
+ "wgpu-types 0.19.2",
  "winapi",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "25.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f968767fe4d3d33747bbd1473ccd55bf0f6451f55d733b5597e67b5deab4ad17"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash 0.38.0+1.3.281",
+ "bit-set 0.8.0",
+ "bitflags 2.10.0",
+ "block",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "core-graphics-types",
+ "glow 0.16.0",
+ "glutin_wgl_sys 0.6.1",
+ "gpu-alloc",
+ "gpu-allocator 0.27.0",
+ "gpu-descriptor 0.3.2",
+ "hashbrown 0.15.5",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.9",
+ "log",
+ "metal 0.31.0",
+ "naga 25.0.1",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "objc",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "smallvec 1.15.1",
+ "thiserror 2.0.17",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types 25.0.0",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -3446,6 +4002,20 @@ checksum = "b671ff9fb03f78b46ff176494ee1ebe7d603393f42664be55b64dc8d53969805"
 dependencies = [
  "bitflags 2.10.0",
  "js-sys",
+ "web-sys",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa49460c2a8ee8edba3fca54325540d904dd85b2e086ada762767e17d06e8bc"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "thiserror 2.0.17",
  "web-sys",
 ]
 
@@ -3502,7 +4072,17 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core",
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
@@ -3516,10 +4096,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3528,15 +4162,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3592,21 +4217,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -3646,12 +4256,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3670,12 +4274,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3691,12 +4289,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3730,12 +4322,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3751,12 +4337,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3778,12 +4358,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3802,12 +4376,6 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -3820,37 +4388,41 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"
-version = "0.29.15"
+version = "0.30.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d59ad965a635657faf09c8f062badd885748428933dad8e8bdd64064d92e5ca"
+checksum = "c66d4b9ed69c4009f6321f762d6e61ad8a2389cd431b97cb1e146812e9e6c732"
 dependencies = [
  "ahash",
- "android-activity",
+ "android-activity 0.6.0",
  "atomic-waker",
  "bitflags 2.10.0",
+ "block2",
  "bytemuck",
  "calloop",
- "cfg_aliases 0.1.1",
+ "cfg_aliases 0.2.1",
+ "concurrent-queue",
  "core-foundation",
  "core-graphics",
  "cursor-icon",
- "icrate",
+ "dpi",
  "js-sys",
  "libc",
- "log",
- "memmap2 0.9.9",
- "ndk",
- "ndk-sys",
+ "memmap2",
+ "ndk 0.9.0",
  "objc2",
- "once_cell",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-ui-kit",
  "orbclient",
  "percent-encoding",
+ "pin-project",
  "raw-window-handle",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "rustix 0.38.44",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
+ "tracing",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3859,8 +4431,8 @@ dependencies = [
  "wayland-protocols",
  "wayland-protocols-plasma",
  "web-sys",
- "web-time 0.2.4",
- "windows-sys 0.48.0",
+ "web-time",
+ "windows-sys 0.52.0",
  "x11-dl",
  "x11rb",
  "xkbcommon-dl",
@@ -3952,9 +4524,9 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "yazi"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
+checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "yoke"
@@ -3981,9 +4553,9 @@ dependencies = [
 
 [[package]]
 name = "zeno"
-version = "0.2.3"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
+checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,23 @@ resolver = "2"
 [workspace.dependencies]
 # Force android-activity to use native-activity feature across all workspace crates
 android-activity = { version = "0.5", features = ["native-activity"] }
+
+# Release profile optimizations for smaller binaries
+[profile.release]
+opt-level = "s"         # Optimize for size (use "z" only for WASM)
+lto = true              # Link-Time Optimization across crates
+codegen-units = 1       # Better optimization (single codegen unit)
+strip = true            # Strip symbols from binary
+panic = "abort"         # Smaller binaries (no unwinding)
+debug = 0               # No debug info
+
+# Maximum size optimization profile (slower builds, smaller binaries)
+[profile.release-small]
+inherits = "release"
+opt-level = "z"         # Optimize for size over speed
+lto = "fat"             # Full LTO for maximum optimization
+
+# WASM-specific profile for web builds
+[profile.wasm-release]
+inherits = "release"
+opt-level = "z"         # Aggressive size optimization for WASM

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -28,9 +28,7 @@ desktop = ["compose-app/desktop"]
 android = ["compose-app/android"]
 web = ["compose-app/web", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:wasm-logger"]
 # Enable real app robot testing
-robot-app = ["compose-testing/robot-app"]
-# HTTP client for web fetch demo (adds ~1MB from rustls/ring)
-http-client = ["dep:reqwest"]
+robot-app = ["compose-testing/robot-app", "logging"]
 # Enable env_logger (adds ~600KB from regex)
 logging = ["dep:env_logger"]
 
@@ -51,7 +49,7 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = { version = "0.10", optional = true }
 anyhow = "1.0"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 
 # Android-specific dependencies (only when building for Android)
 [target.'cfg(target_os = "android")'.dependencies]
@@ -60,6 +58,15 @@ android-activity = { workspace = true }
 # WASM-specific dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1"
+js-sys = "0.3"
+web-sys = { version = "0.3", features = [
+    "Window",
+    "Request",
+    "RequestInit",
+    "RequestMode",
+    "Response",
+    "Headers",
+] }
 
 [dev-dependencies]
 compose-macros = { path = "../../crates/compose-macros" }

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = false
+# Enable wasm-opt with size optimization (can reduce WASM size by 20-40%)
+wasm-opt = ["-Oz", "--enable-bulk-memory", "--enable-mutable-globals", "--enable-nontrapping-float-to-int"]
 
 # Support both binary (desktop) and cdylib (Android)
 # IMPORTANT: The cdylib name (libdesktop_app.so) must match the android.app.lib_name
@@ -28,6 +29,10 @@ android = ["compose-app/android"]
 web = ["compose-app/web", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:wasm-logger"]
 # Enable real app robot testing
 robot-app = ["compose-testing/robot-app"]
+# HTTP client for web fetch demo (adds ~1MB from rustls/ring)
+http-client = ["dep:reqwest"]
+# Enable env_logger (adds ~600KB from regex)
+logging = ["dep:env_logger"]
 
 [dependencies]
 compose-app = { path = "../../crates/compose-app", default-features = false }
@@ -44,9 +49,9 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 
 # Non-WASM dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-env_logger = "0.10"
+env_logger = { version = "0.10", optional = true }
 anyhow = "1.0"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"], optional = true }
 
 # Android-specific dependencies (only when building for Android)
 [target.'cfg(target_os = "android")'.dependencies]

--- a/apps/desktop-demo/build-web.sh
+++ b/apps/desktop-demo/build-web.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 echo "Building RS-Compose Demo for Web..."
 echo ""
@@ -38,7 +37,35 @@ fi
 # - codegen-units=1 for better optimization
 # - wasm-opt runs with -Oz for size optimization
 echo "Building WASM module (optimized for size)..."
+
+# Run wasm-pack build, don't exit on error so we can handle it
+set +e
 "$WASM_PACK" build --target web --out-dir pkg --features web,renderer-wgpu --no-default-features
+BUILD_RESULT=$?
+set -e
+
+if [ $BUILD_RESULT -ne 0 ]; then
+    echo ""
+    echo "wasm-pack build failed with exit code $BUILD_RESULT"
+    echo "This might be due to wasm-opt issues. Retrying without wasm-opt..."
+    echo ""
+    
+    # Create a temporary Cargo.toml patch to disable wasm-opt
+    cp Cargo.toml Cargo.toml.backup
+    sed -i 's/wasm-opt = \[.*\]/wasm-opt = false/' Cargo.toml
+    
+    # Retry the build
+    "$WASM_PACK" build --target web --out-dir pkg --features web,renderer-wgpu --no-default-features
+    BUILD_RESULT=$?
+    
+    # Restore original Cargo.toml
+    mv Cargo.toml.backup Cargo.toml
+    
+    if [ $BUILD_RESULT -ne 0 ]; then
+        echo "Build failed even without wasm-opt"
+        exit 1
+    fi
+fi
 
 # Show resulting binary size
 if [ -f "pkg/desktop_app_bg.wasm" ]; then

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -12,11 +12,8 @@ use compose_ui::{
 use std::cell::RefCell;
 
 mod mineswapper2;
-
-#[cfg(all(not(target_arch = "wasm32"), feature = "http-client"))]
 mod web_fetch;
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "http-client"))]
 use web_fetch::web_fetch_example;
 
 thread_local! {
@@ -29,7 +26,6 @@ pub enum DemoTab {
     Counter,
     CompositionLocal,
     Async,
-    #[cfg(all(not(target_arch = "wasm32"), feature = "http-client"))]
     WebFetch,
     Layout,
     ModifierShowcase,
@@ -42,7 +38,6 @@ impl DemoTab {
             DemoTab::Counter => "Counter App",
             DemoTab::CompositionLocal => "CompositionLocal Test",
             DemoTab::Async => "Async Runtime",
-            #[cfg(all(not(target_arch = "wasm32"), feature = "http-client"))]
             DemoTab::WebFetch => "Web Fetch",
             DemoTab::Layout => "Recursive Layout",
             DemoTab::ModifierShowcase => "Modifiers Showcase",
@@ -190,7 +185,6 @@ pub fn combined_app() {
                     render_tab_button(DemoTab::Counter);
                     render_tab_button(DemoTab::CompositionLocal);
                     render_tab_button(DemoTab::Async);
-                    #[cfg(all(not(target_arch = "wasm32"), feature = "http-client"))]
                     render_tab_button(DemoTab::WebFetch);
                     render_tab_button(DemoTab::Layout);
                     render_tab_button(DemoTab::ModifierShowcase);
@@ -213,7 +207,6 @@ pub fn combined_app() {
                 DemoTab::Counter => counter_app(),
                 DemoTab::CompositionLocal => composition_local_example(),
                 DemoTab::Async => async_runtime_example(),
-                #[cfg(all(not(target_arch = "wasm32"), feature = "http-client"))]
                 DemoTab::WebFetch => web_fetch_example(),
                 DemoTab::Layout => recursive_layout_example(),
                 DemoTab::ModifierShowcase => modifier_showcase_tab(),

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -13,10 +13,10 @@ use std::cell::RefCell;
 
 mod mineswapper2;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "http-client"))]
 mod web_fetch;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "http-client"))]
 use web_fetch::web_fetch_example;
 
 thread_local! {
@@ -29,7 +29,7 @@ pub enum DemoTab {
     Counter,
     CompositionLocal,
     Async,
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "http-client"))]
     WebFetch,
     Layout,
     ModifierShowcase,
@@ -42,7 +42,7 @@ impl DemoTab {
             DemoTab::Counter => "Counter App",
             DemoTab::CompositionLocal => "CompositionLocal Test",
             DemoTab::Async => "Async Runtime",
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(all(not(target_arch = "wasm32"), feature = "http-client"))]
             DemoTab::WebFetch => "Web Fetch",
             DemoTab::Layout => "Recursive Layout",
             DemoTab::ModifierShowcase => "Modifiers Showcase",
@@ -190,7 +190,7 @@ pub fn combined_app() {
                     render_tab_button(DemoTab::Counter);
                     render_tab_button(DemoTab::CompositionLocal);
                     render_tab_button(DemoTab::Async);
-                    #[cfg(not(target_arch = "wasm32"))]
+                    #[cfg(all(not(target_arch = "wasm32"), feature = "http-client"))]
                     render_tab_button(DemoTab::WebFetch);
                     render_tab_button(DemoTab::Layout);
                     render_tab_button(DemoTab::ModifierShowcase);
@@ -213,7 +213,7 @@ pub fn combined_app() {
                 DemoTab::Counter => counter_app(),
                 DemoTab::CompositionLocal => composition_local_example(),
                 DemoTab::Async => async_runtime_example(),
-                #[cfg(not(target_arch = "wasm32"))]
+                #[cfg(all(not(target_arch = "wasm32"), feature = "http-client"))]
                 DemoTab::WebFetch => web_fetch_example(),
                 DemoTab::Layout => recursive_layout_example(),
                 DemoTab::ModifierShowcase => modifier_showcase_tab(),

--- a/apps/desktop-demo/src/lib.rs
+++ b/apps/desktop-demo/src/lib.rs
@@ -17,6 +17,7 @@ fn create_app() -> AppLauncher {
 /// Shared entry point for desktop
 #[cfg(all(not(target_os = "android"), not(target_arch = "wasm32")))]
 pub fn entry_point() {
+    #[cfg(feature = "logging")]
     let _ = env_logger::try_init();
     create_app().run(app::combined_app);
 }

--- a/crates/compose-app/Cargo.toml
+++ b/crates/compose-app/Cargo.toml
@@ -20,9 +20,9 @@ compose-platform-web = { path = "../compose-platform/web", optional = true }
 compose-render-pixels = { path = "../compose-render/pixels", optional = true }
 compose-render-wgpu = { path = "../compose-render/wgpu", optional = true }
 pixels = { version = "0.15", optional = true }
-wgpu = { version = "0.19", optional = true }
-pollster = { version = "0.3", optional = true }
-winit = { version = "0.29", optional = true }
+wgpu = { version = "25.0", optional = true }
+pollster = { version = "0.4", optional = true }
+winit = { version = "0.30", optional = true }
 android-activity = { workspace = true, optional = true }
 android_logger = { version = "0.14", optional = true }
 raw-window-handle = { version = "0.6", optional = true }

--- a/crates/compose-app/src/desktop.rs
+++ b/crates/compose-app/src/desktop.rs
@@ -7,10 +7,11 @@ use compose_app_shell::{default_root_key, AppShell};
 use compose_platform_desktop_winit::DesktopWinitPlatform;
 use compose_render_wgpu::WgpuRenderer;
 use std::sync::Arc;
+use winit::application::ApplicationHandler;
 use winit::dpi::LogicalSize;
-use winit::event::{ElementState, Event, MouseButton, WindowEvent};
-use winit::event_loop::{ControlFlow, EventLoopBuilder};
-use winit::window::WindowBuilder;
+use winit::event::{ElementState, MouseButton, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use winit::window::{Window, WindowId};
 
 #[cfg(feature = "robot")]
 use compose_ui::{LayoutBox, SemanticsAction, SemanticsNode, SemanticsRole};
@@ -379,30 +380,415 @@ impl Robot {
     }
 }
 
+/// Application state that implements winit's ApplicationHandler
+struct App {
+    /// Settings for the application
+    settings: AppSettings,
+    /// Content function to be called (taken on first resume)
+    content: Option<Box<dyn FnMut()>>,
+    /// Window (created on resumed)
+    window: Option<Arc<Window>>,
+    /// WGPU surface
+    surface: Option<wgpu::Surface<'static>>,
+    /// Surface configuration
+    surface_config: Option<wgpu::SurfaceConfiguration>,
+    /// Compose app shell
+    app: Option<AppShell<WgpuRenderer>>,
+    /// Platform adapter
+    platform: Option<DesktopWinitPlatform>,
+    /// Robot controller
+    #[cfg(feature = "robot")]
+    robot_controller: Option<RobotController>,
+}
+
+impl App {
+    fn new(settings: AppSettings, content: impl FnMut() + 'static) -> Self {
+        Self {
+            settings,
+            content: Some(Box::new(content)),
+            window: None,
+            surface: None,
+            surface_config: None,
+            app: None,
+            platform: None,
+            #[cfg(feature = "robot")]
+            robot_controller: None,
+        }
+    }
+
+    #[cfg(feature = "robot")]
+    fn set_robot_controller(&mut self, controller: RobotController) {
+        self.robot_controller = Some(controller);
+    }
+}
+
+impl ApplicationHandler for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        // Create window if not already created
+        if self.window.is_some() {
+            return;
+        }
+
+        let initial_width = self.settings.initial_width;
+        let initial_height = self.settings.initial_height;
+
+        let window = Arc::new(
+            event_loop
+                .create_window(
+                    Window::default_attributes()
+                        .with_title(self.settings.window_title.clone())
+                        .with_inner_size(LogicalSize::new(
+                            initial_width as f64,
+                            initial_height as f64,
+                        )),
+                )
+                .expect("failed to create window"),
+        );
+
+        // Initialize WGPU
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            ..Default::default()
+        });
+
+        let surface = instance
+            .create_surface(window.clone())
+            .expect("failed to create surface");
+
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: Some(&surface),
+            force_fallback_adapter: false,
+        }))
+        .expect("failed to find suitable adapter");
+
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                label: Some("Main Device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::default(),
+                memory_hints: wgpu::MemoryHints::default(),
+                trace: wgpu::Trace::Off,
+            },
+        ))
+        .expect("failed to create device");
+
+        let size = window.inner_size();
+        let surface_caps = surface.get_capabilities(&adapter);
+        let surface_format = surface_caps
+            .formats
+            .iter()
+            .copied()
+            .find(|f| f.is_srgb())
+            .unwrap_or(surface_caps.formats[0]);
+
+        let surface_config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format: surface_format,
+            width: size.width,
+            height: size.height,
+            present_mode: wgpu::PresentMode::Fifo,
+            alpha_mode: surface_caps.alpha_modes[0],
+            view_formats: vec![],
+            desired_maximum_frame_latency: 2,
+        };
+
+        surface.configure(&device, &surface_config);
+
+        // Create renderer with fonts from settings
+        let mut renderer = if let Some(fonts) = self.settings.fonts.take() {
+            WgpuRenderer::new_with_fonts(fonts)
+        } else {
+            WgpuRenderer::new()
+        };
+        renderer.init_gpu(Arc::new(device), Arc::new(queue), surface_format);
+        let initial_scale = window.scale_factor();
+        renderer.set_root_scale(initial_scale as f32);
+
+        // Take the content closure (can only be called once)
+        let content = self.content.take().expect("content already taken");
+        let mut app = AppShell::new(renderer, default_root_key(), content);
+        let mut platform = DesktopWinitPlatform::default();
+        platform.set_scale_factor(initial_scale);
+
+        // Set buffer_size to physical pixels and viewport to logical dp
+        app.set_buffer_size(size.width, size.height);
+        let logical_width = size.width as f32 / initial_scale as f32;
+        let logical_height = size.height as f32 / initial_scale as f32;
+        app.set_viewport(logical_width, logical_height);
+
+        self.window = Some(window);
+        self.surface = Some(surface);
+        self.surface_config = Some(surface_config);
+        self.app = Some(app);
+        self.platform = Some(platform);
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        let Some(window) = &self.window else { return };
+        if window_id != window.id() {
+            return;
+        }
+
+        let Some(app) = &mut self.app else { return };
+        let Some(platform) = &mut self.platform else { return };
+        let Some(surface) = &self.surface else { return };
+        let Some(surface_config) = &mut self.surface_config else { return };
+
+        match event {
+            WindowEvent::CloseRequested => {
+                event_loop.exit();
+            }
+            WindowEvent::Resized(new_size) => {
+                if new_size.width > 0 && new_size.height > 0 {
+                    surface_config.width = new_size.width;
+                    surface_config.height = new_size.height;
+                    let device = app.renderer().device();
+                    surface.configure(device, surface_config);
+
+                    let scale_factor = window.scale_factor();
+                    let logical_width = new_size.width as f32 / scale_factor as f32;
+                    let logical_height = new_size.height as f32 / scale_factor as f32;
+
+                    app.set_buffer_size(new_size.width, new_size.height);
+                    app.set_viewport(logical_width, logical_height);
+                }
+            }
+            WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                platform.set_scale_factor(scale_factor);
+                app.renderer().set_root_scale(scale_factor as f32);
+
+                let new_size = window.inner_size();
+                if new_size.width > 0 && new_size.height > 0 {
+                    surface_config.width = new_size.width;
+                    surface_config.height = new_size.height;
+                    let device = app.renderer().device();
+                    surface.configure(device, surface_config);
+
+                    let logical_width = new_size.width as f32 / scale_factor as f32;
+                    let logical_height = new_size.height as f32 / scale_factor as f32;
+
+                    app.set_buffer_size(new_size.width, new_size.height);
+                    app.set_viewport(logical_width, logical_height);
+                }
+            }
+            WindowEvent::CursorMoved { position, .. } => {
+                let logical = platform.pointer_position(position);
+                app.set_cursor(logical.x, logical.y);
+            }
+            WindowEvent::MouseInput {
+                state,
+                button: MouseButton::Left,
+                ..
+            } => match state {
+                ElementState::Pressed => {
+                    app.pointer_pressed();
+                }
+                ElementState::Released => {
+                    app.pointer_released();
+                }
+            },
+            WindowEvent::KeyboardInput { event, .. } => {
+                use winit::keyboard::{KeyCode, PhysicalKey};
+                if event.state == ElementState::Pressed {
+                    if let PhysicalKey::Code(KeyCode::KeyD) = event.physical_key {
+                        app.log_debug_info();
+                    }
+                }
+            }
+            WindowEvent::Focused(false) => {
+                // Window lost focus - cancel any in-progress gestures
+                app.cancel_gesture();
+            }
+            WindowEvent::CursorLeft { .. } => {
+                // Cursor left the window - cancel any in-progress gestures
+                app.cancel_gesture();
+            }
+            WindowEvent::RedrawRequested => {
+                app.update();
+
+                let output = match surface.get_current_texture() {
+                    Ok(output) => output,
+                    Err(wgpu::SurfaceError::Lost) | Err(wgpu::SurfaceError::Outdated) => {
+                        // Reconfigure surface with current window size
+                        let size = window.inner_size();
+                        if size.width > 0 && size.height > 0 {
+                            surface_config.width = size.width;
+                            surface_config.height = size.height;
+                            let device = app.renderer().device();
+                            surface.configure(device, surface_config);
+                        }
+                        return;
+                    }
+                    Err(wgpu::SurfaceError::OutOfMemory) => {
+                        log::error!("Out of memory, exiting");
+                        event_loop.exit();
+                        return;
+                    }
+                    Err(wgpu::SurfaceError::Timeout) => {
+                        log::debug!("Surface timeout, skipping frame");
+                        return;
+                    }
+                    Err(wgpu::SurfaceError::Other) => {
+                        log::error!("Surface other error, skipping frame");
+                        return;
+                    }
+                };
+
+                let view = output
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+
+                if let Err(err) =
+                    app.renderer()
+                        .render(&view, surface_config.width, surface_config.height)
+                {
+                    log::error!("render failed: {err:?}");
+                    return;
+                }
+
+                output.present();
+            }
+            _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let Some(app) = &mut self.app else { return };
+        let Some(window) = &self.window else { return };
+
+        // Handle pending robot commands
+        #[cfg(feature = "robot")]
+        if let Some(controller) = &mut self.robot_controller {
+            // Process new commands
+            while let Ok(cmd) = controller.rx.try_recv() {
+                match cmd {
+                    RobotCommand::Click { x, y } => {
+                        app.set_cursor(x, y);
+                        app.pointer_pressed();
+                        app.pointer_released();
+                        window.request_redraw();
+                        let _ = controller.tx.send(RobotResponse::Ok);
+                    }
+                    RobotCommand::MoveTo { x, y } => {
+                        app.set_cursor(x, y);
+                        window.request_redraw();
+                        let _ = controller.tx.send(RobotResponse::Ok);
+                    }
+                    RobotCommand::MouseDown => {
+                        app.pointer_pressed();
+                        let _ = controller.tx.send(RobotResponse::Ok);
+                    }
+                    RobotCommand::MouseUp => {
+                        app.pointer_released();
+                        let _ = controller.tx.send(RobotResponse::Ok);
+                    }
+
+                    RobotCommand::TouchDown { x, y } => {
+                        app.set_cursor(x, y);
+                        app.pointer_pressed();
+                        let _ = controller.tx.send(RobotResponse::Ok);
+                    }
+                    RobotCommand::TouchMove { x, y } => {
+                        app.set_cursor(x, y);
+                        let _ = controller.tx.send(RobotResponse::Ok);
+                    }
+                    RobotCommand::TouchUp { x, y } => {
+                        app.set_cursor(x, y);
+                        app.pointer_released();
+                        let _ = controller.tx.send(RobotResponse::Ok);
+                    }
+                    RobotCommand::GetSemantics => {
+                        let semantics = extract_semantics(app);
+                        let _ = controller.tx.send(RobotResponse::Semantics(semantics));
+                    }
+                    RobotCommand::WaitForIdle => {
+                        // Start waiting for idle
+                        controller.waiting_for_idle = true;
+                        controller.idle_iterations = 0;
+                    }
+                    RobotCommand::Exit => {
+                        let _ = controller.tx.send(RobotResponse::Ok);
+                        event_loop.exit();
+                    }
+                }
+            }
+
+            // Handle ongoing wait_for_idle
+            if controller.waiting_for_idle {
+                const MAX_IDLE_ITERATIONS: u32 = 200;
+
+                if !app.needs_redraw() && !app.has_active_animations() {
+                    // App is idle - respond and stop waiting
+                    controller.waiting_for_idle = false;
+                    let _ = controller.tx.send(RobotResponse::Ok);
+                } else {
+                    // Not idle yet - update and check iteration limit
+                    app.update();
+                    controller.idle_iterations += 1;
+
+                    // Periodic diagnostic logging
+                    if controller.idle_iterations % 50 == 0 {
+                        log::debug!(
+                            "wait_for_idle iteration {}: needs_redraw={}, has_animations={}",
+                            controller.idle_iterations,
+                            app.needs_redraw(),
+                            app.has_active_animations()
+                        );
+                    }
+
+                    if controller.idle_iterations >= MAX_IDLE_ITERATIONS {
+                        controller.waiting_for_idle = false;
+                        let _ = controller.tx.send(RobotResponse::Error(
+                            "wait_for_idle: timed out after 200 iterations".to_string()
+                        ));
+                    }
+                }
+            }
+        }
+
+        if app.needs_redraw() {
+            window.request_redraw();
+        }
+
+        // Smart ControlFlow: only Poll when necessary
+        #[cfg(feature = "robot")]
+        let robot_needs_poll = self.robot_controller.is_some();
+
+        #[cfg(not(feature = "robot"))]
+        let robot_needs_poll = false;
+
+        if app.has_active_animations() || robot_needs_poll {
+            event_loop.set_control_flow(ControlFlow::Poll);
+        } else {
+            event_loop.set_control_flow(ControlFlow::Wait);
+        }
+    }
+}
+
 /// Runs a desktop Compose application with wgpu rendering.
 ///
 /// Called by `AppLauncher::run_desktop()`. This is the framework-level
 /// entrypoint that manages the desktop event loop and rendering.
 ///
 /// **Note:** Applications should use `AppLauncher` instead of calling this directly.
-pub fn run(settings: AppSettings, content: impl FnMut() + 'static) -> ! {
-    let mut builder = EventLoopBuilder::new();
-
-    // On Linux, allow creating event loop on any thread when robot driver is active
-    #[cfg(all(target_os = "linux", feature = "robot"))]
-    if settings.test_driver.is_some() {
-        use winit::platform::x11::EventLoopBuilderExtX11;
-        builder.with_any_thread(true);
-    }
-
-    let event_loop = builder
+#[allow(unused_mut)]
+pub fn run(
+    mut settings: AppSettings,
+    content: impl FnMut() + 'static,
+) -> ! {
+    let event_loop = EventLoop::builder()
         .build()
         .expect("failed to create event loop");
-    let frame_proxy = event_loop.create_proxy();
 
     // Spawn test driver if present
     #[cfg(feature = "robot")]
-    let mut robot_controller = if let Some(driver) = settings.test_driver {
+    let robot_controller = if let Some(driver) = settings.test_driver.take() {
         let (controller, robot) = RobotController::new();
         std::thread::spawn(move || {
             driver(robot);
@@ -412,325 +798,14 @@ pub fn run(settings: AppSettings, content: impl FnMut() + 'static) -> ! {
         None
     };
 
-    #[cfg(not(feature = "robot"))]
-    let _robot_controller: Option<()> = None;
+    let mut app = App::new(settings, content);
 
-    let initial_width = settings.initial_width;
-    let initial_height = settings.initial_height;
+    #[cfg(feature = "robot")]
+    if let Some(controller) = robot_controller {
+        app.set_robot_controller(controller);
+    }
 
-    let window = Arc::new(
-        WindowBuilder::new()
-            .with_title(settings.window_title)
-            .with_inner_size(LogicalSize::new(
-                initial_width as f64,
-                initial_height as f64,
-            ))
-            .build(&event_loop)
-            .expect("failed to create window"),
-    );
-
-    // Initialize WGPU
-    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-        backends: wgpu::Backends::all(),
-        ..Default::default()
-    });
-
-    let surface = instance
-        .create_surface(window.clone())
-        .expect("failed to create surface");
-
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::HighPerformance,
-        compatible_surface: Some(&surface),
-        force_fallback_adapter: false,
-    }))
-    .expect("failed to find suitable adapter");
-
-    let (device, queue) = pollster::block_on(adapter.request_device(
-        &wgpu::DeviceDescriptor {
-            label: Some("Main Device"),
-            required_features: wgpu::Features::empty(),
-            required_limits: wgpu::Limits::default(),
-        },
-        None,
-    ))
-    .expect("failed to create device");
-
-    let size = window.inner_size();
-    let surface_caps = surface.get_capabilities(&adapter);
-    let surface_format = surface_caps
-        .formats
-        .iter()
-        .copied()
-        .find(|f| f.is_srgb())
-        .unwrap_or(surface_caps.formats[0]);
-
-    let mut surface_config = wgpu::SurfaceConfiguration {
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-        format: surface_format,
-        width: size.width,
-        height: size.height,
-        present_mode: wgpu::PresentMode::Fifo,
-        alpha_mode: surface_caps.alpha_modes[0],
-        view_formats: vec![],
-        desired_maximum_frame_latency: 2,
-    };
-
-    surface.configure(&device, &surface_config);
-
-    // Create renderer with fonts from settings
-    let mut renderer = if let Some(fonts) = settings.fonts {
-        WgpuRenderer::new_with_fonts(fonts)
-    } else {
-        WgpuRenderer::new()
-    };
-    renderer.init_gpu(Arc::new(device), Arc::new(queue), surface_format);
-    let initial_scale = window.scale_factor();
-    renderer.set_root_scale(initial_scale as f32);
-
-    let mut app = AppShell::new(renderer, default_root_key(), content);
-    let mut platform = DesktopWinitPlatform::default();
-    platform.set_scale_factor(initial_scale);
-
-    app.set_frame_waker({
-        let proxy = frame_proxy.clone();
-        move || {
-            let _ = proxy.send_event(());
-        }
-    });
-
-    // Set buffer_size to physical pixels and viewport to logical dp
-    app.set_buffer_size(size.width, size.height);
-    let logical_width = size.width as f32 / initial_scale as f32;
-    let logical_height = size.height as f32 / initial_scale as f32;
-    app.set_viewport(logical_width, logical_height);
-
-    let _ = event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-        match event {
-            Event::WindowEvent { window_id, event } if window_id == window.id() => match event {
-                WindowEvent::CloseRequested => {
-                    elwt.exit();
-                }
-                WindowEvent::Resized(new_size) => {
-                    if new_size.width > 0 && new_size.height > 0 {
-                        surface_config.width = new_size.width;
-                        surface_config.height = new_size.height;
-                        let device = app.renderer().device();
-                        surface.configure(device, &surface_config);
-
-                        let scale_factor = window.scale_factor();
-                        let logical_width = new_size.width as f32 / scale_factor as f32;
-                        let logical_height = new_size.height as f32 / scale_factor as f32;
-
-                        app.set_buffer_size(new_size.width, new_size.height);
-                        app.set_viewport(logical_width, logical_height);
-                    }
-                }
-                WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
-                    platform.set_scale_factor(scale_factor);
-                    app.renderer().set_root_scale(scale_factor as f32);
-
-                    let new_size = window.inner_size();
-                    if new_size.width > 0 && new_size.height > 0 {
-                        surface_config.width = new_size.width;
-                        surface_config.height = new_size.height;
-                        let device = app.renderer().device();
-                        surface.configure(device, &surface_config);
-
-                        let logical_width = new_size.width as f32 / scale_factor as f32;
-                        let logical_height = new_size.height as f32 / scale_factor as f32;
-
-                        app.set_buffer_size(new_size.width, new_size.height);
-                        app.set_viewport(logical_width, logical_height);
-                    }
-                }
-                WindowEvent::CursorMoved { position, .. } => {
-                    let logical = platform.pointer_position(position);
-                    app.set_cursor(logical.x, logical.y);
-                }
-                WindowEvent::MouseInput {
-                    state,
-                    button: MouseButton::Left,
-                    ..
-                } => match state {
-                    ElementState::Pressed => {
-                        app.pointer_pressed();
-                    }
-                    ElementState::Released => {
-                        app.pointer_released();
-                    }
-                },
-                WindowEvent::KeyboardInput { event, .. } => {
-                    use winit::keyboard::{KeyCode, PhysicalKey};
-                    if event.state == ElementState::Pressed {
-                        if let PhysicalKey::Code(KeyCode::KeyD) = event.physical_key {
-                            app.log_debug_info();
-                        }
-                    }
-                }
-                WindowEvent::Focused(false) => {
-                    // Window lost focus - cancel any in-progress gestures
-                    app.cancel_gesture();
-                }
-                WindowEvent::CursorLeft { .. } => {
-                    // Cursor left the window - cancel any in-progress gestures
-                    app.cancel_gesture();
-                }
-                WindowEvent::RedrawRequested => {
-                    app.update();
-
-                    let output = match surface.get_current_texture() {
-                        Ok(output) => output,
-                        Err(wgpu::SurfaceError::Lost) | Err(wgpu::SurfaceError::Outdated) => {
-                            // Reconfigure surface with current window size
-                            let size = window.inner_size();
-                            if size.width > 0 && size.height > 0 {
-                                surface_config.width = size.width;
-                                surface_config.height = size.height;
-                                let device = app.renderer().device();
-                                surface.configure(device, &surface_config);
-                            }
-                            return;
-                        }
-                        Err(wgpu::SurfaceError::OutOfMemory) => {
-                            log::error!("Out of memory, exiting");
-                            elwt.exit();
-                            return;
-                        }
-                        Err(wgpu::SurfaceError::Timeout) => {
-                            log::debug!("Surface timeout, skipping frame");
-                            return;
-                        }
-                    };
-
-                    let view = output
-                        .texture
-                        .create_view(&wgpu::TextureViewDescriptor::default());
-
-                    if let Err(err) =
-                        app.renderer()
-                            .render(&view, surface_config.width, surface_config.height)
-                    {
-                        log::error!("render failed: {err:?}");
-                        return;
-                    }
-
-                    output.present();
-                }
-                _ => {}
-            },
-            Event::AboutToWait | Event::UserEvent(()) => {
-                // Handle pending robot commands
-                #[cfg(feature = "robot")]
-                if let Some(controller) = &mut robot_controller {
-                    // Process new commands
-                    while let Ok(cmd) = controller.rx.try_recv() {
-                        match cmd {
-                            RobotCommand::Click { x, y } => {
-                                app.set_cursor(x, y);
-                                app.pointer_pressed();
-                                app.pointer_released();
-                                window.request_redraw();
-                                let _ = controller.tx.send(RobotResponse::Ok);
-                            }
-                            RobotCommand::MoveTo { x, y } => {
-                                app.set_cursor(x, y);
-                                window.request_redraw();
-                                let _ = controller.tx.send(RobotResponse::Ok);
-                            }
-                            RobotCommand::MouseDown => {
-                                app.pointer_pressed();
-                                let _ = controller.tx.send(RobotResponse::Ok);
-                            }
-                            RobotCommand::MouseUp => {
-                                app.pointer_released();
-                                let _ = controller.tx.send(RobotResponse::Ok);
-                            }
-
-                            RobotCommand::TouchDown { x, y } => {
-                                app.set_cursor(x, y);
-                                app.pointer_pressed();
-                                let _ = controller.tx.send(RobotResponse::Ok);
-                            }
-                            RobotCommand::TouchMove { x, y } => {
-                                app.set_cursor(x, y);
-                                let _ = controller.tx.send(RobotResponse::Ok);
-                            }
-                            RobotCommand::TouchUp { x, y } => {
-                                app.set_cursor(x, y);
-                                app.pointer_released();
-                                let _ = controller.tx.send(RobotResponse::Ok);
-                            }
-                            RobotCommand::GetSemantics => {
-                                let semantics = extract_semantics(&app);
-                                let _ = controller.tx.send(RobotResponse::Semantics(semantics));
-                            }
-                            RobotCommand::WaitForIdle => {
-                                // Start waiting for idle
-                                controller.waiting_for_idle = true;
-                                controller.idle_iterations = 0;
-                            }
-                            RobotCommand::Exit => {
-                                let _ = controller.tx.send(RobotResponse::Ok);
-                                elwt.exit();
-                            }
-                        }
-                    }
-
-                    // Handle ongoing wait_for_idle
-                    if controller.waiting_for_idle {
-                        const MAX_IDLE_ITERATIONS: u32 = 200;
-
-                        if !app.needs_redraw() && !app.has_active_animations() {
-                            // App is idle - respond and stop waiting
-                            controller.waiting_for_idle = false;
-                            let _ = controller.tx.send(RobotResponse::Ok);
-                        } else {
-                            // Not idle yet - update and check iteration limit
-                            app.update();
-                            controller.idle_iterations += 1;
-
-                            // Periodic diagnostic logging
-                            if controller.idle_iterations % 50 == 0 {
-                                log::debug!(
-                                    "wait_for_idle iteration {}: needs_redraw={}, has_animations={}",
-                                    controller.idle_iterations,
-                                    app.needs_redraw(),
-                                    app.has_active_animations()
-                                );
-                            }
-
-                            if controller.idle_iterations >= MAX_IDLE_ITERATIONS {
-                                controller.waiting_for_idle = false;
-                                let _ = controller.tx.send(RobotResponse::Error(
-                                    "wait_for_idle: timed out after 200 iterations".to_string()
-                                ));
-                            }
-                        }
-                    }
-                }
-
-                if app.needs_redraw() {
-                    window.request_redraw();
-                }
-
-                // Smart ControlFlow: only Poll when necessary
-                #[cfg(feature = "robot")]
-                let robot_needs_poll = robot_controller.is_some();
-
-                #[cfg(not(feature = "robot"))]
-                let robot_needs_poll = false;
-
-                if app.has_active_animations() || robot_needs_poll {
-                    elwt.set_control_flow(ControlFlow::Poll);
-                } else {
-                    elwt.set_control_flow(ControlFlow::Wait);
-                }
-            }
-            _ => {}
-        }
-    });
+    let _ = event_loop.run_app(&mut app);
 
     std::process::exit(0)
 }

--- a/crates/compose-platform/desktop-winit/Cargo.toml
+++ b/crates/compose-platform/desktop-winit/Cargo.toml
@@ -6,6 +6,6 @@ license = "Apache-2.0"
 description = "Desktop winit platform adapter for Compose-RS"
 
 [dependencies]
-winit = "0.29"
+winit = "0.30"
 compose-foundation = { path = "../../compose-foundation" }
 compose-ui-graphics = { path = "../../compose-ui-graphics" }

--- a/crates/compose-render/wgpu/Cargo.toml
+++ b/crates/compose-render/wgpu/Cargo.toml
@@ -13,8 +13,8 @@ compose-ui = { path = "../../compose-ui" }
 compose-core = { path = "../../compose-core" }
 # webgl feature enables WebGL backend for WASM builds
 # Default features include platform-appropriate backends (Vulkan/Metal/DX12)
-wgpu = { version = "0.19", features = ["webgl"] }
+wgpu = { version = "25.0", default-features = false, features = ["wgsl", "webgl"] }
 bytemuck = { version = "1.14", features = ["derive"] }
-glyphon = "0.5"
+glyphon = "0.9"
 log = "0.4"
 lru = "0.12"

--- a/crates/compose-render/wgpu/Cargo.toml
+++ b/crates/compose-render/wgpu/Cargo.toml
@@ -11,6 +11,8 @@ compose-ui-graphics = { path = "../../compose-ui-graphics" }
 compose-foundation = { path = "../../compose-foundation" }
 compose-ui = { path = "../../compose-ui" }
 compose-core = { path = "../../compose-core" }
+# webgl feature enables WebGL backend for WASM builds
+# Default features include platform-appropriate backends (Vulkan/Metal/DX12)
 wgpu = { version = "0.19", features = ["webgl"] }
 bytemuck = { version = "1.14", features = ["derive"] }
 glyphon = "0.5"

--- a/crates/compose-render/wgpu/src/lib.rs
+++ b/crates/compose-render/wgpu/src/lib.rs
@@ -88,12 +88,12 @@ impl SharedTextBuffer {
         // Set metrics and size for unlimited layout
         let metrics = Metrics::new(font_size, font_size * 1.4);
         self.buffer.set_metrics(font_system, metrics);
-        self.buffer.set_size(font_system, f32::MAX, f32::MAX);
+        self.buffer.set_size(font_system, Some(f32::MAX), Some(f32::MAX));
 
         // Set text and shape
         self.buffer
-            .set_text(font_system, text, attrs, Shaping::Advanced);
-        self.buffer.shape_until_scroll(font_system);
+            .set_text(font_system, text, &attrs, Shaping::Advanced);
+        self.buffer.shape_until_scroll(font_system, false);
 
         // Update cached values
         self.text.clear();


### PR DESCRIPTION
Add comprehensive binary size optimizations:

- Enable LTO (Link-Time Optimization) for cross-crate optimization
- Set codegen-units=1 for better optimization at link time
- Enable symbol stripping in release builds
- Use panic=abort to remove unwinding code overhead
- Add release-small profile with opt-level=z for maximum size reduction
- Add wasm-release profile for WASM-specific optimization

WASM-specific improvements:
- Enable wasm-opt with -Oz flag for 20-40% size reduction
- Update build-web.sh to check for wasm-opt availability
- Add binaryen installation to GitHub Pages workflow
- Report WASM binary size after build

These changes can reduce binary sizes by 30-50% for release builds.