### PR TITLE
[codex] add constrained text overflow options

### DIFF
--- a/apps/desktop-demo/robot-runners/robot_renderer_micro_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_renderer_micro_contract.rs
@@ -8,14 +8,14 @@ use cranpose_testing::{crop_screenshot_logical, sample_screenshot_pixel_logical}
 use cranpose_ui::{
     composable, text::SpanStyle, text::TextDecoration, text::TextUnit, Alignment, BasicText,
     BitmapPainter, Box, BoxSpec, Color, ContentScale, Image, ImageBitmap, Modifier, Rect, Row,
-    RowSpec, Size, Text, TextOverflow, TextStyle,
+    RowSpec, Size, Spacer, Text, TextOptions, TextOverflow, TextStyle, TextWithOptions,
 };
 use image::{ImageBuffer, RgbaImage};
 use std::path::Path;
 use std::time::Duration;
 
 const WINDOW_WIDTH: u32 = 180;
-const WINDOW_HEIGHT: u32 = 170;
+const WINDOW_HEIGHT: u32 = 205;
 const SCREENSHOT_PATH: &str = "/tmp/cranpose_renderer_micro_contract.png";
 
 const BACKGROUND_COLOR: Color = Color(0.12, 0.16, 0.24, 1.0);
@@ -23,6 +23,8 @@ const LINE_VERTICAL_COLOR: Color = Color(0.98, 0.98, 0.98, 1.0);
 const LINE_HORIZONTAL_COLOR: Color = Color(0.98, 0.72, 0.30, 1.0);
 const RECT_FILL_COLOR: Color = Color(0.30, 0.78, 0.56, 1.0);
 const PANEL_FILL_COLOR: Color = Color(0.04, 0.05, 0.09, 1.0);
+const BUTTON_FILL_COLOR: Color = Color(0.08, 0.10, 0.14, 1.0);
+const BADGE_FILL_COLOR: Color = Color(0.18, 0.38, 0.92, 1.0);
 const CHESS_LIGHT: [u8; 3] = [240, 240, 240];
 const CHESS_DARK: [u8; 3] = [36, 54, 72];
 const COLOR_TOLERANCE: u8 = 18;
@@ -172,6 +174,22 @@ fn panel_text_style() -> TextStyle {
     })
 }
 
+fn compact_text_style() -> TextStyle {
+    TextStyle::from_span_style(SpanStyle {
+        color: Some(Color::from_rgb_u8(180, 255, 190)),
+        font_size: TextUnit::Sp(18.0),
+        ..SpanStyle::default()
+    })
+}
+
+fn badge_text_style() -> TextStyle {
+    TextStyle::from_span_style(SpanStyle {
+        color: Some(Color::from_rgb_u8(255, 255, 255)),
+        font_size: TextUnit::Sp(10.0),
+        ..SpanStyle::default()
+    })
+}
+
 #[allow(non_snake_case)]
 #[composable]
 fn BitmapIconTextRow(icon: ImageBitmap, modifier: Modifier) {
@@ -269,6 +287,52 @@ fn SourceIconTextRow(icon: ImageBitmap, modifier: Modifier) {
 
 #[allow(non_snake_case)]
 #[composable]
+fn CompactOverflowButton(icon: ImageBitmap, modifier: Modifier) {
+    Row(
+        modifier
+            .size(Size::new(148.0, 28.0))
+            .background(BUTTON_FILL_COLOR)
+            .padding(2.0),
+        RowSpec::default(),
+        move || {
+            Image(
+                BitmapPainter(icon.clone()),
+                Some("Compact icon".to_string()),
+                Modifier::empty().size(Size::new(18.0, 18.0)),
+                Alignment::CENTER,
+                ContentScale::FillBounds,
+                1.0,
+                None,
+            );
+            TextWithOptions(
+                "Save Cranpose WebP",
+                Modifier::empty().weight(1.0),
+                compact_text_style(),
+                TextOptions {
+                    overflow: TextOverflow::ScaleDown {
+                        min_font_size_sp: 9.0,
+                    },
+                    soft_wrap: false,
+                    max_lines: Some(1),
+                    ..TextOptions::default()
+                },
+            );
+            Spacer(Size::new(8.0, 1.0));
+            Box(
+                Modifier::empty()
+                    .size(Size::new(24.0, 18.0))
+                    .background(BADGE_FILL_COLOR),
+                BoxSpec::default().content_alignment(Alignment::CENTER),
+                || {
+                    Text("42", Modifier::empty(), badge_text_style());
+                },
+            );
+        },
+    );
+}
+
+#[allow(non_snake_case)]
+#[composable]
 fn RendererMicroContractApp() {
     let board = cranpose_core::remember(|| generate_chessboard_bitmap(8, 4)).with(|b| b.clone());
     let icon = cranpose_core::remember(generate_icon_bitmap).with(|bitmap| bitmap.clone());
@@ -338,6 +402,7 @@ fn RendererMicroContractApp() {
             );
             BitmapIconTextRow(icon.clone(), Modifier::empty().offset(16.0, 100.0));
             SourceIconTextRow(icon.clone(), Modifier::empty().offset(16.0, 130.0));
+            CompactOverflowButton(icon.clone(), Modifier::empty().offset(16.0, 160.0));
         },
     );
 }
@@ -404,6 +469,8 @@ fn main() {
                 ("chess_1_0", 28.0, 46.0, CHESS_DARK),
                 ("chess_0_1", 20.0, 54.0, CHESS_DARK),
                 ("chess_1_1", 28.0, 54.0, CHESS_LIGHT),
+                ("compact_button", 24.0, 184.0, expected_screenshot_rgb(BUTTON_FILL_COLOR)),
+                ("compact_badge", 143.0, 174.0, expected_screenshot_rgb(BADGE_FILL_COLOR)),
             ] {
                 if let Err(err) = assert_color(&screenshot, label, x, y, expected) {
                     fail(&robot, &err);
@@ -480,10 +547,42 @@ fn main() {
                     ),
                 );
             }
