### PR TITLE
[codex] Fix nested alpha surface crispness

### DIFF
--- a/crates/cranpose-render/wgpu/src/gpu_stats.rs
+++ b/crates/cranpose-render/wgpu/src/gpu_stats.rs
@@ -23,6 +23,7 @@ pub struct LayerSurfaceReasons {
     pub motion_stable_capture: bool,
     pub mixed_direct_content: bool,
     pub non_translation_transform: bool,
+    pub pixel_stable_composite: bool,
 }
 
 impl LayerSurfaceReasons {
@@ -42,7 +43,7 @@ impl LayerSurfaceReasons {
     }
 
     pub fn labels(self) -> impl Iterator<Item = &'static str> {
-        let mut labels = [None; 10];
+        let mut labels = [None; 11];
         let mut len = 0usize;
 
         if self.explicit_offscreen {
@@ -85,6 +86,10 @@ impl LayerSurfaceReasons {
             labels[len] = Some("non_translation_transform");
             len += 1;
         }
+        if self.pixel_stable_composite {
+            labels[len] = Some("pixel_stable_composite");
+            len += 1;
+        }
 
         labels.into_iter().flatten().take(len)
     }
@@ -122,6 +127,7 @@ impl From<SurfaceRequirementSet> for LayerSurfaceReasons {
             mixed_direct_content: requirements.contains(SurfaceRequirement::MixedDirectContent),
             non_translation_transform: requirements
                 .contains(SurfaceRequirement::NonTranslationTransform),
+            pixel_stable_composite: requirements.contains(SurfaceRequirement::PixelStableComposite),
         }
     }
 }
@@ -640,6 +646,7 @@ mod tests {
             SurfaceRequirement::MotionStableCapture,
             SurfaceRequirement::NonTranslationTransform,
             SurfaceRequirement::MixedDirectContent,
+            SurfaceRequirement::PixelStableComposite,
         ];
         for requirement in all_requirements {
             let set = SurfaceRequirementSet::default().with(requirement);

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -6036,7 +6036,12 @@ mod tests {
         let requirements = layer_surface_requirements(&layer);
 
         assert_eq!(requirements.direct_translation, Some(Point::default()));
-        assert!(!requirements.surface_requirements.has_any());
+        assert!(requirements
+            .surface_requirements
+            .contains(SurfaceRequirement::PixelStableComposite));
+        assert!(!requirements
+            .surface_requirements
+            .has_isolating_requirement());
     }
 
     #[test]
@@ -6050,7 +6055,12 @@ mod tests {
             Some(Point::new(11.4, 23.6))
         );
         assert!(
-            !requirements.surface_requirements.has_any(),
+            requirements
+                .surface_requirements
+                .contains(SurfaceRequirement::PixelStableComposite)
+                && !requirements
+                    .surface_requirements
+                    .has_isolating_requirement(),
             "translated plain text should stay on the direct path and isolate only the glyph draw"
         );
     }
@@ -6066,7 +6076,12 @@ mod tests {
             Some(Point::new(14.25, 16.5))
         );
         assert!(
-            !requirements.surface_requirements.has_any(),
+            requirements
+                .surface_requirements
+                .contains(SurfaceRequirement::PixelStableComposite)
+                && !requirements
+                    .surface_requirements
+                    .has_isolating_requirement(),
             "translated text with direct sibling decoration/background should keep the layer direct"
         );
     }
@@ -6310,8 +6325,13 @@ mod tests {
 
         assert_eq!(requirements.direct_translation, Some(Point::default()));
         assert!(
-            !requirements.surface_requirements.has_any(),
-            "decoration-only text should not force any layer surface reasons: {requirements:?}"
+            requirements
+                .surface_requirements
+                .contains(SurfaceRequirement::PixelStableComposite)
+                && !requirements
+                    .surface_requirements
+                    .has_isolating_requirement(),
+            "decoration-only text should not force an isolating layer surface: {requirements:?}"
         );
     }
 
@@ -6678,7 +6698,9 @@ mod tests {
         assert!(!requirements
             .surface_requirements
             .contains(SurfaceRequirement::MixedDirectContent));
-        assert!(!requirements.surface_requirements.has_any());
+        assert!(!requirements
+            .surface_requirements
+            .has_isolating_requirement());
     }
 
     #[test]

