### PR TITLE
[codex] Add SVG painter support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,9 @@ dependencies = [
  "criterion",
  "futures-task",
  "log",
+ "resvg",
  "smallvec",
+ "thiserror 2.0.18",
  "web-time",
 ]
 
@@ -1282,6 +1284,12 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "desktop-app"
@@ -1539,6 +1547,12 @@ dependencies = [
  "miniz_oxide",
  "zlib-rs",
 ]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "foldhash"
@@ -2242,7 +2256,7 @@ dependencies = [
  "image-webp",
  "moxcms",
  "num-traits",
- "png",
+ "png 0.18.1",
  "zune-core",
  "zune-jpeg",
 ]
@@ -2256,6 +2270,12 @@ dependencies = [
  "byteorder-lite",
  "quick-error",
 ]
+
+[[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "indexmap"
@@ -2427,6 +2447,17 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
 
 [[package]]
 name = "kv-log-macro"
@@ -3027,6 +3058,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3121,6 +3158,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -3533,6 +3583,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia 0.11.4",
+ "usvg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3816,6 +3889,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "skrifa"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3925,6 +4013,9 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
 
 [[package]]
 name = "subtle"
@@ -3937,6 +4028,16 @@ name = "svg_fmt"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "swash"
@@ -4073,6 +4174,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
+ "png 0.17.16",
  "tiny-skia-path 0.11.4",
 ]
 
@@ -4087,7 +4189,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "png",
+ "png 0.18.1",
  "tiny-skia-path 0.12.0",
 ]
 
@@ -4391,6 +4493,28 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path 0.11.4",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -5783,6 +5907,12 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yazi"

--- a/crates/cranpose-ui/Cargo.toml
+++ b/crates/cranpose-ui/Cargo.toml
@@ -23,6 +23,8 @@ futures-task = "0.3"
 # WASM-compatible time - web-time is what winit uses internally
 web-time = "1.1"
 log = "0.4"
+resvg = { version = "0.45.1", default-features = false }
+thiserror = "2.0.18"
 
 [features]
 default = []

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -76,10 +76,11 @@ pub use pointer_dispatch::{
     schedule_pointer_repass,
 };
 pub use primitives::{
-    BasicText, BasicTextField, BasicTextFieldOptions, BasicTextWithOptions, BitmapPainter, Box,
-    BoxScope, BoxSpec, BoxWithConstraints, BoxWithConstraintsScope, BoxWithConstraintsScopeImpl,
-    Button, Canvas, Column, ColumnSpec, ContentScale, ForEach, Image, Layout, LayoutNode, Painter,
-    Row, RowSpec, Spacer, SubcomposeLayout, Text, TextWithOptions, DEFAULT_ALPHA,
+    remember_svg, BasicText, BasicTextField, BasicTextFieldOptions, BasicTextWithOptions,
+    BitmapPainter, Box, BoxScope, BoxSpec, BoxWithConstraints, BoxWithConstraintsScope,
+    BoxWithConstraintsScopeImpl, Button, Canvas, Column, ColumnSpec, ContentScale, ForEach, Image,
+    Layout, LayoutNode, Painter, Row, RowSpec, Spacer, SubcomposeLayout, SvgPainter,
+    SvgPainterError, Text, TextWithOptions, DEFAULT_ALPHA,
 };
 // Lazy list exports - single source from cranpose-foundation
 pub use cranpose_foundation::lazy::{LazyListItemInfo, LazyListLayoutInfo, LazyListState};

--- a/crates/cranpose-ui/src/widgets/image.rs
+++ b/crates/cranpose-ui/src/widgets/image.rs
@@ -112,6 +112,11 @@ impl Painter {
         }
     }
 
