### PR TITLE
[codex] bound scroll capture trailing content

### DIFF
--- a/crates/cranpose-render/wgpu/src/normalized_scene.rs
+++ b/crates/cranpose-render/wgpu/src/normalized_scene.rs
@@ -186,9 +186,30 @@ pub(crate) fn collected_layer_bounds(
 }
 
 fn hidden_content_precedes_visible_bounds(visible_bounds: Rect, full_bounds: Rect) -> bool {
-    const TOLERANCE: f32 = 1e-4;
+    full_bounds.x < visible_bounds.x - NORMALIZED_SCENE_AFFINE_TOLERANCE
+        || full_bounds.y < visible_bounds.y - NORMALIZED_SCENE_AFFINE_TOLERANCE
+}
 
-    full_bounds.x < visible_bounds.x - TOLERANCE || full_bounds.y < visible_bounds.y - TOLERANCE
+fn leading_capture_bounds(visible_bounds: Rect, full_bounds: Rect) -> Rect {
+    let left = if full_bounds.x < visible_bounds.x - NORMALIZED_SCENE_AFFINE_TOLERANCE {
+        full_bounds.x
+    } else {
+        visible_bounds.x
+    };
+    let top = if full_bounds.y < visible_bounds.y - NORMALIZED_SCENE_AFFINE_TOLERANCE {
+        full_bounds.y
+    } else {
+        visible_bounds.y
+    };
+    let right = visible_bounds.x + visible_bounds.width;
+    let bottom = visible_bounds.y + visible_bounds.height;
+
+    Rect {
+        x: left,
+        y: top,
+        width: (right - left).max(0.0),
+        height: (bottom - top).max(0.0),
+    }
 }
 
 pub(crate) fn motion_stable_capture_bounds(
@@ -210,7 +231,7 @@ pub(crate) fn motion_stable_capture_bounds(
         (Some(visible_bounds), Some(full_bounds))
             if hidden_content_precedes_visible_bounds(visible_bounds, full_bounds) =>
         {
-            Some(full_bounds)
+            Some(leading_capture_bounds(visible_bounds, full_bounds))
         }
         _ => visible_bounds.or(full_bounds),
     }

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -5727,8 +5727,8 @@ mod tests {
             Rect {
                 x: -24.0,
                 y: 0.0,
-                width: 200.0,
-                height: 480.0,
+                width: 144.0,
+                height: 72.0,
             }
         );
     }
@@ -5768,7 +5768,47 @@ mod tests {
                 x: 0.0,
                 y: -24.0,
                 width: 120.0,
-                height: 200.0,
+                height: 96.0,
+            }
+        );
+    }
+
+    #[test]
+    fn estimate_layer_surface_rect_preserves_hidden_leading_without_trailing_scroll_content() {
+        let mut layer = test_layer(
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 120.0,
+                height: 72.0,
+            },
+            vec![RenderNode::Primitive(PrimitiveEntry {
+                phase: PrimitivePhase::BeforeChildren,
+                node: PrimitiveNode::Draw(DrawPrimitiveNode {
+                    primitive: cranpose_ui_graphics::DrawPrimitive::Rect {
+                        rect: Rect {
+                            x: -16.0,
+                            y: -24.0,
+                            width: 180.0,
+                            height: 240.0,
+                        },
+                        brush: Brush::solid(Color::WHITE),
+                    },
+                    clip: None,
+                }),
+            })],
+        );
+        layer.translated_content_context = true;
+        layer.motion_context_animated = true;
+        layer.clip_to_bounds = true;
+
+        assert_eq!(
+            estimate_layer_surface_rect(&layer),
+            Rect {
+                x: -16.0,
+                y: -24.0,
+                width: 136.0,
+                height: 96.0,
             }
         );
     }


### PR DESCRIPTION
## Summary

Closes #222.

- Tighten motion-stable translated scroll capture bounds so hidden leading content is preserved for stable sampling, while trailing content past the clipped viewport is not kept in the offscreen capture.
- Update WGPU renderer contracts for horizontal, vertical, and two-axis hidden-leading scroll content so clipped viewports do not retain far-edge content that can escape through later compositing paths.

## Validation

- `cargo fmt`
- `cargo test -p cranpose-render-wgpu estimate_layer_surface_rect_ -- --nocapture`
- `cargo test -p cranpose-render-wgpu --lib > render-wgpu.tmp 2>&1`
- `cargo test > 1.tmp 2>&1`
- `cargo clippy > 2.tmp 2>&1`
- `git diff --check`
- `./gradlew :app:assembleRelease` in `apps/android-demo/android`
- `./build-web.sh` in `apps/desktop-demo`
- `./run_robot_test.sh --sequential > robot.tmp 2>&1` (96/96 passed)