### PR TITLE
[codex] Guard post-image text rendering

### DIFF
--- a/apps/desktop-demo/robot-runners/robot_renderer_micro_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_renderer_micro_contract.rs
@@ -8,15 +8,16 @@ use cranpose_testing::{
     capture_screenshot, crop_screenshot_logical, sample_screenshot_pixel_logical,
 };
 use cranpose_ui::{
-    composable, text::SpanStyle, text::TextDecoration, text::TextUnit, Alignment, Box, BoxSpec,
-    Color, ContentScale, Image, ImageBitmap, Modifier, Size, Text, TextStyle,
+    composable, text::SpanStyle, text::TextDecoration, text::TextUnit, Alignment, BasicText, Box,
+    BoxSpec, Canvas, Color, ContentScale, Image, ImageBitmap, Modifier, Rect, Row, RowSpec, Size,
+    Text, TextOverflow, TextStyle,
 };
 use image::{ImageBuffer, RgbaImage};
 use std::path::Path;
 use std::time::Duration;
 
 const WINDOW_WIDTH: u32 = 180;
-const WINDOW_HEIGHT: u32 = 120;
+const WINDOW_HEIGHT: u32 = 170;
 const SCREENSHOT_PATH: &str = "/tmp/cranpose_renderer_micro_contract.png";
 
 const BACKGROUND_COLOR: Color = Color(0.12, 0.16, 0.24, 1.0);
@@ -82,6 +83,14 @@ fn count_bright_pixels(screenshot: &cranpose::RobotScreenshot) -> usize {
         .count()
 }
 
