### PR TITLE
Fix CI build for desktop demo app

### DIFF
--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [package.metadata.wasm-pack.profile.release]
 # Enable wasm-opt with size optimization (can reduce WASM size by 20-40%)
-wasm-opt = ["-Oz", "--enable-bulk-memory", "--enable-mutable-globals", "--enable-nontrapping-float-to-int"]
+wasm-opt = ["-Oz", "--enable-bulk-memory", "--enable-mutable-globals", "--enable-nontrapping-float-to-int", "--enable-sign-ext"]
 
 # Support both binary (desktop) and cdylib (Android)
 # IMPORTANT: The cdylib name (libdesktop_app.so) must match the android.app.lib_name


### PR DESCRIPTION
The wasm-opt validator was failing because the compiled WASM binary uses sign extension instructions (i32.extend8_s, i32.extend16_s) but the --enable-sign-ext feature flag was not enabled during optimization.

This adds the missing flag to the wasm-pack configuration in Cargo.toml.