### PR TITLE
[codex] tighten post-image text robot coverage

### DIFF
--- a/apps/desktop-demo/robot-runners/robot_renderer_micro_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_renderer_micro_contract.rs
@@ -302,7 +302,7 @@ fn RendererMicroContractApp() {
                 || {},
             );
             Image(
-                board.clone(),
+                BitmapPainter(board.clone()),
                 Some("Micro chessboard".to_string()),
                 Modifier::empty()
                     .offset(16.0, 42.0)

--- a/apps/desktop-demo/robot-runners/robot_renderer_micro_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_renderer_micro_contract.rs
@@ -6,9 +6,9 @@
 use cranpose::AppLauncher;
 use cranpose_testing::{crop_screenshot_logical, sample_screenshot_pixel_logical};
 use cranpose_ui::{
-    composable, text::SpanStyle, text::TextDecoration, text::TextUnit, Alignment, BasicText, Box,
-    BoxSpec, Canvas, Color, ContentScale, Image, ImageBitmap, Modifier, Rect, Row, RowSpec, Size,
-    Text, TextOverflow, TextStyle,
+    composable, text::SpanStyle, text::TextDecoration, text::TextUnit, Alignment, BasicText,
+    BitmapPainter, Box, BoxSpec, Color, ContentScale, Image, ImageBitmap, Modifier, Rect, Row,
+    RowSpec, Size, Text, TextOverflow, TextStyle,
 };
 use image::{ImageBuffer, RgbaImage};
 use std::path::Path;
@@ -181,7 +181,7 @@ fn BitmapIconTextRow(icon: ImageBitmap, modifier: Modifier) {
         RowSpec::default(),
         move || {
             Image(
-                icon.clone(),
+                BitmapPainter(icon.clone()),
                 Some("Bitmap icon".to_string()),
                 Modifier::empty().size(Size::new(20.0, 20.0)),
                 Alignment::CENTER,
@@ -219,28 +219,32 @@ fn SourceIconTextRow(icon: ImageBitmap, modifier: Modifier) {
         modifier.size(Size::new(148.0, 24.0)),
         RowSpec::default(),
         move || {
-            Canvas(Modifier::empty().size(Size::new(20.0, 20.0)), {
-                let icon = icon.clone();
-                move |scope| {
-                    scope.draw_image_src(
-                        icon.clone(),
-                        Rect {
-                            x: 2.0,
-                            y: 2.0,
-                            width: 16.0,
-                            height: 16.0,
-                        },
-                        Rect {
-                            x: 0.0,
-                            y: 0.0,
-                            width: 20.0,
-                            height: 20.0,
-                        },
-                        1.0,
-                        None,
-                    );
-                }
-            });
+            Box(
+                Modifier::empty().size(Size::new(20.0, 20.0)).draw_behind({
+                    let icon = icon.clone();
+                    move |scope| {
+                        scope.draw_image_src(
+                            icon.clone(),
+                            Rect {
+                                x: 2.0,
+                                y: 2.0,
+                                width: 16.0,
+                                height: 16.0,
+                            },
+                            Rect {
+                                x: 0.0,
+                                y: 0.0,
+                                width: 20.0,
+                                height: 20.0,
+                            },
+                            1.0,
+                            None,
+                        );
+                    }
+                }),
+                BoxSpec::default(),
+                || {},
+            );
             BasicText(
                 "Source icon",
                 Modifier::empty(),


### PR DESCRIPTION
## Summary

- Tighten the existing renderer micro-contract for issue #216 so it uses `Image(BitmapPainter(...))` explicitly.
- Replace the custom image child path with a fixed-size `Box` using `draw_behind` + `draw_image_src`, matching the issue's requested regression shape.
- Keep the same weighted and non-weighted `BasicText` siblings and pixel assertions so post-image text remains guarded in the robot suite.

## Context

The post-image text rendering behavior was already guarded by the earlier renderer fix in #226. This follow-up closes the remaining acceptance gap in #216 by making the robot coverage match the requested API shape directly.

Closes #216.

## Validation

- `cargo fmt`
- `cargo run --package desktop-app --example robot_renderer_micro_contract --features robot-app`
- `cargo test > 1.tmp 2>&1`
- `cargo clippy > 2.tmp 2>&1`
- `./gradlew :app:assembleRelease` in `apps/android-demo/android`
- `./build-web.sh` in `apps/desktop-demo`
- `./run_robot_test.sh --sequential > robot.tmp 2>&1` (96/96 passed)