### PR TITLE
[codex] Batch blurred shadow source rendering

### DIFF
--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -640,6 +640,14 @@ impl EffectRenderer {
         self.debug_upload_bytes.set(0);
     }
 
+    pub(crate) fn record_blur_pass(&self) {
+        self.debug_blurs.set(self.debug_blurs.get() + 1);
+    }
+
+    pub(crate) fn record_composite_pass(&self) {
+        self.debug_composites.set(self.debug_composites.get() + 1);
+    }
+
     fn write_buffer_at_zero_offset(
         &self,
         queue: &wgpu::Queue,
@@ -689,10 +697,6 @@ impl EffectRenderer {
         tile_mode: TileMode,
         scissor: Option<(u32, u32, u32, u32)>,
     ) {
-        let width = source.width;
-        let height = source.height;
-        let tile_mode_value = tile_mode_uniform_value(tile_mode);
-
         if radius_x <= 0.0 && radius_y <= 0.0 {
             self.composite_to_view(
                 device,
@@ -704,6 +708,52 @@ impl EffectRenderer {
             );
             return;
         }
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Blur Effect Encoder"),
+        });
+        let intermediate = self.encode_blur_scissored_passes(
+            device,
+            queue,
+            &mut encoder,
+            source,
+            dest_view,
+            radius_x,
+            radius_y,
+            tile_mode,
+            scissor,
+        );
+        queue.submit(std::iter::once(encoder.finish()));
+        self.debug_submits.set(self.debug_submits.get() + 1);
+        self.record_blur_pass();
+
+        self.offscreen_pool.release(intermediate);
+    }
+
+    /// Encode a two-pass separable Gaussian blur into an existing command buffer.
+    ///
+    /// The returned intermediate target must stay alive until the caller submits
+    /// the command buffer, then it can be released back to the pool.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn encode_blur_scissored_passes(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        source: &OffscreenTarget,
+        dest_view: &wgpu::TextureView,
+        radius_x: f32,
+        radius_y: f32,
+        tile_mode: TileMode,
+        scissor: Option<(u32, u32, u32, u32)>,
+    ) -> OffscreenTarget {
+        debug_assert!(
+            radius_x > 0.0 || radius_y > 0.0,
+            "zero-radius blur should use the composite fast path"
+        );
+        let width = source.width;
+        let height = source.height;
+        let tile_mode_value = tile_mode_uniform_value(tile_mode);
 
         // Acquire intermediate target for horizontal pass
         let intermediate = self.offscreen_pool.acquire(device, width, height, None);
@@ -739,9 +789,6 @@ impl EffectRenderer {
             &self.effect_linear_sampler,
         );
 
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("Blur Effect Encoder"),
-        });
         {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("Blur Horizontal Pass"),
@@ -790,12 +837,7 @@ impl EffectRenderer {
         }
         drop(source_bind_group);
         drop(intermediate_bind_group);
-        queue.submit(std::iter::once(encoder.finish()));
-        self.debug_submits.set(self.debug_submits.get() + 1);
-        self.debug_blurs.set(self.debug_blurs.get() + 1);
-
-        // Return intermediate to pool
-        self.offscreen_pool.release(intermediate);
+        intermediate
     }
 
     /// Apply a fixed pixel offset to a source texture.
@@ -1129,6 +1171,41 @@ impl EffectRenderer {
             pass.set_scissor_rect(x, y, w, h);
         }
         pass.draw(0..4, 0..1);