+fn count_green_text_pixels(screenshot: &cranpose::RobotScreenshot) -> usize {
+    screenshot
+        .pixels
+        .chunks_exact(4)
+        .filter(|rgba| rgba[1] > 150 && rgba[1] > rgba[0].saturating_add(24) && rgba[1] > rgba[2])
+        .count()
+}
+
 fn save_png(path: &Path, screenshot: &cranpose::RobotScreenshot) -> Result<(), String> {
     let image: RgbaImage = ImageBuffer::from_raw(
         screenshot.width,
@@ -121,10 +130,129 @@ fn generate_chessboard_bitmap(tile_size: u32, tiles_per_side: u32) -> ImageBitma
     ImageBitmap::from_rgba8(side, side, pixels).expect("valid chessboard bitmap")
 }
 
+fn generate_icon_bitmap() -> ImageBitmap {
+    const SIDE: u32 = 20;
+    let mut pixels = vec![0u8; (SIDE * SIDE * 4) as usize];
+    for y in 0..SIDE {
+        for x in 0..SIDE {
+            let rgba = if x < 3 || y < 3 || x >= SIDE - 3 || y >= SIDE - 3 {
+                [255, 230, 48, 255]
+            } else if (x + y) % 2 == 0 {
+                [220, 45, 190, 255]
+            } else {
+                [36, 190, 255, 255]
+            };
+            let index = ((y * SIDE + x) * 4) as usize;
+            pixels[index..index + 4].copy_from_slice(&rgba);
+        }
+    }
+    ImageBitmap::from_rgba8(SIDE, SIDE, pixels).expect("valid icon bitmap")
+}
+
+fn row_text_style() -> TextStyle {
+    TextStyle::from_span_style(SpanStyle {
+        color: Some(Color::from_rgb_u8(180, 255, 190)),
+        font_size: TextUnit::Sp(15.0),
+        ..SpanStyle::default()
+    })
+}
+
+#[allow(non_snake_case)]
+#[composable]
+fn BitmapIconTextRow(icon: ImageBitmap, modifier: Modifier) {
+    let style = row_text_style();
+    Row(
+        modifier.size(Size::new(148.0, 24.0)),
+        RowSpec::default(),
+        move || {
+            Image(
+                icon.clone(),
+                Some("Bitmap icon".to_string()),
+                Modifier::empty().size(Size::new(20.0, 20.0)),
+                Alignment::CENTER,
+                ContentScale::FillBounds,
+                1.0,
+                None,
+            );
+            BasicText(
+                "Bitmap icon text",
+                Modifier::empty().weight(1.0),
+                style.clone(),
+                TextOverflow::Clip,
+                false,
+                1,
+                1,
+            );
+            BasicText(
+                "OK",
+                Modifier::empty(),
+                style.clone(),
+                TextOverflow::Clip,
+                false,
+                1,
+                1,
+            );
+        },
+    );
+}
+
+#[allow(non_snake_case)]
+#[composable]
+fn SourceIconTextRow(icon: ImageBitmap, modifier: Modifier) {
+    let style = row_text_style();
+    Row(
+        modifier.size(Size::new(148.0, 24.0)),
+        RowSpec::default(),
+        move || {
+            Canvas(Modifier::empty().size(Size::new(20.0, 20.0)), {
+                let icon = icon.clone();
+                move |scope| {
+                    scope.draw_image_src(
+                        icon.clone(),
+                        Rect {
+                            x: 2.0,
+                            y: 2.0,
+                            width: 16.0,
+                            height: 16.0,
+                        },
+                        Rect {
+                            x: 0.0,
+                            y: 0.0,
+                            width: 20.0,
+                            height: 20.0,
+                        },
+                        1.0,
+                        None,
+                    );
+                }
+            });
+            BasicText(
+                "Source icon",
+                Modifier::empty(),
+                style.clone(),
+                TextOverflow::Clip,
+                false,
+                1,
+                1,
+            );
+            BasicText(
+                " weighted",
+                Modifier::empty().weight(1.0),
+                style.clone(),
+                TextOverflow::Clip,
+                false,
+                1,
+                1,
+            );
+        },
+    );
+}
+
 #[allow(non_snake_case)]
 #[composable]
 fn RendererMicroContractApp() {
     let board = cranpose_core::remember(|| generate_chessboard_bitmap(8, 4)).with(|b| b.clone());
+    let icon = cranpose_core::remember(generate_icon_bitmap).with(|bitmap| bitmap.clone());
     let underline_style = TextStyle::from_span_style(SpanStyle {
         color: Some(Color(0.97, 0.98, 1.0, 1.0)),
         font_size: TextUnit::Sp(18.0),
@@ -178,6 +306,8 @@ fn RendererMicroContractApp() {
                 Modifier::empty().offset(60.0, 24.0),
                 underline_style.clone(),
             );
+            BitmapIconTextRow(icon.clone(), Modifier::empty().offset(16.0, 100.0));
+            SourceIconTextRow(icon.clone(), Modifier::empty().offset(16.0, 130.0));
         },
     );
 }
@@ -255,10 +385,38 @@ fn main() {
                     ),
                 );
             }
