### PR TITLE
[codex] add shaped clipping for rounded scroll containers

### DIFF
--- a/crates/cranpose-render/common/src/scene_builder.rs
+++ b/crates/cranpose-render/common/src/scene_builder.rs
@@ -20,6 +20,7 @@ use crate::raster_cache::LayerRasterCacheHashes;
 use crate::style_shared::{primitives_for_placement, DrawPlacement};
 
 const TEXT_CLIP_PAD: f32 = 1.0;
+const ROUNDED_CLIP_EDGE_FEATHER: f32 = 1.0;
 
 #[derive(Clone)]
 struct BuildNodeSnapshot {
@@ -577,8 +578,12 @@ fn graphics_layer_with_shaped_clip(
         return graphics_layer;
     }
 
-    let rounded_clip =
-        rounded_corner_alpha_mask_effect(local_bounds.width, local_bounds.height, radii, 1.0);
+    let rounded_clip = rounded_corner_alpha_mask_effect(
+        local_bounds.width,
+        local_bounds.height,
+        radii,
+        ROUNDED_CLIP_EDGE_FEATHER,
+    );
     graphics_layer.render_effect = Some(match graphics_layer.render_effect.take() {
         Some(existing) => existing.then(rounded_clip),
         None => rounded_clip,
@@ -947,10 +952,11 @@ mod tests {
         let uniforms = shader.uniforms();
         assert_eq!(uniforms[0], 100.0);
         assert_eq!(uniforms[1], 40.0);
-        assert_eq!(uniforms[4], 4.0);
-        assert_eq!(uniforms[5], 8.0);
-        assert_eq!(uniforms[6], 12.0);
-        assert_eq!(uniforms[7], 16.0);
+        assert_eq!(uniforms[2], ROUNDED_CLIP_EDGE_FEATHER);
+        assert_eq!(uniforms[3], 4.0);
+        assert_eq!(uniforms[4], 8.0);
+        assert_eq!(uniforms[5], 12.0);
+        assert_eq!(uniforms[6], 16.0);
     }
 
     #[test]

--- a/crates/cranpose-render/common/src/scene_builder.rs
+++ b/crates/cranpose-render/common/src/scene_builder.rs
@@ -7,7 +7,9 @@ use cranpose_ui::{
     prepare_text_layout, DrawCommand, LayoutBox, LayoutNode, ModifierNodeSlices, Point, Rect,
     ResolvedModifiers, Size, SubcomposeLayoutNode, TextLayoutOptions, TextOverflow,
 };
-use cranpose_ui_graphics::{CompositingStrategy, GraphicsLayer};
+use cranpose_ui_graphics::{
+    rounded_corner_alpha_mask_effect, CompositingStrategy, GraphicsLayer, RoundedCornerShape,
+};
 
 use crate::graph::{
     CachePolicy, DrawPrimitiveNode, HitTestNode, IsolationReasons, LayerNode, PrimitiveEntry,
@@ -283,7 +285,13 @@ fn build_layer_node_from_data(
         width: layout_state.size.width,
         height: layout_state.size.height,
     };
-    let graphics_layer = modifier_slices.graphics_layer().unwrap_or_default();
+    let clip_to_bounds = modifier_slices.clip_to_bounds();
+    let graphics_layer = graphics_layer_with_shaped_clip(
+        modifier_slices.graphics_layer().unwrap_or_default(),
+        clip_to_bounds,
+        modifier_slices.corner_shape(),
+        local_bounds,
+    );
     let transform_to_parent =
         layer_transform_to_parent(local_bounds, layout_state.position, &graphics_layer);
     let isolation = isolation_reasons(&graphics_layer);
@@ -292,7 +300,6 @@ fn build_layer_node_from_data(
     } else {
         CachePolicy::None
     };
-    let clip_to_bounds = modifier_slices.clip_to_bounds();
     let click_actions = modifier_slices.click_handlers();
     let pointer_inputs = modifier_slices.pointer_inputs();
     let shadow_clip = clip_to_bounds.then_some(local_bounds);
@@ -509,6 +516,20 @@ fn layout_box_to_snapshot(node: &LayoutBox, parent: Option<&LayoutBox>) -> Build
     for child in &node.children {
         children.push(layout_box_to_snapshot(child, Some(node)));
     }
+    let base_graphics_layer = node.node_data.modifier_slices.graphics_layer();
+    let graphics_layer = graphics_layer_with_shaped_clip(
+        base_graphics_layer.clone().unwrap_or_default(),
+        node.node_data.modifier_slices.clip_to_bounds(),
+        node.node_data.modifier_slices.corner_shape(),
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: node.rect.width,
+            height: node.rect.height,
+        },
+    );
+    let has_graphics_layer =
+        base_graphics_layer.is_some() || graphics_layer.render_effect.is_some();
 
     BuildNodeSnapshot {
         node_id: node.node_id,
@@ -529,9 +550,40 @@ fn layout_box_to_snapshot(node: &LayoutBox, parent: Option<&LayoutBox>) -> Build
         annotated_text: node.node_data.modifier_slices.annotated_string(),
         text_style: node.node_data.modifier_slices.text_style().cloned(),
         text_layout_options: node.node_data.modifier_slices.text_layout_options(),
-        graphics_layer: node.node_data.modifier_slices.graphics_layer(),
+        graphics_layer: has_graphics_layer.then_some(graphics_layer),
         children,
     }
+}
+
+fn graphics_layer_with_shaped_clip(
+    mut graphics_layer: GraphicsLayer,
+    clip_to_bounds: bool,
+    corner_shape: Option<RoundedCornerShape>,
+    local_bounds: Rect,
+) -> GraphicsLayer {
+    if !clip_to_bounds {
+        return graphics_layer;
+    }
+
+    let Some(corner_shape) = corner_shape else {
+        return graphics_layer;
+    };
+    let radii = corner_shape.resolve(local_bounds.width, local_bounds.height);
+    if radii.top_left <= f32::EPSILON
+        && radii.top_right <= f32::EPSILON
+        && radii.bottom_right <= f32::EPSILON
+        && radii.bottom_left <= f32::EPSILON
+    {
+        return graphics_layer;
+    }
+
+    let rounded_clip =
+        rounded_corner_alpha_mask_effect(local_bounds.width, local_bounds.height, radii, 1.0);
+    graphics_layer.render_effect = Some(match graphics_layer.render_effect.take() {
+        Some(existing) => existing.then(rounded_clip),
+        None => rounded_clip,
+    });
+    graphics_layer
 }
 
 fn isolation_reasons(layer: &GraphicsLayer) -> IsolationReasons {
@@ -641,9 +693,9 @@ mod tests {
     };
     use cranpose_ui::{
         Color, DrawCommand, LayoutEngine, LazyColumn, LazyColumnSpec, Modifier, Point, Rect,
-        ResolvedModifiers, Size, Text, TextStyle,
+        ResolvedModifiers, RoundedCornerShape, Size, Text, TextStyle,
     };
-    use cranpose_ui_graphics::{Brush, DrawPrimitive, GraphicsLayer};
+    use cranpose_ui_graphics::{Brush, DrawPrimitive, GraphicsLayer, RenderEffect};
 
     use super::*;
 
@@ -695,6 +747,18 @@ mod tests {
             }
         }
         None
+    }
+
+    fn graph_has_runtime_shader_effect(layer: &LayerNode) -> bool {
+        layer
+            .graphics_layer
+            .render_effect
+            .as_ref()
+            .is_some_and(RenderEffect::contains_runtime_shader)
+            || layer.children.iter().any(|child| match child {
+                RenderNode::Layer(child_layer) => graph_has_runtime_shader_effect(child_layer),
+                RenderNode::Primitive(_) => false,
+            })
     }
 
     fn snapshot_with_translation(tx: f32) -> BuildNodeSnapshot {
@@ -861,6 +925,98 @@ mod tests {
 
         let top_left = child.transform_to_parent.map_point(Point::default());
         assert_eq!(top_left, Point { x: 24.0, y: -2.0 });
+    }
+
+    #[test]
+    fn rounded_clip_to_bounds_injects_per_corner_mask_effect() {
+        let layer = graphics_layer_with_shaped_clip(
+            GraphicsLayer::default(),
+            true,
+            Some(RoundedCornerShape::new(4.0, 8.0, 12.0, 16.0)),
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 40.0,
+            },
+        );
+
+        let Some(RenderEffect::Shader { shader }) = layer.render_effect else {
+            panic!("rounded clip must emit a shader mask");
+        };
+        let uniforms = shader.uniforms();
+        assert_eq!(uniforms[0], 100.0);
+        assert_eq!(uniforms[1], 40.0);
+        assert_eq!(uniforms[4], 4.0);
+        assert_eq!(uniforms[5], 8.0);
+        assert_eq!(uniforms[6], 12.0);
+        assert_eq!(uniforms[7], 16.0);
+    }
+
+    #[test]
+    fn rounded_clip_to_bounds_keeps_existing_effect_inside_mask() {
+        let existing = RenderEffect::blur(3.0);
+        let layer = graphics_layer_with_shaped_clip(
+            GraphicsLayer {
+                render_effect: Some(existing.clone()),
+                ..GraphicsLayer::default()
+            },
+            true,
+            Some(RoundedCornerShape::uniform(10.0)),
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 40.0,
+            },
+        );
+
+        let Some(RenderEffect::Chain { first, second }) = layer.render_effect else {
+            panic!("existing effect should chain into rounded clip mask");
+        };
+        assert_eq!(*first, existing);
+        assert!(
+            matches!(*second, RenderEffect::Shader { .. }),
+            "rounded mask must be the outer effect"
+        );
+    }
+
+    #[test]
+    fn rounded_corners_clip_to_bounds_builds_graph_mask_from_modifier_chain() {
+        let mut composition = cranpose_ui::run_test_composition(|| {
+            cranpose_ui::Box(
+                Modifier::empty()
+                    .width(100.0)
+                    .height(40.0)
+                    .rounded_corner_shape(RoundedCornerShape::new(4.0, 8.0, 12.0, 16.0))
+                    .clip_to_bounds(),
+                cranpose_ui::BoxSpec::default(),
+                || {
+                    Text("rounded child", Modifier::empty(), TextStyle::default());
+                },
+            );
+        });
+
+        let root = composition.root().expect("rounded clip root");
+        let handle = composition.runtime_handle();
+        let mut applier = composition.applier_mut();
+        applier.set_runtime_handle(handle);
+        applier
+            .compute_layout(
+                root,
+                Size {
+                    width: 160.0,
+                    height: 100.0,
+                },
+            )
+            .expect("rounded clip layout");
+        let graph = build_graph_from_applier(&mut applier, root, 1.0).expect("rounded clip graph");
+        applier.clear_runtime_handle();
+
+        assert!(
+            graph_has_runtime_shader_effect(&graph.root),
+            "rounded_corners().clip_to_bounds() must build a shaped mask effect for descendants"
+        );
     }
 
     #[test]