+            let Some(compact_text) = crop_screenshot_logical(&screenshot, 36.0, 156.0, 94.0, 34.0)
+            else {
+                fail(&robot, "failed to crop compact text row");
+            };
+            let Some(compact_gap) = crop_screenshot_logical(&screenshot, 135.0, 158.0, 4.0, 28.0)
+            else {
+                fail(&robot, "failed to crop compact text gap");
+            };
+            let compact_green = count_green_text_pixels(&compact_text);
+            let gap_green = count_green_text_pixels(&compact_gap);
+            if compact_green < 18 {
+                fail(
+                    &robot,
+                    &format!(
+                        "scaled compact text is missing or over-clipped: green_pixels={compact_green}"
+                    ),
+                );
+            }
+            if gap_green != 0 {
+                fail(
+                    &robot,
+                    &format!(
+                        "scaled compact text drew outside its bounds into badge gap: green_pixels={gap_green}"
+                    ),
+                );
+            }
 
             println!(
-                "PASS: renderer micro-contract pixels match expected image/line/fill layout; underlined and post-image text crops are populated (underlined={}, underline_band={}, bitmap_text={}, source_text={}, panel_text={})",
-                underline_bright, underline_band_bright, bitmap_green, source_green, panel_yellow
+                "PASS: renderer micro-contract pixels match expected image/line/fill layout; underlined, post-image, and compact overflow text crops are populated (underlined={}, underline_band={}, bitmap_text={}, source_text={}, panel_text={}, compact_text={}, compact_gap={})",
+                underline_bright,
+                underline_band_bright,
+                bitmap_green,
+                source_green,
+                panel_yellow,
+                compact_green,
+                gap_green
             );
             let _ = robot.exit();
         })