+            let Some(bitmap_row_text) =
+                crop_screenshot_logical(&screenshot, 38.0, 96.0, 134.0, 30.0)
+            else {
+                fail(&robot, "failed to crop bitmap icon text row");
+            };
+            let Some(source_row_text) =
+                crop_screenshot_logical(&screenshot, 38.0, 126.0, 134.0, 30.0)
+            else {
+                fail(&robot, "failed to crop source icon text row");
+            };
+            let bitmap_green = count_green_text_pixels(&bitmap_row_text);
+            let source_green = count_green_text_pixels(&source_row_text);
+            if bitmap_green < 35 {
+                fail(
+                    &robot,
+                    &format!(
+                        "text after Image(BitmapPainter) is missing or clipped: green_pixels={bitmap_green}"
+                    ),
+                );
+            }
+            if source_green < 35 {
+                fail(
+                    &robot,
+                    &format!(
+                        "text after draw_image_src is missing or clipped: green_pixels={source_green}"
+                    ),
+                );
+            }
 
             println!(
-                "PASS: renderer micro-contract pixels match expected image/line/fill layout; underlined text crop looks populated (underlined={}, underline_band={})",
-                underline_bright, underline_band_bright
+                "PASS: renderer micro-contract pixels match expected image/line/fill layout; underlined and post-image text crops are populated (underlined={}, underline_band={}, bitmap_text={}, source_text={})",
+                underline_bright, underline_band_bright, bitmap_green, source_green
             );
             let _ = robot.exit();
         })

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -2477,6 +2477,7 @@ impl GpuRenderer {
                 for batch in prepared_batches.iter_mut() {
                     let draw_result = match batch {
                         PreparedSegmentBatch::Shape { blend_mode, batch } => {
+                            render_pass.set_scissor_rect(0, 0, width, height);
                             self.draw_prepared_shapes(&mut render_pass, *blend_mode, *batch);
                             Ok(())
                         }
@@ -2485,6 +2486,7 @@ impl GpuRenderer {
                             image_cmds,
                         } => self.draw_prepared_images(&mut render_pass, image_cmds, *blend_mode),
                         PreparedSegmentBatch::Text { slot_index } => {
+                            render_pass.set_scissor_rect(0, 0, width, height);
                             self.draw_prepared_text(&mut render_pass, *slot_index)
                         }
                     };

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -2384,27 +2384,28 @@ impl GpuRenderer {
                         end,
                         blend_mode,
                     } => {
-                        // Split large shape batches into chunks that fit
-                        // the shader's fixed-size uniform array.
                         let slice = &ordered_items[start..end];
-                        for chunk_items in slice.chunks(MAX_SHAPES_PER_BATCH) {
-                            let Some(prepared) = self.prepare_shapes_batch(
-                                chunk_items.iter().map(|(_, item)| match item {
-                                    SegmentDrawItem::Shape(shape_index) => &shapes[*shape_index],
-                                    _ => {
-                                        unreachable!("shape batch contains only shape items")
-                                    }
-                                }),
-                                root_scale,
-                                &mut staged_uploads,
-                            ) else {
-                                continue;
-                            };
-                            prepared_batches.push(PreparedSegmentBatch::Shape {
-                                blend_mode,
-                                batch: prepared,
-                            });
+                        if slice.len() > MAX_SHAPES_PER_BATCH {
+                            return Err(format!(
+                                "shape batch contains {} shapes, exceeding the renderer limit of {}",
+                                slice.len(),
+                                MAX_SHAPES_PER_BATCH
+                            ));
                         }
+                        let Some(prepared) = self.prepare_shapes_batch(
+                            slice.iter().map(|(_, item)| match item {
+                                SegmentDrawItem::Shape(shape_index) => &shapes[*shape_index],
+                                _ => unreachable!("shape batch contains only shape items"),
+                            }),
+                            root_scale,
+                            &mut staged_uploads,
+                        ) else {
+                            continue;
+                        };
+                        prepared_batches.push(PreparedSegmentBatch::Shape {
+                            blend_mode,
+                            batch: prepared,
+                        });
                     }
                     SegmentBatchPlan::Image {
                         start,
@@ -2474,19 +2475,36 @@ impl GpuRenderer {
                 });
 
                 let mut result = Ok(());
+                let mut scissor_is_image_local = false;
                 for batch in prepared_batches.iter_mut() {
                     let draw_result = match batch {
                         PreparedSegmentBatch::Shape { blend_mode, batch } => {
-                            render_pass.set_scissor_rect(0, 0, width, height);
+                            if scissor_is_image_local {
+                                render_pass.set_scissor_rect(0, 0, width, height);
+                                scissor_is_image_local = false;
+                            }
                             self.draw_prepared_shapes(&mut render_pass, *blend_mode, *batch);
                             Ok(())
                         }
                         PreparedSegmentBatch::Image {
                             blend_mode,
                             image_cmds,
-                        } => self.draw_prepared_images(&mut render_pass, image_cmds, *blend_mode),
+                        } => {
+                            let draw_result = self.draw_prepared_images(
+                                &mut render_pass,
+                                image_cmds,
+                                *blend_mode,
+                            );
+                            if draw_result.is_ok() {
+                                scissor_is_image_local = true;
+                            }
+                            draw_result
+                        }
                         PreparedSegmentBatch::Text { slot_index } => {
-                            render_pass.set_scissor_rect(0, 0, width, height);
+                            if scissor_is_image_local {
+                                render_pass.set_scissor_rect(0, 0, width, height);
+                                scissor_is_image_local = false;
+                            }
                             self.draw_prepared_text(&mut render_pass, *slot_index)
                         }
                     };
@@ -4214,7 +4232,8 @@ fn segment_batch_plan_at_cursor(
         SegmentDrawItem::Shape(index) => {
             let blend_mode = supported_blend_mode(shapes[index].blend_mode);
             let mut end = start + 1;
-            while end < ordered_items.len() {
+            let shape_limit = (start + MAX_SHAPES_PER_BATCH).min(ordered_items.len());
+            while end < shape_limit {
                 match ordered_items[end].1 {
                     SegmentDrawItem::Shape(next_index)
                         if supported_blend_mode(shapes[next_index].blend_mode) == blend_mode =>
@@ -6930,6 +6949,35 @@ mod tests {
                     start: 2,
                     end: 3,
                     blend_mode: BlendMode::DstOut,
+                }])),
+            ]
+        );
+    }
+
+    #[test]
+    fn segment_command_iter_splits_contiguous_shape_runs_at_uniform_batch_limit() {
+        let ordered_items: Vec<_> = (0..=MAX_SHAPES_PER_BATCH)
+            .map(|index| (index, SegmentDrawItem::Shape(index)))
+            .collect();
+        let shapes: Vec<_> = (0..=MAX_SHAPES_PER_BATCH)
+            .map(|index| test_shape(index, BlendMode::SrcOver))
+            .collect();
+        let images = Vec::new();
+
+        let commands: Vec<_> = SegmentCommandIter::new(&ordered_items, &shapes, &images).collect();
+
+        assert_eq!(
+            commands,
+            vec![
+                SegmentRenderCommand::DrawChunk(chunk(&[SegmentBatchPlan::Shape {
+                    start: 0,
+                    end: MAX_SHAPES_PER_BATCH,
+                    blend_mode: BlendMode::SrcOver,
+                }])),
+                SegmentRenderCommand::DrawChunk(chunk(&[SegmentBatchPlan::Shape {
+                    start: MAX_SHAPES_PER_BATCH,
+                    end: MAX_SHAPES_PER_BATCH + 1,
+                    blend_mode: BlendMode::SrcOver,
                 }])),
             ]
         );


### PR DESCRIPTION
## Summary

- Reset the WGPU render pass scissor before shape and text batches after image batches so image-local scissors cannot leak into later draw kinds in mixed segment chunks.
- Extend `robot_renderer_micro_contract` with rows that place text after `Image(BitmapPainter)` and after a custom `draw_image_src` icon, including weighted and non-weighted `BasicText` siblings.

## Issue

Addresses #216.

## Validation

- `cargo fmt`
- `cargo test > 1.tmp 2>&1`
- `cargo clippy > 2.tmp 2>&1`
- `env CRANPOSE_HEADLESS=1 cargo run --package desktop-app --example robot_renderer_micro_contract --features robot-app`
- `./gradlew :app:assembleRelease > android-build.tmp 2>&1` from `apps/android-demo/android`
- `./build-web.sh > web-build.tmp 2>&1` from `apps/desktop-demo`
- `./run_robot_test.sh --sequential --example robot_winamp_native_window_geometry > robot-winamp-rerun.tmp 2>&1`
- `./run_robot_test.sh --sequential > robot-tests-rerun.tmp 2>&1`