### PR TITLE
[codex] Add backdrop blur glass modifier API

### DIFF
--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -61,10 +61,10 @@ pub use layout::{
 pub use modifier::{
     collect_modifier_slices, collect_semantics_from_modifier, collect_slices_from_modifier,
     BlendMode, Brush, Color, CompositingStrategy, CornerRadii, DpOffset, EdgeInsets,
-    FocusDirection, FocusRequester, GraphicsLayer, LayerShape, Modifier, ModifierNodeSlices,
-    ModifierNodeSlicesDebugStats, Point, PointerEvent, PointerEventKind, PointerInputScope, Rect,
-    RenderEffect, ResolvedBackground, ResolvedModifiers, RoundedCornerShape, RuntimeShader, Shadow,
-    ShadowScope, Size, TransformOrigin,
+    FocusDirection, FocusRequester, GlassMaterial, GraphicsLayer, LayerShape, Modifier,
+    ModifierNodeSlices, ModifierNodeSlicesDebugStats, Point, PointerEvent, PointerEventKind,
+    PointerInputScope, Rect, RenderEffect, ResolvedBackground, ResolvedModifiers,
+    RoundedCornerShape, RuntimeShader, Shadow, ShadowScope, Size, TransformOrigin,
 };
 pub use modifier_nodes::{
     AlphaElement, AlphaNode, BackgroundElement, BackgroundNode, ClickableElement, ClickableNode,

--- a/crates/cranpose-ui/src/modifier/graphics_layer.rs
+++ b/crates/cranpose-ui/src/modifier/graphics_layer.rs
@@ -2,10 +2,22 @@ use super::{inspector_metadata, GraphicsLayer, Modifier};
 use crate::modifier_nodes::{GraphicsLayerElement, LazyGraphicsLayerElement};
 use cranpose_ui_graphics::{
     gradient_cut_mask_effect, gradient_fade_dst_out_effect, rounded_alpha_mask_effect, BlendMode,
-    Color, ColorFilter, CompositingStrategy, GradientCutMaskSpec, GradientFadeMaskSpec, LayerShape,
-    RenderEffect, RoundedCornerShape, RuntimeShader, TransformOrigin,
+    Color, ColorFilter, CompositingStrategy, Dp, GradientCutMaskSpec, GradientFadeMaskSpec,
+    LayerShape, RenderEffect, RoundedCornerShape, RuntimeShader, TransformOrigin,
 };
 use std::rc::Rc;
+
+fn backdrop_blur_layer(radius: Dp, shape: LayerShape) -> GraphicsLayer {
+    let radius_px = radius
+        .to_px(crate::render_state::current_density())
+        .max(0.0);
+    GraphicsLayer {
+        backdrop_effect: (radius_px > 0.0).then(|| RenderEffect::blur(radius_px)),
+        shape,
+        clip: true,
+        ..Default::default()
+    }
+}
 
 impl Modifier {
     /// Apply a lazily evaluated graphics layer.
@@ -195,18 +207,36 @@ impl Modifier {
     }
 
     /// Blur content behind this composable, clipped to the composable bounds.
-    pub fn backdrop_blur(self, radius: f32) -> Self {
-        if radius <= 0.0 {
+    ///
+    /// `radius` is expressed in Dp and converted to px using the current render
+    /// density when modifier slices are evaluated.
+    pub fn backdrop_blur(self, radius: Dp) -> Self {
+        if radius.0 <= 0.0 {
             return self.clip_to_bounds();
         }
 
-        self.backdrop_effect(RenderEffect::blur(radius))
-            .clip_to_bounds()
+        let modifier = Self::with_element(LazyGraphicsLayerElement::new(Rc::new(move || {
+            backdrop_blur_layer(radius, LayerShape::Rectangle)
+        })))
+        .with_inspector_metadata(inspector_metadata("backdropBlur", move |info| {
+            info.add_property("radius", radius.0.to_string());
+        }));
+        self.then(modifier)
     }
 
     /// Apply a frosted glass material: backdrop blur, clipped shape, and tint.
     pub fn glass_material(self, material: GlassMaterial) -> Self {
-        self.backdrop_blur(material.blur_radius)
+        let blur_radius = material.blur_radius;
+        let shape = material.shape;
+        let modifier = Self::with_element(LazyGraphicsLayerElement::new(Rc::new(move || {
+            backdrop_blur_layer(blur_radius, LayerShape::Rounded(shape))
+        })))
+        .with_inspector_metadata(inspector_metadata("glassMaterial", move |info| {
+            info.add_property("blurRadius", blur_radius.0.to_string());
+            info.add_property("shape", format!("{shape:?}"));
+        }));
+
+        self.then(modifier)
             .rounded_corner_shape(material.shape)
             .background(material.tint)
     }
@@ -315,13 +345,13 @@ impl Modifier {
 /// Visual parameters for [`Modifier::glass_material`].
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GlassMaterial {
-    pub blur_radius: f32,
+    pub blur_radius: Dp,
     pub tint: Color,
     pub shape: RoundedCornerShape,
 }
 
 impl GlassMaterial {
-    pub fn new(blur_radius: f32, tint: Color, shape: RoundedCornerShape) -> Self {
+    pub fn new(blur_radius: Dp, tint: Color, shape: RoundedCornerShape) -> Self {
         Self {
             blur_radius,
             tint,

--- a/crates/cranpose-ui/src/modifier/graphics_layer.rs
+++ b/crates/cranpose-ui/src/modifier/graphics_layer.rs
@@ -3,7 +3,7 @@ use crate::modifier_nodes::{GraphicsLayerElement, LazyGraphicsLayerElement};
 use cranpose_ui_graphics::{
     gradient_cut_mask_effect, gradient_fade_dst_out_effect, rounded_alpha_mask_effect, BlendMode,
     Color, ColorFilter, CompositingStrategy, GradientCutMaskSpec, GradientFadeMaskSpec, LayerShape,
-    RenderEffect, RuntimeShader, TransformOrigin,
+    RenderEffect, RoundedCornerShape, RuntimeShader, TransformOrigin,
 };
 use std::rc::Rc;
 
@@ -194,6 +194,23 @@ impl Modifier {
         self.then(modifier)
     }
 
+    /// Blur content behind this composable, clipped to the composable bounds.
+    pub fn backdrop_blur(self, radius: f32) -> Self {
+        if radius <= 0.0 {
+            return self.clip_to_bounds();
+        }
+
+        self.backdrop_effect(RenderEffect::blur(radius))
+            .clip_to_bounds()
+    }
+
+    /// Apply a frosted glass material: backdrop blur, clipped shape, and tint.
+    pub fn glass_material(self, material: GlassMaterial) -> Self {
+        self.backdrop_blur(material.blur_radius)
+            .rounded_corner_shape(material.shape)
+            .background(material.tint)
+    }
+
     /// Convenience alias for applying a backdrop shader effect.
     pub fn shader_background(self, shader: RuntimeShader) -> Self {
         self.backdrop_effect(RenderEffect::runtime_shader(shader))
@@ -292,5 +309,23 @@ impl Modifier {
             ..Default::default()
         };
         self.graphics_layer_value(layer)
+    }
+}
+
+/// Visual parameters for [`Modifier::glass_material`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GlassMaterial {
+    pub blur_radius: f32,
+    pub tint: Color,
+    pub shape: RoundedCornerShape,
+}
+
+impl GlassMaterial {
+    pub fn new(blur_radius: f32, tint: Color, shape: RoundedCornerShape) -> Self {
+        Self {
+            blur_radius,
+            tint,
+            shape,
+        }
     }
 }

--- a/crates/cranpose-ui/src/modifier/mod.rs
+++ b/crates/cranpose-ui/src/modifier/mod.rs
@@ -53,6 +53,7 @@ pub use cranpose_ui_graphics::{
 use cranpose_ui_layout::{Alignment, HorizontalAlignment, IntrinsicSize, VerticalAlignment};
 #[allow(unused_imports)]
 pub use focus::{FocusDirection, FocusRequester};
+pub use graphics_layer::GlassMaterial;
 pub(crate) use local::{
     ModifierLocalAncestorResolver, ModifierLocalSource, ModifierLocalToken, ResolvedModifierLocal,
 };

--- a/crates/cranpose-ui/src/modifier/tests/modifier_tests.rs
+++ b/crates/cranpose-ui/src/modifier/tests/modifier_tests.rs
@@ -1,10 +1,10 @@
 use super::{
     collect_slices_from_modifier, inspector_metadata, modifier_element, Alignment, BlendMode,
     Color, CompositingStrategy, CutDirection, DimensionConstraint, DpOffset, DrawCommand,
-    DynModifierElement, EdgeInsets, GradientCutMaskSpec, GradientFadeMaskSpec, GraphicsLayer,
-    HorizontalAlignment, LayerShape, Modifier, ModifierChainHandle, Point, RenderEffect,
-    RoundedCornerShape, RuntimeShader, SemanticsConfiguration, Shadow, Size, TransformOrigin,
-    VerticalAlignment,
+    DynModifierElement, EdgeInsets, GlassMaterial, GradientCutMaskSpec, GradientFadeMaskSpec,
+    GraphicsLayer, HorizontalAlignment, LayerShape, Modifier, ModifierChainHandle, Point,
+    RenderEffect, RoundedCornerShape, RuntimeShader, SemanticsConfiguration, Shadow, Size,
+    TransformOrigin, VerticalAlignment,
 };
 use cranpose_foundation::{
     DelegatableNode, ModifierNode, ModifierNodeElement, NodeCapabilities, NodeState,
@@ -266,6 +266,64 @@ fn backdrop_effect_modifier_creates_graphics_layer_with_backdrop_effect() {
         found,
         "Expected backdrop_effect to be present in GraphicsLayer"
     );
+}
+
+#[test]
+fn backdrop_blur_clips_backdrop_to_bounds() {
+    let modifier = Modifier::empty().backdrop_blur(12.0);
+    let slices = collect_slices_from_modifier(&modifier);
+
+    assert!(slices.clip_to_bounds());
+    let layer = slices
+        .graphics_layer()
+        .expect("backdrop_blur should install a graphics layer");
+    match layer.backdrop_effect {
+        Some(RenderEffect::Blur {
+            radius_x, radius_y, ..
+        }) => {
+            assert_eq!(radius_x, 12.0);
+            assert_eq!(radius_y, 12.0);
+        }
+        other => panic!("expected blur backdrop effect, got {other:?}"),
+    }
+}
+
+#[test]
+fn glass_material_applies_blur_tint_and_shape() {
+    let tint = Color::from_rgba_u8(245, 253, 255, 150);
+    let shape = RoundedCornerShape::uniform(18.0);
+    let modifier = Modifier::empty().glass_material(GlassMaterial::new(18.0, tint, shape));
+    let slices = collect_slices_from_modifier(&modifier);
+
+    assert!(slices.clip_to_bounds());
+    assert_eq!(slices.corner_shape(), Some(shape));
+
+    let layer = slices
+        .graphics_layer()
+        .expect("glass_material should install a graphics layer");
+    match layer.backdrop_effect {
+        Some(RenderEffect::Blur {
+            radius_x, radius_y, ..
+        }) => {
+            assert_eq!(radius_x, 18.0);
+            assert_eq!(radius_y, 18.0);
+        }
+        other => panic!("expected glass_material blur backdrop, got {other:?}"),
+    }
+
+    let commands = slices.draw_commands();
+    assert_eq!(commands.len(), 1);
+    let DrawCommand::Behind(draw) = &commands[0] else {
+        panic!("glass_material tint should render behind content");
+    };
+    let primitives = draw(Size {
+        width: 100.0,
+        height: 64.0,
+    });
+    let [DrawPrimitive::RoundRect { brush, .. }] = primitives.as_slice() else {
+        panic!("glass_material tint should respect the rounded shape");
+    };
+    assert_eq!(*brush, Brush::Solid(tint));
 }
 
 #[test]

--- a/crates/cranpose-ui/src/modifier/tests/modifier_tests.rs
+++ b/crates/cranpose-ui/src/modifier/tests/modifier_tests.rs
@@ -15,6 +15,22 @@ use cranpose_ui_graphics::{
 use std::cell::Cell;
 use std::rc::Rc;
 
+struct DensityGuard(f32);
+
+impl DensityGuard {
+    fn set(density: f32) -> Self {
+        let previous_density = crate::current_density();
+        crate::set_density(density);
+        Self(previous_density)
+    }
+}
+
+impl Drop for DensityGuard {
+    fn drop(&mut self) {
+        crate::set_density(self.0);
+    }
+}
+
 #[test]
 fn padding_nodes_resolve_padding_values() {
     let modifier = Modifier::empty()
@@ -270,19 +286,21 @@ fn backdrop_effect_modifier_creates_graphics_layer_with_backdrop_effect() {
 
 #[test]
 fn backdrop_blur_clips_backdrop_to_bounds() {
-    let modifier = Modifier::empty().backdrop_blur(12.0);
+    let _density = DensityGuard::set(2.0);
+    let modifier = Modifier::empty().backdrop_blur(Dp(12.0));
     let slices = collect_slices_from_modifier(&modifier);
 
-    assert!(slices.clip_to_bounds());
     let layer = slices
         .graphics_layer()
         .expect("backdrop_blur should install a graphics layer");
+    assert!(layer.clip);
+    assert_eq!(layer.shape, LayerShape::Rectangle);
     match layer.backdrop_effect {
         Some(RenderEffect::Blur {
             radius_x, radius_y, ..
         }) => {
-            assert_eq!(radius_x, 12.0);
-            assert_eq!(radius_y, 12.0);
+            assert_eq!(radius_x, 24.0);
+            assert_eq!(radius_y, 24.0);
         }
         other => panic!("expected blur backdrop effect, got {other:?}"),
     }
@@ -290,23 +308,25 @@ fn backdrop_blur_clips_backdrop_to_bounds() {
 
 #[test]
 fn glass_material_applies_blur_tint_and_shape() {
+    let _density = DensityGuard::set(1.5);
     let tint = Color::from_rgba_u8(245, 253, 255, 150);
     let shape = RoundedCornerShape::uniform(18.0);
-    let modifier = Modifier::empty().glass_material(GlassMaterial::new(18.0, tint, shape));
+    let modifier = Modifier::empty().glass_material(GlassMaterial::new(Dp(18.0), tint, shape));
     let slices = collect_slices_from_modifier(&modifier);
 
-    assert!(slices.clip_to_bounds());
     assert_eq!(slices.corner_shape(), Some(shape));
 
     let layer = slices
         .graphics_layer()
         .expect("glass_material should install a graphics layer");
+    assert!(layer.clip);
+    assert_eq!(layer.shape, LayerShape::Rounded(shape));
     match layer.backdrop_effect {
         Some(RenderEffect::Blur {
             radius_x, radius_y, ..
         }) => {
-            assert_eq!(radius_x, 18.0);
-            assert_eq!(radius_y, 18.0);
+            assert_eq!(radius_x, 27.0);
+            assert_eq!(radius_y, 27.0);
         }
         other => panic!("expected glass_material blur backdrop, got {other:?}"),
     }
@@ -1012,15 +1032,7 @@ fn inner_shadow_large_radius_keeps_fill_and_cutout_pairs_balanced() {
 
 #[test]
 fn inner_shadow_static_uses_density_for_dp_offset() {
-    struct DensityGuard(f32);
-    impl Drop for DensityGuard {
-        fn drop(&mut self) {
-            crate::set_density(self.0);
-        }
-    }
-
-    let guard = DensityGuard(crate::current_density());
-    crate::set_density(2.0);
+    let _density = DensityGuard::set(2.0);
 
     let modifier = Modifier::empty().inner_shadow_value(
         LayerShape::Rectangle,
@@ -1043,8 +1055,6 @@ fn inner_shadow_static_uses_density_for_dp_offset() {
 
     let cutout_x = first_inner_cutout_x(&primitives);
     assert_eq!(cutout_x, Some(4.0));
-
-    drop(guard);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #213 by adding first-class modifier APIs over the existing backdrop-effect renderer path.

## Changes

- Added `Modifier::backdrop_blur(radius)`, which installs a backdrop blur and bounds clipping.
- Added `GlassMaterial` and `Modifier::glass_material(...)` for blur + tint + rounded shape composition.
- Re-exported `GlassMaterial` from `cranpose_ui` and the modifier module.
- Added modifier-slice tests for bounded backdrop blur and glass material blur/tint/shape behavior.

## Validation

- `cargo fmt`
- `cargo test -p cranpose-ui backdrop_blur -- --nocapture`
- `cargo test -p cranpose-ui glass_material -- --nocapture`
- `cargo test -p cranpose-ui --lib -- --nocapture` (348 passed)
- `cargo test > 1.tmp 2>&1` (clean log scan)
- `cargo clippy > 2.tmp 2>&1` (clean log scan)
- `apps/desktop-demo/build-web.sh` (clean log scan)
- `apps/android-demo/android ./gradlew :app:assembleRelease` (clean log scan)
- `env CARGO_BUILD_JOBS=1 CRANPOSE_USE_SCCACHE=0 ./run_robot_test.sh --sequential > robot.tmp 2>&1` (96/96 passed, clean log scan)
