### PR TITLE
[codex] Account for Android surface insets in pointer input

### DIFF
--- a/crates/cranpose-platform/android/src/lib.rs
+++ b/crates/cranpose-platform/android/src/lib.rs
@@ -7,11 +7,17 @@ use cranpose_ui_graphics::Point;
 #[derive(Debug, Clone)]
 pub struct AndroidPlatform {
     scale_factor: f64,
+    input_surface_offset_x_px: f64,
+    input_surface_offset_y_px: f64,
 }
 
 impl Default for AndroidPlatform {
     fn default() -> Self {
-        Self { scale_factor: 1.0 }
+        Self {
+            scale_factor: 1.0,
+            input_surface_offset_x_px: 0.0,
+            input_surface_offset_y_px: 0.0,
+        }
     }
 }
 
@@ -28,20 +34,82 @@ impl AndroidPlatform {
         self.scale_factor = scale_factor;
     }
 
-    /// Converts a physical pointer position into logical coordinates.
+    /// Updates the native-surface offset for Android input coordinates.
     ///
-    /// Android provides pointer positions in physical pixels; this method
-    /// scales them back to logical pixels using the platform's current scale factor.
+    /// Android `MotionEvent` positions are relative to the activity content
+    /// area, while the renderer draws into the full `ANativeWindow`. Freeform
+    /// and desktop window modes can inflate that native surface around the
+    /// content area for shadows/decor, so input must be shifted into native
+    /// surface coordinates before density conversion.
+    pub fn set_input_surface_offset_px(&mut self, x_px: f64, y_px: f64) {
+        self.input_surface_offset_x_px = x_px;
+        self.input_surface_offset_y_px = y_px;
+    }
+
+    /// Returns the configured native-surface input offset in physical pixels.
+    pub fn input_surface_offset_px(&self) -> (f64, f64) {
+        (
+            self.input_surface_offset_x_px,
+            self.input_surface_offset_y_px,
+        )
+    }
+
+    /// Converts a physical Android pointer position into logical coordinates.
+    ///
+    /// Android provides pointer positions in content-relative physical pixels;
+    /// this method first shifts them into the native surface coordinate space,
+    /// then scales them back to logical pixels using the platform's current
+    /// scale factor.
     pub fn pointer_position(&self, physical_x: f64, physical_y: f64) -> Point {
         let scale = self.scale_factor;
         Point {
-            x: (physical_x / scale) as f32,
-            y: (physical_y / scale) as f32,
+            x: ((physical_x + self.input_surface_offset_x_px) / scale) as f32,
+            y: ((physical_y + self.input_surface_offset_y_px) / scale) as f32,
         }
     }
 
     /// Returns the current scale factor (density).
     pub fn scale_factor(&self) -> f32 {
         self.scale_factor as f32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AndroidPlatform;
+
+    #[test]
+    fn default_platform_uses_mdpi_and_zero_input_offset() {
+        let platform = AndroidPlatform::new();
+
+        assert_eq!(platform.scale_factor(), 1.0);
+        assert_eq!(platform.input_surface_offset_px(), (0.0, 0.0));
+        assert_eq!(platform.pointer_position(12.0, 34.0).x, 12.0);
+        assert_eq!(platform.pointer_position(12.0, 34.0).y, 34.0);
+    }
+
+    #[test]
+    fn pointer_position_applies_density() {
+        let mut platform = AndroidPlatform::new();
+        platform.set_scale_factor(2.0);
+
+        let logical = platform.pointer_position(80.0, 120.0);
+
+        assert_eq!(platform.scale_factor(), 2.0);
+        assert_eq!(logical.x, 40.0);
+        assert_eq!(logical.y, 60.0);
+    }
+
+    #[test]
+    fn pointer_position_applies_surface_offset_before_density() {
+        let mut platform = AndroidPlatform::new();
+        platform.set_scale_factor(1.5);
+        platform.set_input_surface_offset_px(39.0, 21.0);
+
+        let logical = platform.pointer_position(111.0, 129.0);
+
+        assert_eq!(platform.input_surface_offset_px(), (39.0, 21.0));
+        assert_eq!(logical.x, 100.0);
+        assert_eq!(logical.y, 100.0);
     }
 }

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -47,6 +47,25 @@ fn get_display_density(app: &android_activity::AndroidApp) -> f32 {
     density_dpi.map(|dpi| dpi as f32 / 160.0).unwrap_or(2.0) // Fallback to xhdpi (2.0) if density unavailable
 }
 