--- a/crates/cranpose-render/common/src/scene_builder.rs
+++ b/crates/cranpose-render/common/src/scene_builder.rs
@@ -454,6 +454,7 @@ fn text_node_from_parts(parts: TextNodeParts<'_>) -> Option<TextPrimitiveNode> {
     let prepared = modifier_slices
         .and_then(|slices| slices.prepare_text_layout(max_width))
         .unwrap_or_else(|| prepare_text_layout(value, &text_style, options, max_width));
+    let visual_style = prepared.visual_style.clone();
     let draw_width = if options.overflow == TextOverflow::Visible {
         prepared.metrics.width
     } else {
@@ -477,9 +478,9 @@ fn text_node_from_parts(parts: TextNodeParts<'_>) -> Option<TextPrimitiveNode> {
         width: content_width,
         height: (local_bounds.height - padding.top - padding.bottom).max(0.0),
     };
-    let font_size = text_style.resolve_font_size(14.0);
+    let font_size = visual_style.resolve_font_size(14.0);
     let expanded_bounds =
-        expand_text_bounds_for_baseline_shift(text_bounds, &text_style, font_size);
+        expand_text_bounds_for_baseline_shift(text_bounds, &visual_style, font_size);
     let clip = if options.overflow == TextOverflow::Visible {
         None
     } else {
@@ -490,7 +491,7 @@ fn text_node_from_parts(parts: TextNodeParts<'_>) -> Option<TextPrimitiveNode> {
         node_id,
         rect,
         text: prepared.text,
-        text_style,
+        text_style: visual_style,
         font_size,
         layout_options: options,
         clip,

--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -1633,6 +1633,7 @@ impl WgpuTextMeasurer {
 
         Some(cranpose_ui::text::PreparedTextLayout {
             text: wrapped_annotated,
+            visual_style: style.clone(),
             metrics: cranpose_ui::TextMetrics {
                 width: size.width.min(max_width),
                 height,

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -76,10 +76,10 @@ pub use pointer_dispatch::{
     schedule_pointer_repass,
 };
 pub use primitives::{
-    BasicText, BasicTextField, BasicTextFieldOptions, BitmapPainter, Box, BoxScope, BoxSpec,
-    BoxWithConstraints, BoxWithConstraintsScope, BoxWithConstraintsScopeImpl, Button, Canvas,
-    Column, ColumnSpec, ContentScale, ForEach, Image, Layout, LayoutNode, Painter, Row, RowSpec,
-    Spacer, SubcomposeLayout, Text, DEFAULT_ALPHA,
+    BasicText, BasicTextField, BasicTextFieldOptions, BasicTextWithOptions, BitmapPainter, Box,
+    BoxScope, BoxSpec, BoxWithConstraints, BoxWithConstraintsScope, BoxWithConstraintsScopeImpl,
+    Button, Canvas, Column, ColumnSpec, ContentScale, ForEach, Image, Layout, LayoutNode, Painter,
+    Row, RowSpec, Spacer, SubcomposeLayout, Text, TextWithOptions, DEFAULT_ALPHA,
 };
 // Lazy list exports - single source from cranpose-foundation
 pub use cranpose_foundation::lazy::{LazyListItemInfo, LazyListLayoutInfo, LazyListState};
@@ -111,7 +111,7 @@ pub use text::{
     prepare_text_layout, prepare_text_layout_for_node, set_text_measurer, LinkAnnotation,
     ParagraphStyle, PlatformParagraphStyle, PlatformSpanStyle, PlatformTextStyle,
     PreparedTextLayout, SpanStyle, StringAnnotation, TextDrawStyle, TextLayoutOptions,
-    TextMeasurer, TextMetrics, TextOverflow, TextShaping, TextStyle,
+    TextMeasurer, TextMetrics, TextOptions, TextOverflow, TextShaping, TextStyle,
 };
 pub use text_field_modifier_node::{TextFieldElement, TextFieldModifierNode};
 pub use text_modifier_node::{TextModifierElement, TextModifierNode};

--- a/crates/cranpose-ui/src/text/layout_options.rs
+++ b/crates/cranpose-ui/src/text/layout_options.rs
@@ -1,5 +1,9 @@
+use std::hash::{Hash, Hasher};
+
+const MIN_SCALE_DOWN_FONT_SIZE_SP: f32 = 1.0;
+
 /// How overflowing text should be handled.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum TextOverflow {
     #[default]
     Clip,
@@ -7,6 +11,66 @@ pub enum TextOverflow {
     Visible,
     StartEllipsis,
     MiddleEllipsis,
+    ScaleDown {
+        min_font_size_sp: f32,
+    },
+}
+
+impl TextOverflow {
+    pub fn normalized(self) -> Self {
+        match self {
+            Self::ScaleDown { min_font_size_sp } => Self::ScaleDown {
+                min_font_size_sp: normalize_scale_down_min_font_size_sp(min_font_size_sp),
+            },
+            other => other,
+        }
+    }
+
+    pub fn scale_down_min_font_size_sp(self) -> Option<f32> {
+        match self.normalized() {
+            Self::ScaleDown { min_font_size_sp } => Some(min_font_size_sp),
+            _ => None,
+        }
+    }
+}
+
+impl PartialEq for TextOverflow {
+    fn eq(&self, other: &Self) -> bool {
+        match ((*self).normalized(), (*other).normalized()) {
+            (Self::Clip, Self::Clip)
+            | (Self::Ellipsis, Self::Ellipsis)
+            | (Self::Visible, Self::Visible)
+            | (Self::StartEllipsis, Self::StartEllipsis)
+            | (Self::MiddleEllipsis, Self::MiddleEllipsis) => true,
+            (
+                Self::ScaleDown {
+                    min_font_size_sp: left,
+                },
+                Self::ScaleDown {
+                    min_font_size_sp: right,
+                },
+            ) => left.to_bits() == right.to_bits(),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for TextOverflow {}
+
+impl Hash for TextOverflow {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match (*self).normalized() {
+            Self::Clip => 0u8.hash(state),
+            Self::Ellipsis => 1u8.hash(state),
+            Self::Visible => 2u8.hash(state),
+            Self::StartEllipsis => 3u8.hash(state),
+            Self::MiddleEllipsis => 4u8.hash(state),
+            Self::ScaleDown { min_font_size_sp } => {
+                5u8.hash(state);
+                min_font_size_sp.to_bits().hash(state);
+            }
+        }
+    }
 }
 
 /// Text layout behavior options matching Compose `BasicText` controls.
@@ -34,10 +98,64 @@ impl TextLayoutOptions {
         let min_lines = self.min_lines.max(1);
         let max_lines = self.max_lines.max(min_lines);
         Self {
-            overflow: self.overflow,
+            overflow: self.overflow.normalized(),
             soft_wrap: self.soft_wrap,
             max_lines,
             min_lines,
+        }
+    }
+}
+
+fn normalize_scale_down_min_font_size_sp(value: f32) -> f32 {
+    if value.is_finite() && value >= MIN_SCALE_DOWN_FONT_SIZE_SP {
+        value
+    } else {
+        MIN_SCALE_DOWN_FONT_SIZE_SP
+    }
+}
+
+/// High-level text widget options for constrained UI text.
+///
+/// `None` for `max_lines` means no explicit line limit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TextOptions {
+    pub overflow: TextOverflow,
+    pub soft_wrap: bool,
+    pub max_lines: Option<usize>,
+    pub min_lines: usize,
+}
+
+impl Default for TextOptions {
+    fn default() -> Self {
+        Self {
+            overflow: TextOverflow::Clip,
+            soft_wrap: true,
+            max_lines: None,
+            min_lines: 1,
+        }
+    }
+}
+
+impl From<TextOptions> for TextLayoutOptions {
+    fn from(options: TextOptions) -> Self {
+        Self {
+            overflow: options.overflow,
+            soft_wrap: options.soft_wrap,
+            max_lines: options.max_lines.unwrap_or(usize::MAX),
+            min_lines: options.min_lines,
+        }
+        .normalized()
+    }
+}
+
+impl From<TextLayoutOptions> for TextOptions {
+    fn from(options: TextLayoutOptions) -> Self {
+        let options = options.normalized();
+        Self {
+            overflow: options.overflow,
+            soft_wrap: options.soft_wrap,
+            max_lines: (options.max_lines != usize::MAX).then_some(options.max_lines),
+            min_lines: options.min_lines,
         }
     }
 }
@@ -70,5 +188,69 @@ mod tests {
 
         assert_eq!(options.min_lines, 3);
         assert_eq!(options.max_lines, 3);
+    }
+
+    #[test]
+    fn normalized_sanitizes_scale_down_min_font_size() {
+        let options = TextLayoutOptions {
+            overflow: TextOverflow::ScaleDown {
+                min_font_size_sp: f32::NAN,
+            },
+            ..Default::default()
+        }
+        .normalized();
+
+        assert_eq!(
+            options.overflow,
+            TextOverflow::ScaleDown {
+                min_font_size_sp: 1.0
+            }
+        );
+    }
+
+    #[test]
+    fn text_options_default_maps_to_unlimited_layout() {
+        let layout = TextLayoutOptions::from(TextOptions::default());
+
+        assert_eq!(layout.overflow, TextOverflow::Clip);
+        assert!(layout.soft_wrap);
+        assert_eq!(layout.max_lines, usize::MAX);
+        assert_eq!(layout.min_lines, 1);
+    }
+
+    #[test]
+    fn text_options_maps_optional_max_lines_to_layout_limit() {
+        let layout = TextLayoutOptions::from(TextOptions {
+            overflow: TextOverflow::Ellipsis,
+            soft_wrap: false,
+            max_lines: Some(1),
+            min_lines: 1,
+        });
+
+        assert_eq!(layout.overflow, TextOverflow::Ellipsis);
+        assert!(!layout.soft_wrap);
+        assert_eq!(layout.max_lines, 1);
+        assert_eq!(layout.min_lines, 1);
+    }
+
+    #[test]
+    fn text_options_preserve_scale_down_overflow() {
+        let layout = TextLayoutOptions::from(TextOptions {
+            overflow: TextOverflow::ScaleDown {
+                min_font_size_sp: 9.0,
+            },
+            soft_wrap: false,
+            max_lines: Some(1),
+            min_lines: 1,
+        });
+
+        assert_eq!(
+            layout.overflow,
+            TextOverflow::ScaleDown {
+                min_font_size_sp: 9.0
+            }
+        );
+        assert!(!layout.soft_wrap);
+        assert_eq!(layout.max_lines, 1);
     }
 }

--- a/crates/cranpose-ui/src/text/measure.rs
+++ b/crates/cranpose-ui/src/text/measure.rs
@@ -8,7 +8,9 @@ use super::paragraph::{Hyphens, LineBreak};
 use super::style::TextStyle;
 
 const ELLIPSIS: &str = "\u{2026}";
+const DEFAULT_FONT_SIZE_SP: f32 = 14.0;
 const WRAP_EPSILON: f32 = 0.5;
+const SCALE_DOWN_SEARCH_STEPS: usize = 14;
 const AUTO_HYPHEN_MIN_SEGMENT_CHARS: usize = 2;
 const AUTO_HYPHEN_MIN_TRAILING_CHARS: usize = 3;
 const AUTO_HYPHEN_PREFERRED_TRAILING_CHARS: usize = 4;
@@ -26,6 +28,7 @@ pub struct TextMetrics {
 #[derive(Clone, Debug, PartialEq)]
 pub struct PreparedTextLayout {
     pub text: crate::text::AnnotatedString,
+    pub visual_style: TextStyle,
     pub metrics: TextMetrics,
     pub did_overflow: bool,
 }
@@ -388,6 +391,18 @@ pub fn prepare_text_layout_with_measurer_for_node<M: TextMeasurer + ?Sized>(
 ) -> PreparedTextLayout {
     let opts = options.normalized();
     let max_width = normalize_max_width(max_width);
+    if let Some(min_font_size_sp) = opts.overflow.scale_down_min_font_size_sp() {
+        return prepare_scale_down_text_layout(
+            measurer,
+            node_id,
+            text,
+            style,
+            opts,
+            max_width,
+            min_font_size_sp,
+        );
+    }
+
     let wrap_width = (opts.soft_wrap && opts.overflow != TextOverflow::Visible)
         .then_some(max_width)
         .flatten();
@@ -492,6 +507,7 @@ pub fn prepare_text_layout_with_measurer_for_node<M: TextMeasurer + ?Sized>(
 
     PreparedTextLayout {
         text: display_annotated,
+        visual_style: style.clone(),
         metrics: TextMetrics {
             width,
             height: layout_line_count as f32 * line_height,
@@ -500,6 +516,182 @@ pub fn prepare_text_layout_with_measurer_for_node<M: TextMeasurer + ?Sized>(
         },
         did_overflow,
     }
+}
+
+fn prepare_scale_down_text_layout<M: TextMeasurer + ?Sized>(
+    measurer: &M,
+    node_id: Option<NodeId>,
+    text: &crate::text::AnnotatedString,
+    style: &TextStyle,
+    options: TextLayoutOptions,
+    max_width: Option<f32>,
+    min_font_size_sp: f32,
+) -> PreparedTextLayout {
+    let clipped_options = TextLayoutOptions {
+        overflow: TextOverflow::Clip,
+        ..options
+    }
+    .normalized();
+
+    let full_size = prepare_scaled_text_layout(
+        measurer,
+        node_id,
+        text,
+        style,
+        clipped_options,
+        max_width,
+        1.0,
+    );
+    let Some(width_limit) = max_width else {
+        return full_size;
+    };
+    if !full_size.did_overflow {
+        return full_size;
+    }
+
+    let base_font_size = style.resolve_font_size(DEFAULT_FONT_SIZE_SP);
+    let min_scale = (min_font_size_sp.min(base_font_size) / base_font_size).clamp(0.0, 1.0);
+    if min_scale >= 1.0 {
+        return full_size;
+    }
+
+    let min_size = prepare_scaled_text_layout(
+        measurer,
+        node_id,
+        text,
+        style,
+        clipped_options,
+        Some(width_limit),
+        min_scale,
+    );
+    if min_size.did_overflow {
+        return min_size;
+    }
+
+    let mut low = min_scale;
+    let mut high = 1.0;
+    let mut best = min_size;
+    for _ in 0..SCALE_DOWN_SEARCH_STEPS {
+        let mid = (low + high) * 0.5;
+        let candidate = prepare_scaled_text_layout(
+            measurer,
+            node_id,
+            text,
+            style,
+            clipped_options,
+            Some(width_limit),
+            mid,
+        );
+        if candidate.did_overflow {
+            high = mid;
+        } else {
+            low = mid;
+            best = candidate;
+        }
+    }
+
+    best
+}
+
+fn prepare_scaled_text_layout<M: TextMeasurer + ?Sized>(
+    measurer: &M,
+    node_id: Option<NodeId>,
+    text: &crate::text::AnnotatedString,
+    style: &TextStyle,
+    options: TextLayoutOptions,
+    max_width: Option<f32>,
+    font_scale: f32,
+) -> PreparedTextLayout {
+    let visual_style = scale_text_style_font_sizes(style, font_scale);
+    let visual_text = scale_annotated_font_sizes(text, font_scale);
+    prepare_text_layout_with_measurer_for_node(
+        measurer,
+        node_id,
+        &visual_text,
+        &visual_style,
+        options,
+        max_width,
+    )
+}
+
+fn scale_annotated_font_sizes(
+    text: &crate::text::AnnotatedString,
+    factor: f32,
+) -> crate::text::AnnotatedString {
+    if is_identity_scale(factor) || text.span_styles.is_empty() {
+        return text.clone();
+    }
+
+    let mut scaled = text.clone();
+    for span in &mut scaled.span_styles {
+        span.item = scale_span_style_font_sizes(&span.item, factor, None);
+    }
+    scaled
+}
+
+fn scale_text_style_font_sizes(style: &TextStyle, factor: f32) -> TextStyle {
+    if is_identity_scale(factor) {
+        return style.clone();
+    }
+
+    let mut scaled = style.clone();
+    scaled.span_style =
+        scale_span_style_font_sizes(&style.span_style, factor, Some(DEFAULT_FONT_SIZE_SP));
+    scaled.paragraph_style.line_height =
+        scale_text_unit_sp(scaled.paragraph_style.line_height, factor);
+    if let Some(mut indent) = scaled.paragraph_style.text_indent {
+        indent.first_line = scale_text_unit_sp(indent.first_line, factor);
+        indent.rest_line = scale_text_unit_sp(indent.rest_line, factor);
+        scaled.paragraph_style.text_indent = Some(indent);
+    }
+    scaled
+}
+
+fn scale_span_style_font_sizes(
+    style: &crate::text::SpanStyle,
+    factor: f32,
+    default_font_size_sp: Option<f32>,
+) -> crate::text::SpanStyle {
+    let mut scaled = style.clone();
+    scaled.font_size = match (style.font_size, default_font_size_sp) {
+        (crate::text::TextUnit::Unspecified, Some(default_size)) => {
+            crate::text::TextUnit::Sp(default_size * factor)
+        }
+        (unit, Some(_)) => scale_text_unit_sp_and_em(unit, factor),
+        (unit, None) => scale_text_unit_sp(unit, factor),
+    };
+    scaled.letter_spacing = scale_text_unit_sp(scaled.letter_spacing, factor);
+    if let Some(crate::text::TextDrawStyle::Stroke { width }) = scaled.draw_style {
+        scaled.draw_style = Some(crate::text::TextDrawStyle::Stroke {
+            width: width * factor,
+        });
+    }
+    scaled
+}
+
+fn scale_text_unit_sp(unit: crate::text::TextUnit, factor: f32) -> crate::text::TextUnit {
+    match unit {
+        crate::text::TextUnit::Sp(value) if value.is_finite() => {
+            crate::text::TextUnit::Sp(value * factor)
+        }
+        other => other,
+    }
+}
+
+fn scale_text_unit_sp_and_em(unit: crate::text::TextUnit, factor: f32) -> crate::text::TextUnit {
+    match unit {
+        crate::text::TextUnit::Sp(value) if value.is_finite() => {
+            crate::text::TextUnit::Sp(value * factor)
+        }
+        crate::text::TextUnit::Em(value) if value.is_finite() => {
+            crate::text::TextUnit::Em(value * factor)
+        }
+        other => other,
+    }
+}
+
+fn is_identity_scale(factor: f32) -> bool {
+    (factor - 1.0).abs() <= f32::EPSILON
 }
 
 #[derive(Clone, Debug)]
@@ -1105,7 +1297,9 @@ fn apply_line_overflow<M: TextMeasurer + ?Sized>(
             TextOverflow::Ellipsis => format!("{line}{ELLIPSIS}"),
             TextOverflow::StartEllipsis => format!("{ELLIPSIS}{line}"),
             TextOverflow::MiddleEllipsis => format!("{ELLIPSIS}{line}"),
-            TextOverflow::Clip | TextOverflow::Visible => line.to_string(),
+            TextOverflow::Clip | TextOverflow::Visible | TextOverflow::ScaleDown { .. } => {
+                line.to_string()
+            }
         };
     };
 
@@ -1126,6 +1320,7 @@ fn apply_line_overflow<M: TextMeasurer + ?Sized>(
                 line.to_string()
             }
         }
+        TextOverflow::ScaleDown { .. } => line.to_string(),
     }
 }
 
@@ -1507,6 +1702,70 @@ mod tests {
         );
         assert!(prepared.text.text.contains(ELLIPSIS));
         assert!(prepared.did_overflow);
+    }
+
+    #[test]
+    fn text_layout_options_scale_down_fits_without_rewriting_text() {
+        let style = TextStyle {
+            span_style: crate::text::SpanStyle {
+                font_size: TextUnit::Sp(20.0),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let options = TextLayoutOptions {
+            overflow: TextOverflow::ScaleDown {
+                min_font_size_sp: 10.0,
+            },
+            soft_wrap: false,
+            max_lines: 1,
+            min_lines: 1,
+        };
+
+        let prepared = prepare_text_layout(
+            &crate::text::AnnotatedString::from("ABCDE"),
+            &style,
+            options,
+            Some(36.0),
+        );
+
+        assert_eq!(prepared.text.text, "ABCDE");
+        assert!(prepared.metrics.width <= 36.0 + WRAP_EPSILON);
+        assert!(!prepared.did_overflow);
+        let visual_font_size = prepared.visual_style.resolve_font_size(14.0);
+        assert!(visual_font_size < 20.0);
+        assert!(visual_font_size >= 10.0);
+    }
+
+    #[test]
+    fn text_layout_options_scale_down_stops_at_minimum_and_clips() {
+        let style = TextStyle {
+            span_style: crate::text::SpanStyle {
+                font_size: TextUnit::Sp(20.0),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let options = TextLayoutOptions {
+            overflow: TextOverflow::ScaleDown {
+                min_font_size_sp: 10.0,
+            },
+            soft_wrap: false,
+            max_lines: 1,
+            min_lines: 1,
+        };
+
+        let prepared = prepare_text_layout(
+            &crate::text::AnnotatedString::from("ABCDEFGHIJ"),
+            &style,
+            options,
+            Some(12.0),
+        );
+
+        assert_eq!(prepared.text.text, "ABCDEFGHIJ");
+        assert!(prepared.did_overflow);
+        assert_eq!(prepared.metrics.width, 12.0);
+        assert_eq!(prepared.visual_style.resolve_font_size(14.0), 10.0);
     }
 
     #[test]

--- a/crates/cranpose-ui/src/text/measure.rs
+++ b/crates/cranpose-ui/src/text/measure.rs
@@ -1,5 +1,6 @@
 use crate::text_layout_result::TextLayoutResult;
 use cranpose_core::NodeId;
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::ops::Range;
 
@@ -550,6 +551,9 @@ fn prepare_scale_down_text_layout<M: TextMeasurer + ?Sized>(
     }
 
     let base_font_size = style.resolve_font_size(DEFAULT_FONT_SIZE_SP);
+    if !base_font_size.is_finite() || base_font_size <= 0.0 {
+        return full_size;
+    }
     let min_scale = (min_font_size_sp.min(base_font_size) / base_font_size).clamp(0.0, 1.0);
     if min_scale >= 1.0 {
         return full_size;
@@ -607,7 +611,7 @@ fn prepare_scaled_text_layout<M: TextMeasurer + ?Sized>(
     prepare_text_layout_with_measurer_for_node(
         measurer,
         node_id,
-        &visual_text,
+        visual_text.as_ref(),
         &visual_style,
         options,
         max_width,
@@ -617,16 +621,16 @@ fn prepare_scaled_text_layout<M: TextMeasurer + ?Sized>(
 fn scale_annotated_font_sizes(
     text: &crate::text::AnnotatedString,
     factor: f32,
-) -> crate::text::AnnotatedString {
-    if is_identity_scale(factor) || text.span_styles.is_empty() {
-        return text.clone();
+) -> Cow<'_, crate::text::AnnotatedString> {
+    if is_identity_scale(factor) || !annotated_text_needs_scaling(text) {
+        return Cow::Borrowed(text);
     }
 
     let mut scaled = text.clone();
     for span in &mut scaled.span_styles {
         span.item = scale_span_style_font_sizes(&span.item, factor, None);
     }
-    scaled
+    Cow::Owned(scaled)
 }
 
 fn scale_text_style_font_sizes(style: &TextStyle, factor: f32) -> TextStyle {
@@ -661,12 +665,34 @@ fn scale_span_style_font_sizes(
         (unit, None) => scale_text_unit_sp(unit, factor),
     };
     scaled.letter_spacing = scale_text_unit_sp(scaled.letter_spacing, factor);
+    if let Some(mut shadow) = scaled.shadow {
+        shadow.offset.x = scale_finite_dimension(shadow.offset.x, factor);
+        shadow.offset.y = scale_finite_dimension(shadow.offset.y, factor);
+        shadow.blur_radius = scale_finite_dimension(shadow.blur_radius, factor);
+        scaled.shadow = Some(shadow);
+    }
     if let Some(crate::text::TextDrawStyle::Stroke { width }) = scaled.draw_style {
         scaled.draw_style = Some(crate::text::TextDrawStyle::Stroke {
             width: width * factor,
         });
     }
     scaled
+}
+
+fn annotated_text_needs_scaling(text: &crate::text::AnnotatedString) -> bool {
+    text.span_styles
+        .iter()
+        .any(|span| span_style_needs_scaling(&span.item))
+}
+
+fn span_style_needs_scaling(style: &crate::text::SpanStyle) -> bool {
+    matches!(style.font_size, crate::text::TextUnit::Sp(value) if value.is_finite())
+        || matches!(style.letter_spacing, crate::text::TextUnit::Sp(value) if value.is_finite())
+        || matches!(
+            style.draw_style,
+            Some(crate::text::TextDrawStyle::Stroke { .. })
+        )
+        || style.shadow.is_some()
 }
 
 fn scale_text_unit_sp(unit: crate::text::TextUnit, factor: f32) -> crate::text::TextUnit {
@@ -687,6 +713,14 @@ fn scale_text_unit_sp_and_em(unit: crate::text::TextUnit, factor: f32) -> crate:
             crate::text::TextUnit::Em(value * factor)
         }
         other => other,
+    }
+}
+
+fn scale_finite_dimension(value: f32, factor: f32) -> f32 {
+    if value.is_finite() {
+        value * factor
+    } else {
+        value
     }
 }
 
@@ -1574,6 +1608,13 @@ mod tests {
         }
     }
 
+    fn assert_f32_close(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() <= 0.01,
+            "actual={actual}, expected={expected}"
+        );
+    }
+
     #[test]
     fn text_layout_options_wraps_and_limits_lines() {
         let style = TextStyle {
@@ -1738,6 +1779,47 @@ mod tests {
     }
 
     #[test]
+    fn text_layout_options_scale_down_scales_root_shadow() {
+        let style = TextStyle {
+            span_style: crate::text::SpanStyle {
+                font_size: TextUnit::Sp(20.0),
+                shadow: Some(crate::text::Shadow {
+                    color: crate::modifier::Color(0.0, 0.0, 0.0, 1.0),
+                    offset: crate::modifier::Point::new(8.0, 4.0),
+                    blur_radius: 6.0,
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let options = TextLayoutOptions {
+            overflow: TextOverflow::ScaleDown {
+                min_font_size_sp: 10.0,
+            },
+            soft_wrap: false,
+            max_lines: 1,
+            min_lines: 1,
+        };
+
+        let prepared = prepare_text_layout(
+            &crate::text::AnnotatedString::from("ABCDE"),
+            &style,
+            options,
+            Some(36.0),
+        );
+
+        let font_scale = prepared.visual_style.resolve_font_size(14.0) / 20.0;
+        let shadow = prepared
+            .visual_style
+            .span_style
+            .shadow
+            .expect("scaled style should retain shadow");
+        assert_f32_close(shadow.offset.x, 8.0 * font_scale);
+        assert_f32_close(shadow.offset.y, 4.0 * font_scale);
+        assert_f32_close(shadow.blur_radius, 6.0 * font_scale);
+    }
+
+    #[test]
     fn text_layout_options_scale_down_stops_at_minimum_and_clips() {
         let style = TextStyle {
             span_style: crate::text::SpanStyle {
@@ -1766,6 +1848,56 @@ mod tests {
         assert!(prepared.did_overflow);
         assert_eq!(prepared.metrics.width, 12.0);
         assert_eq!(prepared.visual_style.resolve_font_size(14.0), 10.0);
+    }
+
+    #[test]
+    fn scale_annotated_font_sizes_borrows_when_spans_need_no_scaling() {
+        let plain = crate::text::AnnotatedString::from("plain");
+        assert!(matches!(
+            scale_annotated_font_sizes(&plain, 0.5),
+            std::borrow::Cow::Borrowed(_)
+        ));
+
+        let colored = crate::text::annotated_string::Builder::new()
+            .push_style(crate::text::SpanStyle {
+                color: Some(crate::modifier::Color(1.0, 0.0, 0.0, 1.0)),
+                ..Default::default()
+            })
+            .append("colored")
+            .pop()
+            .to_annotated_string();
+        assert!(matches!(
+            scale_annotated_font_sizes(&colored, 0.5),
+            std::borrow::Cow::Borrowed(_)
+        ));
+    }
+
+    #[test]
+    fn scale_annotated_font_sizes_scales_span_shadow_geometry() {
+        let text = crate::text::annotated_string::Builder::new()
+            .push_style(crate::text::SpanStyle {
+                shadow: Some(crate::text::Shadow {
+                    color: crate::modifier::Color(0.0, 0.0, 0.0, 1.0),
+                    offset: crate::modifier::Point::new(6.0, 2.0),
+                    blur_radius: 4.0,
+                }),
+                ..Default::default()
+            })
+            .append("shadow")
+            .pop()
+            .to_annotated_string();
+
+        let scaled = scale_annotated_font_sizes(&text, 0.5);
+        let std::borrow::Cow::Owned(scaled) = scaled else {
+            panic!("shadowed span should be scaled into owned text");
+        };
+        let shadow = scaled.span_styles[0]
+            .item
+            .shadow
+            .expect("scaled span should retain shadow");
+        assert_f32_close(shadow.offset.x, 3.0);
+        assert_f32_close(shadow.offset.y, 1.0);
+        assert_f32_close(shadow.blur_radius, 2.0);
     }
 
     #[test]

--- a/crates/cranpose-ui/src/text/mod.rs
+++ b/crates/cranpose-ui/src/text/mod.rs
@@ -14,7 +14,7 @@ pub use font::{
     FileBackedFontFamily, FontFamily, FontFile, FontStyle, FontSynthesis, FontWeight,
     LoadedTypefacePath,
 };
-pub use layout_options::{TextLayoutOptions, TextOverflow};
+pub use layout_options::{TextLayoutOptions, TextOptions, TextOverflow};
 pub use measure::{
     get_cursor_x_for_offset, get_offset_for_position, layout_text, measure_text,
     measure_text_for_node, measure_text_with_options, measure_text_with_options_for_node,

--- a/crates/cranpose-ui/src/text_modifier_node.rs
+++ b/crates/cranpose-ui/src/text_modifier_node.rs
@@ -498,6 +498,7 @@ mod tests {
             self.recorded.borrow_mut().push(node_id);
             crate::text::PreparedTextLayout {
                 text: text.clone(),
+                visual_style: TextStyle::default(),
                 metrics: crate::text::TextMetrics {
                     width: 12.0,
                     height: 18.0,
@@ -642,5 +643,29 @@ mod tests {
         assert_eq!(recorded, vec![Some(88)]);
         assert_eq!(measured_width, prepared_width);
         assert_eq!(measured_height, prepared_height);
+    }
+
+    #[test]
+    fn semantics_uses_source_text_for_scaled_overflow() {
+        let node = TextModifierNode::new(
+            Rc::new(AnnotatedString::from("Save Cranpose WebP")),
+            TextStyle::default(),
+            TextLayoutOptions {
+                overflow: crate::text::TextOverflow::ScaleDown {
+                    min_font_size_sp: 9.0,
+                },
+                soft_wrap: false,
+                max_lines: 1,
+                min_lines: 1,
+            },
+        );
+        let mut config = SemanticsConfiguration::default();
+
+        node.merge_semantics(&mut config);
+
+        assert_eq!(
+            config.content_description.as_deref(),
+            Some("Save Cranpose WebP")
+        );
     }
 }

--- a/crates/cranpose-ui/src/widgets/text.rs
+++ b/crates/cranpose-ui/src/widgets/text.rs
@@ -10,7 +10,7 @@
 use crate::composable;
 use crate::layout::policies::EmptyMeasurePolicy;
 use crate::modifier::Modifier;
-use crate::text::{TextLayoutOptions, TextOverflow, TextStyle};
+use crate::text::{TextLayoutOptions, TextOptions, TextOverflow, TextStyle};
 use crate::text_modifier_node::TextModifierElement;
 use crate::widgets::Layout;
 use cranpose_core::{MutableState, NodeId, State};
@@ -149,20 +149,11 @@ fn compose_basic_text_group(
     text: TextSource,
     modifier: Modifier,
     style: TextStyle,
-    overflow: TextOverflow,
-    soft_wrap: bool,
-    max_lines: usize,
-    min_lines: usize,
+    options: TextLayoutOptions,
 ) -> NodeId {
     let current = text.resolve();
 
-    let options = TextLayoutOptions {
-        overflow,
-        soft_wrap,
-        max_lines,
-        min_lines,
-    }
-    .normalized();
+    let options = options.normalized();
 
     // Create a text modifier element that will add TextModifierNode to the chain
     // TextModifierNode handles measurement, drawing, and semantics
@@ -179,6 +170,19 @@ fn compose_basic_text_group(
 }
 
 #[composable]
+pub fn BasicTextWithOptions<S>(
+    text: S,
+    modifier: Modifier,
+    style: TextStyle,
+    options: TextLayoutOptions,
+) -> NodeId
+where
+    S: IntoTextSource + Clone + PartialEq + 'static,
+{
+    compose_basic_text_group(text.into_text_source(), modifier, style, options)
+}
+
+#[composable]
 pub fn BasicText<S>(
     text: S,
     modifier: Modifier,
@@ -191,15 +195,30 @@ pub fn BasicText<S>(
 where
     S: IntoTextSource + Clone + PartialEq + 'static,
 {
-    compose_basic_text_group(
-        text.into_text_source(),
+    BasicTextWithOptions(
+        text,
         modifier,
         style,
-        overflow,
-        soft_wrap,
-        max_lines,
-        min_lines,
+        TextLayoutOptions {
+            overflow,
+            soft_wrap,
+            max_lines,
+            min_lines,
+        },
     )
+}
+
+#[composable]
+pub fn TextWithOptions<S>(
+    value: S,
+    modifier: Modifier,
+    style: TextStyle,
+    options: TextOptions,
+) -> NodeId
+where
+    S: IntoTextSource + Clone + PartialEq + 'static,
+{
+    BasicTextWithOptions(value, modifier, style, TextLayoutOptions::from(options))
 }
 
 #[composable]
@@ -207,15 +226,7 @@ pub fn Text<S>(value: S, modifier: Modifier, style: TextStyle) -> NodeId
 where
     S: IntoTextSource + Clone + PartialEq + 'static,
 {
-    BasicText(
-        value,
-        modifier,
-        style,
-        TextOverflow::Clip,
-        true,
-        usize::MAX,
-        1,
-    )
+    TextWithOptions(value, modifier, style, TextOptions::default())
 }
 
 #[cfg(test)]
@@ -229,14 +240,30 @@ mod tests {
     #[test]
     fn basic_text_creates_node() {
         let composition = run_test_composition(|| {
-            BasicText(
+            BasicTextWithOptions(
                 "Hello",
                 Modifier::empty(),
                 TextStyle::default(),
-                TextOverflow::Clip,
-                true,
-                usize::MAX,
-                1,
+                TextLayoutOptions::default(),
+            );
+        });
+
+        assert!(composition.root().is_some());
+    }
+
+    #[test]
+    fn text_with_options_creates_node() {
+        let composition = run_test_composition(|| {
+            TextWithOptions(
+                "Hello",
+                Modifier::empty(),
+                TextStyle::default(),
+                TextOptions {
+                    overflow: TextOverflow::Ellipsis,
+                    soft_wrap: false,
+                    max_lines: Some(1),
+                    ..TextOptions::default()
+                },
             );
         });
 

--- a/crates/cranpose-ui/tests/text_options_contract_integration.rs
+++ b/crates/cranpose-ui/tests/text_options_contract_integration.rs
@@ -1,0 +1,59 @@
+use cranpose_ui::{
+    run_test_composition, Modifier, TextLayoutOptions, TextOptions, TextOverflow, TextStyle,
+    TextWithOptions,
+};
+
+#[test]
+fn text_options_express_single_line_ellipsis_contract() {
+    let layout = TextLayoutOptions::from(TextOptions {
+        overflow: TextOverflow::Ellipsis,
+        soft_wrap: false,
+        max_lines: Some(1),
+        ..TextOptions::default()
+    });
+
+    assert_eq!(layout.overflow, TextOverflow::Ellipsis);
+    assert!(!layout.soft_wrap);
+    assert_eq!(layout.max_lines, 1);
+    assert_eq!(layout.min_lines, 1);
+}
+
+#[test]
+fn text_options_express_scale_down_contract() {
+    let layout = TextLayoutOptions::from(TextOptions {
+        overflow: TextOverflow::ScaleDown {
+            min_font_size_sp: 9.0,
+        },
+        soft_wrap: false,
+        max_lines: Some(1),
+        ..TextOptions::default()
+    });
+
+    assert_eq!(
+        layout.overflow,
+        TextOverflow::ScaleDown {
+            min_font_size_sp: 9.0
+        }
+    );
+    assert!(!layout.soft_wrap);
+    assert_eq!(layout.max_lines, 1);
+}
+
+#[test]
+fn text_with_options_is_available_to_integration_users() {
+    let composition = run_test_composition(|| {
+        TextWithOptions(
+            "Save Cranpose WebP",
+            Modifier::empty(),
+            TextStyle::default(),
+            TextOptions {
+                overflow: TextOverflow::Ellipsis,
+                soft_wrap: false,
+                max_lines: Some(1),
+                ..TextOptions::default()
+            },
+        );
+    });
+
+    assert!(composition.root().is_some());
+}


### PR DESCRIPTION
## Summary

Closes #215.

- Add `TextOptions`, `TextWithOptions`, and `BasicTextWithOptions` so high-level text can opt into max lines, soft wrap, ellipsis, and scale-down behavior.
- Add `TextOverflow::ScaleDown { min_font_size_sp }` in the shared text layout contract, with deterministic scale search and renderer-visible `visual_style` propagation.
- Extend the renderer micro-contract with a fixed-width icon + scaled label + badge case that verifies the label is present and does not draw into the badge gap.
- Keep semantics on the source text and add a regression test for scaled overflow semantics.

## Validation

- `cargo fmt`
- `cargo test > 1.tmp 2>&1`
- `cargo clippy > 2.tmp 2>&1`
- `git diff --check`
- `cargo run --package desktop-app --example robot_renderer_micro_contract --features robot-app`
- `./gradlew :app:assembleRelease` in `apps/android-demo/android`
- `./build-web.sh` in `apps/desktop-demo`
- `./run_robot_test.sh --sequential > robot.tmp 2>&1` (96/96 passed)