--- a/crates/cranpose-ui-graphics/src/alpha_mask.rs
+++ b/crates/cranpose-ui-graphics/src/alpha_mask.rs
@@ -177,8 +177,8 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
 ///
 /// Uniform layout:
 /// - 0,1: container size in dp
-/// - 2: corner radius in dp
-/// - 3: edge feather in dp
+/// - 2: edge feather in dp
+/// - 3,4,5,6: corner radii in dp (top-left, top-right, bottom-right, bottom-left)
 pub const ROUNDED_ALPHA_MASK_WGSL: &str = r#"
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
@@ -251,12 +251,12 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     let size_px = container_dp * dp_scale;
 
     let corner_radii_px = max(vec4<f32>(
+        get_float(3u),
         get_float(4u),
         get_float(5u),
         get_float(6u),
-        get_float(7u),
     ) * s, vec4<f32>(0.0));
-    let feather_px = max(get_float(3u) * s, 0.0);
+    let feather_px = max(get_float(2u) * s, 0.0);
     let mask = rounded_rect_alpha(local_px, size_px, corner_radii_px, feather_px);
 
     let sample = textureSample(input_texture, input_sampler, uv);
@@ -389,10 +389,9 @@ pub fn rounded_corner_alpha_mask_effect(
 ) -> RenderEffect {
     let mut shader = RuntimeShader::new(ROUNDED_ALPHA_MASK_WGSL);
     shader.set_float2(0, area_width.max(1.0), area_height.max(1.0));
-    shader.set_float(2, corner_radii.top_left.max(0.0));
-    shader.set_float(3, edge_feather.max(0.0));
+    shader.set_float(2, edge_feather.max(0.0));
     shader.set_float4(
-        4,
+        3,
         corner_radii.top_left.max(0.0),
         corner_radii.top_right.max(0.0),
         corner_radii.bottom_right.max(0.0),
@@ -495,12 +494,11 @@ mod tests {
         let u = shader.uniforms();
         assert_eq!(u[0], 240.0);
         assert_eq!(u[1], 120.0);
-        assert_eq!(u[2], 14.0);
-        assert_eq!(u[3], 6.0);
+        assert_eq!(u[2], 6.0);
+        assert_eq!(u[3], 14.0);
         assert_eq!(u[4], 14.0);
         assert_eq!(u[5], 14.0);
         assert_eq!(u[6], 14.0);
-        assert_eq!(u[7], 14.0);
     }
 
     #[test]
@@ -524,12 +522,11 @@ mod tests {
         let u = shader.uniforms();
         assert_eq!(u[0], 240.0);
         assert_eq!(u[1], 120.0);
-        assert_eq!(u[2], 4.0);
-        assert_eq!(u[3], 2.0);
-        assert_eq!(u[4], 4.0);
-        assert_eq!(u[5], 8.0);
-        assert_eq!(u[6], 12.0);
-        assert_eq!(u[7], 16.0);
+        assert_eq!(u[2], 2.0);
+        assert_eq!(u[3], 4.0);
+        assert_eq!(u[4], 8.0);
+        assert_eq!(u[5], 12.0);
+        assert_eq!(u[6], 16.0);
     }
 
     #[test]

--- a/crates/cranpose-ui-graphics/src/alpha_mask.rs
+++ b/crates/cranpose-ui-graphics/src/alpha_mask.rs
@@ -4,7 +4,7 @@
 //! masking workflows, such as revealing/cutting content with a rounded shape
 //! and a feathered opacity transition.
 
-use crate::{RenderEffect, RuntimeShader};
+use crate::{CornerRadii, RenderEffect, RuntimeShader};
 
 /// Direction of the gradient cut mask.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
@@ -207,15 +207,29 @@ fn get_vec2(index: u32) -> vec2<f32> {
     return vec2<f32>(get_float(index), get_float(index + 1u));
 }
 
-fn sd_round_rect(p: vec2<f32>, half_size: vec2<f32>, radius: f32) -> f32 {
+fn corner_radius_for_point(p: vec2<f32>, radii: vec4<f32>) -> f32 {
+    if (p.x < 0.0) {
+        if (p.y < 0.0) {
+            return radii.x;
+        }
+        return radii.w;
+    }
+    if (p.y < 0.0) {
+        return radii.y;
+    }
+    return radii.z;
+}
+
+fn sd_round_rect(p: vec2<f32>, half_size: vec2<f32>, radii: vec4<f32>) -> f32 {
+    let radius = corner_radius_for_point(p, radii);
     let q = abs(p) - half_size + vec2<f32>(radius);
     return length(max(q, vec2<f32>(0.0))) + min(max(q.x, q.y), 0.0) - radius;
 }
 
-fn rounded_rect_alpha(local_px: vec2<f32>, size_px: vec2<f32>, corner_radius_px: f32, feather_px: f32) -> f32 {
+fn rounded_rect_alpha(local_px: vec2<f32>, size_px: vec2<f32>, corner_radii_px: vec4<f32>, feather_px: f32) -> f32 {
     let half = size_px * 0.5;
     let p = local_px - half;
-    let d = sd_round_rect(p, half, corner_radius_px);
+    let d = sd_round_rect(p, half, corner_radii_px);
     let half_feather = max(feather_px * 0.5, 0.001);
     return 1.0 - smoothstep(-half_feather, half_feather, d);
 }
@@ -236,9 +250,14 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     let local_px = uv * tex_size - effect_rect.xy;
     let size_px = container_dp * dp_scale;
 
-    let corner_radius_px = max(get_float(2u) * s, 0.0);
+    let corner_radii_px = max(vec4<f32>(
+        get_float(4u),
+        get_float(5u),
+        get_float(6u),
+        get_float(7u),
+    ) * s, vec4<f32>(0.0));
     let feather_px = max(get_float(3u) * s, 0.0);
-    let mask = rounded_rect_alpha(local_px, size_px, corner_radius_px, feather_px);
+    let mask = rounded_rect_alpha(local_px, size_px, corner_radii_px, feather_px);
 
     let sample = textureSample(input_texture, input_sampler, uv);
     return sample * mask;
@@ -353,10 +372,32 @@ pub fn rounded_alpha_mask_effect(
     corner_radius: f32,
     edge_feather: f32,
 ) -> RenderEffect {
+    rounded_corner_alpha_mask_effect(
+        area_width,
+        area_height,
+        CornerRadii::uniform(corner_radius),
+        edge_feather,
+    )
+}
+
+/// Builds a rounded alpha mask effect with independent corner radii.
+pub fn rounded_corner_alpha_mask_effect(
+    area_width: f32,
+    area_height: f32,
+    corner_radii: CornerRadii,
+    edge_feather: f32,
+) -> RenderEffect {
     let mut shader = RuntimeShader::new(ROUNDED_ALPHA_MASK_WGSL);
     shader.set_float2(0, area_width.max(1.0), area_height.max(1.0));
-    shader.set_float(2, corner_radius.max(0.0));
+    shader.set_float(2, corner_radii.top_left.max(0.0));
     shader.set_float(3, edge_feather.max(0.0));
+    shader.set_float4(
+        4,
+        corner_radii.top_left.max(0.0),
+        corner_radii.top_right.max(0.0),
+        corner_radii.bottom_right.max(0.0),
+        corner_radii.bottom_left.max(0.0),
+    );
     RenderEffect::runtime_shader(shader)
 }
 
@@ -456,6 +497,39 @@ mod tests {
         assert_eq!(u[1], 120.0);
         assert_eq!(u[2], 14.0);
         assert_eq!(u[3], 6.0);
+        assert_eq!(u[4], 14.0);
+        assert_eq!(u[5], 14.0);
+        assert_eq!(u[6], 14.0);
+        assert_eq!(u[7], 14.0);
+    }
+
+    #[test]
+    fn rounded_corner_alpha_mask_sets_per_corner_uniforms() {
+        let effect = rounded_corner_alpha_mask_effect(
+            240.0,
+            120.0,
+            CornerRadii {
+                top_left: 4.0,
+                top_right: 8.0,
+                bottom_right: 12.0,
+                bottom_left: 16.0,
+            },
+            2.0,
+        );
+        let RenderEffect::Shader { shader } = effect else {
+            panic!("expected shader render effect");
+        };
+
+        assert_eq!(shader.source(), ROUNDED_ALPHA_MASK_WGSL);
+        let u = shader.uniforms();
+        assert_eq!(u[0], 240.0);
+        assert_eq!(u[1], 120.0);
+        assert_eq!(u[2], 4.0);
+        assert_eq!(u[3], 2.0);
+        assert_eq!(u[4], 4.0);
+        assert_eq!(u[5], 8.0);
+        assert_eq!(u[6], 12.0);
+        assert_eq!(u[7], 16.0);
     }
 
     #[test]

--- a/crates/cranpose-ui/src/modifier/slices.rs
+++ b/crates/cranpose-ui/src/modifier/slices.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use std::rc::Rc;
 
 use cranpose_foundation::{ModifierNodeChain, NodeCapabilities, PointerEvent};
-use cranpose_ui_graphics::{ColorFilter, GraphicsLayer, RenderEffect};
+use cranpose_ui_graphics::{ColorFilter, GraphicsLayer, RenderEffect, RoundedCornerShape};
 
 use super::{ModifierChainHandle, Point};
 use crate::draw::DrawCommand;
@@ -35,6 +35,7 @@ pub struct ModifierNodeSlices {
     prepared_text_layout: Option<TextPreparedLayoutHandle>,
     graphics_layer: Option<GraphicsLayer>,
     graphics_layer_resolver: Option<Rc<dyn Fn() -> GraphicsLayer>>,
+    corner_shape: Option<RoundedCornerShape>,
     chain_guard: Option<Rc<ChainGuard>>,
 }
 
@@ -76,6 +77,7 @@ impl Clone for ModifierNodeSlices {
             prepared_text_layout: self.prepared_text_layout.clone(),
             graphics_layer: self.graphics_layer.clone(),
             graphics_layer_resolver: self.graphics_layer_resolver.clone(),
+            corner_shape: self.corner_shape,
             chain_guard: self.chain_guard.clone(),
         }
     }
@@ -228,6 +230,10 @@ impl ModifierNodeSlices {
         }
     }
 
+    pub fn corner_shape(&self) -> Option<RoundedCornerShape> {
+        self.corner_shape
+    }
+
     fn push_graphics_layer(
         &mut self,
         layer: GraphicsLayer,
@@ -304,6 +310,7 @@ impl ModifierNodeSlices {
         self.prepared_text_layout = None;
         self.graphics_layer = None;
         self.graphics_layer_resolver = None;
+        self.corner_shape = None;
         self.chain_guard = None;
     }
 }
@@ -337,6 +344,7 @@ impl fmt::Debug for ModifierNodeSlices {
                 "graphics_layer_resolver",
                 &self.graphics_layer_resolver.is_some(),
             )
+            .field("corner_shape", &self.corner_shape)
             .finish()
     }
 }