+    /// Returns the underlying bitmap.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this painter is not backed by an `ImageBitmap`.
     pub fn bitmap(&self) -> &ImageBitmap {
         self.as_bitmap()
             .expect("Painter::bitmap is only available for BitmapPainter values")
@@ -219,7 +224,7 @@ impl SvgPainter {
     }
 
     fn cached_bitmap(&self, key: SvgRasterKey) -> Result<Option<ImageBitmap>, SvgPainterError> {
-        let cache = self
+        let mut cache = self
             .inner
             .cache
             .lock()
@@ -238,13 +243,10 @@ impl SvgPainter {
     }
 
     fn rasterize_uncached(&self, key: SvgRasterKey) -> Result<ImageBitmap, SvgPainterError> {
-        let pixel_count = (key.width as usize)
+        (key.width as usize)
             .checked_mul(key.height as usize)
             .and_then(|value| value.checked_mul(4))
             .ok_or(SvgPainterError::RasterDimensionsTooLarge)?;
-        if pixel_count == 0 {
-            return Err(SvgPainterError::InvalidRasterDimensions);
-        }
 
         let mut pixmap = resvg::tiny_skia::Pixmap::new(key.width, key.height).ok_or(
             SvgPainterError::RasterAllocationFailed {
@@ -263,12 +265,14 @@ impl SvgPainter {
 }
 
 fn demultiplied_rgba_pixels(pixmap: &resvg::tiny_skia::Pixmap) -> Vec<u8> {
-    let mut pixels = Vec::with_capacity(pixmap.data().len());
-    for pixel in pixmap.pixels() {
-        let color = pixel.demultiply();
-        pixels.extend_from_slice(&[color.red(), color.green(), color.blue(), color.alpha()]);
-    }
-    pixels
+    pixmap
+        .pixels()
+        .iter()
+        .flat_map(|pixel| {
+            let color = pixel.demultiply();
+            [color.red(), color.green(), color.blue(), color.alpha()]
+        })
+        .collect()
 }
 
 impl std::fmt::Debug for SvgPainter {
@@ -295,23 +299,21 @@ impl Hash for SvgPainter {
 }
 
 impl SvgRasterCache {
-    fn get(&self, key: SvgRasterKey) -> Option<ImageBitmap> {
-        self.entries
-            .iter()
-            .find(|entry| entry.key == key)
-            .map(|entry| entry.bitmap.clone())
+    fn get(&mut self, key: SvgRasterKey) -> Option<ImageBitmap> {
+        let position = self.entries.iter().position(|entry| entry.key == key)?;
+        let entry = self.entries.remove(position);
+        let bitmap = entry.bitmap.clone();
+        self.entries.push(entry);
+        Some(bitmap)
     }
 
     fn insert(&mut self, key: SvgRasterKey, bitmap: ImageBitmap) {
-        if let Some(entry) = self.entries.iter_mut().find(|entry| entry.key == key) {
-            entry.bitmap = bitmap;
-            return;
-        }
-
-        self.entries.push(SvgRasterEntry { key, bitmap });
-        if self.entries.len() > SVG_RASTER_CACHE_LIMIT {
+        if let Some(position) = self.entries.iter().position(|entry| entry.key == key) {
+            self.entries.remove(position);
+        } else if self.entries.len() >= SVG_RASTER_CACHE_LIMIT {
             self.entries.remove(0);
         }
+        self.entries.push(SvgRasterEntry { key, bitmap });
     }
 }
 
@@ -721,6 +723,10 @@ mod tests {
         ImageBitmap::from_rgba8(4, 2, vec![255; 4 * 2 * 4]).expect("bitmap")
     }
 
+    fn cache_test_bitmap(width: u32) -> ImageBitmap {
+        ImageBitmap::from_rgba8(width, 1, vec![255; width as usize * 4]).expect("bitmap")
+    }
+
     fn pixel_at(bitmap: &ImageBitmap, x: u32, y: u32) -> [u8; 4] {
         let offset = ((y * bitmap.width() + x) * 4) as usize;
         let pixels = bitmap.pixels();
@@ -780,6 +786,35 @@ mod tests {
             .expect("second raster");
 
         assert_eq!(first.id(), second.id());
+    }
+
+    #[test]
+    fn svg_raster_cache_evicts_least_recently_used_entry() {
+        let mut cache = SvgRasterCache::default();
+        let keys: Vec<SvgRasterKey> = (0..SVG_RASTER_CACHE_LIMIT)
+            .map(|index| SvgRasterKey {
+                width: index as u32 + 1,
+                height: 1,
+            })
+            .collect();
+
+        for key in &keys {
+            cache.insert(*key, cache_test_bitmap(key.width));
+        }
+
+        let recent = cache.get(keys[0]).expect("cached raster");
+        let new_key = SvgRasterKey {
+            width: SVG_RASTER_CACHE_LIMIT as u32 + 1,
+            height: 1,
+        };
+        cache.insert(new_key, cache_test_bitmap(new_key.width));
+
+        assert!(cache.get(keys[1]).is_none());
+        assert_eq!(
+            cache.get(keys[0]).expect("retained raster").id(),
+            recent.id()
+        );
+        assert!(cache.get(new_key).is_some());
     }
 
     #[test]

--- a/crates/cranpose-ui/src/widgets/image.rs
+++ b/crates/cranpose-ui/src/widgets/image.rs
@@ -10,8 +10,15 @@ use crate::widgets::Layout;
 use cranpose_core::NodeId;
 use cranpose_ui_graphics::{ColorFilter, DrawScope, ImageBitmap, ImageSampling};
 use cranpose_ui_layout::{Constraints, MeasurePolicy, MeasureResult};
+use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use thiserror::Error;
 
 pub const DEFAULT_ALPHA: f32 = 1.0;
+const SVG_RASTER_CACHE_LIMIT: usize = 8;
+
+static NEXT_SVG_PAINTER_ID: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ContentScale {
@@ -69,20 +76,45 @@ impl ContentScale {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Painter {
-    bitmap: ImageBitmap,
+    kind: PainterKind,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum PainterKind {
+    Bitmap(ImageBitmap),
+    Svg(SvgPainter),
 }
 
 impl Painter {
     pub fn from_bitmap(bitmap: ImageBitmap) -> Self {
-        Self { bitmap }
+        Self {
+            kind: PainterKind::Bitmap(bitmap),
+        }
+    }
+
+    pub fn from_svg(svg: SvgPainter) -> Self {
+        Self {
+            kind: PainterKind::Svg(svg),
+        }
     }
 
     pub fn intrinsic_size(&self) -> Size {
-        self.bitmap.intrinsic_size()
+        match &self.kind {
+            PainterKind::Bitmap(bitmap) => bitmap.intrinsic_size(),
+            PainterKind::Svg(svg) => svg.intrinsic_size(),
+        }
+    }
+
+    pub fn as_bitmap(&self) -> Option<&ImageBitmap> {
+        match &self.kind {
+            PainterKind::Bitmap(bitmap) => Some(bitmap),
+            PainterKind::Svg(_) => None,
+        }
     }
 
     pub fn bitmap(&self) -> &ImageBitmap {
-        &self.bitmap
+        self.as_bitmap()
+            .expect("Painter::bitmap is only available for BitmapPainter values")
     }
 }
 
@@ -92,8 +124,221 @@ impl From<ImageBitmap> for Painter {
     }
 }
 
+impl From<SvgPainter> for Painter {
+    fn from(value: SvgPainter) -> Self {
+        Self::from_svg(value)
+    }
+}
+
 pub fn BitmapPainter(bitmap: ImageBitmap) -> Painter {
     Painter::from_bitmap(bitmap)
+}
+
+/// Errors returned while parsing or rasterizing an SVG painter.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum SvgPainterError {
+    #[error("failed to parse SVG: {0}")]
+    Parse(String),
+    #[error("SVG raster dimensions must be greater than zero")]
+    InvalidRasterDimensions,
+    #[error("SVG raster dimensions are too large")]
+    RasterDimensionsTooLarge,
+    #[error("failed to allocate SVG raster {width}x{height}")]
+    RasterAllocationFailed { width: u32, height: u32 },
+    #[error("SVG raster cache is unavailable")]
+    RasterCacheUnavailable,
+    #[error(transparent)]
+    ImageBitmap(#[from] cranpose_ui_graphics::ImageBitmapError),
+}
+
+/// Parsed SVG image data that rasterizes on demand for the requested draw size.
+#[derive(Clone)]
+pub struct SvgPainter {
+    inner: Arc<SvgPainterInner>,
+}
+
+struct SvgPainterInner {
+    id: u64,
+    tree: resvg::usvg::Tree,
+    intrinsic_size: Size,
+    cache: Mutex<SvgRasterCache>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct SvgRasterKey {
+    width: u32,
+    height: u32,
+}
+
+#[derive(Clone, Debug)]
+struct SvgRasterEntry {
+    key: SvgRasterKey,
+    bitmap: ImageBitmap,
+}
+
+#[derive(Default, Debug)]
+struct SvgRasterCache {
+    entries: Vec<SvgRasterEntry>,
+}
+
+impl SvgPainter {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, SvgPainterError> {
+        let options = resvg::usvg::Options::default();
+        let tree = resvg::usvg::Tree::from_data(bytes, &options)
+            .map_err(|error| SvgPainterError::Parse(error.to_string()))?;
+        let size = tree.size();
+        let intrinsic_size = Size::new(size.width(), size.height());
+
+        Ok(Self {
+            inner: Arc::new(SvgPainterInner {
+                id: NEXT_SVG_PAINTER_ID.fetch_add(1, Ordering::Relaxed),
+                tree,
+                intrinsic_size,
+                cache: Mutex::new(SvgRasterCache::default()),
+            }),
+        })
+    }
+
+    pub fn id(&self) -> u64 {
+        self.inner.id
+    }
+
+    pub fn intrinsic_size(&self) -> Size {
+        self.inner.intrinsic_size
+    }
+
+    pub fn rasterize(&self, pixel_size: Size) -> Result<ImageBitmap, SvgPainterError> {
+        let key = svg_raster_key(pixel_size)?;
+        if let Some(bitmap) = self.cached_bitmap(key)? {
+            return Ok(bitmap);
+        }
+
+        let bitmap = self.rasterize_uncached(key)?;
+        self.cache_bitmap(key, bitmap.clone())?;
+        Ok(bitmap)
+    }
+
+    fn cached_bitmap(&self, key: SvgRasterKey) -> Result<Option<ImageBitmap>, SvgPainterError> {
+        let cache = self
+            .inner
+            .cache
+            .lock()
+            .map_err(|_| SvgPainterError::RasterCacheUnavailable)?;
+        Ok(cache.get(key))
+    }
+
+    fn cache_bitmap(&self, key: SvgRasterKey, bitmap: ImageBitmap) -> Result<(), SvgPainterError> {
+        let mut cache = self
+            .inner
+            .cache
+            .lock()
+            .map_err(|_| SvgPainterError::RasterCacheUnavailable)?;
+        cache.insert(key, bitmap);
+        Ok(())
+    }
+
+    fn rasterize_uncached(&self, key: SvgRasterKey) -> Result<ImageBitmap, SvgPainterError> {
+        let pixel_count = (key.width as usize)
+            .checked_mul(key.height as usize)
+            .and_then(|value| value.checked_mul(4))
+            .ok_or(SvgPainterError::RasterDimensionsTooLarge)?;
+        if pixel_count == 0 {
+            return Err(SvgPainterError::InvalidRasterDimensions);
+        }
+
+        let mut pixmap = resvg::tiny_skia::Pixmap::new(key.width, key.height).ok_or(
+            SvgPainterError::RasterAllocationFailed {
+                width: key.width,
+                height: key.height,
+            },
+        )?;
+        let transform = resvg::tiny_skia::Transform::from_scale(
+            key.width as f32 / self.inner.intrinsic_size.width,
+            key.height as f32 / self.inner.intrinsic_size.height,
+        );
+        resvg::render(&self.inner.tree, transform, &mut pixmap.as_mut());
+        let pixels = demultiplied_rgba_pixels(&pixmap);
+        Ok(ImageBitmap::from_rgba8(key.width, key.height, pixels)?)
+    }
+}
+
+fn demultiplied_rgba_pixels(pixmap: &resvg::tiny_skia::Pixmap) -> Vec<u8> {
+    let mut pixels = Vec::with_capacity(pixmap.data().len());
+    for pixel in pixmap.pixels() {
+        let color = pixel.demultiply();
+        pixels.extend_from_slice(&[color.red(), color.green(), color.blue(), color.alpha()]);
+    }
+    pixels
+}
+
+impl std::fmt::Debug for SvgPainter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SvgPainter")
+            .field("id", &self.id())
+            .field("intrinsic_size", &self.intrinsic_size())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for SvgPainter {
+    fn eq(&self, other: &Self) -> bool {
+        self.id() == other.id()
+    }
+}
+
+impl Eq for SvgPainter {}
+
+impl Hash for SvgPainter {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id().hash(state);
+    }
+}
+
+impl SvgRasterCache {
+    fn get(&self, key: SvgRasterKey) -> Option<ImageBitmap> {
+        self.entries
+            .iter()
+            .find(|entry| entry.key == key)
+            .map(|entry| entry.bitmap.clone())
+    }
+
+    fn insert(&mut self, key: SvgRasterKey, bitmap: ImageBitmap) {
+        if let Some(entry) = self.entries.iter_mut().find(|entry| entry.key == key) {
+            entry.bitmap = bitmap;
+            return;
+        }
+
+        self.entries.push(SvgRasterEntry { key, bitmap });
+        if self.entries.len() > SVG_RASTER_CACHE_LIMIT {
+            self.entries.remove(0);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct SvgBytesKey {
+    ptr: usize,
+    len: usize,
+}
+
+impl SvgBytesKey {
+    fn new(bytes: &'static [u8]) -> Self {
+        Self {
+            ptr: bytes.as_ptr() as usize,
+            len: bytes.len(),
+        }
+    }
+}
+
+pub fn remember_svg(bytes: &'static [u8]) -> Result<SvgPainter, SvgPainterError> {
+    let key = SvgBytesKey::new(bytes);
+    cranpose_core::withCurrentComposer(|composer| {
+        composer.with_key(&key, |composer| {
+            composer
+                .remember(|| SvgPainter::from_bytes(bytes))
+                .with(|result| result.clone())
+        })
+    })
 }
 
 /// Measure policy for Image that preserves aspect ratio when constraints
@@ -172,8 +417,19 @@ fn destination_rect(
     content_scale: ContentScale,
 ) -> Rect {
     let draw_size = content_scale.scaled_size(src_size, dst_size);
-    let offset_x = alignment.horizontal.align(dst_size.width, draw_size.width);
-    let offset_y = alignment.vertical.align(dst_size.height, draw_size.height);
+    let allows_overflow = content_scale == ContentScale::Crop;
+    let offset_x = aligned_x_offset(
+        alignment.horizontal,
+        dst_size.width,
+        draw_size.width,
+        allows_overflow,
+    );
+    let offset_y = aligned_y_offset(
+        alignment.vertical,
+        dst_size.height,
+        draw_size.height,
+        allows_overflow,
+    );
     Rect {
         x: offset_x,
         y: offset_y,
@@ -182,48 +438,37 @@ fn destination_rect(
     }
 }
 
-fn crop_source_rect(src_size: Size, dst_size: Size, alignment: Alignment) -> Rect {
-    if src_size.width <= 0.0
-        || src_size.height <= 0.0
-        || dst_size.width <= 0.0
-        || dst_size.height <= 0.0
-    {
-        return Rect::from_size(Size::ZERO);
+fn aligned_x_offset(
+    alignment: cranpose_ui_layout::HorizontalAlignment,
+    available: f32,
+    child: f32,
+    allows_overflow: bool,
+) -> f32 {
+    if !allows_overflow {
+        return alignment.align(available, child);
     }
 
-    let src_aspect = src_size.width / src_size.height;
-    let dst_aspect = dst_size.width / dst_size.height;
+    match alignment {
+        cranpose_ui_layout::HorizontalAlignment::Start => 0.0,
+        cranpose_ui_layout::HorizontalAlignment::CenterHorizontally => (available - child) / 2.0,
+        cranpose_ui_layout::HorizontalAlignment::End => available - child,
+    }
+}
 
-    if (src_aspect - dst_aspect).abs() <= f32::EPSILON {
-        return Rect::from_origin_size(crate::modifier::Point::ZERO, src_size);
+fn aligned_y_offset(
+    alignment: cranpose_ui_layout::VerticalAlignment,
+    available: f32,
+    child: f32,
+    allows_overflow: bool,
+) -> f32 {
+    if !allows_overflow {
+        return alignment.align(available, child);
     }
 
-    if src_aspect > dst_aspect {
-        // Source is wider than destination: crop width.
-        let crop_width = src_size.height * dst_aspect;
-        let x = alignment
-            .horizontal
-            .align(src_size.width, crop_width)
-            .clamp(0.0, (src_size.width - crop_width).max(0.0));
-        Rect {
-            x,
-            y: 0.0,
-            width: crop_width,
-            height: src_size.height,
-        }
-    } else {
-        // Source is taller than destination: crop height.
-        let crop_height = src_size.width / dst_aspect;
-        let y = alignment
-            .vertical
-            .align(src_size.height, crop_height)
-            .clamp(0.0, (src_size.height - crop_height).max(0.0));
-        Rect {
-            x: 0.0,
-            y,
-            width: src_size.width,
-            height: crop_height,
-        }
+    match alignment {
+        cranpose_ui_layout::VerticalAlignment::Top => 0.0,
+        cranpose_ui_layout::VerticalAlignment::CenterVertically => (available - child) / 2.0,
+        cranpose_ui_layout::VerticalAlignment::Bottom => available - child,
     }
 }
 
@@ -276,6 +521,115 @@ fn map_destination_clip_to_source(
     }
 }
 
+fn image_destination_clip(
+    src_size: Size,
+    container_size: Size,
+    alignment: Alignment,
+    content_scale: ContentScale,
+) -> Option<(Rect, Rect)> {
+    let dst_rect = destination_rect(src_size, container_size, alignment, content_scale);
+    if dst_rect.width <= 0.0 || dst_rect.height <= 0.0 {
+        return None;
+    }
+
+    let container_rect = Rect::from_size(container_size);
+    let clipped_dst_rect = dst_rect.intersect(container_rect)?;
+    Some((dst_rect, clipped_dst_rect))
+}
+
+fn draw_bitmap_painter(
+    scope: &mut dyn DrawScope,
+    bitmap: ImageBitmap,
+    intrinsic_size: Size,
+    alignment: Alignment,
+    content_scale: ContentScale,
+    alpha: f32,
+    color_filter: Option<ColorFilter>,
+) {
+    let container_size = scope.size();
+    let Some((dst_rect, clipped_dst_rect)) =
+        image_destination_clip(intrinsic_size, container_size, alignment, content_scale)
+    else {
+        return;
+    };
+    let full_src_rect = Rect::from_size(Size::new(bitmap.width() as f32, bitmap.height() as f32));
+    let Some(clipped_src_rect) =
+        map_destination_clip_to_source(full_src_rect, dst_rect, clipped_dst_rect)
+    else {
+        return;
+    };
+    scope.draw_image_src_sampled(
+        bitmap,
+        clipped_src_rect,
+        clipped_dst_rect,
+        alpha,
+        color_filter,
+        ImageSampling::Linear,
+    );
+}
+
+fn draw_svg_painter(
+    scope: &mut dyn DrawScope,
+    svg: SvgPainter,
+    intrinsic_size: Size,
+    alignment: Alignment,
+    content_scale: ContentScale,
+    alpha: f32,
+    color_filter: Option<ColorFilter>,
+) {
+    let container_size = scope.size();
+    let Some((dst_rect, clipped_dst_rect)) =
+        image_destination_clip(intrinsic_size, container_size, alignment, content_scale)
+    else {
+        return;
+    };
+    let density = crate::render_state::current_density();
+    let pixel_size = Size::new(dst_rect.width * density, dst_rect.height * density);
+    let bitmap = match svg.rasterize(pixel_size) {
+        Ok(bitmap) => bitmap,
+        Err(error) => {
+            log::warn!("failed to rasterize SVG painter: {error}");
+            return;
+        }
+    };
+    let full_src_rect = Rect::from_size(Size::new(bitmap.width() as f32, bitmap.height() as f32));
+    let Some(clipped_src_rect) =
+        map_destination_clip_to_source(full_src_rect, dst_rect, clipped_dst_rect)
+    else {
+        return;
+    };
+    scope.draw_image_src_sampled(
+        bitmap,
+        clipped_src_rect,
+        clipped_dst_rect,
+        alpha,
+        color_filter,
+        ImageSampling::Linear,
+    );
+}
+
+fn svg_raster_key(pixel_size: Size) -> Result<SvgRasterKey, SvgPainterError> {
+    let width = svg_raster_axis(pixel_size.width)?;
+    let height = svg_raster_axis(pixel_size.height)?;
+    width
+        .checked_mul(height)
+        .and_then(|value| value.checked_mul(4))
+        .ok_or(SvgPainterError::RasterDimensionsTooLarge)?;
+    Ok(SvgRasterKey { width, height })
+}
+
+fn svg_raster_axis(value: f32) -> Result<u32, SvgPainterError> {
+    if !value.is_finite() || value <= 0.0 {
+        return Err(SvgPainterError::InvalidRasterDimensions);
+    }
+
+    let rounded = value.ceil();
+    if rounded > u32::MAX as f32 {
+        return Err(SvgPainterError::RasterDimensionsTooLarge);
+    }
+    Ok(rounded as u32)
+}
+
 #[composable]
 pub fn Image<P>(
     painter: P,
@@ -290,10 +644,8 @@ where
     P: Into<Painter> + Clone + PartialEq + 'static,
 {
     let painter = painter.into();
-    // Treat bitmap pixels as dp (1 image-pixel = 1 dp).  This keeps images
-    // at the same visual size on every screen density.  On hi-dpi screens the
-    // bitmap is upscaled by the renderer, which is the correct behaviour for
-    // web-loaded and most application images.
+    // Painter intrinsic units are logical dp. Bitmap painters use 1 source pixel
+    // per dp; SVG painters rasterize at draw size and current density.
     let intrinsic_dp = painter.intrinsic_size();
     let draw_alpha = alpha.clamp(0.0, 1.0);
     let draw_painter = painter.clone();
@@ -317,44 +669,25 @@ where
                 if container_size.width <= 0.0 || container_size.height <= 0.0 {
                     return;
                 }
-                if content_scale == ContentScale::Crop {
-                    // For Crop, sample the centered/biased source sub-rect directly.
-                    let src_rect = crop_source_rect(intrinsic_dp, container_size, alignment);
-                    if src_rect.width <= 0.0 || src_rect.height <= 0.0 {
-                        return;
-                    }
-                    scope.draw_image_src_sampled(
-                        draw_painter.bitmap().clone(),
-                        src_rect,
-                        Rect::from_size(container_size),
+                match &draw_painter.kind {
+                    PainterKind::Bitmap(bitmap) => draw_bitmap_painter(
+                        scope,
+                        bitmap.clone(),
+                        intrinsic_dp,
+                        alignment,
+                        content_scale,
                         draw_alpha,
                         color_filter,
-                        ImageSampling::Linear,
-                    );
-                } else {
-                    let dst_rect =
-                        destination_rect(intrinsic_dp, container_size, alignment, content_scale);
-                    if dst_rect.width <= 0.0 || dst_rect.height <= 0.0 {
-                        return;
-                    }
-                    let container_rect = Rect::from_size(container_size);
-                    let Some(clipped_dst_rect) = dst_rect.intersect(container_rect) else {
-                        return;
-                    };
-                    let full_src_rect = Rect::from_size(intrinsic_dp);
-                    let Some(clipped_src_rect) =
-                        map_destination_clip_to_source(full_src_rect, dst_rect, clipped_dst_rect)
-                    else {
-                        return;
-                    };
-                    scope.draw_image_src_sampled(
-                        draw_painter.bitmap().clone(),
-                        clipped_src_rect,
-                        clipped_dst_rect,
+                    ),
+                    PainterKind::Svg(svg) => draw_svg_painter(
+                        scope,
+                        svg.clone(),
+                        intrinsic_dp,
+                        alignment,
+                        content_scale,
                         draw_alpha,
                         color_filter,
-                        ImageSampling::Linear,
-                    );
+                    ),
                 }
             });
 
@@ -372,8 +705,31 @@ mod tests {
     use super::*;
     use crate::layout::core::Alignment;
 
+    const RED_RECT_SVG: &[u8] = br##"
+        <svg xmlns="http://www.w3.org/2000/svg" width="10" height="20" viewBox="0 0 10 20">
+          <rect x="0" y="0" width="10" height="20" fill="#ff0000"/>
+        </svg>
+    "##;
+
+    const TRANSPARENT_CENTER_SVG: &[u8] = br##"
+        <svg xmlns="http://www.w3.org/2000/svg" width="4" height="4" viewBox="0 0 4 4">
+          <rect x="1" y="1" width="2" height="2" fill="#00ff00"/>
+        </svg>
+    "##;
+
     fn sample_bitmap() -> ImageBitmap {
         ImageBitmap::from_rgba8(4, 2, vec![255; 4 * 2 * 4]).expect("bitmap")
+    }
+
+    fn pixel_at(bitmap: &ImageBitmap, x: u32, y: u32) -> [u8; 4] {
+        let offset = ((y * bitmap.width() + x) * 4) as usize;
+        let pixels = bitmap.pixels();
+        [
+            pixels[offset],
+            pixels[offset + 1],
+            pixels[offset + 2],
+            pixels[offset + 3],
+        ]
     }
 
     #[test]
@@ -382,6 +738,69 @@ mod tests {
         let painter = BitmapPainter(bitmap.clone());
         assert_eq!(painter.intrinsic_size(), Size::new(4.0, 2.0));
         assert_eq!(painter.bitmap(), &bitmap);
+    }
+
+    #[test]
+    fn svg_painter_reports_intrinsic_size() {
+        let painter = SvgPainter::from_bytes(RED_RECT_SVG).expect("svg painter");
+        assert_eq!(painter.intrinsic_size(), Size::new(10.0, 20.0));
+    }
+
+    #[test]
+    fn svg_painter_rasterizes_requested_dimensions() {
+        let painter = SvgPainter::from_bytes(RED_RECT_SVG).expect("svg painter");
+        let bitmap = painter
+            .rasterize(Size::new(5.0, 10.0))
+            .expect("rasterized svg");
+
+        assert_eq!(bitmap.width(), 5);
+        assert_eq!(bitmap.height(), 10);
+        assert_eq!(pixel_at(&bitmap, 2, 5), [255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn svg_painter_preserves_transparency() {
+        let painter = SvgPainter::from_bytes(TRANSPARENT_CENTER_SVG).expect("svg painter");
+        let bitmap = painter
+            .rasterize(Size::new(4.0, 4.0))
+            .expect("rasterized svg");
+
+        assert_eq!(pixel_at(&bitmap, 0, 0), [0, 0, 0, 0]);
+        assert_eq!(pixel_at(&bitmap, 2, 2), [0, 255, 0, 255]);
+    }
+
+    #[test]
+    fn svg_painter_reuses_cached_raster_for_same_size() {
+        let painter = SvgPainter::from_bytes(RED_RECT_SVG).expect("svg painter");
+        let first = painter
+            .rasterize(Size::new(8.0, 8.0))
+            .expect("first raster");
+        let second = painter
+            .rasterize(Size::new(8.0, 8.0))
+            .expect("second raster");
+
+        assert_eq!(first.id(), second.id());
+    }
+
+    #[test]
+    fn svg_painter_rasterizes_distinct_sizes_separately() {
+        let painter = SvgPainter::from_bytes(RED_RECT_SVG).expect("svg painter");
+        let small = painter
+            .rasterize(Size::new(8.0, 8.0))
+            .expect("small raster");
+        let large = painter
+            .rasterize(Size::new(16.0, 16.0))
+            .expect("large raster");
+
+        assert_ne!(small.id(), large.id());
+        assert_eq!(large.width(), 16);
+        assert_eq!(large.height(), 16);
+    }
+
+    #[test]
+    fn svg_painter_rejects_invalid_bytes() {
+        let err = SvgPainter::from_bytes(b"not svg").expect_err("invalid svg");
+        assert!(matches!(err, SvgPainterError::Parse(_)));
     }
 
     #[test]
@@ -417,10 +836,14 @@ mod tests {
     }
 
     #[test]
-    fn crop_source_rect_is_centered_for_wide_source() {
+    fn crop_destination_clip_maps_centered_wide_source() {
         let src = Size::new(200.0, 100.0);
         let dst = Size::new(100.0, 100.0);
-        let rect = crop_source_rect(src, dst, Alignment::CENTER);
+        let (dst_rect, clipped_dst_rect) =
+            image_destination_clip(src, dst, Alignment::CENTER, ContentScale::Crop)
+                .expect("destination clip");
+        let rect = map_destination_clip_to_source(Rect::from_size(src), dst_rect, clipped_dst_rect)
+            .expect("source clip");
         assert_eq!(
             rect,
             Rect {
@@ -433,10 +856,14 @@ mod tests {
     }
 
     #[test]
-    fn crop_source_rect_honors_start_alignment() {
+    fn crop_destination_clip_honors_start_alignment() {
         let src = Size::new(200.0, 100.0);
         let dst = Size::new(100.0, 100.0);
-        let rect = crop_source_rect(src, dst, Alignment::TOP_START);
+        let (dst_rect, clipped_dst_rect) =
+            image_destination_clip(src, dst, Alignment::TOP_START, ContentScale::Crop)
+                .expect("destination clip");
+        let rect = map_destination_clip_to_source(Rect::from_size(src), dst_rect, clipped_dst_rect)
+            .expect("source clip");
         assert_eq!(
             rect,
             Rect {

--- a/crates/cranpose-ui/tests/svg_painter_integration.rs
+++ b/crates/cranpose-ui/tests/svg_painter_integration.rs
@@ -1,0 +1,53 @@
+use cranpose_ui::{
+    Alignment, Color, ColorFilter, ContentScale, HeadlessRenderer, Image, LayoutEngine, Modifier,
+    PaintLayer, RenderOp, Size, SvgPainter, DEFAULT_ALPHA,
+};
+
+const ICON_SVG: &[u8] = br##"
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+      <path d="M4 12h16" fill="none" stroke="#000000" stroke-width="4" stroke-linecap="round"/>
+      <path d="M12 4v16" fill="none" stroke="#000000" stroke-width="4" stroke-linecap="round"/>
+    </svg>
+"##;
+
+#[test]
+fn svg_painter_renders_through_image_composable() {
+    let painter = SvgPainter::from_bytes(ICON_SVG).expect("svg painter");
+    let mut composition = cranpose_ui::run_test_composition({
+        let painter = painter.clone();
+        move || {
+            Image(
+                painter.clone(),
+                Some("Add".to_string()),
+                Modifier::empty().size(Size::new(24.0, 24.0)),
+                Alignment::CENTER,
+                ContentScale::Fit,
+                DEFAULT_ALPHA,
+                Some(ColorFilter::tint(Color::from_rgba_u8(10, 20, 30, 255))),
+            );
+        }
+    });
+
+    let root = composition.root().expect("image root");
+    let handle = composition.runtime_handle();
+    let layout = {
+        let mut applier = composition.applier_mut();
+        applier.set_runtime_handle(handle);
+        let layout = applier
+            .compute_layout(root, Size::new(64.0, 64.0))
+            .expect("layout");
+        applier.clear_runtime_handle();
+        layout
+    };
+
+    let scene = HeadlessRenderer::new().render(&layout);
+    assert!(scene.operations().iter().any(|op| {
+        matches!(
+            op,
+            RenderOp::Primitive {
+                layer: PaintLayer::Behind,
+                ..
+            }
+        )
+    }));
+}


### PR DESCRIPTION
Closes #214.

## What changed
- Added `SvgPainter::from_bytes` plus `remember_svg` for parsed SVG reuse inside composition.
- Extended `Image`/`Painter` so SVG painters rasterize at draw size and current density, then flow through the existing bitmap render primitive for desktop, web, Android, and headless rendering.
- Added per-painter raster caching keyed by output pixel size, preserving transparency and supporting existing `ColorFilter` tint behavior.
- Kept `resvg` default features disabled and selected `resvg 0.45.1` so SVG parsing shares the existing `roxmltree 0.20` dependency line.

## Validation
- `cargo fmt`
- `env CARGO_BUILD_JOBS=1 cargo test -p cranpose-ui widgets::image::tests -- --nocapture`
- `env CARGO_BUILD_JOBS=1 cargo test -p cranpose-ui --test svg_painter_integration -- --nocapture`
- `env CARGO_BUILD_JOBS=1 cargo test > 1.tmp 2>&1` (log scan clean)
- `env CARGO_BUILD_JOBS=1 cargo clippy > 2.tmp 2>&1` (log scan clean)
- `apps/android-demo/android`: `env CARGO_BUILD_JOBS=1 ./gradlew :app:assembleRelease > ../../../android-build.tmp 2>&1` (log scan clean)
- `apps/desktop-demo`: `env CARGO_BUILD_JOBS=1 ./build-web.sh > ../../wasm-build.tmp 2>&1` (log scan clean)
- `env CARGO_BUILD_JOBS=1 CRANPOSE_USE_SCCACHE=0 ./run_robot_test.sh --sequential > robot.tmp 2>&1` (96/96 passed; log scan clean)
- `cargo tree -i resvg`
- `cargo tree -i roxmltree`
- `cargo tree --duplicates`
- `git diff --check`