--- a/crates/cranpose-render/wgpu/src/surface_plan.rs
+++ b/crates/cranpose-render/wgpu/src/surface_plan.rs
@@ -14,7 +14,6 @@ const SURFACE_PLAN_AFFINE_TOLERANCE: f32 = 1e-4;
 pub(crate) struct LayerSurfaceRequirements {
     pub(crate) direct_translation: Option<Point>,
     pub(crate) surface_requirements: SurfaceRequirementSet,
-    pub(crate) pixel_stable_composite: bool,
 }
 
 impl LayerSurfaceRequirements {
@@ -149,7 +148,13 @@ fn layer_contains_gpu_effect_text_primitives(layer: &LayerNode) -> bool {
 }
 
 fn draw_primitive_is_pixel_sensitive(draw: &cranpose_ui_graphics::DrawPrimitive) -> bool {
-    matches!(draw, cranpose_ui_graphics::DrawPrimitive::Image { .. })
+    match draw {
+        cranpose_ui_graphics::DrawPrimitive::Image { .. } => true,
+        cranpose_ui_graphics::DrawPrimitive::Blend { primitive, .. } => {
+            draw_primitive_is_pixel_sensitive(primitive)
+        }
+        _ => false,
+    }
 }
 
 pub(crate) fn layer_needs_rigid_snap(layer: &LayerNode, translated_content_context: bool) -> bool {
@@ -226,13 +231,7 @@ pub(crate) fn composite_sample_mode_for_requirements(
         surface_capture_active,
         requirements,
     );
-    if effective.contains(SurfaceRequirement::MotionStableCapture)
-        || requirements.pixel_stable_composite
-    {
-        CompositeSampleMode::Box4
-    } else {
-        CompositeSampleMode::Linear
-    }
+    effective.composite_sample_mode()
 }
 
 pub(crate) fn layer_surface_target_scale(
@@ -355,11 +354,10 @@ pub(crate) fn layer_surface_requirements_cached(
                 PrimitiveNode::Text(text) => {
                     has_direct_safe_primitive = true;
                     let needs_local_surface = text_primitive_needs_local_surface(text);
-                    if !needs_local_surface {
-                        has_pixel_sensitive_content = true;
-                    }
                     if needs_local_surface {
                         surface_requirements.insert(SurfaceRequirement::TextMaterialMask);
+                    } else {
+                        has_pixel_sensitive_content = true;
                     }
                 }
                 PrimitiveNode::Draw(draw) => match &draw.primitive {
@@ -379,7 +377,10 @@ pub(crate) fn layer_surface_requirements_cached(
                     child_layer.as_ref(),
                     layer_surface_requirements_cache,
                 );
-                if child_requirements.pixel_stable_composite {
+                if child_requirements
+                    .surface_requirements
+                    .contains(SurfaceRequirement::PixelStableComposite)
+                {
                     has_pixel_sensitive_content = true;
                 }
                 if child_requirements
@@ -400,12 +401,14 @@ pub(crate) fn layer_surface_requirements_cached(
         surface_requirements.insert(SurfaceRequirement::NonTranslationTransform);
     }
 
+    if has_pixel_sensitive_content && direct_translation.is_some() && !layer.motion_context_animated
+    {
+        surface_requirements.insert(SurfaceRequirement::PixelStableComposite);
+    }
+
     let requirements = LayerSurfaceRequirements {
         direct_translation,
         surface_requirements,
-        pixel_stable_composite: has_pixel_sensitive_content
-            && direct_translation.is_some()
-            && !layer.motion_context_animated,
     };
     layer_surface_requirements_cache.insert(cache_key, requirements);
     requirements
@@ -414,16 +417,20 @@ pub(crate) fn layer_surface_requirements_cached(
 #[cfg(test)]
 mod tests {
     use super::{
-        composite_sample_mode_for_requirements, layer_surface_requirements,
-        layer_surface_target_scale,
+        composite_sample_mode_for_effect_layer, composite_sample_mode_for_requirements,
+        effect_layer_target_scale, layer_surface_requirements, layer_surface_target_scale,
     };
     use crate::effect_renderer::CompositeSampleMode;
+    use crate::scene::EffectLayer;
     use crate::surface_requirements::{SurfaceRequirement, MOTION_STABLE_SURFACE_SCALE_MULTIPLIER};
     use cranpose_render_common::graph::{
-        CachePolicy, IsolationReasons, LayerNode, ProjectiveTransform, RenderNode,
+        CachePolicy, DrawPrimitiveNode, IsolationReasons, LayerNode, PrimitiveEntry, PrimitiveNode,
+        PrimitivePhase, ProjectiveTransform, RenderNode,
     };
     use cranpose_render_common::raster_cache::LayerRasterCacheHashes;
-    use cranpose_ui_graphics::{GraphicsLayer, Rect};
+    use cranpose_ui_graphics::{
+        BlendMode, DrawPrimitive, GraphicsLayer, ImageBitmap, ImageSampling, Rect,
+    };
 
     fn test_layer(local_bounds: Rect) -> LayerNode {
         LayerNode {
@@ -444,6 +451,82 @@ mod tests {
             cache_hashes_valid: false,
             children: Vec::<RenderNode>::new(),
         }
+    }
+
+    #[test]
+    fn blended_image_marks_layer_pixel_stable_without_forcing_isolation() {
+        let mut layer = test_layer(Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 120.0,
+            height: 80.0,
+        });
+        let image = ImageBitmap::from_rgba8(1, 1, vec![255, 255, 255, 255]).expect("image");
+        let image_rect = Rect {
+            x: 4.0,
+            y: 6.0,
+            width: 16.0,
+            height: 16.0,
+        };
+        layer.children.push(RenderNode::Primitive(PrimitiveEntry {
+            phase: PrimitivePhase::BeforeChildren,
+            node: PrimitiveNode::Draw(DrawPrimitiveNode {
+                primitive: DrawPrimitive::Blend {
+                    primitive: Box::new(DrawPrimitive::Image {
+                        rect: image_rect,
+                        image,
+                        alpha: 1.0,
+                        color_filter: None,
+                        sampling: ImageSampling::Nearest,
+                        src_rect: None,
+                    }),
+                    blend_mode: BlendMode::SrcOver,
+                },
+                clip: None,
+            }),
+        }));
+
+        let requirements = layer_surface_requirements(&layer);
+
+        assert!(requirements
+            .surface_requirements
+            .contains(SurfaceRequirement::PixelStableComposite));
+        assert!(!requirements.has_isolating_requirement());
+        assert_eq!(
+            composite_sample_mode_for_requirements(false, false, requirements),
+            CompositeSampleMode::Box4
+        );
+        assert_eq!(
+            layer_surface_target_scale(false, false, requirements, 2.0),
+            2.0
+        );
+    }
+
+    #[test]
+    fn effect_layer_pixel_stable_requirement_uses_box4_without_motion_scale() {
+        let layer = EffectLayer {
+            rect: Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 120.0,
+                height: 80.0,
+            },
+            clip: None,
+            snap_anchor: None,
+            effect: None,
+            blend_mode: BlendMode::SrcOver,
+            composite_alpha: 1.0,
+            z_start: 0,
+            z_end: 1,
+            requirements: crate::surface_requirements::SurfaceRequirementSet::default()
+                .with(SurfaceRequirement::PixelStableComposite),
+        };
+
+        assert_eq!(
+            composite_sample_mode_for_effect_layer(&layer),
+            CompositeSampleMode::Box4
+        );
+        assert_eq!(effect_layer_target_scale(&layer, 3.0), 3.0);
     }
 
     #[test]

--- a/crates/cranpose-render/wgpu/src/surface_plan.rs
+++ b/crates/cranpose-render/wgpu/src/surface_plan.rs
@@ -14,6 +14,7 @@ const SURFACE_PLAN_AFFINE_TOLERANCE: f32 = 1e-4;
 pub(crate) struct LayerSurfaceRequirements {
     pub(crate) direct_translation: Option<Point>,
     pub(crate) surface_requirements: SurfaceRequirementSet,
+    pub(crate) pixel_stable_composite: bool,
 }
 
 impl LayerSurfaceRequirements {
@@ -147,6 +148,10 @@ fn layer_contains_gpu_effect_text_primitives(layer: &LayerNode) -> bool {
     })
 }
 
+fn draw_primitive_is_pixel_sensitive(draw: &cranpose_ui_graphics::DrawPrimitive) -> bool {
+    matches!(draw, cranpose_ui_graphics::DrawPrimitive::Image { .. })
+}
+
 pub(crate) fn layer_needs_rigid_snap(layer: &LayerNode, translated_content_context: bool) -> bool {
     (translated_content_context
         && (layer_contains_draw_primitives(layer) || layer_contains_text_primitives(layer)))
@@ -216,12 +221,18 @@ pub(crate) fn composite_sample_mode_for_requirements(
     surface_capture_active: bool,
     requirements: LayerSurfaceRequirements,
 ) -> CompositeSampleMode {
-    effective_surface_requirements(
+    let effective = effective_surface_requirements(
         translated_content_context,
         surface_capture_active,
         requirements,
-    )
-    .composite_sample_mode()
+    );
+    if effective.contains(SurfaceRequirement::MotionStableCapture)
+        || requirements.pixel_stable_composite
+    {
+        CompositeSampleMode::Box4
+    } else {
+        CompositeSampleMode::Linear
+    }
 }
 
 pub(crate) fn layer_surface_target_scale(
@@ -336,13 +347,18 @@ pub(crate) fn layer_surface_requirements_cached(
     let direct_translation = direct_translation(layer.transform_to_parent);
     let mut has_direct_safe_primitive = false;
     let mut has_isolating_child_layer = false;
+    let mut has_pixel_sensitive_content = false;
 
     for child in &layer.children {
         match child {
             RenderNode::Primitive(primitive) => match &primitive.node {
                 PrimitiveNode::Text(text) => {
                     has_direct_safe_primitive = true;
-                    if text_primitive_needs_local_surface(text) {
+                    let needs_local_surface = text_primitive_needs_local_surface(text);
+                    if !needs_local_surface {
+                        has_pixel_sensitive_content = true;
+                    }
+                    if needs_local_surface {
                         surface_requirements.insert(SurfaceRequirement::TextMaterialMask);
                     }
                 }
@@ -350,7 +366,12 @@ pub(crate) fn layer_surface_requirements_cached(
                     cranpose_ui_graphics::DrawPrimitive::Shadow(_) => {
                         surface_requirements.insert(SurfaceRequirement::ImmediateShadow);
                     }
-                    _ => has_direct_safe_primitive = true,
+                    primitive => {
+                        has_direct_safe_primitive = true;
+                        if draw_primitive_is_pixel_sensitive(primitive) {
+                            has_pixel_sensitive_content = true;
+                        }
+                    }
                 },
             },
             RenderNode::Layer(child_layer) => {
@@ -358,6 +379,9 @@ pub(crate) fn layer_surface_requirements_cached(
                     child_layer.as_ref(),
                     layer_surface_requirements_cache,
                 );
+                if child_requirements.pixel_stable_composite {
+                    has_pixel_sensitive_content = true;
+                }
                 if child_requirements
                     .surface_requirements
                     .has_isolating_requirement()
@@ -379,6 +403,9 @@ pub(crate) fn layer_surface_requirements_cached(
     let requirements = LayerSurfaceRequirements {
         direct_translation,
         surface_requirements,
+        pixel_stable_composite: has_pixel_sensitive_content
+            && direct_translation.is_some()
+            && !layer.motion_context_animated,
     };
     layer_surface_requirements_cache.insert(cache_key, requirements);
     requirements

--- a/crates/cranpose-render/wgpu/src/surface_requirements.rs
+++ b/crates/cranpose-render/wgpu/src/surface_requirements.rs
@@ -14,6 +14,7 @@ pub(crate) enum SurfaceRequirement {
     MotionStableCapture,
     NonTranslationTransform,
     MixedDirectContent,
+    PixelStableComposite,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
@@ -32,6 +33,7 @@ impl SurfaceRequirementSet {
     const MOTION_STABLE_CAPTURE: u16 = 1 << 7;
     const NON_TRANSLATION_TRANSFORM: u16 = 1 << 8;
     const MIXED_DIRECT_CONTENT: u16 = 1 << 9;
+    const PIXEL_STABLE_COMPOSITE: u16 = 1 << 10;
 
     pub(crate) fn insert(&mut self, requirement: SurfaceRequirement) {
         self.bits |= Self::bit(requirement);
@@ -46,13 +48,10 @@ impl SurfaceRequirementSet {
         (self.bits & Self::bit(requirement)) != 0
     }
 
-    #[cfg(test)]
-    pub(crate) fn has_any(self) -> bool {
-        self.bits != 0
-    }
-
     pub(crate) fn has_isolating_requirement(self) -> bool {
-        (self.bits & !(Self::MIXED_DIRECT_CONTENT | Self::IMMEDIATE_SHADOW)) != 0
+        (self.bits
+            & !(Self::MIXED_DIRECT_CONTENT | Self::IMMEDIATE_SHADOW | Self::PIXEL_STABLE_COMPOSITE))
+            != 0
     }
 
     pub(crate) fn has_renderer_forced_surface(self) -> bool {
@@ -82,6 +81,10 @@ impl SurfaceRequirementSet {
                 SurfaceRequirement::MixedDirectContent,
                 "mixed_direct_content",
             ),
+            (
+                SurfaceRequirement::PixelStableComposite,
+                "pixel_stable_composite",
+            ),
         ];
 
         ORDERED
@@ -106,7 +109,9 @@ impl SurfaceRequirementSet {
     }
 
     pub(crate) fn composite_sample_mode(self) -> CompositeSampleMode {
-        if self.contains(SurfaceRequirement::MotionStableCapture) {
+        if self.contains(SurfaceRequirement::MotionStableCapture)
+            || self.contains(SurfaceRequirement::PixelStableComposite)
+        {
             CompositeSampleMode::Box4
         } else {
             CompositeSampleMode::Linear
@@ -133,6 +138,7 @@ impl SurfaceRequirementSet {
             SurfaceRequirement::MotionStableCapture => Self::MOTION_STABLE_CAPTURE,
             SurfaceRequirement::NonTranslationTransform => Self::NON_TRANSLATION_TRANSFORM,
             SurfaceRequirement::MixedDirectContent => Self::MIXED_DIRECT_CONTENT,
+            SurfaceRequirement::PixelStableComposite => Self::PIXEL_STABLE_COMPOSITE,
         }
     }
 }
@@ -149,6 +155,8 @@ impl FromIterator<SurfaceRequirement> for SurfaceRequirementSet {
 
 #[cfg(test)]
 mod tests {
+    use crate::effect_renderer::CompositeSampleMode;
+
     use super::{SurfaceRequirement, SurfaceRequirementSet};
 
     #[test]
@@ -179,5 +187,19 @@ mod tests {
 
         assert!(!requirements.has_isolating_requirement());
         assert!(!requirements.has_renderer_forced_surface());
+    }
+
+    #[test]
+    fn pixel_stable_composite_uses_box4_without_forcing_surface() {
+        let requirements =
+            SurfaceRequirementSet::default().with(SurfaceRequirement::PixelStableComposite);
+
+        assert!(!requirements.has_isolating_requirement());
+        assert!(!requirements.has_renderer_forced_surface());
+        assert_eq!(
+            requirements.composite_sample_mode(),
+            CompositeSampleMode::Box4
+        );
+        assert_eq!(requirements.target_scale(3.0), 3.0);
     }
 }

--- a/crates/cranpose-render/wgpu/tests/effect_semantics.rs
+++ b/crates/cranpose-render/wgpu/tests/effect_semantics.rs
@@ -18,8 +18,8 @@ use cranpose_ui::text::{
 };
 use cranpose_ui::TextLayoutOptions;
 use cranpose_ui_graphics::{
-    BlendMode, Brush, Color, DrawPrimitive, GraphicsLayer, Point, Rect, RenderEffect,
-    ShadowPrimitive,
+    BlendMode, Brush, Color, DrawPrimitive, GraphicsLayer, ImageBitmap, ImageSampling, Point, Rect,
+    RenderEffect, ShadowPrimitive,
 };
 
 const FRAME_WIDTH: u32 = 128;
@@ -732,6 +732,50 @@ fn translated_showcase_card_surface_stays_exact_at_fractional_root_scale() {
             max_differing_pixels: SHOWCASE_CARD_MAX_DIFFERING_PIXELS,
             max_pixel_difference: SHOWCASE_CARD_MAX_PIXEL_DIFFERENCE,
         },
+    );
+}
+
+#[test]
+fn static_alpha_surface_keeps_nested_text_and_icon_crisp_at_fractional_offset() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!(
+                "skipping static alpha surface crispness assertions because headless WGPU init failed: {}",
+                err
+            );
+            return;
+        }
+    };
+
+    let base_translation = Point::new(20.0, 18.0);
+    renderer.scene_mut().graph = Some(alpha_icon_text_surface_fixture(base_translation));
+    let base_frame = renderer
+        .capture_frame(150, 86)
+        .expect("base alpha surface capture should succeed");
+    let base_stats = renderer.last_frame_stats().expect("base frame stats");
+    assert_eq!(
+        base_stats.isolated_layer_renders, 1,
+        "alpha card should isolate exactly its local surface: {base_stats:?}"
+    );
+
+    let fractional_translation = Point::new(20.4, 18.4);
+    renderer.scene_mut().graph = Some(alpha_icon_text_surface_fixture(fractional_translation));
+    let fractional_frame = renderer
+        .capture_frame(150, 86)
+        .expect("fractional alpha surface capture should succeed");
+
+    let size = (94, 46);
+    let base = normalize_translated_region_at_scale(&base_frame, base_translation, size, 1.0);
+    let fractional =
+        normalize_translated_region_at_scale(&fractional_frame, fractional_translation, size, 1.0);
+
+    assert_exact_normalized_match(
+        "static translucent nested icon/text surface",
+        &base,
+        &fractional,
+        size.0,
+        size.1,
     );
 }
 
@@ -1808,6 +1852,152 @@ fn gradient_stroke_text_fixture() -> RenderGraph {
         solid_rect(frame_rect(), Color::BLACK),
         RenderNode::Layer(Box::new(text_leaf)),
     ])
+}
+
+fn crisp_icon_bitmap() -> ImageBitmap {
+    const SIZE: u32 = 16;
+    let mut pixels = vec![0u8; (SIZE * SIZE * 4) as usize];
+    for y in 0..SIZE {
+        for x in 0..SIZE {
+            let stroke =
+                x == 1 || x == SIZE - 2 || y == 1 || y == SIZE - 2 || x == y || x + y == SIZE - 1;
+            let rgba = if stroke {
+                [250, 252, 255, 255]
+            } else {
+                [18, 26, 38, 255]
+            };
+            let index = ((y * SIZE + x) * 4) as usize;
+            pixels[index..index + 4].copy_from_slice(&rgba);
+        }
+    }
+    ImageBitmap::from_rgba8(SIZE, SIZE, pixels).expect("valid crisp icon")
+}
+
+fn alpha_icon_text_surface_fixture(translation: Point) -> RenderGraph {
+    let icon = crisp_icon_bitmap();
+    let text_style = TextStyle::from_span_style(SpanStyle {
+        color: Some(Color::WHITE),
+        font_size: TextUnit::Sp(15.0),
+        ..Default::default()
+    });
+    let icon_leaf = layer(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 32.0,
+            height: 32.0,
+        },
+        ProjectiveTransform::translation(8.0, 7.0),
+        GraphicsLayer::default(),
+        vec![RenderNode::Primitive(PrimitiveEntry {
+            phase: PrimitivePhase::BeforeChildren,
+            node: PrimitiveNode::Draw(DrawPrimitiveNode {
+                primitive: DrawPrimitive::Image {
+                    rect: Rect {
+                        x: 0.0,
+                        y: 0.0,
+                        width: 32.0,
+                        height: 32.0,
+                    },
+                    image: icon,
+                    alpha: 1.0,
+                    color_filter: None,
+                    sampling: ImageSampling::Nearest,
+                    src_rect: None,
+                },
+                clip: None,
+            }),
+        })],
+    );
+    let text_leaf = layer(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 44.0,
+            height: 22.0,
+        },
+        ProjectiveTransform::translation(47.0, 12.0),
+        GraphicsLayer::default(),
+        vec![RenderNode::Primitive(PrimitiveEntry {
+            phase: PrimitivePhase::BeforeChildren,
+            node: PrimitiveNode::Text(Box::new(TextPrimitiveNode {
+                node_id: 104,
+                rect: Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 44.0,
+                    height: 22.0,
+                },
+                text: AnnotatedString::from("Meta"),
+                text_style,
+                font_size: 15.0,
+                layout_options: TextLayoutOptions::default(),
+                clip: None,
+            })),
+        })],
+    );
+    let alpha_surface = layer(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 94.0,
+            height: 46.0,
+        },
+        ProjectiveTransform::translation(translation.x, translation.y),
+        GraphicsLayer {
+            alpha: 0.82,
+            ..GraphicsLayer::default()
+        },
+        vec![
+            RenderNode::Primitive(PrimitiveEntry {
+                phase: PrimitivePhase::BeforeChildren,
+                node: PrimitiveNode::Draw(DrawPrimitiveNode {
+                    primitive: DrawPrimitive::RoundRect {
+                        rect: Rect {
+                            x: 0.0,
+                            y: 0.0,
+                            width: 94.0,
+                            height: 46.0,
+                        },
+                        brush: Brush::solid(Color(0.16, 0.18, 0.24, 1.0)),
+                        radii: cranpose_ui_graphics::CornerRadii::uniform(12.0),
+                    },
+                    clip: None,
+                }),
+            }),
+            RenderNode::Layer(Box::new(icon_leaf)),
+            RenderNode::Layer(Box::new(text_leaf)),
+        ],
+    );
+
+    RenderGraph::new(layer(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 150.0,
+            height: 86.0,
+        },
+        ProjectiveTransform::identity(),
+        GraphicsLayer::default(),
+        vec![
+            RenderNode::Primitive(PrimitiveEntry {
+                phase: PrimitivePhase::BeforeChildren,
+                node: PrimitiveNode::Draw(DrawPrimitiveNode {
+                    primitive: DrawPrimitive::Rect {
+                        rect: Rect {
+                            x: 0.0,
+                            y: 0.0,
+                            width: 150.0,
+                            height: 86.0,
+                        },
+                        brush: Brush::solid(Color::BLACK),
+                    },
+                    clip: None,
+                }),
+            }),
+            RenderNode::Layer(Box::new(alpha_surface)),
+        ],
+    ))
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #227 by keeping static offscreen captures that contain plain text or image content on a pixel-stable composite path.

## Root Cause

Direct text is already snapped before rasterization, but static translucent/alpha layer captures were composited back with the default linear resolve at fractional destination offsets. That made nested text and small icon content softer than equivalent direct content.

## Changes

- Added `pixel_stable_composite` to the WGPU layer surface plan. It does not force layer isolation, but when another reason already captures the layer, it selects the existing Box4 snap resolve at normal root scale.
- Limited the classification to static direct plain text and image content, leaving complex text material surfaces and animated motion paths on their existing policies.
- Refactored pixel-stable compositing into `SurfaceRequirement::PixelStableComposite` so effect layers inherit the sample mode without forcing isolation or increasing target scale.
- Added coverage for blended image primitives, effect-layer sample mode inheritance, and fractional nested alpha card text/icon crispness.

## Validation

- `cargo fmt`
- `cargo test -p cranpose-render-wgpu --test effect_semantics -- --nocapture`
- `cargo test -p cranpose-render-wgpu --lib -- --nocapture`
- `cargo test > 1.tmp 2>&1` (clean log scan)
- `cargo clippy > 2.tmp 2>&1` (clean log scan)
- `apps/desktop-demo/build-web.sh` (clean log scan)
- `apps/android-demo/android ./gradlew :app:assembleRelease` (clean log scan)
- `env CARGO_BUILD_JOBS=1 CRANPOSE_USE_SCCACHE=0 ./run_robot_test.sh --sequential > robot.tmp 2>&1` (96/96 passed, clean log scan)
- GitHub Actions run `25492392069` passed, including workspace tests/clippy, WASM, Android release, and all robot shards.
