### PR TITLE
Add native Winamp window support

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust (nightly for wasm-pack artifact output)
         uses: dtolnay/rust-toolchain@nightly
@@ -63,7 +63,7 @@ jobs:
           touch _site/.nojekyll
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   deploy:
     environment:
@@ -74,4 +74,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       should_publish: ${{ steps.sync.outputs.should_publish }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
@@ -241,7 +241,7 @@ jobs:
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
             artifact_name: cranpose-demo-windows-x86_64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -172,7 +172,7 @@ jobs:
             -DestinationPath ${{ matrix.artifact_name }}.zip
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: |
@@ -184,7 +184,7 @@ jobs:
     name: Build Android APK
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -215,7 +215,7 @@ jobs:
         run: ./gradlew :app:assembleRelease -PrustFastRelease=false
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cranpose-demo-android
           path: apps/android-demo/android/app/build/outputs/apk/release/app-release.apk
@@ -226,7 +226,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, build-android]
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -208,7 +208,7 @@ jobs:
           --stage-artifact-shards 16
 
       - name: Upload robot examples shard 1
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-1
           path: target/robot-artifacts/robot-examples-1.tar
@@ -216,7 +216,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 2
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-2
           path: target/robot-artifacts/robot-examples-2.tar
@@ -224,7 +224,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 3
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-3
           path: target/robot-artifacts/robot-examples-3.tar
@@ -232,7 +232,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 4
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-4
           path: target/robot-artifacts/robot-examples-4.tar
@@ -240,7 +240,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 5
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-5
           path: target/robot-artifacts/robot-examples-5.tar
@@ -248,7 +248,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 6
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-6
           path: target/robot-artifacts/robot-examples-6.tar
@@ -256,7 +256,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 7
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-7
           path: target/robot-artifacts/robot-examples-7.tar
@@ -264,7 +264,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 8
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-8
           path: target/robot-artifacts/robot-examples-8.tar
@@ -272,7 +272,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 9
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-9
           path: target/robot-artifacts/robot-examples-9.tar
@@ -280,7 +280,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 10
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-10
           path: target/robot-artifacts/robot-examples-10.tar
@@ -288,7 +288,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 11
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-11
           path: target/robot-artifacts/robot-examples-11.tar
@@ -296,7 +296,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 12
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-12
           path: target/robot-artifacts/robot-examples-12.tar
@@ -304,7 +304,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 13
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-13
           path: target/robot-artifacts/robot-examples-13.tar
@@ -312,7 +312,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 14
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-14
           path: target/robot-artifacts/robot-examples-14.tar
@@ -320,7 +320,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 15
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-15
           path: target/robot-artifacts/robot-examples-15.tar
@@ -328,7 +328,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload robot examples shard 16
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: robot-examples-16
           path: target/robot-artifacts/robot-examples-16.tar
@@ -359,7 +359,7 @@ jobs:
             xvfb xauth xdotool imagemagick
 
       - name: Download robot examples
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: robot-examples-${{ matrix.shard_index }}
           path: target/robot-artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,7 @@ dependencies = [
  "web-sys",
  "wgpu 28.0.0",
  "winit",
+ "x11rb",
 ]
 
 [[package]]

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -121,6 +121,11 @@ name = "robot_winamp_native_window_geometry"
 path = "robot-runners/robot_winamp_native_window_geometry.rs"
 required-features = ["robot-app"]
 
+[[example]]
+name = "winamp_standalone"
+path = "examples/winamp_standalone.rs"
+required-features = ["desktop", "renderer-wgpu"]
+
 
 
 [[example]]

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -116,6 +116,11 @@ name = "robot_shader_rect"
 path = "robot-runners/robot_shader_rect.rs"
 required-features = ["robot-app"]
 
+[[example]]
+name = "robot_winamp_native_window_geometry"
+path = "robot-runners/robot_winamp_native_window_geometry.rs"
+required-features = ["robot-app"]
+
 
 
 [[example]]

--- a/apps/desktop-demo/examples/winamp_standalone.rs
+++ b/apps/desktop-demo/examples/winamp_standalone.rs
@@ -1,0 +1,10 @@
+use cranpose::AppLauncher;
+use desktop_app::{app::WinampStandaloneApp, fonts::DEMO_FONTS};
+
+fn main() {
+    AppLauncher::new()
+        .with_title("Winamp Standalone")
+        .with_size(1, 1)
+        .with_fonts(DEMO_FONTS)
+        .run_windows(WinampStandaloneApp);
+}

--- a/apps/desktop-demo/robot-runners/robot_lazy_list.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_list.rs
@@ -7,8 +7,7 @@
 
 use cranpose::AppLauncher;
 use cranpose_testing::{
-    find_button_in_semantics, find_in_semantics, find_text_by_prefix_in_semantics, find_text_exact,
-    find_text_in_semantics, root_bounds,
+    find_button_in_semantics, find_text_by_prefix_in_semantics, find_text_in_semantics, root_bounds,
 };
 use cranpose_testing::{find_element_by_text_exact, print_semantics_with_bounds, union_bounds};
 use desktop_app::app;
@@ -79,23 +78,41 @@ fn main() {
             };
 
             // Find items with FULL BOUNDS (x, y, width, height)
-            let find_visible_items_with_bounds = || {
+            let find_visible_items_with_bounds = |list_bounds: Option<(f32, f32, f32, f32)>| {
                 type Rect = (f32, f32, f32, f32);
                 type VisibleItemBounds = (usize, Rect, Rect);
 
-                let mut items: Vec<VisibleItemBounds> = Vec::new(); // (index, row_bounds, group_bounds)
-                for i in 0..20 {
+                let Ok(semantics) = robot.get_semantics() else {
+                    return Vec::new();
+                };
+                let mut items: Vec<VisibleItemBounds> = Vec::new();
+                for i in 0..100 {
                     let item_text = format!("ItemRow #{}", i);
-                    let item_bounds = find_in_semantics(&robot, |elem| {
-                        find_text_exact(elem, &item_text)
-                    });
-                    if let Some(row_bounds) = item_bounds {
+                    if let Some(row_elem) = find_element_by_text_exact(&semantics, &item_text) {
+                        let row_bounds = (
+                            row_elem.bounds.x,
+                            row_elem.bounds.y,
+                            row_elem.bounds.width,
+                            row_elem.bounds.height,
+                        );
                         let hello_text = format!("Hello #{}", i);
-                        let hello_bounds = find_in_semantics(&robot, |elem| {
-                            find_text_exact(elem, &hello_text)
-                        });
+                        let hello_bounds =
+                            find_element_by_text_exact(&semantics, &hello_text).map(|elem| {
+                                (
+                                    elem.bounds.x,
+                                    elem.bounds.y,
+                                    elem.bounds.width,
+                                    elem.bounds.height,
+                                )
+                            });
                         let group_bounds = union_bounds(row_bounds, hello_bounds);
-                        items.push((i, row_bounds, group_bounds));
+                        let intersects_viewport = list_bounds.is_none_or(|(_, y, _, h)| {
+                            let group_bottom = group_bounds.1 + group_bounds.3;
+                            group_bottom > y && group_bounds.1 < y + h
+                        });
+                        if intersects_viewport {
+                            items.push((i, row_bounds, group_bounds));
+                        }
                     }
                 }
                 items
@@ -187,6 +204,7 @@ fn main() {
                     )
                     .ok();
                 std::thread::sleep(Duration::from_millis(200));
+                let _ = robot.wait_for_idle();
 
                 let after_drag_index = read_stat("FirstIndex: ").unwrap_or(initial_first_index);
                 if after_drag_index <= initial_first_index {
@@ -208,7 +226,7 @@ fn main() {
 
             // Step 3: Find all visible items with FULL BOUNDS
             println!("\n--- Step 3: Validate item BOUNDS (detecting overlaps) ---");
-            let mut items = find_visible_items_with_bounds();
+            let mut items = find_visible_items_with_bounds(list_bounds);
             items.sort_by(|a, b| {
                 let a_y = (a.2).1;
                 let b_y = (b.2).1;

--- a/apps/desktop-demo/robot-runners/robot_scroll_jump.rs
+++ b/apps/desktop-demo/robot-runners/robot_scroll_jump.rs
@@ -57,7 +57,7 @@ fn main() {
             }
 
             fn find_item_y(robot: &Robot, item_num: i32) -> Option<f32> {
-                let text = format!("Item {}", item_num);
+                let text = format!("Item #{}", item_num);
                 find_in_semantics(robot, |elem| find_text(elem, &text))
                     .map(|(_, y, _, h)| y + h / 2.0)
             }

--- a/apps/desktop-demo/robot-runners/robot_shader_backdrop_drag.rs
+++ b/apps/desktop-demo/robot-runners/robot_shader_backdrop_drag.rs
@@ -6,6 +6,7 @@ use cranpose::AppLauncher;
 use cranpose_testing::{
     capture_screenshot, changed_pixel_count, changed_pixel_count_in_region,
     find_button_in_semantics, find_text_in_semantics, screenshot_logical_size,
+    scroll_text_into_view, ScrollConfig,
 };
 use desktop_app::app;
 use std::time::Duration;
@@ -27,6 +28,16 @@ fn scroll_up(robot: &cranpose::Robot) {
     cranpose_testing::scroll_up(robot, 620.0, 220.0, 720.0);
 }
 
+fn effect_scroll_config() -> ScrollConfig {
+    ScrollConfig {
+        center_x: 620.0,
+        down_from_y: 720.0,
+        down_to_y: 220.0,
+        up_from_y: 220.0,
+        up_to_y: 720.0,
+    }
+}
+
 fn set_slider_fraction(robot: &cranpose::Robot, prefix: &str, fraction: f32) -> Option<f32> {
     cranpose_testing::set_slider_fraction(
         robot,
@@ -34,13 +45,7 @@ fn set_slider_fraction(robot: &cranpose::Robot, prefix: &str, fraction: f32) -> 
         fraction,
         EFFECT_SLIDER_WIDTH,
         EFFECT_SLIDER_TOUCH_OFFSET_Y,
-        cranpose_testing::ScrollConfig {
-            center_x: 620.0,
-            down_from_y: 720.0,
-            down_to_y: 220.0,
-            up_from_y: 220.0,
-            up_to_y: 720.0,
-        },
+        effect_scroll_config(),
     )
 }
 
@@ -108,7 +113,8 @@ fn main() {
                 nested_parent, nested_child_off
             );
 
-            let Some((label_x, label_y, label_w, label_h)) = find_text_in_semantics(&robot, "Child backdrop")
+            let Some((label_x, label_y, label_w, label_h)) =
+                scroll_text_into_view(&robot, "Child backdrop", 24, effect_scroll_config())
             else {
                 println!("✗ Could not find 'Child backdrop' label");
                 std::process::exit(1);

--- a/apps/desktop-demo/robot-runners/robot_shadow_fields.rs
+++ b/apps/desktop-demo/robot-runners/robot_shadow_fields.rs
@@ -5,9 +5,9 @@
 
 use cranpose::AppLauncher;
 use cranpose_testing::{
-    capture_screenshot, changed_pixel_count, changed_pixel_count_in_region, find_bounds_by_text,
-    find_button_in_semantics, find_text_by_prefix_in_semantics, logical_region_to_pixel_bounds,
-    root_bounds,
+    capture_screenshot, changed_pixel_count, changed_pixel_count_in_region,
+    find_button_in_semantics, logical_region_to_pixel_bounds, scroll_prefix_into_view,
+    scroll_text_into_view, ScrollConfig,
 };
 use desktop_app::app;
 use image::{ImageBuffer, Rgba, RgbaImage};
@@ -154,78 +154,14 @@ fn shadow_rect_from_label(shadow_label_bounds: (f32, f32, f32, f32)) -> (f32, f3
     )
 }
 
-fn scroll_down(robot: &cranpose::Robot) {
-    cranpose_testing::scroll_down(robot, 620.0, 760.0, 220.0);
-}
-
-fn scroll_up(robot: &cranpose::Robot) {
-    cranpose_testing::scroll_up(robot, 620.0, 220.0, 760.0);
-}
-
-fn y_is_visible(robot: &cranpose::Robot, y: f32) -> bool {
-    cranpose_testing::y_is_visible(robot, y)
-}
-
-fn scroll_text_into_view(
-    robot: &cranpose::Robot,
-    text: &str,
-    max_attempts: usize,
-) -> Option<(f32, f32, f32, f32)> {
-    for attempt in 0..max_attempts {
-        if let Some(bounds) = find_bounds_by_text(robot, text) {
-            let center_y = bounds.1 + bounds.3 * 0.5;
-            if y_is_visible(robot, center_y) {
-                return Some(bounds);
-            }
-            let Some((_, root_y, _, root_h)) = root_bounds(robot) else {
-                return Some(bounds);
-            };
-            let viewport_mid = root_y + root_h * 0.5;
-            if center_y > viewport_mid {
-                scroll_down(robot);
-            } else {
-                scroll_up(robot);
-            }
-        } else {
-            if attempt % 2 == 0 {
-                scroll_down(robot);
-            } else {
-                scroll_up(robot);
-            }
-        }
+fn shadow_scroll_config() -> ScrollConfig {
+    ScrollConfig {
+        center_x: 620.0,
+        down_from_y: 760.0,
+        down_to_y: 220.0,
+        up_from_y: 220.0,
+        up_to_y: 760.0,
     }
-    None
-}
-
-fn scroll_prefix_into_view(
-    robot: &cranpose::Robot,
-    prefix: &str,
-    max_attempts: usize,
-) -> Option<(f32, f32, f32, f32, String)> {
-    for attempt in 0..max_attempts {
-        if let Some(bounds) = find_text_by_prefix_in_semantics(robot, prefix) {
-            let center_y = bounds.1 + bounds.3 * 0.5;
-            if y_is_visible(robot, center_y) {
-                return Some(bounds);
-            }
-            let Some((_, root_y, _, root_h)) = root_bounds(robot) else {
-                return Some(bounds);
-            };
-            let viewport_mid = root_y + root_h * 0.5;
-            if center_y > viewport_mid {
-                scroll_down(robot);
-            } else {
-                scroll_up(robot);
-            }
-        } else {
-            if attempt % 2 == 0 {
-                scroll_down(robot);
-            } else {
-                scroll_up(robot);
-            }
-        }
-    }
-    None
 }
 
 fn set_slider_fraction(robot: &cranpose::Robot, prefix: &str, fraction: f32) -> Option<f32> {
@@ -235,13 +171,7 @@ fn set_slider_fraction(robot: &cranpose::Robot, prefix: &str, fraction: f32) -> 
         fraction,
         SHADOW_SLIDER_WIDTH,
         SLIDER_TOUCH_OFFSET_Y,
-        cranpose_testing::ScrollConfig {
-            center_x: 620.0,
-            down_from_y: 760.0,
-            down_to_y: 220.0,
-            up_from_y: 220.0,
-            up_to_y: 760.0,
-        },
+        shadow_scroll_config(),
     )
 }
 
@@ -278,14 +208,17 @@ fn main() {
             std::thread::sleep(Duration::from_millis(320));
             let _ = robot.wait_for_idle();
 
-            if scroll_text_into_view(&robot, "GraphicsLayer Fields", 18).is_none() {
+            if scroll_text_into_view(&robot, "GraphicsLayer Fields", 18, shadow_scroll_config())
+                .is_none()
+            {
                 println!("FATAL: could not find 'GraphicsLayer Fields'");
                 let _ = robot.exit();
                 std::process::exit(1);
             }
 
-            if scroll_text_into_view(&robot, "Shadow Fields", 40).is_none()
-                && scroll_prefix_into_view(&robot, "shadow_elevation", 40).is_none()
+            if scroll_text_into_view(&robot, "Shadow Fields", 40, shadow_scroll_config()).is_none()
+                && scroll_prefix_into_view(&robot, "shadow_elevation", 40, shadow_scroll_config())
+                    .is_none()
             {
                 println!("FATAL: could not find 'Shadow Fields'");
                 let _ = robot.exit();
@@ -303,17 +236,18 @@ fn main() {
                 ambient_alpha, spot_alpha
             );
 
-            let shadow_label_bounds = scroll_text_into_view(&robot, "shadow", 14).or_else(|| {
-                // Fallback: derive right-preview label area from the stable "none" label.
-                scroll_text_into_view(&robot, "none", 10).map(|none| {
-                    (
-                        none.0 + NONE_LABEL_TO_SHADOW_LABEL_X,
-                        none.1,
-                        none.2,
-                        none.3,
-                    )
-                })
-            });
+            let shadow_label_bounds =
+                scroll_text_into_view(&robot, "shadow", 14, shadow_scroll_config()).or_else(|| {
+                    // Fallback: derive right-preview label area from the stable "none" label.
+                    scroll_text_into_view(&robot, "none", 10, shadow_scroll_config()).map(|none| {
+                        (
+                            none.0 + NONE_LABEL_TO_SHADOW_LABEL_X,
+                            none.1,
+                            none.2,
+                            none.3,
+                        )
+                    })
+                });
             let Some(shadow_label_bounds) = shadow_label_bounds else {
                 println!("FATAL: could not find 'shadow' label in preview");
                 let _ = robot.exit();

--- a/apps/desktop-demo/robot-runners/robot_winamp_native_window_geometry.rs
+++ b/apps/desktop-demo/robot-runners/robot_winamp_native_window_geometry.rs
@@ -1,0 +1,1253 @@
+//! Robot test for native Winamp sub-window geometry.
+
+use cranpose::AppLauncher;
+use cranpose_testing::find_button_in_semantics;
+use desktop_app::app::{self, DemoTab};
+use std::collections::HashMap;
+use std::process::Command;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+const WINDOW_TITLE: &str = "Robot Winamp Native Geometry";
+const MOVE_STEPS: usize = 12;
+const FAST_MOVE_STEPS: usize = 8;
+const FAST_MOVE_DX: i32 = 24;
+const FAST_MOVE_DY: i32 = 11;
+const PIXEL_TRACE_STEPS: usize = 48;
+const PIXEL_TRACE_STALL_TIMEOUT: Duration = Duration::from_millis(90);
+const GROUP_MOVE_STEP_TIMEOUT: Duration = Duration::from_millis(500);
+const OFFSET_EPSILON: i32 = 3;
+const FIND_WINDOW_POLL: Duration = Duration::from_millis(4);
+const FIND_WINDOW_TIMEOUT: Duration = Duration::from_millis(12_000);
+const SETUP_POSITION_TIMEOUT: Duration = Duration::from_millis(1200);
+const CACHED_RESTORE_TIMEOUT: Duration = Duration::from_millis(1_000);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct WindowGeometry {
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PointerLocation {
+    x: i32,
+    y: i32,
+    window: u64,
+}
+
+impl WindowGeometry {
+    fn offset_from(self, other: Self) -> (i32, i32) {
+        (self.x - other.x, self.y - other.y)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct WinampWindows {
+    main: u64,
+    equalizer: u64,
+    playlist: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct WinampGeometries {
+    main: WindowGeometry,
+    equalizer: WindowGeometry,
+    playlist: WindowGeometry,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct DragTraceSample {
+    pointer: PointerLocation,
+    geometries: WinampGeometries,
+    elapsed: Duration,
+}
+
+impl WinampWindows {
+    fn geometries(self) -> WinampGeometries {
+        let geometries = window_geometries(self.window_ids());
+        WinampGeometries {
+            main: geometry_from_snapshot(&geometries, self.main),
+            equalizer: geometry_from_snapshot(&geometries, self.equalizer),
+            playlist: geometry_from_snapshot(&geometries, self.playlist),
+        }
+    }
+
+    fn window_ids(self) -> [u64; 3] {
+        [self.main, self.equalizer, self.playlist]
+    }
+}
+
+fn main() {
+    env_logger::init();
+    println!("=== Robot Winamp Native Window Geometry ===");
+
+    AppLauncher::new()
+        .with_title(WINDOW_TITLE)
+        .with_size(1200, 800)
+        .with_headless(false)
+        .with_test_driver(|robot| {
+            let pid = std::process::id();
+            let host_window = find_app_window(pid);
+            let host_origin = host_window_origin();
+            move_window(host_window, host_origin.x, host_origin.y);
+            std::thread::sleep(Duration::from_millis(250));
+            robot.wait_for_idle().expect("host window positioned");
+
+            let appeared_at = Instant::now();
+            click_button_now(&robot, "Winamp");
+            let windows = find_winamp_windows(pid);
+            let appearance_elapsed = appeared_at.elapsed();
+            robot.wait_for_idle().expect("initial Winamp idle");
+            std::thread::sleep(Duration::from_millis(500));
+            robot
+                .wait_for_idle()
+                .expect("initial native windows settled");
+            println!(
+                "native windows appeared in {}ms: {:?}",
+                appearance_elapsed.as_millis(),
+                windows
+            );
+            println!("appeared: {:?}", windows.geometries());
+            let origin = arrange_origin(windows);
+
+            place_attached_chain(windows, origin.x, origin.y);
+            assert_attached_offsets("arranged", windows.geometries());
+
+            drag_main_and_assert_offsets("drag-main", windows);
+            place_attached_chain(windows, origin.x + 10, origin.y + 5);
+            drag_main_one_pixel_trace_and_assert_continuity("drag-main-pixel-trace", windows);
+            place_attached_chain(windows, origin.x + 20, origin.y + 10);
+            drag_main_fast_and_assert_offsets("drag-main-fast", windows);
+            place_attached_chain(windows, origin.x + 40, origin.y + 20);
+            drag_and_assert_only_dragged("drag-playlist", windows, windows.playlist);
+            place_attached_chain(windows, origin.x + 80, origin.y + 40);
+            drag_and_assert_only_dragged("drag-equalizer", windows, windows.equalizer);
+            place_attached_chain(windows, origin.x + 100, origin.y + 50);
+            move_main_with_window_manager_and_assert_offsets("wm-move-main", windows, 31, 19);
+
+            click_button(&robot, "Dock");
+            assert_windows_absent(pid, "after Dock");
+
+            let restore_started = Instant::now();
+            click_button_now(&robot, "Undock");
+            let restored_windows = find_winamp_windows(pid);
+            let restore_elapsed = restore_started.elapsed();
+            println!(
+                "native windows restored after Undock in {}ms: {:?}",
+                restore_elapsed.as_millis(),
+                restored_windows
+            );
+            assert_eq!(
+                windows.window_ids(),
+                restored_windows.window_ids(),
+                "Undock recreated native windows instead of restoring cached OS windows"
+            );
+            assert!(
+                restore_elapsed <= CACHED_RESTORE_TIMEOUT,
+                "Undock restore took {}ms, expected cached native windows to return within {}ms",
+                restore_elapsed.as_millis(),
+                CACHED_RESTORE_TIMEOUT.as_millis()
+            );
+            click_button(&robot, "Counter App");
+            assert_windows_absent(pid, "after tab switch");
+
+            robot.exit().expect("exit");
+        })
+        .run(|| app::combined_app_with_initial_tab(Some(DemoTab::Counter)));
+}
+
+fn arrange_origin(windows: WinampWindows) -> WindowGeometry {
+    let geometries = windows.geometries();
+    let total_width = geometries.main.width + geometries.playlist.width;
+    let total_height =
+        geometries.main.height + geometries.equalizer.height.max(geometries.playlist.height);
+    let desired_margin = 120;
+    let monitor = *monitor_rects()
+        .iter()
+        .max_by_key(|monitor| monitor.width * monitor.height)
+        .expect("at least one monitor");
+    let margin_x = desired_margin.min(((monitor.width - total_width).max(0) / 2).max(8));
+    let margin_y = desired_margin.min(((monitor.height - total_height).max(0) / 2).max(8));
+    let max_x = monitor.x + monitor.width - total_width - margin_x;
+    let max_y = monitor.y + monitor.height - total_height - margin_y;
+    WindowGeometry {
+        x: (monitor.x + margin_x).min(max_x.max(monitor.x)),
+        y: (monitor.y + margin_y).min(max_y.max(monitor.y)),
+        width: geometries.main.width,
+        height: geometries.main.height,
+    }
+}
+
+fn host_window_origin() -> WindowGeometry {
+    let monitor = *monitor_rects()
+        .iter()
+        .max_by_key(|monitor| monitor.width * monitor.height)
+        .expect("at least one monitor");
+    WindowGeometry {
+        x: monitor.x + 160,
+        y: monitor.y + 120,
+        width: 1200,
+        height: 800,
+    }
+}
+
+fn find_app_window(pid: u32) -> u64 {
+    let deadline = Instant::now() + FIND_WINDOW_TIMEOUT;
+    while Instant::now() < deadline {
+        if let Some(id) = find_window_id_by_exact_title(pid, WINDOW_TITLE) {
+            return id;
+        }
+        std::thread::sleep(FIND_WINDOW_POLL);
+    }
+    panic!(
+        "host app window {WINDOW_TITLE:?} for pid {pid} not found; visible windows: {:?}",
+        visible_windows_summary()
+    );
+}
+
+fn find_winamp_windows(pid: u32) -> WinampWindows {
+    let deadline = Instant::now() + FIND_WINDOW_TIMEOUT;
+    while Instant::now() < deadline {
+        let ids = find_window_ids_by_title(pid);
+        if let (Some(main), Some(equalizer), Some(playlist)) = (
+            ids.get("Winamp").copied(),
+            ids.get("Winamp Equalizer").copied(),
+            ids.get("Winamp Playlist").copied(),
+        ) {
+            return WinampWindows {
+                main,
+                equalizer,
+                playlist,
+            };
+        }
+        if let Some(windows) = find_winamp_windows_from_visible_summary() {
+            return windows;
+        }
+        std::thread::sleep(FIND_WINDOW_POLL);
+    }
+
+    panic!(
+        "Winamp native windows for pid {pid} not found; visible windows: {:?}",
+        visible_windows_summary()
+    );
+}
+
+fn find_winamp_windows_from_visible_summary() -> Option<WinampWindows> {
+    let mut ids = HashMap::new();
+    for (id, title, geometry) in visible_windows_summary() {
+        let Some(title) = title else {
+            continue;
+        };
+        if !matches!(
+            title.as_str(),
+            "Winamp" | "Winamp Equalizer" | "Winamp Playlist"
+        ) {
+            continue;
+        }
+        if geometry.is_some() {
+            ids.insert(title, id);
+        }
+    }
+
+    Some(WinampWindows {
+        main: ids.get("Winamp").copied()?,
+        equalizer: ids.get("Winamp Equalizer").copied()?,
+        playlist: ids.get("Winamp Playlist").copied()?,
+    })
+}
+
+fn find_window_id_by_exact_title(pid: u32, title: &str) -> Option<u64> {
+    if let Some(mut windows) = wmctrl_window_ids_by_title(pid) {
+        if let Some(id) = windows.remove(title) {
+            return Some(id);
+        }
+    }
+
+    find_window_ids_by_exact_title(pid, title)
+        .into_iter()
+        .next()
+}
+
+fn find_window_ids(pid: u32, title: &str) -> Vec<u64> {
+    find_window_ids_by_exact_title(pid, title)
+}
+
+fn find_window_ids_by_title(pid: u32) -> HashMap<String, u64> {
+    if let Some(windows) = wmctrl_window_ids_by_title(pid) {
+        let windows: HashMap<_, _> = windows
+            .into_iter()
+            .filter(|(title, id)| {
+                matches!(
+                    title.as_str(),
+                    "Winamp" | "Winamp Equalizer" | "Winamp Playlist"
+                ) && window_geometries([*id]).contains_key(id)
+            })
+            .collect();
+        if !windows.is_empty() {
+            return windows;
+        }
+    }
+
+    let mut windows = HashMap::new();
+    for title in ["Winamp", "Winamp Equalizer", "Winamp Playlist"] {
+        if let Some(id) = find_window_ids_by_exact_title(pid, title)
+            .into_iter()
+            .next()
+        {
+            windows.insert(title.to_string(), id);
+        }
+    }
+    windows
+}
+
+fn wmctrl_window_ids_by_title(pid: u32) -> Option<HashMap<String, u64>> {
+    let output = Command::new("wmctrl").arg("-lpG").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let pid = pid.to_string();
+    let mut windows = HashMap::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let parts: Vec<_> = line.split_whitespace().collect();
+        if parts.len() < 9 || parts[2] != pid {
+            continue;
+        }
+        let title = parts[8..].join(" ");
+        let id = u64::from_str_radix(parts[0].trim_start_matches("0x"), 16).ok()?;
+        windows.insert(title, id);
+    }
+    (!windows.is_empty()).then_some(windows)
+}
+
+fn find_window_ids_by_exact_title(pid: u32, title: &str) -> Vec<u64> {
+    let pid = pid.to_string();
+    let pid_matches = xdotool_search_title(
+        ["search", "--onlyvisible", "--pid", &pid, "--name", title],
+        title,
+    );
+    if !pid_matches.is_empty() {
+        return pid_matches;
+    }
+
+    visible_windows_summary()
+        .into_iter()
+        .filter_map(|(id, candidate_title, _)| {
+            (candidate_title.as_deref() == Some(title)).then_some(id)
+        })
+        .collect()
+}
+
+fn xdotool_search_title<const N: usize>(args: [&str; N], title: &str) -> Vec<u64> {
+    let output = Command::new("xdotool")
+        .args(args)
+        .output()
+        .expect("xdotool search");
+    if !output.status.success() {
+        return Vec::new();
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().parse::<u64>().ok())
+        .filter(|id| window_title(*id).as_deref() == Some(title))
+        .collect()
+}
+
+fn monitor_rects() -> &'static [WindowGeometry] {
+    static MONITORS: OnceLock<Vec<WindowGeometry>> = OnceLock::new();
+    MONITORS.get_or_init(|| {
+        if let Some(monitors) = xrandr_monitor_rects() {
+            return monitors;
+        }
+
+        let output = Command::new("xdotool")
+            .arg("getdisplaygeometry")
+            .output()
+            .expect("xdotool getdisplaygeometry");
+        assert!(output.status.success(), "xdotool getdisplaygeometry failed");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut parts = stdout.split_whitespace();
+        vec![WindowGeometry {
+            x: 0,
+            y: 0,
+            width: parts
+                .next()
+                .expect("display width")
+                .parse()
+                .expect("display width"),
+            height: parts
+                .next()
+                .expect("display height")
+                .parse()
+                .expect("display height"),
+        }]
+    })
+}
+
+fn xrandr_monitor_rects() -> Option<Vec<WindowGeometry>> {
+    let output = Command::new("xrandr").arg("--listmonitors").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let monitors: Vec<_> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(parse_monitor_rect)
+        .collect();
+    (!monitors.is_empty()).then_some(monitors)
+}
+
+fn parse_monitor_rect(line: &str) -> Option<WindowGeometry> {
+    let geometry = line
+        .split_whitespace()
+        .find(|part| part.contains('x') && part.contains('+'))?;
+    let (geometry, y) = geometry.rsplit_once('+')?;
+    let (size, x) = geometry.rsplit_once('+')?;
+    let (width, rest) = size.split_once('/')?;
+    let (_, height) = rest.split_once('x')?;
+    let height = height.split_once('/').map_or(height, |(height, _)| height);
+    Some(WindowGeometry {
+        x: x.parse().ok()?,
+        y: y.parse().ok()?,
+        width: width.parse().ok()?,
+        height: height.parse().ok()?,
+    })
+}
+
+fn assert_windows_absent(pid: u32, label: &str) {
+    for _ in 0..20 {
+        let ids = [
+            find_window_ids(pid, "Winamp"),
+            find_window_ids(pid, "Winamp Equalizer"),
+            find_window_ids(pid, "Winamp Playlist"),
+        ];
+        if ids.iter().all(Vec::is_empty) {
+            println!("{label}: native windows absent");
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let windows = find_window_ids_by_title(pid);
+    let geometries: Vec<_> = windows
+        .iter()
+        .map(|(title, id)| (title.clone(), *id, window_geometry(*id)))
+        .collect();
+    panic!("{label}: native Winamp windows are still visible for pid {pid}: {geometries:?}");
+}
+
+fn place_attached_chain(windows: WinampWindows, x: i32, y: i32) {
+    let sizes = windows.geometries();
+    place_window_for_setup("place-chain-main", windows.main, x, y);
+    place_window_for_setup(
+        "place-chain-equalizer",
+        windows.equalizer,
+        x,
+        y + sizes.main.height,
+    );
+    place_window_for_setup(
+        "place-chain-playlist",
+        windows.playlist,
+        x + sizes.equalizer.width,
+        y + sizes.main.height,
+    );
+    std::thread::sleep(Duration::from_millis(220));
+    println!("place attached chain: {:?}", windows.geometries());
+}
+
+fn place_window_for_setup(label: &str, window_id: u64, x: i32, y: i32) {
+    activate_window(window_id);
+    move_window(window_id, x, y);
+    let mut last_move_requested = Instant::now();
+    let deadline = Instant::now() + SETUP_POSITION_TIMEOUT;
+    while Instant::now() < deadline {
+        let geometry = window_geometry(window_id);
+        if (geometry.x - x).abs() <= OFFSET_EPSILON && (geometry.y - y).abs() <= OFFSET_EPSILON {
+            std::thread::sleep(Duration::from_millis(180));
+            let stable = window_geometry(window_id);
+            if (stable.x - x).abs() <= OFFSET_EPSILON && (stable.y - y).abs() <= OFFSET_EPSILON {
+                return;
+            }
+        }
+        if last_move_requested.elapsed() >= Duration::from_millis(50) {
+            move_window(window_id, x, y);
+            last_move_requested = Instant::now();
+        }
+        std::thread::sleep(Duration::from_millis(8));
+    }
+
+    panic!(
+        "{label}: OS window did not reach setup position target=({x},{y}) actual={:?}",
+        window_geometry(window_id)
+    );
+}
+
+fn drag_main_and_assert_offsets(label: &str, windows: WinampWindows) {
+    drag_and_assert_offsets(label, windows, windows.main, true);
+}
+
+fn drag_main_one_pixel_trace_and_assert_continuity(label: &str, windows: WinampWindows) {
+    let initial = assert_attached_offsets(label, windows.geometries());
+    let (start_x, start_y) = drag_start_for_window(windows, windows.main);
+
+    activate_window(windows.main);
+    mousemove_in_window_exact(label, windows.main, start_x, start_y);
+    std::thread::sleep(Duration::from_millis(100));
+    assert_pointer_over_window(label, windows.main);
+    xdotool(["mousedown", "1"]);
+    std::thread::sleep(Duration::from_millis(60));
+
+    let mut trace = Vec::with_capacity(PIXEL_TRACE_STEPS + 1);
+    trace.push(DragTraceSample {
+        pointer: pointer_location(),
+        geometries: windows.geometries(),
+        elapsed: Duration::ZERO,
+    });
+
+    for step in 1..=PIXEL_TRACE_STEPS {
+        let previous = *trace.last().expect("previous trace sample");
+        mousemove_relative(1, 0);
+        trace.push(wait_for_one_pixel_drag_step(label, step, windows, previous));
+        std::thread::sleep(Duration::from_millis(8));
+    }
+
+    xdotool(["mouseup", "1"]);
+    std::thread::sleep(Duration::from_millis(120));
+    print_drag_trace(label, &trace);
+    assert_pixel_drag_trace_continuity(label, initial, &trace);
+    assert_group_stays_stable(
+        label,
+        windows,
+        windows.geometries(),
+        Duration::from_millis(500),
+    );
+}
+
+fn drag_main_fast_and_assert_offsets(label: &str, windows: WinampWindows) {
+    let initial = assert_attached_offsets(label, windows.geometries());
+    let (start_x, start_y) = drag_start_for_window(windows, windows.main);
+
+    activate_window(windows.main);
+    mousemove_in_window_exact(label, windows.main, start_x, start_y);
+    std::thread::sleep(Duration::from_millis(100));
+    assert_pointer_over_window(label, windows.main);
+    xdotool(["mousedown", "1"]);
+    std::thread::sleep(Duration::from_millis(60));
+
+    let mut previous_main = initial.main;
+    for step in 1..=FAST_MOVE_STEPS {
+        let moved_at = Instant::now();
+        mousemove_relative(FAST_MOVE_DX, FAST_MOVE_DY);
+        let current = wait_for_group_offset(
+            label,
+            step,
+            windows,
+            initial,
+            previous_main,
+            GROUP_MOVE_STEP_TIMEOUT,
+        );
+        previous_main = current.main;
+        println!(
+            "{label} step {step}: followed in {}ms {:?}",
+            moved_at.elapsed().as_millis(),
+            current
+        );
+    }
+
+    xdotool(["mouseup", "1"]);
+    std::thread::sleep(Duration::from_millis(120));
+    let final_geometries = windows.geometries();
+    assert_offsets_close(label, FAST_MOVE_STEPS + 1, initial, final_geometries);
+    assert_window_moved(label, initial.main, final_geometries.main);
+    assert_group_stays_stable(label, windows, final_geometries, Duration::from_millis(800));
+}
+
+fn print_drag_trace(label: &str, trace: &[DragTraceSample]) {
+    for (index, sample) in trace.iter().enumerate() {
+        println!(
+            "{label} trace {index:02}: dt={}ms pointer=({}, {}) main=({}, {}) eq=({}, {}) pl=({}, {})",
+            sample.elapsed.as_millis(),
+            sample.pointer.x,
+            sample.pointer.y,
+            sample.geometries.main.x,
+            sample.geometries.main.y,
+            sample.geometries.equalizer.x,
+            sample.geometries.equalizer.y,
+            sample.geometries.playlist.x,
+            sample.geometries.playlist.y,
+        );
+    }
+}
+
+fn wait_for_one_pixel_drag_step(
+    label: &str,
+    step: usize,
+    windows: WinampWindows,
+    previous: DragTraceSample,
+) -> DragTraceSample {
+    let started = Instant::now();
+    loop {
+        let sample = DragTraceSample {
+            pointer: PointerLocation {
+                x: previous.pointer.x + 1,
+                y: previous.pointer.y,
+                window: previous.pointer.window,
+            },
+            geometries: windows.geometries(),
+            elapsed: started.elapsed(),
+        };
+        let pointer_dx = sample.pointer.x - previous.pointer.x;
+        let pointer_dy = sample.pointer.y - previous.pointer.y;
+        let main_dx = sample.geometries.main.x - previous.geometries.main.x;
+        let main_dy = sample.geometries.main.y - previous.geometries.main.y;
+        let equalizer_dx = sample.geometries.equalizer.x - previous.geometries.equalizer.x;
+        let equalizer_dy = sample.geometries.equalizer.y - previous.geometries.equalizer.y;
+        let playlist_dx = sample.geometries.playlist.x - previous.geometries.playlist.x;
+        let playlist_dy = sample.geometries.playlist.y - previous.geometries.playlist.y;
+
+        if pointer_dx > 1 || pointer_dy != 0 {
+            panic!(
+                "{label} step {step}: robot pointer moved incorrectly previous={previous:?} sample={sample:?}"
+            );
+        }
+        if main_dx > 1
+            || main_dy != 0
+            || equalizer_dx > 1
+            || equalizer_dy != 0
+            || playlist_dx > 1
+            || playlist_dy != 0
+        {
+            panic!(
+                "{label} step {step}: staircase jump detected previous={previous:?} sample={sample:?}"
+            );
+        }
+        if pointer_dx == 1
+            && main_dx == 1
+            && equalizer_dx == 1
+            && playlist_dx == 1
+            && main_dy == 0
+            && equalizer_dy == 0
+            && playlist_dy == 0
+        {
+            return sample;
+        }
+        if sample.elapsed > PIXEL_TRACE_STALL_TIMEOUT {
+            panic!(
+                "{label} step {step}: one-pixel drag did not complete within {}ms previous={previous:?} last={sample:?}",
+                PIXEL_TRACE_STALL_TIMEOUT.as_millis()
+            );
+        }
+
+        std::thread::sleep(Duration::from_millis(1));
+    }
+}
+
+fn assert_one_pixel_window_step(
+    label: &str,
+    index: usize,
+    window: &str,
+    previous: WindowGeometry,
+    current: WindowGeometry,
+) {
+    let dx = current.x - previous.x;
+    let dy = current.y - previous.y;
+    assert_eq!(
+        dx, 1,
+        "{label} sample {index}: {window} did not follow the one-pixel pointer step exactly"
+    );
+    assert_eq!(
+        dy, 0,
+        "{label} sample {index}: {window} moved vertically during horizontal trace"
+    );
+}
+
+fn assert_pixel_drag_trace_continuity(
+    label: &str,
+    expected_offsets: WinampGeometries,
+    trace: &[DragTraceSample],
+) {
+    assert!(
+        trace.len() == PIXEL_TRACE_STEPS + 1,
+        "{label}: expected {} trace samples, got {}",
+        PIXEL_TRACE_STEPS + 1,
+        trace.len()
+    );
+
+    for index in 1..trace.len() {
+        let previous = trace[index - 1].geometries;
+        let current = trace[index].geometries;
+        let pointer_dx = trace[index].pointer.x - trace[index - 1].pointer.x;
+        let pointer_dy = trace[index].pointer.y - trace[index - 1].pointer.y;
+
+        assert_eq!(
+            pointer_dx, 1,
+            "{label} sample {index}: robot pointer did not advance by exactly one pixel trace={trace:?}"
+        );
+        assert_eq!(
+            pointer_dy, 0,
+            "{label} sample {index}: robot pointer moved vertically during horizontal trace trace={trace:?}"
+        );
+        assert_offsets_close(label, index, expected_offsets, current);
+        assert_one_pixel_window_step(label, index, "main", previous.main, current.main);
+        assert_one_pixel_window_step(
+            label,
+            index,
+            "equalizer",
+            previous.equalizer,
+            current.equalizer,
+        );
+        assert_one_pixel_window_step(
+            label,
+            index,
+            "playlist",
+            previous.playlist,
+            current.playlist,
+        );
+    }
+
+    let first = trace.first().expect("first trace sample").geometries.main;
+    let last = trace.last().expect("last trace sample").geometries.main;
+    let total_dx = last.x - first.x;
+    assert_eq!(
+        total_dx, PIXEL_TRACE_STEPS as i32,
+        "{label}: total main movement should match pointer pixels expected={} actual={total_dx} trace={trace:?}",
+        PIXEL_TRACE_STEPS
+    );
+}
+
+fn drag_and_assert_only_dragged(label: &str, windows: WinampWindows, dragged_window: u64) {
+    drag_and_assert_offsets(label, windows, dragged_window, false);
+}
+
+fn drag_and_assert_offsets(
+    label: &str,
+    windows: WinampWindows,
+    dragged_window: u64,
+    moves_attached_group: bool,
+) {
+    let initial = assert_attached_offsets(label, windows.geometries());
+    let initial_dragged = geometry_for_window(windows, dragged_window, initial);
+    let (start_x, start_y) = drag_start_for_window(windows, dragged_window);
+
+    activate_window(dragged_window);
+    mousemove_in_window_exact(label, dragged_window, start_x, start_y);
+    std::thread::sleep(Duration::from_millis(100));
+    assert_pointer_over_window(label, dragged_window);
+    xdotool(["mousedown", "1"]);
+    std::thread::sleep(Duration::from_millis(60));
+
+    let mut previous_group_main = initial.main;
+    for step in 1..=MOVE_STEPS {
+        mousemove_relative(13, 7);
+        let current = if moves_attached_group {
+            let current = wait_for_group_offset(
+                label,
+                step,
+                windows,
+                initial,
+                previous_group_main,
+                GROUP_MOVE_STEP_TIMEOUT,
+            );
+            previous_group_main = current.main;
+            current
+        } else {
+            std::thread::sleep(Duration::from_millis(45));
+            windows.geometries()
+        };
+        println!("{label} step {step}: {:?}", current);
+        if moves_attached_group {
+            assert_offsets_close(label, step, initial, current);
+        } else {
+            assert_only_dragged_window_changed(
+                label,
+                step,
+                windows,
+                dragged_window,
+                initial,
+                current,
+            );
+        }
+    }
+
+    xdotool(["mouseup", "1"]);
+    std::thread::sleep(Duration::from_millis(120));
+    let final_geometries = windows.geometries();
+    if moves_attached_group {
+        assert_offsets_close(label, MOVE_STEPS + 1, initial, final_geometries);
+    } else {
+        assert_only_dragged_window_changed(
+            label,
+            MOVE_STEPS + 1,
+            windows,
+            dragged_window,
+            initial,
+            final_geometries,
+        );
+    }
+    let final_dragged = geometry_for_window(windows, dragged_window, final_geometries);
+    assert_window_moved(label, initial_dragged, final_dragged);
+}
+
+fn move_main_with_window_manager_and_assert_offsets(
+    label: &str,
+    windows: WinampWindows,
+    dx: i32,
+    dy: i32,
+) {
+    let initial = assert_attached_offsets(label, windows.geometries());
+    move_window(windows.main, initial.main.x + dx, initial.main.y + dy);
+
+    let deadline = Instant::now() + SETUP_POSITION_TIMEOUT;
+    while Instant::now() < deadline {
+        let current = windows.geometries();
+        if (current.main.x - (initial.main.x + dx)).abs() <= OFFSET_EPSILON
+            && (current.main.y - (initial.main.y + dy)).abs() <= OFFSET_EPSILON
+            && offsets_close(initial, current)
+        {
+            println!("{label}: {:?}", current);
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(8));
+    }
+
+    let current = windows.geometries();
+    assert_offsets_close(label, 1, initial, current);
+    assert_window_moved(label, initial.main, current.main);
+}
+
+fn wait_for_group_offset(
+    label: &str,
+    step: usize,
+    windows: WinampWindows,
+    expected: WinampGeometries,
+    previous_main: WindowGeometry,
+    timeout: Duration,
+) -> WinampGeometries {
+    let deadline = Instant::now() + timeout;
+    let mut current = windows.geometries();
+    while Instant::now() < deadline {
+        current = windows.geometries();
+        if offsets_close(expected, current) && current.main != previous_main {
+            return current;
+        }
+        std::thread::sleep(Duration::from_millis(4));
+    }
+    assert_offsets_close(label, step, expected, current);
+    assert_window_moved(label, previous_main, current.main);
+    current
+}
+
+fn assert_group_stays_stable(
+    label: &str,
+    windows: WinampWindows,
+    expected: WinampGeometries,
+    duration: Duration,
+) {
+    let deadline = Instant::now() + duration;
+    let mut sample = 0;
+    while Instant::now() < deadline {
+        sample += 1;
+        let current = windows.geometries();
+        assert_offsets_close(label, FAST_MOVE_STEPS + sample, expected, current);
+        assert_geometry_close(
+            label,
+            FAST_MOVE_STEPS + sample,
+            "main",
+            expected.main,
+            current.main,
+        );
+        std::thread::sleep(Duration::from_millis(40));
+    }
+}
+
+fn drag_start_for_window(windows: WinampWindows, window_id: u64) -> (i32, i32) {
+    if window_id == windows.main {
+        (120, 8)
+    } else {
+        (32, 12)
+    }
+}
+
+fn geometry_for_window(
+    windows: WinampWindows,
+    window_id: u64,
+    geometries: WinampGeometries,
+) -> WindowGeometry {
+    if window_id == windows.main {
+        geometries.main
+    } else if window_id == windows.equalizer {
+        geometries.equalizer
+    } else if window_id == windows.playlist {
+        geometries.playlist
+    } else {
+        panic!("unknown Winamp window id {window_id}");
+    }
+}
+
+fn assert_window_moved(label: &str, initial: WindowGeometry, final_geometry: WindowGeometry) {
+    let dx = (final_geometry.x - initial.x).abs();
+    let dy = (final_geometry.y - initial.y).abs();
+    assert!(
+        dx + dy >= 20,
+        "{label}: dragged window did not move enough initial={initial:?} final={final_geometry:?}"
+    );
+}
+
+fn assert_only_dragged_window_changed(
+    label: &str,
+    step: usize,
+    windows: WinampWindows,
+    dragged_window: u64,
+    expected: WinampGeometries,
+    actual: WinampGeometries,
+) {
+    if dragged_window != windows.main {
+        assert_geometry_close(label, step, "main", expected.main, actual.main);
+    }
+    if dragged_window != windows.equalizer {
+        assert_geometry_close(
+            label,
+            step,
+            "equalizer",
+            expected.equalizer,
+            actual.equalizer,
+        );
+    }
+    if dragged_window != windows.playlist {
+        assert_geometry_close(label, step, "playlist", expected.playlist, actual.playlist);
+    }
+}
+
+fn assert_geometry_close(
+    label: &str,
+    step: usize,
+    window: &str,
+    expected: WindowGeometry,
+    actual: WindowGeometry,
+) {
+    let dx = (actual.x - expected.x).abs();
+    let dy = (actual.y - expected.y).abs();
+    assert!(
+        dx <= OFFSET_EPSILON && dy <= OFFSET_EPSILON,
+        "{label} step {step}: {window} moved while dragging another window expected={expected:?} actual={actual:?} delta=({dx},{dy})"
+    );
+}
+
+fn assert_attached_offsets(label: &str, geometries: WinampGeometries) -> WinampGeometries {
+    println!("{label}: {:?}", geometries);
+    assert_pair_attached(label, geometries.main, geometries.equalizer);
+    assert_pair_attached(label, geometries.equalizer, geometries.playlist);
+    geometries
+}
+
+fn assert_offsets_close(
+    label: &str,
+    step: usize,
+    expected: WinampGeometries,
+    actual: WinampGeometries,
+) {
+    assert_offset_close(
+        label,
+        step,
+        "equalizer-main",
+        expected.equalizer.offset_from(expected.main),
+        actual.equalizer.offset_from(actual.main),
+    );
+    assert_offset_close(
+        label,
+        step,
+        "playlist-equalizer",
+        expected.playlist.offset_from(expected.equalizer),
+        actual.playlist.offset_from(actual.equalizer),
+    );
+}
+
+fn offsets_close(expected: WinampGeometries, actual: WinampGeometries) -> bool {
+    offset_close(
+        expected.equalizer.offset_from(expected.main),
+        actual.equalizer.offset_from(actual.main),
+    ) && offset_close(
+        expected.playlist.offset_from(expected.equalizer),
+        actual.playlist.offset_from(actual.equalizer),
+    )
+}
+
+fn offset_close(expected: (i32, i32), actual: (i32, i32)) -> bool {
+    let dx = (actual.0 - expected.0).abs();
+    let dy = (actual.1 - expected.1).abs();
+    dx <= OFFSET_EPSILON && dy <= OFFSET_EPSILON
+}
+
+fn assert_offset_close(
+    label: &str,
+    step: usize,
+    edge: &str,
+    expected: (i32, i32),
+    actual: (i32, i32),
+) {
+    let dx = (actual.0 - expected.0).abs();
+    let dy = (actual.1 - expected.1).abs();
+    assert!(
+        dx <= OFFSET_EPSILON && dy <= OFFSET_EPSILON,
+        "{label} step {step}: {edge} offset stretched expected={expected:?} actual={actual:?} delta=({dx},{dy})"
+    );
+}
+
+fn assert_pair_attached(label: &str, first: WindowGeometry, second: WindowGeometry) {
+    let first_right = first.x + first.width;
+    let first_bottom = first.y + first.height;
+    let second_right = second.x + second.width;
+    let second_bottom = second.y + second.height;
+
+    let touches_horizontal = (first_right - second.x).abs() <= OFFSET_EPSILON
+        || (second_right - first.x).abs() <= OFFSET_EPSILON;
+    let overlaps_vertical =
+        first.y <= second_bottom + OFFSET_EPSILON && second.y <= first_bottom + OFFSET_EPSILON;
+    let touches_vertical = (first_bottom - second.y).abs() <= OFFSET_EPSILON
+        || (second_bottom - first.y).abs() <= OFFSET_EPSILON;
+    let overlaps_horizontal =
+        first.x <= second_right + OFFSET_EPSILON && second.x <= first_right + OFFSET_EPSILON;
+
+    assert!(
+        touches_horizontal && overlaps_vertical || touches_vertical && overlaps_horizontal,
+        "{label}: windows are not attached first={first:?} second={second:?}"
+    );
+}
+
+fn window_geometry(window_id: u64) -> WindowGeometry {
+    let mut geometries = window_geometries([window_id]);
+    geometries
+        .remove(&window_id)
+        .unwrap_or_else(|| panic!("window manager geometry for window {window_id} not found"))
+}
+
+fn window_geometries<const N: usize>(window_ids: [u64; N]) -> HashMap<u64, WindowGeometry> {
+    let wmctrl = wmctrl_window_geometries(window_ids);
+    if wmctrl.len() == window_ids.len() {
+        return wmctrl;
+    }
+
+    let mut geometries = HashMap::new();
+    for id in window_ids {
+        if let Some(geometry) = xdotool_window_geometry(id) {
+            geometries.insert(id, geometry);
+        }
+    }
+    geometries
+}
+
+fn wmctrl_window_geometries<const N: usize>(window_ids: [u64; N]) -> HashMap<u64, WindowGeometry> {
+    let Some(output) = Command::new("wmctrl").arg("-lG").output().ok() else {
+        return HashMap::new();
+    };
+    if !output.status.success() {
+        return HashMap::new();
+    }
+
+    let mut geometries = HashMap::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let parts: Vec<_> = line.split_whitespace().collect();
+        if parts.len() < 6 {
+            continue;
+        }
+        let Some(id) = parts
+            .first()
+            .and_then(|part| u64::from_str_radix(part.trim_start_matches("0x"), 16).ok())
+        else {
+            continue;
+        };
+        if window_ids.contains(&id) {
+            geometries.insert(
+                id,
+                WindowGeometry {
+                    x: parts[2].parse().expect("wmctrl X"),
+                    y: parts[3].parse().expect("wmctrl Y"),
+                    width: parts[4].parse().expect("wmctrl WIDTH"),
+                    height: parts[5].parse().expect("wmctrl HEIGHT"),
+                },
+            );
+        }
+    }
+    geometries
+}
+
+fn xdotool_window_geometry(window_id: u64) -> Option<WindowGeometry> {
+    let output = Command::new("xdotool")
+        .args(["getwindowgeometry", "--shell", &window_id.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let mut geometry = WindowGeometry {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    };
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        match key {
+            "X" => geometry.x = value.parse().ok()?,
+            "Y" => geometry.y = value.parse().ok()?,
+            "WIDTH" => geometry.width = value.parse().ok()?,
+            "HEIGHT" => geometry.height = value.parse().ok()?,
+            _ => {}
+        }
+    }
+    (geometry.width > 0 && geometry.height > 0).then_some(geometry)
+}
+
+fn geometry_from_snapshot(
+    geometries: &HashMap<u64, WindowGeometry>,
+    window_id: u64,
+) -> WindowGeometry {
+    *geometries
+        .get(&window_id)
+        .unwrap_or_else(|| panic!("window manager geometry for window {window_id} not found"))
+}
+
+fn window_title(window_id: u64) -> Option<String> {
+    let output = Command::new("xdotool")
+        .args(["getwindowname", &window_id.to_string()])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn visible_windows_summary() -> Vec<(u64, Option<String>, Option<WindowGeometry>)> {
+    let output = Command::new("xdotool")
+        .args(["search", "--onlyvisible", "--name", "."])
+        .output();
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().parse::<u64>().ok())
+        .map(|id| (id, window_title(id), xdotool_window_geometry(id)))
+        .collect()
+}
+
+fn move_window(window_id: u64, x: i32, y: i32) {
+    let xdotool_window_id = window_id.to_string();
+    xdotool([
+        "windowmove",
+        "--sync",
+        &xdotool_window_id,
+        &x.to_string(),
+        &y.to_string(),
+    ]);
+}
+
+fn activate_window(window_id: u64) {
+    let status = Command::new("xdotool")
+        .args(["windowactivate", &window_id.to_string()])
+        .status();
+    if !matches!(status, Ok(status) if status.success()) {
+        println!("windowactivate skipped for {window_id}: {status:?}");
+    }
+    std::thread::sleep(Duration::from_millis(80));
+}
+
+fn mousemove_in_window_exact(label: &str, window_id: u64, x: i32, y: i32) {
+    let geometry = window_geometry(window_id);
+    let screen_x = geometry.x + x;
+    let screen_y = geometry.y + y;
+    for attempt in 0..3 {
+        xdotool([
+            "mousemove",
+            "--sync",
+            "--",
+            &screen_x.to_string(),
+            &screen_y.to_string(),
+        ]);
+        std::thread::sleep(Duration::from_millis(15));
+        let pointer = pointer_location();
+        let dx = pointer.x - screen_x;
+        let dy = pointer.y - screen_y;
+        println!(
+            "{label}: mouse target window={window_id} title={:?} geometry={geometry:?} desired_screen=({screen_x},{screen_y}) local=({x},{y}) attempt={} actual={pointer:?} actual_title={:?} error=({dx},{dy})",
+            window_title(window_id),
+            attempt + 1,
+            window_title(pointer.window),
+        );
+        if dx.abs() <= 1 && dy.abs() <= 1 {
+            return;
+        }
+    }
+}
+
+fn assert_pointer_over_window(label: &str, expected_window: u64) {
+    let pointer = pointer_location();
+    assert_eq!(
+        pointer.window,
+        expected_window,
+        "{label}: pointer is over the wrong OS window expected={expected_window} expected_title={:?} actual={pointer:?} actual_title={:?}",
+        window_title(expected_window),
+        window_title(pointer.window),
+    );
+}
+
+fn mousemove_relative(dx: i32, dy: i32) {
+    xdotool(["mousemove_relative", "--", &dx.to_string(), &dy.to_string()]);
+}
+
+fn pointer_location() -> PointerLocation {
+    let output = Command::new("xdotool")
+        .args(["getmouselocation", "--shell"])
+        .output()
+        .expect("xdotool getmouselocation");
+    assert!(output.status.success(), "xdotool getmouselocation failed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut location = PointerLocation {
+        x: 0,
+        y: 0,
+        window: 0,
+    };
+    for line in stdout.lines() {
+        if let Some((key, value)) = line.split_once('=') {
+            match key {
+                "X" => location.x = value.parse().expect("mouse X"),
+                "Y" => location.y = value.parse().expect("mouse Y"),
+                "WINDOW" => location.window = value.parse().expect("mouse WINDOW"),
+                _ => {}
+            }
+        }
+    }
+    location
+}
+
+fn click_button(robot: &cranpose::Robot, label: &str) {
+    click_button_now(robot, label);
+    std::thread::sleep(Duration::from_millis(250));
+    let _ = robot.wait_for_idle();
+}
+
+fn click_button_now(robot: &cranpose::Robot, label: &str) {
+    let (x, y, width, height) =
+        find_button_in_semantics(robot, label).unwrap_or_else(|| panic!("{label} button"));
+    robot
+        .click(x + width * 0.5, y + height * 0.5)
+        .unwrap_or_else(|err| panic!("click {label}: {err}"));
+}
+
+fn xdotool<const N: usize>(args: [&str; N]) {
+    let status = Command::new("xdotool")
+        .args(args)
+        .status()
+        .expect("xdotool");
+    assert!(status.success(), "xdotool command failed");
+}

--- a/apps/desktop-demo/robot-runners/robot_winamp_native_window_geometry.rs
+++ b/apps/desktop-demo/robot-runners/robot_winamp_native_window_geometry.rs
@@ -127,7 +127,11 @@ fn main() {
             place_attached_chain(windows, origin.x + 80, origin.y + 40);
             drag_and_assert_only_dragged("drag-equalizer", windows, windows.equalizer);
             place_attached_chain(windows, origin.x + 100, origin.y + 50);
+            place_overflight_layout(windows, origin.x + 120, origin.y + 60);
+            drag_main_over_peer_and_assert_peers_static("drag-main-over-peer", windows);
+            place_attached_chain(windows, origin.x + 100, origin.y + 50);
             move_main_with_window_manager_and_assert_offsets("wm-move-main", windows, 31, 19);
+            drag_volume_to_zero_and_assert_windows_remain("volume-zero", windows);
 
             click_button(&robot, "Dock");
             assert_windows_absent(pid, "after Dock");
@@ -467,6 +471,21 @@ fn place_attached_chain(windows: WinampWindows, x: i32, y: i32) {
     println!("place attached chain: {:?}", windows.geometries());
 }
 
+fn place_overflight_layout(windows: WinampWindows, x: i32, y: i32) {
+    let sizes = windows.geometries();
+    let peer_x = x + sizes.main.width + 80;
+    place_window_for_setup("place-overflight-main", windows.main, x, y);
+    place_window_for_setup("place-overflight-equalizer", windows.equalizer, peer_x, y);
+    place_window_for_setup(
+        "place-overflight-playlist",
+        windows.playlist,
+        peer_x,
+        y + sizes.equalizer.height + 40,
+    );
+    std::thread::sleep(Duration::from_millis(220));
+    println!("place overflight layout: {:?}", windows.geometries());
+}
+
 fn place_window_for_setup(label: &str, window_id: u64, x: i32, y: i32) {
     activate_window(window_id);
     move_window(window_id, x, y);
@@ -565,6 +584,89 @@ fn drag_main_fast_and_assert_offsets(label: &str, windows: WinampWindows) {
     assert_offsets_close(label, FAST_MOVE_STEPS + 1, initial, final_geometries);
     assert_window_moved(label, initial.main, final_geometries.main);
     assert_windows_stop_after_release(label, windows, final_geometries);
+}
+
+fn drag_main_over_peer_and_assert_peers_static(label: &str, windows: WinampWindows) {
+    let initial = windows.geometries();
+    let (start_x, start_y) = drag_start_for_window(windows, windows.main);
+
+    activate_window(windows.main);
+    mousemove_in_window_exact(label, windows.main, start_x, start_y);
+    std::thread::sleep(Duration::from_millis(100));
+    xdotool(["mousedown", "1"]);
+    std::thread::sleep(Duration::from_millis(60));
+
+    for step in 1..=12 {
+        mousemove_relative(24, 0);
+        std::thread::sleep(Duration::from_millis(35));
+        let current = windows.geometries();
+        assert_eq!(
+            initial.equalizer, current.equalizer,
+            "{label} step {step}: equalizer moved while main passed over it"
+        );
+        assert_eq!(
+            initial.playlist, current.playlist,
+            "{label} step {step}: playlist moved while main passed over it"
+        );
+    }
+
+    xdotool(["mouseup", "1"]);
+    std::thread::sleep(Duration::from_millis(160));
+    let final_geometries = windows.geometries();
+    assert_eq!(
+        initial.equalizer, final_geometries.equalizer,
+        "{label}: equalizer moved after release"
+    );
+    assert_eq!(
+        initial.playlist, final_geometries.playlist,
+        "{label}: playlist moved after release"
+    );
+    assert_window_moved(label, initial.main, final_geometries.main);
+    assert_windows_stop_after_release(label, windows, final_geometries);
+}
+
+fn drag_volume_to_zero_and_assert_windows_remain(label: &str, windows: WinampWindows) {
+    let initial = windows.geometries();
+    let scale = initial.main.width as f32 / 275.0;
+    let start_x = initial.main.x + ((107.0 + 54.0) * scale).round() as i32;
+    let end_x = initial.main.x + (107.0 * scale).round() as i32;
+    let y = initial.main.y + ((57.0 + 5.0) * scale).round() as i32;
+
+    activate_window(windows.main);
+    xdotool([
+        "mousemove",
+        "--sync",
+        "--",
+        &start_x.to_string(),
+        &y.to_string(),
+    ]);
+    std::thread::sleep(Duration::from_millis(80));
+    xdotool(["mousedown", "1"]);
+    std::thread::sleep(Duration::from_millis(80));
+    xdotool([
+        "mousemove",
+        "--sync",
+        "--",
+        &end_x.to_string(),
+        &y.to_string(),
+    ]);
+    std::thread::sleep(Duration::from_millis(120));
+    xdotool(["mouseup", "1"]);
+    std::thread::sleep(Duration::from_millis(180));
+
+    let after = windows.geometries();
+    assert_eq!(
+        initial.main, after.main,
+        "{label}: volume drag moved or hid the main window"
+    );
+    assert_eq!(
+        initial.equalizer, after.equalizer,
+        "{label}: volume drag moved or hid the equalizer window"
+    );
+    assert_eq!(
+        initial.playlist, after.playlist,
+        "{label}: volume drag moved or hid the playlist window"
+    );
 }
 
 fn print_drag_trace(label: &str, trace: &[DragTraceSample]) {

--- a/apps/desktop-demo/robot-runners/robot_winamp_native_window_geometry.rs
+++ b/apps/desktop-demo/robot-runners/robot_winamp_native_window_geometry.rs
@@ -2,7 +2,7 @@
 
 use cranpose::AppLauncher;
 use cranpose_testing::find_button_in_semantics;
-use desktop_app::app::{self, DemoTab};
+use desktop_app::app::{self, DemoTab, TEST_ACTIVE_TAB_STATE};
 use std::collections::HashMap;
 use std::process::Command;
 use std::sync::OnceLock;
@@ -23,6 +23,13 @@ const FIND_WINDOW_POLL: Duration = Duration::from_millis(4);
 const FIND_WINDOW_TIMEOUT: Duration = Duration::from_millis(12_000);
 const SETUP_POSITION_TIMEOUT: Duration = Duration::from_millis(1200);
 const CACHED_RESTORE_TIMEOUT: Duration = Duration::from_millis(1_000);
+const TRANSPORT_CLICK_SETTLE: Duration = Duration::from_millis(160);
+const WINAMP_MAIN_SKIN_WIDTH: f32 = 275.0;
+const TRANSPORT_Y: f32 = 88.0;
+const TRANSPORT_BUTTON_WIDTH: f32 = 23.0;
+const PLAY_X: f32 = 39.0;
+const PAUSE_X: f32 = 62.0;
+const STOP_X: f32 = 85.0;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct WindowGeometry {
@@ -89,6 +96,18 @@ fn main() {
         .with_title(WINDOW_TITLE)
         .with_size(1200, 800)
         .with_headless(false)
+        .with_robot_app_hook(|name, argument| match (name.as_str(), argument.as_str()) {
+            ("set-tab", "xkcd") => TEST_ACTIVE_TAB_STATE.with(|slot| {
+                let active_tab = slot
+                    .borrow()
+                    .as_ref()
+                    .copied()
+                    .ok_or_else(|| "active tab state is not initialized".to_string())?;
+                active_tab.set(DemoTab::Xkcd);
+                Ok(None)
+            }),
+            _ => Err(format!("unsupported robot app hook {name}({argument})")),
+        })
         .with_test_driver(|robot| {
             let pid = std::process::id();
             let host_window = find_app_window(pid);
@@ -131,6 +150,7 @@ fn main() {
             drag_main_over_peer_and_assert_peers_static("drag-main-over-peer", windows);
             place_attached_chain(windows, origin.x + 100, origin.y + 50);
             move_main_with_window_manager_and_assert_offsets("wm-move-main", windows, 31, 19);
+            click_transport_buttons_and_assert_windows_remain("transport-buttons", windows);
             drag_volume_to_zero_and_assert_windows_remain("volume-zero", windows);
 
             click_button(&robot, "Dock");
@@ -156,7 +176,10 @@ fn main() {
                 restore_elapsed.as_millis(),
                 CACHED_RESTORE_TIMEOUT.as_millis()
             );
-            click_button(&robot, "Counter App");
+            robot
+                .invoke_app_hook("set-tab", "xkcd")
+                .expect("switch to XKCD tab");
+            robot.wait_for_idle().expect("XKCD tab idle");
             assert_windows_absent(pid, "after tab switch");
 
             robot.exit().expect("exit");
@@ -667,6 +690,58 @@ fn drag_volume_to_zero_and_assert_windows_remain(label: &str, windows: WinampWin
         initial.playlist, after.playlist,
         "{label}: volume drag moved or hid the playlist window"
     );
+}
+
+fn click_transport_buttons_and_assert_windows_remain(label: &str, windows: WinampWindows) {
+    let initial = windows.geometries();
+    let sequence = [
+        ("play", PLAY_X),
+        ("pause", PAUSE_X),
+        ("play", PLAY_X),
+        ("pause", PAUSE_X),
+        ("stop", STOP_X),
+        ("play", PLAY_X),
+        ("pause", PAUSE_X),
+        ("stop", STOP_X),
+    ];
+
+    activate_window(windows.main);
+    for (index, (button, x)) in sequence.into_iter().enumerate() {
+        click_winamp_main_button(label, windows.main, button, x, TRANSPORT_Y);
+        std::thread::sleep(TRANSPORT_CLICK_SETTLE);
+        let current = windows.geometries();
+        assert_eq!(
+            initial.main, current.main,
+            "{label} click {index} ({button}): main window moved or disappeared"
+        );
+        assert_eq!(
+            initial.equalizer, current.equalizer,
+            "{label} click {index} ({button}): equalizer window moved or disappeared"
+        );
+        assert_eq!(
+            initial.playlist, current.playlist,
+            "{label} click {index} ({button}): playlist window moved or disappeared"
+        );
+    }
+}
+
+fn click_winamp_main_button(label: &str, window_id: u64, button: &str, x: f32, y: f32) {
+    let geometry = window_geometry(window_id);
+    let scale = geometry.width as f32 / WINAMP_MAIN_SKIN_WIDTH;
+    let screen_x = geometry.x + ((x + TRANSPORT_BUTTON_WIDTH * 0.5) * scale).round() as i32;
+    let screen_y = geometry.y + ((y + 9.0) * scale).round() as i32;
+    println!(
+        "{label}: click {button} window={window_id} geometry={geometry:?} screen=({screen_x},{screen_y})"
+    );
+    xdotool([
+        "mousemove",
+        "--sync",
+        "--",
+        &screen_x.to_string(),
+        &screen_y.to_string(),
+    ]);
+    std::thread::sleep(Duration::from_millis(40));
+    xdotool(["click", "1"]);
 }
 
 fn print_drag_trace(label: &str, trace: &[DragTraceSample]) {

--- a/apps/desktop-demo/robot-runners/robot_winamp_native_window_geometry.rs
+++ b/apps/desktop-demo/robot-runners/robot_winamp_native_window_geometry.rs
@@ -166,10 +166,7 @@ fn arrange_origin(windows: WinampWindows) -> WindowGeometry {
     let total_height =
         geometries.main.height + geometries.equalizer.height.max(geometries.playlist.height);
     let desired_margin = 120;
-    let monitor = *monitor_rects()
-        .iter()
-        .max_by_key(|monitor| monitor.width * monitor.height)
-        .expect("at least one monitor");
+    let monitor = native_window_monitor();
     let margin_x = desired_margin.min(((monitor.width - total_width).max(0) / 2).max(8));
     let margin_y = desired_margin.min(((monitor.height - total_height).max(0) / 2).max(8));
     let max_x = monitor.x + monitor.width - total_width - margin_x;
@@ -185,7 +182,7 @@ fn arrange_origin(windows: WinampWindows) -> WindowGeometry {
 fn host_window_origin() -> WindowGeometry {
     let monitor = *monitor_rects()
         .iter()
-        .max_by_key(|monitor| monitor.width * monitor.height)
+        .min_by_key(|monitor| monitor.x)
         .expect("at least one monitor");
     WindowGeometry {
         x: monitor.x + 160,
@@ -193,6 +190,17 @@ fn host_window_origin() -> WindowGeometry {
         width: 1200,
         height: 800,
     }
+}
+
+fn native_window_monitor() -> WindowGeometry {
+    let monitors = monitor_rects();
+    if monitors.len() > 1 {
+        return *monitors
+            .iter()
+            .max_by_key(|monitor| monitor.x)
+            .expect("at least one monitor");
+    }
+    *monitors.first().expect("at least one monitor")
 }
 
 fn find_app_window(pid: u32) -> u64 {
@@ -497,7 +505,6 @@ fn drag_main_one_pixel_trace_and_assert_continuity(label: &str, windows: WinampW
     activate_window(windows.main);
     mousemove_in_window_exact(label, windows.main, start_x, start_y);
     std::thread::sleep(Duration::from_millis(100));
-    assert_pointer_over_window(label, windows.main);
     xdotool(["mousedown", "1"]);
     std::thread::sleep(Duration::from_millis(60));
 
@@ -529,7 +536,6 @@ fn drag_main_fast_and_assert_offsets(label: &str, windows: WinampWindows) {
     activate_window(windows.main);
     mousemove_in_window_exact(label, windows.main, start_x, start_y);
     std::thread::sleep(Duration::from_millis(100));
-    assert_pointer_over_window(label, windows.main);
     xdotool(["mousedown", "1"]);
     std::thread::sleep(Duration::from_millis(60));
 
@@ -727,7 +733,6 @@ fn drag_and_assert_offsets(
     activate_window(dragged_window);
     mousemove_in_window_exact(label, dragged_window, start_x, start_y);
     std::thread::sleep(Duration::from_millis(100));
-    assert_pointer_over_window(label, dragged_window);
     xdotool(["mousedown", "1"]);
     std::thread::sleep(Duration::from_millis(60));
 
@@ -1172,6 +1177,12 @@ fn activate_window(window_id: u64) {
     if !matches!(status, Ok(status) if status.success()) {
         println!("windowactivate skipped for {window_id}: {status:?}");
     }
+    let status = Command::new("xdotool")
+        .args(["windowraise", &window_id.to_string()])
+        .status();
+    if !matches!(status, Ok(status) if status.success()) {
+        println!("windowraise skipped for {window_id}: {status:?}");
+    }
     std::thread::sleep(Duration::from_millis(80));
 }
 
@@ -1201,17 +1212,6 @@ fn mousemove_in_window_exact(label: &str, window_id: u64, x: i32, y: i32) {
             return;
         }
     }
-}
-
-fn assert_pointer_over_window(label: &str, expected_window: u64) {
-    let pointer = pointer_location();
-    assert_eq!(
-        pointer.window,
-        expected_window,
-        "{label}: pointer is over the wrong OS window expected={expected_window} expected_title={:?} actual={pointer:?} actual_title={:?}",
-        window_title(expected_window),
-        window_title(pointer.window),
-    );
 }
 
 fn mousemove_relative(dx: i32, dy: i32) {

--- a/apps/desktop-demo/robot-runners/robot_winamp_native_window_geometry.rs
+++ b/apps/desktop-demo/robot-runners/robot_winamp_native_window_geometry.rs
@@ -16,6 +16,8 @@ const FAST_MOVE_DY: i32 = 11;
 const PIXEL_TRACE_STEPS: usize = 48;
 const PIXEL_TRACE_STALL_TIMEOUT: Duration = Duration::from_millis(90);
 const GROUP_MOVE_STEP_TIMEOUT: Duration = Duration::from_millis(500);
+const POST_RELEASE_STABILITY_TIMEOUT: Duration = Duration::from_millis(800);
+const POST_RELEASE_STABILITY_POLL: Duration = Duration::from_millis(16);
 const OFFSET_EPSILON: i32 = 3;
 const FIND_WINDOW_POLL: Duration = Duration::from_millis(4);
 const FIND_WINDOW_TIMEOUT: Duration = Duration::from_millis(12_000);
@@ -50,7 +52,7 @@ struct WinampWindows {
     playlist: u64,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct WinampGeometries {
     main: WindowGeometry,
     equalizer: WindowGeometry,
@@ -517,12 +519,7 @@ fn drag_main_one_pixel_trace_and_assert_continuity(label: &str, windows: WinampW
     std::thread::sleep(Duration::from_millis(120));
     print_drag_trace(label, &trace);
     assert_pixel_drag_trace_continuity(label, initial, &trace);
-    assert_group_stays_stable(
-        label,
-        windows,
-        windows.geometries(),
-        Duration::from_millis(500),
-    );
+    assert_windows_stop_after_release(label, windows, windows.geometries());
 }
 
 fn drag_main_fast_and_assert_offsets(label: &str, windows: WinampWindows) {
@@ -561,7 +558,7 @@ fn drag_main_fast_and_assert_offsets(label: &str, windows: WinampWindows) {
     let final_geometries = windows.geometries();
     assert_offsets_close(label, FAST_MOVE_STEPS + 1, initial, final_geometries);
     assert_window_moved(label, initial.main, final_geometries.main);
-    assert_group_stays_stable(label, windows, final_geometries, Duration::from_millis(800));
+    assert_windows_stop_after_release(label, windows, final_geometries);
 }
 
 fn print_drag_trace(label: &str, trace: &[DragTraceSample]) {
@@ -590,11 +587,7 @@ fn wait_for_one_pixel_drag_step(
     let started = Instant::now();
     loop {
         let sample = DragTraceSample {
-            pointer: PointerLocation {
-                x: previous.pointer.x + 1,
-                y: previous.pointer.y,
-                window: previous.pointer.window,
-            },
+            pointer: pointer_location(),
             geometries: windows.geometries(),
             elapsed: started.elapsed(),
         };
@@ -788,6 +781,7 @@ fn drag_and_assert_offsets(
     }
     let final_dragged = geometry_for_window(windows, dragged_window, final_geometries);
     assert_window_moved(label, initial_dragged, final_dragged);
+    assert_windows_stop_after_release(label, windows, final_geometries);
 }
 
 fn move_main_with_window_manager_and_assert_offsets(
@@ -796,6 +790,11 @@ fn move_main_with_window_manager_and_assert_offsets(
     dx: i32,
     dy: i32,
 ) {
+    if !window_manager_supports_net_active_window() {
+        println!("{label}: skipping external window-manager move; _NET_ACTIVE_WINDOW unsupported");
+        return;
+    }
+
     let initial = assert_attached_offsets(label, windows.geometries());
     move_window(windows.main, initial.main.x + dx, initial.main.y + dy);
 
@@ -807,6 +806,7 @@ fn move_main_with_window_manager_and_assert_offsets(
             && offsets_close(initial, current)
         {
             println!("{label}: {:?}", current);
+            assert_windows_stop_after_release(label, windows, current);
             return;
         }
         std::thread::sleep(Duration::from_millis(8));
@@ -815,6 +815,21 @@ fn move_main_with_window_manager_and_assert_offsets(
     let current = windows.geometries();
     assert_offsets_close(label, 1, initial, current);
     assert_window_moved(label, initial.main, current.main);
+    assert_windows_stop_after_release(label, windows, current);
+}
+
+fn window_manager_supports_net_active_window() -> bool {
+    let Some(output) = Command::new("xprop")
+        .args(["-root", "_NET_SUPPORTED"])
+        .output()
+        .ok()
+    else {
+        return true;
+    };
+    if !output.status.success() {
+        return true;
+    }
+    String::from_utf8_lossy(&output.stdout).contains("_NET_ACTIVE_WINDOW")
 }
 
 fn wait_for_group_offset(
@@ -839,26 +854,24 @@ fn wait_for_group_offset(
     current
 }
 
-fn assert_group_stays_stable(
+fn assert_windows_stop_after_release(
     label: &str,
     windows: WinampWindows,
     expected: WinampGeometries,
-    duration: Duration,
 ) {
-    let deadline = Instant::now() + duration;
+    let deadline = Instant::now() + POST_RELEASE_STABILITY_TIMEOUT;
     let mut sample = 0;
+    let mut samples = Vec::new();
     while Instant::now() < deadline {
         sample += 1;
         let current = windows.geometries();
-        assert_offsets_close(label, FAST_MOVE_STEPS + sample, expected, current);
-        assert_geometry_close(
-            label,
-            FAST_MOVE_STEPS + sample,
-            "main",
-            expected.main,
-            current.main,
-        );
-        std::thread::sleep(Duration::from_millis(40));
+        samples.push(current);
+        if current != expected {
+            panic!(
+                "{label} post-release sample {sample}: native windows kept moving after mouseup expected={expected:?} actual={current:?} samples={samples:?}"
+            );
+        }
+        std::thread::sleep(POST_RELEASE_STABILITY_POLL);
     }
 }
 

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -42,7 +42,7 @@ pub(crate) use shaders::ShaderSection;
 use shaders::ShadersTab;
 use text_showcase::TextShowcaseTab;
 use web_fetch::web_fetch_example;
-use winamp::WinampTab;
+use winamp::{remember_winamp_tab_state, WinampTab, WinampTabState};
 use xkcd::xkcd_tab;
 
 thread_local! {
@@ -368,15 +368,16 @@ fn TabBarHorizontal(active_tab: cranpose_core::MutableState<DemoTab>) {
 fn TabContent(
     active_tab: cranpose_core::MutableState<DemoTab>,
     startup: StartupSelection,
+    winamp_tab_state: WinampTabState,
     modifier: Modifier,
 ) {
     let active = active_tab.get();
     cranpose_ui::Box(modifier.clip_to_bounds(), BoxSpec::default(), move || {
         cranpose_core::with_key(&active, || {
             if tab_requires_scroll(active) {
-                ScrollableTab(move || render_active_tab(active, startup));
+                ScrollableTab(move || render_active_tab(active, startup, winamp_tab_state));
             } else {
-                render_active_tab(active, startup);
+                render_active_tab(active, startup, winamp_tab_state);
             }
         });
     });
@@ -397,8 +398,9 @@ pub fn combined_app_with_initial_tab(initial_tab: Option<DemoTab>) {
 
 #[composable]
 pub(crate) fn combined_app_with_startup(startup: StartupSelection) {
-    let active_tab =
-        cranpose_core::useState(move || startup.initial_tab.unwrap_or(DemoTab::Counter));
+    let initial_tab = startup.initial_tab.unwrap_or(DemoTab::Counter);
+    let active_tab = cranpose_core::useState(move || initial_tab);
+    let winamp_tab_state = remember_winamp_tab_state();
     TEST_ACTIVE_TAB_STATE.with(|cell| {
         *cell.borrow_mut() = Some(active_tab);
     });
@@ -417,6 +419,7 @@ pub(crate) fn combined_app_with_startup(startup: StartupSelection) {
             TabContent(
                 active_tab,
                 startup,
+                winamp_tab_state,
                 Modifier::empty().fill_max_width().weight(1.0),
             );
         },
@@ -437,7 +440,7 @@ fn tab_requires_scroll(tab: DemoTab) -> bool {
 }
 
 #[composable]
-fn render_active_tab(active: DemoTab, startup: StartupSelection) {
+fn render_active_tab(active: DemoTab, startup: StartupSelection, winamp_tab_state: WinampTabState) {
     match active {
         DemoTab::Counter => counter_app(),
         DemoTab::CompositionLocal => composition_local_example(),
@@ -452,7 +455,7 @@ fn render_active_tab(active: DemoTab, startup: StartupSelection) {
         DemoTab::HackerNews => HackerNewsTab(),
         DemoTab::Images => images_tab(),
         DemoTab::Text => TextShowcaseTab(),
-        DemoTab::Winamp => WinampTab(),
+        DemoTab::Winamp => WinampTab(winamp_tab_state),
         DemoTab::Xkcd => xkcd_tab(),
         DemoTab::Shaders => ShadersTab(startup.initial_shader_section),
         DemoTab::ShaderRect => ShaderRectTab(),

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -42,6 +42,7 @@ pub(crate) use shaders::ShaderSection;
 use shaders::ShadersTab;
 use text_showcase::TextShowcaseTab;
 use web_fetch::web_fetch_example;
+pub use winamp::WinampStandaloneApp;
 use winamp::{remember_winamp_tab_state, WinampTab, WinampTabState};
 use xkcd::xkcd_tab;
 

--- a/apps/desktop-demo/src/app/winamp/mod.rs
+++ b/apps/desktop-demo/src/app/winamp/mod.rs
@@ -31,6 +31,25 @@ fn winamp_press_debug_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("WINAMP_PRESS_DEBUG").is_some())
 }
 
+fn winamp_native_trace_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("CRANPOSE_NATIVE_TRACE").is_some())
+}
+
+fn trace_winamp_state(action: &str, state: &WinampState) {
+    if winamp_native_trace_enabled() {
+        println!(
+            "winamp trace: action={action} closed={} playback={:?} eq_visible={} playlist_visible={} volume={:.3} status={:?}",
+            state.closed,
+            state.playback,
+            state.eq_visible,
+            state.playlist_visible,
+            state.volume,
+            state.status
+        );
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PlaybackState {
     Stopped,
@@ -40,6 +59,7 @@ enum PlaybackState {
 
 #[derive(Clone, Debug, PartialEq)]
 struct WinampState {
+    closed: bool,
     playback: PlaybackState,
     shuffle: bool,
     repeat: bool,
@@ -58,6 +78,7 @@ struct WinampState {
 impl Default for WinampState {
     fn default() -> Self {
         Self {
+            closed: false,
             playback: PlaybackState::Stopped,
             shuffle: false,
             repeat: false,
@@ -82,10 +103,19 @@ enum WinampDragTarget {
 }
 
 #[derive(Clone, Copy, PartialEq)]
+enum WinampCloseAction {
+    SetStatus,
+    CloseApp,
+}
+
+#[derive(Clone, Copy, PartialEq)]
 enum WinampWindowSize {
     Fixed(Size),
     State(WindowState),
 }
+
+const MAIN_TITLE_DRAG_HIT_AREA: SpriteRect = (16.0, 0.0, 228.0, 14.0);
+const EQ_TITLE_DRAG_HIT_AREA: SpriteRect = (0.0, 0.0, 264.0, 14.0);
 
 impl WinampWindowSize {
     fn get(self) -> Size {
@@ -268,6 +298,7 @@ fn WinampInlineStage(
                 skin.clone(),
                 state,
                 WinampDragTarget::Inline(windows.main),
+                WinampCloseAction::SetStatus,
                 scale,
             );
 
@@ -313,7 +344,13 @@ fn WinampNativeWindows(
             {
                 let skin = skin.clone();
                 move || {
-                    MainWindow(skin.clone(), state, WinampDragTarget::NativeGroup, scale);
+                    MainWindow(
+                        skin.clone(),
+                        state,
+                        WinampDragTarget::NativeGroup,
+                        WinampCloseAction::SetStatus,
+                        scale,
+                    );
                 }
             },
         );
@@ -378,6 +415,9 @@ pub fn WinampStandaloneApp() {
         playlist: rememberWindowState(PLAYLIST_WIDTH, PLAYLIST_HEIGHT),
     };
     let snapshot = state.get();
+    if snapshot.closed {
+        return;
+    }
     let skin = match remember_winamp_skin() {
         Ok(skin) => skin,
         Err(error) => {
@@ -401,6 +441,7 @@ pub fn WinampStandaloneApp() {
                         skin.clone(),
                         state,
                         WinampDragTarget::NativeGroup,
+                        WinampCloseAction::CloseApp,
                         ui_scale(),
                     );
                 }
@@ -467,6 +508,7 @@ fn MainWindow(
     skin: WinampSkin,
     state: MutableState<WinampState>,
     drag_target: WinampDragTarget,
+    close_action: WinampCloseAction,
     scale: f32,
 ) {
     let snapshot = state.get();
@@ -484,7 +526,7 @@ fn MainWindow(
                 scale,
             );
 
-            WindowDragHandle(drag_target, TITLE_DRAG_AREA, scale);
+            WindowDragHandle(drag_target, MAIN_TITLE_DRAG_HIT_AREA, scale);
 
             {
                 let state_click = state;
@@ -538,7 +580,17 @@ fn MainWindow(
                     POS_CLOSE_BUTTON.1,
                     scale,
                     move || {
-                        state_click.update(|s| s.status = "Close".to_string());
+                        state_click.update(|s| match close_action {
+                            WinampCloseAction::SetStatus => {
+                                s.status = "Close".to_string();
+                                trace_winamp_state("main-close-status", s);
+                            }
+                            WinampCloseAction::CloseApp => {
+                                s.closed = true;
+                                s.status = "Closed".to_string();
+                                trace_winamp_state("main-close-app", s);
+                            }
+                        });
                     },
                 );
             }
@@ -644,7 +696,10 @@ fn MainWindow(
                     VOLUME_BG_HEIGHT,
                     scale,
                     move |fraction| {
-                        state_drag.update(|s| s.volume = fraction);
+                        state_drag.update(|s| {
+                            s.volume = fraction;
+                            trace_winamp_state("volume", s);
+                        });
                     },
                 );
             }
@@ -776,6 +831,7 @@ fn MainWindow(
                             } else {
                                 "Equalizer Hidden".to_string()
                             };
+                            trace_winamp_state("main-eq-toggle", s);
                         });
                     },
                 );
@@ -808,6 +864,7 @@ fn MainWindow(
                             } else {
                                 "Playlist Hidden".to_string()
                             };
+                            trace_winamp_state("main-playlist-toggle", s);
                         });
                     },
                 );
@@ -846,7 +903,7 @@ fn EqualizerWindow(
                 scale,
             );
 
-            WindowDragHandle(drag_target, EQ_DRAG_AREA, scale);
+            WindowDragHandle(drag_target, EQ_TITLE_DRAG_HIT_AREA, scale);
 
             {
                 let state_click = state;
@@ -861,6 +918,7 @@ fn EqualizerWindow(
                         state_click.update(|s| {
                             s.eq_visible = false;
                             s.status = "Equalizer Hidden".to_string();
+                            trace_winamp_state("eq-close", s);
                         });
                     },
                 );
@@ -1519,6 +1577,7 @@ fn TransportButtons(cbuttons: ImageBitmap, state: MutableState<WinampState>, sca
                 state_click.update(|s| {
                     s.playback = PlaybackState::Playing;
                     s.status = "Play".to_string();
+                    trace_winamp_state("play", s);
                 });
             },
         );
@@ -1537,6 +1596,7 @@ fn TransportButtons(cbuttons: ImageBitmap, state: MutableState<WinampState>, sca
                 state_click.update(|s| {
                     s.playback = PlaybackState::Paused;
                     s.status = "Pause".to_string();
+                    trace_winamp_state("pause", s);
                 });
             },
         );
@@ -1555,6 +1615,7 @@ fn TransportButtons(cbuttons: ImageBitmap, state: MutableState<WinampState>, sca
                 state_click.update(|s| {
                     s.playback = PlaybackState::Stopped;
                     s.status = "Stop".to_string();
+                    trace_winamp_state("stop", s);
                 });
             },
         );

--- a/apps/desktop-demo/src/app/winamp/mod.rs
+++ b/apps/desktop-demo/src/app/winamp/mod.rs
@@ -11,11 +11,15 @@ mod sprites;
 use std::rc::Rc;
 use std::sync::OnceLock;
 
+use cranpose::{
+    rememberWindowState, Window, WindowConfig, WindowModifierExt, WindowResizeDirection,
+    WindowState,
+};
 use cranpose_core::{self, MutableState};
 use cranpose_foundation::PointerButton;
 use cranpose_ui::{
-    composable, current_density, Box, BoxSpec, Canvas, Color, Column, ColumnSpec, Modifier, Point,
-    PointerEventKind, PointerInputScope, Text, TextStyle,
+    composable, current_density, Box, BoxSpec, Button, Canvas, Color, Column, ColumnSpec, Modifier,
+    Point, PointerEventKind, PointerInputScope, Size, Text, TextStyle,
 };
 use cranpose_ui_graphics::{ImageBitmap, Rect};
 
@@ -71,40 +75,98 @@ impl Default for WinampState {
     }
 }
 
-#[composable]
-pub(crate) fn WinampTab() {
-    let skin_result = cranpose_core::remember(|| {
-        let wsz = include_bytes!("../../../assets/winamp.wsz");
-        load_skin(wsz).map_err(|err| format!("{err:#}"))
-    })
-    .with(|result| result.clone());
+#[derive(Clone, Copy, PartialEq)]
+enum WinampDragTarget {
+    Inline(MutableState<Point>),
+    NativeGroup {
+        windows: WinampNativeWindowStates,
+        dragged: WinampWindowId,
+    },
+}
 
-    let skin = match skin_result {
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum WinampWindowId {
+    Main,
+    Equalizer,
+    Playlist,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum WinampWindowSize {
+    Fixed(Size),
+    State(WindowState),
+}
+
+impl WinampWindowSize {
+    fn get(self) -> Size {
+        match self {
+            Self::Fixed(size) => size,
+            Self::State(state) => state.size(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) struct WinampTabState {
+    player: MutableState<WinampState>,
+    detached: MutableState<bool>,
+    inline_windows: WinampInlineWindowStates,
+    native_windows: WinampNativeWindowStates,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct WinampInlineWindowStates {
+    main: MutableState<Point>,
+    equalizer: MutableState<Point>,
+    playlist: MutableState<Point>,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct WinampNativeWindowStates {
+    main: WindowState,
+    equalizer: WindowState,
+    playlist: WindowState,
+}
+
+#[derive(Clone, Copy)]
+struct WinampWindowPlacement {
+    title: &'static str,
+    host_position: Point,
+    state: WindowState,
+}
+
+#[composable]
+pub(crate) fn remember_winamp_tab_state() -> WinampTabState {
+    WinampTabState {
+        player: cranpose_core::useState(WinampState::default),
+        detached: cranpose_core::useState(native_winamp_windows_available),
+        inline_windows: WinampInlineWindowStates {
+            main: cranpose_core::useState(|| Point::new(26.0, 22.0)),
+            equalizer: cranpose_core::useState(|| Point::new(26.0, 142.0)),
+            playlist: cranpose_core::useState(|| Point::new(336.0, 22.0)),
+        },
+        native_windows: WinampNativeWindowStates {
+            main: rememberWindowState(MAIN_WIDTH, MAIN_HEIGHT),
+            equalizer: rememberWindowState(EQ_WIDTH, EQ_HEIGHT),
+            playlist: rememberWindowState(PLAYLIST_WIDTH, PLAYLIST_HEIGHT),
+        },
+    }
+}
+
+#[composable]
+pub(crate) fn WinampTab(tab_state: WinampTabState) {
+    let scale = ui_scale();
+    let state = tab_state.player;
+    let native_available = native_winamp_windows_available();
+    let detached = native_available && tab_state.detached.get();
+    let snapshot = state.get();
+    let skin = match remember_winamp_skin() {
         Ok(skin) => skin,
         Err(error) => {
-            Column(
-                Modifier::empty().padding(16.0),
-                ColumnSpec::default(),
-                move || {
-                    Text(
-                        "Failed to load Winamp skin",
-                        Modifier::empty(),
-                        TextStyle::default(),
-                    );
-                    Text(error.clone(), Modifier::empty(), TextStyle::default());
-                },
-            );
+            WinampSkinError(error);
             return;
         }
     };
-
-    let scale = ui_scale();
-    let main_position = cranpose_core::useState(|| Point::new(26.0, 22.0));
-    let eq_position = cranpose_core::useState(|| Point::new(26.0, 142.0));
-    let pl_position = cranpose_core::useState(|| Point::new(336.0, 22.0));
-    let state = cranpose_core::useState(WinampState::default);
-
-    let snapshot = state.get();
 
     Column(
         Modifier::empty()
@@ -126,46 +188,227 @@ pub(crate) fn WinampTab() {
                 TextStyle::default(),
             );
 
-            Box(
-                Modifier::empty()
-                    .fill_max_size()
-                    .clip_to_bounds()
-                    .background(Color(0.02, 0.02, 0.03, 1.0))
-                    .rounded_corners(8.0),
-                BoxSpec::default(),
-                {
-                    let skin = skin.clone();
-                    move || {
-                        MainWindow(skin.clone(), state, main_position, scale);
+            if native_available {
+                DockToggleButton(tab_state.detached, detached);
+            }
 
-                        if state.get().eq_visible {
-                            EqualizerWindow(skin.clone(), state, eq_position, scale);
-                        }
+            if !detached {
+                WinampInlineStage(skin.clone(), state, tab_state.inline_windows, scale);
+            } else {
+                WinampNativeWindows(
+                    skin.clone(),
+                    state,
+                    tab_state.inline_windows,
+                    tab_state.native_windows,
+                    scale,
+                    snapshot.clone(),
+                );
+            }
+        },
+    );
+}
 
-                        if state.get().playlist_visible {
-                            PlaylistWindow(skin.pledit.clone(), state, pl_position, scale);
-                        }
-                    }
-                },
+fn remember_winamp_skin() -> Result<WinampSkin, String> {
+    cranpose_core::remember(|| {
+        let wsz = include_bytes!("../../../assets/winamp.wsz");
+        load_skin(wsz).map_err(|err| format!("{err:#}"))
+    })
+    .with(|result| result.clone())
+}
+
+#[composable]
+fn WinampSkinError(error: String) {
+    Column(
+        Modifier::empty().padding(16.0),
+        ColumnSpec::default(),
+        move || {
+            Text(
+                "Failed to load Winamp skin",
+                Modifier::empty(),
+                TextStyle::default(),
+            );
+            Text(error.clone(), Modifier::empty(), TextStyle::default());
+        },
+    );
+}
+
+#[composable]
+fn DockToggleButton(detached_state: MutableState<bool>, detached: bool) {
+    Button(
+        Modifier::empty()
+            .padding(8.0)
+            .background(Color(0.18, 0.34, 0.58, 1.0))
+            .rounded_corners(8.0)
+            .padding(8.0),
+        move || {
+            detached_state.set(!detached_state.get_non_reactive());
+        },
+        move || {
+            Text(
+                if detached { "Dock" } else { "Undock" },
+                Modifier::empty(),
+                TextStyle::default(),
             );
         },
     );
 }
 
 #[composable]
+fn WinampInlineStage(
+    skin: WinampSkin,
+    state: MutableState<WinampState>,
+    windows: WinampInlineWindowStates,
+    scale: f32,
+) {
+    Box(
+        Modifier::empty()
+            .fill_max_size()
+            .clip_to_bounds()
+            .background(Color(0.02, 0.02, 0.03, 1.0))
+            .rounded_corners(8.0),
+        BoxSpec::default(),
+        move || {
+            MainWindow(
+                skin.clone(),
+                state,
+                WinampDragTarget::Inline(windows.main),
+                scale,
+            );
+
+            if state.get().eq_visible {
+                EqualizerWindow(
+                    skin.clone(),
+                    state,
+                    WinampDragTarget::Inline(windows.equalizer),
+                    scale,
+                );
+            }
+
+            if state.get().playlist_visible {
+                PlaylistWindow(
+                    skin.pledit.clone(),
+                    state,
+                    WinampDragTarget::Inline(windows.playlist),
+                    WinampWindowSize::Fixed(Size::new(PLAYLIST_WIDTH, PLAYLIST_HEIGHT)),
+                    scale,
+                );
+            }
+        },
+    );
+}
+
+#[composable]
+fn WinampNativeWindows(
+    skin: WinampSkin,
+    state: MutableState<WinampState>,
+    inline_windows: WinampInlineWindowStates,
+    native_windows: WinampNativeWindowStates,
+    scale: f32,
+    snapshot: WinampState,
+) {
+    Window(
+        "winamp-main",
+        winamp_window_config(
+            WinampWindowPlacement {
+                title: "Winamp",
+                host_position: inline_windows.main.get(),
+                state: native_windows.main,
+            },
+            native_windows,
+            WinampWindowId::Main,
+        ),
+        {
+            let skin = skin.clone();
+            move || {
+                MainWindow(
+                    skin.clone(),
+                    state,
+                    WinampDragTarget::NativeGroup {
+                        windows: native_windows,
+                        dragged: WinampWindowId::Main,
+                    },
+                    scale,
+                );
+            }
+        },
+    );
+
+    if snapshot.eq_visible {
+        Window(
+            "winamp-equalizer",
+            winamp_window_config(
+                WinampWindowPlacement {
+                    title: "Winamp Equalizer",
+                    host_position: inline_windows.equalizer.get(),
+                    state: native_windows.equalizer,
+                },
+                native_windows,
+                WinampWindowId::Equalizer,
+            ),
+            {
+                let skin = skin.clone();
+                move || {
+                    EqualizerWindow(
+                        skin.clone(),
+                        state,
+                        WinampDragTarget::NativeGroup {
+                            windows: native_windows,
+                            dragged: WinampWindowId::Equalizer,
+                        },
+                        scale,
+                    );
+                }
+            },
+        );
+    }
+
+    if snapshot.playlist_visible {
+        Window(
+            "winamp-playlist",
+            winamp_window_config(
+                WinampWindowPlacement {
+                    title: "Winamp Playlist",
+                    host_position: inline_windows.playlist.get(),
+                    state: native_windows.playlist,
+                },
+                native_windows,
+                WinampWindowId::Playlist,
+            )
+            .with_resizable(true)
+            .with_min_size(
+                scaled(PLAYLIST_WIDTH, scale),
+                scaled(PLAYLIST_HEIGHT, scale),
+            ),
+            {
+                let pledit = skin.pledit.clone();
+                move || {
+                    PlaylistWindow(
+                        pledit.clone(),
+                        state,
+                        WinampDragTarget::NativeGroup {
+                            windows: native_windows,
+                            dragged: WinampWindowId::Playlist,
+                        },
+                        WinampWindowSize::State(native_windows.playlist),
+                        scale,
+                    );
+                }
+            },
+        );
+    }
+}
+
+#[composable]
 fn MainWindow(
     skin: WinampSkin,
     state: MutableState<WinampState>,
-    window_position: MutableState<Point>,
+    drag_target: WinampDragTarget,
     scale: f32,
 ) {
     let snapshot = state.get();
-    let position = window_position.get();
 
     Box(
-        Modifier::empty()
-            .size_points(scaled(MAIN_WIDTH, scale), scaled(MAIN_HEIGHT, scale))
-            .offset(snap_to_pixel(position.x), snap_to_pixel(position.y)),
+        winamp_window_modifier(MAIN_WIDTH, MAIN_HEIGHT, scale, drag_target),
         BoxSpec::default(),
         move || {
             Sprite(skin.main.clone(), MAIN_WINDOW, 0.0, 0.0, scale);
@@ -177,7 +420,7 @@ fn MainWindow(
                 scale,
             );
 
-            WindowDragHandle(window_position, TITLE_DRAG_AREA, scale);
+            WindowDragHandle(drag_target, TITLE_DRAG_AREA, scale);
 
             {
                 let state_click = state;
@@ -513,16 +756,13 @@ fn MainWindow(
 fn EqualizerWindow(
     skin: WinampSkin,
     state: MutableState<WinampState>,
-    window_position: MutableState<Point>,
+    drag_target: WinampDragTarget,
     scale: f32,
 ) {
     let snapshot = state.get();
-    let position = window_position.get();
 
     Box(
-        Modifier::empty()
-            .size_points(scaled(EQ_WIDTH, scale), scaled(EQ_HEIGHT, scale))
-            .offset(snap_to_pixel(position.x), snap_to_pixel(position.y)),
+        winamp_window_modifier(EQ_WIDTH, EQ_HEIGHT, scale, drag_target),
         BoxSpec::default(),
         move || {
             Sprite(skin.eqmain.clone(), EQ_WINDOW, 0.0, 0.0, scale);
@@ -542,7 +782,7 @@ fn EqualizerWindow(
                 scale,
             );
 
-            WindowDragHandle(window_position, EQ_DRAG_AREA, scale);
+            WindowDragHandle(drag_target, EQ_DRAG_AREA, scale);
 
             {
                 let state_click = state;
@@ -688,27 +928,31 @@ fn EqualizerWindow(
 fn PlaylistWindow(
     pledit: ImageBitmap,
     state: MutableState<WinampState>,
-    window_position: MutableState<Point>,
+    drag_target: WinampDragTarget,
+    window_size: WinampWindowSize,
     scale: f32,
 ) {
     let snapshot = state.get();
-    let position = window_position.get();
+    let window_size = window_size.get();
+    let skin_scale = scale.max(f32::EPSILON);
+    let width = (window_size.width / skin_scale).max(PLAYLIST_WIDTH);
+    let height = (window_size.height / skin_scale).max(PLAYLIST_HEIGHT);
+    let right_x = width - PLAYLIST_RIGHT_TILE.2;
+    let bottom_y = height - PLAYLIST_BOTTOM_LEFT_CORNER.3;
+    let list_width = (right_x - PLAYLIST_LIST_BG.0).max(1.0);
+    let list_height = (bottom_y - PLAYLIST_LIST_BG.1).max(1.0);
+    let title_min_x = PLAYLIST_TOP_LEFT_CORNER.2;
+    let title_max_x = (width - PLAYLIST_TOP_RIGHT_CORNER.2 - PLAYLIST_TITLE_BAR.2).max(title_min_x);
+    let title_x = ((width - PLAYLIST_TITLE_BAR.2) * 0.5).clamp(title_min_x, title_max_x);
+    let scroll_track_x = width - 15.0;
 
     Box(
-        Modifier::empty()
-            .size_points(
-                scaled(PLAYLIST_WIDTH, scale),
-                scaled(PLAYLIST_HEIGHT, scale),
-            )
-            .offset(snap_to_pixel(position.x), snap_to_pixel(position.y)),
+        winamp_window_modifier(width, height, scale, drag_target),
         BoxSpec::default(),
         move || {
             Box(
                 Modifier::empty()
-                    .size_points(
-                        scaled(PLAYLIST_LIST_BG.2, scale),
-                        scaled(PLAYLIST_LIST_BG.3, scale),
-                    )
+                    .size_points(scaled(list_width, scale), scaled(list_height, scale))
                     .absolute_offset(
                         scaled(PLAYLIST_LIST_BG.0, scale),
                         scaled(PLAYLIST_LIST_BG.1, scale),
@@ -719,59 +963,69 @@ fn PlaylistWindow(
             );
 
             Sprite(pledit.clone(), PLAYLIST_TOP_LEFT_CORNER, 0.0, 0.0, scale);
-            for x in PLAYLIST_TOP_TILE_XS {
-                Sprite(pledit.clone(), PLAYLIST_TOP_TILE, x, 0.0, scale);
-            }
-            Sprite(
+            StretchSprite(
                 pledit.clone(),
-                PLAYLIST_TITLE_BAR,
-                POS_PLAYLIST_TITLE_BAR.0,
-                POS_PLAYLIST_TITLE_BAR.1,
+                PLAYLIST_TOP_TILE,
+                PLAYLIST_TOP_LEFT_CORNER.2,
+                0.0,
+                width - PLAYLIST_TOP_LEFT_CORNER.2 - PLAYLIST_TOP_RIGHT_CORNER.2,
+                PLAYLIST_TOP_TILE.3,
                 scale,
             );
+            Sprite(pledit.clone(), PLAYLIST_TITLE_BAR, title_x, 0.0, scale);
             Sprite(
                 pledit.clone(),
                 PLAYLIST_TOP_RIGHT_CORNER,
-                POS_PLAYLIST_TOP_RIGHT.0,
-                POS_PLAYLIST_TOP_RIGHT.1,
+                width - PLAYLIST_TOP_RIGHT_CORNER.2,
+                0.0,
                 scale,
             );
 
-            for y in PLAYLIST_SIDE_TILE_YS {
-                Sprite(pledit.clone(), PLAYLIST_LEFT_TILE, 0.0, y, scale);
-                Sprite(
-                    pledit.clone(),
-                    PLAYLIST_RIGHT_TILE,
-                    POS_PLAYLIST_RIGHT_X,
-                    y,
-                    scale,
-                );
-            }
+            StretchSprite(
+                pledit.clone(),
+                PLAYLIST_LEFT_TILE,
+                0.0,
+                PLAYLIST_TOP_LEFT_CORNER.3,
+                PLAYLIST_LEFT_TILE.2,
+                bottom_y - PLAYLIST_TOP_LEFT_CORNER.3,
+                scale,
+            );
+            StretchSprite(
+                pledit.clone(),
+                PLAYLIST_RIGHT_TILE,
+                right_x,
+                PLAYLIST_TOP_RIGHT_CORNER.3,
+                PLAYLIST_RIGHT_TILE.2,
+                bottom_y - PLAYLIST_TOP_RIGHT_CORNER.3,
+                scale,
+            );
 
-            Sprite(
+            StretchSprite(
                 pledit.clone(),
                 PLAYLIST_BOTTOM_LEFT_CORNER,
-                POS_PLAYLIST_BOTTOM_LEFT.0,
-                POS_PLAYLIST_BOTTOM_LEFT.1,
+                0.0,
+                bottom_y,
+                width - PLAYLIST_BOTTOM_RIGHT_CORNER.2,
+                PLAYLIST_BOTTOM_LEFT_CORNER.3,
                 scale,
             );
             Sprite(
                 pledit.clone(),
                 PLAYLIST_BOTTOM_RIGHT_CORNER,
-                POS_PLAYLIST_BOTTOM_RIGHT.0,
-                POS_PLAYLIST_BOTTOM_RIGHT.1,
+                width - PLAYLIST_BOTTOM_RIGHT_CORNER.2,
+                bottom_y,
                 scale,
             );
-            let scroll_y = PLAYLIST_SCROLL_TRACK.1
+            let scroll_y = PLAYLIST_LIST_BG.1
                 + vertical_slider_thumb_y_down(
                     snapshot.playlist_scroll,
-                    PLAYLIST_SCROLL_TRACK.3,
+                    list_height,
                     PLAYLIST_SCROLL_HANDLE.3,
                 );
             Sprite(
                 pledit.clone(),
                 PLAYLIST_SCROLL_HANDLE,
-                PLAYLIST_SCROLL_TRACK.0,
+                scroll_track_x,
                 scroll_y,
                 scale,
             );
@@ -779,10 +1033,10 @@ fn PlaylistWindow(
             {
                 let state_drag = state;
                 VerticalDragSlider(
-                    PLAYLIST_SCROLL_TRACK.0,
-                    PLAYLIST_SCROLL_TRACK.1,
+                    scroll_track_x,
+                    PLAYLIST_LIST_BG.1,
                     PLAYLIST_SCROLL_TRACK.2,
-                    PLAYLIST_SCROLL_TRACK.3,
+                    list_height,
                     scale,
                     false,
                     move |fraction| {
@@ -791,7 +1045,16 @@ fn PlaylistWindow(
                 );
             }
 
-            WindowDragHandle(window_position, PLAYLIST_DRAG_AREA, scale);
+            WindowDragHandle(drag_target, (0.0, 0.0, width, PLAYLIST_DRAG_AREA.3), scale);
+            WindowResizeHandle(
+                drag_target,
+                WindowResizeDirection::SouthEast,
+                width - 16.0,
+                height - 16.0,
+                16.0,
+                16.0,
+                scale,
+            );
         },
     );
 }
@@ -800,6 +1063,34 @@ fn PlaylistWindow(
 fn Sprite(image: ImageBitmap, source: SpriteRect, x: f32, y: f32, scale: f32) {
     let w = scaled(source.2, scale);
     let h = scaled(source.3, scale);
+    Canvas(
+        Modifier::empty()
+            .size_points(w, h)
+            .absolute_offset(scaled(x, scale), scaled(y, scale)),
+        move |scope| {
+            let dst = Rect {
+                x: 0.0,
+                y: 0.0,
+                width: w,
+                height: h,
+            };
+            scope.draw_image_src(image.clone(), to_rect(source), dst, 1.0, None);
+        },
+    );
+}
+
+#[composable]
+fn StretchSprite(
+    image: ImageBitmap,
+    source: SpriteRect,
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    scale: f32,
+) {
+    let w = scaled(width.max(1.0), scale);
+    let h = scaled(height.max(1.0), scale);
     Canvas(
         Modifier::empty()
             .size_points(w, h)
@@ -1046,53 +1337,89 @@ fn VerticalDragSlider(
 }
 
 #[composable]
-fn WindowDragHandle(window_position: MutableState<Point>, area: SpriteRect, scale: f32) {
-    let drag_offset = cranpose_core::useState(|| None::<Point>);
+fn WindowDragHandle(drag_target: WinampDragTarget, area: SpriteRect, scale: f32) {
+    let modifier = Modifier::empty()
+        .size_points(scaled(area.2, scale), scaled(area.3, scale))
+        .absolute_offset(scaled(area.0, scale), scaled(area.1, scale));
+
+    match drag_target {
+        WinampDragTarget::NativeGroup { .. } => {
+            Box(modifier.window_drag_area(), BoxSpec::default(), || {});
+        }
+        WinampDragTarget::Inline(window_position) => {
+            let drag_offset = cranpose_core::useState(|| None::<Point>);
+
+            Box(
+                modifier.pointer_input((), {
+                    move |scope: PointerInputScope| async move {
+                        scope
+                            .await_pointer_event_scope(|await_scope| async move {
+                                loop {
+                                    let event = await_scope.await_pointer_event().await;
+                                    match event.kind {
+                                        PointerEventKind::Down => {
+                                            let current = window_position.get();
+                                            drag_offset.set(Some(Point::new(
+                                                event.global_position.x - current.x,
+                                                event.global_position.y - current.y,
+                                            )));
+                                            event.consume();
+                                        }
+                                        PointerEventKind::Move => {
+                                            if !event.buttons.contains(PointerButton::Primary) {
+                                                drag_offset.set(None);
+                                                continue;
+                                            }
+                                            if let Some(offset) = drag_offset.get() {
+                                                window_position.set(Point::new(
+                                                    snap_to_pixel(
+                                                        event.global_position.x - offset.x,
+                                                    ),
+                                                    snap_to_pixel(
+                                                        event.global_position.y - offset.y,
+                                                    ),
+                                                ));
+                                                event.consume();
+                                            }
+                                        }
+                                        PointerEventKind::Up | PointerEventKind::Cancel => {
+                                            drag_offset.set(None);
+                                        }
+                                        PointerEventKind::Scroll
+                                        | PointerEventKind::Enter
+                                        | PointerEventKind::Exit => {}
+                                    }
+                                }
+                            })
+                            .await;
+                    }
+                }),
+                BoxSpec::default(),
+                || {},
+            );
+        }
+    }
+}
+
+#[composable]
+fn WindowResizeHandle(
+    drag_target: WinampDragTarget,
+    direction: WindowResizeDirection,
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    scale: f32,
+) {
+    if !matches!(drag_target, WinampDragTarget::NativeGroup { .. }) {
+        return;
+    }
 
     Box(
         Modifier::empty()
-            .size_points(scaled(area.2, scale), scaled(area.3, scale))
-            .absolute_offset(scaled(area.0, scale), scaled(area.1, scale))
-            .pointer_input((), {
-                move |scope: PointerInputScope| async move {
-                    scope
-                        .await_pointer_event_scope(|await_scope| async move {
-                            loop {
-                                let event = await_scope.await_pointer_event().await;
-                                match event.kind {
-                                    PointerEventKind::Down => {
-                                        let current = window_position.get();
-                                        drag_offset.set(Some(Point::new(
-                                            event.global_position.x - current.x,
-                                            event.global_position.y - current.y,
-                                        )));
-                                        event.consume();
-                                    }
-                                    PointerEventKind::Move => {
-                                        if !event.buttons.contains(PointerButton::Primary) {
-                                            drag_offset.set(None);
-                                            continue;
-                                        }
-                                        if let Some(offset) = drag_offset.get() {
-                                            window_position.set(Point::new(
-                                                snap_to_pixel(event.global_position.x - offset.x),
-                                                snap_to_pixel(event.global_position.y - offset.y),
-                                            ));
-                                            event.consume();
-                                        }
-                                    }
-                                    PointerEventKind::Up | PointerEventKind::Cancel => {
-                                        drag_offset.set(None);
-                                    }
-                                    PointerEventKind::Scroll
-                                    | PointerEventKind::Enter
-                                    | PointerEventKind::Exit => {}
-                                }
-                            }
-                        })
-                        .await;
-                }
-            }),
+            .size_points(scaled(width, scale), scaled(height, scale))
+            .absolute_offset(scaled(x, scale), scaled(y, scale))
+            .window_resize_area(direction),
         BoxSpec::default(),
         || {},
     );
@@ -1200,6 +1527,374 @@ fn TransportButtons(cbuttons: ImageBitmap, state: MutableState<WinampState>, sca
     }
 }
 
+const WINAMP_NATIVE_HOST_OFFSET_X: f32 = 640.0;
+const WINAMP_NATIVE_HOST_OFFSET_Y: f32 = 118.0;
+const WINAMP_ATTACH_EPSILON: f32 = 3.0;
+const WINAMP_SNAP_DISTANCE: f32 = 8.0;
+
+fn native_winamp_windows_available() -> bool {
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        not(target_os = "android"),
+        not(target_os = "ios")
+    ))]
+    {
+        std::env::var_os("CRANPOSE_WINAMP_INLINE").is_none()
+    }
+
+    #[cfg(any(target_arch = "wasm32", target_os = "android", target_os = "ios"))]
+    {
+        false
+    }
+}
+
+fn base_winamp_window_config(placement: WinampWindowPlacement) -> WindowConfig {
+    let state_size = placement.state.size();
+    WindowConfig::borderless(placement.title, state_size.width, state_size.height)
+        .with_host_window_position(
+            snap_to_pixel(placement.host_position.x + WINAMP_NATIVE_HOST_OFFSET_X),
+            snap_to_pixel(placement.host_position.y + WINAMP_NATIVE_HOST_OFFSET_Y),
+        )
+        .with_transparent(false)
+        .with_resizable(false)
+        .with_visible(true)
+}
+
+fn winamp_window_config(
+    placement: WinampWindowPlacement,
+    native_windows: WinampNativeWindowStates,
+    window_id: WinampWindowId,
+) -> WindowConfig {
+    let state = placement.state;
+    base_winamp_window_config(placement)
+        .on_moved(move |x, y| {
+            move_attached_winamp_window(native_windows, window_id, Point::new(x, y));
+        })
+        .with_state(state)
+}
+
+fn move_attached_winamp_window(
+    native_windows: WinampNativeWindowStates,
+    moved: WinampWindowId,
+    new_position: Point,
+) {
+    let moved_state = native_windows.state(moved);
+    let Some(old_position) = moved_state.position_non_reactive() else {
+        moved_state.set_position(Some(new_position));
+        return;
+    };
+    if moved != WinampWindowId::Main {
+        moved_state.set_position(Some(Point::new(
+            snap_to_pixel(new_position.x),
+            snap_to_pixel(new_position.y),
+        )));
+        return;
+    }
+
+    let delta = Point::new(
+        new_position.x - old_position.x,
+        new_position.y - old_position.y,
+    );
+    move_winamp_component_by_delta(native_windows, WinampWindowId::Main, delta);
+}
+
+fn move_winamp_component_by_delta(
+    native_windows: WinampNativeWindowStates,
+    dragged: WinampWindowId,
+    delta: Point,
+) {
+    if delta.x.abs() <= f32::EPSILON && delta.y.abs() <= f32::EPSILON {
+        return;
+    }
+
+    let snapshots = winamp_window_snapshots(native_windows);
+    let moved = move_winamp_snapshots(&snapshots, dragged, delta);
+    apply_winamp_window_snapshots(native_windows, moved);
+}
+
+fn apply_winamp_window_snapshots(
+    native_windows: WinampNativeWindowStates,
+    snapshots: Vec<WinampWindowSnapshot>,
+) {
+    for snapshot in snapshots {
+        native_windows
+            .state(snapshot.id)
+            .set_position(Some(Point::new(
+                snap_to_pixel(snapshot.position.x),
+                snap_to_pixel(snapshot.position.y),
+            )));
+    }
+}
+
+impl WinampNativeWindowStates {
+    fn state(self, id: WinampWindowId) -> WindowState {
+        match id {
+            WinampWindowId::Main => self.main,
+            WinampWindowId::Equalizer => self.equalizer,
+            WinampWindowId::Playlist => self.playlist,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct WinampWindowSnapshot {
+    id: WinampWindowId,
+    position: Point,
+    size: Size,
+}
+
+fn winamp_window_snapshots(native_windows: WinampNativeWindowStates) -> Vec<WinampWindowSnapshot> {
+    [
+        WinampWindowId::Main,
+        WinampWindowId::Equalizer,
+        WinampWindowId::Playlist,
+    ]
+    .into_iter()
+    .filter_map(|id| {
+        let state = native_windows.state(id);
+        Some(WinampWindowSnapshot {
+            id,
+            position: state.position_non_reactive()?,
+            size: state.size_non_reactive(),
+        })
+    })
+    .collect()
+}
+
+fn attached_winamp_component(
+    snapshots: &[WinampWindowSnapshot],
+    dragged: WinampWindowId,
+) -> Vec<WinampWindowId> {
+    let mut component = vec![dragged];
+    let mut changed = true;
+
+    while changed {
+        changed = false;
+        for candidate in snapshots {
+            if component.contains(&candidate.id) {
+                continue;
+            }
+
+            let attached_to_component = snapshots
+                .iter()
+                .filter(|snapshot| component.contains(&snapshot.id))
+                .any(|snapshot| {
+                    rects_attached(
+                        candidate.position,
+                        candidate.size,
+                        snapshot.position,
+                        snapshot.size,
+                    )
+                });
+            if attached_to_component {
+                component.push(candidate.id);
+                changed = true;
+            }
+        }
+    }
+
+    component
+}
+
+fn move_winamp_snapshots(
+    snapshots: &[WinampWindowSnapshot],
+    dragged: WinampWindowId,
+    delta: Point,
+) -> Vec<WinampWindowSnapshot> {
+    let mut component = attached_winamp_component(snapshots, dragged);
+    move_winamp_snapshots_for_component(snapshots, &mut component, delta, true)
+}
+
+fn move_winamp_snapshots_for_component(
+    snapshots: &[WinampWindowSnapshot],
+    component: &mut Vec<WinampWindowId>,
+    delta: Point,
+    expand_component: bool,
+) -> Vec<WinampWindowSnapshot> {
+    let mut moved = snapshots.to_vec();
+    translate_winamp_snapshots(&mut moved, component, delta);
+
+    if expand_component {
+        while let Some(snap) = closest_winamp_snap(&moved, component) {
+            translate_winamp_snapshots(&mut moved, component, snap.delta);
+            for id in attached_winamp_component(&moved, snap.target) {
+                if !component.contains(&id) {
+                    component.push(id);
+                }
+            }
+        }
+    } else if let Some(snap) = closest_winamp_snap(&moved, component) {
+        translate_winamp_snapshots(&mut moved, component, snap.delta);
+    }
+
+    moved
+}
+
+fn translate_winamp_snapshots(
+    snapshots: &mut [WinampWindowSnapshot],
+    component: &[WinampWindowId],
+    delta: Point,
+) {
+    if delta.x.abs() <= f32::EPSILON && delta.y.abs() <= f32::EPSILON {
+        return;
+    }
+
+    for snapshot in snapshots {
+        if component.contains(&snapshot.id) {
+            snapshot.position.x += delta.x;
+            snapshot.position.y += delta.y;
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct WinampSnap {
+    target: WinampWindowId,
+    delta: Point,
+    distance: f32,
+    contact: f32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct WinampSnapCandidate {
+    delta: Point,
+    contact: f32,
+}
+
+fn closest_winamp_snap(
+    snapshots: &[WinampWindowSnapshot],
+    component: &[WinampWindowId],
+) -> Option<WinampSnap> {
+    let mut closest = None::<WinampSnap>;
+
+    for moving in snapshots
+        .iter()
+        .filter(|snapshot| component.contains(&snapshot.id))
+    {
+        for stationary in snapshots
+            .iter()
+            .filter(|snapshot| !component.contains(&snapshot.id))
+        {
+            for candidate in winamp_snap_candidates(*moving, *stationary) {
+                let snap = WinampSnap {
+                    target: stationary.id,
+                    delta: candidate.delta,
+                    distance: candidate.delta.x.abs() + candidate.delta.y.abs(),
+                    contact: candidate.contact,
+                };
+                if closest.is_none_or(|current| {
+                    snap.contact > current.contact
+                        || snap.contact == current.contact && snap.distance < current.distance
+                }) {
+                    closest = Some(snap);
+                }
+            }
+        }
+    }
+
+    closest
+}
+
+fn winamp_snap_candidates(
+    moving: WinampWindowSnapshot,
+    stationary: WinampWindowSnapshot,
+) -> Vec<WinampSnapCandidate> {
+    let moving_left = moving.position.x;
+    let moving_top = moving.position.y;
+    let moving_right = moving.position.x + moving.size.width;
+    let moving_bottom = moving.position.y + moving.size.height;
+    let stationary_left = stationary.position.x;
+    let stationary_top = stationary.position.y;
+    let stationary_right = stationary.position.x + stationary.size.width;
+    let stationary_bottom = stationary.position.y + stationary.size.height;
+
+    let mut candidates = Vec::new();
+    if ranges_overlap_strict(moving_top, moving_bottom, stationary_top, stationary_bottom) {
+        let contact =
+            range_overlap_length(moving_top, moving_bottom, stationary_top, stationary_bottom);
+        if near_snap(moving_right, stationary_left) {
+            candidates.push(WinampSnapCandidate {
+                delta: Point::new(stationary_left - moving_right, 0.0),
+                contact,
+            });
+        }
+        if near_snap(moving_left, stationary_right) {
+            candidates.push(WinampSnapCandidate {
+                delta: Point::new(stationary_right - moving_left, 0.0),
+                contact,
+            });
+        }
+    }
+    if ranges_overlap_strict(moving_left, moving_right, stationary_left, stationary_right) {
+        let contact =
+            range_overlap_length(moving_left, moving_right, stationary_left, stationary_right);
+        if near_snap(moving_bottom, stationary_top) {
+            candidates.push(WinampSnapCandidate {
+                delta: Point::new(0.0, stationary_top - moving_bottom),
+                contact,
+            });
+        }
+        if near_snap(moving_top, stationary_bottom) {
+            candidates.push(WinampSnapCandidate {
+                delta: Point::new(0.0, stationary_bottom - moving_top),
+                contact,
+            });
+        }
+    }
+
+    candidates
+}
+
+fn rects_attached(child: Point, child_size: Size, main: Point, main_size: Size) -> bool {
+    let child_right = child.x + child_size.width;
+    let child_bottom = child.y + child_size.height;
+    let main_right = main.x + main_size.width;
+    let main_bottom = main.y + main_size.height;
+
+    let touches_horizontal = near(child.x, main_right) || near(child_right, main.x);
+    let overlaps_vertical = ranges_overlap(child.y, child_bottom, main.y, main_bottom);
+    let touches_vertical = near(child.y, main_bottom) || near(child_bottom, main.y);
+    let overlaps_horizontal = ranges_overlap(child.x, child_right, main.x, main_right);
+
+    touches_horizontal && overlaps_vertical || touches_vertical && overlaps_horizontal
+}
+
+fn near(a: f32, b: f32) -> bool {
+    (a - b).abs() <= WINAMP_ATTACH_EPSILON
+}
+
+fn near_snap(a: f32, b: f32) -> bool {
+    (a - b).abs() <= WINAMP_SNAP_DISTANCE
+}
+
+fn ranges_overlap(a_start: f32, a_end: f32, b_start: f32, b_end: f32) -> bool {
+    a_start <= b_end + WINAMP_ATTACH_EPSILON && b_start <= a_end + WINAMP_ATTACH_EPSILON
+}
+
+fn ranges_overlap_strict(a_start: f32, a_end: f32, b_start: f32, b_end: f32) -> bool {
+    a_start < b_end && b_start < a_end
+}
+
+fn range_overlap_length(a_start: f32, a_end: f32, b_start: f32, b_end: f32) -> f32 {
+    (a_end.min(b_end) - a_start.max(b_start)).max(0.0)
+}
+
+fn winamp_window_modifier(
+    width: f32,
+    height: f32,
+    scale: f32,
+    drag_target: WinampDragTarget,
+) -> Modifier {
+    let modifier = Modifier::empty().size_points(scaled(width, scale), scaled(height, scale));
+    match drag_target {
+        WinampDragTarget::Inline(position) => {
+            let position = position.get();
+            modifier.offset(snap_to_pixel(position.x), snap_to_pixel(position.y))
+        }
+        WinampDragTarget::NativeGroup { .. } => modifier,
+    }
+}
+
 fn ui_scale() -> f32 {
     // Skin pixel coordinates map directly to dp.  On high-density screens the
     // renderer upscales automatically, keeping the skin at the same visual
@@ -1280,5 +1975,400 @@ mod tests {
         assert_eq!(vertical_slider_thumb_y(2.0, 63.0, 11.0), 0.0);
         assert_eq!(vertical_slider_thumb_y_down(-1.0, 145.0, 18.0), 0.0);
         assert_eq!(vertical_slider_thumb_y_down(2.0, 145.0, 18.0), 127.0);
+    }
+
+    #[test]
+    fn winamp_windows_attach_by_touching_edges() {
+        let main = Point::new(100.0, 200.0);
+        let main_size = Size::new(275.0, 116.0);
+        let child_size = Size::new(275.0, 116.0);
+
+        assert!(rects_attached(
+            Point::new(375.0, 200.0),
+            child_size,
+            main,
+            main_size
+        ));
+        assert!(rects_attached(
+            Point::new(101.0, 316.0),
+            child_size,
+            main,
+            main_size
+        ));
+        assert!(!rects_attached(
+            Point::new(420.0, 200.0),
+            child_size,
+            main,
+            main_size
+        ));
+    }
+
+    #[test]
+    fn winamp_windows_do_not_attach_through_visible_snap_gap() {
+        let main = Point::new(100.0, 200.0);
+        let main_size = Size::new(275.0, 116.0);
+        let child_size = Size::new(275.0, 116.0);
+
+        assert!(!rects_attached(
+            Point::new(379.0, 204.0),
+            child_size,
+            main,
+            main_size
+        ));
+        assert_eq!(
+            snap_candidate_deltas(
+                WinampWindowSnapshot {
+                    id: WinampWindowId::Equalizer,
+                    position: Point::new(379.0, 204.0),
+                    size: child_size,
+                },
+                WinampWindowSnapshot {
+                    id: WinampWindowId::Main,
+                    position: main,
+                    size: main_size,
+                },
+            ),
+            vec![Point::new(-4.0, 0.0)]
+        );
+        assert!(!rects_attached(
+            Point::new(390.0, 204.0),
+            child_size,
+            main,
+            main_size
+        ));
+    }
+
+    #[test]
+    fn winamp_attached_component_follows_pairwise_connections() {
+        let snapshots = attached_chain_snapshots();
+
+        assert_eq!(
+            sorted_component(&snapshots, WinampWindowId::Main),
+            vec![
+                WinampWindowId::Main,
+                WinampWindowId::Equalizer,
+                WinampWindowId::Playlist
+            ]
+        );
+        assert_eq!(
+            sorted_component(&snapshots, WinampWindowId::Equalizer),
+            vec![
+                WinampWindowId::Main,
+                WinampWindowId::Equalizer,
+                WinampWindowId::Playlist
+            ]
+        );
+        assert_eq!(
+            sorted_component(&snapshots, WinampWindowId::Playlist),
+            vec![
+                WinampWindowId::Main,
+                WinampWindowId::Equalizer,
+                WinampWindowId::Playlist
+            ]
+        );
+    }
+
+    #[test]
+    fn winamp_attached_component_handles_each_pair_topology() {
+        let main_equalizer = [
+            WinampWindowSnapshot {
+                id: WinampWindowId::Main,
+                position: Point::new(100.0, 100.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Equalizer,
+                position: Point::new(100.0, 216.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Playlist,
+                position: Point::new(700.0, 216.0),
+                size: Size::new(275.0, 116.0),
+            },
+        ];
+        assert_eq!(
+            sorted_component(&main_equalizer, WinampWindowId::Main),
+            vec![WinampWindowId::Main, WinampWindowId::Equalizer]
+        );
+        assert_eq!(
+            sorted_component(&main_equalizer, WinampWindowId::Playlist),
+            vec![WinampWindowId::Playlist]
+        );
+
+        let equalizer_playlist = [
+            WinampWindowSnapshot {
+                id: WinampWindowId::Main,
+                position: Point::new(100.0, 100.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Equalizer,
+                position: Point::new(500.0, 216.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Playlist,
+                position: Point::new(775.0, 216.0),
+                size: Size::new(275.0, 116.0),
+            },
+        ];
+        assert_eq!(
+            sorted_component(&equalizer_playlist, WinampWindowId::Equalizer),
+            vec![WinampWindowId::Equalizer, WinampWindowId::Playlist]
+        );
+        assert_eq!(
+            sorted_component(&equalizer_playlist, WinampWindowId::Main),
+            vec![WinampWindowId::Main]
+        );
+
+        let main_playlist = [
+            WinampWindowSnapshot {
+                id: WinampWindowId::Main,
+                position: Point::new(100.0, 100.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Equalizer,
+                position: Point::new(900.0, 216.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Playlist,
+                position: Point::new(375.0, 100.0),
+                size: Size::new(275.0, 116.0),
+            },
+        ];
+        assert_eq!(
+            sorted_component(&main_playlist, WinampWindowId::Playlist),
+            vec![WinampWindowId::Main, WinampWindowId::Playlist]
+        );
+        assert_eq!(
+            sorted_component(&main_playlist, WinampWindowId::Equalizer),
+            vec![WinampWindowId::Equalizer]
+        );
+    }
+
+    #[test]
+    fn winamp_attached_component_leaves_all_separated_windows_out() {
+        let snapshots = [
+            WinampWindowSnapshot {
+                id: WinampWindowId::Main,
+                position: Point::new(100.0, 100.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Equalizer,
+                position: Point::new(500.0, 100.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Playlist,
+                position: Point::new(900.0, 100.0),
+                size: Size::new(275.0, 116.0),
+            },
+        ];
+
+        assert_eq!(
+            sorted_component(&snapshots, WinampWindowId::Main),
+            vec![WinampWindowId::Main]
+        );
+        assert_eq!(
+            sorted_component(&snapshots, WinampWindowId::Equalizer),
+            vec![WinampWindowId::Equalizer]
+        );
+        assert_eq!(
+            sorted_component(&snapshots, WinampWindowId::Playlist),
+            vec![WinampWindowId::Playlist]
+        );
+    }
+
+    #[test]
+    fn winamp_move_snaps_separate_playlist_into_main_equalizer_component() {
+        let snapshots = [
+            WinampWindowSnapshot {
+                id: WinampWindowId::Main,
+                position: Point::new(100.0, 100.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Equalizer,
+                position: Point::new(100.0, 216.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Playlist,
+                position: Point::new(390.0, 216.0),
+                size: Size::new(275.0, 116.0),
+            },
+        ];
+
+        assert_eq!(
+            snap_candidate_deltas(
+                WinampWindowSnapshot {
+                    id: WinampWindowId::Equalizer,
+                    position: Point::new(110.0, 216.0),
+                    size: Size::new(275.0, 116.0),
+                },
+                snapshots[2],
+            ),
+            vec![Point::new(5.0, 0.0)]
+        );
+
+        let moved = move_winamp_snapshots(&snapshots, WinampWindowId::Main, Point::new(10.0, 0.0));
+
+        assert_eq!(
+            snapshot_position(&moved, WinampWindowId::Equalizer),
+            Point::new(115.0, 216.0)
+        );
+        assert_eq!(
+            snapshot_position(&moved, WinampWindowId::Playlist),
+            Point::new(390.0, 216.0)
+        );
+        assert_eq!(
+            sorted_component(&moved, WinampWindowId::Main),
+            vec![
+                WinampWindowId::Main,
+                WinampWindowId::Equalizer,
+                WinampWindowId::Playlist
+            ]
+        );
+    }
+
+    #[test]
+    fn winamp_child_drag_snaps_without_moving_attached_neighbors() {
+        let snapshots = [
+            WinampWindowSnapshot {
+                id: WinampWindowId::Main,
+                position: Point::new(100.0, 100.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Equalizer,
+                position: Point::new(100.0, 216.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Playlist,
+                position: Point::new(386.0, 216.0),
+                size: Size::new(275.0, 116.0),
+            },
+        ];
+
+        let mut component = vec![WinampWindowId::Playlist];
+        let snapped = move_winamp_snapshots_for_component(
+            &snapshots,
+            &mut component,
+            Point::new(-8.0, 0.0),
+            false,
+        );
+        assert_eq!(
+            snapshot_position(&snapped, WinampWindowId::Playlist),
+            Point::new(375.0, 216.0)
+        );
+        assert_eq!(
+            snapshot_position(&snapped, WinampWindowId::Main),
+            Point::new(100.0, 100.0)
+        );
+        assert_eq!(
+            snapshot_position(&snapped, WinampWindowId::Equalizer),
+            Point::new(100.0, 216.0)
+        );
+
+        let moved_again = move_winamp_snapshots_for_component(
+            &snapped,
+            &mut component,
+            Point::new(12.0, 7.0),
+            false,
+        );
+        assert_eq!(
+            snapshot_position(&moved_again, WinampWindowId::Main),
+            Point::new(100.0, 100.0)
+        );
+        assert_eq!(
+            snapshot_position(&moved_again, WinampWindowId::Equalizer),
+            Point::new(100.0, 216.0)
+        );
+        assert_eq!(
+            snapshot_position(&moved_again, WinampWindowId::Playlist),
+            Point::new(387.0, 223.0)
+        );
+    }
+
+    #[test]
+    fn winamp_main_drag_session_keeps_initial_component_for_large_delta() {
+        let snapshots = attached_chain_snapshots();
+        let mut component = attached_winamp_component(&snapshots, WinampWindowId::Main);
+
+        let moved = move_winamp_snapshots_for_component(
+            &snapshots,
+            &mut component,
+            Point::new(220.0, 90.0),
+            true,
+        );
+
+        assert_eq!(
+            snapshot_position(&moved, WinampWindowId::Equalizer),
+            Point::new(320.0, 306.0)
+        );
+        assert_eq!(
+            snapshot_position(&moved, WinampWindowId::Playlist),
+            Point::new(595.0, 306.0)
+        );
+        assert_eq!(
+            sorted_component(&moved, WinampWindowId::Main),
+            vec![
+                WinampWindowId::Main,
+                WinampWindowId::Equalizer,
+                WinampWindowId::Playlist
+            ]
+        );
+    }
+
+    fn attached_chain_snapshots() -> [WinampWindowSnapshot; 3] {
+        [
+            WinampWindowSnapshot {
+                id: WinampWindowId::Main,
+                position: Point::new(100.0, 100.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Equalizer,
+                position: Point::new(100.0, 216.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Playlist,
+                position: Point::new(375.0, 216.0),
+                size: Size::new(275.0, 116.0),
+            },
+        ]
+    }
+
+    fn sorted_component(
+        snapshots: &[WinampWindowSnapshot],
+        dragged: WinampWindowId,
+    ) -> Vec<WinampWindowId> {
+        let mut component = attached_winamp_component(snapshots, dragged);
+        component.sort_by_key(|id| *id as u8);
+        component
+    }
+
+    fn snapshot_position(snapshots: &[WinampWindowSnapshot], id: WinampWindowId) -> Point {
+        snapshots
+            .iter()
+            .find(|snapshot| snapshot.id == id)
+            .expect("snapshot")
+            .position
+    }
+
+    fn snap_candidate_deltas(
+        moving: WinampWindowSnapshot,
+        stationary: WinampWindowSnapshot,
+    ) -> Vec<Point> {
+        winamp_snap_candidates(moving, stationary)
+            .into_iter()
+            .map(|candidate| candidate.delta)
+            .collect()
     }
 }

--- a/apps/desktop-demo/src/app/winamp/mod.rs
+++ b/apps/desktop-demo/src/app/winamp/mod.rs
@@ -12,8 +12,8 @@ use std::rc::Rc;
 use std::sync::OnceLock;
 
 use cranpose::{
-    rememberWindowState, Window, WindowConfig, WindowModifierExt, WindowResizeDirection,
-    WindowState,
+    rememberWindowState, WindowAttachPolicy, WindowConfig, WindowGroup, WindowId,
+    WindowModifierExt, WindowMoveMode, WindowNode, WindowResizeDirection, WindowState,
 };
 use cranpose_core::{self, MutableState};
 use cranpose_foundation::PointerButton;
@@ -78,17 +78,7 @@ impl Default for WinampState {
 #[derive(Clone, Copy, PartialEq)]
 enum WinampDragTarget {
     Inline(MutableState<Point>),
-    NativeGroup {
-        windows: WinampNativeWindowStates,
-        dragged: WinampWindowId,
-    },
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-enum WinampWindowId {
-    Main,
-    Equalizer,
-    Playlist,
+    NativeGroup,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -111,7 +101,7 @@ pub(crate) struct WinampTabState {
     player: MutableState<WinampState>,
     detached: MutableState<bool>,
     inline_windows: WinampInlineWindowStates,
-    native_windows: WinampNativeWindowStates,
+    peer_windows: WinampPeerWindowStates,
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -122,58 +112,23 @@ struct WinampInlineWindowStates {
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
-struct WinampNativeWindowStates {
+struct WinampPeerWindowStates {
     main: WindowState,
     equalizer: WindowState,
     playlist: WindowState,
-    drag_session: MutableState<Option<WinampNativeDragSession>>,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct WinampNativeDragSession {
-    dragged: WinampWindowId,
-    component: WinampWindowComponent,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct WinampWindowComponent(u8);
-
-impl WinampWindowComponent {
-    fn from_ids(ids: &[WinampWindowId]) -> Self {
-        Self(ids.iter().fold(0, |mask, id| mask | id.component_bit()))
-    }
-
-    fn ids(self) -> Vec<WinampWindowId> {
-        [
-            WinampWindowId::Main,
-            WinampWindowId::Equalizer,
-            WinampWindowId::Playlist,
-        ]
-        .into_iter()
-        .filter(|id| self.contains(*id))
-        .collect()
-    }
-
-    fn contains(self, id: WinampWindowId) -> bool {
-        self.0 & id.component_bit() != 0
-    }
-}
-
-impl WinampWindowId {
-    fn component_bit(self) -> u8 {
-        match self {
-            WinampWindowId::Main => 1 << 0,
-            WinampWindowId::Equalizer => 1 << 1,
-            WinampWindowId::Playlist => 1 << 2,
-        }
-    }
 }
 
 #[derive(Clone, Copy)]
 struct WinampWindowPlacement {
     title: &'static str,
-    host_position: Point,
+    initial_position: WinampInitialWindowPosition,
     state: WindowState,
+}
+
+#[derive(Clone, Copy)]
+enum WinampInitialWindowPosition {
+    Host(Point),
+    Screen(Point),
 }
 
 #[composable]
@@ -186,11 +141,10 @@ pub(crate) fn remember_winamp_tab_state() -> WinampTabState {
             equalizer: cranpose_core::useState(|| Point::new(26.0, 142.0)),
             playlist: cranpose_core::useState(|| Point::new(336.0, 22.0)),
         },
-        native_windows: WinampNativeWindowStates {
+        peer_windows: WinampPeerWindowStates {
             main: rememberWindowState(MAIN_WIDTH, MAIN_HEIGHT),
             equalizer: rememberWindowState(EQ_WIDTH, EQ_HEIGHT),
             playlist: rememberWindowState(PLAYLIST_WIDTH, PLAYLIST_HEIGHT),
-            drag_session: cranpose_core::useState(|| None::<WinampNativeDragSession>),
         },
     }
 }
@@ -241,7 +195,7 @@ pub(crate) fn WinampTab(tab_state: WinampTabState) {
                     skin.clone(),
                     state,
                     tab_state.inline_windows,
-                    tab_state.native_windows,
+                    tab_state.peer_windows,
                     scale,
                     snapshot.clone(),
                 );
@@ -344,100 +298,168 @@ fn WinampNativeWindows(
     skin: WinampSkin,
     state: MutableState<WinampState>,
     inline_windows: WinampInlineWindowStates,
-    native_windows: WinampNativeWindowStates,
+    peer_windows: WinampPeerWindowStates,
     scale: f32,
     snapshot: WinampState,
 ) {
-    Window(
-        "winamp-main",
-        winamp_window_config(
-            WinampWindowPlacement {
+    WindowGroup("winamp", winamp_attach_policy(), move || {
+        WindowNode(
+            winamp_main_window_id(),
+            winamp_window_config(WinampWindowPlacement {
                 title: "Winamp",
-                host_position: inline_windows.main.get(),
-                state: native_windows.main,
-            },
-            native_windows,
-            WinampWindowId::Main,
-        ),
-        {
-            let skin = skin.clone();
-            move || {
-                MainWindow(
-                    skin.clone(),
-                    state,
-                    WinampDragTarget::NativeGroup {
-                        windows: native_windows,
-                        dragged: WinampWindowId::Main,
-                    },
-                    scale,
-                );
-            }
-        },
-    );
-
-    if snapshot.eq_visible {
-        Window(
-            "winamp-equalizer",
-            winamp_window_config(
-                WinampWindowPlacement {
-                    title: "Winamp Equalizer",
-                    host_position: inline_windows.equalizer.get(),
-                    state: native_windows.equalizer,
-                },
-                native_windows,
-                WinampWindowId::Equalizer,
-            ),
+                initial_position: WinampInitialWindowPosition::Host(inline_windows.main.get()),
+                state: peer_windows.main,
+            }),
             {
                 let skin = skin.clone();
                 move || {
-                    EqualizerWindow(
+                    MainWindow(skin.clone(), state, WinampDragTarget::NativeGroup, scale);
+                }
+            },
+        );
+
+        if snapshot.eq_visible {
+            WindowNode(
+                winamp_equalizer_window_id(),
+                winamp_window_config(WinampWindowPlacement {
+                    title: "Winamp Equalizer",
+                    initial_position: WinampInitialWindowPosition::Host(
+                        inline_windows.equalizer.get(),
+                    ),
+                    state: peer_windows.equalizer,
+                }),
+                {
+                    let skin = skin.clone();
+                    move || {
+                        EqualizerWindow(skin.clone(), state, WinampDragTarget::NativeGroup, scale);
+                    }
+                },
+            );
+        }
+
+        if snapshot.playlist_visible {
+            WindowNode(
+                winamp_playlist_window_id(),
+                winamp_window_config(WinampWindowPlacement {
+                    title: "Winamp Playlist",
+                    initial_position: WinampInitialWindowPosition::Host(
+                        inline_windows.playlist.get(),
+                    ),
+                    state: peer_windows.playlist,
+                })
+                .with_resizable(true)
+                .with_min_size(
+                    scaled(PLAYLIST_WIDTH, scale),
+                    scaled(PLAYLIST_HEIGHT, scale),
+                ),
+                {
+                    let pledit = skin.pledit.clone();
+                    move || {
+                        PlaylistWindow(
+                            pledit.clone(),
+                            state,
+                            WinampDragTarget::NativeGroup,
+                            WinampWindowSize::State(peer_windows.playlist),
+                            scale,
+                        );
+                    }
+                },
+            );
+        }
+    });
+}
+
+#[composable]
+pub fn WinampStandaloneApp() {
+    let state = cranpose_core::useState(WinampState::default);
+    let peer_windows = WinampPeerWindowStates {
+        main: rememberWindowState(MAIN_WIDTH, MAIN_HEIGHT),
+        equalizer: rememberWindowState(EQ_WIDTH, EQ_HEIGHT),
+        playlist: rememberWindowState(PLAYLIST_WIDTH, PLAYLIST_HEIGHT),
+    };
+    let snapshot = state.get();
+    let skin = match remember_winamp_skin() {
+        Ok(skin) => skin,
+        Err(error) => {
+            WinampSkinError(error);
+            return;
+        }
+    };
+
+    WindowGroup("winamp", winamp_attach_policy(), move || {
+        WindowNode(
+            winamp_main_window_id(),
+            winamp_window_config(WinampWindowPlacement {
+                title: "Winamp",
+                initial_position: WinampInitialWindowPosition::Screen(Point::new(140.0, 120.0)),
+                state: peer_windows.main,
+            }),
+            {
+                let skin = skin.clone();
+                move || {
+                    MainWindow(
                         skin.clone(),
                         state,
-                        WinampDragTarget::NativeGroup {
-                            windows: native_windows,
-                            dragged: WinampWindowId::Equalizer,
-                        },
-                        scale,
+                        WinampDragTarget::NativeGroup,
+                        ui_scale(),
                     );
                 }
             },
         );
-    }
 
-    if snapshot.playlist_visible {
-        Window(
-            "winamp-playlist",
-            winamp_window_config(
-                WinampWindowPlacement {
-                    title: "Winamp Playlist",
-                    host_position: inline_windows.playlist.get(),
-                    state: native_windows.playlist,
+        if snapshot.eq_visible {
+            WindowNode(
+                winamp_equalizer_window_id(),
+                winamp_window_config(WinampWindowPlacement {
+                    title: "Winamp Equalizer",
+                    initial_position: WinampInitialWindowPosition::Screen(Point::new(
+                        140.0,
+                        120.0 + MAIN_HEIGHT,
+                    )),
+                    state: peer_windows.equalizer,
+                }),
+                {
+                    let skin = skin.clone();
+                    move || {
+                        EqualizerWindow(
+                            skin.clone(),
+                            state,
+                            WinampDragTarget::NativeGroup,
+                            ui_scale(),
+                        );
+                    }
                 },
-                native_windows,
-                WinampWindowId::Playlist,
-            )
-            .with_resizable(true)
-            .with_min_size(
-                scaled(PLAYLIST_WIDTH, scale),
-                scaled(PLAYLIST_HEIGHT, scale),
-            ),
-            {
-                let pledit = skin.pledit.clone();
-                move || {
-                    PlaylistWindow(
-                        pledit.clone(),
-                        state,
-                        WinampDragTarget::NativeGroup {
-                            windows: native_windows,
-                            dragged: WinampWindowId::Playlist,
-                        },
-                        WinampWindowSize::State(native_windows.playlist),
-                        scale,
-                    );
-                }
-            },
-        );
-    }
+            );
+        }
+
+        if snapshot.playlist_visible {
+            WindowNode(
+                winamp_playlist_window_id(),
+                winamp_window_config(WinampWindowPlacement {
+                    title: "Winamp Playlist",
+                    initial_position: WinampInitialWindowPosition::Screen(Point::new(
+                        140.0 + EQ_WIDTH,
+                        120.0 + MAIN_HEIGHT,
+                    )),
+                    state: peer_windows.playlist,
+                })
+                .with_resizable(true)
+                .with_min_size(PLAYLIST_WIDTH, PLAYLIST_HEIGHT),
+                {
+                    let pledit = skin.pledit.clone();
+                    move || {
+                        PlaylistWindow(
+                            pledit.clone(),
+                            state,
+                            WinampDragTarget::NativeGroup,
+                            WinampWindowSize::State(peer_windows.playlist),
+                            ui_scale(),
+                        );
+                    }
+                },
+            );
+        }
+    });
 }
 
 #[composable]
@@ -1385,15 +1407,8 @@ fn WindowDragHandle(drag_target: WinampDragTarget, area: SpriteRect, scale: f32)
         .absolute_offset(scaled(area.0, scale), scaled(area.1, scale));
 
     match drag_target {
-        WinampDragTarget::NativeGroup { windows, dragged } => {
-            Box(
-                modifier.window_drag_area_with_callbacks(
-                    move || start_winamp_native_drag_session(windows, dragged),
-                    move || finish_winamp_native_drag_session(windows),
-                ),
-                BoxSpec::default(),
-                || {},
-            );
+        WinampDragTarget::NativeGroup => {
+            Box(modifier.window_drag_area(), BoxSpec::default(), || {});
         }
         WinampDragTarget::Inline(window_position) => {
             let drag_offset = cranpose_core::useState(|| None::<Point>);
@@ -1460,7 +1475,7 @@ fn WindowResizeHandle(
     height: f32,
     scale: f32,
 ) {
-    if !matches!(drag_target, WinampDragTarget::NativeGroup { .. }) {
+    if !matches!(drag_target, WinampDragTarget::NativeGroup) {
         return;
     }
 
@@ -1599,375 +1614,45 @@ fn native_winamp_windows_available() -> bool {
 
 fn base_winamp_window_config(placement: WinampWindowPlacement) -> WindowConfig {
     let state_size = placement.state.size();
-    WindowConfig::borderless(placement.title, state_size.width, state_size.height)
-        .with_host_window_position(
-            snap_to_pixel(placement.host_position.x + WINAMP_NATIVE_HOST_OFFSET_X),
-            snap_to_pixel(placement.host_position.y + WINAMP_NATIVE_HOST_OFFSET_Y),
-        )
+    let config = WindowConfig::borderless(placement.title, state_size.width, state_size.height);
+    let config = match placement.initial_position {
+        WinampInitialWindowPosition::Host(position) => config.with_host_window_position(
+            snap_to_pixel(position.x + WINAMP_NATIVE_HOST_OFFSET_X),
+            snap_to_pixel(position.y + WINAMP_NATIVE_HOST_OFFSET_Y),
+        ),
+        WinampInitialWindowPosition::Screen(position) => {
+            config.with_position(snap_to_pixel(position.x), snap_to_pixel(position.y))
+        }
+    };
+    config
         .with_transparent(false)
         .with_resizable(false)
         .with_visible(true)
 }
 
-fn winamp_window_config(
-    placement: WinampWindowPlacement,
-    native_windows: WinampNativeWindowStates,
-    window_id: WinampWindowId,
-) -> WindowConfig {
+fn winamp_window_config(placement: WinampWindowPlacement) -> WindowConfig {
     let state = placement.state;
-    base_winamp_window_config(placement)
-        .on_moved(move |x, y| {
-            move_attached_winamp_window(native_windows, window_id, Point::new(x, y));
-        })
-        .with_state(state)
+    base_winamp_window_config(placement).with_state(state)
 }
 
-fn move_attached_winamp_window(
-    native_windows: WinampNativeWindowStates,
-    moved: WinampWindowId,
-    new_position: Point,
-) {
-    let moved_state = native_windows.state(moved);
-    let Some(old_position) = moved_state.position_non_reactive() else {
-        moved_state.set_position(Some(new_position));
-        return;
-    };
-    if moved != WinampWindowId::Main {
-        moved_state.set_position(Some(Point::new(
-            snap_to_pixel(new_position.x),
-            snap_to_pixel(new_position.y),
-        )));
-        return;
-    }
-
-    let delta = Point::new(
-        new_position.x - old_position.x,
-        new_position.y - old_position.y,
-    );
-    move_winamp_component_by_delta(native_windows, WinampWindowId::Main, delta);
+fn winamp_attach_policy() -> WindowAttachPolicy {
+    WindowAttachPolicy::new(
+        WINAMP_SNAP_DISTANCE,
+        WINAMP_ATTACH_EPSILON,
+        WindowMoveMode::DragLeaderOnly(vec![winamp_main_window_id()]),
+    )
 }
 
-fn move_winamp_component_by_delta(
-    native_windows: WinampNativeWindowStates,
-    dragged: WinampWindowId,
-    delta: Point,
-) {
-    if delta.x.abs() <= f32::EPSILON && delta.y.abs() <= f32::EPSILON {
-        return;
-    }
-
-    let snapshots = winamp_window_snapshots(native_windows);
-    let moved = if let Some(session) = native_windows
-        .drag_session
-        .get_non_reactive()
-        .filter(|session| session.dragged == dragged)
-    {
-        let component = session.component.ids();
-        move_winamp_snapshots_for_fixed_component(&snapshots, &component, delta)
-    } else {
-        move_winamp_snapshots(&snapshots, dragged, delta)
-    };
-    apply_winamp_window_snapshots(native_windows, moved);
+fn winamp_main_window_id() -> WindowId {
+    WindowId::from_static("winamp-main")
 }
 
-fn start_winamp_native_drag_session(
-    native_windows: WinampNativeWindowStates,
-    dragged: WinampWindowId,
-) {
-    let snapshots = winamp_window_snapshots(native_windows);
-    if snapshots.iter().all(|snapshot| snapshot.id != dragged) {
-        native_windows.drag_session.set(None);
-        return;
-    }
-
-    let component = attached_winamp_component(&snapshots, dragged);
-    native_windows
-        .drag_session
-        .set(Some(WinampNativeDragSession {
-            dragged,
-            component: WinampWindowComponent::from_ids(&component),
-        }));
+fn winamp_equalizer_window_id() -> WindowId {
+    WindowId::from_static("winamp-equalizer")
 }
 
-fn finish_winamp_native_drag_session(native_windows: WinampNativeWindowStates) {
-    native_windows.drag_session.set(None);
-}
-
-fn apply_winamp_window_snapshots(
-    native_windows: WinampNativeWindowStates,
-    snapshots: Vec<WinampWindowSnapshot>,
-) {
-    for snapshot in snapshots {
-        native_windows
-            .state(snapshot.id)
-            .set_position(Some(Point::new(
-                snap_to_pixel(snapshot.position.x),
-                snap_to_pixel(snapshot.position.y),
-            )));
-    }
-}
-
-impl WinampNativeWindowStates {
-    fn state(self, id: WinampWindowId) -> WindowState {
-        match id {
-            WinampWindowId::Main => self.main,
-            WinampWindowId::Equalizer => self.equalizer,
-            WinampWindowId::Playlist => self.playlist,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-struct WinampWindowSnapshot {
-    id: WinampWindowId,
-    position: Point,
-    size: Size,
-}
-
-fn winamp_window_snapshots(native_windows: WinampNativeWindowStates) -> Vec<WinampWindowSnapshot> {
-    [
-        WinampWindowId::Main,
-        WinampWindowId::Equalizer,
-        WinampWindowId::Playlist,
-    ]
-    .into_iter()
-    .filter_map(|id| {
-        let state = native_windows.state(id);
-        Some(WinampWindowSnapshot {
-            id,
-            position: state.position_non_reactive()?,
-            size: state.size_non_reactive(),
-        })
-    })
-    .collect()
-}
-
-fn attached_winamp_component(
-    snapshots: &[WinampWindowSnapshot],
-    dragged: WinampWindowId,
-) -> Vec<WinampWindowId> {
-    let mut component = vec![dragged];
-    let mut changed = true;
-
-    while changed {
-        changed = false;
-        for candidate in snapshots {
-            if component.contains(&candidate.id) {
-                continue;
-            }
-
-            let attached_to_component = snapshots
-                .iter()
-                .filter(|snapshot| component.contains(&snapshot.id))
-                .any(|snapshot| {
-                    rects_attached(
-                        candidate.position,
-                        candidate.size,
-                        snapshot.position,
-                        snapshot.size,
-                    )
-                });
-            if attached_to_component {
-                component.push(candidate.id);
-                changed = true;
-            }
-        }
-    }
-
-    component
-}
-
-fn move_winamp_snapshots(
-    snapshots: &[WinampWindowSnapshot],
-    dragged: WinampWindowId,
-    delta: Point,
-) -> Vec<WinampWindowSnapshot> {
-    let mut component = attached_winamp_component(snapshots, dragged);
-    move_winamp_snapshots_for_component(snapshots, &mut component, delta, true)
-}
-
-fn move_winamp_snapshots_for_fixed_component(
-    snapshots: &[WinampWindowSnapshot],
-    component: &[WinampWindowId],
-    delta: Point,
-) -> Vec<WinampWindowSnapshot> {
-    let mut moved = snapshots.to_vec();
-    translate_winamp_snapshots(&mut moved, component, delta);
-    moved
-}
-
-fn move_winamp_snapshots_for_component(
-    snapshots: &[WinampWindowSnapshot],
-    component: &mut Vec<WinampWindowId>,
-    delta: Point,
-    expand_component: bool,
-) -> Vec<WinampWindowSnapshot> {
-    let mut moved = snapshots.to_vec();
-    translate_winamp_snapshots(&mut moved, component, delta);
-
-    if expand_component {
-        while let Some(snap) = closest_winamp_snap(&moved, component) {
-            translate_winamp_snapshots(&mut moved, component, snap.delta);
-            for id in attached_winamp_component(&moved, snap.target) {
-                if !component.contains(&id) {
-                    component.push(id);
-                }
-            }
-        }
-    } else if let Some(snap) = closest_winamp_snap(&moved, component) {
-        translate_winamp_snapshots(&mut moved, component, snap.delta);
-    }
-
-    moved
-}
-
-fn translate_winamp_snapshots(
-    snapshots: &mut [WinampWindowSnapshot],
-    component: &[WinampWindowId],
-    delta: Point,
-) {
-    if delta.x.abs() <= f32::EPSILON && delta.y.abs() <= f32::EPSILON {
-        return;
-    }
-
-    for snapshot in snapshots {
-        if component.contains(&snapshot.id) {
-            snapshot.position.x += delta.x;
-            snapshot.position.y += delta.y;
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-struct WinampSnap {
-    target: WinampWindowId,
-    delta: Point,
-    distance: f32,
-    contact: f32,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-struct WinampSnapCandidate {
-    delta: Point,
-    contact: f32,
-}
-
-fn closest_winamp_snap(
-    snapshots: &[WinampWindowSnapshot],
-    component: &[WinampWindowId],
-) -> Option<WinampSnap> {
-    let mut closest = None::<WinampSnap>;
-
-    for moving in snapshots
-        .iter()
-        .filter(|snapshot| component.contains(&snapshot.id))
-    {
-        for stationary in snapshots
-            .iter()
-            .filter(|snapshot| !component.contains(&snapshot.id))
-        {
-            for candidate in winamp_snap_candidates(*moving, *stationary) {
-                let snap = WinampSnap {
-                    target: stationary.id,
-                    delta: candidate.delta,
-                    distance: candidate.delta.x.abs() + candidate.delta.y.abs(),
-                    contact: candidate.contact,
-                };
-                if closest.is_none_or(|current| {
-                    snap.contact > current.contact
-                        || snap.contact == current.contact && snap.distance < current.distance
-                }) {
-                    closest = Some(snap);
-                }
-            }
-        }
-    }
-
-    closest
-}
-
-fn winamp_snap_candidates(
-    moving: WinampWindowSnapshot,
-    stationary: WinampWindowSnapshot,
-) -> Vec<WinampSnapCandidate> {
-    let moving_left = moving.position.x;
-    let moving_top = moving.position.y;
-    let moving_right = moving.position.x + moving.size.width;
-    let moving_bottom = moving.position.y + moving.size.height;
-    let stationary_left = stationary.position.x;
-    let stationary_top = stationary.position.y;
-    let stationary_right = stationary.position.x + stationary.size.width;
-    let stationary_bottom = stationary.position.y + stationary.size.height;
-
-    let mut candidates = Vec::new();
-    if ranges_overlap_strict(moving_top, moving_bottom, stationary_top, stationary_bottom) {
-        let contact =
-            range_overlap_length(moving_top, moving_bottom, stationary_top, stationary_bottom);
-        if near_snap(moving_right, stationary_left) {
-            candidates.push(WinampSnapCandidate {
-                delta: Point::new(stationary_left - moving_right, 0.0),
-                contact,
-            });
-        }
-        if near_snap(moving_left, stationary_right) {
-            candidates.push(WinampSnapCandidate {
-                delta: Point::new(stationary_right - moving_left, 0.0),
-                contact,
-            });
-        }
-    }
-    if ranges_overlap_strict(moving_left, moving_right, stationary_left, stationary_right) {
-        let contact =
-            range_overlap_length(moving_left, moving_right, stationary_left, stationary_right);
-        if near_snap(moving_bottom, stationary_top) {
-            candidates.push(WinampSnapCandidate {
-                delta: Point::new(0.0, stationary_top - moving_bottom),
-                contact,
-            });
-        }
-        if near_snap(moving_top, stationary_bottom) {
-            candidates.push(WinampSnapCandidate {
-                delta: Point::new(0.0, stationary_bottom - moving_top),
-                contact,
-            });
-        }
-    }
-
-    candidates
-}
-
-fn rects_attached(child: Point, child_size: Size, main: Point, main_size: Size) -> bool {
-    let child_right = child.x + child_size.width;
-    let child_bottom = child.y + child_size.height;
-    let main_right = main.x + main_size.width;
-    let main_bottom = main.y + main_size.height;
-
-    let touches_horizontal = near(child.x, main_right) || near(child_right, main.x);
-    let overlaps_vertical = ranges_overlap(child.y, child_bottom, main.y, main_bottom);
-    let touches_vertical = near(child.y, main_bottom) || near(child_bottom, main.y);
-    let overlaps_horizontal = ranges_overlap(child.x, child_right, main.x, main_right);
-
-    touches_horizontal && overlaps_vertical || touches_vertical && overlaps_horizontal
-}
-
-fn near(a: f32, b: f32) -> bool {
-    (a - b).abs() <= WINAMP_ATTACH_EPSILON
-}
-
-fn near_snap(a: f32, b: f32) -> bool {
-    (a - b).abs() <= WINAMP_SNAP_DISTANCE
-}
-
-fn ranges_overlap(a_start: f32, a_end: f32, b_start: f32, b_end: f32) -> bool {
-    a_start <= b_end + WINAMP_ATTACH_EPSILON && b_start <= a_end + WINAMP_ATTACH_EPSILON
-}
-
-fn ranges_overlap_strict(a_start: f32, a_end: f32, b_start: f32, b_end: f32) -> bool {
-    a_start < b_end && b_start < a_end
-}
-
-fn range_overlap_length(a_start: f32, a_end: f32, b_start: f32, b_end: f32) -> f32 {
-    (a_end.min(b_end) - a_start.max(b_start)).max(0.0)
+fn winamp_playlist_window_id() -> WindowId {
+    WindowId::from_static("winamp-playlist")
 }
 
 fn winamp_window_modifier(
@@ -1982,7 +1667,7 @@ fn winamp_window_modifier(
             let position = position.get();
             modifier.offset(snap_to_pixel(position.x), snap_to_pixel(position.y))
         }
-        WinampDragTarget::NativeGroup { .. } => modifier,
+        WinampDragTarget::NativeGroup => modifier,
     }
 }
 
@@ -2066,470 +1751,5 @@ mod tests {
         assert_eq!(vertical_slider_thumb_y(2.0, 63.0, 11.0), 0.0);
         assert_eq!(vertical_slider_thumb_y_down(-1.0, 145.0, 18.0), 0.0);
         assert_eq!(vertical_slider_thumb_y_down(2.0, 145.0, 18.0), 127.0);
-    }
-
-    #[test]
-    fn winamp_windows_attach_by_touching_edges() {
-        let main = Point::new(100.0, 200.0);
-        let main_size = Size::new(275.0, 116.0);
-        let child_size = Size::new(275.0, 116.0);
-
-        assert!(rects_attached(
-            Point::new(375.0, 200.0),
-            child_size,
-            main,
-            main_size
-        ));
-        assert!(rects_attached(
-            Point::new(101.0, 316.0),
-            child_size,
-            main,
-            main_size
-        ));
-        assert!(!rects_attached(
-            Point::new(420.0, 200.0),
-            child_size,
-            main,
-            main_size
-        ));
-    }
-
-    #[test]
-    fn winamp_windows_do_not_attach_through_visible_snap_gap() {
-        let main = Point::new(100.0, 200.0);
-        let main_size = Size::new(275.0, 116.0);
-        let child_size = Size::new(275.0, 116.0);
-
-        assert!(!rects_attached(
-            Point::new(379.0, 204.0),
-            child_size,
-            main,
-            main_size
-        ));
-        assert_eq!(
-            snap_candidate_deltas(
-                WinampWindowSnapshot {
-                    id: WinampWindowId::Equalizer,
-                    position: Point::new(379.0, 204.0),
-                    size: child_size,
-                },
-                WinampWindowSnapshot {
-                    id: WinampWindowId::Main,
-                    position: main,
-                    size: main_size,
-                },
-            ),
-            vec![Point::new(-4.0, 0.0)]
-        );
-        assert!(!rects_attached(
-            Point::new(390.0, 204.0),
-            child_size,
-            main,
-            main_size
-        ));
-    }
-
-    #[test]
-    fn winamp_attached_component_follows_pairwise_connections() {
-        let snapshots = attached_chain_snapshots();
-
-        assert_eq!(
-            sorted_component(&snapshots, WinampWindowId::Main),
-            vec![
-                WinampWindowId::Main,
-                WinampWindowId::Equalizer,
-                WinampWindowId::Playlist
-            ]
-        );
-        assert_eq!(
-            sorted_component(&snapshots, WinampWindowId::Equalizer),
-            vec![
-                WinampWindowId::Main,
-                WinampWindowId::Equalizer,
-                WinampWindowId::Playlist
-            ]
-        );
-        assert_eq!(
-            sorted_component(&snapshots, WinampWindowId::Playlist),
-            vec![
-                WinampWindowId::Main,
-                WinampWindowId::Equalizer,
-                WinampWindowId::Playlist
-            ]
-        );
-    }
-
-    #[test]
-    fn winamp_attached_component_handles_each_pair_topology() {
-        let main_equalizer = [
-            WinampWindowSnapshot {
-                id: WinampWindowId::Main,
-                position: Point::new(100.0, 100.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Equalizer,
-                position: Point::new(100.0, 216.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Playlist,
-                position: Point::new(700.0, 216.0),
-                size: Size::new(275.0, 116.0),
-            },
-        ];
-        assert_eq!(
-            sorted_component(&main_equalizer, WinampWindowId::Main),
-            vec![WinampWindowId::Main, WinampWindowId::Equalizer]
-        );
-        assert_eq!(
-            sorted_component(&main_equalizer, WinampWindowId::Playlist),
-            vec![WinampWindowId::Playlist]
-        );
-
-        let equalizer_playlist = [
-            WinampWindowSnapshot {
-                id: WinampWindowId::Main,
-                position: Point::new(100.0, 100.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Equalizer,
-                position: Point::new(500.0, 216.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Playlist,
-                position: Point::new(775.0, 216.0),
-                size: Size::new(275.0, 116.0),
-            },
-        ];
-        assert_eq!(
-            sorted_component(&equalizer_playlist, WinampWindowId::Equalizer),
-            vec![WinampWindowId::Equalizer, WinampWindowId::Playlist]
-        );
-        assert_eq!(
-            sorted_component(&equalizer_playlist, WinampWindowId::Main),
-            vec![WinampWindowId::Main]
-        );
-
-        let main_playlist = [
-            WinampWindowSnapshot {
-                id: WinampWindowId::Main,
-                position: Point::new(100.0, 100.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Equalizer,
-                position: Point::new(900.0, 216.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Playlist,
-                position: Point::new(375.0, 100.0),
-                size: Size::new(275.0, 116.0),
-            },
-        ];
-        assert_eq!(
-            sorted_component(&main_playlist, WinampWindowId::Playlist),
-            vec![WinampWindowId::Main, WinampWindowId::Playlist]
-        );
-        assert_eq!(
-            sorted_component(&main_playlist, WinampWindowId::Equalizer),
-            vec![WinampWindowId::Equalizer]
-        );
-    }
-
-    #[test]
-    fn winamp_attached_component_leaves_all_separated_windows_out() {
-        let snapshots = [
-            WinampWindowSnapshot {
-                id: WinampWindowId::Main,
-                position: Point::new(100.0, 100.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Equalizer,
-                position: Point::new(500.0, 100.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Playlist,
-                position: Point::new(900.0, 100.0),
-                size: Size::new(275.0, 116.0),
-            },
-        ];
-
-        assert_eq!(
-            sorted_component(&snapshots, WinampWindowId::Main),
-            vec![WinampWindowId::Main]
-        );
-        assert_eq!(
-            sorted_component(&snapshots, WinampWindowId::Equalizer),
-            vec![WinampWindowId::Equalizer]
-        );
-        assert_eq!(
-            sorted_component(&snapshots, WinampWindowId::Playlist),
-            vec![WinampWindowId::Playlist]
-        );
-    }
-
-    #[test]
-    fn winamp_move_snaps_separate_playlist_into_main_equalizer_component() {
-        let snapshots = [
-            WinampWindowSnapshot {
-                id: WinampWindowId::Main,
-                position: Point::new(100.0, 100.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Equalizer,
-                position: Point::new(100.0, 216.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Playlist,
-                position: Point::new(390.0, 216.0),
-                size: Size::new(275.0, 116.0),
-            },
-        ];
-
-        assert_eq!(
-            snap_candidate_deltas(
-                WinampWindowSnapshot {
-                    id: WinampWindowId::Equalizer,
-                    position: Point::new(110.0, 216.0),
-                    size: Size::new(275.0, 116.0),
-                },
-                snapshots[2],
-            ),
-            vec![Point::new(5.0, 0.0)]
-        );
-
-        let moved = move_winamp_snapshots(&snapshots, WinampWindowId::Main, Point::new(10.0, 0.0));
-
-        assert_eq!(
-            snapshot_position(&moved, WinampWindowId::Equalizer),
-            Point::new(115.0, 216.0)
-        );
-        assert_eq!(
-            snapshot_position(&moved, WinampWindowId::Playlist),
-            Point::new(390.0, 216.0)
-        );
-        assert_eq!(
-            sorted_component(&moved, WinampWindowId::Main),
-            vec![
-                WinampWindowId::Main,
-                WinampWindowId::Equalizer,
-                WinampWindowId::Playlist
-            ]
-        );
-    }
-
-    #[test]
-    fn winamp_child_drag_snaps_without_moving_attached_neighbors() {
-        let snapshots = [
-            WinampWindowSnapshot {
-                id: WinampWindowId::Main,
-                position: Point::new(100.0, 100.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Equalizer,
-                position: Point::new(100.0, 216.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Playlist,
-                position: Point::new(386.0, 216.0),
-                size: Size::new(275.0, 116.0),
-            },
-        ];
-
-        let mut component = vec![WinampWindowId::Playlist];
-        let snapped = move_winamp_snapshots_for_component(
-            &snapshots,
-            &mut component,
-            Point::new(-8.0, 0.0),
-            false,
-        );
-        assert_eq!(
-            snapshot_position(&snapped, WinampWindowId::Playlist),
-            Point::new(375.0, 216.0)
-        );
-        assert_eq!(
-            snapshot_position(&snapped, WinampWindowId::Main),
-            Point::new(100.0, 100.0)
-        );
-        assert_eq!(
-            snapshot_position(&snapped, WinampWindowId::Equalizer),
-            Point::new(100.0, 216.0)
-        );
-
-        let moved_again = move_winamp_snapshots_for_component(
-            &snapped,
-            &mut component,
-            Point::new(12.0, 7.0),
-            false,
-        );
-        assert_eq!(
-            snapshot_position(&moved_again, WinampWindowId::Main),
-            Point::new(100.0, 100.0)
-        );
-        assert_eq!(
-            snapshot_position(&moved_again, WinampWindowId::Equalizer),
-            Point::new(100.0, 216.0)
-        );
-        assert_eq!(
-            snapshot_position(&moved_again, WinampWindowId::Playlist),
-            Point::new(387.0, 223.0)
-        );
-    }
-
-    #[test]
-    fn winamp_frozen_drag_component_keeps_initial_windows_for_large_delta() {
-        let snapshots = attached_chain_snapshots();
-        let component = attached_winamp_component(&snapshots, WinampWindowId::Main);
-
-        let moved = move_winamp_snapshots_for_fixed_component(
-            &snapshots,
-            &component,
-            Point::new(220.0, 90.0),
-        );
-
-        assert_eq!(
-            snapshot_position(&moved, WinampWindowId::Main),
-            Point::new(320.0, 190.0)
-        );
-        assert_eq!(
-            snapshot_position(&moved, WinampWindowId::Equalizer),
-            Point::new(320.0, 306.0)
-        );
-        assert_eq!(
-            snapshot_position(&moved, WinampWindowId::Playlist),
-            Point::new(595.0, 306.0)
-        );
-        assert_eq!(
-            sorted_component(&moved, WinampWindowId::Main),
-            vec![
-                WinampWindowId::Main,
-                WinampWindowId::Equalizer,
-                WinampWindowId::Playlist
-            ]
-        );
-    }
-
-    #[test]
-    fn winamp_frozen_drag_component_does_not_attach_new_window() {
-        let snapshots = [
-            WinampWindowSnapshot {
-                id: WinampWindowId::Main,
-                position: Point::new(100.0, 100.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Equalizer,
-                position: Point::new(100.0, 216.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Playlist,
-                position: Point::new(386.0, 216.0),
-                size: Size::new(275.0, 116.0),
-            },
-        ];
-        let component = vec![WinampWindowId::Main, WinampWindowId::Equalizer];
-
-        let moved =
-            move_winamp_snapshots_for_fixed_component(&snapshots, &component, Point::new(8.0, 0.0));
-
-        assert_eq!(
-            snapshot_position(&moved, WinampWindowId::Main),
-            Point::new(108.0, 100.0)
-        );
-        assert_eq!(
-            snapshot_position(&moved, WinampWindowId::Equalizer),
-            Point::new(108.0, 216.0)
-        );
-        assert_eq!(
-            snapshot_position(&moved, WinampWindowId::Playlist),
-            Point::new(386.0, 216.0)
-        );
-
-        let moved_again =
-            move_winamp_snapshots_for_fixed_component(&moved, &component, Point::new(12.0, 4.0));
-        assert_eq!(
-            snapshot_position(&moved_again, WinampWindowId::Main),
-            Point::new(120.0, 104.0)
-        );
-        assert_eq!(
-            snapshot_position(&moved_again, WinampWindowId::Equalizer),
-            Point::new(120.0, 220.0)
-        );
-        assert_eq!(
-            snapshot_position(&moved_again, WinampWindowId::Playlist),
-            Point::new(386.0, 216.0)
-        );
-    }
-
-    #[test]
-    fn winamp_drag_session_component_roundtrips_ids() {
-        let component =
-            WinampWindowComponent::from_ids(&[WinampWindowId::Playlist, WinampWindowId::Main]);
-
-        assert!(component.contains(WinampWindowId::Main));
-        assert!(!component.contains(WinampWindowId::Equalizer));
-        assert!(component.contains(WinampWindowId::Playlist));
-        assert_eq!(
-            component.ids(),
-            vec![WinampWindowId::Main, WinampWindowId::Playlist]
-        );
-    }
-
-    fn attached_chain_snapshots() -> [WinampWindowSnapshot; 3] {
-        [
-            WinampWindowSnapshot {
-                id: WinampWindowId::Main,
-                position: Point::new(100.0, 100.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Equalizer,
-                position: Point::new(100.0, 216.0),
-                size: Size::new(275.0, 116.0),
-            },
-            WinampWindowSnapshot {
-                id: WinampWindowId::Playlist,
-                position: Point::new(375.0, 216.0),
-                size: Size::new(275.0, 116.0),
-            },
-        ]
-    }
-
-    fn sorted_component(
-        snapshots: &[WinampWindowSnapshot],
-        dragged: WinampWindowId,
-    ) -> Vec<WinampWindowId> {
-        let mut component = attached_winamp_component(snapshots, dragged);
-        component.sort_by_key(|id| *id as u8);
-        component
-    }
-
-    fn snapshot_position(snapshots: &[WinampWindowSnapshot], id: WinampWindowId) -> Point {
-        snapshots
-            .iter()
-            .find(|snapshot| snapshot.id == id)
-            .expect("snapshot")
-            .position
-    }
-
-    fn snap_candidate_deltas(
-        moving: WinampWindowSnapshot,
-        stationary: WinampWindowSnapshot,
-    ) -> Vec<Point> {
-        winamp_snap_candidates(moving, stationary)
-            .into_iter()
-            .map(|candidate| candidate.delta)
-            .collect()
     }
 }

--- a/apps/desktop-demo/src/app/winamp/mod.rs
+++ b/apps/desktop-demo/src/app/winamp/mod.rs
@@ -126,6 +126,47 @@ struct WinampNativeWindowStates {
     main: WindowState,
     equalizer: WindowState,
     playlist: WindowState,
+    drag_session: MutableState<Option<WinampNativeDragSession>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct WinampNativeDragSession {
+    dragged: WinampWindowId,
+    component: WinampWindowComponent,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct WinampWindowComponent(u8);
+
+impl WinampWindowComponent {
+    fn from_ids(ids: &[WinampWindowId]) -> Self {
+        Self(ids.iter().fold(0, |mask, id| mask | id.component_bit()))
+    }
+
+    fn ids(self) -> Vec<WinampWindowId> {
+        [
+            WinampWindowId::Main,
+            WinampWindowId::Equalizer,
+            WinampWindowId::Playlist,
+        ]
+        .into_iter()
+        .filter(|id| self.contains(*id))
+        .collect()
+    }
+
+    fn contains(self, id: WinampWindowId) -> bool {
+        self.0 & id.component_bit() != 0
+    }
+}
+
+impl WinampWindowId {
+    fn component_bit(self) -> u8 {
+        match self {
+            WinampWindowId::Main => 1 << 0,
+            WinampWindowId::Equalizer => 1 << 1,
+            WinampWindowId::Playlist => 1 << 2,
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -149,6 +190,7 @@ pub(crate) fn remember_winamp_tab_state() -> WinampTabState {
             main: rememberWindowState(MAIN_WIDTH, MAIN_HEIGHT),
             equalizer: rememberWindowState(EQ_WIDTH, EQ_HEIGHT),
             playlist: rememberWindowState(PLAYLIST_WIDTH, PLAYLIST_HEIGHT),
+            drag_session: cranpose_core::useState(|| None::<WinampNativeDragSession>),
         },
     }
 }
@@ -1343,8 +1385,15 @@ fn WindowDragHandle(drag_target: WinampDragTarget, area: SpriteRect, scale: f32)
         .absolute_offset(scaled(area.0, scale), scaled(area.1, scale));
 
     match drag_target {
-        WinampDragTarget::NativeGroup { .. } => {
-            Box(modifier.window_drag_area(), BoxSpec::default(), || {});
+        WinampDragTarget::NativeGroup { windows, dragged } => {
+            Box(
+                modifier.window_drag_area_with_callbacks(
+                    move || start_winamp_native_drag_session(windows, dragged),
+                    move || finish_winamp_native_drag_session(windows),
+                ),
+                BoxSpec::default(),
+                || {},
+            );
         }
         WinampDragTarget::Inline(window_position) => {
             let drag_offset = cranpose_core::useState(|| None::<Point>);
@@ -1608,8 +1657,40 @@ fn move_winamp_component_by_delta(
     }
 
     let snapshots = winamp_window_snapshots(native_windows);
-    let moved = move_winamp_snapshots(&snapshots, dragged, delta);
+    let moved = if let Some(session) = native_windows
+        .drag_session
+        .get_non_reactive()
+        .filter(|session| session.dragged == dragged)
+    {
+        let component = session.component.ids();
+        move_winamp_snapshots_for_fixed_component(&snapshots, &component, delta)
+    } else {
+        move_winamp_snapshots(&snapshots, dragged, delta)
+    };
     apply_winamp_window_snapshots(native_windows, moved);
+}
+
+fn start_winamp_native_drag_session(
+    native_windows: WinampNativeWindowStates,
+    dragged: WinampWindowId,
+) {
+    let snapshots = winamp_window_snapshots(native_windows);
+    if snapshots.iter().all(|snapshot| snapshot.id != dragged) {
+        native_windows.drag_session.set(None);
+        return;
+    }
+
+    let component = attached_winamp_component(&snapshots, dragged);
+    native_windows
+        .drag_session
+        .set(Some(WinampNativeDragSession {
+            dragged,
+            component: WinampWindowComponent::from_ids(&component),
+        }));
+}
+
+fn finish_winamp_native_drag_session(native_windows: WinampNativeWindowStates) {
+    native_windows.drag_session.set(None);
 }
 
 fn apply_winamp_window_snapshots(
@@ -1703,6 +1784,16 @@ fn move_winamp_snapshots(
 ) -> Vec<WinampWindowSnapshot> {
     let mut component = attached_winamp_component(snapshots, dragged);
     move_winamp_snapshots_for_component(snapshots, &mut component, delta, true)
+}
+
+fn move_winamp_snapshots_for_fixed_component(
+    snapshots: &[WinampWindowSnapshot],
+    component: &[WinampWindowId],
+    delta: Point,
+) -> Vec<WinampWindowSnapshot> {
+    let mut moved = snapshots.to_vec();
+    translate_winamp_snapshots(&mut moved, component, delta);
+    moved
 }
 
 fn move_winamp_snapshots_for_component(
@@ -2296,17 +2387,20 @@ mod tests {
     }
 
     #[test]
-    fn winamp_main_drag_session_keeps_initial_component_for_large_delta() {
+    fn winamp_frozen_drag_component_keeps_initial_windows_for_large_delta() {
         let snapshots = attached_chain_snapshots();
-        let mut component = attached_winamp_component(&snapshots, WinampWindowId::Main);
+        let component = attached_winamp_component(&snapshots, WinampWindowId::Main);
 
-        let moved = move_winamp_snapshots_for_component(
+        let moved = move_winamp_snapshots_for_fixed_component(
             &snapshots,
-            &mut component,
+            &component,
             Point::new(220.0, 90.0),
-            true,
         );
 
+        assert_eq!(
+            snapshot_position(&moved, WinampWindowId::Main),
+            Point::new(320.0, 190.0)
+        );
         assert_eq!(
             snapshot_position(&moved, WinampWindowId::Equalizer),
             Point::new(320.0, 306.0)
@@ -2322,6 +2416,73 @@ mod tests {
                 WinampWindowId::Equalizer,
                 WinampWindowId::Playlist
             ]
+        );
+    }
+
+    #[test]
+    fn winamp_frozen_drag_component_does_not_attach_new_window() {
+        let snapshots = [
+            WinampWindowSnapshot {
+                id: WinampWindowId::Main,
+                position: Point::new(100.0, 100.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Equalizer,
+                position: Point::new(100.0, 216.0),
+                size: Size::new(275.0, 116.0),
+            },
+            WinampWindowSnapshot {
+                id: WinampWindowId::Playlist,
+                position: Point::new(386.0, 216.0),
+                size: Size::new(275.0, 116.0),
+            },
+        ];
+        let component = vec![WinampWindowId::Main, WinampWindowId::Equalizer];
+
+        let moved =
+            move_winamp_snapshots_for_fixed_component(&snapshots, &component, Point::new(8.0, 0.0));
+
+        assert_eq!(
+            snapshot_position(&moved, WinampWindowId::Main),
+            Point::new(108.0, 100.0)
+        );
+        assert_eq!(
+            snapshot_position(&moved, WinampWindowId::Equalizer),
+            Point::new(108.0, 216.0)
+        );
+        assert_eq!(
+            snapshot_position(&moved, WinampWindowId::Playlist),
+            Point::new(386.0, 216.0)
+        );
+
+        let moved_again =
+            move_winamp_snapshots_for_fixed_component(&moved, &component, Point::new(12.0, 4.0));
+        assert_eq!(
+            snapshot_position(&moved_again, WinampWindowId::Main),
+            Point::new(120.0, 104.0)
+        );
+        assert_eq!(
+            snapshot_position(&moved_again, WinampWindowId::Equalizer),
+            Point::new(120.0, 220.0)
+        );
+        assert_eq!(
+            snapshot_position(&moved_again, WinampWindowId::Playlist),
+            Point::new(386.0, 216.0)
+        );
+    }
+
+    #[test]
+    fn winamp_drag_session_component_roundtrips_ids() {
+        let component =
+            WinampWindowComponent::from_ids(&[WinampWindowId::Playlist, WinampWindowId::Main]);
+
+        assert!(component.contains(WinampWindowId::Main));
+        assert!(!component.contains(WinampWindowId::Equalizer));
+        assert!(component.contains(WinampWindowId::Playlist));
+        assert_eq!(
+            component.ids(),
+            vec![WinampWindowId::Main, WinampWindowId::Playlist]
         );
     }
 

--- a/crates/cranpose-app-shell/src/lib.rs
+++ b/crates/cranpose-app-shell/src/lib.rs
@@ -95,7 +95,6 @@ where
     /// Dev options for debugging and performance monitoring
     dev_options: DevOptions,
     dev_overlay_controls: Vec<DevOverlayControl>,
-    before_recompose: Option<Box<dyn FnMut()>>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -221,7 +220,6 @@ where
             clipboard: arboard::Clipboard::new().ok(),
             dev_options: DevOptions::default(),
             dev_overlay_controls: Vec::new(),
-            before_recompose: None,
         };
         shell.process_frame();
         shell
@@ -306,10 +304,6 @@ where
 
     pub fn clear_frame_waker(&mut self) {
         self.runtime.clear_frame_waker();
-    }
-
-    pub fn set_before_recompose(&mut self, callback: impl FnMut() + 'static) {
-        self.before_recompose = Some(Box::new(callback));
     }
 
     pub fn should_render(&self) -> bool {
@@ -398,9 +392,6 @@ where
                 );
             }
             if should_render {
-                if let Some(before_recompose) = &mut self.before_recompose {
-                    before_recompose();
-                }
                 let Some(root_key) = self.composition.root_key() else {
                     self.process_frame();
                     self.is_dirty = false;

--- a/crates/cranpose-app-shell/src/lib.rs
+++ b/crates/cranpose-app-shell/src/lib.rs
@@ -95,6 +95,7 @@ where
     /// Dev options for debugging and performance monitoring
     dev_options: DevOptions,
     dev_overlay_controls: Vec<DevOverlayControl>,
+    before_recompose: Option<Box<dyn FnMut()>>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -172,7 +173,17 @@ where
     R: Renderer,
     R::Error: Debug,
 {
-    pub fn new(mut renderer: R, root_key: Key, content: impl FnMut() + 'static) -> Self {
+    pub fn new(renderer: R, root_key: Key, content: impl FnMut() + 'static) -> Self {
+        Self::new_with_size(renderer, root_key, content, (800, 600), (800.0, 600.0))
+    }
+
+    pub fn new_with_size(
+        mut renderer: R,
+        root_key: Key,
+        content: impl FnMut() + 'static,
+        buffer_size: (u32, u32),
+        viewport: (f32, f32),
+    ) -> Self {
         // Initialize FPS tracking
         fps_monitor::init_fps_tracker();
 
@@ -189,8 +200,8 @@ where
             content: build,
             renderer,
             cursor: (0.0, 0.0),
-            viewport: (800.0, 600.0),
-            buffer_size: (800, 600),
+            viewport,
+            buffer_size,
             start_time: Instant::now(),
             layout_tree: None,
             semantics_tree: None,
@@ -210,6 +221,7 @@ where
             clipboard: arboard::Clipboard::new().ok(),
             dev_options: DevOptions::default(),
             dev_overlay_controls: Vec::new(),
+            before_recompose: None,
         };
         shell.process_frame();
         shell
@@ -296,6 +308,10 @@ where
         self.runtime.clear_frame_waker();
     }
 
+    pub fn set_before_recompose(&mut self, callback: impl FnMut() + 'static) {
+        self.before_recompose = Some(Box::new(callback));
+    }
+
     pub fn should_render(&self) -> bool {
         if self.layout_requested
             || self.scene_dirty
@@ -333,6 +349,12 @@ where
     /// Marks the shell as dirty, indicating a redraw is needed.
     pub fn mark_dirty(&mut self) {
         self.is_dirty = true;
+    }
+
+    pub fn request_root_render(&mut self) {
+        self.composition.request_root_render();
+        self.request_forced_layout_pass();
+        self.mark_dirty();
     }
 
     fn request_layout_pass(&mut self) {
@@ -376,6 +398,9 @@ where
                 );
             }
             if should_render {
+                if let Some(before_recompose) = &mut self.before_recompose {
+                    before_recompose();
+                }
                 let Some(root_key) = self.composition.root_key() else {
                     self.process_frame();
                     self.is_dirty = false;

--- a/crates/cranpose-core/src/composition.rs
+++ b/crates/cranpose-core/src/composition.rs
@@ -100,6 +100,11 @@ impl<A: Applier + 'static> Composition<A> {
         std::mem::take(&mut self.root_render_requested)
     }
 
+    pub fn request_root_render(&mut self) {
+        self.root_render_requested = true;
+        self.runtime.handle().schedule();
+    }
+
     fn record_pass_stats(
         &mut self,
         commands: &CommandQueue,

--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -960,6 +960,29 @@ impl TextSystemState {
 
 type SharedTextSystemState = Arc<Mutex<TextSystemState>>;
 
+#[derive(Clone)]
+pub struct WgpuTextSystem {
+    render: SharedTextSystemState,
+    measure: SharedTextSystemState,
+}
+
+impl WgpuTextSystem {
+    pub fn from_fonts(fonts: &[&[u8]]) -> Self {
+        Self {
+            render: Arc::new(Mutex::new(TextSystemState::from_fonts(fonts))),
+            measure: Arc::new(Mutex::new(TextSystemState::from_fonts(fonts))),
+        }
+    }
+
+    fn install_measurer(&self) {
+        set_text_measurer(WgpuTextMeasurer::new(Arc::clone(&self.measure)));
+    }
+
+    fn render_state(&self) -> SharedTextSystemState {
+        Arc::clone(&self.render)
+    }
+}
+
 /// WGPU-based renderer for GPU-accelerated 2D rendering.
 ///
 /// This renderer supports:
@@ -970,7 +993,7 @@ type SharedTextSystemState = Arc<Mutex<TextSystemState>>;
 pub struct WgpuRenderer {
     scene: Scene,
     gpu_renderer: Option<GpuRenderer>,
-    render_text_state: TextSystemState,
+    render_text_state: SharedTextSystemState,
     /// Root scale factor for text rendering (use for density scaling)
     root_scale: f32,
 }
@@ -983,15 +1006,16 @@ impl WgpuRenderer {
     ///
     /// Call [`init_gpu`][Self::init_gpu] before rendering.
     pub fn new(fonts: &[&[u8]]) -> Self {
-        let render_text_state = TextSystemState::from_fonts(fonts);
-        let measure_text_state = Arc::new(Mutex::new(TextSystemState::from_fonts(fonts)));
-        let text_measurer = WgpuTextMeasurer::new(measure_text_state);
-        set_text_measurer(text_measurer.clone());
+        Self::with_text_system(WgpuTextSystem::from_fonts(fonts))
+    }
+
+    pub fn with_text_system(text_system: WgpuTextSystem) -> Self {
+        text_system.install_measurer();
 
         Self {
             scene: Scene::new(),
             gpu_renderer: None,
-            render_text_state,
+            render_text_state: text_system.render_state(),
             root_scale: 1.0,
         }
     }
@@ -1034,14 +1058,9 @@ impl WgpuRenderer {
                 .graph
                 .as_ref()
                 .ok_or_else(|| WgpuRendererError::Wgpu("scene graph is missing".to_string()))?;
-            let result = gpu_renderer.render(
-                &mut self.render_text_state,
-                view,
-                graph,
-                width,
-                height,
-                self.root_scale,
-            );
+            let mut text_state = self.render_text_state.lock().unwrap();
+            let result =
+                gpu_renderer.render(&mut text_state, view, graph, width, height, self.root_scale);
             result.map_err(WgpuRendererError::Wgpu)
         } else {
             Err(WgpuRendererError::Wgpu(
@@ -1074,14 +1093,9 @@ impl WgpuRenderer {
                 .graph
                 .as_ref()
                 .ok_or_else(|| WgpuRendererError::Wgpu("scene graph is missing".to_string()))?;
+            let mut text_state = self.render_text_state.lock().unwrap();
             let pixels = gpu_renderer
-                .render_to_rgba_pixels(
-                    &mut self.render_text_state,
-                    graph,
-                    width,
-                    height,
-                    root_scale,
-                )
+                .render_to_rgba_pixels(&mut text_state, graph, width, height, root_scale)
                 .map_err(WgpuRendererError::Wgpu)?;
             Ok(CapturedFrame {
                 width,
@@ -2820,7 +2834,7 @@ mod tests {
 
             let _ = cranpose_ui::text::measure_text(&text, &style);
 
-            tx.send(renderer.render_text_state.text_cache.len())
+            tx.send(renderer.render_text_state.lock().unwrap().text_cache.len())
                 .expect("send render text cache size");
         });
 

--- a/crates/cranpose-testing/src/robot_helpers.rs
+++ b/crates/cranpose-testing/src/robot_helpers.rs
@@ -236,7 +236,12 @@ fn find_button_in_semantics_by(
             break;
         };
 
-        let Some((axis, dir)) = overflow_axis_direction(current, root) else {
+        let Some((axis, _dir)) = overflow_axis_direction(current, root) else {
+            break;
+        };
+
+        let Some((scroll_delta_x, scroll_delta_y)) = scroll_delta_for_overflow(current, root, axis)
+        else {
             break;
         };
 
@@ -254,11 +259,8 @@ fn find_button_in_semantics_by(
 
         let start_x = sx + sw / 2.0;
         let start_y = sy + sh / 2.0;
-        let (end_x, end_y) = match axis {
-            TabAxis::Horizontal => (start_x + dir * SCROLL_STEP, start_y),
-            TabAxis::Vertical => (start_x, start_y + dir * SCROLL_STEP),
-        };
-        let _ = robot.drag(start_x, start_y, end_x, end_y);
+        let _ = robot.mouse_move(start_x, start_y);
+        let _ = robot.mouse_scroll(scroll_delta_x, scroll_delta_y);
         std::thread::sleep(Duration::from_millis(SCROLL_SETTLE_MS));
         let _ = robot.wait_for_idle();
 
@@ -566,7 +568,6 @@ pub fn root_bounds(robot: &cranpose::Robot) -> Option<RectBounds> {
 }
 
 const VISIBILITY_PADDING: f32 = 4.0;
-const SCROLL_STEP: f32 = 240.0;
 const SCROLL_SETTLE_MS: u64 = 140;
 type TextMatcher = fn(&str, &str) -> bool;
 
@@ -676,6 +677,27 @@ fn overflow_axis_direction(bounds: RectBounds, root: RectBounds) -> Option<(TabA
         Some((TabAxis::Vertical, 1.0))
     } else {
         Some((TabAxis::Vertical, -1.0))
+    }
+}
+
+fn scroll_delta_for_overflow(
+    bounds: RectBounds,
+    root: RectBounds,
+    axis: TabAxis,
+) -> Option<(f32, f32)> {
+    let (x, y, w, h) = bounds;
+    let (rx, ry, rw, rh) = root;
+    let left = rx + VISIBILITY_PADDING;
+    let right = rx + rw - VISIBILITY_PADDING;
+    let top = ry + VISIBILITY_PADDING;
+    let bottom = ry + rh - VISIBILITY_PADDING;
+
+    match axis {
+        TabAxis::Horizontal if x < left => Some((left - x, 0.0)),
+        TabAxis::Horizontal if x + w > right => Some((-(x + w - right), 0.0)),
+        TabAxis::Vertical if y < top => Some((0.0, top - y)),
+        TabAxis::Vertical if y + h > bottom => Some((0.0, -(y + h - bottom))),
+        _ => None,
     }
 }
 
@@ -1270,6 +1292,24 @@ mod tests {
         assert_eq!(
             overflow_axis_direction(target, root),
             Some((TabAxis::Vertical, 1.0))
+        );
+    }
+
+    #[test]
+    fn scroll_delta_for_overflow_moves_target_toward_visible_area() {
+        let root = (0.0, 0.0, 300.0, 200.0);
+
+        assert_eq!(
+            scroll_delta_for_overflow((320.0, 20.0, 80.0, 30.0), root, TabAxis::Horizontal),
+            Some((-104.0, 0.0))
+        );
+        assert_eq!(
+            scroll_delta_for_overflow((-42.0, 20.0, 80.0, 30.0), root, TabAxis::Horizontal),
+            Some((46.0, 0.0))
+        );
+        assert_eq!(
+            scroll_delta_for_overflow((20.0, 190.0, 80.0, 30.0), root, TabAxis::Vertical),
+            Some((0.0, -24.0))
         );
     }
 

--- a/crates/cranpose-testing/src/robot_helpers.rs
+++ b/crates/cranpose-testing/src/robot_helpers.rs
@@ -1184,6 +1184,48 @@ pub fn y_is_visible(robot: &cranpose::Robot, y: f32) -> bool {
     y >= top && y <= bottom
 }
 
+fn scroll_toward_y(robot: &cranpose::Robot, y: f32, cfg: ScrollConfig) {
+    let Some((_, root_y, _, root_h)) = root_bounds(robot) else {
+        return;
+    };
+    let viewport_mid = root_y + root_h * 0.5;
+    let distance = ((y - viewport_mid).abs() / 5.0).clamp(24.0, 140.0);
+    if y > viewport_mid {
+        let target_y = (cfg.down_from_y - distance).max(cfg.down_to_y);
+        let _ = robot.drag(cfg.center_x, cfg.down_from_y, cfg.center_x, target_y);
+    } else {
+        let target_y = (cfg.up_from_y + distance).min(cfg.up_to_y);
+        let _ = robot.drag(cfg.center_x, cfg.up_from_y, cfg.center_x, target_y);
+    }
+    std::thread::sleep(std::time::Duration::from_millis(140));
+    let _ = robot.wait_for_idle();
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MissingTargetScrollDirection {
+    Down,
+    Up,
+}
+
+fn missing_target_scroll_direction(attempt: usize) -> MissingTargetScrollDirection {
+    if attempt % 4 == 3 {
+        MissingTargetScrollDirection::Up
+    } else {
+        MissingTargetScrollDirection::Down
+    }
+}
+
+fn scroll_for_missing_target(robot: &cranpose::Robot, cfg: ScrollConfig, attempt: usize) {
+    match missing_target_scroll_direction(attempt) {
+        MissingTargetScrollDirection::Down => {
+            scroll_down(robot, cfg.center_x, cfg.down_from_y, cfg.down_to_y);
+        }
+        MissingTargetScrollDirection::Up => {
+            scroll_up(robot, cfg.center_x, cfg.up_from_y, cfg.up_to_y);
+        }
+    }
+}
+
 /// Configuration for scroll-into-view helpers so we don't need too many arguments.
 #[derive(Clone, Copy, Debug)]
 pub struct ScrollConfig {
@@ -1208,22 +1250,31 @@ pub fn scroll_prefix_into_view(
             if y_is_visible(robot, center_y) {
                 return Some(bounds);
             }
-            let Some((_, root_y, _, root_h)) = root_bounds(robot) else {
-                return Some(bounds);
-            };
-            let viewport_mid = root_y + root_h * 0.5;
-            if center_y > viewport_mid {
-                scroll_down(robot, cfg.center_x, cfg.down_from_y, cfg.down_to_y);
-            } else {
-                scroll_up(robot, cfg.center_x, cfg.up_from_y, cfg.up_to_y);
-            }
+            scroll_toward_y(robot, center_y, cfg);
         } else {
-            // Not found yet — alternate directions to find it
-            if attempt % 2 == 0 {
-                scroll_down(robot, cfg.center_x, cfg.down_from_y, cfg.down_to_y);
-            } else {
-                scroll_up(robot, cfg.center_x, cfg.up_from_y, cfg.up_to_y);
+            scroll_for_missing_target(robot, cfg, attempt);
+        }
+    }
+    None
+}
+
+/// Scroll until a semantics node with exactly matching text is visible.
+/// Returns bounds `(x, y, w, h)`.
+pub fn scroll_text_into_view(
+    robot: &cranpose::Robot,
+    text: &str,
+    max_attempts: usize,
+    cfg: ScrollConfig,
+) -> Option<(f32, f32, f32, f32)> {
+    for attempt in 0..max_attempts {
+        if let Some(bounds) = find_bounds_by_text(robot, text) {
+            let center_y = bounds.1 + bounds.3 * 0.5;
+            if y_is_visible(robot, center_y) {
+                return Some(bounds);
             }
+            scroll_toward_y(robot, center_y, cfg);
+        } else {
+            scroll_for_missing_target(robot, cfg, attempt);
         }
     }
     None
@@ -1310,6 +1361,25 @@ mod tests {
         assert_eq!(
             scroll_delta_for_overflow((20.0, 190.0, 80.0, 30.0), root, TabAxis::Vertical),
             Some((0.0, -24.0))
+        );
+    }
+
+    #[test]
+    fn missing_target_scroll_searches_down_with_periodic_reverse() {
+        let directions: Vec<_> = (0..8).map(missing_target_scroll_direction).collect();
+
+        assert_eq!(
+            directions,
+            vec![
+                MissingTargetScrollDirection::Down,
+                MissingTargetScrollDirection::Down,
+                MissingTargetScrollDirection::Down,
+                MissingTargetScrollDirection::Up,
+                MissingTargetScrollDirection::Down,
+                MissingTargetScrollDirection::Down,
+                MissingTargetScrollDirection::Down,
+                MissingTargetScrollDirection::Up,
+            ]
         );
     }
 

--- a/crates/cranpose/Cargo.toml
+++ b/crates/cranpose/Cargo.toml
@@ -72,3 +72,6 @@ console_error_panic_hook = "0.1"
 android-activity = { workspace = true }
 android_logger = "0.15"
 raw-window-handle = "0.6"
+
+[target.'cfg(all(target_os = "linux", not(target_arch = "wasm32")))'.dependencies]
+x11rb = "0.13.2"

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -1052,6 +1052,12 @@ struct PendingNativeWindowPositions {
     positions: VecDeque<(f32, f32)>,
 }
 
+#[derive(Clone, Copy)]
+enum NativeWindowGraphPositionSource {
+    CachedThenCurrent,
+    CurrentThenCached,
+}
+
 impl PendingNativeWindowPositions {
     fn push(&mut self, position: (f32, f32)) {
         if self
@@ -1551,7 +1557,13 @@ impl App {
     fn native_window_graph_snapshots(&self) -> Vec<WindowGraphPeerSnapshot> {
         self.native_windows
             .values()
-            .filter_map(|native| self.native_window_graph_snapshot(native, None))
+            .filter_map(|native| {
+                self.native_window_graph_snapshot(
+                    native,
+                    None,
+                    NativeWindowGraphPositionSource::CachedThenCurrent,
+                )
+            })
             .collect()
     }
 
@@ -1560,9 +1572,38 @@ impl App {
         native: &NativeWindowSurface,
         position: Option<cranpose_ui::Point>,
     ) -> Vec<WindowGraphPeerSnapshot> {
-        let mut snapshots = self.native_window_graph_snapshots();
+        self.native_window_graph_snapshots_with_source(
+            native,
+            position,
+            NativeWindowGraphPositionSource::CachedThenCurrent,
+        )
+    }
+
+    fn native_window_graph_snapshots_with_current_positions(
+        &self,
+        native: &NativeWindowSurface,
+        position: Option<cranpose_ui::Point>,
+    ) -> Vec<WindowGraphPeerSnapshot> {
+        self.native_window_graph_snapshots_with_source(
+            native,
+            position,
+            NativeWindowGraphPositionSource::CurrentThenCached,
+        )
+    }
+
+    fn native_window_graph_snapshots_with_source(
+        &self,
+        native: &NativeWindowSurface,
+        position: Option<cranpose_ui::Point>,
+        source: NativeWindowGraphPositionSource,
+    ) -> Vec<WindowGraphPeerSnapshot> {
+        let mut snapshots: Vec<_> = self
+            .native_windows
+            .values()
+            .filter_map(|native| self.native_window_graph_snapshot(native, None, source))
+            .collect();
         snapshots.retain(|snapshot| snapshot.node.id != native.key);
-        if let Some(snapshot) = self.native_window_graph_snapshot(native, position) {
+        if let Some(snapshot) = self.native_window_graph_snapshot(native, position, source) {
             snapshots.push(snapshot);
         }
         snapshots
@@ -1572,20 +1613,18 @@ impl App {
         &self,
         native: &NativeWindowSurface,
         position: Option<cranpose_ui::Point>,
+        source: NativeWindowGraphPositionSource,
     ) -> Option<WindowGraphPeerSnapshot> {
-        let position = position
-            .or_else(|| {
-                self.native_window_positions
-                    .get(&native.key)
-                    .map(|(x, y)| cranpose_ui::Point::new(*x, *y))
-            })
-            .or_else(|| {
-                current_native_window_position(native).map(|(x, y)| cranpose_ui::Point::new(x, y))
-            })
-            .or_else(|| match (native.options.x, native.options.y) {
-                (Some(x), Some(y)) => Some(cranpose_ui::Point::new(x, y)),
-                _ => None,
-            })?;
+        let cached_position = self.native_window_positions.get(&native.key).copied();
+        let current_position = current_native_window_position(native);
+        let options_position = native_window_options_position(&native.options);
+        let position = native_window_graph_position(
+            position,
+            cached_position,
+            current_position,
+            options_position,
+            source,
+        )?;
         Some(WindowGraphPeerSnapshot {
             node: WindowGraphNodeSnapshot {
                 id: native.key,
@@ -2196,8 +2235,11 @@ impl App {
                         (Some(x), Some(y)) => Some(cranpose_ui::Point::new(x, y)),
                         _ => None,
                     });
-                let previous_graph_snapshots =
-                    self.native_window_graph_snapshots_with(&native, previous_graph_position);
+                let previous_graph_snapshots = self
+                    .native_window_graph_snapshots_with_current_positions(
+                        &native,
+                        previous_graph_position,
+                    );
                 let position = current_native_window_position(&native).unwrap_or_else(|| {
                     let logical = position.to_logical::<f64>(native.window.scale_factor());
                     (logical.x as f32, logical.y as f32)
@@ -2717,6 +2759,33 @@ fn current_native_window_position(native: &NativeWindowSurface) -> Option<(f32, 
     current_native_window_physical_position(&native.window).map(|position| {
         let logical = position.to_logical::<f64>(native.window.scale_factor());
         (logical.x as f32, logical.y as f32)
+    })
+}
+
+fn native_window_options_position(options: &NativeWindowOptions) -> Option<(f32, f32)> {
+    match (options.x, options.y) {
+        (Some(x), Some(y)) => Some((x, y)),
+        _ => None,
+    }
+}
+
+fn native_window_graph_position(
+    override_position: Option<cranpose_ui::Point>,
+    cached_position: Option<(f32, f32)>,
+    current_position: Option<(f32, f32)>,
+    options_position: Option<(f32, f32)>,
+    source: NativeWindowGraphPositionSource,
+) -> Option<cranpose_ui::Point> {
+    override_position.or_else(|| {
+        let selected = match source {
+            NativeWindowGraphPositionSource::CachedThenCurrent => {
+                cached_position.or(current_position).or(options_position)
+            }
+            NativeWindowGraphPositionSource::CurrentThenCached => {
+                current_position.or(cached_position).or(options_position)
+            }
+        }?;
+        Some(cranpose_ui::Point::new(selected.0, selected.1))
     })
 }
 
@@ -4654,11 +4723,11 @@ fn char_to_key_code(ch: char) -> cranpose_app_shell::KeyCode {
 #[cfg(test)]
 mod tests {
     use super::{
-        clamp_rect_to_monitor_delta, nearest_monitor_to_rect,
+        clamp_rect_to_monitor_delta, native_window_graph_position, nearest_monitor_to_rect,
         physical_surface_rect_contains_pointer, primary_declaration_host_needs_direct_update,
         primary_frame_waker_uses_event_proxy, primary_surface_redraw_drives_app, App, DesktopRect,
-        NativeWindowDragSession, NativeWindowOptions, NativeWindowPollingDragSession,
-        NativeWindowPositionOrigin, PendingNativeWindowPositions,
+        NativeWindowDragSession, NativeWindowGraphPositionSource, NativeWindowOptions,
+        NativeWindowPollingDragSession, NativeWindowPositionOrigin, PendingNativeWindowPositions,
     };
     use std::time::Instant;
     use winit::dpi::{PhysicalPosition, PhysicalSize};
@@ -4829,6 +4898,45 @@ mod tests {
 
         assert!(!pending.acknowledge((100.0, 200.0)));
         assert!(!pending.acknowledge((140.0, 240.0)));
+    }
+
+    #[test]
+    fn native_window_graph_position_keeps_cache_first_for_programmatic_moves() {
+        let position = native_window_graph_position(
+            None,
+            Some((100.0, 200.0)),
+            Some((140.0, 240.0)),
+            Some((160.0, 260.0)),
+            NativeWindowGraphPositionSource::CachedThenCurrent,
+        );
+
+        assert_eq!(position, Some(cranpose_ui::Point::new(100.0, 200.0)));
+    }
+
+    #[test]
+    fn native_window_graph_position_uses_current_position_for_external_moves() {
+        let position = native_window_graph_position(
+            None,
+            Some((100.0, 200.0)),
+            Some((140.0, 240.0)),
+            Some((160.0, 260.0)),
+            NativeWindowGraphPositionSource::CurrentThenCached,
+        );
+
+        assert_eq!(position, Some(cranpose_ui::Point::new(140.0, 240.0)));
+    }
+
+    #[test]
+    fn native_window_graph_position_override_wins_over_position_source() {
+        let position = native_window_graph_position(
+            Some(cranpose_ui::Point::new(80.0, 90.0)),
+            Some((100.0, 200.0)),
+            Some((140.0, 240.0)),
+            Some((160.0, 260.0)),
+            NativeWindowGraphPositionSource::CurrentThenCached,
+        );
+
+        assert_eq!(position, Some(cranpose_ui::Point::new(80.0, 90.0)));
     }
 
     #[test]

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -31,6 +31,7 @@ use winit::window::{
 };
 
 const NATIVE_WINDOW_DRAG_POLL_INTERVAL: Duration = Duration::from_millis(16);
+const NATIVE_WINDOW_POSITION_POLL_INTERVAL: Duration = Duration::from_millis(16);
 const NATIVE_WINDOW_PLACEMENT_MARGIN: f32 = 32.0;
 
 #[cfg(feature = "robot")]
@@ -1090,6 +1091,10 @@ impl PendingNativeWindowPositions {
     fn clear(&mut self) {
         self.positions.clear();
     }
+
+    fn has_pending(&self) -> bool {
+        !self.positions.is_empty()
+    }
 }
 
 impl NativeWindowSurface {
@@ -1127,6 +1132,7 @@ struct App {
     closed_native_windows: HashSet<NativeWindowKey>,
     /// Framework-owned peer-window topology and drag sessions.
     window_graph: WindowGraphState,
+    next_native_window_position_poll_at: Instant,
     /// Current keyboard modifiers (shift, ctrl, alt, meta)
     current_modifiers: winit::keyboard::ModifiersState,
     /// Last known cursor position in logical pixels
@@ -1179,6 +1185,8 @@ impl App {
             native_window_positions: HashMap::new(),
             closed_native_windows: HashSet::new(),
             window_graph: WindowGraphState::default(),
+            next_native_window_position_poll_at: Instant::now()
+                + NATIVE_WINDOW_POSITION_POLL_INTERVAL,
             current_modifiers: winit::keyboard::ModifiersState::empty(),
             last_cursor_position: None,
             #[cfg(feature = "robot")]
@@ -2120,6 +2128,111 @@ impl App {
             moved |= self.finish_window_graph_drag();
         }
         moved
+    }
+
+    fn poll_external_native_window_moves(&mut self, now: Instant) -> bool {
+        if self.native_windows.is_empty() || self.next_native_window_position_poll_at > now {
+            return false;
+        }
+        self.next_native_window_position_poll_at = now + NATIVE_WINDOW_POSITION_POLL_INTERVAL;
+
+        let mut external_moves = Vec::new();
+        let native_window_positions = &mut self.native_window_positions;
+        for (window_id, native) in &mut self.native_windows {
+            if !native.options.visible || native.active_drag.is_some() {
+                continue;
+            }
+            let Some(position) = current_native_window_position(native) else {
+                continue;
+            };
+            if native.pending_outer_positions.acknowledge(position) {
+                native_window_positions.insert(native.key, position);
+                update_native_options_position(&mut native.options, position.0, position.1);
+                continue;
+            }
+            if native.pending_outer_positions.has_pending()
+                || native_window_positions
+                    .get(&native.key)
+                    .is_some_and(|known| native_window_positions_close(*known, position))
+            {
+                continue;
+            }
+
+            let previous_state_position =
+                native.state.and_then(|state| state.position_non_reactive());
+            let previous_graph_position = native_window_positions
+                .get(&native.key)
+                .map(|(x, y)| cranpose_ui::Point::new(*x, *y))
+                .or(previous_state_position)
+                .or_else(|| {
+                    native_window_options_position(&native.options)
+                        .map(|(x, y)| cranpose_ui::Point::new(x, y))
+                });
+            external_moves.push((
+                *window_id,
+                native.key,
+                position,
+                previous_state_position,
+                previous_graph_position,
+            ));
+        }
+
+        let mut moved = false;
+        for (window_id, key, position, previous_state_position, previous_graph_position) in
+            external_moves
+        {
+            moved |= self.reconcile_external_native_window_move(
+                window_id,
+                key,
+                position,
+                previous_state_position,
+                previous_graph_position,
+            );
+        }
+        moved
+    }
+
+    fn reconcile_external_native_window_move(
+        &mut self,
+        window_id: WinitWindowId,
+        key: NativeWindowKey,
+        position: (f32, f32),
+        previous_state_position: Option<cranpose_ui::Point>,
+        previous_graph_position: Option<cranpose_ui::Point>,
+    ) -> bool {
+        let Some(native) = self.native_windows.get(&window_id) else {
+            return false;
+        };
+        let previous_graph_snapshots = self
+            .native_window_graph_snapshots_with_current_positions(native, previous_graph_position);
+
+        let Some(native) = self.native_windows.get_mut(&window_id) else {
+            return false;
+        };
+        if native.active_drag.is_some() || native.pending_outer_positions.has_pending() {
+            return false;
+        }
+
+        trace_native_window(format_args!(
+            "poll external move key={:?} pos=({:.1},{:.1})",
+            key, position.0, position.1
+        ));
+        self.native_window_positions.insert(key, position);
+        update_native_options_position(&mut native.options, position.0, position.1);
+        let position = cranpose_ui::Point::new(position.0, position.1);
+        notify_native_window_moved(&native.events, position.x, position.y);
+        sync_native_window_state_position(
+            native.state,
+            previous_state_position,
+            position.x,
+            position.y,
+        );
+
+        let graph_moves = self
+            .window_graph
+            .external_move(&previous_graph_snapshots, key, position);
+        self.apply_window_graph_moves(graph_moves);
+        true
     }
 
     fn update_native_window_polling_drag_target(
@@ -3790,6 +3903,10 @@ impl ApplicationHandler for App {
             self.refresh_native_window_requests();
             self.sync_native_windows(event_loop);
         }
+        if self.poll_external_native_window_moves(now) {
+            self.refresh_native_window_requests();
+            self.sync_native_windows(event_loop);
+        }
 
         let frame_interval = self.frame_interval();
         let last_frame_start_time = self.last_frame_start_time;
@@ -4162,6 +4279,11 @@ impl ApplicationHandler for App {
 
         let mut native_has_active_animations = false;
         let mut native_drag_deadline: Option<Instant> = None;
+        let native_position_poll_deadline = self
+            .native_windows
+            .values()
+            .any(|native| native.options.visible && native.active_drag.is_none())
+            .then_some(self.next_native_window_position_poll_at);
         let mut native_frame_cap_deadline: Option<Instant> = None;
         let mut native_next_event_time: Option<Instant> = None;
         for native in self.native_windows.values_mut() {
@@ -4218,11 +4340,15 @@ impl ApplicationHandler for App {
         // Poll continuously when:
         // - Active animations are running
         // - Robot test is active
-        if robot_needs_poll || native_drag_deadline.is_some() {
+        if robot_needs_poll
+            || native_drag_deadline.is_some()
+            || native_position_poll_deadline.is_some_and(|deadline| deadline <= now)
+        {
             event_loop.set_control_flow(ControlFlow::Poll);
         } else if let Some(deadline) = [
             next_frame_time.filter(|_| waiting_for_frame_cap),
             native_frame_cap_deadline,
+            native_position_poll_deadline,
         ]
         .into_iter()
         .flatten()
@@ -4898,6 +5024,17 @@ mod tests {
 
         assert!(!pending.acknowledge((100.0, 200.0)));
         assert!(!pending.acknowledge((140.0, 240.0)));
+    }
+
+    #[test]
+    fn pending_native_window_positions_report_unacknowledged_programmatic_moves() {
+        let mut pending = PendingNativeWindowPositions::default();
+
+        assert!(!pending.has_pending());
+        pending.push((100.0, 200.0));
+        assert!(pending.has_pending());
+        assert!(pending.acknowledge((100.0, 200.0)));
+        assert!(!pending.has_pending());
     }
 
     #[test]

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -6,7 +6,7 @@ use crate::launcher::{AppSettings, LaunchError};
 use crate::native_window::{
     self, NativeWindowEvents, NativeWindowKey, NativeWindowOptions, NativeWindowPositionOrigin,
     NativeWindowRequest, WindowGraphMove, WindowGraphNodeSnapshot, WindowGraphPeerSnapshot,
-    WindowGraphState, WindowResizeDirection, WindowState,
+    WindowGraphState, WindowGroupId, WindowResizeDirection, WindowState,
 };
 #[cfg(feature = "robot")]
 use cranpose_app_shell::RuntimeLeakDebugStats;
@@ -23,14 +23,15 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use winit::application::ApplicationHandler;
-use winit::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, Position};
+use winit::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Position};
 use winit::event::{ButtonSource, ElementState, MouseButton, WindowEvent};
-use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
 use winit::window::{
     ResizeDirection, Window, WindowAttributes, WindowId as WinitWindowId, WindowLevel,
 };
 
 const NATIVE_WINDOW_DRAG_POLL_INTERVAL: Duration = Duration::from_millis(16);
+const NATIVE_WINDOW_PLACEMENT_MARGIN: f32 = 32.0;
 
 #[cfg(feature = "robot")]
 use cranpose_ui::{SemanticsAction, SemanticsNode, SemanticsRole};
@@ -896,6 +897,7 @@ struct NativeWindowSurface {
     window: Arc<dyn Window>,
     surface: wgpu::Surface<'static>,
     surface_config: wgpu::SurfaceConfiguration,
+    surface_caps: wgpu::SurfaceCapabilities,
     app: AppShell<WgpuRenderer>,
     platform: DesktopWinitPlatform,
     last_cursor_position: Option<(f32, f32)>,
@@ -913,15 +915,115 @@ struct NativeWindowShell {
     create_started: Instant,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct DesktopRect {
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+}
+
+impl DesktopRect {
+    fn right(self) -> f32 {
+        self.x + self.width
+    }
+
+    fn bottom(self) -> f32 {
+        self.y + self.height
+    }
+
+    fn center(self) -> cranpose_ui::Point {
+        cranpose_ui::Point::new(self.x + self.width / 2.0, self.y + self.height / 2.0)
+    }
+
+    fn contains_rect_with_margin(self, rect: Self, margin: f32) -> bool {
+        rect.x >= self.x + margin
+            && rect.right() <= self.right() - margin
+            && rect.y >= self.y + margin
+            && rect.bottom() <= self.bottom() - margin
+    }
+
+    fn distance_to_point(self, point: cranpose_ui::Point) -> f32 {
+        let dx = if point.x < self.x {
+            self.x - point.x
+        } else if point.x > self.right() {
+            point.x - self.right()
+        } else {
+            0.0
+        };
+        let dy = if point.y < self.y {
+            self.y - point.y
+        } else if point.y > self.bottom() {
+            point.y - self.bottom()
+        } else {
+            0.0
+        };
+        dx * dx + dy * dy
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum NativeWindowPlacementGroupKey {
+    Group(WindowGroupId),
+    Window(NativeWindowKey),
+}
+
 #[derive(Clone, Copy, Debug)]
-struct NativeWindowDragSession {
+enum NativeWindowDragSession {
+    Platform { next_poll_at: Instant },
+    Polling(NativeWindowPollingDragSession),
+}
+
+impl NativeWindowDragSession {
+    fn platform(now: Instant) -> Self {
+        Self::Platform {
+            next_poll_at: now + NATIVE_WINDOW_DRAG_POLL_INTERVAL,
+        }
+    }
+
+    fn next_poll_at(self) -> Instant {
+        match self {
+            Self::Platform { next_poll_at } => next_poll_at,
+            Self::Polling(session) => session.next_poll_at,
+        }
+    }
+
+    fn set_next_poll_at(&mut self, next_poll_at: Instant) {
+        match self {
+            Self::Platform {
+                next_poll_at: current,
+                ..
+            }
+            | Self::Polling(NativeWindowPollingDragSession {
+                next_poll_at: current,
+                ..
+            }) => {
+                *current = next_poll_at;
+            }
+        }
+    }
+
+    fn polling_mut(&mut self) -> Option<&mut NativeWindowPollingDragSession> {
+        match self {
+            Self::Platform { .. } => None,
+            Self::Polling(session) => Some(session),
+        }
+    }
+
+    fn finishes_on_global_pointer_release(self) -> bool {
+        matches!(self, Self::Platform { .. })
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct NativeWindowPollingDragSession {
     start_pointer_screen: PhysicalPosition<f64>,
     start_window_outer: PhysicalPosition<i32>,
     last_target_outer: PhysicalPosition<i32>,
     next_poll_at: Instant,
 }
 
-impl NativeWindowDragSession {
+impl NativeWindowPollingDragSession {
     fn new(
         start_pointer_screen: PhysicalPosition<f64>,
         start_window_outer: PhysicalPosition<i32>,
@@ -1033,6 +1135,8 @@ struct App {
     recorder: Option<crate::recorder::InputRecorder>,
     /// Launch failure captured during window/GPU initialization.
     launch_error: Rc<RefCell<Option<LaunchError>>>,
+    /// Event-loop wake path used when the primary declaration host is hidden.
+    event_proxy: EventLoopProxy,
     frame_pacing_mode: FramePacingMode,
     last_frame_start_time: Option<Instant>,
     vsync_interval: Duration,
@@ -1043,6 +1147,7 @@ impl App {
         mut settings: AppSettings,
         content: impl FnMut() + 'static,
         launch_error: Rc<RefCell<Option<LaunchError>>>,
+        event_proxy: EventLoopProxy,
     ) -> Self {
         // Create recorder if recording is enabled
         let recorder = settings
@@ -1076,6 +1181,7 @@ impl App {
             robot_app_hook,
             recorder,
             launch_error,
+            event_proxy,
             frame_pacing_mode,
             last_frame_start_time: None,
             vsync_interval: default_vsync_interval(),
@@ -1097,6 +1203,43 @@ impl App {
     fn refresh_native_window_requests(&mut self) {
         if let Some(app) = &mut self.app {
             app.update();
+        }
+    }
+
+    fn refresh_and_sync_native_windows(&mut self, event_loop: &dyn ActiveEventLoop) {
+        self.refresh_native_window_requests();
+        self.sync_native_windows(event_loop);
+    }
+
+    fn handle_primary_frame_requested(&mut self, event_loop: &dyn ActiveEventLoop) {
+        let direct_declaration_update = {
+            let Some(app) = &mut self.app else {
+                return;
+            };
+            let needs_redraw = app.needs_redraw() || app.has_active_animations();
+            if !needs_redraw {
+                return;
+            }
+            let direct_declaration_update = primary_declaration_host_needs_direct_update(
+                self.settings.primary_window_visible,
+                self.settings.headless,
+                needs_redraw,
+                false,
+            );
+            if direct_declaration_update {
+                trace_native_window(format_args!(
+                    "primary declaration host proxy update visible={} headless={}",
+                    self.settings.primary_window_visible, self.settings.headless
+                ));
+                app.update();
+            }
+            direct_declaration_update
+        };
+
+        if direct_declaration_update {
+            self.sync_native_windows(event_loop);
+        } else if let Some(window) = &self.window {
+            window.request_redraw();
         }
     }
 
@@ -1142,6 +1285,10 @@ impl App {
             .collect();
         for window_id in stale_window_ids {
             if let Some(native) = self.native_windows.get(&window_id) {
+                trace_native_window(format_args!(
+                    "sync stale key={:?} title={:?} visible={}",
+                    native.key, native.options.title, native.options.visible
+                ));
                 if let Some((x, y)) = current_native_window_position(native) {
                     self.native_window_positions.insert(native.key, (x, y));
                     notify_native_window_moved(&native.events, x, y);
@@ -1159,6 +1306,10 @@ impl App {
         let mut native_windows_to_create = Vec::new();
         for request in requests {
             if self.closed_native_windows.contains(&request.key) {
+                trace_native_window(format_args!(
+                    "sync skip closed key={:?} title={:?}",
+                    request.key, request.options.title
+                ));
                 continue;
             }
 
@@ -1177,9 +1328,17 @@ impl App {
                     );
                     if revision_changed {
                         native.revision = request.revision;
+                        trace_native_window(format_args!(
+                            "sync update content key={:?} title={:?}",
+                            native.key, native.options.title
+                        ));
                         native.app.request_root_render();
                         native.window.request_redraw();
                     } else if options_changed && request.options.visible {
+                        trace_native_window(format_args!(
+                            "sync update options key={:?} title={:?} visible={}",
+                            native.key, native.options.title, request.options.visible
+                        ));
                         native.window.request_redraw();
                     }
                     continue;
@@ -1190,8 +1349,17 @@ impl App {
             native_windows_to_create.push(request);
         }
 
+        self.place_initial_native_windows_on_visible_monitors(
+            event_loop,
+            &mut native_windows_to_create,
+        );
+
         let mut native_window_shells = Vec::with_capacity(native_windows_to_create.len());
         for request in native_windows_to_create {
+            trace_native_window(format_args!(
+                "sync create key={:?} title={:?} visible={}",
+                request.key, request.options.title, request.options.visible
+            ));
             match Self::create_native_window_shell(event_loop, request, self.settings.headless) {
                 Ok(shell) => native_window_shells.push(shell),
                 Err(error) => {
@@ -1219,6 +1387,79 @@ impl App {
             "sync done in {}ms",
             sync_started.elapsed().as_millis()
         ));
+        if self.hidden_bootstrap_has_no_visible_peer_windows() {
+            event_loop.exit();
+        }
+    }
+
+    fn hidden_bootstrap_has_no_visible_peer_windows(&self) -> bool {
+        if self.settings.primary_window_visible || self.settings.headless {
+            return false;
+        }
+        if self
+            .native_windows
+            .values()
+            .any(|native| native.options.visible)
+        {
+            return false;
+        }
+
+        let requests = native_window::native_window_requests();
+        requests.is_empty()
+            || requests
+                .iter()
+                .all(|request| self.closed_native_windows.contains(&request.key))
+    }
+
+    fn place_initial_native_windows_on_visible_monitors(
+        &self,
+        event_loop: &dyn ActiveEventLoop,
+        requests: &mut [NativeWindowRequest],
+    ) {
+        let monitors = logical_monitor_rects(event_loop);
+        if monitors.is_empty() {
+            return;
+        }
+
+        let mut groups: HashMap<NativeWindowPlacementGroupKey, Vec<usize>> = HashMap::new();
+        for (index, request) in requests.iter().enumerate() {
+            if !request.options.visible
+                || !Self::native_window_options_have_screen_position(&request.options)
+            {
+                continue;
+            }
+            let key = request.group.as_ref().map_or(
+                NativeWindowPlacementGroupKey::Window(request.key),
+                |group| NativeWindowPlacementGroupKey::Group(group.id),
+            );
+            groups.entry(key).or_default().push(index);
+        }
+
+        for indices in groups.values() {
+            let Some(bounds) = native_window_request_bounds(requests, indices) else {
+                continue;
+            };
+            if monitors.iter().any(|monitor| {
+                monitor.contains_rect_with_margin(bounds, NATIVE_WINDOW_PLACEMENT_MARGIN)
+            }) {
+                continue;
+            }
+
+            let monitor = nearest_monitor_to_rect(&monitors, bounds);
+            let delta =
+                clamp_rect_to_monitor_delta(bounds, monitor, NATIVE_WINDOW_PLACEMENT_MARGIN);
+            if delta.x.abs() <= f32::EPSILON && delta.y.abs() <= f32::EPSILON {
+                continue;
+            }
+
+            for index in indices {
+                let options = &mut requests[*index].options;
+                if let (Some(x), Some(y)) = (options.x, options.y) {
+                    options.x = Some(x + delta.x);
+                    options.y = Some(y + delta.y);
+                }
+            }
+        }
     }
 
     fn native_window_request_for_host(&self, request: &NativeWindowRequest) -> NativeWindowRequest {
@@ -1279,7 +1520,10 @@ impl App {
     }
 
     fn remember_native_window_position(&mut self, native: &NativeWindowSurface) {
-        if let Some((x, y)) = current_native_window_position(native) {
+        if let Some((x, y)) = Self::initial_native_window_position(
+            &native.options,
+            current_native_window_position(native),
+        ) {
             self.native_window_positions.insert(native.key, (x, y));
             if let Some(state) = native.state {
                 if state.position_non_reactive().is_none() {
@@ -1287,6 +1531,20 @@ impl App {
                 }
             }
             notify_native_window_moved(&native.events, x, y);
+        }
+    }
+
+    fn initial_native_window_position(
+        options: &NativeWindowOptions,
+        current_position: Option<(f32, f32)>,
+    ) -> Option<(f32, f32)> {
+        if Self::native_window_options_have_screen_position(options) {
+            Some((
+                options.x.expect("screen x should exist"),
+                options.y.expect("screen y should exist"),
+            ))
+        } else {
+            current_position
         }
     }
 
@@ -1511,6 +1769,7 @@ impl App {
             window,
             surface,
             surface_config,
+            surface_caps,
             app,
             platform,
             last_cursor_position: None,
@@ -1670,32 +1929,106 @@ impl App {
         true
     }
 
+    fn handle_native_primary_pressed(&mut self, native: &mut NativeWindowSurface) -> bool {
+        let drag_requested = Rc::new(Cell::new(false));
+        let drag_requested_for_handler = Rc::clone(&drag_requested);
+        let drag_handler: Rc<dyn Fn() -> bool> = Rc::new(move || {
+            drag_requested_for_handler.set(true);
+            true
+        });
+        let resize_window = native.window.clone();
+        let resize_handler: Rc<dyn Fn(WindowResizeDirection)> = Rc::new(move |direction| {
+            if let Err(error) = resize_window.drag_resize_window(native_resize_direction(direction))
+            {
+                log::debug!("native window resize request failed: {error}");
+            }
+        });
+        let handled =
+            native_window::with_native_window_drag_handler(drag_handler, resize_handler, || {
+                native_window::with_native_window_surface_origin(
+                    native_window_surface_origin(&native.window),
+                    || native.app.pointer_pressed(),
+                )
+            });
+        if handled {
+            native.window.request_redraw();
+            if drag_requested.get() {
+                trace_native_window(format_args!("drag requested key={:?}", native.key));
+                Self::sync_native_window_position_from_os(
+                    native,
+                    &mut self.native_window_positions,
+                );
+                for other_native in self.native_windows.values_mut() {
+                    Self::sync_native_window_position_from_os(
+                        other_native,
+                        &mut self.native_window_positions,
+                    );
+                }
+                let graph_snapshots = self.native_window_graph_snapshots_with(native, None);
+                self.window_graph.start_drag(&graph_snapshots, native.key);
+                if !Self::start_native_window_drag(native) {
+                    trace_native_window(format_args!(
+                        "drag cancel key={:?} reason=start-failed",
+                        native.key
+                    ));
+                    self.window_graph.cancel_drag();
+                }
+            }
+        }
+        handled
+    }
+
     fn start_native_window_drag(native: &mut NativeWindowSurface) -> bool {
-        let fallback_position = native
-            .last_cursor_physical_position
-            .and_then(|position| native_window_screen_pointer_physical(&native.window, position));
-        let Some(pointer) = native_window_global_pointer_state()
+        let now = Instant::now();
+        if let Some(session) = Self::native_window_polling_drag_session(native, now) {
+            let pointer = session.start_pointer_screen;
+            let window_outer = session.start_window_outer;
+            native.active_drag = Some(NativeWindowDragSession::Polling(session));
+            trace_native_window(format_args!(
+                "drag start polling key={:?} pointer=({:.1},{:.1}) outer=({},{})",
+                native.key, pointer.x, pointer.y, window_outer.x, window_outer.y
+            ));
+            return true;
+        }
+
+        match native.window.drag_window() {
+            Ok(()) => {
+                native.active_drag = Some(NativeWindowDragSession::platform(now));
+                trace_native_window(format_args!("drag start platform key={:?}", native.key));
+                return true;
+            }
+            Err(error) => {
+                log::debug!("native window drag request failed: {error}");
+            }
+        }
+
+        false
+    }
+
+    fn native_window_polling_drag_session(
+        native: &NativeWindowSurface,
+        now: Instant,
+    ) -> Option<NativeWindowPollingDragSession> {
+        let pointer = native_window_global_pointer_state()
             .map(|state| state.position)
-            .or(fallback_position)
-        else {
-            return false;
-        };
-        let Some(window_outer) = current_native_window_physical_position(&native.window) else {
-            return false;
-        };
-        native.active_drag = Some(NativeWindowDragSession::new(
+            .or_else(|| {
+                native.last_cursor_physical_position.and_then(|position| {
+                    native_window_screen_pointer_physical(&native.window, position)
+                })
+            })?;
+        let window_outer = current_native_window_physical_position(&native.window)?;
+        Some(NativeWindowPollingDragSession::new(
             pointer,
             window_outer,
-            Instant::now(),
-        ));
-        true
+            now,
+        ))
     }
 
     fn poll_active_native_window_drags(&mut self, now: Instant) -> bool {
         let has_due_drag = self.native_windows.values().any(|native| {
             native
                 .active_drag
-                .is_some_and(|active_drag| active_drag.next_poll_at <= now)
+                .is_some_and(|active_drag| active_drag.next_poll_at() <= now)
         });
         if !has_due_drag {
             return false;
@@ -1708,24 +2041,34 @@ impl App {
             let Some(active_drag) = native.active_drag.as_mut() else {
                 continue;
             };
-            if active_drag.next_poll_at > now {
+            if active_drag.next_poll_at() > now {
                 continue;
             }
-            active_drag.next_poll_at = now + NATIVE_WINDOW_DRAG_POLL_INTERVAL;
+            active_drag.set_next_poll_at(now + NATIVE_WINDOW_DRAG_POLL_INTERVAL);
 
             let Some(pointer) = pointer else {
+                trace_native_window(format_args!(
+                    "drag poll skipped key={:?} reason=no-global-pointer",
+                    native.key
+                ));
                 continue;
             };
-            if !pointer.primary_down {
+            if !pointer.primary_down && active_drag.finishes_on_global_pointer_release() {
                 native.active_drag = None;
                 finish_drag = true;
+                trace_native_window(format_args!(
+                    "drag finish key={:?} reason=global-release",
+                    native.key
+                ));
                 if native.app.pointer_released() {
                     native.window.request_redraw();
                 }
                 native.app.sync_selection_to_primary();
                 continue;
             }
-            if let Some(update) = Self::update_native_window_drag_target(native, pointer.position) {
+            if let Some(update) =
+                Self::update_native_window_polling_drag_target(native, pointer.position)
+            {
                 updates.push(update);
             }
         }
@@ -1740,17 +2083,21 @@ impl App {
         moved
     }
 
-    fn update_native_window_drag_target(
+    fn update_native_window_polling_drag_target(
         native: &mut NativeWindowSurface,
         pointer: PhysicalPosition<f64>,
     ) -> Option<(NativeWindowKey, cranpose_ui::Point)> {
-        let active_drag = native.active_drag.as_mut()?;
+        let active_drag = native.active_drag.as_mut()?.polling_mut()?;
         let target = active_drag.target_for_pointer(pointer);
         if target == active_drag.last_target_outer {
             return None;
         }
         active_drag.last_target_outer = target;
         let logical = target.to_logical::<f64>(native.window.scale_factor());
+        trace_native_window(format_args!(
+            "drag target key={:?} logical=({:.1},{:.1}) physical=({},{})",
+            native.key, logical.x, logical.y, target.x, target.y
+        ));
         Some((
             native.key,
             cranpose_ui::Point::new(logical.x as f32, logical.y as f32),
@@ -1774,6 +2121,7 @@ impl App {
         let mut finish_graph_drag_after_insert = false;
         match event {
             WindowEvent::CloseRequested => {
+                trace_native_window(format_args!("event close-request key={:?}", native.key));
                 notify_native_window_close_requested(&native.events);
                 self.remember_native_window_position(&native);
                 self.native_window_ids.remove(&native.key);
@@ -1856,22 +2204,55 @@ impl App {
                 });
                 let acknowledged_programmatic_move =
                     native.pending_outer_positions.acknowledge(position);
+                trace_native_window(format_args!(
+                    "event moved key={:?} pos=({:.1},{:.1}) acknowledged={} active_drag={}",
+                    native.key,
+                    position.0,
+                    position.1,
+                    acknowledged_programmatic_move,
+                    native.active_drag.is_some()
+                ));
                 self.native_window_positions.insert(native.key, position);
                 update_native_options_position(&mut native.options, position.0, position.1);
                 if !acknowledged_programmatic_move {
+                    let position = cranpose_ui::Point::new(position.0, position.1);
                     native.pending_outer_positions.clear();
-                    notify_native_window_moved(&native.events, position.0, position.1);
+                    notify_native_window_moved(&native.events, position.x, position.y);
                     sync_native_window_state_position(
                         native.state,
                         previous_state_position,
-                        position.0,
-                        position.1,
+                        position.x,
+                        position.y,
                     );
-                    graph_moves_after_insert = self.window_graph.external_move(
-                        &previous_graph_snapshots,
-                        native.key,
-                        cranpose_ui::Point::new(position.0, position.1),
-                    );
+                    if native.active_drag.is_some() {
+                        graph_moves_after_insert = self.window_graph.drag_to(native.key, position);
+                    } else if native_window_global_pointer_state().is_some_and(|pointer| {
+                        pointer.primary_down
+                            && native_window_surface_contains_pointer(&native, pointer.position)
+                            && previous_graph_position.is_some_and(|previous| {
+                                native_window_surface_at_logical_position_contains_pointer(
+                                    &native.window,
+                                    previous,
+                                    pointer.position,
+                                )
+                            })
+                    }) {
+                        self.window_graph
+                            .start_drag(&previous_graph_snapshots, native.key);
+                        native.active_drag =
+                            Some(NativeWindowDragSession::platform(Instant::now()));
+                        trace_native_window(format_args!(
+                            "drag start inferred-platform key={:?}",
+                            native.key
+                        ));
+                        graph_moves_after_insert = self.window_graph.drag_to(native.key, position);
+                    } else {
+                        graph_moves_after_insert = self.window_graph.external_move(
+                            &previous_graph_snapshots,
+                            native.key,
+                            position,
+                        );
+                    }
                     sync_after_event = true;
                 }
             }
@@ -1886,7 +2267,7 @@ impl App {
                     .or(fallback_pointer)
                 {
                     if let Some((key, position)) =
-                        Self::update_native_window_drag_target(&mut native, pointer)
+                        Self::update_native_window_polling_drag_target(&mut native, pointer)
                     {
                         graph_drag_after_insert = Some((key, position));
                         sync_after_event = true;
@@ -1897,6 +2278,7 @@ impl App {
                     || native.app.set_cursor(logical.x, logical.y),
                 );
                 if handled {
+                    native.window.request_redraw();
                     sync_after_event = true;
                 }
             }
@@ -1917,6 +2299,10 @@ impl App {
                 button: ButtonSource::Mouse(MouseButton::Left),
                 ..
             } => {
+                trace_native_window(format_args!(
+                    "event pointer-button key={:?} state={:?} cursor={:?}",
+                    native.key, state, native.last_cursor_position
+                ));
                 if let Some((x, y)) = native.last_cursor_position {
                     native_window::with_native_window_surface_origin(
                         native_window_surface_origin(&native.window),
@@ -1925,59 +2311,39 @@ impl App {
                 }
                 match state {
                     ElementState::Pressed => {
-                        let drag_requested = Rc::new(Cell::new(false));
-                        let drag_requested_for_handler = Rc::clone(&drag_requested);
-                        let drag_handler: Rc<dyn Fn() -> bool> = Rc::new(move || {
-                            drag_requested_for_handler.set(true);
-                            true
-                        });
-                        let resize_window = native.window.clone();
-                        let resize_handler: Rc<dyn Fn(WindowResizeDirection)> =
-                            Rc::new(move |direction| {
-                                if let Err(error) = resize_window
-                                    .drag_resize_window(native_resize_direction(direction))
-                                {
-                                    log::debug!("native window resize request failed: {error}");
-                                }
-                            });
-                        let handled = native_window::with_native_window_drag_handler(
-                            drag_handler,
-                            resize_handler,
-                            || {
-                                native_window::with_native_window_surface_origin(
-                                    native_window_surface_origin(&native.window),
-                                    || native.app.pointer_pressed(),
-                                )
-                            },
-                        );
-                        if handled {
-                            if drag_requested.get() {
-                                Self::sync_native_window_position_from_os(
-                                    &mut native,
-                                    &mut self.native_window_positions,
-                                );
-                                for other_native in self.native_windows.values_mut() {
-                                    Self::sync_native_window_position_from_os(
-                                        other_native,
-                                        &mut self.native_window_positions,
-                                    );
-                                }
-                                let graph_snapshots =
-                                    self.native_window_graph_snapshots_with(&native, None);
-                                self.window_graph.start_drag(&graph_snapshots, native.key);
-                                Self::start_native_window_drag(&mut native);
-                            }
+                        if self.handle_native_primary_pressed(&mut native) {
                             sync_after_event = true;
                         }
                     }
                     ElementState::Released => {
+                        let fallback_pointer =
+                            native.last_cursor_physical_position.and_then(|position| {
+                                native_window_screen_pointer_physical(&native.window, position)
+                            });
+                        if let Some(pointer) = native_window_global_pointer_state()
+                            .map(|state| state.position)
+                            .or(fallback_pointer)
+                        {
+                            if let Some((key, position)) =
+                                Self::update_native_window_polling_drag_target(&mut native, pointer)
+                            {
+                                graph_drag_after_insert = Some((key, position));
+                            }
+                        }
                         finish_graph_drag_after_insert = native.active_drag.take().is_some();
+                        if finish_graph_drag_after_insert {
+                            trace_native_window(format_args!(
+                                "drag finish key={:?} reason=local-release",
+                                native.key
+                            ));
+                        }
                         let handled = native_window::with_native_window_surface_origin(
                             native_window_surface_origin(&native.window),
                             || native.app.pointer_released(),
                         );
                         native.app.sync_selection_to_primary();
                         if handled {
+                            native.window.request_redraw();
                             sync_after_event = true;
                         }
                     }
@@ -2037,7 +2403,7 @@ impl App {
                 sync_after_event = true;
             }
             if sync_after_event {
-                self.sync_native_windows(event_loop);
+                self.refresh_and_sync_native_windows(event_loop);
             }
         }
     }
@@ -2127,6 +2493,102 @@ fn frame_interval_for_mode(mode: FramePacingMode, vsync_interval: Duration) -> O
         FramePacingMode::Hard60 => Some(Duration::from_nanos(16_666_667)),
         FramePacingMode::Hard120 => Some(Duration::from_nanos(8_333_333)),
         FramePacingMode::NoVsync => None,
+    }
+}
+
+fn logical_monitor_rects(event_loop: &dyn ActiveEventLoop) -> Vec<DesktopRect> {
+    event_loop
+        .available_monitors()
+        .filter_map(|monitor| logical_monitor_rect(&monitor))
+        .collect()
+}
+
+fn logical_monitor_rect(monitor: &winit::monitor::MonitorHandle) -> Option<DesktopRect> {
+    let position = monitor.position()?;
+    let scale_factor = monitor.scale_factor() as f32;
+    if scale_factor <= 0.0 {
+        return None;
+    }
+    let size = monitor.current_video_mode()?.size();
+    Some(DesktopRect {
+        x: position.x as f32 / scale_factor,
+        y: position.y as f32 / scale_factor,
+        width: size.width as f32 / scale_factor,
+        height: size.height as f32 / scale_factor,
+    })
+}
+
+fn native_window_request_bounds(
+    requests: &[NativeWindowRequest],
+    indices: &[usize],
+) -> Option<DesktopRect> {
+    let mut bounds = None::<DesktopRect>;
+    for index in indices {
+        let options = &requests[*index].options;
+        let (Some(x), Some(y)) = (options.x, options.y) else {
+            continue;
+        };
+        let rect = DesktopRect {
+            x,
+            y,
+            width: options.width.max(1.0),
+            height: options.height.max(1.0),
+        };
+        bounds = Some(match bounds {
+            Some(current) => union_desktop_rect(current, rect),
+            None => rect,
+        });
+    }
+    bounds
+}
+
+fn union_desktop_rect(a: DesktopRect, b: DesktopRect) -> DesktopRect {
+    let x = a.x.min(b.x);
+    let y = a.y.min(b.y);
+    let right = a.right().max(b.right());
+    let bottom = a.bottom().max(b.bottom());
+    DesktopRect {
+        x,
+        y,
+        width: right - x,
+        height: bottom - y,
+    }
+}
+
+fn nearest_monitor_to_rect(monitors: &[DesktopRect], rect: DesktopRect) -> DesktopRect {
+    let center = rect.center();
+    *monitors
+        .iter()
+        .min_by(|a, b| {
+            a.distance_to_point(center)
+                .total_cmp(&b.distance_to_point(center))
+        })
+        .expect("at least one monitor")
+}
+
+fn clamp_rect_to_monitor_delta(
+    rect: DesktopRect,
+    monitor: DesktopRect,
+    margin: f32,
+) -> cranpose_ui::Point {
+    let target_x = clamped_axis_origin(rect.x, rect.width, monitor.x, monitor.width, margin);
+    let target_y = clamped_axis_origin(rect.y, rect.height, monitor.y, monitor.height, margin);
+    cranpose_ui::Point::new(target_x - rect.x, target_y - rect.y)
+}
+
+fn clamped_axis_origin(
+    origin: f32,
+    length: f32,
+    monitor_origin: f32,
+    monitor_length: f32,
+    margin: f32,
+) -> f32 {
+    let min = monitor_origin + margin;
+    let max = monitor_origin + monitor_length - margin - length;
+    if max >= min {
+        origin.clamp(min, max)
+    } else {
+        monitor_origin + (monitor_length - length) / 2.0
     }
 }
 
@@ -2281,6 +2743,49 @@ fn native_window_screen_pointer_physical(
         outer.x as f64 + surface.x as f64 + local.x,
         outer.y as f64 + surface.y as f64 + local.y,
     ))
+}
+
+fn native_window_surface_contains_pointer(
+    native: &NativeWindowSurface,
+    pointer: PhysicalPosition<f64>,
+) -> bool {
+    let Some(outer) = current_native_window_physical_position(&native.window) else {
+        return false;
+    };
+    physical_surface_rect_contains_pointer(
+        outer,
+        native.window.surface_position(),
+        native.window.surface_size(),
+        pointer,
+    )
+}
+
+fn native_window_surface_at_logical_position_contains_pointer(
+    window: &Arc<dyn Window>,
+    position: cranpose_ui::Point,
+    pointer: PhysicalPosition<f64>,
+) -> bool {
+    let outer = LogicalPosition::new(position.x as f64, position.y as f64)
+        .to_physical::<i32>(window.scale_factor());
+    physical_surface_rect_contains_pointer(
+        outer,
+        window.surface_position(),
+        window.surface_size(),
+        pointer,
+    )
+}
+
+fn physical_surface_rect_contains_pointer(
+    outer: PhysicalPosition<i32>,
+    surface: PhysicalPosition<i32>,
+    size: PhysicalSize<u32>,
+    pointer: PhysicalPosition<f64>,
+) -> bool {
+    let x = outer.x as f64 + surface.x as f64;
+    let y = outer.y as f64 + surface.y as f64;
+    let right = x + size.width as f64;
+    let bottom = y + size.height as f64;
+    pointer.x >= x && pointer.x <= right && pointer.y >= y && pointer.y <= bottom
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -2499,6 +3004,31 @@ fn trace_native_window_timing(args: std::fmt::Arguments<'_>) {
     if std::env::var_os("CRANPOSE_NATIVE_WINDOW_TIMING").is_some() {
         println!("native window timing: {args}");
     }
+}
+
+fn trace_native_window(args: std::fmt::Arguments<'_>) {
+    if std::env::var_os("CRANPOSE_NATIVE_TRACE").is_some() {
+        println!("native window trace: {args}");
+    }
+}
+
+fn primary_surface_redraw_drives_app(primary_window_visible: bool, headless: bool) -> bool {
+    primary_window_visible && !headless
+}
+
+fn primary_frame_waker_uses_event_proxy(primary_window_visible: bool, headless: bool) -> bool {
+    !primary_surface_redraw_drives_app(primary_window_visible, headless)
+}
+
+fn primary_declaration_host_needs_direct_update(
+    primary_window_visible: bool,
+    headless: bool,
+    needs_redraw: bool,
+    waiting_for_frame_cap: bool,
+) -> bool {
+    needs_redraw
+        && !waiting_for_frame_cap
+        && !primary_surface_redraw_drives_app(primary_window_visible, headless)
 }
 
 fn configure_app_surface_size(
@@ -2776,6 +3306,10 @@ fn dispatch_ime_event(app: &mut AppShell<WgpuRenderer>, ime_event: winit::event:
 }
 
 impl ApplicationHandler for App {
+    fn proxy_wake_up(&mut self, event_loop: &dyn ActiveEventLoop) {
+        self.handle_primary_frame_requested(event_loop);
+    }
+
     fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
         // Create window if not already created
         if self.window.is_some() {
@@ -2898,8 +3432,17 @@ impl ApplicationHandler for App {
         // Runtime-driven frame scheduling: Compose invalidations and animations
         // request frames via the runtime waker, not per-input host redraw forcing.
         let frame_waker_window = window.clone();
+        let frame_waker_event_proxy = self.event_proxy.clone();
+        let use_event_proxy = primary_frame_waker_uses_event_proxy(
+            self.settings.primary_window_visible,
+            self.settings.headless,
+        );
         app.set_frame_waker(move || {
-            frame_waker_window.request_redraw();
+            if use_event_proxy {
+                frame_waker_event_proxy.wake_up();
+            } else {
+                frame_waker_window.request_redraw();
+            }
         });
 
         let mut platform = DesktopWinitPlatform::default();
@@ -3058,6 +3601,18 @@ impl ApplicationHandler for App {
                                 self.frame_pacing_mode = mode;
                                 self.last_frame_start_time = None;
                                 window.request_redraw();
+                                for native in self.native_windows.values_mut() {
+                                    apply_frame_pacing_mode(
+                                        &mut native.app,
+                                        &native.surface,
+                                        &mut native.surface_config,
+                                        Some(&native.surface_caps),
+                                        mode,
+                                    );
+                                    native.frame_pacing_mode = mode;
+                                    native.last_frame_start_time = None;
+                                    native.window.request_redraw();
+                                }
                                 return;
                             }
                         }
@@ -3171,7 +3726,9 @@ impl ApplicationHandler for App {
         let frame_interval = self.frame_interval();
         let last_frame_start_time = self.last_frame_start_time;
         let Some(app) = &mut self.app else { return };
-        let Some(window) = &self.window else { return };
+        let Some(window) = self.window.clone() else {
+            return;
+        };
 
         // Handle pending robot commands
         #[cfg(feature = "robot")]
@@ -3513,8 +4070,26 @@ impl ApplicationHandler for App {
             .and_then(|started_at| frame_interval.map(|interval| started_at + interval));
         let waiting_for_frame_cap =
             needs_redraw && next_frame_time.is_some_and(|deadline| deadline > now);
+        let direct_declaration_update = primary_declaration_host_needs_direct_update(
+            self.settings.primary_window_visible,
+            self.settings.headless,
+            needs_redraw,
+            waiting_for_frame_cap,
+        );
         if needs_redraw && !waiting_for_frame_cap {
-            window.request_redraw();
+            if direct_declaration_update {
+                trace_native_window(format_args!(
+                    "primary declaration host direct update visible={} headless={}",
+                    self.settings.primary_window_visible, self.settings.headless
+                ));
+                app.update();
+            } else {
+                window.request_redraw();
+            }
+        }
+        let primary_next_event_time = app.next_event_time();
+        if direct_declaration_update {
+            self.sync_native_windows(event_loop);
         }
 
         let mut native_has_active_animations = false;
@@ -3541,10 +4116,11 @@ impl ApplicationHandler for App {
                 native.window.request_redraw();
             }
             if let Some(active_drag) = native.active_drag {
+                let next_poll_at = active_drag.next_poll_at();
                 native_drag_deadline = Some(
                     native_drag_deadline
-                        .map(|current| current.min(active_drag.next_poll_at))
-                        .unwrap_or(active_drag.next_poll_at),
+                        .map(|current| current.min(next_poll_at))
+                        .unwrap_or(next_poll_at),
                 );
             }
             if waiting_for_frame_cap {
@@ -3574,10 +4150,9 @@ impl ApplicationHandler for App {
         // Poll continuously when:
         // - Active animations are running
         // - Robot test is active
-        if robot_needs_poll {
+        if robot_needs_poll || native_drag_deadline.is_some() {
             event_loop.set_control_flow(ControlFlow::Poll);
         } else if let Some(deadline) = [
-            native_drag_deadline,
             next_frame_time.filter(|_| waiting_for_frame_cap),
             native_frame_cap_deadline,
         ]
@@ -3588,7 +4163,7 @@ impl ApplicationHandler for App {
             event_loop.set_control_flow(ControlFlow::WaitUntil(deadline));
         } else if has_active_animations || native_has_active_animations {
             event_loop.set_control_flow(ControlFlow::Poll);
-        } else if let Some(next_time) = [app.next_event_time(), native_next_event_time]
+        } else if let Some(next_time) = [primary_next_event_time, native_next_event_time]
             .into_iter()
             .flatten()
             .min()
@@ -3616,6 +4191,7 @@ pub fn try_run(
     let event_loop = EventLoop::builder()
         .build()
         .map_err(LaunchError::EventLoopCreate)?;
+    let event_proxy = event_loop.create_proxy();
     let launch_error = Rc::new(RefCell::new(None));
 
     // Spawn test driver if present
@@ -3636,7 +4212,7 @@ pub fn try_run(
         None
     };
 
-    let mut app = App::new(settings, content, Rc::clone(&launch_error));
+    let mut app = App::new(settings, content, Rc::clone(&launch_error), event_proxy);
 
     #[cfg(feature = "robot")]
     if let Some(controller) = robot_controller {
@@ -4079,11 +4655,14 @@ fn char_to_key_code(ch: char) -> cranpose_app_shell::KeyCode {
 #[cfg(test)]
 mod tests {
     use super::{
-        App, NativeWindowDragSession, NativeWindowOptions, NativeWindowPositionOrigin,
-        PendingNativeWindowPositions,
+        clamp_rect_to_monitor_delta, nearest_monitor_to_rect,
+        physical_surface_rect_contains_pointer, primary_declaration_host_needs_direct_update,
+        primary_frame_waker_uses_event_proxy, primary_surface_redraw_drives_app, App, DesktopRect,
+        NativeWindowDragSession, NativeWindowOptions, NativeWindowPollingDragSession,
+        NativeWindowPositionOrigin, PendingNativeWindowPositions,
     };
     use std::time::Instant;
-    use winit::dpi::PhysicalPosition;
+    use winit::dpi::{PhysicalPosition, PhysicalSize};
 
     #[cfg(feature = "robot")]
     use super::{
@@ -4119,6 +4698,109 @@ mod tests {
     }
 
     #[test]
+    fn native_window_initial_position_prefers_declaration_over_early_os_position() {
+        let options = NativeWindowOptions::new("child", 100.0, 50.0).with_position(10.0, 20.0);
+
+        assert_eq!(
+            App::initial_native_window_position(&options, Some((0.0, 0.0))),
+            Some((10.0, 20.0))
+        );
+    }
+
+    #[test]
+    fn native_window_initial_position_uses_os_position_without_declaration() {
+        let options = NativeWindowOptions::new("child", 100.0, 50.0);
+
+        assert_eq!(
+            App::initial_native_window_position(&options, Some((30.0, 40.0))),
+            Some((30.0, 40.0))
+        );
+    }
+
+    #[test]
+    fn native_window_group_bounds_move_from_virtual_gap_to_nearest_monitor() {
+        let monitors = [
+            DesktopRect {
+                x: 0.0,
+                y: 630.0,
+                width: 1420.0,
+                height: 800.0,
+            },
+            DesktopRect {
+                x: 1920.0,
+                y: 0.0,
+                width: 3840.0,
+                height: 2160.0,
+            },
+        ];
+        let group_bounds = DesktopRect {
+            x: 140.0,
+            y: 120.0,
+            width: 550.0,
+            height: 319.0,
+        };
+
+        let monitor = nearest_monitor_to_rect(&monitors, group_bounds);
+        let delta = clamp_rect_to_monitor_delta(group_bounds, monitor, 32.0);
+
+        assert_eq!(monitor, monitors[0]);
+        assert_eq!(delta, cranpose_ui::Point::new(0.0, 542.0));
+    }
+
+    #[test]
+    fn native_window_group_bounds_preserve_visible_position() {
+        let monitor = DesktopRect {
+            x: 0.0,
+            y: 630.0,
+            width: 1420.0,
+            height: 800.0,
+        };
+        let group_bounds = DesktopRect {
+            x: 140.0,
+            y: 700.0,
+            width: 550.0,
+            height: 319.0,
+        };
+
+        let delta = clamp_rect_to_monitor_delta(group_bounds, monitor, 32.0);
+
+        assert_eq!(delta, cranpose_ui::Point::new(0.0, 0.0));
+    }
+
+    #[test]
+    fn visible_primary_surface_drives_redraw_updates() {
+        assert!(primary_surface_redraw_drives_app(true, false));
+        assert!(!primary_surface_redraw_drives_app(false, false));
+        assert!(!primary_surface_redraw_drives_app(true, true));
+    }
+
+    #[test]
+    fn hidden_primary_frame_waker_uses_event_loop_proxy() {
+        assert!(!primary_frame_waker_uses_event_proxy(true, false));
+        assert!(primary_frame_waker_uses_event_proxy(false, false));
+        assert!(primary_frame_waker_uses_event_proxy(true, true));
+    }
+
+    #[test]
+    fn hidden_primary_declaration_host_updates_without_redraw_event() {
+        assert!(primary_declaration_host_needs_direct_update(
+            false, false, true, false
+        ));
+        assert!(primary_declaration_host_needs_direct_update(
+            true, true, true, false
+        ));
+        assert!(!primary_declaration_host_needs_direct_update(
+            true, false, true, false
+        ));
+        assert!(!primary_declaration_host_needs_direct_update(
+            false, false, true, true
+        ));
+        assert!(!primary_declaration_host_needs_direct_update(
+            false, false, false, false
+        ));
+    }
+
+    #[test]
     fn pending_native_window_positions_acknowledge_stale_programmatic_moves() {
         let mut pending = PendingNativeWindowPositions::default();
         pending.push((100.0, 200.0));
@@ -4151,8 +4833,8 @@ mod tests {
     }
 
     #[test]
-    fn native_window_drag_target_is_anchored_to_drag_start() {
-        let session = NativeWindowDragSession::new(
+    fn native_window_polling_drag_target_is_anchored_to_drag_start() {
+        let session = NativeWindowPollingDragSession::new(
             PhysicalPosition::new(100.0, 50.0),
             PhysicalPosition::new(300, 200),
             Instant::now(),
@@ -4169,8 +4851,8 @@ mod tests {
     }
 
     #[test]
-    fn native_window_drag_target_does_not_accumulate_window_manager_lag() {
-        let session = NativeWindowDragSession::new(
+    fn native_window_polling_drag_target_does_not_accumulate_window_manager_lag() {
+        let session = NativeWindowPollingDragSession::new(
             PhysicalPosition::new(100.0, 50.0),
             PhysicalPosition::new(300, 200),
             Instant::now(),
@@ -4185,6 +4867,41 @@ mod tests {
             PhysicalPosition::new(320, 200),
             "the target must be based on the drag start, not on the last reported window position"
         );
+    }
+
+    #[test]
+    fn native_window_polling_drag_uses_local_release_event() {
+        let now = Instant::now();
+
+        assert!(
+            !NativeWindowDragSession::Polling(NativeWindowPollingDragSession::new(
+                PhysicalPosition::new(100.0, 50.0),
+                PhysicalPosition::new(300, 200),
+                now,
+            ))
+            .finishes_on_global_pointer_release()
+        );
+        assert!(NativeWindowDragSession::platform(now).finishes_on_global_pointer_release());
+    }
+
+    #[test]
+    fn inferred_native_drag_requires_pointer_over_surface() {
+        let outer = PhysicalPosition::new(300, 200);
+        let surface = PhysicalPosition::new(8, 28);
+        let size = PhysicalSize::new(120, 60);
+
+        assert!(physical_surface_rect_contains_pointer(
+            outer,
+            surface,
+            size,
+            PhysicalPosition::new(320.0, 240.0)
+        ));
+        assert!(!physical_surface_rect_contains_pointer(
+            outer,
+            surface,
+            size,
+            PhysicalPosition::new(299.0, 240.0)
+        ));
     }
 
     #[cfg(feature = "robot")]

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -1849,21 +1849,17 @@ impl App {
             WindowEvent::KeyboardInput { event, .. } => {
                 dispatch_keyboard_input(&mut native.app, self.current_modifiers, event);
             }
-            WindowEvent::Focused(false) => {
-                native.active_drag = None;
+            WindowEvent::Focused(false) if native.active_drag.is_none() => {
                 cancel_app_input(&mut native.app);
             }
+            WindowEvent::Focused(false) => {}
             WindowEvent::Ime(ime_event) => {
                 dispatch_ime_event(&mut native.app, ime_event);
             }
-            WindowEvent::PointerLeft { .. } => {
-                let drag_still_has_global_pointer = native.active_drag.is_some()
-                    && native_window_global_pointer_state().is_some_and(|state| state.primary_down);
-                if !drag_still_has_global_pointer {
-                    native.active_drag = None;
-                    native.app.cancel_gesture();
-                }
+            WindowEvent::PointerLeft { .. } if native.active_drag.is_none() => {
+                native.app.cancel_gesture();
             }
+            WindowEvent::PointerLeft { .. } => {}
             WindowEvent::RedrawRequested => {
                 if let Some(deadline) = native.last_frame_start_time.and_then(|started_at| {
                     native

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -3,26 +3,29 @@
 //! This module provides the desktop event loop implementation using winit.
 
 use crate::launcher::{AppSettings, LaunchError};
+use crate::native_window::{
+    self, NativeWindowEvents, NativeWindowKey, NativeWindowOptions, NativeWindowPositionOrigin,
+    NativeWindowRequest, WindowResizeDirection, WindowState,
+};
 #[cfg(feature = "robot")]
 use cranpose_app_shell::RuntimeLeakDebugStats;
 use cranpose_app_shell::{default_root_key, AppShell, FramePacingMode};
 use cranpose_platform_desktop_winit::DesktopWinitPlatform;
-use cranpose_render_wgpu::WgpuRenderer;
 #[cfg(feature = "robot")]
 use cranpose_render_wgpu::{DebugCpuAllocationStats, RenderStatsSnapshot};
+use cranpose_render_wgpu::{WgpuRenderer, WgpuTextSystem};
 #[cfg(feature = "robot")]
 use std::any::Any;
-use std::cell::RefCell;
-#[cfg(feature = "robot")]
-use std::collections::HashMap;
+use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use winit::application::ApplicationHandler;
-use winit::dpi::LogicalSize;
+use winit::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, Position};
 use winit::event::{ButtonSource, ElementState, MouseButton, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
-use winit::window::{Window, WindowAttributes, WindowId};
+use winit::window::{ResizeDirection, Window, WindowAttributes, WindowId, WindowLevel};
 
 #[cfg(feature = "robot")]
 use cranpose_ui::{SemanticsAction, SemanticsNode, SemanticsRole};
@@ -869,6 +872,111 @@ impl Robot {
 }
 
 /// Application state that implements winit's ApplicationHandler
+struct DesktopGpuContext {
+    instance: wgpu::Instance,
+    adapter: wgpu::Adapter,
+    adapter_backend: wgpu::Backend,
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    text_system: WgpuTextSystem,
+}
+
+struct NativeWindowSurface {
+    key: NativeWindowKey,
+    revision: u64,
+    options: NativeWindowOptions,
+    events: NativeWindowEvents,
+    state: Option<WindowState>,
+    window: Arc<dyn Window>,
+    surface: wgpu::Surface<'static>,
+    surface_config: wgpu::SurfaceConfiguration,
+    app: AppShell<WgpuRenderer>,
+    platform: DesktopWinitPlatform,
+    last_cursor_position: Option<(f32, f32)>,
+    last_cursor_physical_position: Option<PhysicalPosition<f64>>,
+    frame_pacing_mode: FramePacingMode,
+    last_frame_start_time: Option<Instant>,
+    vsync_interval: Duration,
+    pending_outer_positions: PendingNativeWindowPositions,
+    active_drag: Option<NativeWindowDragSession>,
+}
+
+struct NativeWindowShell {
+    request: NativeWindowRequest,
+    window: Arc<dyn Window>,
+    create_started: Instant,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct NativeWindowDragSession {
+    last_pointer_screen: PhysicalPosition<f64>,
+}
+
+#[derive(Default)]
+struct PendingNativeWindowPositions {
+    positions: VecDeque<PendingNativeWindowPosition>,
+}
+
+struct PendingNativeWindowPosition {
+    position: (f32, f32),
+    created_at: Instant,
+}
+
+impl PendingNativeWindowPositions {
+    fn push(&mut self, position: (f32, f32)) {
+        if self
+            .positions
+            .back()
+            .is_some_and(|pending| native_window_positions_close(pending.position, position))
+        {
+            return;
+        }
+        self.positions.push_back(PendingNativeWindowPosition {
+            position,
+            created_at: Instant::now(),
+        });
+        while self.positions.len() > 16 {
+            self.positions.pop_front();
+        }
+    }
+
+    fn acknowledge(&mut self, position: (f32, f32)) -> bool {
+        let Some(index) = self
+            .positions
+            .iter()
+            .position(|pending| native_window_positions_close(pending.position, position))
+        else {
+            return false;
+        };
+        for _ in 0..=index {
+            self.positions.pop_front();
+        }
+        true
+    }
+
+    fn has_fresh_pending(&mut self, max_age: Duration) -> bool {
+        let now = Instant::now();
+        while self
+            .positions
+            .front()
+            .is_some_and(|pending| now.duration_since(pending.created_at) > max_age)
+        {
+            self.positions.pop_front();
+        }
+        !self.positions.is_empty()
+    }
+
+    fn clear(&mut self) {
+        self.positions.clear();
+    }
+}
+
+impl NativeWindowSurface {
+    fn frame_interval(&self) -> Option<Duration> {
+        frame_interval_for_mode(self.frame_pacing_mode, self.vsync_interval)
+    }
+}
+
 struct App {
     /// Settings for the application
     settings: AppSettings,
@@ -886,6 +994,16 @@ struct App {
     app: Option<AppShell<WgpuRenderer>>,
     /// Platform adapter
     platform: Option<DesktopWinitPlatform>,
+    /// Shared GPU objects used by all desktop surfaces.
+    gpu_context: Option<DesktopGpuContext>,
+    /// Native sub-window surfaces keyed by the operating-system window id.
+    native_windows: HashMap<WindowId, NativeWindowSurface>,
+    /// Declarative native sub-window ids mapped to their current OS window id.
+    native_window_ids: HashMap<NativeWindowKey, WindowId>,
+    /// Last observed OS positions for declarative native sub-windows.
+    native_window_positions: HashMap<NativeWindowKey, (f32, f32)>,
+    /// Native sub-windows closed by the user while still declared by composition.
+    closed_native_windows: HashSet<NativeWindowKey>,
     /// Current keyboard modifiers (shift, ctrl, alt, meta)
     current_modifiers: winit::keyboard::ModifiersState,
     /// Last known cursor position in logical pixels
@@ -929,6 +1047,11 @@ impl App {
             surface_caps: None,
             app: None,
             platform: None,
+            gpu_context: None,
+            native_windows: HashMap::new(),
+            native_window_ids: HashMap::new(),
+            native_window_positions: HashMap::new(),
+            closed_native_windows: HashSet::new(),
             current_modifiers: winit::keyboard::ModifiersState::empty(),
             last_cursor_position: None,
             #[cfg(feature = "robot")]
@@ -952,12 +1075,827 @@ impl App {
     }
 
     fn frame_interval(&self) -> Option<Duration> {
-        match self.frame_pacing_mode {
-            FramePacingMode::Vsync => Some(self.vsync_interval),
-            FramePacingMode::Hard60 => Some(Duration::from_nanos(16_666_667)),
-            FramePacingMode::Hard120 => Some(Duration::from_nanos(8_333_333)),
-            FramePacingMode::NoVsync => None,
+        frame_interval_for_mode(self.frame_pacing_mode, self.vsync_interval)
+    }
+
+    fn refresh_native_window_requests(&mut self) {
+        if let Some(app) = &mut self.app {
+            app.update();
         }
+    }
+
+    fn sync_native_windows(&mut self, event_loop: &dyn ActiveEventLoop) {
+        if self.gpu_context.is_none() {
+            return;
+        }
+
+        let has_requests = native_window::has_native_window_requests();
+        if self.native_windows.is_empty() && self.closed_native_windows.is_empty() && !has_requests
+        {
+            return;
+        }
+        if !has_requests
+            && self.closed_native_windows.is_empty()
+            && self
+                .native_windows
+                .values()
+                .all(|native| !native.options.visible)
+        {
+            return;
+        }
+
+        let sync_started = Instant::now();
+        let requests = native_window::native_window_requests();
+        let active_keys: HashSet<NativeWindowKey> =
+            requests.iter().map(|request| request.key).collect();
+        trace_native_window_timing(format_args!(
+            "sync start requests={} existing={}",
+            requests.len(),
+            self.native_windows.len()
+        ));
+
+        self.closed_native_windows
+            .retain(|key| active_keys.contains(key));
+
+        let stale_window_ids: Vec<WindowId> = self
+            .native_windows
+            .iter()
+            .filter_map(|(window_id, native)| {
+                (!active_keys.contains(&native.key)).then_some(*window_id)
+            })
+            .collect();
+        for window_id in stale_window_ids {
+            if let Some(native) = self.native_windows.get(&window_id) {
+                if let Some((x, y)) = current_native_window_position(native) {
+                    self.native_window_positions.insert(native.key, (x, y));
+                    notify_native_window_moved(&native.events, x, y);
+                }
+            }
+            if let Some(native) = self.native_windows.get_mut(&window_id) {
+                if native.options.visible {
+                    native.window.set_visible(false);
+                    native.options.visible = false;
+                    cancel_app_input(&mut native.app);
+                }
+            }
+        }
+
+        let mut native_windows_to_create = Vec::new();
+        for request in requests {
+            if self.closed_native_windows.contains(&request.key) {
+                continue;
+            }
+
+            let request = self.native_window_request_for_host(&request);
+            if let Some(window_id) = self.native_window_ids.get(&request.key).copied() {
+                if let Some(native) = self.native_windows.get_mut(&window_id) {
+                    native.events = request.events.clone();
+                    native.state = request.state;
+                    let revision_changed = native.revision != request.revision;
+                    let options_changed = native.options != request.options;
+                    Self::apply_native_window_options(
+                        native,
+                        &request.options,
+                        self.settings.headless,
+                    );
+                    if revision_changed {
+                        native.revision = request.revision;
+                        native.app.request_root_render();
+                        native.window.request_redraw();
+                    } else if options_changed && request.options.visible {
+                        native.window.request_redraw();
+                    }
+                    continue;
+                }
+                self.native_window_ids.remove(&request.key);
+            }
+
+            native_windows_to_create.push(request);
+        }
+
+        let mut native_window_shells = Vec::with_capacity(native_windows_to_create.len());
+        for request in native_windows_to_create {
+            match Self::create_native_window_shell(event_loop, request, self.settings.headless) {
+                Ok(shell) => native_window_shells.push(shell),
+                Err(error) => {
+                    self.abort_launch(event_loop, error);
+                    return;
+                }
+            }
+        }
+
+        for shell in native_window_shells {
+            match self.create_native_window(shell) {
+                Ok(native) => {
+                    let window_id = native.window.id();
+                    self.remember_native_window_position(&native);
+                    self.native_window_ids.insert(native.key, window_id);
+                    self.native_windows.insert(window_id, native);
+                }
+                Err(error) => {
+                    self.abort_launch(event_loop, error);
+                    return;
+                }
+            }
+        }
+        trace_native_window_timing(format_args!(
+            "sync done in {}ms",
+            sync_started.elapsed().as_millis()
+        ));
+    }
+
+    fn native_window_request_for_host(&self, request: &NativeWindowRequest) -> NativeWindowRequest {
+        let mut request = request.clone();
+        Self::apply_native_window_state_to_options(&mut request.options, request.state);
+        if Self::native_window_options_have_screen_position(&request.options) {
+            request.options = self.resolve_native_window_options(&request.options);
+        } else if let Some((x, y)) = self.native_window_positions.get(&request.key).copied() {
+            request.options.x = Some(x);
+            request.options.y = Some(y);
+            request.options.position_origin = NativeWindowPositionOrigin::Screen;
+        } else {
+            request.options = self.resolve_native_window_options(&request.options);
+        }
+        request
+    }
+
+    fn apply_native_window_state_to_options(
+        options: &mut NativeWindowOptions,
+        state: Option<WindowState>,
+    ) {
+        let Some(state) = state else {
+            return;
+        };
+        let size = state.size_non_reactive();
+        options.width = size.width;
+        options.height = size.height;
+        if let Some(position) = state.position_non_reactive() {
+            options.x = Some(position.x);
+            options.y = Some(position.y);
+            options.position_origin = NativeWindowPositionOrigin::Screen;
+        }
+    }
+
+    fn resolve_native_window_options(&self, options: &NativeWindowOptions) -> NativeWindowOptions {
+        let mut options = options.clone();
+        if options.position_origin == NativeWindowPositionOrigin::HostWindow {
+            if let (Some(x), Some(y), Some((host_x, host_y))) =
+                (options.x, options.y, self.host_window_position())
+            {
+                options.x = Some(host_x + x);
+                options.y = Some(host_y + y);
+            }
+            options.position_origin = NativeWindowPositionOrigin::Screen;
+        }
+        options
+    }
+
+    fn native_window_options_have_screen_position(options: &NativeWindowOptions) -> bool {
+        options.position_origin == NativeWindowPositionOrigin::Screen
+            && options.x.is_some()
+            && options.y.is_some()
+    }
+
+    fn host_window_position(&self) -> Option<(f32, f32)> {
+        let window = self.window.as_ref()?;
+        logical_outer_position(window)
+    }
+
+    fn remember_native_window_position(&mut self, native: &NativeWindowSurface) {
+        if let Some((x, y)) = current_native_window_position(native) {
+            self.native_window_positions.insert(native.key, (x, y));
+            if let Some(state) = native.state {
+                if state.position_non_reactive().is_none() {
+                    state.set_position(Some(cranpose_ui::Point::new(x, y)));
+                }
+            }
+            notify_native_window_moved(&native.events, x, y);
+        }
+    }
+
+    fn create_native_window_shell(
+        event_loop: &dyn ActiveEventLoop,
+        request: NativeWindowRequest,
+        headless: bool,
+    ) -> Result<NativeWindowShell, LaunchError> {
+        let create_started = Instant::now();
+        let options = &request.options;
+        let attributes = native_window_attributes(options, headless);
+
+        let window: Arc<dyn Window> = event_loop
+            .create_window(attributes)
+            .map_err(LaunchError::WindowCreate)?
+            .into();
+        trace_native_window_timing(format_args!(
+            "{} create_window {}ms",
+            options.title,
+            create_started.elapsed().as_millis()
+        ));
+        Ok(NativeWindowShell {
+            request,
+            window,
+            create_started,
+        })
+    }
+
+    fn create_native_window(
+        &self,
+        shell: NativeWindowShell,
+    ) -> Result<NativeWindowSurface, LaunchError> {
+        let NativeWindowShell {
+            request,
+            window,
+            create_started,
+        } = shell;
+        let context = self
+            .gpu_context
+            .as_ref()
+            .expect("native windows require an initialized desktop GPU context");
+
+        let options = &request.options;
+        let surface = context
+            .instance
+            .create_surface(window.clone())
+            .map_err(LaunchError::SurfaceCreate)?;
+        trace_native_window_timing(format_args!(
+            "{} create_surface {}ms",
+            options.title,
+            create_started.elapsed().as_millis()
+        ));
+        let surface_caps = surface.get_capabilities(&context.adapter);
+        let surface_format = select_surface_format(&surface_caps);
+        let present_mode = desktop_present_mode(&surface_caps, self.frame_pacing_mode);
+        let size = window.surface_size();
+        let surface_config = surface_config_for_window(
+            &surface_caps,
+            surface_format,
+            size.width.max(1),
+            size.height.max(1),
+            present_mode,
+            options.transparent,
+            self.frame_pacing_mode,
+        );
+        surface.configure(&context.device, &surface_config);
+        trace_native_window_timing(format_args!(
+            "{} configure {}ms",
+            options.title,
+            create_started.elapsed().as_millis()
+        ));
+
+        let scale_factor = window.scale_factor();
+        let renderer = wgpu_renderer_for_surface(
+            context.text_system.clone(),
+            Arc::clone(&context.device),
+            Arc::clone(&context.queue),
+            surface_format,
+            context.adapter_backend,
+            scale_factor,
+        );
+        trace_native_window_timing(format_args!(
+            "{} renderer {}ms",
+            options.title,
+            create_started.elapsed().as_millis()
+        ));
+        cranpose_ui::set_density(scale_factor as f32);
+
+        let content = request.content.clone();
+        let viewport = (
+            surface_config.width as f32 / scale_factor as f32,
+            surface_config.height as f32 / scale_factor as f32,
+        );
+        let mut app = AppShell::new_with_size(
+            renderer,
+            default_root_key(),
+            move || {
+                (content.borrow_mut())();
+            },
+            (surface_config.width, surface_config.height),
+            viewport,
+        );
+        let mut dev_options = self.settings.dev_options.clone();
+        dev_options.frame_pacing_mode = self.frame_pacing_mode;
+        dev_options.frame_pacing_controls = false;
+        app.set_dev_options(dev_options);
+        trace_native_window_timing(format_args!(
+            "{} app_shell {}ms",
+            options.title,
+            create_started.elapsed().as_millis()
+        ));
+
+        let frame_waker_window = window.clone();
+        app.set_frame_waker(move || {
+            frame_waker_window.request_redraw();
+        });
+
+        let mut platform = DesktopWinitPlatform::default();
+        platform.set_scale_factor(scale_factor);
+        window.request_redraw();
+        trace_native_window_timing(format_args!(
+            "{} create done {}ms",
+            options.title,
+            create_started.elapsed().as_millis()
+        ));
+
+        Ok(NativeWindowSurface {
+            key: request.key,
+            revision: request.revision,
+            options: request.options.clone(),
+            events: request.events.clone(),
+            state: request.state,
+            window,
+            surface,
+            surface_config,
+            app,
+            platform,
+            last_cursor_position: None,
+            last_cursor_physical_position: None,
+            frame_pacing_mode: self.frame_pacing_mode,
+            last_frame_start_time: None,
+            vsync_interval: default_vsync_interval(),
+            pending_outer_positions: PendingNativeWindowPositions::default(),
+            active_drag: None,
+        })
+    }
+
+    fn apply_native_window_options(
+        native: &mut NativeWindowSurface,
+        options: &NativeWindowOptions,
+        headless: bool,
+    ) {
+        if native.options.title != options.title {
+            native.window.set_title(&options.title);
+        }
+        if native.options.decorations != options.decorations {
+            native.window.set_decorations(options.decorations);
+        }
+        if native.options.resizable != options.resizable {
+            native.window.set_resizable(options.resizable);
+        }
+        if native.options.transparent != options.transparent {
+            native.window.set_transparent(options.transparent);
+        }
+        if native.options.always_on_top != options.always_on_top {
+            native
+                .window
+                .set_window_level(native_window_level(options.always_on_top));
+        }
+        if native.options.min_width != options.min_width
+            || native.options.min_height != options.min_height
+        {
+            native
+                .window
+                .set_min_surface_size(match (options.min_width, options.min_height) {
+                    (Some(width), Some(height)) => {
+                        Some(LogicalSize::new(width.max(1.0) as f64, height.max(1.0) as f64).into())
+                    }
+                    _ => None,
+                });
+        }
+        if native.options.max_width != options.max_width
+            || native.options.max_height != options.max_height
+        {
+            native
+                .window
+                .set_max_surface_size(match (options.max_width, options.max_height) {
+                    (Some(width), Some(height)) => {
+                        Some(LogicalSize::new(width.max(1.0) as f64, height.max(1.0) as f64).into())
+                    }
+                    _ => None,
+                });
+        }
+        if native.options.visible != options.visible {
+            native.window.set_visible(!headless && options.visible);
+        }
+        if native.options.x != options.x || native.options.y != options.y {
+            if let (Some(x), Some(y)) = (options.x, options.y) {
+                native.pending_outer_positions.push((x, y));
+                native
+                    .window
+                    .set_outer_position(Position::Logical(LogicalPosition::new(
+                        x as f64, y as f64,
+                    )));
+            }
+        }
+        if native.options.width != options.width || native.options.height != options.height {
+            if let Some(size) = native.window.request_surface_size(
+                LogicalSize::new(
+                    options.width.max(1.0) as f64,
+                    options.height.max(1.0) as f64,
+                )
+                .into(),
+            ) {
+                Self::resize_native_surface(native, size.width, size.height);
+            }
+        }
+        native.options = options.clone();
+    }
+
+    fn resize_native_surface(native: &mut NativeWindowSurface, width: u32, height: u32) {
+        configure_app_surface_size(
+            &mut native.app,
+            &native.window,
+            &native.surface,
+            &mut native.surface_config,
+            width,
+            height,
+        );
+    }
+
+    fn start_native_window_drag(native: &mut NativeWindowSurface) -> bool {
+        let fallback_position = native
+            .last_cursor_physical_position
+            .and_then(|position| native_window_screen_pointer_physical(&native.window, position));
+        let Some(pointer) = native_window_global_pointer_physical().or(fallback_position) else {
+            return false;
+        };
+        native.active_drag = Some(NativeWindowDragSession {
+            last_pointer_screen: pointer,
+        });
+        true
+    }
+
+    fn poll_active_native_window_drags(&mut self) -> bool {
+        let Some(pointer) = native_window_global_pointer_physical() else {
+            return false;
+        };
+        let mut updates = Vec::new();
+        for native in self.native_windows.values_mut() {
+            if native.active_drag.is_some() {
+                if let Some(update) = Self::update_native_window_drag(native, pointer) {
+                    updates.push(update);
+                }
+            }
+        }
+        let moved = !updates.is_empty();
+        for (key, position) in updates {
+            self.native_window_positions.insert(key, position);
+        }
+        moved
+    }
+
+    fn poll_native_window_positions(&mut self) -> bool {
+        let mut changed = false;
+        let native_window_positions = &mut self.native_window_positions;
+        for native in self.native_windows.values_mut() {
+            if !native.options.visible {
+                continue;
+            }
+            let Some(position) = current_native_window_position(native) else {
+                continue;
+            };
+            if native_window_positions
+                .get(&native.key)
+                .is_some_and(|known| native_window_positions_close(*known, position))
+            {
+                continue;
+            }
+
+            let acknowledged_programmatic_move =
+                native.pending_outer_positions.acknowledge(position);
+            if !acknowledged_programmatic_move
+                && native
+                    .pending_outer_positions
+                    .has_fresh_pending(Duration::from_millis(180))
+            {
+                continue;
+            }
+
+            let previous_state_position =
+                native.state.and_then(|state| state.position_non_reactive());
+            native_window_positions.insert(native.key, position);
+            update_native_options_position(&mut native.options, position.0, position.1);
+            if acknowledged_programmatic_move {
+                continue;
+            }
+
+            native.pending_outer_positions.clear();
+            notify_native_window_moved(&native.events, position.0, position.1);
+            sync_native_window_state_position(
+                native.state,
+                previous_state_position,
+                position.0,
+                position.1,
+            );
+            changed = true;
+        }
+        changed
+    }
+
+    fn update_native_window_drag(
+        native: &mut NativeWindowSurface,
+        pointer: PhysicalPosition<f64>,
+    ) -> Option<(NativeWindowKey, (f32, f32))> {
+        let active_drag = native.active_drag.as_mut()?;
+        let delta = PhysicalPosition::new(
+            pointer.x - active_drag.last_pointer_screen.x,
+            pointer.y - active_drag.last_pointer_screen.y,
+        );
+        active_drag.last_pointer_screen = pointer;
+        if delta.x.abs() <= f64::EPSILON && delta.y.abs() <= f64::EPSILON {
+            return None;
+        }
+
+        let current = current_native_window_physical_position(&native.window)?;
+        let target = PhysicalPosition::new(
+            (current.x as f64 + delta.x).round() as i32,
+            (current.y as f64 + delta.y).round() as i32,
+        );
+        let logical = target.to_logical::<f64>(native.window.scale_factor());
+        let logical_position = (logical.x as f32, logical.y as f32);
+        native.pending_outer_positions.push(logical_position);
+        if !native_window_set_outer_position_physical(&native.window, target) {
+            native.window.set_outer_position(Position::Physical(target));
+        }
+        update_native_options_position(&mut native.options, logical_position.0, logical_position.1);
+        let previous_state_position = native.state.and_then(|state| state.position_non_reactive());
+        notify_native_window_moved(&native.events, logical_position.0, logical_position.1);
+        sync_native_window_state_position(
+            native.state,
+            previous_state_position,
+            logical_position.0,
+            logical_position.1,
+        );
+        Some((native.key, logical_position))
+    }
+
+    fn native_window_event(
+        &mut self,
+        event_loop: &dyn ActiveEventLoop,
+        window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        let Some(mut native) = self.native_windows.remove(&window_id) else {
+            return;
+        };
+
+        let mut keep_window = true;
+        let mut sync_after_event = false;
+        match event {
+            WindowEvent::CloseRequested => {
+                notify_native_window_close_requested(&native.events);
+                self.remember_native_window_position(&native);
+                self.native_window_ids.remove(&native.key);
+                self.closed_native_windows.insert(native.key);
+                keep_window = false;
+            }
+            WindowEvent::SurfaceResized(new_size) => {
+                let previous_state_size = native.state.map(|state| state.size_non_reactive());
+                update_native_options_size(
+                    &mut native.options,
+                    &native.window,
+                    new_size.width,
+                    new_size.height,
+                );
+                notify_native_window_resized(
+                    &native.events,
+                    &native.window,
+                    new_size.width,
+                    new_size.height,
+                );
+                sync_native_window_state_size(
+                    native.state,
+                    previous_state_size,
+                    &native.window,
+                    new_size.width,
+                    new_size.height,
+                );
+                Self::resize_native_surface(&mut native, new_size.width, new_size.height);
+                sync_after_event = true;
+            }
+            WindowEvent::ScaleFactorChanged {
+                scale_factor,
+                mut surface_size_writer,
+            } => {
+                let previous_state_size = native.state.map(|state| state.size_non_reactive());
+                update_app_scale_factor(&mut native.app, &mut native.platform, scale_factor);
+
+                let new_size = native.window.surface_size();
+                let _ = surface_size_writer.request_surface_size(new_size);
+                update_native_options_size(
+                    &mut native.options,
+                    &native.window,
+                    new_size.width,
+                    new_size.height,
+                );
+                notify_native_window_resized(
+                    &native.events,
+                    &native.window,
+                    new_size.width,
+                    new_size.height,
+                );
+                sync_native_window_state_size(
+                    native.state,
+                    previous_state_size,
+                    &native.window,
+                    new_size.width,
+                    new_size.height,
+                );
+                Self::resize_native_surface(&mut native, new_size.width, new_size.height);
+                sync_after_event = true;
+            }
+            WindowEvent::Moved(position) => {
+                native.vsync_interval = monitor_refresh_interval(&native.window);
+                let previous_state_position =
+                    native.state.and_then(|state| state.position_non_reactive());
+                let logical = position.to_logical::<f64>(native.window.scale_factor());
+                let position = (logical.x as f32, logical.y as f32);
+                let acknowledged_programmatic_move =
+                    native.pending_outer_positions.acknowledge(position);
+                self.native_window_positions.insert(native.key, position);
+                update_native_options_position(&mut native.options, position.0, position.1);
+                if !acknowledged_programmatic_move {
+                    native.pending_outer_positions.clear();
+                    notify_native_window_moved(&native.events, position.0, position.1);
+                    sync_native_window_state_position(
+                        native.state,
+                        previous_state_position,
+                        position.0,
+                        position.1,
+                    );
+                    sync_after_event = true;
+                }
+            }
+            WindowEvent::PointerMoved { position, .. } => {
+                let logical = native.platform.pointer_position(position);
+                native.last_cursor_position = Some((logical.x, logical.y));
+                native.last_cursor_physical_position = Some(position);
+                let fallback_pointer =
+                    native_window_screen_pointer_physical(&native.window, position);
+                if let Some(pointer) = native_window_global_pointer_physical().or(fallback_pointer)
+                {
+                    if let Some((key, position)) =
+                        Self::update_native_window_drag(&mut native, pointer)
+                    {
+                        self.native_window_positions.insert(key, position);
+                        event_loop.set_control_flow(ControlFlow::Poll);
+                        sync_after_event = true;
+                    }
+                }
+                let handled = native_window::with_native_window_surface_origin(
+                    native_window_surface_origin(&native.window),
+                    || native.app.set_cursor(logical.x, logical.y),
+                );
+                if handled {
+                    sync_after_event = true;
+                }
+            }
+            WindowEvent::ModifiersChanged(modifiers) => {
+                self.current_modifiers = modifiers.state();
+            }
+            WindowEvent::MouseWheel { delta, .. } => {
+                dispatch_mouse_wheel(
+                    &mut native.app,
+                    &native.platform,
+                    self.current_modifiers,
+                    native.last_cursor_position,
+                    delta,
+                );
+            }
+            WindowEvent::PointerButton {
+                state,
+                button: ButtonSource::Mouse(MouseButton::Left),
+                ..
+            } => {
+                if let Some((x, y)) = native.last_cursor_position {
+                    native_window::with_native_window_surface_origin(
+                        native_window_surface_origin(&native.window),
+                        || native.app.set_cursor(x, y),
+                    );
+                }
+                match state {
+                    ElementState::Pressed => {
+                        let drag_requested = Rc::new(Cell::new(false));
+                        let drag_requested_for_handler = Rc::clone(&drag_requested);
+                        let drag_handler: Rc<dyn Fn()> = Rc::new(move || {
+                            drag_requested_for_handler.set(true);
+                        });
+                        let resize_window = native.window.clone();
+                        let resize_handler: Rc<dyn Fn(WindowResizeDirection)> =
+                            Rc::new(move |direction| {
+                                if let Err(error) = resize_window
+                                    .drag_resize_window(native_resize_direction(direction))
+                                {
+                                    log::debug!("native window resize request failed: {error}");
+                                }
+                            });
+                        let handled = native_window::with_native_window_drag_handler(
+                            drag_handler,
+                            resize_handler,
+                            || {
+                                native_window::with_native_window_surface_origin(
+                                    native_window_surface_origin(&native.window),
+                                    || native.app.pointer_pressed(),
+                                )
+                            },
+                        );
+                        if handled {
+                            if drag_requested.get() && Self::start_native_window_drag(&mut native) {
+                                event_loop.set_control_flow(ControlFlow::Poll);
+                            }
+                            sync_after_event = true;
+                        }
+                    }
+                    ElementState::Released => {
+                        native.active_drag = None;
+                        let handled = native_window::with_native_window_surface_origin(
+                            native_window_surface_origin(&native.window),
+                            || native.app.pointer_released(),
+                        );
+                        native.app.sync_selection_to_primary();
+                        if handled {
+                            sync_after_event = true;
+                        }
+                    }
+                }
+            }
+            WindowEvent::PointerButton {
+                state: ElementState::Pressed,
+                button: ButtonSource::Mouse(MouseButton::Middle),
+                ..
+            } => {
+                dispatch_middle_click_paste(&mut native.app, native.last_cursor_position);
+            }
+            WindowEvent::KeyboardInput { event, .. } => {
+                dispatch_keyboard_input(&mut native.app, self.current_modifiers, event);
+            }
+            WindowEvent::Focused(false) => {
+                native.active_drag = None;
+                cancel_app_input(&mut native.app);
+            }
+            WindowEvent::Ime(ime_event) => {
+                dispatch_ime_event(&mut native.app, ime_event);
+            }
+            WindowEvent::PointerLeft { .. } => {
+                native.active_drag = None;
+                native.app.cancel_gesture();
+            }
+            WindowEvent::RedrawRequested => {
+                if let Some(deadline) = native.last_frame_start_time.and_then(|started_at| {
+                    native
+                        .frame_interval()
+                        .map(|interval| started_at + interval)
+                }) {
+                    if deadline > Instant::now() {
+                        event_loop.set_control_flow(ControlFlow::WaitUntil(deadline));
+                        self.native_windows.insert(window_id, native);
+                        return;
+                    }
+                }
+                Self::redraw_native_window(event_loop, &mut native);
+            }
+            _ => {}
+        }
+
+        if keep_window {
+            self.native_windows.insert(window_id, native);
+            if sync_after_event {
+                self.sync_native_windows(event_loop);
+            }
+        }
+    }
+
+    fn redraw_native_window(event_loop: &dyn ActiveEventLoop, native: &mut NativeWindowSurface) {
+        let frame_started_at = Instant::now();
+        let scale_factor = native.window.scale_factor();
+        cranpose_ui::set_density(scale_factor as f32);
+        native.app.update();
+
+        let output = match native.surface.get_current_texture() {
+            Ok(output) => output,
+            Err(wgpu::SurfaceError::Lost) | Err(wgpu::SurfaceError::Outdated) => {
+                let size = native.window.surface_size();
+                Self::resize_native_surface(native, size.width, size.height);
+                return;
+            }
+            Err(wgpu::SurfaceError::OutOfMemory) => {
+                log::error!("native window surface out of memory, exiting");
+                event_loop.exit();
+                return;
+            }
+            Err(wgpu::SurfaceError::Timeout) => {
+                log::debug!("native window surface timeout, skipping frame");
+                return;
+            }
+            Err(wgpu::SurfaceError::Other) => {
+                log::error!("native window surface other error, skipping frame");
+                return;
+            }
+        };
+
+        let view = output
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        if let Err(error) = native.app.renderer().render(
+            &view,
+            native.surface_config.width,
+            native.surface_config.height,
+        ) {
+            log::error!("native window render failed: {error:?}");
+            return;
+        }
+
+        output.present();
+        native.last_frame_start_time = Some(frame_started_at);
     }
 
     #[cfg(feature = "robot")]
@@ -995,6 +1933,545 @@ fn desired_frame_latency(mode: FramePacingMode) -> u32 {
     }
 }
 
+fn frame_interval_for_mode(mode: FramePacingMode, vsync_interval: Duration) -> Option<Duration> {
+    match mode {
+        FramePacingMode::Vsync => Some(vsync_interval),
+        FramePacingMode::Hard60 => Some(Duration::from_nanos(16_666_667)),
+        FramePacingMode::Hard120 => Some(Duration::from_nanos(8_333_333)),
+        FramePacingMode::NoVsync => None,
+    }
+}
+
+fn native_window_attributes(options: &NativeWindowOptions, headless: bool) -> WindowAttributes {
+    let mut attributes = WindowAttributes::default()
+        .with_title(options.title.clone())
+        .with_surface_size(LogicalSize::new(
+            options.width.max(1.0) as f64,
+            options.height.max(1.0) as f64,
+        ))
+        .with_decorations(options.decorations)
+        .with_transparent(options.transparent)
+        .with_resizable(options.resizable)
+        .with_visible(!headless && options.visible)
+        .with_window_level(native_window_level(options.always_on_top));
+    if let (Some(width), Some(height)) = (options.min_width, options.min_height) {
+        attributes = attributes.with_min_surface_size(LogicalSize::new(
+            width.max(1.0) as f64,
+            height.max(1.0) as f64,
+        ));
+    }
+    if let (Some(width), Some(height)) = (options.max_width, options.max_height) {
+        attributes = attributes.with_max_surface_size(LogicalSize::new(
+            width.max(1.0) as f64,
+            height.max(1.0) as f64,
+        ));
+    }
+    if let (Some(x), Some(y)) = (options.x, options.y) {
+        attributes =
+            attributes.with_position(Position::Logical(LogicalPosition::new(x as f64, y as f64)));
+    }
+    attributes
+}
+
+fn desktop_present_mode(
+    surface_caps: &wgpu::SurfaceCapabilities,
+    frame_pacing_mode: FramePacingMode,
+) -> wgpu::PresentMode {
+    if std::env::var_os("CRANPOSE_PRESENT_MODE").is_some() {
+        crate::present_mode::select_present_mode(surface_caps)
+    } else {
+        crate::present_mode::select_present_mode_for_frame_pacing(surface_caps, frame_pacing_mode)
+    }
+}
+
+fn surface_config_for_window(
+    surface_caps: &wgpu::SurfaceCapabilities,
+    surface_format: wgpu::TextureFormat,
+    width: u32,
+    height: u32,
+    present_mode: wgpu::PresentMode,
+    transparent: bool,
+    frame_pacing_mode: FramePacingMode,
+) -> wgpu::SurfaceConfiguration {
+    wgpu::SurfaceConfiguration {
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        format: surface_format,
+        width,
+        height,
+        present_mode,
+        alpha_mode: select_alpha_mode(surface_caps, transparent),
+        view_formats: vec![],
+        desired_maximum_frame_latency: desired_frame_latency(frame_pacing_mode),
+    }
+}
+
+fn wgpu_renderer_for_surface(
+    text_system: WgpuTextSystem,
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    surface_format: wgpu::TextureFormat,
+    backend: wgpu::Backend,
+    scale_factor: f64,
+) -> WgpuRenderer {
+    let mut renderer = WgpuRenderer::with_text_system(text_system);
+    renderer.set_root_scale(scale_factor as f32);
+    renderer.init_gpu(device, queue, surface_format, backend);
+    renderer
+}
+
+fn select_surface_format(surface_caps: &wgpu::SurfaceCapabilities) -> wgpu::TextureFormat {
+    surface_caps
+        .formats
+        .iter()
+        .copied()
+        .find(|f| f.is_srgb())
+        .unwrap_or(surface_caps.formats[0])
+}
+
+fn select_alpha_mode(
+    surface_caps: &wgpu::SurfaceCapabilities,
+    transparent: bool,
+) -> wgpu::CompositeAlphaMode {
+    if transparent {
+        surface_caps
+            .alpha_modes
+            .iter()
+            .copied()
+            .find(|mode| *mode == wgpu::CompositeAlphaMode::PreMultiplied)
+            .unwrap_or(surface_caps.alpha_modes[0])
+    } else {
+        surface_caps
+            .alpha_modes
+            .iter()
+            .copied()
+            .find(|mode| *mode == wgpu::CompositeAlphaMode::Opaque)
+            .unwrap_or(surface_caps.alpha_modes[0])
+    }
+}
+
+fn native_window_level(always_on_top: bool) -> WindowLevel {
+    if always_on_top {
+        WindowLevel::AlwaysOnTop
+    } else {
+        WindowLevel::Normal
+    }
+}
+
+fn current_native_window_physical_position(
+    window: &Arc<dyn Window>,
+) -> Option<PhysicalPosition<i32>> {
+    native_window_x11_outer_position_physical(window).or_else(|| window.outer_position().ok())
+}
+
+fn current_native_window_position(native: &NativeWindowSurface) -> Option<(f32, f32)> {
+    current_native_window_physical_position(&native.window).map(|position| {
+        let logical = position.to_logical::<f64>(native.window.scale_factor());
+        (logical.x as f32, logical.y as f32)
+    })
+}
+
+fn native_window_positions_close(a: (f32, f32), b: (f32, f32)) -> bool {
+    (a.0 - b.0).abs() <= 1.0 && (a.1 - b.1).abs() <= 1.0
+}
+
+fn native_window_surface_origin(window: &Arc<dyn Window>) -> Option<cranpose_ui::Point> {
+    let outer = current_native_window_physical_position(window)?;
+    let surface = window.surface_position();
+    let scale_factor = window.scale_factor();
+    let physical = winit::dpi::PhysicalPosition::new(outer.x + surface.x, outer.y + surface.y);
+    let logical = physical.to_logical::<f64>(scale_factor);
+    Some(cranpose_ui::Point::new(logical.x as f32, logical.y as f32))
+}
+
+fn native_window_screen_pointer_physical(
+    window: &Arc<dyn Window>,
+    local: PhysicalPosition<f64>,
+) -> Option<PhysicalPosition<f64>> {
+    let outer = current_native_window_physical_position(window)?;
+    let surface = window.surface_position();
+    Some(PhysicalPosition::new(
+        outer.x as f64 + surface.x as f64 + local.x,
+        outer.y as f64 + surface.y as f64 + local.y,
+    ))
+}
+
+#[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
+struct X11PointerClient {
+    connection: x11rb::rust_connection::RustConnection,
+    root: u32,
+}
+
+#[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
+enum X11PointerClientState {
+    Available(Box<X11PointerClient>),
+    Unavailable,
+}
+
+#[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
+thread_local! {
+    static X11_POINTER_CLIENT: RefCell<Option<X11PointerClientState>> = const { RefCell::new(None) };
+}
+
+#[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
+impl X11PointerClient {
+    fn connect() -> Option<Self> {
+        use x11rb::connection::Connection;
+
+        let (connection, screen_num) = x11rb::connect(None).ok()?;
+        let root = connection.setup().roots.get(screen_num)?.root;
+        Some(Self { connection, root })
+    }
+
+    fn pointer(&self) -> Option<PhysicalPosition<f64>> {
+        use x11rb::protocol::xproto::ConnectionExt;
+
+        let reply = self
+            .connection
+            .query_pointer(self.root)
+            .ok()?
+            .reply()
+            .ok()?;
+        Some(PhysicalPosition::new(
+            reply.root_x as f64,
+            reply.root_y as f64,
+        ))
+    }
+
+    fn configure_window(&self, window: u32, position: PhysicalPosition<i32>) -> Option<()> {
+        use x11rb::connection::Connection;
+        use x11rb::protocol::xproto::{ConfigureWindowAux, ConnectionExt};
+
+        self.connection
+            .configure_window(
+                window,
+                &ConfigureWindowAux::new().x(position.x).y(position.y),
+            )
+            .ok()?;
+        self.connection.flush().ok()?;
+        Some(())
+    }
+
+    fn window_position(&self, window: u32) -> Option<PhysicalPosition<i32>> {
+        use x11rb::protocol::xproto::ConnectionExt;
+
+        let reply = self
+            .connection
+            .translate_coordinates(window, self.root, 0, 0)
+            .ok()?
+            .reply()
+            .ok()?;
+        Some(PhysicalPosition::new(
+            reply.dst_x as i32,
+            reply.dst_y as i32,
+        ))
+    }
+}
+
+#[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
+fn native_window_global_pointer_physical() -> Option<PhysicalPosition<f64>> {
+    X11_POINTER_CLIENT.with(|slot| {
+        if slot.borrow().is_none() {
+            *slot.borrow_mut() = Some(
+                X11PointerClient::connect()
+                    .map(Box::new)
+                    .map(X11PointerClientState::Available)
+                    .unwrap_or(X11PointerClientState::Unavailable),
+            );
+        }
+
+        match slot.borrow().as_ref()? {
+            X11PointerClientState::Available(client) => client.pointer(),
+            X11PointerClientState::Unavailable => None,
+        }
+    })
+}
+
+#[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
+fn native_window_x11_id(window: &Arc<dyn Window>) -> Option<u32> {
+    use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    match window.window_handle().ok()?.as_raw() {
+        RawWindowHandle::Xlib(handle) => Some(handle.window as u32),
+        RawWindowHandle::Xcb(handle) => Some(handle.window.get()),
+        _ => None,
+    }
+}
+
+#[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
+fn native_window_x11_outer_position_physical(
+    window: &Arc<dyn Window>,
+) -> Option<PhysicalPosition<i32>> {
+    let window_id = native_window_x11_id(window)?;
+    X11_POINTER_CLIENT.with(|slot| {
+        if slot.borrow().is_none() {
+            *slot.borrow_mut() = Some(
+                X11PointerClient::connect()
+                    .map(Box::new)
+                    .map(X11PointerClientState::Available)
+                    .unwrap_or(X11PointerClientState::Unavailable),
+            );
+        }
+
+        match slot.borrow().as_ref()? {
+            X11PointerClientState::Available(client) => client.window_position(window_id),
+            X11PointerClientState::Unavailable => None,
+        }
+    })
+}
+
+#[cfg(not(all(target_os = "linux", not(target_arch = "wasm32"))))]
+fn native_window_x11_outer_position_physical(
+    _window: &Arc<dyn Window>,
+) -> Option<PhysicalPosition<i32>> {
+    None
+}
+
+#[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
+fn native_window_set_outer_position_physical(
+    window: &Arc<dyn Window>,
+    position: PhysicalPosition<i32>,
+) -> bool {
+    let Some(window_id) = native_window_x11_id(window) else {
+        return false;
+    };
+    X11_POINTER_CLIENT.with(|slot| {
+        if slot.borrow().is_none() {
+            *slot.borrow_mut() = Some(
+                X11PointerClient::connect()
+                    .map(Box::new)
+                    .map(X11PointerClientState::Available)
+                    .unwrap_or(X11PointerClientState::Unavailable),
+            );
+        }
+
+        match slot.borrow().as_ref() {
+            Some(X11PointerClientState::Available(client)) => {
+                client.configure_window(window_id, position).is_some()
+            }
+            _ => false,
+        }
+    })
+}
+
+#[cfg(not(all(target_os = "linux", not(target_arch = "wasm32"))))]
+fn native_window_set_outer_position_physical(
+    _window: &Arc<dyn Window>,
+    _position: PhysicalPosition<i32>,
+) -> bool {
+    false
+}
+
+#[cfg(not(all(target_os = "linux", not(target_arch = "wasm32"))))]
+fn native_window_global_pointer_physical() -> Option<PhysicalPosition<f64>> {
+    None
+}
+
+fn update_native_options_position(options: &mut NativeWindowOptions, x: f32, y: f32) {
+    options.x = Some(x);
+    options.y = Some(y);
+    options.position_origin = NativeWindowPositionOrigin::Screen;
+}
+
+fn update_native_options_size(
+    options: &mut NativeWindowOptions,
+    window: &Arc<dyn Window>,
+    width: u32,
+    height: u32,
+) {
+    let scale_factor = window.scale_factor() as f32;
+    if scale_factor > 0.0 {
+        options.width = width.max(1) as f32 / scale_factor;
+        options.height = height.max(1) as f32 / scale_factor;
+    }
+}
+
+fn sync_native_window_state_position(
+    state: Option<WindowState>,
+    previous_position: Option<cranpose_ui::Point>,
+    x: f32,
+    y: f32,
+) {
+    let Some(state) = state else {
+        return;
+    };
+    if state.position_non_reactive() == previous_position {
+        state.set_position(Some(cranpose_ui::Point::new(x, y)));
+    }
+}
+
+fn sync_native_window_state_size(
+    state: Option<WindowState>,
+    previous_size: Option<cranpose_ui::Size>,
+    window: &Arc<dyn Window>,
+    width: u32,
+    height: u32,
+) {
+    let Some(state) = state else {
+        return;
+    };
+    let Some(previous_size) = previous_size else {
+        return;
+    };
+    if state.size_non_reactive() != previous_size {
+        return;
+    }
+    let scale_factor = window.scale_factor() as f32;
+    if scale_factor > 0.0 {
+        state.set_size(cranpose_ui::Size::new(
+            width.max(1) as f32 / scale_factor,
+            height.max(1) as f32 / scale_factor,
+        ));
+    }
+}
+
+fn trace_native_window_timing(args: std::fmt::Arguments<'_>) {
+    if std::env::var_os("CRANPOSE_NATIVE_WINDOW_TIMING").is_some() {
+        println!("native window timing: {args}");
+    }
+}
+
+fn configure_app_surface_size(
+    app: &mut AppShell<WgpuRenderer>,
+    window: &Arc<dyn Window>,
+    surface: &wgpu::Surface<'static>,
+    surface_config: &mut wgpu::SurfaceConfiguration,
+    width: u32,
+    height: u32,
+) {
+    if width == 0 || height == 0 {
+        return;
+    }
+
+    surface_config.width = width;
+    surface_config.height = height;
+    let device = app.renderer().device();
+    surface.configure(device, surface_config);
+    update_app_viewport(app, window, width, height);
+}
+
+fn update_app_viewport(
+    app: &mut AppShell<WgpuRenderer>,
+    window: &Arc<dyn Window>,
+    width: u32,
+    height: u32,
+) {
+    let scale_factor = window.scale_factor();
+    app.set_buffer_size(width, height);
+    app.set_viewport(
+        width as f32 / scale_factor as f32,
+        height as f32 / scale_factor as f32,
+    );
+}
+
+fn update_app_scale_factor(
+    app: &mut AppShell<WgpuRenderer>,
+    platform: &mut DesktopWinitPlatform,
+    scale_factor: f64,
+) {
+    platform.set_scale_factor(scale_factor);
+    app.renderer().set_root_scale(scale_factor as f32);
+    cranpose_ui::set_density(scale_factor as f32);
+}
+
+fn dispatch_mouse_wheel(
+    app: &mut AppShell<WgpuRenderer>,
+    platform: &DesktopWinitPlatform,
+    current_modifiers: winit::keyboard::ModifiersState,
+    cursor_position: Option<(f32, f32)>,
+    delta: winit::event::MouseScrollDelta,
+) {
+    if let Some((x, y)) = cursor_position {
+        app.set_cursor(x, y);
+    }
+
+    let mut logical_delta = platform.scroll_delta(delta);
+    let alt_pressed = current_modifiers.contains(winit::keyboard::ModifiersState::ALT);
+    if alt_pressed {
+        if logical_delta.x.abs() <= f32::EPSILON {
+            logical_delta.x = logical_delta.y;
+        }
+        logical_delta.y = 0.0;
+    }
+
+    log::trace!(
+        target: "cranpose::input",
+        "desktop wheel delta ({:.2},{:.2}) alt={}",
+        logical_delta.x,
+        logical_delta.y,
+        alt_pressed
+    );
+
+    app.pointer_scrolled(logical_delta.x, logical_delta.y);
+}
+
+fn dispatch_middle_click_paste(
+    app: &mut AppShell<WgpuRenderer>,
+    cursor_position: Option<(f32, f32)>,
+) {
+    if let Some((x, y)) = cursor_position {
+        app.set_cursor(x, y);
+    }
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        not(target_os = "android"),
+        not(target_os = "ios")
+    ))]
+    if let Some(text) = app.get_primary_selection() {
+        app.on_paste(&text);
+    }
+}
+
+fn cancel_app_input(app: &mut AppShell<WgpuRenderer>) {
+    app.cancel_gesture();
+    let _ = app.on_ime_preedit("", None);
+}
+
+fn logical_outer_position(window: &Arc<dyn Window>) -> Option<(f32, f32)> {
+    window.outer_position().ok().map(|position| {
+        let logical = position.to_logical::<f64>(window.scale_factor());
+        (logical.x as f32, logical.y as f32)
+    })
+}
+
+fn notify_native_window_moved(events: &NativeWindowEvents, x: f32, y: f32) {
+    if let Some(on_moved) = &events.on_moved {
+        on_moved(x, y);
+    }
+}
+
+fn notify_native_window_resized(
+    events: &NativeWindowEvents,
+    window: &Arc<dyn Window>,
+    width: u32,
+    height: u32,
+) {
+    if let Some(on_resized) = &events.on_resized {
+        let scale_factor = window.scale_factor() as f32;
+        if scale_factor > 0.0 {
+            on_resized(width as f32 / scale_factor, height as f32 / scale_factor);
+        }
+    }
+}
+
+fn notify_native_window_close_requested(events: &NativeWindowEvents) {
+    if let Some(on_close_requested) = &events.on_close_requested {
+        on_close_requested();
+    }
+}
+
+fn native_resize_direction(direction: WindowResizeDirection) -> ResizeDirection {
+    match direction {
+        WindowResizeDirection::East => ResizeDirection::East,
+        WindowResizeDirection::North => ResizeDirection::North,
+        WindowResizeDirection::NorthEast => ResizeDirection::NorthEast,
+        WindowResizeDirection::NorthWest => ResizeDirection::NorthWest,
+        WindowResizeDirection::South => ResizeDirection::South,
+        WindowResizeDirection::SouthEast => ResizeDirection::SouthEast,
+        WindowResizeDirection::SouthWest => ResizeDirection::SouthWest,
+        WindowResizeDirection::West => ResizeDirection::West,
+    }
+}
+
 fn default_vsync_interval() -> Duration {
     Duration::from_nanos(16_666_667)
 }
@@ -1009,6 +2486,122 @@ fn monitor_refresh_interval(window: &Arc<dyn Window>) -> Duration {
             Duration::from_nanos(nanos)
         })
         .unwrap_or_else(default_vsync_interval)
+}
+
+fn dispatch_keyboard_input(
+    app: &mut AppShell<WgpuRenderer>,
+    current_modifiers: winit::keyboard::ModifiersState,
+    event: winit::event::KeyEvent,
+) {
+    use cranpose_app_shell::{KeyEvent, KeyEventType};
+    use winit::keyboard::Key;
+
+    let event_type = match event.state {
+        ElementState::Pressed => KeyEventType::KeyDown,
+        ElementState::Released => KeyEventType::KeyUp,
+    };
+    let text = match &event.logical_key {
+        Key::Character(s) => s.to_string(),
+        _ => String::new(),
+    };
+    let key_code = app_key_code(event.physical_key);
+    let key_event = KeyEvent::new(key_code, text, app_modifiers(current_modifiers), event_type);
+
+    if key_code == cranpose_app_shell::KeyCode::D && event_type == KeyEventType::KeyDown {
+        app.log_debug_info();
+    }
+
+    app.on_key_event(&key_event);
+}
+
+fn app_key_code(physical_key: winit::keyboard::PhysicalKey) -> cranpose_app_shell::KeyCode {
+    use cranpose_app_shell::KeyCode;
+    use winit::keyboard::PhysicalKey;
+
+    match physical_key {
+        PhysicalKey::Code(code) => match code {
+            winit::keyboard::KeyCode::KeyA => KeyCode::A,
+            winit::keyboard::KeyCode::KeyB => KeyCode::B,
+            winit::keyboard::KeyCode::KeyC => KeyCode::C,
+            winit::keyboard::KeyCode::KeyD => KeyCode::D,
+            winit::keyboard::KeyCode::KeyE => KeyCode::E,
+            winit::keyboard::KeyCode::KeyF => KeyCode::F,
+            winit::keyboard::KeyCode::KeyG => KeyCode::G,
+            winit::keyboard::KeyCode::KeyH => KeyCode::H,
+            winit::keyboard::KeyCode::KeyI => KeyCode::I,
+            winit::keyboard::KeyCode::KeyJ => KeyCode::J,
+            winit::keyboard::KeyCode::KeyK => KeyCode::K,
+            winit::keyboard::KeyCode::KeyL => KeyCode::L,
+            winit::keyboard::KeyCode::KeyM => KeyCode::M,
+            winit::keyboard::KeyCode::KeyN => KeyCode::N,
+            winit::keyboard::KeyCode::KeyO => KeyCode::O,
+            winit::keyboard::KeyCode::KeyP => KeyCode::P,
+            winit::keyboard::KeyCode::KeyQ => KeyCode::Q,
+            winit::keyboard::KeyCode::KeyR => KeyCode::R,
+            winit::keyboard::KeyCode::KeyS => KeyCode::S,
+            winit::keyboard::KeyCode::KeyT => KeyCode::T,
+            winit::keyboard::KeyCode::KeyU => KeyCode::U,
+            winit::keyboard::KeyCode::KeyV => KeyCode::V,
+            winit::keyboard::KeyCode::KeyW => KeyCode::W,
+            winit::keyboard::KeyCode::KeyX => KeyCode::X,
+            winit::keyboard::KeyCode::KeyY => KeyCode::Y,
+            winit::keyboard::KeyCode::KeyZ => KeyCode::Z,
+            winit::keyboard::KeyCode::Digit0 => KeyCode::Digit0,
+            winit::keyboard::KeyCode::Digit1 => KeyCode::Digit1,
+            winit::keyboard::KeyCode::Digit2 => KeyCode::Digit2,
+            winit::keyboard::KeyCode::Digit3 => KeyCode::Digit3,
+            winit::keyboard::KeyCode::Digit4 => KeyCode::Digit4,
+            winit::keyboard::KeyCode::Digit5 => KeyCode::Digit5,
+            winit::keyboard::KeyCode::Digit6 => KeyCode::Digit6,
+            winit::keyboard::KeyCode::Digit7 => KeyCode::Digit7,
+            winit::keyboard::KeyCode::Digit8 => KeyCode::Digit8,
+            winit::keyboard::KeyCode::Digit9 => KeyCode::Digit9,
+            winit::keyboard::KeyCode::Backspace => KeyCode::Backspace,
+            winit::keyboard::KeyCode::Delete => KeyCode::Delete,
+            winit::keyboard::KeyCode::Enter => KeyCode::Enter,
+            winit::keyboard::KeyCode::Tab => KeyCode::Tab,
+            winit::keyboard::KeyCode::Space => KeyCode::Space,
+            winit::keyboard::KeyCode::Escape => KeyCode::Escape,
+            winit::keyboard::KeyCode::ArrowUp => KeyCode::ArrowUp,
+            winit::keyboard::KeyCode::ArrowDown => KeyCode::ArrowDown,
+            winit::keyboard::KeyCode::ArrowLeft => KeyCode::ArrowLeft,
+            winit::keyboard::KeyCode::ArrowRight => KeyCode::ArrowRight,
+            winit::keyboard::KeyCode::Home => KeyCode::Home,
+            winit::keyboard::KeyCode::End => KeyCode::End,
+            _ => KeyCode::Unknown,
+        },
+        _ => KeyCode::Unknown,
+    }
+}
+
+fn app_modifiers(
+    current_modifiers: winit::keyboard::ModifiersState,
+) -> cranpose_app_shell::Modifiers {
+    cranpose_app_shell::Modifiers {
+        shift: current_modifiers.contains(winit::keyboard::ModifiersState::SHIFT),
+        ctrl: current_modifiers.contains(winit::keyboard::ModifiersState::CONTROL),
+        alt: current_modifiers.contains(winit::keyboard::ModifiersState::ALT),
+        meta: current_modifiers.contains(winit::keyboard::ModifiersState::META),
+    }
+}
+
+fn dispatch_ime_event(app: &mut AppShell<WgpuRenderer>, ime_event: winit::event::Ime) {
+    use winit::event::Ime;
+
+    match ime_event {
+        Ime::Preedit(text, cursor) => {
+            app.on_ime_preedit(&text, cursor);
+        }
+        Ime::Commit(text) => {
+            let _ = app.on_ime_preedit("", None);
+            app.on_paste(&text);
+        }
+        Ime::Enabled => {}
+        Ime::Disabled => {
+            app.on_ime_preedit("", None);
+        }
+        Ime::DeleteSurrounding { .. } => {}
+    }
 }
 
 impl ApplicationHandler for App {
@@ -1086,50 +2679,42 @@ impl ApplicationHandler for App {
 
         let size = window.surface_size();
         let surface_caps = surface.get_capabilities(&adapter);
-        let surface_format = surface_caps
-            .formats
-            .iter()
-            .copied()
-            .find(|f| f.is_srgb())
-            .unwrap_or(surface_caps.formats[0]);
+        let surface_format = select_surface_format(&surface_caps);
 
-        let present_mode = if std::env::var_os("CRANPOSE_PRESENT_MODE").is_some() {
-            crate::present_mode::select_present_mode(&surface_caps)
-        } else {
-            crate::present_mode::select_present_mode_for_frame_pacing(
-                &surface_caps,
-                self.frame_pacing_mode,
-            )
-        };
-        let surface_config = wgpu::SurfaceConfiguration {
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            format: surface_format,
-            width: size.width,
-            height: size.height,
+        let present_mode = desktop_present_mode(&surface_caps, self.frame_pacing_mode);
+        let surface_config = surface_config_for_window(
+            &surface_caps,
+            surface_format,
+            size.width.max(1),
+            size.height.max(1),
             present_mode,
-            alpha_mode: surface_caps.alpha_modes[0],
-            view_formats: vec![],
-            desired_maximum_frame_latency: desired_frame_latency(self.frame_pacing_mode),
-        };
+            false,
+            self.frame_pacing_mode,
+        );
+
+        let device = Arc::new(device);
+        let queue = Arc::new(queue);
 
         surface.configure(&device, &surface_config);
 
         // Create renderer with fonts from settings
-        let fonts: &[&[u8]] = self.settings.fonts.take().unwrap_or(&[]);
-        let mut renderer = WgpuRenderer::new(fonts);
-        renderer.init_gpu(
-            Arc::new(device),
-            Arc::new(queue),
+        let fonts: &[&[u8]] = self.settings.fonts.unwrap_or(&[]);
+        let text_system = WgpuTextSystem::from_fonts(fonts);
+        let initial_scale = window.scale_factor();
+        let renderer = wgpu_renderer_for_surface(
+            text_system.clone(),
+            Arc::clone(&device),
+            Arc::clone(&queue),
             surface_format,
             adapter_info.backend,
+            initial_scale,
         );
-        let initial_scale = window.scale_factor();
-        renderer.set_root_scale(initial_scale as f32);
         cranpose_ui::set_density(initial_scale as f32);
 
         // Take the content closure (can only be called once)
         let content = self.content.take().expect("content already taken");
         let mut app = AppShell::new(renderer, default_root_key(), content);
+        app.set_before_recompose(native_window::clear_native_window_requests);
         #[cfg(feature = "robot")]
         app.set_semantics_enabled(self.robot_controller.is_some());
 
@@ -1160,6 +2745,15 @@ impl ApplicationHandler for App {
         self.surface_caps = Some(surface_caps);
         self.app = Some(app);
         self.platform = Some(platform);
+        self.gpu_context = Some(DesktopGpuContext {
+            instance,
+            adapter,
+            adapter_backend: adapter_info.backend,
+            device,
+            queue,
+            text_system,
+        });
+        self.sync_native_windows(event_loop);
     }
 
     fn window_event(
@@ -1168,8 +2762,12 @@ impl ApplicationHandler for App {
         window_id: WindowId,
         event: WindowEvent,
     ) {
-        let Some(window) = &self.window else { return };
+        let Some(window) = &self.window else {
+            self.native_window_event(event_loop, window_id, event);
+            return;
+        };
         if window_id != window.id() {
+            self.native_window_event(event_loop, window_id, event);
             return;
         }
 
@@ -1187,6 +2785,7 @@ impl ApplicationHandler for App {
             return;
         };
 
+        let mut sync_native_windows_after_event = false;
         match event {
             WindowEvent::CloseRequested => {
                 // Save recording if active
@@ -1198,39 +2797,32 @@ impl ApplicationHandler for App {
                 event_loop.exit();
             }
             WindowEvent::SurfaceResized(new_size) if new_size.width > 0 && new_size.height > 0 => {
-                surface_config.width = new_size.width;
-                surface_config.height = new_size.height;
-                let device = app.renderer().device();
-                surface.configure(device, surface_config);
-
-                let scale_factor = window.scale_factor();
-                let logical_width = new_size.width as f32 / scale_factor as f32;
-                let logical_height = new_size.height as f32 / scale_factor as f32;
-
-                app.set_buffer_size(new_size.width, new_size.height);
-                app.set_viewport(logical_width, logical_height);
+                configure_app_surface_size(
+                    app,
+                    window,
+                    surface,
+                    surface_config,
+                    new_size.width,
+                    new_size.height,
+                );
             }
             WindowEvent::ScaleFactorChanged {
                 scale_factor,
                 mut surface_size_writer,
             } => {
-                platform.set_scale_factor(scale_factor);
-                app.renderer().set_root_scale(scale_factor as f32);
-                cranpose_ui::set_density(scale_factor as f32);
+                update_app_scale_factor(app, platform, scale_factor);
 
                 let new_size = window.surface_size();
                 let _ = surface_size_writer.request_surface_size(new_size);
                 if new_size.width > 0 && new_size.height > 0 {
-                    surface_config.width = new_size.width;
-                    surface_config.height = new_size.height;
-                    let device = app.renderer().device();
-                    surface.configure(device, surface_config);
-
-                    let logical_width = new_size.width as f32 / scale_factor as f32;
-                    let logical_height = new_size.height as f32 / scale_factor as f32;
-
-                    app.set_buffer_size(new_size.width, new_size.height);
-                    app.set_viewport(logical_width, logical_height);
+                    configure_app_surface_size(
+                        app,
+                        window,
+                        surface,
+                        surface_config,
+                        new_size.width,
+                        new_size.height,
+                    );
                 }
             }
             WindowEvent::Moved(_) => {
@@ -1255,30 +2847,13 @@ impl ApplicationHandler for App {
                 self.current_modifiers = modifiers.state();
             }
             WindowEvent::MouseWheel { delta, .. } => {
-                if let Some((x, y)) = self.last_cursor_position {
-                    app.set_cursor(x, y);
-                }
-
-                let mut logical_delta = platform.scroll_delta(delta);
-                let alt_pressed = self
-                    .current_modifiers
-                    .contains(winit::keyboard::ModifiersState::ALT);
-                if alt_pressed {
-                    if logical_delta.x.abs() <= f32::EPSILON {
-                        logical_delta.x = logical_delta.y;
-                    }
-                    logical_delta.y = 0.0;
-                }
-
-                log::trace!(
-                    target: "cranpose::input",
-                    "desktop wheel delta ({:.2},{:.2}) alt={}",
-                    logical_delta.x,
-                    logical_delta.y,
-                    alt_pressed
+                dispatch_mouse_wheel(
+                    app,
+                    platform,
+                    self.current_modifiers,
+                    self.last_cursor_position,
+                    delta,
                 );
-
-                app.pointer_scrolled(logical_delta.x, logical_delta.y);
             }
             WindowEvent::PointerButton {
                 state,
@@ -1333,146 +2908,16 @@ impl ApplicationHandler for App {
                 button: ButtonSource::Mouse(MouseButton::Middle),
                 ..
             } => {
-                if let Some((x, y)) = self.last_cursor_position {
-                    app.set_cursor(x, y);
-                }
-                #[cfg(all(
-                    not(target_arch = "wasm32"),
-                    not(target_os = "android"),
-                    not(target_os = "ios")
-                ))]
-                if let Some(text) = app.get_primary_selection() {
-                    app.on_paste(&text);
-                }
+                dispatch_middle_click_paste(app, self.last_cursor_position);
             }
             WindowEvent::KeyboardInput { event, .. } => {
-                use cranpose_app_shell::{KeyCode, KeyEvent, KeyEventType, Modifiers};
-                use winit::keyboard::{Key, PhysicalKey};
-
-                // Convert winit key event to cranpose-ui KeyEvent
-                let event_type = match event.state {
-                    ElementState::Pressed => KeyEventType::KeyDown,
-                    ElementState::Released => KeyEventType::KeyUp,
-                };
-
-                // Get text from logical key
-                let text = match &event.logical_key {
-                    Key::Character(s) => s.to_string(),
-                    _ => String::new(),
-                };
-
-                // Convert physical key to KeyCode
-                let key_code = match event.physical_key {
-                    PhysicalKey::Code(code) => match code {
-                        winit::keyboard::KeyCode::KeyA => KeyCode::A,
-                        winit::keyboard::KeyCode::KeyB => KeyCode::B,
-                        winit::keyboard::KeyCode::KeyC => KeyCode::C,
-                        winit::keyboard::KeyCode::KeyD => KeyCode::D,
-                        winit::keyboard::KeyCode::KeyE => KeyCode::E,
-                        winit::keyboard::KeyCode::KeyF => KeyCode::F,
-                        winit::keyboard::KeyCode::KeyG => KeyCode::G,
-                        winit::keyboard::KeyCode::KeyH => KeyCode::H,
-                        winit::keyboard::KeyCode::KeyI => KeyCode::I,
-                        winit::keyboard::KeyCode::KeyJ => KeyCode::J,
-                        winit::keyboard::KeyCode::KeyK => KeyCode::K,
-                        winit::keyboard::KeyCode::KeyL => KeyCode::L,
-                        winit::keyboard::KeyCode::KeyM => KeyCode::M,
-                        winit::keyboard::KeyCode::KeyN => KeyCode::N,
-                        winit::keyboard::KeyCode::KeyO => KeyCode::O,
-                        winit::keyboard::KeyCode::KeyP => KeyCode::P,
-                        winit::keyboard::KeyCode::KeyQ => KeyCode::Q,
-                        winit::keyboard::KeyCode::KeyR => KeyCode::R,
-                        winit::keyboard::KeyCode::KeyS => KeyCode::S,
-                        winit::keyboard::KeyCode::KeyT => KeyCode::T,
-                        winit::keyboard::KeyCode::KeyU => KeyCode::U,
-                        winit::keyboard::KeyCode::KeyV => KeyCode::V,
-                        winit::keyboard::KeyCode::KeyW => KeyCode::W,
-                        winit::keyboard::KeyCode::KeyX => KeyCode::X,
-                        winit::keyboard::KeyCode::KeyY => KeyCode::Y,
-                        winit::keyboard::KeyCode::KeyZ => KeyCode::Z,
-                        winit::keyboard::KeyCode::Digit0 => KeyCode::Digit0,
-                        winit::keyboard::KeyCode::Digit1 => KeyCode::Digit1,
-                        winit::keyboard::KeyCode::Digit2 => KeyCode::Digit2,
-                        winit::keyboard::KeyCode::Digit3 => KeyCode::Digit3,
-                        winit::keyboard::KeyCode::Digit4 => KeyCode::Digit4,
-                        winit::keyboard::KeyCode::Digit5 => KeyCode::Digit5,
-                        winit::keyboard::KeyCode::Digit6 => KeyCode::Digit6,
-                        winit::keyboard::KeyCode::Digit7 => KeyCode::Digit7,
-                        winit::keyboard::KeyCode::Digit8 => KeyCode::Digit8,
-                        winit::keyboard::KeyCode::Digit9 => KeyCode::Digit9,
-                        winit::keyboard::KeyCode::Backspace => KeyCode::Backspace,
-                        winit::keyboard::KeyCode::Delete => KeyCode::Delete,
-                        winit::keyboard::KeyCode::Enter => KeyCode::Enter,
-                        winit::keyboard::KeyCode::Tab => KeyCode::Tab,
-                        winit::keyboard::KeyCode::Space => KeyCode::Space,
-                        winit::keyboard::KeyCode::Escape => KeyCode::Escape,
-                        winit::keyboard::KeyCode::ArrowUp => KeyCode::ArrowUp,
-                        winit::keyboard::KeyCode::ArrowDown => KeyCode::ArrowDown,
-                        winit::keyboard::KeyCode::ArrowLeft => KeyCode::ArrowLeft,
-                        winit::keyboard::KeyCode::ArrowRight => KeyCode::ArrowRight,
-                        winit::keyboard::KeyCode::Home => KeyCode::Home,
-                        winit::keyboard::KeyCode::End => KeyCode::End,
-                        _ => KeyCode::Unknown,
-                    },
-                    _ => KeyCode::Unknown,
-                };
-
-                // Convert winit modifier state to our Modifiers struct
-                let modifiers = Modifiers {
-                    shift: self
-                        .current_modifiers
-                        .contains(winit::keyboard::ModifiersState::SHIFT),
-                    ctrl: self
-                        .current_modifiers
-                        .contains(winit::keyboard::ModifiersState::CONTROL),
-                    alt: self
-                        .current_modifiers
-                        .contains(winit::keyboard::ModifiersState::ALT),
-                    meta: self
-                        .current_modifiers
-                        .contains(winit::keyboard::ModifiersState::META),
-                };
-
-                let key_event = KeyEvent::new(key_code, text, modifiers, event_type);
-
-                // Special: still handle D for debug info
-                if key_code == KeyCode::D && event_type == KeyEventType::KeyDown {
-                    app.log_debug_info();
-                }
-
-                // Dispatch to text fields
-                app.on_key_event(&key_event);
+                dispatch_keyboard_input(app, self.current_modifiers, event);
             }
             WindowEvent::Focused(false) => {
-                // Window lost focus - cancel any in-progress gestures
-                app.cancel_gesture();
-                // Clear any active IME composition
-                let _ = app.on_ime_preedit("", None);
+                cancel_app_input(app);
             }
             WindowEvent::Ime(ime_event) => {
-                use winit::event::Ime;
-                match ime_event {
-                    Ime::Preedit(text, cursor) => {
-                        // IME is composing - show preedit text with underline
-                        app.on_ime_preedit(&text, cursor);
-                    }
-                    Ime::Commit(text) => {
-                        // IME finished - commit the final text
-                        // First clear composition state, then insert the final text
-                        let _ = app.on_ime_preedit("", None);
-                        app.on_paste(&text);
-                    }
-                    Ime::Enabled => {
-                        // IME was enabled - no action needed
-                    }
-                    Ime::Disabled => {
-                        // IME was disabled - clear any composition state
-                        app.on_ime_preedit("", None);
-                    }
-                    Ime::DeleteSurrounding { .. } => {
-                        // IME asks to delete surrounding text; not yet handled by app shell.
-                    }
-                }
+                dispatch_ime_event(app, ime_event);
             }
             WindowEvent::PointerLeft { .. } => {
                 app.cancel_gesture();
@@ -1486,19 +2931,22 @@ impl ApplicationHandler for App {
                 }
                 log::trace!(target: "cranpose::input", "desktop redraw requested");
                 let frame_started_at = Instant::now();
+                cranpose_ui::set_density(window.scale_factor() as f32);
                 app.update();
+                sync_native_windows_after_event = true;
 
                 let output = match surface.get_current_texture() {
                     Ok(output) => output,
                     Err(wgpu::SurfaceError::Lost) | Err(wgpu::SurfaceError::Outdated) => {
-                        // Reconfigure surface with current window size
                         let size = window.surface_size();
-                        if size.width > 0 && size.height > 0 {
-                            surface_config.width = size.width;
-                            surface_config.height = size.height;
-                            let device = app.renderer().device();
-                            surface.configure(device, surface_config);
-                        }
+                        configure_app_surface_size(
+                            app,
+                            window,
+                            surface,
+                            surface_config,
+                            size.width,
+                            size.height,
+                        );
                         return;
                     }
                     Err(wgpu::SurfaceError::OutOfMemory) => {
@@ -1533,9 +2981,21 @@ impl ApplicationHandler for App {
             }
             _ => {}
         }
+
+        if sync_native_windows_after_event {
+            self.refresh_native_window_requests();
+            self.sync_native_windows(event_loop);
+        }
     }
 
     fn about_to_wait(&mut self, event_loop: &dyn ActiveEventLoop) {
+        let native_positions_changed = self.poll_native_window_positions();
+        let native_drag_moved = self.poll_active_native_window_drags();
+        if native_positions_changed || native_drag_moved {
+            self.refresh_native_window_requests();
+            self.sync_native_windows(event_loop);
+        }
+
         let frame_interval = self.frame_interval();
         let last_frame_start_time = self.last_frame_start_time;
         let Some(app) = &mut self.app else { return };
@@ -1886,6 +3346,47 @@ impl ApplicationHandler for App {
             window.request_redraw();
         }
 
+        let mut native_has_active_animations = false;
+        let mut native_has_active_drag = false;
+        let mut native_frame_cap_deadline: Option<Instant> = None;
+        let mut native_next_event_time: Option<Instant> = None;
+        for native in self.native_windows.values_mut() {
+            if !native.options.visible {
+                continue;
+            }
+
+            let has_active_animations = native.app.has_active_animations();
+            native_has_active_animations |= has_active_animations;
+            native_has_active_drag |= native.active_drag.is_some();
+            let needs_redraw = native.app.needs_redraw() || has_active_animations;
+            let next_frame_time = native.last_frame_start_time.and_then(|started_at| {
+                native
+                    .frame_interval()
+                    .map(|interval| started_at + interval)
+            });
+            let waiting_for_frame_cap =
+                needs_redraw && next_frame_time.is_some_and(|deadline| deadline > now);
+
+            if needs_redraw && !waiting_for_frame_cap {
+                native.window.request_redraw();
+            }
+            if waiting_for_frame_cap {
+                let deadline = next_frame_time.expect("native frame cap deadline should exist");
+                native_frame_cap_deadline = Some(
+                    native_frame_cap_deadline
+                        .map(|current| current.min(deadline))
+                        .unwrap_or(deadline),
+                );
+            }
+            if let Some(next_time) = native.app.next_event_time() {
+                native_next_event_time = Some(
+                    native_next_event_time
+                        .map(|current| current.min(next_time))
+                        .unwrap_or(next_time),
+                );
+            }
+        }
+
         // Smart ControlFlow: only Poll when necessary
         #[cfg(feature = "robot")]
         let robot_needs_poll = self.robot_controller.is_some();
@@ -1896,13 +3397,24 @@ impl ApplicationHandler for App {
         // Poll continuously when:
         // - Active animations are running
         // - Robot test is active
-        if waiting_for_frame_cap {
-            event_loop.set_control_flow(ControlFlow::WaitUntil(
-                next_frame_time.expect("frame cap deadline should exist"),
-            ));
-        } else if has_active_animations || robot_needs_poll {
+        if native_has_active_drag || robot_needs_poll {
             event_loop.set_control_flow(ControlFlow::Poll);
-        } else if let Some(next_time) = app.next_event_time() {
+        } else if let Some(deadline) = [
+            next_frame_time.filter(|_| waiting_for_frame_cap),
+            native_frame_cap_deadline,
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+        {
+            event_loop.set_control_flow(ControlFlow::WaitUntil(deadline));
+        } else if has_active_animations || native_has_active_animations {
+            event_loop.set_control_flow(ControlFlow::Poll);
+        } else if let Some(next_time) = [app.next_event_time(), native_next_event_time]
+            .into_iter()
+            .flatten()
+            .min()
+        {
             // Cursor blink uses timer-based scheduling (not continuous poll)
             event_loop.set_control_flow(ControlFlow::WaitUntil(next_time));
         } else {
@@ -1922,6 +3434,7 @@ pub fn try_run(
     mut settings: AppSettings,
     content: impl FnMut() + 'static,
 ) -> Result<(), LaunchError> {
+    native_window::clear_native_window_requests();
     let event_loop = EventLoop::builder()
         .build()
         .map_err(LaunchError::EventLoopCreate)?;
@@ -1953,6 +3466,7 @@ pub fn try_run(
     }
 
     let run_result = event_loop.run_app(app);
+    native_window::clear_native_window_requests();
     if let Some(error) = launch_error.borrow_mut().take() {
         return Err(error);
     }
@@ -2386,6 +3900,10 @@ fn char_to_key_code(ch: char) -> cranpose_app_shell::KeyCode {
 
 #[cfg(test)]
 mod tests {
+    use super::{
+        App, NativeWindowOptions, NativeWindowPositionOrigin, PendingNativeWindowPositions,
+    };
+
     #[cfg(feature = "robot")]
     use super::{
         find_button_in_trees, find_text_in_trees, panic_payload_message,
@@ -2401,6 +3919,55 @@ mod tests {
     };
     #[cfg(feature = "robot")]
     use std::rc::Rc;
+
+    #[test]
+    fn native_window_screen_position_is_declarative() {
+        let options = NativeWindowOptions::new("child", 100.0, 50.0).with_position(10.0, 20.0);
+        assert!(App::native_window_options_have_screen_position(&options));
+    }
+
+    #[test]
+    fn native_window_host_position_needs_resolution() {
+        let options =
+            NativeWindowOptions::new("child", 100.0, 50.0).with_host_window_position(10.0, 20.0);
+        assert_eq!(
+            options.position_origin,
+            NativeWindowPositionOrigin::HostWindow
+        );
+        assert!(!App::native_window_options_have_screen_position(&options));
+    }
+
+    #[test]
+    fn pending_native_window_positions_acknowledge_stale_programmatic_moves() {
+        let mut pending = PendingNativeWindowPositions::default();
+        pending.push((100.0, 200.0));
+        pending.push((140.0, 230.0));
+
+        assert!(pending.acknowledge((100.0, 200.0)));
+        assert!(pending.acknowledge((140.0, 230.0)));
+        assert!(!pending.acknowledge((190.0, 260.0)));
+    }
+
+    #[test]
+    fn pending_native_window_positions_match_fractional_window_manager_rounding() {
+        let mut pending = PendingNativeWindowPositions::default();
+        pending.push((100.4, 200.4));
+
+        assert!(pending.acknowledge((101.0, 201.0)));
+        assert!(!pending.acknowledge((101.0, 201.0)));
+    }
+
+    #[test]
+    fn pending_native_window_positions_can_be_cleared_after_external_move() {
+        let mut pending = PendingNativeWindowPositions::default();
+        pending.push((100.0, 200.0));
+        pending.push((140.0, 240.0));
+
+        pending.clear();
+
+        assert!(!pending.acknowledge((100.0, 200.0)));
+        assert!(!pending.acknowledge((140.0, 240.0)));
+    }
 
     #[cfg(feature = "robot")]
     #[test]

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -5,7 +5,8 @@
 use crate::launcher::{AppSettings, LaunchError};
 use crate::native_window::{
     self, NativeWindowEvents, NativeWindowKey, NativeWindowOptions, NativeWindowPositionOrigin,
-    NativeWindowRequest, WindowResizeDirection, WindowState,
+    NativeWindowRequest, WindowGraphMove, WindowGraphNodeSnapshot, WindowGraphPeerSnapshot,
+    WindowGraphState, WindowResizeDirection, WindowState,
 };
 #[cfg(feature = "robot")]
 use cranpose_app_shell::RuntimeLeakDebugStats;
@@ -25,7 +26,9 @@ use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, Position};
 use winit::event::{ButtonSource, ElementState, MouseButton, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
-use winit::window::{ResizeDirection, Window, WindowAttributes, WindowId, WindowLevel};
+use winit::window::{
+    ResizeDirection, Window, WindowAttributes, WindowId as WinitWindowId, WindowLevel,
+};
 
 const NATIVE_WINDOW_DRAG_POLL_INTERVAL: Duration = Duration::from_millis(16);
 
@@ -889,6 +892,7 @@ struct NativeWindowSurface {
     options: NativeWindowOptions,
     events: NativeWindowEvents,
     state: Option<WindowState>,
+    group: Option<native_window::NativeWindowGroupMembership>,
     window: Arc<dyn Window>,
     surface: wgpu::Surface<'static>,
     surface_config: wgpu::SurfaceConfiguration,
@@ -1006,13 +1010,15 @@ struct App {
     /// Shared GPU objects used by all desktop surfaces.
     gpu_context: Option<DesktopGpuContext>,
     /// Native sub-window surfaces keyed by the operating-system window id.
-    native_windows: HashMap<WindowId, NativeWindowSurface>,
+    native_windows: HashMap<WinitWindowId, NativeWindowSurface>,
     /// Declarative native sub-window ids mapped to their current OS window id.
-    native_window_ids: HashMap<NativeWindowKey, WindowId>,
+    native_window_ids: HashMap<NativeWindowKey, WinitWindowId>,
     /// Last observed OS positions for declarative native sub-windows.
     native_window_positions: HashMap<NativeWindowKey, (f32, f32)>,
     /// Native sub-windows closed by the user while still declared by composition.
     closed_native_windows: HashSet<NativeWindowKey>,
+    /// Framework-owned peer-window topology and drag sessions.
+    window_graph: WindowGraphState,
     /// Current keyboard modifiers (shift, ctrl, alt, meta)
     current_modifiers: winit::keyboard::ModifiersState,
     /// Last known cursor position in logical pixels
@@ -1061,6 +1067,7 @@ impl App {
             native_window_ids: HashMap::new(),
             native_window_positions: HashMap::new(),
             closed_native_windows: HashSet::new(),
+            window_graph: WindowGraphState::default(),
             current_modifiers: winit::keyboard::ModifiersState::empty(),
             last_cursor_position: None,
             #[cfg(feature = "robot")]
@@ -1126,7 +1133,7 @@ impl App {
         self.closed_native_windows
             .retain(|key| active_keys.contains(key));
 
-        let stale_window_ids: Vec<WindowId> = self
+        let stale_window_ids: Vec<WinitWindowId> = self
             .native_windows
             .iter()
             .filter_map(|(window_id, native)| {
@@ -1160,6 +1167,7 @@ impl App {
                 if let Some(native) = self.native_windows.get_mut(&window_id) {
                     native.events = request.events.clone();
                     native.state = request.state;
+                    native.group = request.group.clone();
                     let revision_changed = native.revision != request.revision;
                     let options_changed = native.options != request.options;
                     Self::apply_native_window_options(
@@ -1280,6 +1288,94 @@ impl App {
             }
             notify_native_window_moved(&native.events, x, y);
         }
+    }
+
+    fn native_window_graph_snapshots(&self) -> Vec<WindowGraphPeerSnapshot> {
+        self.native_windows
+            .values()
+            .filter_map(|native| self.native_window_graph_snapshot(native, None))
+            .collect()
+    }
+
+    fn native_window_graph_snapshots_with(
+        &self,
+        native: &NativeWindowSurface,
+        position: Option<cranpose_ui::Point>,
+    ) -> Vec<WindowGraphPeerSnapshot> {
+        let mut snapshots = self.native_window_graph_snapshots();
+        snapshots.retain(|snapshot| snapshot.node.id != native.key);
+        if let Some(snapshot) = self.native_window_graph_snapshot(native, position) {
+            snapshots.push(snapshot);
+        }
+        snapshots
+    }
+
+    fn native_window_graph_snapshot(
+        &self,
+        native: &NativeWindowSurface,
+        position: Option<cranpose_ui::Point>,
+    ) -> Option<WindowGraphPeerSnapshot> {
+        let position = position
+            .or_else(|| {
+                self.native_window_positions
+                    .get(&native.key)
+                    .map(|(x, y)| cranpose_ui::Point::new(*x, *y))
+            })
+            .or_else(|| {
+                current_native_window_position(native).map(|(x, y)| cranpose_ui::Point::new(x, y))
+            })
+            .or_else(|| match (native.options.x, native.options.y) {
+                (Some(x), Some(y)) => Some(cranpose_ui::Point::new(x, y)),
+                _ => None,
+            })?;
+        Some(WindowGraphPeerSnapshot {
+            node: WindowGraphNodeSnapshot {
+                id: native.key,
+                position,
+                size: native
+                    .state
+                    .map(WindowState::size_non_reactive)
+                    .unwrap_or_else(|| {
+                        cranpose_ui::Size::new(native.options.width, native.options.height)
+                    }),
+            },
+            group: native.group.clone(),
+        })
+    }
+
+    fn apply_window_graph_drag(
+        &mut self,
+        dragged: NativeWindowKey,
+        target: cranpose_ui::Point,
+    ) -> bool {
+        let moves = self.window_graph.drag_to(dragged, target);
+        self.apply_window_graph_moves(moves)
+    }
+
+    fn finish_window_graph_drag(&mut self) -> bool {
+        let snapshots = self.native_window_graph_snapshots();
+        let moves = self.window_graph.finish_drag(&snapshots);
+        self.apply_window_graph_moves(moves)
+    }
+
+    fn apply_window_graph_moves(&mut self, moves: Vec<WindowGraphMove>) -> bool {
+        let mut moved = false;
+        for window_move in moves {
+            let Some(window_id) = self.native_window_ids.get(&window_move.id).copied() else {
+                continue;
+            };
+            let Some(native) = self.native_windows.get_mut(&window_id) else {
+                continue;
+            };
+            if Self::apply_native_window_position(native, window_move.position) {
+                self.native_window_positions.insert(
+                    window_move.id,
+                    (window_move.position.x, window_move.position.y),
+                );
+                moved = true;
+            }
+        }
+        moved
     }
 
     fn create_native_window_shell(
@@ -1411,6 +1507,7 @@ impl App {
             options: request.options.clone(),
             events: request.events.clone(),
             state: request.state,
+            group: request.group.clone(),
             window,
             surface,
             surface_config,
@@ -1542,6 +1639,37 @@ impl App {
         true
     }
 
+    fn apply_native_window_position(
+        native: &mut NativeWindowSurface,
+        position: cranpose_ui::Point,
+    ) -> bool {
+        let logical_position = (position.x, position.y);
+        if current_native_window_position(native).is_some_and(|current| {
+            (current.0 - logical_position.0).abs() <= f32::EPSILON
+                && (current.1 - logical_position.1).abs() <= f32::EPSILON
+        }) {
+            update_native_options_position(&mut native.options, position.x, position.y);
+            return false;
+        }
+
+        native.pending_outer_positions.push(logical_position);
+        let logical = LogicalPosition::new(position.x as f64, position.y as f64);
+        let physical = logical.to_physical::<i32>(native.window.scale_factor());
+        if !native_window_set_outer_position_physical(&native.window, physical) {
+            native.window.set_outer_position(Position::Logical(logical));
+        }
+        update_native_options_position(&mut native.options, position.x, position.y);
+        let previous_state_position = native.state.and_then(|state| state.position_non_reactive());
+        notify_native_window_moved(&native.events, position.x, position.y);
+        sync_native_window_state_position(
+            native.state,
+            previous_state_position,
+            position.x,
+            position.y,
+        );
+        true
+    }
+
     fn start_native_window_drag(native: &mut NativeWindowSurface) -> bool {
         let fallback_position = native
             .last_cursor_physical_position
@@ -1575,6 +1703,7 @@ impl App {
 
         let pointer = native_window_global_pointer_state();
         let mut updates = Vec::new();
+        let mut finish_drag = false;
         for native in self.native_windows.values_mut() {
             let Some(active_drag) = native.active_drag.as_mut() else {
                 continue;
@@ -1589,28 +1718,32 @@ impl App {
             };
             if !pointer.primary_down {
                 native.active_drag = None;
+                finish_drag = true;
                 if native.app.pointer_released() {
                     native.window.request_redraw();
                 }
                 native.app.sync_selection_to_primary();
                 continue;
             }
-            if let Some(update) = Self::update_native_window_drag(native, pointer.position) {
+            if let Some(update) = Self::update_native_window_drag_target(native, pointer.position) {
                 updates.push(update);
             }
         }
 
-        let moved = !updates.is_empty();
+        let mut moved = !updates.is_empty();
         for (key, position) in updates {
-            self.native_window_positions.insert(key, position);
+            moved |= self.apply_window_graph_drag(key, position);
+        }
+        if finish_drag {
+            moved |= self.finish_window_graph_drag();
         }
         moved
     }
 
-    fn update_native_window_drag(
+    fn update_native_window_drag_target(
         native: &mut NativeWindowSurface,
         pointer: PhysicalPosition<f64>,
-    ) -> Option<(NativeWindowKey, (f32, f32))> {
+    ) -> Option<(NativeWindowKey, cranpose_ui::Point)> {
         let active_drag = native.active_drag.as_mut()?;
         let target = active_drag.target_for_pointer(pointer);
         if target == active_drag.last_target_outer {
@@ -1618,27 +1751,16 @@ impl App {
         }
         active_drag.last_target_outer = target;
         let logical = target.to_logical::<f64>(native.window.scale_factor());
-        let logical_position = (logical.x as f32, logical.y as f32);
-        native.pending_outer_positions.push(logical_position);
-        if !native_window_set_outer_position_physical(&native.window, target) {
-            native.window.set_outer_position(Position::Physical(target));
-        }
-        update_native_options_position(&mut native.options, logical_position.0, logical_position.1);
-        let previous_state_position = native.state.and_then(|state| state.position_non_reactive());
-        notify_native_window_moved(&native.events, logical_position.0, logical_position.1);
-        sync_native_window_state_position(
-            native.state,
-            previous_state_position,
-            logical_position.0,
-            logical_position.1,
-        );
-        Some((native.key, logical_position))
+        Some((
+            native.key,
+            cranpose_ui::Point::new(logical.x as f32, logical.y as f32),
+        ))
     }
 
     fn native_window_event(
         &mut self,
         event_loop: &dyn ActiveEventLoop,
-        window_id: WindowId,
+        window_id: WinitWindowId,
         event: WindowEvent,
     ) {
         let Some(mut native) = self.native_windows.remove(&window_id) else {
@@ -1647,6 +1769,9 @@ impl App {
 
         let mut keep_window = true;
         let mut sync_after_event = false;
+        let mut graph_drag_after_insert = None::<(NativeWindowKey, cranpose_ui::Point)>;
+        let mut graph_moves_after_insert = Vec::<WindowGraphMove>::new();
+        let mut finish_graph_drag_after_insert = false;
         match event {
             WindowEvent::CloseRequested => {
                 notify_native_window_close_requested(&native.events);
@@ -1714,6 +1839,17 @@ impl App {
                 native.vsync_interval = monitor_refresh_interval(&native.window);
                 let previous_state_position =
                     native.state.and_then(|state| state.position_non_reactive());
+                let previous_graph_position = self
+                    .native_window_positions
+                    .get(&native.key)
+                    .map(|(x, y)| cranpose_ui::Point::new(*x, *y))
+                    .or(previous_state_position)
+                    .or_else(|| match (native.options.x, native.options.y) {
+                        (Some(x), Some(y)) => Some(cranpose_ui::Point::new(x, y)),
+                        _ => None,
+                    });
+                let previous_graph_snapshots =
+                    self.native_window_graph_snapshots_with(&native, previous_graph_position);
                 let position = current_native_window_position(&native).unwrap_or_else(|| {
                     let logical = position.to_logical::<f64>(native.window.scale_factor());
                     (logical.x as f32, logical.y as f32)
@@ -1731,6 +1867,11 @@ impl App {
                         position.0,
                         position.1,
                     );
+                    graph_moves_after_insert = self.window_graph.external_move(
+                        &previous_graph_snapshots,
+                        native.key,
+                        cranpose_ui::Point::new(position.0, position.1),
+                    );
                     sync_after_event = true;
                 }
             }
@@ -1745,9 +1886,9 @@ impl App {
                     .or(fallback_pointer)
                 {
                     if let Some((key, position)) =
-                        Self::update_native_window_drag(&mut native, pointer)
+                        Self::update_native_window_drag_target(&mut native, pointer)
                     {
-                        self.native_window_positions.insert(key, position);
+                        graph_drag_after_insert = Some((key, position));
                         sync_after_event = true;
                     }
                 }
@@ -1821,13 +1962,16 @@ impl App {
                                         &mut self.native_window_positions,
                                     );
                                 }
+                                let graph_snapshots =
+                                    self.native_window_graph_snapshots_with(&native, None);
+                                self.window_graph.start_drag(&graph_snapshots, native.key);
                                 Self::start_native_window_drag(&mut native);
                             }
                             sync_after_event = true;
                         }
                     }
                     ElementState::Released => {
-                        native.active_drag = None;
+                        finish_graph_drag_after_insert = native.active_drag.take().is_some();
                         let handled = native_window::with_native_window_surface_origin(
                             native_window_surface_origin(&native.window),
                             || native.app.pointer_released(),
@@ -1879,6 +2023,19 @@ impl App {
 
         if keep_window {
             self.native_windows.insert(window_id, native);
+            if !graph_moves_after_insert.is_empty()
+                && self.apply_window_graph_moves(graph_moves_after_insert)
+            {
+                sync_after_event = true;
+            }
+            if let Some((key, position)) = graph_drag_after_insert {
+                if self.apply_window_graph_drag(key, position) {
+                    sync_after_event = true;
+                }
+            }
+            if finish_graph_drag_after_insert && self.finish_window_graph_drag() {
+                sync_after_event = true;
+            }
             if sync_after_event {
                 self.sync_native_windows(event_loop);
             }
@@ -2628,6 +2785,7 @@ impl ApplicationHandler for App {
         let initial_width = self.settings.initial_width;
         let initial_height = self.settings.initial_height;
         let headless = self.settings.headless;
+        let primary_window_visible = self.settings.primary_window_visible;
 
         let window: Arc<dyn Window> = match event_loop.create_window(
             WindowAttributes::default()
@@ -2637,7 +2795,7 @@ impl ApplicationHandler for App {
                     initial_height as f64,
                 ))
                 // Hide window in headless mode for parallel robot testing
-                .with_visible(!headless),
+                .with_visible(!headless && primary_window_visible),
         ) {
             Ok(window) => window.into(),
             Err(error) => {
@@ -2767,13 +2925,14 @@ impl ApplicationHandler for App {
             queue,
             text_system,
         });
+        self.refresh_native_window_requests();
         self.sync_native_windows(event_loop);
     }
 
     fn window_event(
         &mut self,
         event_loop: &dyn ActiveEventLoop,
-        window_id: WindowId,
+        window_id: WinitWindowId,
         event: WindowEvent,
     ) {
         let Some(window) = &self.window else {

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -27,6 +27,8 @@ use winit::event::{ButtonSource, ElementState, MouseButton, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::window::{ResizeDirection, Window, WindowAttributes, WindowId, WindowLevel};
 
+const NATIVE_WINDOW_DRAG_POLL_INTERVAL: Duration = Duration::from_millis(16);
+
 #[cfg(feature = "robot")]
 use cranpose_ui::{SemanticsAction, SemanticsNode, SemanticsRole};
 
@@ -909,17 +911,39 @@ struct NativeWindowShell {
 
 #[derive(Clone, Copy, Debug)]
 struct NativeWindowDragSession {
-    last_pointer_screen: PhysicalPosition<f64>,
+    start_pointer_screen: PhysicalPosition<f64>,
+    start_window_outer: PhysicalPosition<i32>,
+    last_target_outer: PhysicalPosition<i32>,
+    next_poll_at: Instant,
+}
+
+impl NativeWindowDragSession {
+    fn new(
+        start_pointer_screen: PhysicalPosition<f64>,
+        start_window_outer: PhysicalPosition<i32>,
+        now: Instant,
+    ) -> Self {
+        Self {
+            start_pointer_screen,
+            start_window_outer,
+            last_target_outer: start_window_outer,
+            next_poll_at: now + NATIVE_WINDOW_DRAG_POLL_INTERVAL,
+        }
+    }
+
+    fn target_for_pointer(&self, pointer: PhysicalPosition<f64>) -> PhysicalPosition<i32> {
+        PhysicalPosition::new(
+            (self.start_window_outer.x as f64 + pointer.x - self.start_pointer_screen.x).round()
+                as i32,
+            (self.start_window_outer.y as f64 + pointer.y - self.start_pointer_screen.y).round()
+                as i32,
+        )
+    }
 }
 
 #[derive(Default)]
 struct PendingNativeWindowPositions {
-    positions: VecDeque<PendingNativeWindowPosition>,
-}
-
-struct PendingNativeWindowPosition {
-    position: (f32, f32),
-    created_at: Instant,
+    positions: VecDeque<(f32, f32)>,
 }
 
 impl PendingNativeWindowPositions {
@@ -927,14 +951,11 @@ impl PendingNativeWindowPositions {
         if self
             .positions
             .back()
-            .is_some_and(|pending| native_window_positions_close(pending.position, position))
+            .is_some_and(|pending| native_window_positions_close(*pending, position))
         {
             return;
         }
-        self.positions.push_back(PendingNativeWindowPosition {
-            position,
-            created_at: Instant::now(),
-        });
+        self.positions.push_back(position);
         while self.positions.len() > 16 {
             self.positions.pop_front();
         }
@@ -944,7 +965,7 @@ impl PendingNativeWindowPositions {
         let Some(index) = self
             .positions
             .iter()
-            .position(|pending| native_window_positions_close(pending.position, position))
+            .position(|pending| native_window_positions_close(*pending, position))
         else {
             return false;
         };
@@ -952,18 +973,6 @@ impl PendingNativeWindowPositions {
             self.positions.pop_front();
         }
         true
-    }
-
-    fn has_fresh_pending(&mut self, max_age: Duration) -> bool {
-        let now = Instant::now();
-        while self
-            .positions
-            .front()
-            .is_some_and(|pending| now.duration_since(pending.created_at) > max_age)
-        {
-            self.positions.pop_front();
-        }
-        !self.positions.is_empty()
     }
 
     fn clear(&mut self) {
@@ -1469,11 +1478,11 @@ impl App {
         if native.options.x != options.x || native.options.y != options.y {
             if let (Some(x), Some(y)) = (options.x, options.y) {
                 native.pending_outer_positions.push((x, y));
-                native
-                    .window
-                    .set_outer_position(Position::Logical(LogicalPosition::new(
-                        x as f64, y as f64,
-                    )));
+                let logical = LogicalPosition::new(x as f64, y as f64);
+                let physical = logical.to_physical::<i32>(native.window.scale_factor());
+                if !native_window_set_outer_position_physical(&native.window, physical) {
+                    native.window.set_outer_position(Position::Logical(logical));
+                }
             }
         }
         if native.options.width != options.width || native.options.height != options.height {
@@ -1501,31 +1510,96 @@ impl App {
         );
     }
 
+    fn sync_native_window_position_from_os(
+        native: &mut NativeWindowSurface,
+        native_window_positions: &mut HashMap<NativeWindowKey, (f32, f32)>,
+    ) -> bool {
+        let Some(position) = current_native_window_position(native) else {
+            return false;
+        };
+        if native_window_positions
+            .get(&native.key)
+            .is_some_and(|known| native_window_positions_close(*known, position))
+            && native
+                .state
+                .and_then(|state| state.position_non_reactive())
+                .is_some_and(|known| native_window_positions_close((known.x, known.y), position))
+        {
+            return false;
+        }
+
+        let previous_state_position = native.state.and_then(|state| state.position_non_reactive());
+        native_window_positions.insert(native.key, position);
+        update_native_options_position(&mut native.options, position.0, position.1);
+        native.pending_outer_positions.clear();
+        notify_native_window_moved(&native.events, position.0, position.1);
+        sync_native_window_state_position(
+            native.state,
+            previous_state_position,
+            position.0,
+            position.1,
+        );
+        true
+    }
+
     fn start_native_window_drag(native: &mut NativeWindowSurface) -> bool {
         let fallback_position = native
             .last_cursor_physical_position
             .and_then(|position| native_window_screen_pointer_physical(&native.window, position));
-        let Some(pointer) = native_window_global_pointer_physical().or(fallback_position) else {
+        let Some(pointer) = native_window_global_pointer_state()
+            .map(|state| state.position)
+            .or(fallback_position)
+        else {
             return false;
         };
-        native.active_drag = Some(NativeWindowDragSession {
-            last_pointer_screen: pointer,
-        });
+        let Some(window_outer) = current_native_window_physical_position(&native.window) else {
+            return false;
+        };
+        native.active_drag = Some(NativeWindowDragSession::new(
+            pointer,
+            window_outer,
+            Instant::now(),
+        ));
         true
     }
 
-    fn poll_active_native_window_drags(&mut self) -> bool {
-        let Some(pointer) = native_window_global_pointer_physical() else {
+    fn poll_active_native_window_drags(&mut self, now: Instant) -> bool {
+        let has_due_drag = self.native_windows.values().any(|native| {
+            native
+                .active_drag
+                .is_some_and(|active_drag| active_drag.next_poll_at <= now)
+        });
+        if !has_due_drag {
             return false;
-        };
+        }
+
+        let pointer = native_window_global_pointer_state();
         let mut updates = Vec::new();
         for native in self.native_windows.values_mut() {
-            if native.active_drag.is_some() {
-                if let Some(update) = Self::update_native_window_drag(native, pointer) {
-                    updates.push(update);
+            let Some(active_drag) = native.active_drag.as_mut() else {
+                continue;
+            };
+            if active_drag.next_poll_at > now {
+                continue;
+            }
+            active_drag.next_poll_at = now + NATIVE_WINDOW_DRAG_POLL_INTERVAL;
+
+            let Some(pointer) = pointer else {
+                continue;
+            };
+            if !pointer.primary_down {
+                native.active_drag = None;
+                if native.app.pointer_released() {
+                    native.window.request_redraw();
                 }
+                native.app.sync_selection_to_primary();
+                continue;
+            }
+            if let Some(update) = Self::update_native_window_drag(native, pointer.position) {
+                updates.push(update);
             }
         }
+
         let moved = !updates.is_empty();
         for (key, position) in updates {
             self.native_window_positions.insert(key, position);
@@ -1533,73 +1607,16 @@ impl App {
         moved
     }
 
-    fn poll_native_window_positions(&mut self) -> bool {
-        let mut changed = false;
-        let native_window_positions = &mut self.native_window_positions;
-        for native in self.native_windows.values_mut() {
-            if !native.options.visible {
-                continue;
-            }
-            let Some(position) = current_native_window_position(native) else {
-                continue;
-            };
-            if native_window_positions
-                .get(&native.key)
-                .is_some_and(|known| native_window_positions_close(*known, position))
-            {
-                continue;
-            }
-
-            let acknowledged_programmatic_move =
-                native.pending_outer_positions.acknowledge(position);
-            if !acknowledged_programmatic_move
-                && native
-                    .pending_outer_positions
-                    .has_fresh_pending(Duration::from_millis(180))
-            {
-                continue;
-            }
-
-            let previous_state_position =
-                native.state.and_then(|state| state.position_non_reactive());
-            native_window_positions.insert(native.key, position);
-            update_native_options_position(&mut native.options, position.0, position.1);
-            if acknowledged_programmatic_move {
-                continue;
-            }
-
-            native.pending_outer_positions.clear();
-            notify_native_window_moved(&native.events, position.0, position.1);
-            sync_native_window_state_position(
-                native.state,
-                previous_state_position,
-                position.0,
-                position.1,
-            );
-            changed = true;
-        }
-        changed
-    }
-
     fn update_native_window_drag(
         native: &mut NativeWindowSurface,
         pointer: PhysicalPosition<f64>,
     ) -> Option<(NativeWindowKey, (f32, f32))> {
         let active_drag = native.active_drag.as_mut()?;
-        let delta = PhysicalPosition::new(
-            pointer.x - active_drag.last_pointer_screen.x,
-            pointer.y - active_drag.last_pointer_screen.y,
-        );
-        active_drag.last_pointer_screen = pointer;
-        if delta.x.abs() <= f64::EPSILON && delta.y.abs() <= f64::EPSILON {
+        let target = active_drag.target_for_pointer(pointer);
+        if target == active_drag.last_target_outer {
             return None;
         }
-
-        let current = current_native_window_physical_position(&native.window)?;
-        let target = PhysicalPosition::new(
-            (current.x as f64 + delta.x).round() as i32,
-            (current.y as f64 + delta.y).round() as i32,
-        );
+        active_drag.last_target_outer = target;
         let logical = target.to_logical::<f64>(native.window.scale_factor());
         let logical_position = (logical.x as f32, logical.y as f32);
         native.pending_outer_positions.push(logical_position);
@@ -1697,8 +1714,10 @@ impl App {
                 native.vsync_interval = monitor_refresh_interval(&native.window);
                 let previous_state_position =
                     native.state.and_then(|state| state.position_non_reactive());
-                let logical = position.to_logical::<f64>(native.window.scale_factor());
-                let position = (logical.x as f32, logical.y as f32);
+                let position = current_native_window_position(&native).unwrap_or_else(|| {
+                    let logical = position.to_logical::<f64>(native.window.scale_factor());
+                    (logical.x as f32, logical.y as f32)
+                });
                 let acknowledged_programmatic_move =
                     native.pending_outer_positions.acknowledge(position);
                 self.native_window_positions.insert(native.key, position);
@@ -1721,13 +1740,14 @@ impl App {
                 native.last_cursor_physical_position = Some(position);
                 let fallback_pointer =
                     native_window_screen_pointer_physical(&native.window, position);
-                if let Some(pointer) = native_window_global_pointer_physical().or(fallback_pointer)
+                if let Some(pointer) = native_window_global_pointer_state()
+                    .map(|state| state.position)
+                    .or(fallback_pointer)
                 {
                     if let Some((key, position)) =
                         Self::update_native_window_drag(&mut native, pointer)
                     {
                         self.native_window_positions.insert(key, position);
-                        event_loop.set_control_flow(ControlFlow::Poll);
                         sync_after_event = true;
                     }
                 }
@@ -1766,8 +1786,9 @@ impl App {
                     ElementState::Pressed => {
                         let drag_requested = Rc::new(Cell::new(false));
                         let drag_requested_for_handler = Rc::clone(&drag_requested);
-                        let drag_handler: Rc<dyn Fn()> = Rc::new(move || {
+                        let drag_handler: Rc<dyn Fn() -> bool> = Rc::new(move || {
                             drag_requested_for_handler.set(true);
+                            true
                         });
                         let resize_window = native.window.clone();
                         let resize_handler: Rc<dyn Fn(WindowResizeDirection)> =
@@ -1789,8 +1810,18 @@ impl App {
                             },
                         );
                         if handled {
-                            if drag_requested.get() && Self::start_native_window_drag(&mut native) {
-                                event_loop.set_control_flow(ControlFlow::Poll);
+                            if drag_requested.get() {
+                                Self::sync_native_window_position_from_os(
+                                    &mut native,
+                                    &mut self.native_window_positions,
+                                );
+                                for other_native in self.native_windows.values_mut() {
+                                    Self::sync_native_window_position_from_os(
+                                        other_native,
+                                        &mut self.native_window_positions,
+                                    );
+                                }
+                                Self::start_native_window_drag(&mut native);
                             }
                             sync_after_event = true;
                         }
@@ -1826,8 +1857,12 @@ impl App {
                 dispatch_ime_event(&mut native.app, ime_event);
             }
             WindowEvent::PointerLeft { .. } => {
-                native.active_drag = None;
-                native.app.cancel_gesture();
+                let drag_still_has_global_pointer = native.active_drag.is_some()
+                    && native_window_global_pointer_state().is_some_and(|state| state.primary_down);
+                if !drag_still_has_global_pointer {
+                    native.active_drag = None;
+                    native.app.cancel_gesture();
+                }
             }
             WindowEvent::RedrawRequested => {
                 if let Some(deadline) = native.last_frame_start_time.and_then(|started_at| {
@@ -2095,25 +2130,31 @@ fn native_window_screen_pointer_physical(
     ))
 }
 
+#[derive(Clone, Copy, Debug)]
+struct NativeWindowPointerState {
+    position: PhysicalPosition<f64>,
+    primary_down: bool,
+}
+
 #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
-struct X11PointerClient {
+struct X11WindowClient {
     connection: x11rb::rust_connection::RustConnection,
     root: u32,
 }
 
 #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
-enum X11PointerClientState {
-    Available(Box<X11PointerClient>),
+enum X11WindowClientState {
+    Available(Box<X11WindowClient>),
     Unavailable,
 }
 
 #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
 thread_local! {
-    static X11_POINTER_CLIENT: RefCell<Option<X11PointerClientState>> = const { RefCell::new(None) };
+    static X11_WINDOW_CLIENT: RefCell<Option<X11WindowClientState>> = const { RefCell::new(None) };
 }
 
 #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
-impl X11PointerClient {
+impl X11WindowClient {
     fn connect() -> Option<Self> {
         use x11rb::connection::Connection;
 
@@ -2122,8 +2163,8 @@ impl X11PointerClient {
         Some(Self { connection, root })
     }
 
-    fn pointer(&self) -> Option<PhysicalPosition<f64>> {
-        use x11rb::protocol::xproto::ConnectionExt;
+    fn pointer_state(&self) -> Option<NativeWindowPointerState> {
+        use x11rb::protocol::xproto::{ConnectionExt, KeyButMask};
 
         let reply = self
             .connection
@@ -2131,10 +2172,11 @@ impl X11PointerClient {
             .ok()?
             .reply()
             .ok()?;
-        Some(PhysicalPosition::new(
-            reply.root_x as f64,
-            reply.root_y as f64,
-        ))
+        let mask = u16::from(reply.mask);
+        Some(NativeWindowPointerState {
+            position: PhysicalPosition::new(reply.root_x as f64, reply.root_y as f64),
+            primary_down: mask & u16::from(KeyButMask::BUTTON1) != 0,
+        })
     }
 
     fn configure_window(&self, window: u32, position: PhysicalPosition<i32>) -> Option<()> {
@@ -2168,22 +2210,32 @@ impl X11PointerClient {
 }
 
 #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
-fn native_window_global_pointer_physical() -> Option<PhysicalPosition<f64>> {
-    X11_POINTER_CLIENT.with(|slot| {
+fn with_x11_window_client<R>(f: impl FnOnce(&X11WindowClient) -> R) -> Option<R> {
+    X11_WINDOW_CLIENT.with(|slot| {
         if slot.borrow().is_none() {
             *slot.borrow_mut() = Some(
-                X11PointerClient::connect()
+                X11WindowClient::connect()
                     .map(Box::new)
-                    .map(X11PointerClientState::Available)
-                    .unwrap_or(X11PointerClientState::Unavailable),
+                    .map(X11WindowClientState::Available)
+                    .unwrap_or(X11WindowClientState::Unavailable),
             );
         }
 
         match slot.borrow().as_ref()? {
-            X11PointerClientState::Available(client) => client.pointer(),
-            X11PointerClientState::Unavailable => None,
+            X11WindowClientState::Available(client) => Some(f(client)),
+            X11WindowClientState::Unavailable => None,
         }
     })
+}
+
+#[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
+fn native_window_global_pointer_state() -> Option<NativeWindowPointerState> {
+    with_x11_window_client(X11WindowClient::pointer_state).flatten()
+}
+
+#[cfg(not(all(target_os = "linux", not(target_arch = "wasm32"))))]
+fn native_window_global_pointer_state() -> Option<NativeWindowPointerState> {
+    None
 }
 
 #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
@@ -2202,21 +2254,7 @@ fn native_window_x11_outer_position_physical(
     window: &Arc<dyn Window>,
 ) -> Option<PhysicalPosition<i32>> {
     let window_id = native_window_x11_id(window)?;
-    X11_POINTER_CLIENT.with(|slot| {
-        if slot.borrow().is_none() {
-            *slot.borrow_mut() = Some(
-                X11PointerClient::connect()
-                    .map(Box::new)
-                    .map(X11PointerClientState::Available)
-                    .unwrap_or(X11PointerClientState::Unavailable),
-            );
-        }
-
-        match slot.borrow().as_ref()? {
-            X11PointerClientState::Available(client) => client.window_position(window_id),
-            X11PointerClientState::Unavailable => None,
-        }
-    })
+    with_x11_window_client(|client| client.window_position(window_id)).flatten()
 }
 
 #[cfg(not(all(target_os = "linux", not(target_arch = "wasm32"))))]
@@ -2234,23 +2272,8 @@ fn native_window_set_outer_position_physical(
     let Some(window_id) = native_window_x11_id(window) else {
         return false;
     };
-    X11_POINTER_CLIENT.with(|slot| {
-        if slot.borrow().is_none() {
-            *slot.borrow_mut() = Some(
-                X11PointerClient::connect()
-                    .map(Box::new)
-                    .map(X11PointerClientState::Available)
-                    .unwrap_or(X11PointerClientState::Unavailable),
-            );
-        }
-
-        match slot.borrow().as_ref() {
-            Some(X11PointerClientState::Available(client)) => {
-                client.configure_window(window_id, position).is_some()
-            }
-            _ => false,
-        }
-    })
+    with_x11_window_client(|client| client.configure_window(window_id, position).is_some())
+        .unwrap_or(false)
 }
 
 #[cfg(not(all(target_os = "linux", not(target_arch = "wasm32"))))]
@@ -2259,11 +2282,6 @@ fn native_window_set_outer_position_physical(
     _position: PhysicalPosition<i32>,
 ) -> bool {
     false
-}
-
-#[cfg(not(all(target_os = "linux", not(target_arch = "wasm32"))))]
-fn native_window_global_pointer_physical() -> Option<PhysicalPosition<f64>> {
-    None
 }
 
 fn update_native_options_position(options: &mut NativeWindowOptions, x: f32, y: f32) {
@@ -2989,9 +3007,8 @@ impl ApplicationHandler for App {
     }
 
     fn about_to_wait(&mut self, event_loop: &dyn ActiveEventLoop) {
-        let native_positions_changed = self.poll_native_window_positions();
-        let native_drag_moved = self.poll_active_native_window_drags();
-        if native_positions_changed || native_drag_moved {
+        let now = Instant::now();
+        if self.poll_active_native_window_drags(now) {
             self.refresh_native_window_requests();
             self.sync_native_windows(event_loop);
         }
@@ -3337,7 +3354,6 @@ impl ApplicationHandler for App {
                 "about_to_wait needs_redraw={needs_redraw}"
             );
         }
-        let now = Instant::now();
         let next_frame_time = last_frame_start_time
             .and_then(|started_at| frame_interval.map(|interval| started_at + interval));
         let waiting_for_frame_cap =
@@ -3347,7 +3363,7 @@ impl ApplicationHandler for App {
         }
 
         let mut native_has_active_animations = false;
-        let mut native_has_active_drag = false;
+        let mut native_drag_deadline: Option<Instant> = None;
         let mut native_frame_cap_deadline: Option<Instant> = None;
         let mut native_next_event_time: Option<Instant> = None;
         for native in self.native_windows.values_mut() {
@@ -3357,7 +3373,6 @@ impl ApplicationHandler for App {
 
             let has_active_animations = native.app.has_active_animations();
             native_has_active_animations |= has_active_animations;
-            native_has_active_drag |= native.active_drag.is_some();
             let needs_redraw = native.app.needs_redraw() || has_active_animations;
             let next_frame_time = native.last_frame_start_time.and_then(|started_at| {
                 native
@@ -3369,6 +3384,13 @@ impl ApplicationHandler for App {
 
             if needs_redraw && !waiting_for_frame_cap {
                 native.window.request_redraw();
+            }
+            if let Some(active_drag) = native.active_drag {
+                native_drag_deadline = Some(
+                    native_drag_deadline
+                        .map(|current| current.min(active_drag.next_poll_at))
+                        .unwrap_or(active_drag.next_poll_at),
+                );
             }
             if waiting_for_frame_cap {
                 let deadline = next_frame_time.expect("native frame cap deadline should exist");
@@ -3397,9 +3419,10 @@ impl ApplicationHandler for App {
         // Poll continuously when:
         // - Active animations are running
         // - Robot test is active
-        if native_has_active_drag || robot_needs_poll {
+        if robot_needs_poll {
             event_loop.set_control_flow(ControlFlow::Poll);
         } else if let Some(deadline) = [
+            native_drag_deadline,
             next_frame_time.filter(|_| waiting_for_frame_cap),
             native_frame_cap_deadline,
         ]
@@ -3901,8 +3924,11 @@ fn char_to_key_code(ch: char) -> cranpose_app_shell::KeyCode {
 #[cfg(test)]
 mod tests {
     use super::{
-        App, NativeWindowOptions, NativeWindowPositionOrigin, PendingNativeWindowPositions,
+        App, NativeWindowDragSession, NativeWindowOptions, NativeWindowPositionOrigin,
+        PendingNativeWindowPositions,
     };
+    use std::time::Instant;
+    use winit::dpi::PhysicalPosition;
 
     #[cfg(feature = "robot")]
     use super::{
@@ -3967,6 +3993,43 @@ mod tests {
 
         assert!(!pending.acknowledge((100.0, 200.0)));
         assert!(!pending.acknowledge((140.0, 240.0)));
+    }
+
+    #[test]
+    fn native_window_drag_target_is_anchored_to_drag_start() {
+        let session = NativeWindowDragSession::new(
+            PhysicalPosition::new(100.0, 50.0),
+            PhysicalPosition::new(300, 200),
+            Instant::now(),
+        );
+
+        assert_eq!(
+            session.target_for_pointer(PhysicalPosition::new(112.0, 57.0)),
+            PhysicalPosition::new(312, 207)
+        );
+        assert_eq!(
+            session.target_for_pointer(PhysicalPosition::new(120.0, 50.0)),
+            PhysicalPosition::new(320, 200)
+        );
+    }
+
+    #[test]
+    fn native_window_drag_target_does_not_accumulate_window_manager_lag() {
+        let session = NativeWindowDragSession::new(
+            PhysicalPosition::new(100.0, 50.0),
+            PhysicalPosition::new(300, 200),
+            Instant::now(),
+        );
+
+        let first_target = session.target_for_pointer(PhysicalPosition::new(112.0, 50.0));
+        let second_target = session.target_for_pointer(PhysicalPosition::new(120.0, 50.0));
+
+        assert_eq!(first_target, PhysicalPosition::new(312, 200));
+        assert_eq!(
+            second_target,
+            PhysicalPosition::new(320, 200),
+            "the target must be based on the drag start, not on the last reported window position"
+        );
     }
 
     #[cfg(feature = "robot")]

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -3420,7 +3420,6 @@ impl ApplicationHandler for App {
         // Take the content closure (can only be called once)
         let content = self.content.take().expect("content already taken");
         let mut app = AppShell::new(renderer, default_root_key(), content);
-        app.set_before_recompose(native_window::clear_native_window_requests);
         #[cfg(feature = "robot")]
         app.set_semantics_enabled(self.robot_controller.is_some());
 

--- a/crates/cranpose/src/launcher.rs
+++ b/crates/cranpose/src/launcher.rs
@@ -28,6 +28,11 @@ pub struct AppSettings {
     /// robot tests to run in parallel without cluttering the screen
     /// and enables CI environments without a display server.
     pub headless: bool,
+    /// Whether the launcher-created primary desktop window should be visible.
+    ///
+    /// Multi-window apps can hide this bootstrap surface and declare their
+    /// visible operating-system windows through `run_windows`.
+    pub primary_window_visible: bool,
     /// Development options for debugging and performance monitoring
     #[cfg(all(feature = "desktop", feature = "renderer-wgpu"))]
     pub dev_options: cranpose_app_shell::DevOptions,
@@ -54,6 +59,7 @@ impl Default for AppSettings {
             fonts: None,
             android_use_system_fonts: false,
             headless: false,
+            primary_window_visible: true,
             #[cfg(all(feature = "desktop", feature = "renderer-wgpu"))]
             dev_options: cranpose_app_shell::DevOptions::default(),
             #[cfg(all(feature = "desktop", feature = "renderer-wgpu"))]
@@ -434,6 +440,32 @@ impl AppLauncher {
     ))]
     pub fn run(self, content: impl FnMut() + 'static) -> ! {
         self.try_run(content)
+            .unwrap_or_else(|error| panic!("desktop launch failed: {error}"));
+        std::process::exit(0)
+    }
+
+    /// Run a desktop app that declares its visible operating-system windows directly.
+    ///
+    /// The primary launcher surface is kept hidden; content should declare peer
+    /// windows with `WindowNode` or `Window`.
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_os = "android")
+    ))]
+    pub fn try_run_windows(mut self, content: impl FnMut() + 'static) -> Result<(), LaunchError> {
+        self.settings.primary_window_visible = false;
+        self.try_run(content)
+    }
+
+    /// Run a desktop app that declares its visible operating-system windows directly.
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_os = "android")
+    ))]
+    pub fn run_windows(self, content: impl FnMut() + 'static) -> ! {
+        self.try_run_windows(content)
             .unwrap_or_else(|error| panic!("desktop launch failed: {error}"));
         std::process::exit(0)
     }

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -21,8 +21,9 @@ mod native_window;
 pub use launcher::LaunchError;
 pub use launcher::{AppLauncher, AppSettings};
 pub use native_window::{
-    current_native_window_surface_origin, rememberWindowState, Window, WindowConfig,
-    WindowModifierExt, WindowResizeDirection, WindowState,
+    current_native_window_surface_origin, rememberWindowState, Window, WindowAttachPolicy,
+    WindowConfig, WindowGroup, WindowId, WindowModifierExt, WindowMoveMode, WindowNode,
+    WindowResizeDirection, WindowState,
 };
 #[cfg(feature = "renderer-wgpu")]
 mod present_mode;
@@ -48,7 +49,8 @@ pub type RobotAppHook = dyn FnMut(String, String) -> Result<Option<String>, Stri
 /// Convenience imports for Cranpose applications.
 pub mod prelude {
     pub use crate::{
-        rememberWindowState, AppLauncher, AppSettings, Window, WindowConfig, WindowModifierExt,
+        rememberWindowState, AppLauncher, AppSettings, Window, WindowAttachPolicy, WindowConfig,
+        WindowGroup, WindowId, WindowModifierExt, WindowMoveMode, WindowNode,
         WindowResizeDirection, WindowState,
     };
     pub use cranpose_core::{mutableStateOf, remember, rememberUpdatedState, useState};

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -16,9 +16,14 @@ compile_error!(
 compile_error!("cranpose requires either `renderer-pixels` or `renderer-wgpu` feature.");
 
 mod launcher;
+mod native_window;
 #[cfg(all(feature = "desktop", feature = "renderer-wgpu"))]
 pub use launcher::LaunchError;
 pub use launcher::{AppLauncher, AppSettings};
+pub use native_window::{
+    current_native_window_surface_origin, rememberWindowState, Window, WindowConfig,
+    WindowModifierExt, WindowResizeDirection, WindowState,
+};
 #[cfg(feature = "renderer-wgpu")]
 mod present_mode;
 
@@ -42,7 +47,10 @@ pub type RobotAppHook = dyn FnMut(String, String) -> Result<Option<String>, Stri
 
 /// Convenience imports for Cranpose applications.
 pub mod prelude {
-    pub use crate::{AppLauncher, AppSettings};
+    pub use crate::{
+        rememberWindowState, AppLauncher, AppSettings, Window, WindowConfig, WindowModifierExt,
+        WindowResizeDirection, WindowState,
+    };
     pub use cranpose_core::{mutableStateOf, remember, rememberUpdatedState, useState};
     pub use cranpose_services::*;
     pub use cranpose_ui::*;

--- a/crates/cranpose/src/native_window.rs
+++ b/crates/cranpose/src/native_window.rs
@@ -1504,6 +1504,207 @@ mod tests {
         (runtime, position, size, state)
     }
 
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    fn reset_request_test_state() {
+        clear_native_window_requests();
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    fn request_exists(key: NativeWindowKey) -> bool {
+        native_window_requests()
+            .into_iter()
+            .any(|request| request.key == key)
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    fn request_test_composition() -> (
+        cranpose_core::Runtime,
+        cranpose_core::Composition<cranpose_core::MemoryApplier>,
+    ) {
+        let runtime = cranpose_core::Runtime::new(Arc::new(cranpose_core::DefaultScheduler));
+        let composition = cranpose_core::Composition::with_runtime(
+            cranpose_core::MemoryApplier::new(),
+            runtime.clone(),
+        );
+        (runtime, composition)
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[composable]
+    #[allow(non_snake_case)]
+    fn RequestCounterText(counter: cranpose_core::MutableState<i32>) {
+        cranpose_ui::Text(
+            format!("Counter {}", counter.get()),
+            cranpose_ui::Modifier::empty(),
+            cranpose_ui::TextStyle::default(),
+        );
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[composable]
+    #[allow(non_snake_case)]
+    fn PersistentRequestRoot(counter: cranpose_core::MutableState<i32>) {
+        RequestCounterText(counter);
+        WindowNode(
+            WindowId::from_static("persistent-request"),
+            WindowConfig::new("Persistent request", 100.0, 50.0),
+            || {},
+        );
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[composable]
+    #[allow(non_snake_case)]
+    fn ConditionalRequestRoot(show: cranpose_core::MutableState<bool>) {
+        if show.get() {
+            WindowNode(
+                WindowId::from_static("conditional-request"),
+                WindowConfig::new("Conditional request", 100.0, 50.0),
+                || {},
+            );
+        }
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[composable]
+    #[allow(non_snake_case)]
+    fn KeyedReplacementRequestRoot(show: cranpose_core::MutableState<bool>) {
+        let active = show.get();
+        cranpose_core::with_key(&active, || {
+            if active {
+                WindowNode(
+                    WindowId::from_static("keyed-replacement-request"),
+                    WindowConfig::new("Keyed replacement request", 100.0, 50.0),
+                    || {},
+                );
+            } else {
+                cranpose_ui::Text(
+                    "Inactive branch",
+                    cranpose_ui::Modifier::empty(),
+                    cranpose_ui::TextStyle::default(),
+                );
+            }
+        });
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn native_window_request_survives_unrelated_scoped_recompose() {
+        reset_request_test_state();
+
+        let (runtime, mut composition) = request_test_composition();
+        let counter = cranpose_core::MutableState::with_runtime(0i32, runtime.handle());
+        let key = WindowId::from_static("persistent-request");
+        let root_key = cranpose_core::location_key(file!(), line!(), column!());
+        composition
+            .render_stable(root_key, || PersistentRequestRoot(counter))
+            .expect("initial persistent native-window request render");
+        assert!(request_exists(key));
+
+        counter.set(1);
+        composition
+            .reconcile(root_key, || PersistentRequestRoot(counter))
+            .expect("persistent native-window request reconcile");
+
+        assert!(
+            request_exists(key),
+            "unchanged native-window declarations must stay registered when only a sibling scope recomposes"
+        );
+        clear_native_window_requests();
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn native_window_request_unregisters_when_conditional_declaration_is_removed() {
+        reset_request_test_state();
+
+        let (runtime, mut composition) = request_test_composition();
+        let show = cranpose_core::MutableState::with_runtime(true, runtime.handle());
+        let key = WindowId::from_static("conditional-request");
+        let root_key = cranpose_core::location_key(file!(), line!(), column!());
+        composition
+            .render_stable(root_key, || ConditionalRequestRoot(show))
+            .expect("initial conditional native-window request render");
+        assert!(request_exists(key));
+
+        show.set(false);
+        composition
+            .reconcile(root_key, || ConditionalRequestRoot(show))
+            .expect("conditional native-window request reconcile");
+
+        assert!(
+            !request_exists(key),
+            "removed native-window declarations must unregister through their disposable owner"
+        );
+        clear_native_window_requests();
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn native_window_request_unregisters_when_keyed_branch_is_replaced() {
+        reset_request_test_state();
+
+        let (runtime, mut composition) = request_test_composition();
+        let show = cranpose_core::MutableState::with_runtime(true, runtime.handle());
+        let key = WindowId::from_static("keyed-replacement-request");
+        let root_key = cranpose_core::location_key(file!(), line!(), column!());
+        composition
+            .render_stable(root_key, || KeyedReplacementRequestRoot(show))
+            .expect("initial keyed native-window request render");
+        assert!(request_exists(key));
+
+        show.set(false);
+        composition
+            .reconcile(root_key, || KeyedReplacementRequestRoot(show))
+            .expect("keyed native-window request reconcile");
+
+        assert!(
+            !request_exists(key),
+            "keyed branch replacement must unregister native-window declarations from the inactive branch"
+        );
+        clear_native_window_requests();
+    }
+
     #[test]
     fn borderless_options_disable_decorations_and_resizing() {
         let options = NativeWindowOptions::borderless("Tool", 100.0, 50.0);

--- a/crates/cranpose/src/native_window.rs
+++ b/crates/cranpose/src/native_window.rs
@@ -1,5 +1,7 @@
 //! Declarative native window support.
 
+use cranpose_core::MutableState;
+use cranpose_ui::{composable, Modifier, Point, PointerEventKind, PointerInputScope, Size};
 #[cfg(all(
     feature = "desktop",
     feature = "renderer-wgpu",
@@ -20,15 +22,6 @@ use std::collections::HashMap;
 ))]
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
-#[cfg(all(
-    feature = "desktop",
-    feature = "renderer-wgpu",
-    not(target_arch = "wasm32")
-))]
-use std::rc::Weak;
-
-use cranpose_core::MutableState;
-use cranpose_ui::{composable, Modifier, Point, PointerEventKind, PointerInputScope, Size};
 
 /// A stable identifier for a declarative native window.
 #[cfg(all(
@@ -512,7 +505,7 @@ pub(crate) type NativeWindowContent = Rc<RefCell<Box<dyn FnMut()>>>;
 ))]
 type NativeWindowOwner = Rc<()>;
 
-type NativeWindowDragHandler = Rc<dyn Fn()>;
+type NativeWindowDragHandler = Rc<dyn Fn() -> bool>;
 type NativeWindowResizeHandler = Rc<dyn Fn(WindowResizeDirection)>;
 
 #[cfg(all(
@@ -536,20 +529,8 @@ pub(crate) struct NativeWindowRequest {
     feature = "renderer-wgpu",
     not(target_arch = "wasm32")
 ))]
-struct NativeWindowRevision {
-    content: Weak<RefCell<Box<dyn FnMut()>>>,
-    revision: u64,
-}
-
-#[cfg(all(
-    feature = "desktop",
-    feature = "renderer-wgpu",
-    not(target_arch = "wasm32")
-))]
 thread_local! {
     static NATIVE_WINDOWS: RefCell<HashMap<NativeWindowKey, NativeWindowRequest>> =
-        RefCell::new(HashMap::new());
-    static NATIVE_WINDOW_REVISIONS: RefCell<HashMap<NativeWindowKey, NativeWindowRevision>> =
         RefCell::new(HashMap::new());
     static NEXT_NATIVE_WINDOW_REVISION: Cell<u64> = const { Cell::new(1) };
 }
@@ -631,8 +612,7 @@ fn request_native_window_drag() -> bool {
     CURRENT_NATIVE_WINDOW_DRAG.with(|slot| {
         let handler = slot.borrow().clone();
         if let Some(handler) = handler {
-            handler();
-            true
+            handler()
         } else {
             false
         }
@@ -760,7 +740,7 @@ fn register_native_window(
     content: NativeWindowContent,
     owner: NativeWindowOwner,
 ) {
-    let revision = native_window_content_revision(key, &content);
+    let revision = next_native_window_revision();
     NATIVE_WINDOWS.with(|windows| {
         windows.borrow_mut().insert(
             key,
@@ -792,30 +772,6 @@ fn unregister_native_window(key: NativeWindowKey, owner: NativeWindowOwner) {
             windows.remove(&key);
         }
     });
-}
-
-#[cfg(all(
-    feature = "desktop",
-    feature = "renderer-wgpu",
-    not(target_arch = "wasm32")
-))]
-fn native_window_content_revision(key: NativeWindowKey, content: &NativeWindowContent) -> u64 {
-    NATIVE_WINDOW_REVISIONS.with(|revisions| {
-        let content = Rc::downgrade(content);
-        let mut revisions = revisions.borrow_mut();
-        if let Some(state) = revisions.get_mut(&key) {
-            if state.content.ptr_eq(&content) {
-                return state.revision;
-            }
-            state.content = content;
-            state.revision = next_native_window_revision();
-            return state.revision;
-        }
-
-        let revision = next_native_window_revision();
-        revisions.insert(key, NativeWindowRevision { content, revision });
-        revision
-    })
 }
 
 #[cfg(all(
@@ -1011,6 +967,25 @@ mod tests {
         assert!(!request_native_window_drag());
     }
 
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn drag_request_uses_handler_result() {
+        let resize_handler: NativeWindowResizeHandler = Rc::new(|_| {});
+
+        with_native_window_drag_handler(Rc::new(|| true), Rc::clone(&resize_handler), || {
+            assert!(request_native_window_drag());
+        });
+        with_native_window_drag_handler(Rc::new(|| false), resize_handler, || {
+            assert!(!request_native_window_drag());
+        });
+
+        assert!(!request_native_window_drag());
+    }
+
     #[test]
     fn resize_request_reports_missing_handler() {
         assert!(!request_native_window_resize(
@@ -1108,7 +1083,7 @@ mod tests {
         let requests = native_window_requests();
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].key, key);
-        assert_eq!(requests[0].revision, initial_revision);
+        assert_ne!(requests[0].revision, initial_revision);
         assert!(!requests[0].options.visible);
 
         clear_native_window_requests();
@@ -1121,7 +1096,7 @@ mod tests {
         not(target_arch = "wasm32")
     ))]
     #[test]
-    fn registry_revisions_change_when_content_identity_changes() {
+    fn registry_revisions_change_on_each_declaration() {
         clear_native_window_requests();
 
         let key = NativeWindowKey::from_static("content-update");
@@ -1151,6 +1126,53 @@ mod tests {
             NativeWindowEvents::new(),
             None,
             second_content,
+            owner,
+        );
+        let second_revision = native_window_requests()
+            .into_iter()
+            .next()
+            .expect("second native window request")
+            .revision;
+
+        assert_ne!(first_revision, second_revision);
+
+        clear_native_window_requests();
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn registry_revisions_change_when_same_content_is_updated() {
+        clear_native_window_requests();
+
+        let key = NativeWindowKey::from_static("same-content-update");
+        let owner = test_owner();
+        let content: NativeWindowContent =
+            Rc::new(RefCell::new(Box::new(|| {}) as Box<dyn FnMut()>));
+
+        register_native_window(
+            key,
+            NativeWindowOptions::new("Panel", 100.0, 50.0),
+            NativeWindowEvents::new(),
+            None,
+            Rc::clone(&content),
+            Rc::clone(&owner),
+        );
+        let first_revision = native_window_requests()
+            .into_iter()
+            .next()
+            .expect("first native window request")
+            .revision;
+
+        register_native_window(
+            key,
+            NativeWindowOptions::new("Panel", 100.0, 50.0),
+            NativeWindowEvents::new(),
+            None,
+            content,
             owner,
         );
         let second_revision = native_window_requests()
@@ -1217,7 +1239,7 @@ mod tests {
         not(target_arch = "wasm32")
     ))]
     #[test]
-    fn clear_preserves_same_content_revision() {
+    fn clear_does_not_reuse_same_content_revision() {
         clear_native_window_requests();
 
         let key = NativeWindowKey::from_static("remove-window");
@@ -1256,7 +1278,7 @@ mod tests {
             .expect("registered native window request after cleanup")
             .revision;
 
-        assert_eq!(first_revision, second_revision);
+        assert_ne!(first_revision, second_revision);
 
         clear_native_window_requests();
     }

--- a/crates/cranpose/src/native_window.rs
+++ b/crates/cranpose/src/native_window.rs
@@ -450,6 +450,16 @@ pub trait WindowModifierExt {
     /// native desktop sub-window, so the same UI can be used inline.
     fn window_drag_area(self) -> Modifier;
 
+    /// Marks this component as a drag target and reports the native drag lifecycle.
+    ///
+    /// The callbacks run only when an OS-window drag is actually accepted by
+    /// the current native desktop sub-window.
+    fn window_drag_area_with_callbacks(
+        self,
+        on_started: impl Fn() + 'static,
+        on_finished: impl Fn() + 'static,
+    ) -> Modifier;
+
     /// Marks this component as a resize target for its containing OS window.
     ///
     /// The modifier is inert when the component is not currently rendered in a
@@ -459,17 +469,53 @@ pub trait WindowModifierExt {
 
 impl WindowModifierExt for Modifier {
     fn window_drag_area(self) -> Modifier {
-        self.pointer_input((), move |scope: PointerInputScope| async move {
-            scope
-                .await_pointer_event_scope(|await_scope| async move {
-                    loop {
-                        let event = await_scope.await_pointer_event().await;
-                        if event.kind == PointerEventKind::Down && request_native_window_drag() {
-                            event.consume();
+        self.window_drag_area_with_callbacks(|| {}, || {})
+    }
+
+    fn window_drag_area_with_callbacks(
+        self,
+        on_started: impl Fn() + 'static,
+        on_finished: impl Fn() + 'static,
+    ) -> Modifier {
+        let on_started: Rc<dyn Fn()> = Rc::new(on_started);
+        let on_finished: Rc<dyn Fn()> = Rc::new(on_finished);
+        self.pointer_input((), move |scope: PointerInputScope| {
+            let on_started = on_started.clone();
+            let on_finished = on_finished.clone();
+            async move {
+                scope
+                    .await_pointer_event_scope(|await_scope| async move {
+                        let mut dragging = false;
+                        loop {
+                            let event = await_scope.await_pointer_event().await;
+                            match event.kind {
+                                PointerEventKind::Down => {
+                                    if request_native_window_drag() {
+                                        dragging = true;
+                                        event.consume();
+                                        on_started();
+                                    }
+                                }
+                                PointerEventKind::Move => {
+                                    if dragging && event.buttons == Default::default() {
+                                        dragging = false;
+                                        on_finished();
+                                    }
+                                }
+                                PointerEventKind::Up | PointerEventKind::Cancel => {
+                                    if dragging {
+                                        dragging = false;
+                                        on_finished();
+                                    }
+                                }
+                                PointerEventKind::Scroll
+                                | PointerEventKind::Enter
+                                | PointerEventKind::Exit => {}
+                            }
                         }
-                    }
-                })
-                .await;
+                    })
+                    .await;
+            }
         })
     }
 
@@ -984,6 +1030,56 @@ mod tests {
         });
 
         assert!(!request_native_window_drag());
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn drag_area_callbacks_follow_accepted_native_drag_lifecycle() {
+        use cranpose_ui::{collect_slices_from_modifier, PointerEvent};
+        use std::cell::Cell;
+
+        let started = Rc::new(Cell::new(0));
+        let finished = Rc::new(Cell::new(0));
+        let modifier = Modifier::empty().window_drag_area_with_callbacks(
+            {
+                let started = Rc::clone(&started);
+                move || started.set(started.get() + 1)
+            },
+            {
+                let finished = Rc::clone(&finished);
+                move || finished.set(finished.get() + 1)
+            },
+        );
+        let slices = collect_slices_from_modifier(&modifier);
+        let handler = slices
+            .pointer_inputs()
+            .first()
+            .expect("window drag pointer handler")
+            .clone();
+        let resize_handler: NativeWindowResizeHandler = Rc::new(|_| {});
+
+        with_native_window_drag_handler(Rc::new(|| true), resize_handler, || {
+            let down = PointerEvent::new(
+                PointerEventKind::Down,
+                Point::new(4.0, 5.0),
+                Point::new(4.0, 5.0),
+            );
+            handler(down.clone());
+            assert!(down.is_consumed());
+
+            handler(PointerEvent::new(
+                PointerEventKind::Up,
+                Point::new(4.0, 5.0),
+                Point::new(4.0, 5.0),
+            ));
+        });
+
+        assert_eq!(started.get(), 1);
+        assert_eq!(finished.get(), 1);
     }
 
     #[test]

--- a/crates/cranpose/src/native_window.rs
+++ b/crates/cranpose/src/native_window.rs
@@ -1,0 +1,1263 @@
+//! Declarative native window support.
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+use std::cell::Cell;
+use std::cell::RefCell;
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+use std::collections::HashMap;
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+use std::hash::{Hash, Hasher};
+use std::rc::Rc;
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+use std::rc::Weak;
+
+use cranpose_core::MutableState;
+use cranpose_ui::{composable, Modifier, Point, PointerEventKind, PointerInputScope, Size};
+
+/// A stable identifier for a declarative native window.
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct NativeWindowKey(u64);
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+impl NativeWindowKey {
+    /// Creates a native window key from a static application identifier.
+    pub fn from_static(id: &'static str) -> Self {
+        Self(hash_id(id))
+    }
+}
+
+/// Coordinate space used by a native window's configured position.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NativeWindowPositionOrigin {
+    /// Position is expressed in operating-system screen coordinates.
+    Screen,
+    /// Position is expressed relative to the owning application window.
+    HostWindow,
+}
+
+/// Configuration for a declarative native window.
+#[derive(Clone, Debug, PartialEq)]
+pub struct NativeWindowOptions {
+    /// Window title exposed to the operating system.
+    pub title: String,
+    /// Initial content width in logical pixels.
+    pub width: f32,
+    /// Initial content height in logical pixels.
+    pub height: f32,
+    /// Optional initial outer-window x position in the configured coordinate space.
+    pub x: Option<f32>,
+    /// Optional initial outer-window y position in the configured coordinate space.
+    pub y: Option<f32>,
+    /// Coordinate space used by `x` and `y`.
+    pub position_origin: NativeWindowPositionOrigin,
+    /// Whether the operating system should draw window decorations.
+    pub decorations: bool,
+    /// Whether the window surface requests compositor transparency.
+    pub transparent: bool,
+    /// Whether the operating system should allow interactive resizing.
+    pub resizable: bool,
+    /// Whether the window should be visible when created.
+    pub visible: bool,
+    /// Whether the window should be kept above normal windows.
+    pub always_on_top: bool,
+    /// Optional minimum content width in logical pixels.
+    pub min_width: Option<f32>,
+    /// Optional minimum content height in logical pixels.
+    pub min_height: Option<f32>,
+    /// Optional maximum content width in logical pixels.
+    pub max_width: Option<f32>,
+    /// Optional maximum content height in logical pixels.
+    pub max_height: Option<f32>,
+}
+
+impl NativeWindowOptions {
+    /// Creates a decorated native window with a fixed initial size.
+    pub fn new(title: impl Into<String>, width: f32, height: f32) -> Self {
+        Self {
+            title: title.into(),
+            width,
+            height,
+            x: None,
+            y: None,
+            position_origin: NativeWindowPositionOrigin::Screen,
+            decorations: true,
+            transparent: false,
+            resizable: true,
+            visible: true,
+            always_on_top: false,
+            min_width: None,
+            min_height: None,
+            max_width: None,
+            max_height: None,
+        }
+    }
+
+    /// Creates a borderless, non-resizable native window with a fixed initial size.
+    pub fn borderless(title: impl Into<String>, width: f32, height: f32) -> Self {
+        Self {
+            decorations: false,
+            resizable: false,
+            ..Self::new(title, width, height)
+        }
+    }
+
+    /// Sets the initial outer-window position in logical screen coordinates.
+    pub fn with_position(mut self, x: f32, y: f32) -> Self {
+        self.x = Some(x);
+        self.y = Some(y);
+        self.position_origin = NativeWindowPositionOrigin::Screen;
+        self
+    }
+
+    /// Sets the initial outer-window position relative to the host application window.
+    pub fn with_host_window_position(mut self, x: f32, y: f32) -> Self {
+        self.x = Some(x);
+        self.y = Some(y);
+        self.position_origin = NativeWindowPositionOrigin::HostWindow;
+        self
+    }
+
+    /// Sets whether compositor transparency should be requested.
+    pub fn with_transparent(mut self, transparent: bool) -> Self {
+        self.transparent = transparent;
+        self
+    }
+
+    /// Sets whether the operating system should allow interactive resizing.
+    pub fn with_resizable(mut self, resizable: bool) -> Self {
+        self.resizable = resizable;
+        self
+    }
+
+    /// Sets whether the window should be visible when created.
+    pub fn with_visible(mut self, visible: bool) -> Self {
+        self.visible = visible;
+        self
+    }
+
+    /// Sets whether the window should be kept above normal windows.
+    pub fn with_always_on_top(mut self, always_on_top: bool) -> Self {
+        self.always_on_top = always_on_top;
+        self
+    }
+
+    /// Sets the minimum content size in logical pixels.
+    pub fn with_min_size(mut self, width: f32, height: f32) -> Self {
+        self.min_width = Some(width);
+        self.min_height = Some(height);
+        self
+    }
+
+    /// Sets the maximum content size in logical pixels.
+    pub fn with_max_size(mut self, width: f32, height: f32) -> Self {
+        self.max_width = Some(width);
+        self.max_height = Some(height);
+        self
+    }
+}
+
+/// Event callbacks emitted by a declarative native window.
+#[derive(Clone, Default)]
+pub(crate) struct NativeWindowEvents {
+    pub(crate) on_moved: Option<Rc<dyn Fn(f32, f32)>>,
+    pub(crate) on_resized: Option<Rc<dyn Fn(f32, f32)>>,
+    pub(crate) on_close_requested: Option<Rc<dyn Fn()>>,
+}
+
+impl NativeWindowEvents {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn with_on_moved(mut self, callback: impl Fn(f32, f32) + 'static) -> Self {
+        let next = Rc::new(callback);
+        self.on_moved = Some(match self.on_moved.take() {
+            Some(previous) => Rc::new(move |x, y| {
+                previous(x, y);
+                next(x, y);
+            }),
+            None => next,
+        });
+        self
+    }
+
+    fn with_on_resized(mut self, callback: impl Fn(f32, f32) + 'static) -> Self {
+        let next = Rc::new(callback);
+        self.on_resized = Some(match self.on_resized.take() {
+            Some(previous) => Rc::new(move |width, height| {
+                previous(width, height);
+                next(width, height);
+            }),
+            None => next,
+        });
+        self
+    }
+
+    fn with_on_close_requested(mut self, callback: impl Fn() + 'static) -> Self {
+        let next = Rc::new(callback);
+        self.on_close_requested = Some(match self.on_close_requested.take() {
+            Some(previous) => Rc::new(move || {
+                previous();
+                next();
+            }),
+            None => next,
+        });
+        self
+    }
+}
+
+/// Mutable position and size state for a declarative OS window.
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct WindowState {
+    position: MutableState<Option<Point>>,
+    size: MutableState<Size>,
+}
+
+impl WindowState {
+    /// Returns the last known outer-window position in logical screen coordinates.
+    pub fn position(self) -> Option<Point> {
+        self.position.get()
+    }
+
+    /// Returns the last known outer-window position without subscribing to changes.
+    pub fn position_non_reactive(self) -> Option<Point> {
+        self.position.get_non_reactive()
+    }
+
+    /// Updates the stored outer-window position.
+    pub fn set_position(self, position: Option<Point>) {
+        if self.position.get_non_reactive() != position {
+            self.position.set(position);
+        }
+    }
+
+    /// Moves the stored outer-window position by a logical delta when a position is known.
+    pub fn translate(self, dx: f32, dy: f32) {
+        if let Some(position) = self.position_non_reactive() {
+            self.set_position(Some(Point::new(position.x + dx, position.y + dy)));
+        }
+    }
+
+    /// Returns the current content size in logical pixels.
+    pub fn size(self) -> Size {
+        self.size.get()
+    }
+
+    /// Returns the current content size without subscribing to changes.
+    pub fn size_non_reactive(self) -> Size {
+        self.size.get_non_reactive()
+    }
+
+    /// Updates the stored content size in logical pixels.
+    pub fn set_size(self, size: Size) {
+        if self.size.get_non_reactive() != size {
+            self.size.set(size);
+        }
+    }
+}
+
+/// Remembers native-window position and size across recompositions.
+#[allow(non_snake_case)]
+#[composable]
+pub fn rememberWindowState(width: f32, height: f32) -> WindowState {
+    WindowState {
+        position: cranpose_core::useState(|| None::<Point>),
+        size: cranpose_core::useState(move || Size::new(width, height)),
+    }
+}
+
+/// Declarative configuration for an operating-system window.
+///
+/// Use this with [`Window`] to render a composable subtree into a separate OS
+/// window on desktop. Platforms without native sub-window support render the
+/// content inline, so pointer input and other composable behavior stay shared.
+#[derive(Clone)]
+pub struct WindowConfig {
+    options: NativeWindowOptions,
+    callbacks: NativeWindowEvents,
+    state: Option<WindowState>,
+}
+
+impl WindowConfig {
+    /// Creates a decorated, resizable window with a fixed initial content size.
+    pub fn new(title: impl Into<String>, width: f32, height: f32) -> Self {
+        Self {
+            options: NativeWindowOptions::new(title, width, height),
+            callbacks: NativeWindowEvents::new(),
+            state: None,
+        }
+    }
+
+    /// Creates a decorated, resizable window using a remembered state size.
+    pub fn new_for_state(title: impl Into<String>, state: WindowState) -> Self {
+        let size = state.size();
+        Self::new(title, size.width, size.height).with_state(state)
+    }
+
+    /// Creates a borderless, non-resizable window with a fixed initial content size.
+    pub fn borderless(title: impl Into<String>, width: f32, height: f32) -> Self {
+        Self {
+            options: NativeWindowOptions::borderless(title, width, height),
+            callbacks: NativeWindowEvents::new(),
+            state: None,
+        }
+    }
+
+    /// Creates a borderless, non-resizable window using a remembered state size.
+    pub fn borderless_for_state(title: impl Into<String>, state: WindowState) -> Self {
+        let size = state.size();
+        Self::borderless(title, size.width, size.height).with_state(state)
+    }
+
+    /// Sets the initial outer-window position in logical screen coordinates.
+    pub fn with_position(mut self, x: f32, y: f32) -> Self {
+        self.options = self.options.with_position(x, y);
+        self
+    }
+
+    /// Sets the initial outer-window position relative to the host application window.
+    pub fn with_host_window_position(mut self, x: f32, y: f32) -> Self {
+        self.options = self.options.with_host_window_position(x, y);
+        self
+    }
+
+    /// Sets whether compositor transparency should be requested.
+    pub fn with_transparent(mut self, transparent: bool) -> Self {
+        self.options = self.options.with_transparent(transparent);
+        self
+    }
+
+    /// Sets whether the operating system should allow interactive resizing.
+    pub fn with_resizable(mut self, resizable: bool) -> Self {
+        self.options = self.options.with_resizable(resizable);
+        self
+    }
+
+    /// Sets whether the window should be visible when created.
+    pub fn with_visible(mut self, visible: bool) -> Self {
+        self.options = self.options.with_visible(visible);
+        self
+    }
+
+    /// Sets whether the window should be kept above normal windows.
+    pub fn with_always_on_top(mut self, always_on_top: bool) -> Self {
+        self.options = self.options.with_always_on_top(always_on_top);
+        self
+    }
+
+    /// Sets the minimum content size in logical pixels.
+    pub fn with_min_size(mut self, width: f32, height: f32) -> Self {
+        self.options = self.options.with_min_size(width, height);
+        self
+    }
+
+    /// Sets the maximum content size in logical pixels.
+    pub fn with_max_size(mut self, width: f32, height: f32) -> Self {
+        self.options = self.options.with_max_size(width, height);
+        self
+    }
+
+    /// Called when the operating system reports an external outer-window move.
+    ///
+    /// Position changes requested through [`WindowState`] are acknowledged by the
+    /// desktop host without re-entering this callback.
+    pub fn on_moved(mut self, callback: impl Fn(f32, f32) + 'static) -> Self {
+        self.callbacks = self.callbacks.with_on_moved(callback);
+        self
+    }
+
+    /// Called when the operating system reports a new content size.
+    pub fn on_resized(mut self, callback: impl Fn(f32, f32) + 'static) -> Self {
+        self.callbacks = self.callbacks.with_on_resized(callback);
+        self
+    }
+
+    /// Called when the operating system requests that this window close.
+    pub fn on_close_requested(mut self, callback: impl Fn() + 'static) -> Self {
+        self.callbacks = self.callbacks.with_on_close_requested(callback);
+        self
+    }
+
+    /// Binds this configuration to a remembered [`WindowState`].
+    ///
+    /// The current state supplies the requested position and size. The desktop
+    /// window host keeps the state in sync with the operating system unless an
+    /// explicit callback updates it first.
+    pub fn with_state(mut self, state: WindowState) -> Self {
+        let size = state.size();
+        self.options.width = size.width;
+        self.options.height = size.height;
+        if let Some(position) = state.position() {
+            self.options.x = Some(position.x);
+            self.options.y = Some(position.y);
+            self.options.position_origin = NativeWindowPositionOrigin::Screen;
+        }
+        self.state = Some(state);
+        self
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (NativeWindowOptions, NativeWindowEvents, Option<WindowState>) {
+        (self.options, self.callbacks, self.state)
+    }
+}
+
+/// Edge or corner used by [`WindowModifierExt::window_resize_area`].
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum WindowResizeDirection {
+    /// Resize from the east edge.
+    East,
+    /// Resize from the north edge.
+    North,
+    /// Resize from the north-east corner.
+    NorthEast,
+    /// Resize from the north-west corner.
+    NorthWest,
+    /// Resize from the south edge.
+    South,
+    /// Resize from the south-east corner.
+    SouthEast,
+    /// Resize from the south-west corner.
+    SouthWest,
+    /// Resize from the west edge.
+    West,
+}
+
+/// Modifier helpers for composables rendered in OS windows.
+pub trait WindowModifierExt {
+    /// Marks this component as a drag target for its containing OS window.
+    ///
+    /// The modifier is inert when the component is not currently rendered in a
+    /// native desktop sub-window, so the same UI can be used inline.
+    fn window_drag_area(self) -> Modifier;
+
+    /// Marks this component as a resize target for its containing OS window.
+    ///
+    /// The modifier is inert when the component is not currently rendered in a
+    /// native desktop sub-window.
+    fn window_resize_area(self, direction: WindowResizeDirection) -> Modifier;
+}
+
+impl WindowModifierExt for Modifier {
+    fn window_drag_area(self) -> Modifier {
+        self.pointer_input((), move |scope: PointerInputScope| async move {
+            scope
+                .await_pointer_event_scope(|await_scope| async move {
+                    loop {
+                        let event = await_scope.await_pointer_event().await;
+                        if event.kind == PointerEventKind::Down && request_native_window_drag() {
+                            event.consume();
+                        }
+                    }
+                })
+                .await;
+        })
+    }
+
+    fn window_resize_area(self, direction: WindowResizeDirection) -> Modifier {
+        self.pointer_input(direction, move |scope: PointerInputScope| async move {
+            scope
+                .await_pointer_event_scope(|await_scope| async move {
+                    loop {
+                        let event = await_scope.await_pointer_event().await;
+                        if event.kind == PointerEventKind::Down
+                            && request_native_window_resize(direction)
+                        {
+                            event.consume();
+                        }
+                    }
+                })
+                .await;
+        })
+    }
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+pub(crate) type NativeWindowContent = Rc<RefCell<Box<dyn FnMut()>>>;
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+type NativeWindowOwner = Rc<()>;
+
+type NativeWindowDragHandler = Rc<dyn Fn()>;
+type NativeWindowResizeHandler = Rc<dyn Fn(WindowResizeDirection)>;
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+#[derive(Clone)]
+pub(crate) struct NativeWindowRequest {
+    pub(crate) key: NativeWindowKey,
+    pub(crate) options: NativeWindowOptions,
+    pub(crate) events: NativeWindowEvents,
+    pub(crate) state: Option<WindowState>,
+    pub(crate) content: NativeWindowContent,
+    pub(crate) revision: u64,
+    owner: NativeWindowOwner,
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+struct NativeWindowRevision {
+    content: Weak<RefCell<Box<dyn FnMut()>>>,
+    revision: u64,
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+thread_local! {
+    static NATIVE_WINDOWS: RefCell<HashMap<NativeWindowKey, NativeWindowRequest>> =
+        RefCell::new(HashMap::new());
+    static NATIVE_WINDOW_REVISIONS: RefCell<HashMap<NativeWindowKey, NativeWindowRevision>> =
+        RefCell::new(HashMap::new());
+    static NEXT_NATIVE_WINDOW_REVISION: Cell<u64> = const { Cell::new(1) };
+}
+
+thread_local! {
+    static CURRENT_NATIVE_WINDOW_DRAG: RefCell<Option<NativeWindowDragHandler>> = const { RefCell::new(None) };
+    static CURRENT_NATIVE_WINDOW_RESIZE: RefCell<Option<NativeWindowResizeHandler>> = const { RefCell::new(None) };
+    static CURRENT_NATIVE_WINDOW_SURFACE_ORIGIN: RefCell<Option<Point>> = const { RefCell::new(None) };
+}
+
+/// Renders content in an operating-system window owned by the current composition.
+///
+/// On desktop this creates or updates a separate OS window. Other platforms compose
+/// the content inline so the same UI remains usable without native sub-window support.
+#[allow(non_snake_case)]
+#[composable(no_skip)]
+pub fn Window(id: &'static str, config: WindowConfig, content: impl FnMut() + 'static) {
+    let (options, events, state) = config.into_parts();
+    NativeWindowWithEvents(id, options, events, state, content);
+}
+
+#[allow(non_snake_case)]
+#[composable(no_skip)]
+fn NativeWindowWithEvents(
+    id: &'static str,
+    options: NativeWindowOptions,
+    events: NativeWindowEvents,
+    state: Option<WindowState>,
+    content: impl FnMut() + 'static,
+) {
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    {
+        let key = NativeWindowKey::from_static(id);
+        let owner = cranpose_core::remember(|| Rc::new(())).with(Rc::clone);
+        let content_cell =
+            cranpose_core::remember(|| Rc::new(RefCell::new(Box::new(|| {}) as Box<dyn FnMut()>)))
+                .with(Rc::clone);
+        *content_cell.borrow_mut() = Box::new(content);
+
+        {
+            let options = options.clone();
+            let events = events.clone();
+            let content = Rc::clone(&content_cell);
+            let owner = Rc::clone(&owner);
+            cranpose_core::SideEffect(move || {
+                register_native_window(key, options, events, state, content, owner);
+            });
+        }
+
+        {
+            let owner = Rc::clone(&owner);
+            cranpose_core::DisposableEffect!(key, move |scope| {
+                scope.on_dispose(move || unregister_native_window(key, owner))
+            });
+        }
+    }
+
+    #[cfg(not(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    )))]
+    {
+        let mut content = content;
+        let _ = (id, options, events, state);
+        content();
+    }
+}
+
+/// Requests that the current native window begin an operating-system window drag.
+///
+/// This returns `true` when a desktop native window is currently dispatching the
+/// pointer event and the request was forwarded to the platform window.
+fn request_native_window_drag() -> bool {
+    CURRENT_NATIVE_WINDOW_DRAG.with(|slot| {
+        let handler = slot.borrow().clone();
+        if let Some(handler) = handler {
+            handler();
+            true
+        } else {
+            false
+        }
+    })
+}
+
+fn request_native_window_resize(direction: WindowResizeDirection) -> bool {
+    CURRENT_NATIVE_WINDOW_RESIZE.with(|slot| {
+        let handler = slot.borrow().clone();
+        if let Some(handler) = handler {
+            handler(direction);
+            true
+        } else {
+            false
+        }
+    })
+}
+
+/// Returns the desktop-space origin of the current native window surface while
+/// dispatching input inside a native window.
+///
+/// This is `None` for inline content and outside native-window input dispatch.
+pub fn current_native_window_surface_origin() -> Option<Point> {
+    CURRENT_NATIVE_WINDOW_SURFACE_ORIGIN.with(|slot| *slot.borrow())
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+pub(crate) fn native_window_requests() -> Vec<NativeWindowRequest> {
+    NATIVE_WINDOWS.with(|windows| windows.borrow().values().cloned().collect())
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+pub(crate) fn has_native_window_requests() -> bool {
+    NATIVE_WINDOWS.with(|windows| !windows.borrow().is_empty())
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+pub(crate) fn clear_native_window_requests() {
+    NATIVE_WINDOWS.with(|windows| windows.borrow_mut().clear());
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+pub(crate) fn with_native_window_drag_handler<R>(
+    handler: NativeWindowDragHandler,
+    resize_handler: NativeWindowResizeHandler,
+    f: impl FnOnce() -> R,
+) -> R {
+    struct WindowHandlerGuard;
+
+    impl Drop for WindowHandlerGuard {
+        fn drop(&mut self) {
+            CURRENT_NATIVE_WINDOW_DRAG.with(|slot| {
+                *slot.borrow_mut() = None;
+            });
+            CURRENT_NATIVE_WINDOW_RESIZE.with(|slot| {
+                *slot.borrow_mut() = None;
+            });
+        }
+    }
+
+    CURRENT_NATIVE_WINDOW_DRAG.with(|slot| {
+        *slot.borrow_mut() = Some(handler);
+    });
+    CURRENT_NATIVE_WINDOW_RESIZE.with(|slot| {
+        *slot.borrow_mut() = Some(resize_handler);
+    });
+    let _guard = WindowHandlerGuard;
+    f()
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+pub(crate) fn with_native_window_surface_origin<R>(
+    origin: Option<Point>,
+    f: impl FnOnce() -> R,
+) -> R {
+    struct SurfaceOriginGuard(Option<Point>);
+
+    impl Drop for SurfaceOriginGuard {
+        fn drop(&mut self) {
+            CURRENT_NATIVE_WINDOW_SURFACE_ORIGIN.with(|slot| {
+                *slot.borrow_mut() = self.0;
+            });
+        }
+    }
+
+    let previous = CURRENT_NATIVE_WINDOW_SURFACE_ORIGIN.with(|slot| {
+        let previous = *slot.borrow();
+        *slot.borrow_mut() = origin;
+        previous
+    });
+    let _guard = SurfaceOriginGuard(previous);
+    f()
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn register_native_window(
+    key: NativeWindowKey,
+    options: NativeWindowOptions,
+    events: NativeWindowEvents,
+    state: Option<WindowState>,
+    content: NativeWindowContent,
+    owner: NativeWindowOwner,
+) {
+    let revision = native_window_content_revision(key, &content);
+    NATIVE_WINDOWS.with(|windows| {
+        windows.borrow_mut().insert(
+            key,
+            NativeWindowRequest {
+                key,
+                options,
+                events,
+                state,
+                content,
+                revision,
+                owner,
+            },
+        );
+    });
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn unregister_native_window(key: NativeWindowKey, owner: NativeWindowOwner) {
+    NATIVE_WINDOWS.with(|windows| {
+        let mut windows = windows.borrow_mut();
+        if windows
+            .get(&key)
+            .is_some_and(|request| Rc::ptr_eq(&request.owner, &owner))
+        {
+            windows.remove(&key);
+        }
+    });
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn native_window_content_revision(key: NativeWindowKey, content: &NativeWindowContent) -> u64 {
+    NATIVE_WINDOW_REVISIONS.with(|revisions| {
+        let content = Rc::downgrade(content);
+        let mut revisions = revisions.borrow_mut();
+        if let Some(state) = revisions.get_mut(&key) {
+            if state.content.ptr_eq(&content) {
+                return state.revision;
+            }
+            state.content = content;
+            state.revision = next_native_window_revision();
+            return state.revision;
+        }
+
+        let revision = next_native_window_revision();
+        revisions.insert(key, NativeWindowRevision { content, revision });
+        revision
+    })
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn next_native_window_revision() -> u64 {
+    NEXT_NATIVE_WINDOW_REVISION.with(|revision| {
+        let current = revision.get();
+        revision.set(current.wrapping_add(1).max(1));
+        current
+    })
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn hash_id(id: &'static str) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    id.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn test_window_state(
+        width: f32,
+        height: f32,
+    ) -> (
+        cranpose_core::Runtime,
+        cranpose_core::OwnedMutableState<Option<Point>>,
+        cranpose_core::OwnedMutableState<Size>,
+        WindowState,
+    ) {
+        let runtime = cranpose_core::Runtime::new(Arc::new(cranpose_core::DefaultScheduler));
+        let handle = runtime.handle();
+        let position =
+            cranpose_core::OwnedMutableState::with_runtime(None::<Point>, handle.clone());
+        let size = cranpose_core::OwnedMutableState::with_runtime(Size::new(width, height), handle);
+        let state = WindowState {
+            position: position.handle(),
+            size: size.handle(),
+        };
+        (runtime, position, size, state)
+    }
+
+    #[test]
+    fn borderless_options_disable_decorations_and_resizing() {
+        let options = NativeWindowOptions::borderless("Tool", 100.0, 50.0);
+        assert_eq!(options.title, "Tool");
+        assert_eq!(options.width, 100.0);
+        assert_eq!(options.height, 50.0);
+        assert_eq!(options.position_origin, NativeWindowPositionOrigin::Screen);
+        assert!(!options.decorations);
+        assert!(!options.resizable);
+        assert!(options.visible);
+    }
+
+    #[test]
+    fn option_builders_update_specific_fields() {
+        let options = NativeWindowOptions::new("Panel", 10.0, 20.0)
+            .with_position(3.0, 4.0)
+            .with_transparent(true)
+            .with_resizable(false)
+            .with_visible(false)
+            .with_always_on_top(true)
+            .with_min_size(5.0, 6.0)
+            .with_max_size(50.0, 60.0);
+        assert_eq!(options.x, Some(3.0));
+        assert_eq!(options.y, Some(4.0));
+        assert_eq!(options.position_origin, NativeWindowPositionOrigin::Screen);
+        assert!(options.transparent);
+        assert!(!options.resizable);
+        assert!(!options.visible);
+        assert!(options.always_on_top);
+        assert_eq!(options.min_width, Some(5.0));
+        assert_eq!(options.min_height, Some(6.0));
+        assert_eq!(options.max_width, Some(50.0));
+        assert_eq!(options.max_height, Some(60.0));
+    }
+
+    #[test]
+    fn host_window_position_records_origin() {
+        let options =
+            NativeWindowOptions::new("Panel", 10.0, 20.0).with_host_window_position(3.0, 4.0);
+        assert_eq!(options.x, Some(3.0));
+        assert_eq!(options.y, Some(4.0));
+        assert_eq!(
+            options.position_origin,
+            NativeWindowPositionOrigin::HostWindow
+        );
+    }
+
+    #[test]
+    fn events_builder_registers_move_callback() {
+        let events = NativeWindowEvents::new().with_on_moved(|_, _| {});
+        assert!(events.on_moved.is_some());
+    }
+
+    #[test]
+    fn window_state_accessors_update_position_and_size() {
+        let (_runtime, _position_owner, _size_owner, state) = test_window_state(100.0, 50.0);
+
+        assert_eq!(state.position_non_reactive(), None);
+        assert_eq!(state.size_non_reactive(), Size::new(100.0, 50.0));
+
+        state.set_position(Some(Point::new(4.0, 8.0)));
+        assert_eq!(state.position_non_reactive(), Some(Point::new(4.0, 8.0)));
+
+        state.translate(3.0, -2.0);
+        assert_eq!(state.position_non_reactive(), Some(Point::new(7.0, 6.0)));
+
+        state.set_size(Size::new(120.0, 64.0));
+        assert_eq!(state.size_non_reactive(), Size::new(120.0, 64.0));
+    }
+
+    #[test]
+    fn window_config_collects_window_settings_and_callbacks() {
+        let config = WindowConfig::borderless("Panel", 100.0, 50.0)
+            .with_host_window_position(7.0, 9.0)
+            .with_transparent(true)
+            .with_resizable(false)
+            .with_visible(false)
+            .with_always_on_top(true)
+            .with_min_size(20.0, 10.0)
+            .with_max_size(400.0, 200.0)
+            .on_moved(|_, _| {})
+            .on_resized(|_, _| {})
+            .on_close_requested(|| {});
+
+        let (options, callbacks, state) = config.into_parts();
+        assert_eq!(options.title, "Panel");
+        assert_eq!(options.width, 100.0);
+        assert_eq!(options.height, 50.0);
+        assert_eq!(options.x, Some(7.0));
+        assert_eq!(options.y, Some(9.0));
+        assert_eq!(
+            options.position_origin,
+            NativeWindowPositionOrigin::HostWindow
+        );
+        assert!(!options.decorations);
+        assert!(options.transparent);
+        assert!(!options.resizable);
+        assert!(!options.visible);
+        assert!(options.always_on_top);
+        assert_eq!(options.min_width, Some(20.0));
+        assert_eq!(options.min_height, Some(10.0));
+        assert_eq!(options.max_width, Some(400.0));
+        assert_eq!(options.max_height, Some(200.0));
+        assert!(callbacks.on_moved.is_some());
+        assert!(callbacks.on_resized.is_some());
+        assert!(callbacks.on_close_requested.is_some());
+        assert!(state.is_none());
+    }
+
+    #[test]
+    fn state_window_configs_bind_size_position() {
+        let (_runtime, _position_owner, _size_owner, state) = test_window_state(100.0, 50.0);
+        state.set_position(Some(Point::new(7.0, 9.0)));
+
+        let (options, callbacks, bound_state) =
+            WindowConfig::borderless_for_state("Panel", state).into_parts();
+        assert_eq!(options.title, "Panel");
+        assert_eq!(options.width, 100.0);
+        assert_eq!(options.height, 50.0);
+        assert_eq!(options.x, Some(7.0));
+        assert_eq!(options.y, Some(9.0));
+        assert!(!options.decorations);
+        assert!(!options.resizable);
+        assert!(bound_state == Some(state));
+        assert!(callbacks.on_moved.is_none());
+        assert!(callbacks.on_resized.is_none());
+
+        state.set_size(Size::new(320.0, 200.0));
+
+        let (decorated_options, _, decorated_state) =
+            WindowConfig::new_for_state("Decorated", state).into_parts();
+        assert_eq!(decorated_options.width, 320.0);
+        assert_eq!(decorated_options.height, 200.0);
+        assert!(decorated_options.decorations);
+        assert!(decorated_options.resizable);
+        assert!(decorated_state == Some(state));
+    }
+
+    #[test]
+    fn drag_request_reports_missing_handler() {
+        assert!(!request_native_window_drag());
+    }
+
+    #[test]
+    fn resize_request_reports_missing_handler() {
+        assert!(!request_native_window_resize(
+            WindowResizeDirection::SouthEast
+        ));
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn native_window_surface_origin_is_scoped_to_dispatch() {
+        assert_eq!(current_native_window_surface_origin(), None);
+
+        with_native_window_surface_origin(Some(Point::new(4.0, 8.0)), || {
+            assert_eq!(
+                current_native_window_surface_origin(),
+                Some(Point::new(4.0, 8.0))
+            );
+            with_native_window_surface_origin(Some(Point::new(12.0, 16.0)), || {
+                assert_eq!(
+                    current_native_window_surface_origin(),
+                    Some(Point::new(12.0, 16.0))
+                );
+            });
+            assert_eq!(
+                current_native_window_surface_origin(),
+                Some(Point::new(4.0, 8.0))
+            );
+        });
+
+        assert_eq!(current_native_window_surface_origin(), None);
+    }
+
+    #[test]
+    fn static_keys_are_stable() {
+        assert_eq!(
+            NativeWindowKey::from_static("stable"),
+            NativeWindowKey::from_static("stable")
+        );
+        assert_ne!(
+            NativeWindowKey::from_static("stable"),
+            NativeWindowKey::from_static("other")
+        );
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    fn test_owner() -> NativeWindowOwner {
+        Rc::new(())
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn registry_replaces_native_window_declarations_by_key() {
+        clear_native_window_requests();
+
+        let key = NativeWindowKey::from_static("visibility-update");
+        let owner = test_owner();
+        let content: NativeWindowContent =
+            Rc::new(RefCell::new(Box::new(|| {}) as Box<dyn FnMut()>));
+
+        register_native_window(
+            key,
+            NativeWindowOptions::new("Panel", 100.0, 50.0).with_visible(true),
+            NativeWindowEvents::new(),
+            None,
+            Rc::clone(&content),
+            Rc::clone(&owner),
+        );
+        let initial_revision = native_window_requests()
+            .into_iter()
+            .next()
+            .expect("first native window request")
+            .revision;
+
+        register_native_window(
+            key,
+            NativeWindowOptions::new("Panel", 100.0, 50.0).with_visible(false),
+            NativeWindowEvents::new(),
+            None,
+            content,
+            owner,
+        );
+
+        let requests = native_window_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].key, key);
+        assert_eq!(requests[0].revision, initial_revision);
+        assert!(!requests[0].options.visible);
+
+        clear_native_window_requests();
+        assert!(native_window_requests().is_empty());
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn registry_revisions_change_when_content_identity_changes() {
+        clear_native_window_requests();
+
+        let key = NativeWindowKey::from_static("content-update");
+        let owner = test_owner();
+        let first_content: NativeWindowContent =
+            Rc::new(RefCell::new(Box::new(|| {}) as Box<dyn FnMut()>));
+        let second_content: NativeWindowContent =
+            Rc::new(RefCell::new(Box::new(|| {}) as Box<dyn FnMut()>));
+
+        register_native_window(
+            key,
+            NativeWindowOptions::new("Panel", 100.0, 50.0),
+            NativeWindowEvents::new(),
+            None,
+            first_content,
+            Rc::clone(&owner),
+        );
+        let first_revision = native_window_requests()
+            .into_iter()
+            .next()
+            .expect("first native window request")
+            .revision;
+
+        register_native_window(
+            key,
+            NativeWindowOptions::new("Panel", 100.0, 50.0),
+            NativeWindowEvents::new(),
+            None,
+            second_content,
+            owner,
+        );
+        let second_revision = native_window_requests()
+            .into_iter()
+            .next()
+            .expect("second native window request")
+            .revision;
+
+        assert_ne!(first_revision, second_revision);
+
+        clear_native_window_requests();
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn unregister_ignores_stale_owner_after_redeclaration() {
+        clear_native_window_requests();
+
+        let key = NativeWindowKey::from_static("reattach-window");
+        let stale_owner = test_owner();
+        let current_owner = test_owner();
+        let first_content: NativeWindowContent =
+            Rc::new(RefCell::new(Box::new(|| {}) as Box<dyn FnMut()>));
+        let second_content: NativeWindowContent =
+            Rc::new(RefCell::new(Box::new(|| {}) as Box<dyn FnMut()>));
+
+        register_native_window(
+            key,
+            NativeWindowOptions::new("Panel", 100.0, 50.0),
+            NativeWindowEvents::new(),
+            None,
+            Rc::clone(&first_content),
+            Rc::clone(&stale_owner),
+        );
+
+        register_native_window(
+            key,
+            NativeWindowOptions::new("Panel", 100.0, 50.0),
+            NativeWindowEvents::new(),
+            None,
+            Rc::clone(&second_content),
+            Rc::clone(&current_owner),
+        );
+        unregister_native_window(key, stale_owner);
+
+        let requests = native_window_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].key, key);
+        assert!(Rc::ptr_eq(&requests[0].content, &second_content));
+
+        unregister_native_window(key, current_owner);
+        assert!(native_window_requests().is_empty());
+
+        clear_native_window_requests();
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn clear_preserves_same_content_revision() {
+        clear_native_window_requests();
+
+        let key = NativeWindowKey::from_static("remove-window");
+        let owner = test_owner();
+        let content: NativeWindowContent =
+            Rc::new(RefCell::new(Box::new(|| {}) as Box<dyn FnMut()>));
+
+        register_native_window(
+            key,
+            NativeWindowOptions::new("Panel", 100.0, 50.0),
+            NativeWindowEvents::new(),
+            None,
+            Rc::clone(&content),
+            Rc::clone(&owner),
+        );
+        let first_revision = native_window_requests()
+            .into_iter()
+            .next()
+            .expect("registered native window request")
+            .revision;
+
+        clear_native_window_requests();
+        assert!(native_window_requests().is_empty());
+
+        register_native_window(
+            key,
+            NativeWindowOptions::new("Panel", 100.0, 50.0),
+            NativeWindowEvents::new(),
+            None,
+            content,
+            owner,
+        );
+        let second_revision = native_window_requests()
+            .into_iter()
+            .next()
+            .expect("registered native window request after cleanup")
+            .revision;
+
+        assert_eq!(first_revision, second_revision);
+
+        clear_native_window_requests();
+    }
+}

--- a/crates/cranpose/src/native_window.rs
+++ b/crates/cranpose/src/native_window.rs
@@ -1124,6 +1124,10 @@ impl WindowGraphState {
             .collect()
     }
 
+    pub(crate) fn cancel_drag(&mut self) {
+        self.active_drag = None;
+    }
+
     pub(crate) fn finish_drag(
         &mut self,
         windows: &[WindowGraphPeerSnapshot],
@@ -1970,6 +1974,37 @@ mod tests {
             Some(Point::new(216.0, 100.0))
         );
         assert!(second_release_moves.is_empty());
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn graph_cancel_drag_discards_active_capture_without_release_moves() {
+        let main = WindowId::from_static("main");
+        let group = graph_group(WindowAttachPolicy::default());
+        let windows = vec![
+            graph_node(
+                "main",
+                Point::new(100.0, 100.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+            graph_node(
+                "playlist",
+                Point::new(216.0, 100.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+        ];
+
+        let mut graph = WindowGraphState::default();
+        graph.start_drag(&windows, main);
+        graph.cancel_drag();
+
+        assert!(graph.finish_drag(&windows).is_empty());
     }
 
     #[cfg(all(

--- a/crates/cranpose/src/native_window.rs
+++ b/crates/cranpose/src/native_window.rs
@@ -15,31 +15,42 @@ use std::cell::RefCell;
     not(target_arch = "wasm32")
 ))]
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::rc::Rc;
+
+/// A stable identifier for a declarative operating-system window.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct WindowId(u64);
+
+impl WindowId {
+    /// Creates a window identifier from a static application identifier.
+    pub fn from_static(id: &'static str) -> Self {
+        Self(hash_id(id))
+    }
+}
+
 #[cfg(all(
     feature = "desktop",
     feature = "renderer-wgpu",
     not(target_arch = "wasm32")
 ))]
-use std::hash::{Hash, Hasher};
-use std::rc::Rc;
+pub(crate) type NativeWindowKey = WindowId;
 
-/// A stable identifier for a declarative native window.
 #[cfg(all(
     feature = "desktop",
     feature = "renderer-wgpu",
     not(target_arch = "wasm32")
 ))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct NativeWindowKey(u64);
+pub(crate) struct WindowGroupId(u64);
 
 #[cfg(all(
     feature = "desktop",
     feature = "renderer-wgpu",
     not(target_arch = "wasm32")
 ))]
-impl NativeWindowKey {
-    /// Creates a native window key from a static application identifier.
-    pub fn from_static(id: &'static str) -> Self {
+impl WindowGroupId {
+    fn from_static(id: &'static str) -> Self {
         Self(hash_id(id))
     }
 }
@@ -86,6 +97,72 @@ pub struct NativeWindowOptions {
     pub max_width: Option<f32>,
     /// Optional maximum content height in logical pixels.
     pub max_height: Option<f32>,
+}
+
+/// Movement behavior for a group of attached peer windows.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WindowMoveMode {
+    /// Dragging any window in the group moves its attached component.
+    AllAttached,
+    /// Only the listed windows move their attached component; other windows move alone.
+    DragLeaderOnly(Vec<WindowId>),
+}
+
+impl WindowMoveMode {
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    fn moves_attached_component(&self, window_id: WindowId) -> bool {
+        match self {
+            Self::AllAttached => true,
+            Self::DragLeaderOnly(leaders) => leaders.contains(&window_id),
+        }
+    }
+}
+
+/// Attachment and snapping policy for a declarative peer-window group.
+#[derive(Clone, Debug, PartialEq)]
+pub struct WindowAttachPolicy {
+    /// Maximum edge distance, in logical pixels, that counts as a snap target.
+    pub snap_distance: f32,
+    /// Maximum edge distance, in logical pixels, that counts as attached.
+    pub attach_epsilon: f32,
+    /// Determines which dragged windows move attached neighbors.
+    pub move_mode: WindowMoveMode,
+}
+
+impl WindowAttachPolicy {
+    /// Creates a peer-window attachment policy.
+    pub fn new(snap_distance: f32, attach_epsilon: f32, move_mode: WindowMoveMode) -> Self {
+        Self {
+            snap_distance,
+            attach_epsilon,
+            move_mode,
+        }
+    }
+}
+
+impl Default for WindowAttachPolicy {
+    fn default() -> Self {
+        Self {
+            snap_distance: 8.0,
+            attach_epsilon: 3.0,
+            move_mode: WindowMoveMode::AllAttached,
+        }
+    }
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct NativeWindowGroupMembership {
+    pub(crate) id: WindowGroupId,
+    pub(crate) policy: WindowAttachPolicy,
 }
 
 impl NativeWindowOptions {
@@ -565,6 +642,7 @@ pub(crate) struct NativeWindowRequest {
     pub(crate) options: NativeWindowOptions,
     pub(crate) events: NativeWindowEvents,
     pub(crate) state: Option<WindowState>,
+    pub(crate) group: Option<NativeWindowGroupMembership>,
     pub(crate) content: NativeWindowContent,
     pub(crate) revision: u64,
     owner: NativeWindowOwner,
@@ -585,6 +663,12 @@ thread_local! {
     static CURRENT_NATIVE_WINDOW_DRAG: RefCell<Option<NativeWindowDragHandler>> = const { RefCell::new(None) };
     static CURRENT_NATIVE_WINDOW_RESIZE: RefCell<Option<NativeWindowResizeHandler>> = const { RefCell::new(None) };
     static CURRENT_NATIVE_WINDOW_SURFACE_ORIGIN: RefCell<Option<Point>> = const { RefCell::new(None) };
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    static CURRENT_WINDOW_GROUP: RefCell<Option<NativeWindowGroupMembership>> = const { RefCell::new(None) };
 }
 
 /// Renders content in an operating-system window owned by the current composition.
@@ -595,13 +679,56 @@ thread_local! {
 #[composable(no_skip)]
 pub fn Window(id: &'static str, config: WindowConfig, content: impl FnMut() + 'static) {
     let (options, events, state) = config.into_parts();
+    let window_id = WindowId::from_static(id);
+    NativeWindowWithEvents(window_id, options, events, state, content);
+}
+
+/// Renders content in a peer operating-system window.
+///
+/// This is the first-class multi-window spelling. [`Window`] remains a compact
+/// alias for the same peer-window declaration.
+#[allow(non_snake_case)]
+#[composable(no_skip)]
+pub fn WindowNode(id: WindowId, config: WindowConfig, content: impl FnMut() + 'static) {
+    let (options, events, state) = config.into_parts();
     NativeWindowWithEvents(id, options, events, state, content);
+}
+
+/// Applies attachment and move policy to all peer windows declared inside it.
+#[allow(non_snake_case)]
+#[composable(no_skip)]
+pub fn WindowGroup(id: &'static str, policy: WindowAttachPolicy, content: impl FnMut() + 'static) {
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    {
+        with_window_group(
+            NativeWindowGroupMembership {
+                id: WindowGroupId::from_static(id),
+                policy,
+            },
+            content,
+        );
+    }
+
+    #[cfg(not(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    )))]
+    {
+        let _ = (id, policy);
+        let mut content = content;
+        content();
+    }
 }
 
 #[allow(non_snake_case)]
 #[composable(no_skip)]
 fn NativeWindowWithEvents(
-    id: &'static str,
+    id: WindowId,
     options: NativeWindowOptions,
     events: NativeWindowEvents,
     state: Option<WindowState>,
@@ -613,7 +740,8 @@ fn NativeWindowWithEvents(
         not(target_arch = "wasm32")
     ))]
     {
-        let key = NativeWindowKey::from_static(id);
+        let key = id;
+        let group = current_window_group();
         let owner = cranpose_core::remember(|| Rc::new(())).with(Rc::clone);
         let content_cell =
             cranpose_core::remember(|| Rc::new(RefCell::new(Box::new(|| {}) as Box<dyn FnMut()>)))
@@ -626,7 +754,7 @@ fn NativeWindowWithEvents(
             let content = Rc::clone(&content_cell);
             let owner = Rc::clone(&owner);
             cranpose_core::SideEffect(move || {
-                register_native_window(key, options, events, state, content, owner);
+                register_native_window(key, options, events, state, group, content, owner);
             });
         }
 
@@ -778,11 +906,44 @@ pub(crate) fn with_native_window_surface_origin<R>(
     feature = "renderer-wgpu",
     not(target_arch = "wasm32")
 ))]
+fn current_window_group() -> Option<NativeWindowGroupMembership> {
+    CURRENT_WINDOW_GROUP.with(|slot| slot.borrow().clone())
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn with_window_group<R>(group: NativeWindowGroupMembership, f: impl FnOnce() -> R) -> R {
+    struct WindowGroupGuard(Option<NativeWindowGroupMembership>);
+
+    impl Drop for WindowGroupGuard {
+        fn drop(&mut self) {
+            CURRENT_WINDOW_GROUP.with(|slot| {
+                *slot.borrow_mut() = self.0.take();
+            });
+        }
+    }
+
+    let previous = CURRENT_WINDOW_GROUP.with(|slot| slot.borrow_mut().replace(group));
+    let guard = WindowGroupGuard(previous);
+    let result = f();
+    drop(guard);
+    result
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
 fn register_native_window(
     key: NativeWindowKey,
     options: NativeWindowOptions,
     events: NativeWindowEvents,
     state: Option<WindowState>,
+    group: Option<NativeWindowGroupMembership>,
     content: NativeWindowContent,
     owner: NativeWindowOwner,
 ) {
@@ -795,6 +956,7 @@ fn register_native_window(
                 options,
                 events,
                 state,
+                group,
                 content,
                 revision,
                 owner,
@@ -833,15 +995,483 @@ fn next_native_window_revision() -> u64 {
     })
 }
 
+fn hash_id(id: &'static str) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    id.hash(&mut hasher);
+    hasher.finish()
+}
+
 #[cfg(all(
     feature = "desktop",
     feature = "renderer-wgpu",
     not(target_arch = "wasm32")
 ))]
-fn hash_id(id: &'static str) -> u64 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    id.hash(&mut hasher);
-    hasher.finish()
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct WindowGraphNodeSnapshot {
+    pub(crate) id: WindowId,
+    pub(crate) position: Point,
+    pub(crate) size: Size,
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct WindowGraphPeerSnapshot {
+    pub(crate) node: WindowGraphNodeSnapshot,
+    pub(crate) group: Option<NativeWindowGroupMembership>,
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct WindowGraphMove {
+    pub(crate) id: WindowId,
+    pub(crate) position: Point,
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+#[derive(Clone, Debug)]
+struct WindowGraphDragSession {
+    group: Option<NativeWindowGroupMembership>,
+    dragged: WindowId,
+    start_dragged_position: Point,
+    captured: Vec<WindowGraphNodeSnapshot>,
+}
+
+/// Framework-owned topology and drag state for peer operating-system windows.
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+#[derive(Default)]
+pub(crate) struct WindowGraphState {
+    active_drag: Option<WindowGraphDragSession>,
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+impl WindowGraphState {
+    pub(crate) fn start_drag(&mut self, windows: &[WindowGraphPeerSnapshot], dragged: WindowId) {
+        let Some(dragged_window) = windows.iter().find(|window| window.node.id == dragged) else {
+            self.active_drag = None;
+            return;
+        };
+        let group = dragged_window.group.clone();
+        let captured = if let Some(group) = &group {
+            let group_windows = group_windows(windows, group);
+            let moves_attached = group.policy.move_mode.moves_attached_component(dragged);
+            let component = if moves_attached {
+                attached_component(&group_windows, dragged, group.policy.attach_epsilon)
+            } else {
+                vec![dragged]
+            };
+            group_windows
+                .into_iter()
+                .filter(|window| component.contains(&window.id))
+                .collect()
+        } else {
+            vec![dragged_window.node]
+        };
+
+        self.active_drag = Some(WindowGraphDragSession {
+            group,
+            dragged,
+            start_dragged_position: dragged_window.node.position,
+            captured,
+        });
+    }
+
+    pub(crate) fn drag_to(
+        &self,
+        dragged: WindowId,
+        target_position: Point,
+    ) -> Vec<WindowGraphMove> {
+        let Some(session) = &self.active_drag else {
+            return vec![WindowGraphMove {
+                id: dragged,
+                position: target_position,
+            }];
+        };
+        if session.dragged != dragged {
+            return Vec::new();
+        }
+
+        let delta = Point::new(
+            target_position.x - session.start_dragged_position.x,
+            target_position.y - session.start_dragged_position.y,
+        );
+        session
+            .captured
+            .iter()
+            .map(|window| WindowGraphMove {
+                id: window.id,
+                position: Point::new(window.position.x + delta.x, window.position.y + delta.y),
+            })
+            .collect()
+    }
+
+    pub(crate) fn finish_drag(
+        &mut self,
+        windows: &[WindowGraphPeerSnapshot],
+    ) -> Vec<WindowGraphMove> {
+        let Some(session) = self.active_drag.take() else {
+            return Vec::new();
+        };
+        let Some(group) = &session.group else {
+            return Vec::new();
+        };
+        let group_windows = group_windows(windows, group);
+        if group_windows
+            .iter()
+            .all(|window| window.id != session.dragged)
+        {
+            return Vec::new();
+        }
+
+        let moves_attached = group
+            .policy
+            .move_mode
+            .moves_attached_component(session.dragged);
+        let mut component = if moves_attached {
+            attached_component(&group_windows, session.dragged, group.policy.attach_epsilon)
+        } else {
+            vec![session.dragged]
+        };
+        if let Some(snap) = closest_snap(&group_windows, &component, group.policy.snap_distance) {
+            let mut moved = group_windows;
+            translate_nodes(&mut moved, &component, snap.delta);
+            if moves_attached {
+                for id in attached_component(&moved, snap.target, group.policy.attach_epsilon) {
+                    if !component.contains(&id) {
+                        component.push(id);
+                    }
+                }
+            }
+            return moved
+                .into_iter()
+                .filter(|window| component.contains(&window.id))
+                .map(|window| WindowGraphMove {
+                    id: window.id,
+                    position: window.position,
+                })
+                .collect();
+        }
+
+        Vec::new()
+    }
+
+    pub(crate) fn external_move(
+        &self,
+        windows: &[WindowGraphPeerSnapshot],
+        moved: WindowId,
+        new_position: Point,
+    ) -> Vec<WindowGraphMove> {
+        let Some(moved_window) = windows.iter().find(|window| window.node.id == moved) else {
+            return Vec::new();
+        };
+        let Some(group) = &moved_window.group else {
+            return Vec::new();
+        };
+        if !group.policy.move_mode.moves_attached_component(moved) {
+            return Vec::new();
+        }
+
+        let delta = Point::new(
+            new_position.x - moved_window.node.position.x,
+            new_position.y - moved_window.node.position.y,
+        );
+        if delta.x.abs() <= f32::EPSILON && delta.y.abs() <= f32::EPSILON {
+            return Vec::new();
+        }
+        let group_windows = group_windows(windows, group);
+        let component = attached_component(&group_windows, moved, group.policy.attach_epsilon);
+        group_windows
+            .into_iter()
+            .filter(|window| component.contains(&window.id) && window.id != moved)
+            .map(|window| WindowGraphMove {
+                id: window.id,
+                position: Point::new(window.position.x + delta.x, window.position.y + delta.y),
+            })
+            .collect()
+    }
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn group_windows(
+    windows: &[WindowGraphPeerSnapshot],
+    group: &NativeWindowGroupMembership,
+) -> Vec<WindowGraphNodeSnapshot> {
+    windows
+        .iter()
+        .filter(|window| {
+            window
+                .group
+                .as_ref()
+                .is_some_and(|candidate| candidate.id == group.id)
+        })
+        .map(|window| window.node)
+        .collect()
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn attached_component(
+    windows: &[WindowGraphNodeSnapshot],
+    dragged: WindowId,
+    attach_epsilon: f32,
+) -> Vec<WindowId> {
+    let mut component = vec![dragged];
+    let mut changed = true;
+
+    while changed {
+        changed = false;
+        for candidate in windows {
+            if component.contains(&candidate.id) {
+                continue;
+            }
+            let attached_to_component = windows
+                .iter()
+                .filter(|window| component.contains(&window.id))
+                .any(|window| rects_attached(candidate, window, attach_epsilon));
+            if attached_to_component {
+                component.push(candidate.id);
+                changed = true;
+            }
+        }
+    }
+
+    component
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn rects_attached(
+    child: &WindowGraphNodeSnapshot,
+    main: &WindowGraphNodeSnapshot,
+    attach_epsilon: f32,
+) -> bool {
+    let child_right = child.position.x + child.size.width;
+    let child_bottom = child.position.y + child.size.height;
+    let main_right = main.position.x + main.size.width;
+    let main_bottom = main.position.y + main.size.height;
+
+    let touches_horizontal = near(child.position.x, main_right, attach_epsilon)
+        || near(child_right, main.position.x, attach_epsilon);
+    let overlaps_vertical = ranges_overlap(
+        child.position.y,
+        child_bottom,
+        main.position.y,
+        main_bottom,
+        attach_epsilon,
+    );
+    let touches_vertical = near(child.position.y, main_bottom, attach_epsilon)
+        || near(child_bottom, main.position.y, attach_epsilon);
+    let overlaps_horizontal = ranges_overlap(
+        child.position.x,
+        child_right,
+        main.position.x,
+        main_right,
+        attach_epsilon,
+    );
+
+    touches_horizontal && overlaps_vertical || touches_vertical && overlaps_horizontal
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct GraphSnap {
+    target: WindowId,
+    delta: Point,
+    distance: f32,
+    contact: f32,
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct GraphSnapCandidate {
+    delta: Point,
+    contact: f32,
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn closest_snap(
+    windows: &[WindowGraphNodeSnapshot],
+    component: &[WindowId],
+    snap_distance: f32,
+) -> Option<GraphSnap> {
+    let mut closest = None::<GraphSnap>;
+
+    for moving in windows
+        .iter()
+        .filter(|window| component.contains(&window.id))
+    {
+        for stationary in windows
+            .iter()
+            .filter(|window| !component.contains(&window.id))
+        {
+            for candidate in snap_candidates(moving, stationary, snap_distance) {
+                let snap = GraphSnap {
+                    target: stationary.id,
+                    delta: candidate.delta,
+                    distance: candidate.delta.x.abs() + candidate.delta.y.abs(),
+                    contact: candidate.contact,
+                };
+                if closest.is_none_or(|current| {
+                    snap.contact > current.contact
+                        || snap.contact == current.contact && snap.distance < current.distance
+                }) {
+                    closest = Some(snap);
+                }
+            }
+        }
+    }
+
+    closest
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn snap_candidates(
+    moving: &WindowGraphNodeSnapshot,
+    stationary: &WindowGraphNodeSnapshot,
+    snap_distance: f32,
+) -> Vec<GraphSnapCandidate> {
+    let moving_left = moving.position.x;
+    let moving_top = moving.position.y;
+    let moving_right = moving.position.x + moving.size.width;
+    let moving_bottom = moving.position.y + moving.size.height;
+    let stationary_left = stationary.position.x;
+    let stationary_top = stationary.position.y;
+    let stationary_right = stationary.position.x + stationary.size.width;
+    let stationary_bottom = stationary.position.y + stationary.size.height;
+
+    let mut candidates = Vec::new();
+    if ranges_overlap_strict(moving_top, moving_bottom, stationary_top, stationary_bottom) {
+        let contact =
+            range_overlap_length(moving_top, moving_bottom, stationary_top, stationary_bottom);
+        if near(moving_right, stationary_left, snap_distance) {
+            candidates.push(GraphSnapCandidate {
+                delta: Point::new(stationary_left - moving_right, 0.0),
+                contact,
+            });
+        }
+        if near(moving_left, stationary_right, snap_distance) {
+            candidates.push(GraphSnapCandidate {
+                delta: Point::new(stationary_right - moving_left, 0.0),
+                contact,
+            });
+        }
+    }
+    if ranges_overlap_strict(moving_left, moving_right, stationary_left, stationary_right) {
+        let contact =
+            range_overlap_length(moving_left, moving_right, stationary_left, stationary_right);
+        if near(moving_bottom, stationary_top, snap_distance) {
+            candidates.push(GraphSnapCandidate {
+                delta: Point::new(0.0, stationary_top - moving_bottom),
+                contact,
+            });
+        }
+        if near(moving_top, stationary_bottom, snap_distance) {
+            candidates.push(GraphSnapCandidate {
+                delta: Point::new(0.0, stationary_bottom - moving_top),
+                contact,
+            });
+        }
+    }
+
+    candidates
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn translate_nodes(windows: &mut [WindowGraphNodeSnapshot], component: &[WindowId], delta: Point) {
+    if delta.x.abs() <= f32::EPSILON && delta.y.abs() <= f32::EPSILON {
+        return;
+    }
+    for window in windows {
+        if component.contains(&window.id) {
+            window.position.x += delta.x;
+            window.position.y += delta.y;
+        }
+    }
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn near(a: f32, b: f32, distance: f32) -> bool {
+    (a - b).abs() <= distance
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn ranges_overlap(a_start: f32, a_end: f32, b_start: f32, b_end: f32, attach_epsilon: f32) -> bool {
+    a_start <= b_end + attach_epsilon && b_start <= a_end + attach_epsilon
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn ranges_overlap_strict(a_start: f32, a_end: f32, b_start: f32, b_end: f32) -> bool {
+    a_start < b_end && b_start < a_end
+}
+
+#[cfg(all(
+    feature = "desktop",
+    feature = "renderer-wgpu",
+    not(target_arch = "wasm32")
+))]
+fn range_overlap_length(a_start: f32, a_end: f32, b_start: f32, b_end: f32) -> f32 {
+    (a_end.min(b_end) - a_start.max(b_start)).max(0.0)
 }
 
 #[cfg(test)]
@@ -1118,6 +1748,11 @@ mod tests {
         assert_eq!(current_native_window_surface_origin(), None);
     }
 
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
     #[test]
     fn static_keys_are_stable() {
         assert_eq!(
@@ -1127,6 +1762,263 @@ mod tests {
         assert_ne!(
             NativeWindowKey::from_static("stable"),
             NativeWindowKey::from_static("other")
+        );
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    fn graph_group(policy: WindowAttachPolicy) -> NativeWindowGroupMembership {
+        NativeWindowGroupMembership {
+            id: WindowGroupId::from_static("test-group"),
+            policy,
+        }
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    fn graph_node(
+        id: &'static str,
+        position: Point,
+        size: Size,
+        group: &NativeWindowGroupMembership,
+    ) -> WindowGraphPeerSnapshot {
+        WindowGraphPeerSnapshot {
+            node: WindowGraphNodeSnapshot {
+                id: WindowId::from_static(id),
+                position,
+                size,
+            },
+            group: Some(group.clone()),
+        }
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    fn graph_position(moves: &[WindowGraphMove], id: WindowId) -> Option<Point> {
+        moves
+            .iter()
+            .find(|window_move| window_move.id == id)
+            .map(|window_move| window_move.position)
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn graph_drag_capture_freezes_attached_component() {
+        let main = WindowId::from_static("main");
+        let eq = WindowId::from_static("eq");
+        let playlist = WindowId::from_static("playlist");
+        let group = graph_group(WindowAttachPolicy::default());
+        let windows = vec![
+            graph_node(
+                "main",
+                Point::new(100.0, 100.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+            graph_node(
+                "eq",
+                Point::new(100.0, 150.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+            graph_node(
+                "playlist",
+                Point::new(240.0, 150.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+        ];
+
+        let mut graph = WindowGraphState::default();
+        graph.start_drag(&windows, main);
+        let moves = graph.drag_to(main, Point::new(120.0, 100.0));
+
+        assert_eq!(graph_position(&moves, main), Some(Point::new(120.0, 100.0)));
+        assert_eq!(graph_position(&moves, eq), Some(Point::new(120.0, 150.0)));
+        assert_eq!(graph_position(&moves, playlist), None);
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn graph_does_not_attach_new_window_during_drag() {
+        let main = WindowId::from_static("main");
+        let playlist = WindowId::from_static("playlist");
+        let group = graph_group(WindowAttachPolicy::default());
+        let windows = vec![
+            graph_node(
+                "main",
+                Point::new(100.0, 100.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+            graph_node(
+                "playlist",
+                Point::new(216.0, 100.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+        ];
+
+        let mut graph = WindowGraphState::default();
+        graph.start_drag(&windows, main);
+        let moves = graph.drag_to(main, Point::new(112.0, 100.0));
+
+        assert_eq!(graph_position(&moves, main), Some(Point::new(112.0, 100.0)));
+        assert_eq!(graph_position(&moves, playlist), None);
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn graph_does_not_detach_captured_component_during_fast_drag() {
+        let main = WindowId::from_static("main");
+        let eq = WindowId::from_static("eq");
+        let group = graph_group(WindowAttachPolicy::default());
+        let windows = vec![
+            graph_node(
+                "main",
+                Point::new(100.0, 100.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+            graph_node(
+                "eq",
+                Point::new(100.0, 150.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+        ];
+
+        let mut graph = WindowGraphState::default();
+        graph.start_drag(&windows, main);
+        let moves = graph.drag_to(main, Point::new(400.0, 280.0));
+
+        assert_eq!(graph_position(&moves, main), Some(Point::new(400.0, 280.0)));
+        assert_eq!(graph_position(&moves, eq), Some(Point::new(400.0, 330.0)));
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn graph_release_recomputes_attachment_once() {
+        let main = WindowId::from_static("main");
+        let playlist = WindowId::from_static("playlist");
+        let group = graph_group(WindowAttachPolicy::default());
+        let start = vec![
+            graph_node(
+                "main",
+                Point::new(100.0, 100.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+            graph_node(
+                "playlist",
+                Point::new(216.0, 100.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+        ];
+        let finish = vec![
+            graph_node(
+                "main",
+                Point::new(112.0, 100.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+            graph_node(
+                "playlist",
+                Point::new(216.0, 100.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+        ];
+
+        let mut graph = WindowGraphState::default();
+        graph.start_drag(&start, main);
+        let release_moves = graph.finish_drag(&finish);
+        let second_release_moves = graph.finish_drag(&finish);
+
+        assert_eq!(
+            graph_position(&release_moves, main),
+            Some(Point::new(116.0, 100.0))
+        );
+        assert_eq!(
+            graph_position(&release_moves, playlist),
+            Some(Point::new(216.0, 100.0))
+        );
+        assert!(second_release_moves.is_empty());
+    }
+
+    #[cfg(all(
+        feature = "desktop",
+        feature = "renderer-wgpu",
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn graph_drag_leader_only_moves_attached_component() {
+        let main = WindowId::from_static("main");
+        let eq = WindowId::from_static("eq");
+        let group = graph_group(WindowAttachPolicy::new(
+            8.0,
+            3.0,
+            WindowMoveMode::DragLeaderOnly(vec![main]),
+        ));
+        let windows = vec![
+            graph_node(
+                "main",
+                Point::new(100.0, 100.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+            graph_node(
+                "eq",
+                Point::new(100.0, 150.0),
+                Size::new(100.0, 50.0),
+                &group,
+            ),
+        ];
+
+        let mut graph = WindowGraphState::default();
+        graph.start_drag(&windows, eq);
+        let eq_moves = graph.drag_to(eq, Point::new(130.0, 170.0));
+        graph.start_drag(&windows, main);
+        let main_moves = graph.drag_to(main, Point::new(130.0, 110.0));
+
+        assert_eq!(
+            graph_position(&eq_moves, eq),
+            Some(Point::new(130.0, 170.0))
+        );
+        assert_eq!(graph_position(&eq_moves, main), None);
+        assert_eq!(
+            graph_position(&main_moves, main),
+            Some(Point::new(130.0, 110.0))
+        );
+        assert_eq!(
+            graph_position(&main_moves, eq),
+            Some(Point::new(130.0, 160.0))
         );
     }
 
@@ -1158,6 +2050,7 @@ mod tests {
             NativeWindowOptions::new("Panel", 100.0, 50.0).with_visible(true),
             NativeWindowEvents::new(),
             None,
+            None,
             Rc::clone(&content),
             Rc::clone(&owner),
         );
@@ -1171,6 +2064,7 @@ mod tests {
             key,
             NativeWindowOptions::new("Panel", 100.0, 50.0).with_visible(false),
             NativeWindowEvents::new(),
+            None,
             None,
             content,
             owner,
@@ -1207,6 +2101,7 @@ mod tests {
             NativeWindowOptions::new("Panel", 100.0, 50.0),
             NativeWindowEvents::new(),
             None,
+            None,
             first_content,
             Rc::clone(&owner),
         );
@@ -1220,6 +2115,7 @@ mod tests {
             key,
             NativeWindowOptions::new("Panel", 100.0, 50.0),
             NativeWindowEvents::new(),
+            None,
             None,
             second_content,
             owner,
@@ -1254,6 +2150,7 @@ mod tests {
             NativeWindowOptions::new("Panel", 100.0, 50.0),
             NativeWindowEvents::new(),
             None,
+            None,
             Rc::clone(&content),
             Rc::clone(&owner),
         );
@@ -1267,6 +2164,7 @@ mod tests {
             key,
             NativeWindowOptions::new("Panel", 100.0, 50.0),
             NativeWindowEvents::new(),
+            None,
             None,
             content,
             owner,
@@ -1304,6 +2202,7 @@ mod tests {
             NativeWindowOptions::new("Panel", 100.0, 50.0),
             NativeWindowEvents::new(),
             None,
+            None,
             Rc::clone(&first_content),
             Rc::clone(&stale_owner),
         );
@@ -1312,6 +2211,7 @@ mod tests {
             key,
             NativeWindowOptions::new("Panel", 100.0, 50.0),
             NativeWindowEvents::new(),
+            None,
             None,
             Rc::clone(&second_content),
             Rc::clone(&current_owner),
@@ -1348,6 +2248,7 @@ mod tests {
             NativeWindowOptions::new("Panel", 100.0, 50.0),
             NativeWindowEvents::new(),
             None,
+            None,
             Rc::clone(&content),
             Rc::clone(&owner),
         );
@@ -1364,6 +2265,7 @@ mod tests {
             key,
             NativeWindowOptions::new("Panel", 100.0, 50.0),
             NativeWindowEvents::new(),
+            None,
             None,
             content,
             owner,

--- a/crates/cranpose/src/present_mode.rs
+++ b/crates/cranpose/src/present_mode.rs
@@ -1,5 +1,6 @@
 //! Present mode selection helpers for WGPU surfaces.
 
+#[cfg(any(test, feature = "desktop"))]
 use cranpose_app_shell::FramePacingMode;
 
 /// Selects the present mode based on `CRANPOSE_PRESENT_MODE` and surface capabilities.
@@ -32,6 +33,7 @@ fn select_present_mode_for_request(
     wgpu::PresentMode::AutoNoVsync
 }
 
+#[cfg(any(test, feature = "desktop"))]
 pub(crate) fn select_present_mode_for_frame_pacing(
     caps: &wgpu::SurfaceCapabilities,
     mode: FramePacingMode,
@@ -44,6 +46,7 @@ pub(crate) fn select_present_mode_for_frame_pacing(
     }
 }
 
+#[cfg(any(test, feature = "desktop"))]
 fn supported_or_auto(
     caps: &wgpu::SurfaceCapabilities,
     preferred: wgpu::PresentMode,


### PR DESCRIPTION
## Summary
- add declarative native sub-window API and desktop runtime support
- rework Winamp demo to use native windows with dock/undock, playlist resize, and attached main-window movement
- add CI-safe Winamp native geometry robot coverage, including Xvfb fallbacks and per-pixel movement analysis

## Verification
- cargo test > 1.tmp 2>&1
- cargo clippy > 2.tmp 2>&1
- ./run_robot_test.sh --sequential --example robot_winamp_native_window_geometry
- xvfb-run -a ./run_robot_test.sh --skip-build --sequential --example robot_winamp_native_window_geometry
- ./run_robot_test.sh --sequential
- apps/desktop-demo/build-web.sh
- apps/android-demo/android ./gradlew :app:assembleRelease
- cargo tree --duplicates
- cargo tree -i x11rb
- git diff --check