@@ -480,6 +488,8 @@ pub fn collect_modifier_slices_into(chain: &ModifierNodeChain, slices: &mut Modi
             }
         });
     }
+
+    slices.corner_shape = corner_shape;
 
     // Convert background + shape into a draw command
     if let Some(color) = background_color {

--- a/crates/cranpose-ui/src/modifier/tests/modifier_tests.rs
+++ b/crates/cranpose-ui/src/modifier/tests/modifier_tests.rs
@@ -1166,6 +1166,15 @@ fn rounded_alpha_mask_modifier_sets_render_effect_shader() {
 }
 
 #[test]
+fn rounded_corners_records_corner_shape_without_background() {
+    let shape = RoundedCornerShape::new(4.0, 8.0, 12.0, 16.0);
+    let modifier = Modifier::empty().rounded_corner_shape(shape);
+    let slices = collect_slices_from_modifier(&modifier);
+
+    assert_eq!(slices.corner_shape(), Some(shape));
+}
+
+#[test]
 fn gradient_fade_dst_out_modifier_sets_render_effect_shader() {
     use crate::modifier_nodes::GraphicsLayerNode;
 


### PR DESCRIPTION
## Summary
- Preserve `rounded_corners` shape metadata in modifier slices even when no background is present.
- Convert `rounded_corners(...).clip_to_bounds()` into an outer rounded alpha mask on the layer while retaining rectangular clipping for culling and bounds.
- Extend the rounded alpha mask shader to support independent corner radii.

Closes #221.

## Validation
- `cargo test > 1.tmp 2>&1`
- `cargo clippy > 2.tmp 2>&1`
- `cargo fmt`
- `git diff --check`
- `./gradlew :app:assembleRelease > android-build.tmp 2>&1` in `apps/android-demo/android`
- `./build-web.sh > wasm-build.tmp 2>&1` in `apps/desktop-demo`
- `./run_robot_test.sh --sequential > robot.tmp 2>&1`