### PR TITLE
[codex] fix scoped recomposition parent hints

### DIFF
--- a/crates/cranpose-core/src/composer.rs
+++ b/crates/cranpose-core/src/composer.rs
@@ -365,6 +365,7 @@ pub(crate) struct ParentFrame {
     pub(crate) new_children: ChildList,
     pub(crate) new_children_membership: Option<HashSet<NodeId>>,
     pub(crate) attach_mode: ParentAttachMode,
+    pub(crate) synthetic_root: bool,
 }
 
 const LARGE_DEFERRED_CHILD_TRACKING_THRESHOLD: usize = 16;
@@ -424,6 +425,7 @@ impl ComposerCore {
                 new_children: ChildList::new(),
                 new_children_membership: None,
                 attach_mode: ParentAttachMode::DeferredSync,
+                synthetic_root: true,
             }]
         } else {
             Vec::new()
@@ -633,6 +635,14 @@ impl Composer {
 
     pub(crate) fn parent_stack(&self) -> RefMut<'_, Vec<ParentFrame>> {
         self.core.parent_stack.borrow_mut()
+    }
+
+    fn current_parent_hint(&self) -> Option<NodeId> {
+        let stack = self.core.parent_stack.borrow();
+        let stack_hint = stack
+            .last()
+            .and_then(|frame| (!frame.synthetic_root).then_some(frame.id));
+        stack_hint.or_else(|| self.core.recranpose_parent_hint.get())
     }
 
     pub(crate) fn subcompose_stack(&self) -> RefMut<'_, Vec<SubcomposeFrame>> {
@@ -881,7 +891,7 @@ impl Composer {
 
         scope_ref.snapshot_locals(self.current_local_stack());
         {
-            let parent_hint = self.parent_stack().last().map(|frame| frame.id);
+            let parent_hint = self.current_parent_hint();
             scope_ref.set_parent_hint(parent_hint);
         }
 

--- a/crates/cranpose-core/src/composer.rs
+++ b/crates/cranpose-core/src/composer.rs
@@ -368,6 +368,12 @@ pub(crate) struct ParentFrame {
     pub(crate) synthetic_root: bool,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum InitialParentFrame {
+    SyntheticRoot,
+    RealParent,
+}
+
 const LARGE_DEFERRED_CHILD_TRACKING_THRESHOLD: usize = 16;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -417,6 +423,7 @@ impl ComposerCore {
         runtime: RuntimeHandle,
         observer: SnapshotStateObserver,
         root: Option<NodeId>,
+        initial_parent_frame: InitialParentFrame,
     ) -> Self {
         let parent_stack = if let Some(root_id) = root {
             vec![ParentFrame {
@@ -425,7 +432,7 @@ impl ComposerCore {
                 new_children: ChildList::new(),
                 new_children_membership: None,
                 attach_mode: ParentAttachMode::DeferredSync,
-                synthetic_root: true,
+                synthetic_root: matches!(initial_parent_frame, InitialParentFrame::SyntheticRoot),
             }]
         } else {
             Vec::new()
@@ -474,6 +481,26 @@ impl Composer {
         observer: SnapshotStateObserver,
         root: Option<NodeId>,
     ) -> Self {
+        Self::new_with_shared_state_with_parent_frame(
+            shared_state,
+            slots,
+            applier,
+            runtime,
+            observer,
+            root,
+            InitialParentFrame::SyntheticRoot,
+        )
+    }
+
+    fn new_with_shared_state_with_parent_frame(
+        shared_state: Rc<ComposerRuntimeState>,
+        slots: Rc<SlotsHost>,
+        applier: Rc<dyn ApplierHost>,
+        runtime: RuntimeHandle,
+        observer: SnapshotStateObserver,
+        root: Option<NodeId>,
+        initial_parent_frame: InitialParentFrame,
+    ) -> Self {
         shared_state.bind_applier_host(&applier);
         bind_slots_host_to_runtime_state(&shared_state, &slots);
         let core = Rc::new(ComposerCore::new(
@@ -483,6 +510,7 @@ impl Composer {
             runtime,
             observer,
             root,
+            initial_parent_frame,
         ));
         Self { core }
     }
@@ -494,7 +522,7 @@ impl Composer {
         observer: SnapshotStateObserver,
         root: Option<NodeId>,
     ) -> Self {
-        Self::new_with_shared_state(
+        Self::new_with_shared_state_with_parent_frame(
             slots
                 .runtime_state()
                 .unwrap_or_else(|| Rc::new(ComposerRuntimeState::default())),
@@ -503,6 +531,7 @@ impl Composer {
             runtime,
             observer,
             root,
+            InitialParentFrame::RealParent,
         )
     }
 
@@ -1324,6 +1353,7 @@ impl Composer {
             runtime_handle.clone(),
             self.observer(),
             root,
+            InitialParentFrame::RealParent,
         ));
         core.phase.set(phase);
         *core.local_stack.borrow_mut() = locals;
@@ -1380,6 +1410,7 @@ impl Composer {
             runtime_handle.clone(),
             self.observer(),
             root,
+            InitialParentFrame::RealParent,
         ));
         core.phase.set(phase);
         *core.local_stack.borrow_mut() = locals;

--- a/crates/cranpose-core/src/composition.rs
+++ b/crates/cranpose-core/src/composition.rs
@@ -432,6 +432,9 @@ impl<A: Applier + 'static> Composition<A> {
                         self.observer.clone(),
                         self.root,
                     );
+                    // Scoped recomposition attaches emitted roots through scope parent hints.
+                    // A synthetic root frame would reparent skipped descendants to the root.
+                    composer.parent_stack().clear();
                     self.observer.begin_frame();
                     let (root, commands, side_effects, requested_root_render, compact_applier) =
                         composer.install(|composer| {

--- a/crates/cranpose-core/src/emit.rs
+++ b/crates/cranpose-core/src/emit.rs
@@ -298,6 +298,9 @@ impl Composer {
 
         // During recomposition, preserve the original parent when possible.
         if let Some(parent_hint) = self.core.recranpose_parent_hint.get() {
+            if parent_hint == id {
+                return;
+            }
             let parent_status = {
                 let mut applier = self.borrow_applier();
                 applier
@@ -384,6 +387,7 @@ impl Composer {
             new_children: ChildList::new(),
             new_children_membership: None,
             attach_mode,
+            synthetic_root: false,
         });
     }
 
@@ -399,6 +403,7 @@ impl Composer {
                 new_children,
                 new_children_membership: _new_children_membership,
                 attach_mode,
+                synthetic_root: _synthetic_root,
             } = frame;
 
             log::trace!(target: "cranpose::compose::parent", "pop_parent: node #{}", id);

--- a/crates/cranpose-core/src/emit.rs
+++ b/crates/cranpose-core/src/emit.rs
@@ -299,6 +299,10 @@ impl Composer {
         // During recomposition, preserve the original parent when possible.
         if let Some(parent_hint) = self.core.recranpose_parent_hint.get() {
             if parent_hint == id {
+                debug_assert_ne!(
+                    parent_hint, id,
+                    "a node cannot be attached as its own parent"
+                );
                 return;
             }
             let parent_status = {

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -2110,6 +2110,14 @@ fn update_typed_node<N: Node + 'static>(node: &mut dyn Node, id: NodeId) -> Resu
 }
 
 fn insert_child_with_reparenting(applier: &mut dyn Applier, parent_id: NodeId, child_id: NodeId) {
+    if parent_id == child_id {
+        debug_assert_ne!(
+            parent_id, child_id,
+            "a node cannot be attached as its own child"
+        );
+        return;
+    }
+
     let old_parent = applier
         .get_mut(child_id)
         .ok()

--- a/crates/cranpose-core/src/tests/composition_and_recompose_scope_tests.rs
+++ b/crates/cranpose-core/src/tests/composition_and_recompose_scope_tests.rs
@@ -3561,3 +3561,294 @@ fn keyed_child_moved_between_parents_rebuilds_without_stale_attachment() {
         );
     }
 }
+
+#[test]
+fn conditional_nested_child_recompose_keeps_parent_order() {
+    thread_local! {
+        static ROOT_ID: Cell<Option<NodeId>> = const { Cell::new(None) };
+        static QUEUE_ROW_ID: Cell<Option<NodeId>> = const { Cell::new(None) };
+        static CURRENT_ROW_ID: Cell<Option<NodeId>> = const { Cell::new(None) };
+        static STATUS_ROW_ID: Cell<Option<NodeId>> = const { Cell::new(None) };
+        static FIELD_ID: Cell<Option<NodeId>> = const { Cell::new(None) };
+    }
+
+    #[allow(non_snake_case)]
+    #[composable]
+    fn Leaf(label: &'static str) -> NodeId {
+        cranpose_core::with_current_composer(|composer| {
+            composer.emit_node(|| TrackingChild {
+                label: label.to_string(),
+                ..TrackingChild::default()
+            })
+        })
+    }
+
+    #[allow(non_snake_case)]
+    #[composable]
+    fn QueueRow() -> NodeId {
+        let id = cranpose_core::with_current_composer(|composer| {
+            composer.emit_node(RecordingNode::default)
+        });
+        QUEUE_ROW_ID.with(|slot| slot.set(Some(id)));
+        cranpose_core::push_parent(id);
+        Leaf("queue");
+        cranpose_core::pop_parent();
+        id
+    }
+
+    #[allow(non_snake_case)]
+    #[composable]
+    fn CurrentField(field_text: MutableState<&'static str>) -> NodeId {
+        let _ = field_text.value();
+        let id = Leaf("field");
+        FIELD_ID.with(|slot| slot.set(Some(id)));
+        id
+    }
+
+    #[allow(non_snake_case)]
+    #[composable]
+    fn CurrentRow(field_text: MutableState<&'static str>) -> NodeId {
+        let id = cranpose_core::with_current_composer(|composer| {
+            composer.emit_node(RecordingNode::default)
+        });
+        CURRENT_ROW_ID.with(|slot| slot.set(Some(id)));
+        cranpose_core::push_parent(id);
+        CurrentField(field_text);
+        cranpose_core::pop_parent();
+        id
+    }
+
+    #[allow(non_snake_case)]
+    #[composable]
+    fn StatusRow() -> NodeId {
+        let id = cranpose_core::with_current_composer(|composer| {
+            composer.emit_node(RecordingNode::default)
+        });
+        STATUS_ROW_ID.with(|slot| slot.set(Some(id)));
+        cranpose_core::push_parent(id);
+        Leaf("status");
+        cranpose_core::pop_parent();
+        id
+    }
+
+    #[allow(non_snake_case)]
+    #[composable]
+    fn Root(show_current: MutableState<bool>, field_text: MutableState<&'static str>) -> NodeId {
+        let show_current = show_current.value();
+        let id = cranpose_core::with_current_composer(|composer| {
+            composer.emit_node(RecordingNode::default)
+        });
+        ROOT_ID.with(|slot| slot.set(Some(id)));
+        cranpose_core::push_parent(id);
+        QueueRow();
+        if show_current {
+            CurrentRow(field_text);
+        }
+        StatusRow();
+        cranpose_core::pop_parent();
+        id
+    }
+
+    fn drain(composition: &mut Composition<MemoryApplier>, context: &'static str) {
+        while composition.process_invalid_scopes().expect(context) {}
+    }
+
+    fn captured_id(slot: &'static std::thread::LocalKey<Cell<Option<NodeId>>>) -> NodeId {
+        slot.with(|cell| cell.get())
+            .expect("node id should be captured")
+    }
+
+    fn assert_row_order(
+        composition: &mut Composition<MemoryApplier>,
+        root_id: NodeId,
+        queue_id: NodeId,
+        current_id: NodeId,
+        status_id: NodeId,
+        field_id: NodeId,
+    ) {
+        let mut applier = composition.applier_mut();
+        let tree = applier.dump_tree(Some(root_id));
+        let root_children = applier
+            .with_node::<RecordingNode, _>(root_id, |node| node.children.clone())
+            .expect("root node should exist");
+        let current_children = applier
+            .with_node::<RecordingNode, _>(current_id, |node| node.children.clone())
+            .expect("current row should exist");
+        let field_parent = applier
+            .with_node::<TrackingChild, _>(field_id, |node| node.parent())
+            .expect("field node should exist");
+
+        assert_eq!(
+            root_children,
+            vec![queue_id, current_id, status_id],
+            "conditional row must stay before the status sibling; tree=\n{tree}",
+        );
+        assert_eq!(
+            current_children,
+            vec![field_id],
+            "field node must remain inside the conditional row; tree=\n{tree}",
+        );
+        assert_eq!(
+            field_parent,
+            Some(current_id),
+            "field parent link must stay on the conditional row; tree=\n{tree}",
+        );
+    }
+
+    let mut composition = test_composition();
+    let runtime = composition.runtime_handle();
+    let show_current = MutableState::with_runtime(false, runtime.clone());
+    let field_text = MutableState::with_runtime("title", runtime);
+    let root_key = location_key(file!(), line!(), column!());
+
+    composition
+        .render(root_key, || {
+            Root(show_current, field_text);
+        })
+        .expect("initial render");
+
+    show_current.set(true);
+    drain(&mut composition, "insert current row");
+
+    let root_id = captured_id(&ROOT_ID);
+    let queue_id = captured_id(&QUEUE_ROW_ID);
+    let current_id = captured_id(&CURRENT_ROW_ID);
+    let status_id = captured_id(&STATUS_ROW_ID);
+    let field_id = captured_id(&FIELD_ID);
+    assert_row_order(
+        &mut composition,
+        root_id,
+        queue_id,
+        current_id,
+        status_id,
+        field_id,
+    );
+
+    field_text.set("edited");
+    drain(&mut composition, "edit field text");
+
+    assert_row_order(
+        &mut composition,
+        root_id,
+        queue_id,
+        current_id,
+        status_id,
+        field_id,
+    );
+}
+
+#[test]
+fn scoped_recompose_after_root_replay_does_not_self_parent_root() {
+    thread_local! {
+        static ROOT_ID: Cell<Option<NodeId>> = const { Cell::new(None) };
+    }
+
+    #[derive(Default)]
+    struct RootReplayNode {
+        id: Option<NodeId>,
+        raw_parent: Option<NodeId>,
+        children: Vec<NodeId>,
+    }
+
+    impl Node for RootReplayNode {
+        fn set_node_id(&mut self, id: NodeId) {
+            self.id = Some(id);
+        }
+
+        fn parent(&self) -> Option<NodeId> {
+            match (self.raw_parent, self.id) {
+                (Some(parent), Some(id)) if parent == id => None,
+                (parent, _) => parent,
+            }
+        }
+
+        fn on_attached_to_parent(&mut self, parent: NodeId) {
+            self.raw_parent = Some(parent);
+        }
+
+        fn on_removed_from_parent(&mut self) {
+            self.raw_parent = None;
+        }
+
+        fn insert_child(&mut self, child: NodeId) {
+            if !self.children.contains(&child) {
+                self.children.push(child);
+            }
+        }
+
+        fn remove_child(&mut self, child: NodeId) {
+            self.children.retain(|&id| id != child);
+        }
+
+        fn children(&self) -> Vec<NodeId> {
+            self.children.clone()
+        }
+    }
+
+    #[allow(non_snake_case)]
+    #[composable]
+    fn Child(value: i32) -> NodeId {
+        cranpose_core::with_current_composer(|composer| {
+            composer.emit_node(|| TrackingChild {
+                label: value.to_string(),
+                ..TrackingChild::default()
+            })
+        })
+    }
+
+    #[allow(non_snake_case)]
+    #[composable]
+    fn Root(value: MutableState<i32>) -> NodeId {
+        let value = value.value();
+        let id = cranpose_core::with_current_composer(|composer| {
+            composer.emit_node(RootReplayNode::default)
+        });
+        ROOT_ID.with(|slot| slot.set(Some(id)));
+        cranpose_core::push_parent(id);
+        Child(value);
+        cranpose_core::pop_parent();
+        id
+    }
+
+    fn root_raw_parent(
+        composition: &mut Composition<MemoryApplier>,
+        root_id: NodeId,
+    ) -> Option<NodeId> {
+        composition
+            .applier_mut()
+            .with_node::<RootReplayNode, _>(root_id, |node| node.raw_parent)
+            .expect("root node should exist")
+    }
+
+    let mut composition = test_composition();
+    let runtime = composition.runtime_handle();
+    let value = MutableState::with_runtime(0, runtime);
+    let root_key = location_key(file!(), line!(), column!());
+
+    composition
+        .render(root_key, || {
+            Root(value);
+        })
+        .expect("initial render");
+    let root_id = ROOT_ID.with(|slot| slot.get()).expect("root id");
+
+    composition.request_root_render();
+    composition
+        .reconcile(root_key, || {
+            Root(value);
+        })
+        .expect("forced root replay");
+    assert_eq!(root_raw_parent(&mut composition, root_id), None);
+
+    value.set(1);
+    while composition
+        .process_invalid_scopes()
+        .expect("scoped root recomposition")
+    {}
+
+    assert_eq!(
+        root_raw_parent(&mut composition, root_id),
+        None,
+        "a root scope replay must not attach its root node as its own child",
+    );
+}

--- a/crates/cranpose-core/src/tests/composition_and_recompose_scope_tests.rs
+++ b/crates/cranpose-core/src/tests/composition_and_recompose_scope_tests.rs
@@ -3191,6 +3191,41 @@ fn subcompose_in_retains_root_level_groups() {
 }
 
 #[test]
+fn subcompose_slot_root_level_scopes_keep_container_parent_hint() {
+    let (handle, _runtime) = runtime_handle();
+    let mut slots = SlotTable::default();
+    let mut applier = test_applier();
+    let container_id = applier.create(Box::<RecordingNode>::default());
+    let (composer, slots_host, applier_host) =
+        setup_composer(&mut slots, &mut applier, handle, None);
+    let subcompose_slots = Rc::new(SlotsHost::new(SlotTable::new()));
+    let group_key = location_key(file!(), line!(), column!());
+
+    let (_, scopes) = composer
+        .subcompose_slot(&subcompose_slots, Some(container_id), |composer| {
+            composer.with_group(group_key, |_| {
+                cranpose_test_node(TrackingChild::default);
+            });
+        })
+        .expect("subcompose_slot render");
+
+    assert!(
+        !scopes.is_empty(),
+        "subcompose_slot must record scopes for later scoped recomposition"
+    );
+    for scope in &scopes {
+        assert_eq!(
+            scope.parent_hint(),
+            Some(container_id),
+            "top-level subcompose scopes must reattach through their real container",
+        );
+    }
+
+    drop(composer);
+    teardown_composer(&mut slots, &mut applier, slots_host, applier_host);
+}
+
+#[test]
 fn subcompose_in_retained_root_level_nodes_stay_live_while_hidden_and_restore_same_id() {
     let (handle, _runtime) = runtime_handle();
     let mut slots = SlotTable::default();


### PR DESCRIPTION
Fixes #220.

## What changed
- Treat root composition's initial frame as synthetic so root scopes do not record themselves as parents.
- Keep public and subcomposition composer roots as real parent frames so top-level subcompose scopes retain their container parent hints.
- Clear the initial root frame for scoped recomposition, so skipped descendants are reattached through recorded scope parent hints instead of being promoted under the root.
- Guard child insertion against self-parenting at both the emitted-node path and the shared reparent helper.
- Add core regressions for the conditional TextField row ordering bug, root replay followed by scoped recomposition, and subcompose root-level parent hints.

## Root cause
Scoped recomposition inherited an initial root parent frame from the composer core. When a nested scope replay skipped an emitted child, that frame could rewrite the child parent to the root, moving the conditional row content below later siblings. A forced root replay could also record the root scope's parent hint as the root itself, which allowed a later scoped replay to attach the root as its own child.

## Validation
- `cargo fmt`
- `cargo test -p cranpose-core subcompose_slot_root_level_scopes_keep_container_parent_hint -- --nocapture`
- `cargo test -p cranpose-core composition_and_recompose_scope_tests -- --nocapture`
- `cargo test > 1.tmp 2>&1`
- `cargo clippy > 2.tmp 2>&1`
- `apps/desktop-demo/build-web.sh > wasm-build.tmp 2>&1`
- `apps/android-demo/android ./gradlew :app:assembleRelease > android-build.tmp 2>&1`
- `./run_robot_test.sh --sequential > robot.tmp 2>&1` (96/96 passed)