+fn update_android_platform_geometry(
+    app: &android_activity::AndroidApp,
+    android_platform: &mut AndroidPlatform,
+) -> f32 {
+    let density = get_display_density(app);
+    android_platform.set_scale_factor(density as f64);
+
+    let content_rect = app.content_rect();
+    if content_rect.right > content_rect.left && content_rect.bottom > content_rect.top {
+        android_platform
+            .set_input_surface_offset_px(content_rect.left as f64, content_rect.top as f64);
+    } else {
+        android_platform.set_input_surface_offset_px(0.0, 0.0);
+    }
+
+    cranpose_ui::set_density(density);
+    density
+}
+
 /// Renders a single frame. Returns true if out of memory (should exit).
 fn render_once(resources: &mut GpuResources, shell: &mut AppShell<WgpuRenderer>) -> bool {
     shell.update();
@@ -281,11 +300,16 @@ pub fn run(
 
                             surface.configure(&device, &surface_config);
 
-                            // Get display density and update platform
-                            let density = get_display_density(&app);
-                            android_platform.set_scale_factor(density as f64);
-                            cranpose_ui::set_density(density);
-                            log::info!("Display density: {:.2}x", density);
+                            let density =
+                                update_android_platform_geometry(&app, &mut android_platform);
+                            let (input_offset_x, input_offset_y) =
+                                android_platform.input_surface_offset_px();
+                            log::info!(
+                                "Display density: {:.2}x, input surface offset: ({:.1}, {:.1}) px",
+                                density,
+                                input_offset_x,
+                                input_offset_y
+                            );
 
                             // Create or reuse app shell
                             if app_shell.is_none() {
@@ -369,14 +393,17 @@ pub fn run(
                             let width = native_window.width() as u32;
                             let height = native_window.height() as u32;
 
-                            let density = get_display_density(&app);
-                            android_platform.set_scale_factor(density as f64);
-                            cranpose_ui::set_density(density);
+                            let density =
+                                update_android_platform_geometry(&app, &mut android_platform);
+                            let (input_offset_x, input_offset_y) =
+                                android_platform.input_surface_offset_px();
                             log::info!(
-                                "Window resized to {}x{} at {:.2}x density",
+                                "Window resized to {}x{} at {:.2}x density with input surface offset ({:.1}, {:.1}) px",
                                 width,
                                 height,
-                                density
+                                density,
+                                input_offset_x,
+                                input_offset_y
                             );
 
                             if let (Some(resources), Some(shell)) =
@@ -403,6 +430,17 @@ pub fn run(
                                 }
                             }
                         }
+                    }
+                    MainEvent::ContentRectChanged { .. } => {
+                        let density = update_android_platform_geometry(&app, &mut android_platform);
+                        let (input_offset_x, input_offset_y) =
+                            android_platform.input_surface_offset_px();
+                        log::info!(
+                            "Content rect changed; input surface offset: ({:.1}, {:.1}) px at {:.2}x density",
+                            input_offset_x,
+                            input_offset_y,
+                            density
+                        );
                     }
                     MainEvent::RedrawNeeded { .. } => {
                         if let Some(shell) = &mut app_shell {

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -66,6 +66,17 @@ fn update_android_platform_geometry(
     density
 }
 
+fn update_android_shell_geometry(shell: &mut AppShell<WgpuRenderer>, density: f32) {
+    shell.renderer().set_root_scale(density);
+
+    let (width, height) = shell.buffer_size();
+    if width > 0 && height > 0 {
+        let width_dp = width as f32 / density;
+        let height_dp = height as f32 / density;
+        shell.set_viewport(width_dp, height_dp);
+    }
+}
+
 /// Renders a single frame. Returns true if out of memory (should exit).
 fn render_once(resources: &mut GpuResources, shell: &mut AppShell<WgpuRenderer>) -> bool {
     shell.update();
@@ -419,14 +430,7 @@ pub fn run(
                                     // Set buffer_size to physical pixels
                                     shell.set_buffer_size(width, height);
 
-                                    // Set viewport to logical dp (marks dirty internally)
-                                    let width_dp = width as f32 / density;
-                                    let height_dp = height as f32 / density;
-                                    shell.set_viewport(width_dp, height_dp);
-
-                                    // Update renderer scale
-                                    shell.renderer().set_root_scale(density);
-                                    cranpose_ui::set_density(density);
+                                    update_android_shell_geometry(shell, density);
                                 }
                             }
                         }
@@ -441,6 +445,10 @@ pub fn run(
                             input_offset_y,
                             density
                         );
+
+                        if let Some(shell) = &mut app_shell {
+                            update_android_shell_geometry(shell, density);
+                        }
                     }
                     MainEvent::RedrawNeeded { .. } => {
                         if let Some(shell) = &mut app_shell {


### PR DESCRIPTION
## Summary

Fixes #240 by converting Android MotionEvent coordinates into the rendered native-surface coordinate space before density conversion.

## Changes

- Added a native-surface input offset to `AndroidPlatform` and applied it before logical pointer conversion.
- Refreshed Android platform geometry from `AndroidApp::content_rect()` on window init, resize, and content-rect changes.
- Added unit tests for density-only conversion and surface-offset-before-density conversion.

## Validation

- `cargo fmt`
- `cargo test -p cranpose-platform-android`
- `env CARGO_BUILD_JOBS=1 cargo test > 1.tmp 2>&1` (clean log scan)
- `env CARGO_BUILD_JOBS=1 cargo clippy > 2.tmp 2>&1` (clean log scan)
- `apps/android-demo/android env CARGO_BUILD_JOBS=1 ./gradlew :app:assembleRelease > ../../../android-build.tmp 2>&1` (clean log scan)
- `apps/desktop-demo env CARGO_BUILD_JOBS=1 ./build-web.sh > ../../wasm-build.tmp 2>&1` (clean log scan)
- `env CARGO_BUILD_JOBS=1 CRANPOSE_USE_SCCACHE=0 ./run_robot_test.sh --sequential > robot.tmp 2>&1` (96/96 passed, clean log scan)
- `git diff --check`