+    }
+
+    /// Encode an offscreen composite pass into an existing command buffer.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn encode_composite_to_view_scissored_with_alpha_and_mask_and_blend_mode(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        source: &OffscreenTarget,
+        dest_view: &wgpu::TextureView,
+        alpha: f32,
+        load_op: wgpu::LoadOp<wgpu::Color>,
+        scissor: Option<(u32, u32, u32, u32)>,
+        rounded_mask: Option<RoundedCompositeMask>,
+        blend_mode: BlendMode,
+        dest_viewport: Option<(f32, f32, f32, f32)>,
+        sample_mode: CompositeSampleMode,
+    ) {
+        self.encode_composite_to_view_pass(
+            device,
+            queue,
+            encoder,
+            source,
+            dest_view,
+            CompositePassOptions {
+                alpha,
+                load_op,
+                scissor,
+                rounded_mask,
+                blend_mode,
+                dest_viewport,
+                sample_mode,
+            },
+        );
     }
 
     /// Composite an offscreen target onto a destination view with an optional scissor region

--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -747,16 +747,50 @@ impl EffectRenderer {
         tile_mode: TileMode,
         scissor: Option<(u32, u32, u32, u32)>,
     ) -> OffscreenTarget {
+        let intermediate = self
+            .offscreen_pool
+            .acquire(device, source.width, source.height, None);
+        self.encode_blur_scissored_ping_pong_passes(
+            device,
+            queue,
+            encoder,
+            source,
+            &intermediate,
+            dest_view,
+            radius_x,
+            radius_y,
+            tile_mode,
+            scissor,
+        );
+        intermediate
+    }
+
+    /// Encode a two-pass separable Gaussian blur using one caller-owned scratch
+    /// target. The horizontal pass writes source -> scratch, and the vertical
+    /// pass writes scratch -> dest_view.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn encode_blur_scissored_ping_pong_passes(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        source: &OffscreenTarget,
+        scratch: &OffscreenTarget,
+        dest_view: &wgpu::TextureView,
+        radius_x: f32,
+        radius_y: f32,
+        tile_mode: TileMode,
+        scissor: Option<(u32, u32, u32, u32)>,
+    ) {
         debug_assert!(
             radius_x > 0.0 || radius_y > 0.0,
             "zero-radius blur should use the composite fast path"
         );
         let width = source.width;
         let height = source.height;
+        debug_assert_eq!(scratch.width, width);
+        debug_assert_eq!(scratch.height, height);
         let tile_mode_value = tile_mode_uniform_value(tile_mode);
-
-        // Acquire intermediate target for horizontal pass
-        let intermediate = self.offscreen_pool.acquire(device, width, height, None);
 
         // Upload both pass uniforms up front and execute both passes in a single submit.
         let horizontal_uniforms = BlurUniforms {
@@ -783,7 +817,7 @@ impl EffectRenderer {
             &self.effect_texture_bind_group_layout,
             &self.effect_linear_sampler,
         );
-        let intermediate_bind_group = intermediate.get_or_create_bind_group(
+        let scratch_bind_group = scratch.get_or_create_bind_group(
             device,
             &self.effect_texture_bind_group_layout,
             &self.effect_linear_sampler,
@@ -793,7 +827,7 @@ impl EffectRenderer {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("Blur Horizontal Pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: &intermediate.view,
+                    view: &scratch.view,
                     resolve_target: None,
                     depth_slice: None,
                     ops: wgpu::Operations {
@@ -828,7 +862,7 @@ impl EffectRenderer {
                 ..Default::default()
             });
             pass.set_pipeline(&self.blur_pipeline);
-            pass.set_bind_group(0, &*intermediate_bind_group, &[]);
+            pass.set_bind_group(0, &*scratch_bind_group, &[]);
             pass.set_bind_group(1, &self.blur_uniform_bind_group_vertical, &[]);
             if let Some((x, y, w, h)) = scissor {
                 pass.set_scissor_rect(x, y, w, h);
@@ -836,8 +870,7 @@ impl EffectRenderer {
             pass.draw(0..4, 0..1);
         }
         drop(source_bind_group);
-        drop(intermediate_bind_group);
-        intermediate
+        drop(scratch_bind_group);
     }
 
     /// Apply a fixed pixel offset to a source texture.

--- a/crates/cranpose-render/wgpu/src/gpu_stats.rs
+++ b/crates/cranpose-render/wgpu/src/gpu_stats.rs
@@ -36,7 +36,6 @@ impl LayerSurfaceReasons {
             || self.backdrop
             || self.group_opacity
             || self.blend_mode
-            || self.immediate_shadow
             || self.text_local_surface
             || self.motion_stable_capture
             || self.non_translation_transform
@@ -105,7 +104,7 @@ impl LayerSurfaceReasons {
     }
 
     pub fn has_renderer_forced_surface(self) -> bool {
-        self.immediate_shadow || self.text_local_surface || self.non_translation_transform
+        self.text_local_surface || self.non_translation_transform
     }
 }
 
@@ -528,7 +527,7 @@ mod tests {
                 height: 5.0,
             },
             LayerSurfaceReasons {
-                immediate_shadow: true,
+                text_local_surface: true,
                 ..LayerSurfaceReasons::default()
             },
         );
@@ -575,6 +574,7 @@ mod tests {
     fn layer_surface_reasons_report_runtime_only_bits() {
         let reasons = LayerSurfaceReasons {
             immediate_shadow: true,
+            text_local_surface: true,
             mixed_direct_content: true,
             ..LayerSurfaceReasons::default()
         };
@@ -583,9 +583,32 @@ mod tests {
         assert!(reasons.has_renderer_forced_surface());
         assert_eq!(
             reasons.labels().collect::<Vec<_>>(),
-            vec!["immediate_shadow", "mixed_direct_content"]
+            vec![
+                "immediate_shadow",
+                "text_local_surface",
+                "mixed_direct_content"
+            ]
         );
-        assert_eq!(reasons.display(), "immediate_shadow+mixed_direct_content");
+        assert_eq!(
+            reasons.display(),
+            "immediate_shadow+text_local_surface+mixed_direct_content"
+        );
+    }
+
+    #[test]
+    fn immediate_shadow_only_is_diagnostic_not_isolating() {
+        let reasons = LayerSurfaceReasons {
+            immediate_shadow: true,
+            ..LayerSurfaceReasons::default()
+        };
+
+        assert!(!reasons.has_any());
+        assert!(!reasons.has_renderer_forced_surface());
+        assert_eq!(
+            reasons.labels().collect::<Vec<_>>(),
+            vec!["immediate_shadow"]
+        );
+        assert_eq!(reasons.display(), "immediate_shadow");
     }
 
     #[test]
@@ -644,7 +667,7 @@ mod tests {
                     height: 10.0,
                 },
                 LayerSurfaceReasons {
-                    immediate_shadow: true,
+                    text_local_surface: true,
                     ..LayerSurfaceReasons::default()
                 },
             );

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -18,16 +18,14 @@ use crate::scene::{
     TextDraw,
 };
 use crate::shaders;
-#[cfg(test)]
-use crate::surface_executor::DevicePixelBounds;
 use crate::surface_executor::{
     apply_backdrop_layer_to_target as execute_apply_backdrop_layer_to_target,
     axis_aligned_quad_rect, device_pixel_bounds_for_rect, offscreen_byte_size,
     render_effect_layer_to_target as execute_render_effect_layer_to_target,
     render_layer_surface as execute_render_layer_surface,
     render_root_direct as execute_render_root_direct, scaled_quad, snap_delta_for_anchor,
-    snap_motion_stable_dest_quad, surface_target_size, CachedLayerSurface, LayerSurface,
-    LayerSurfaceTexture, SurfaceExecutionBackend,
+    snap_motion_stable_dest_quad, surface_target_size, CachedLayerSurface, DevicePixelBounds,
+    LayerSurface, LayerSurfaceTexture, SurfaceExecutionBackend,
 };
 #[cfg(test)]
 use crate::surface_executor::{clamp_effect_surface_scale, visible_layer_rect};
@@ -2784,6 +2782,22 @@ impl GpuRenderer {
         let bounds_h = device_bounds.height;
         let pixel_radius = shadow.blur_radius * root_scale;
 
+        if shadow.texts.is_empty()
+            && shadow.shapes.len() == 1
+            && self.render_single_shape_blurred_shadow_draw(
+                target_view,
+                shadow,
+                device_bounds,
+                pixel_radius,
+                processing_scissor,
+                width,
+                height,
+                root_scale,
+            )
+        {
+            return;
+        }
+
         // 1. Acquire bounds-sized offscreen source.
         let source = self.acquire_offscreen(bounds_w, bounds_h);
 
@@ -2906,6 +2920,116 @@ impl GpuRenderer {
         // Restore viewport uniform to full size so subsequent image/text rendering
         // (which shares the uniform_buffer but doesn't write to it) works correctly.
         self.write_viewport_uniforms(width, height, [0.0, 0.0]);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn render_single_shape_blurred_shadow_draw(
+        &mut self,
+        target_view: &wgpu::TextureView,
+        shadow: &ShadowDraw,
+        device_bounds: DevicePixelBounds,
+        pixel_radius: f32,
+        processing_scissor: Option<(u32, u32, u32, u32)>,
+        width: u32,
+        height: u32,
+        root_scale: f32,
+    ) -> bool {
+        let bounds_w = device_bounds.width;
+        let bounds_h = device_bounds.height;
+        let viewport_offset = [device_bounds.x, device_bounds.y];
+        let (shape, blend_mode) = &shadow.shapes[0];
+
+        let mut staged_uploads = std::mem::take(&mut self.staged_uploads);
+        staged_uploads.clear();
+        self.stage_viewport_uniforms(&mut staged_uploads, bounds_w, bounds_h, viewport_offset);
+        let Some(prepared_shape) =
+            self.prepare_shapes_batch(std::iter::once(shape), root_scale, &mut staged_uploads)
+        else {
+            self.staged_uploads = staged_uploads;
+            return false;
+        };
+
+        let source = self.acquire_offscreen(bounds_w, bounds_h);
+        let dest = self.acquire_offscreen(bounds_w, bounds_h);
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Single Shape Shadow Encoder"),
+            });
+        self.flush_staged_uploads(&mut encoder, &staged_uploads);
+        {
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Single Shape Shadow Source Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &source.view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            self.draw_prepared_shapes(&mut render_pass, *blend_mode, prepared_shape);
+        }
+
+        let intermediate = self.effect_renderer.encode_blur_scissored_passes(
+            &self.device,
+            &self.queue,
+            &mut encoder,
+            &source,
+            &dest.view,
+            pixel_radius,
+            pixel_radius,
+            TileMode::Decal,
+            None,
+        );
+
+        let clip_scissor = shadow
+            .clip
+            .and_then(|clip| scissor_rect_for_rect(clip, root_scale, width, height));
+        let scissor = clip_scissor.or(processing_scissor);
+        let rounded_mask = inner_shadow_composite_mask(shadow, root_scale).map(|mut mask| {
+            mask.rect[0] -= viewport_offset[0];
+            mask.rect[1] -= viewport_offset[1];
+            mask
+        });
+        let dest_viewport = Some((
+            viewport_offset[0],
+            viewport_offset[1],
+            bounds_w as f32,
+            bounds_h as f32,
+        ));
+        self.effect_renderer
+            .encode_composite_to_view_scissored_with_alpha_and_mask_and_blend_mode(
+                &self.device,
+                &self.queue,
+                &mut encoder,
+                &dest,
+                target_view,
+                1.0,
+                wgpu::LoadOp::Load,
+                scissor,
+                rounded_mask,
+                BlendMode::SrcOver,
+                dest_viewport,
+                CompositeSampleMode::Linear,
+            );
+
+        self.queue.submit(std::iter::once(encoder.finish()));
+        self.frame_stats.bump_submits();
+        self.effect_renderer.record_blur_pass();
+        self.effect_renderer.record_composite_pass();
+        self.effect_renderer.offscreen_pool.release(source);
+        self.effect_renderer.offscreen_pool.release(intermediate);
+        self.effect_renderer.offscreen_pool.release(dest);
+        self.write_viewport_uniforms(width, height, [0.0, 0.0]);
+        self.staged_uploads = staged_uploads;
+        true
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -2368,8 +2368,7 @@ impl GpuRenderer {
         load_op: wgpu::LoadOp<wgpu::Color>,
     ) -> Result<bool, String> {
         let mut prepared_batches: Vec<PreparedSegmentBatch> = Vec::new();
-        let mut staged_uploads = std::mem::take(&mut self.staged_uploads);
-        staged_uploads.clear();
+        let mut staged_uploads = self.take_staged_uploads();
         let result = (|| {
             if chunk.needs_viewport_uniforms() {
                 self.stage_viewport_uniforms(&mut staged_uploads, width, height, [0.0, 0.0]);
@@ -2523,7 +2522,7 @@ impl GpuRenderer {
             render_result?;
             Ok(true)
         })();
-        self.staged_uploads = staged_uploads;
+        self.restore_staged_uploads(staged_uploads);
         result
     }
 
@@ -2543,6 +2542,21 @@ impl GpuRenderer {
     ) {
         let uniforms = Self::viewport_uniforms(width, height, viewport_offset);
         staged_uploads.stage(UploadTarget::Uniform, bytemuck::bytes_of(&uniforms));
+    }
+
+    fn take_staged_uploads(&mut self) -> StagedBufferUploads {
+        let mut staged_uploads = std::mem::take(&mut self.staged_uploads);
+        debug_assert!(
+            staged_uploads.is_empty(),
+            "renderer-owned staged uploads should be restored as empty scratch storage"
+        );
+        staged_uploads.clear();
+        staged_uploads
+    }
+
+    fn restore_staged_uploads(&mut self, mut staged_uploads: StagedBufferUploads) {
+        staged_uploads.clear();
+        self.staged_uploads = staged_uploads;
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -2939,18 +2953,17 @@ impl GpuRenderer {
         let viewport_offset = [device_bounds.x, device_bounds.y];
         let (shape, blend_mode) = &shadow.shapes[0];
 
-        let mut staged_uploads = std::mem::take(&mut self.staged_uploads);
-        staged_uploads.clear();
+        let mut staged_uploads = self.take_staged_uploads();
         self.stage_viewport_uniforms(&mut staged_uploads, bounds_w, bounds_h, viewport_offset);
         let Some(prepared_shape) =
             self.prepare_shapes_batch(std::iter::once(shape), root_scale, &mut staged_uploads)
         else {
-            self.staged_uploads = staged_uploads;
+            self.restore_staged_uploads(staged_uploads);
             return false;
         };
 
         let source = self.acquire_offscreen(bounds_w, bounds_h);
-        let dest = self.acquire_offscreen(bounds_w, bounds_h);
+        let scratch = self.acquire_offscreen(bounds_w, bounds_h);
         let mut encoder = self
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -2977,12 +2990,13 @@ impl GpuRenderer {
             self.draw_prepared_shapes(&mut render_pass, *blend_mode, prepared_shape);
         }
 
-        let intermediate = self.effect_renderer.encode_blur_scissored_passes(
+        self.effect_renderer.encode_blur_scissored_ping_pong_passes(
             &self.device,
             &self.queue,
             &mut encoder,
             &source,
-            &dest.view,
+            &scratch,
+            &source.view,
             pixel_radius,
             pixel_radius,
             TileMode::Decal,
@@ -3009,7 +3023,7 @@ impl GpuRenderer {
                 &self.device,
                 &self.queue,
                 &mut encoder,
-                &dest,
+                &source,
                 target_view,
                 1.0,
                 wgpu::LoadOp::Load,
@@ -3024,11 +3038,10 @@ impl GpuRenderer {
         self.frame_stats.bump_submits();
         self.effect_renderer.record_blur_pass();
         self.effect_renderer.record_composite_pass();
+        self.effect_renderer.offscreen_pool.release(scratch);
         self.effect_renderer.offscreen_pool.release(source);
-        self.effect_renderer.offscreen_pool.release(intermediate);
-        self.effect_renderer.offscreen_pool.release(dest);
         self.write_viewport_uniforms(width, height, [0.0, 0.0]);
-        self.staged_uploads = staged_uploads;
+        self.restore_staged_uploads(staged_uploads);
         true
     }
 
@@ -3453,16 +3466,15 @@ impl GpuRenderer {
     ) where
         I: Iterator<Item = &'a DrawShape>,
     {
-        let mut staged_uploads = std::mem::take(&mut self.staged_uploads);
-        staged_uploads.clear();
+        let mut staged_uploads = self.take_staged_uploads();
         self.stage_viewport_uniforms(&mut staged_uploads, width, height, viewport_offset);
         let Some(batch) = self.prepare_shapes_batch(layer_shapes, root_scale, &mut staged_uploads)
         else {
-            self.staged_uploads = staged_uploads;
+            self.restore_staged_uploads(staged_uploads);
             return;
         };
         self.flush_staged_uploads(encoder, &staged_uploads);
-        self.staged_uploads = staged_uploads;
+        self.restore_staged_uploads(staged_uploads);
         let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: Some("Shape Pass"),
             color_attachments: &[Some(wgpu::RenderPassColorAttachment {

--- a/crates/cranpose-render/wgpu/src/surface_executor.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor.rs
@@ -2,7 +2,6 @@ mod backend;
 mod geometry;
 mod render_paths;
 
-#[cfg(test)]
 pub(crate) use backend::DevicePixelBounds;
 pub(crate) use backend::{
     CachedLayerSurface, LayerSurface, LayerSurfaceTexture, SurfaceExecutionBackend,

--- a/crates/cranpose-render/wgpu/src/surface_requirements.rs
+++ b/crates/cranpose-render/wgpu/src/surface_requirements.rs
@@ -52,12 +52,11 @@ impl SurfaceRequirementSet {
     }
 
     pub(crate) fn has_isolating_requirement(self) -> bool {
-        (self.bits & !Self::MIXED_DIRECT_CONTENT) != 0
+        (self.bits & !(Self::MIXED_DIRECT_CONTENT | Self::IMMEDIATE_SHADOW)) != 0
     }
 
     pub(crate) fn has_renderer_forced_surface(self) -> bool {
-        self.contains(SurfaceRequirement::ImmediateShadow)
-            || self.contains(SurfaceRequirement::TextMaterialMask)
+        self.contains(SurfaceRequirement::TextMaterialMask)
             || self.contains(SurfaceRequirement::NonTranslationTransform)
     }
 
@@ -171,5 +170,14 @@ mod tests {
     #[test]
     fn display_reports_none_for_empty_set() {
         assert_eq!(SurfaceRequirementSet::default().display(), "none");
+    }
+
+    #[test]
+    fn immediate_shadow_is_ordered_draw_work_not_layer_isolation() {
+        let requirements =
+            SurfaceRequirementSet::default().with(SurfaceRequirement::ImmediateShadow);
+
+        assert!(!requirements.has_isolating_requirement());
+        assert!(!requirements.has_renderer_forced_surface());
     }
 }

--- a/crates/cranpose-render/wgpu/tests/effect_semantics.rs
+++ b/crates/cranpose-render/wgpu/tests/effect_semantics.rs
@@ -17,7 +17,10 @@ use cranpose_ui::text::{
     TextUnit,
 };
 use cranpose_ui::TextLayoutOptions;
-use cranpose_ui_graphics::{Brush, Color, DrawPrimitive, GraphicsLayer, Point, Rect, RenderEffect};
+use cranpose_ui_graphics::{
+    BlendMode, Brush, Color, DrawPrimitive, GraphicsLayer, Point, Rect, RenderEffect,
+    ShadowPrimitive,
+};
 
 const FRAME_WIDTH: u32 = 128;
 const FRAME_HEIGHT: u32 = 96;
@@ -552,6 +555,59 @@ fn translated_content_wrapper_with_decorated_shadow_text_uses_bounded_local_surf
     assert!(
         !isolated.is_empty(),
         "translated-content decorated text should report an isolated text surface in stats: {stats:?}"
+    );
+}
+
+#[test]
+fn repeated_translated_drop_shadow_layers_stay_on_direct_path() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!(
+                "skipping repeated drop-shadow batching assertions because headless WGPU init failed: {}",
+                err
+            );
+            return;
+        }
+    };
+
+    const CARD_COUNT: usize = 8;
+    renderer.scene_mut().graph = Some(repeated_drop_shadow_layers_fixture(CARD_COUNT));
+    let frame = renderer
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("repeated drop-shadow capture should succeed");
+    let stats = renderer
+        .last_frame_stats()
+        .expect("repeated drop-shadow frame stats");
+
+    assert!(
+        bright_pixel_count(
+            &frame,
+            Rect {
+                x: 8.0,
+                y: 12.0,
+                width: 112.0,
+                height: 68.0,
+            },
+            80,
+        ) > 600,
+        "shadowed cards should remain visible after direct-path flattening"
+    );
+    assert_eq!(
+        stats.isolated_layer_renders, 0,
+        "drop-shadow-only translated layers should flatten into the parent target instead of isolating every card: {stats:?}"
+    );
+    assert!(
+        stats.offscreen_acquires <= (CARD_COUNT as u32) * 2,
+        "one blurred drop shadow should need only source and destination shadow targets: {stats:?}"
+    );
+    assert!(
+        stats.composite_passes <= CARD_COUNT as u32,
+        "drop shadows should composite once per card and avoid a second layer-surface composite: {stats:?}"
+    );
+    assert!(
+        stats.submits <= (CARD_COUNT as u32) * 2 + 1,
+        "single-shape blurred drop shadows should submit once per shadow plus surrounding direct draw chunks: {stats:?}"
     );
 }
 
@@ -1346,6 +1402,79 @@ fn translation_only_wrapper_with_decorated_shadow_text_fixture(
             }),
             ..Default::default()
         }),
+    )
+}
+
+fn repeated_drop_shadow_layers_fixture(card_count: usize) -> RenderGraph {
+    let columns = 4usize;
+    let card_width = 22.0;
+    let card_height = 14.0;
+    let gap_x = 8.0;
+    let gap_y = 10.0;
+
+    let mut children = Vec::with_capacity(card_count + 1);
+    children.push(solid_rect(frame_rect(), Color::BLACK));
+    for index in 0..card_count {
+        let column = index % columns;
+        let row = index / columns;
+        let x = 12.0 + column as f32 * (card_width + gap_x);
+        let y = 14.0 + row as f32 * (card_height + gap_y);
+        children.push(RenderNode::Layer(Box::new(shadowed_card_layer(
+            Point::new(x, y),
+            card_width,
+            card_height,
+            index,
+        ))));
+    }
+
+    graph(children)
+}
+
+fn shadowed_card_layer(
+    translation: Point,
+    card_width: f32,
+    card_height: f32,
+    index: usize,
+) -> cranpose_render_common::graph::LayerNode {
+    let card_rect = Rect {
+        x: 0.0,
+        y: 0.0,
+        width: card_width,
+        height: card_height,
+    };
+    let shadow_rect = Rect {
+        x: 0.0,
+        y: 3.0,
+        width: card_width,
+        height: card_height,
+    };
+    let shade = 0.52 + (index % 3) as f32 * 0.08;
+    layer(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: card_width,
+            height: card_height + 6.0,
+        },
+        ProjectiveTransform::translation(translation.x, translation.y),
+        GraphicsLayer::default(),
+        vec![
+            RenderNode::Primitive(PrimitiveEntry {
+                phase: PrimitivePhase::BeforeChildren,
+                node: PrimitiveNode::Draw(DrawPrimitiveNode {
+                    primitive: DrawPrimitive::Shadow(ShadowPrimitive::Drop {
+                        shape: Box::new(DrawPrimitive::Rect {
+                            rect: shadow_rect,
+                            brush: Brush::solid(Color(0.0, 0.0, 0.0, 0.50)),
+                        }),
+                        blur_radius: 5.0,
+                        blend_mode: BlendMode::SrcOver,
+                    }),
+                    clip: None,
+                }),
+            }),
+            solid_rect(card_rect, Color(shade, 0.78, 0.94, 1.0)),
+        ],
     )
 }
 


### PR DESCRIPTION
## Summary

Fixes #229 by removing `ImmediateShadow` as a layer-isolating surface requirement and keeping shadow primitives as ordered draw work in the parent scene when the layer is otherwise direct-renderable.

The common blurred drop-shadow path now records source shape rendering, blur, and composite into one command buffer for a single queue submit per shadow. The single-shape blur now uses a two-target ping-pong path instead of holding source, destination, and an internal intermediate target at the same time.

## Root Cause

Repeated card shadows were paying for two independent costs:

- `DrawPrimitive::Shadow` marked the containing layer as `ImmediateShadow`, and `ImmediateShadow` counted as an isolating requirement. That forced one layer surface/composite per card even when the card content could render directly.
- The one-shape blurred shadow path submitted source rendering, blur, and composite as separate queue submissions and initially held three offscreen targets concurrently.

## What Changed

- `ImmediateShadow` is now diagnostic ordered draw work, not a layer-isolation reason.
- Renderer forced-surface checks no longer treat plain shadows as runtime-cache candidates by themselves.
- Added an encoder-based blur/composite API so the single-shape blurred shadow path can batch source, blur, and composite into one command buffer.
- Added a caller-owned blur scratch path so single-shape shadows use only source + scratch offscreen targets.
- Restored staged uploads as empty renderer scratch storage so unflushed staging state cannot be discarded by the fast path.
- Added a WGPU regression test for repeated translated drop-shadow layers asserting:
  - zero isolated layer renders,
  - at most two offscreen target acquires per shadow,
  - one composite pass per shadow,
  - bounded queue submissions.

## Review Mitigation

Addressed the valid Gemini review comments:

- Staged upload scratch is now restored empty through `take_staged_uploads` / `restore_staged_uploads` instead of leaving stale staged copies around the renderer.
- Single-shape blurred shadows now use the source texture as the final vertical blur destination and one scratch target for the horizontal pass, removing the third concurrent offscreen target.

## Validation

Local:

- `cargo test -p cranpose-render-wgpu --test effect_semantics repeated_translated_drop_shadow_layers_stay_on_direct_path`
- `cargo test`
- `cargo clippy`
- `./gradlew :app:assembleRelease` from `apps/android-demo/android`
- `./build-web.sh` from `apps/desktop-demo`
- `./run_robot_test.sh --sequential` built and ran all 96 robot tests; 95 passed, with `robot_winamp_native_window_geometry` missing a 90 ms native-window drag timing budget while the host was hot.
- `./run_robot_test.sh --sequential --example robot_winamp_native_window_geometry` passed immediately on targeted rerun.

CI:

- Rust workflow run 25445529752 passed: Linux tests/clippy/format, Android release build, wasm build, robot e2e build, all 16 robot shards, and aggregate robot e2e.