### PR TITLE
[codex] Support Android overlay surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,6 +956,7 @@ dependencies = [
  "cranpose-ui",
  "jni",
  "log",
+ "ndk",
  "pixels",
  "pollster 0.4.0",
  "raw-window-handle",

--- a/apps/android-demo/android/app/build.gradle.kts
+++ b/apps/android-demo/android/app/build.gradle.kts
@@ -89,6 +89,9 @@ android {
     }
 
     sourceSets {
+        getByName("main") {
+            java.srcDirs("../../../../crates/cranpose/android/java")
+        }
         getByName("debug") {
             // Path relative to app/ directory. Cargo builds to android/target/android/
             jniLibs.srcDirs("../target/android")

--- a/apps/android-demo/android/app/src/main/AndroidManifest.xml
+++ b/apps/android-demo/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <application
         android:allowBackup="true"
         android:label="Compose Demo"

--- a/crates/cranpose/Cargo.toml
+++ b/crates/cranpose/Cargo.toml
@@ -72,6 +72,7 @@ console_error_panic_hook = "0.1"
 android-activity = { workspace = true }
 android_logger = "0.15"
 jni = "0.21.1"
+ndk = "0.9.0"
 raw-window-handle = "0.6"
 
 [target.'cfg(all(target_os = "linux", not(target_arch = "wasm32")))'.dependencies]

--- a/crates/cranpose/README.md
+++ b/crates/cranpose/README.md
@@ -37,8 +37,36 @@ Behavior by Android windowing mode:
     requests.
 -   Freeform and desktop-windowing activities can honor `Window.setLayout`, then
     Cranpose reconfigures WGPU and the viewport from the following resize event.
--   Overlay windows are a separate Android surface and permission model. This
-    API sizes only the current `NativeActivity` host window.
+-   Overlay windows have a separate Android surface and permission model; when
+    overlay mode is active, the same state resizes that surface through
+    `WindowManager.updateViewLayout`.
+
+## Android Overlay Windows
+
+Apps that need a true always-on-top Android surface can opt into Cranpose's
+overlay backend with `AppLauncher::with_android_overlay_window(...)`. The
+overlay renders the app root into a Java `SurfaceView` attached through
+`WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY`; pointer events from that
+surface are translated into the same Cranpose input path as activity touches.
+
+Android overlay requirements:
+
+-   Declare `android.permission.SYSTEM_ALERT_WINDOW` in the host manifest.
+-   Ask the user for overlay permission before launch; Cranpose falls back to
+    the activity surface when Android denies or cannot create the overlay.
+-   Include `crates/cranpose/android/java` in the Android source set so the
+    `dev.cranpose.android.CranposeOverlayWindow` helper is packaged with the
+    app.
+-   Use Android 8.0/API 26 or newer for `TYPE_APPLICATION_OVERLAY`.
+-   Treat always-on-top overlays as a product and Play policy risk; Android may
+    deny, revoke, or restrict the permission outside Cranpose's control.
+
+The overlay surface has its own lifecycle: `SurfaceView` creation, resize, touch,
+and destroy callbacks are queued into the Rust Android event loop, and Cranpose
+keeps the `ANativeWindow` reference alive for as long as WGPU uses that surface.
+Apps can resize the active overlay with `rememberAndroidHostWindowState`; the
+runtime forwards accepted size requests to `WindowManager.updateViewLayout` and
+reconfigures WGPU from the following `SurfaceView` resize callback.
 
 ## Architecture
 

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeOverlayWindow.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeOverlayWindow.java
@@ -1,0 +1,208 @@
+package dev.cranpose.android;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.graphics.PixelFormat;
+import android.os.Build;
+import android.provider.Settings;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.view.Surface;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
+import android.view.View;
+import android.view.WindowManager;
+
+public final class CranposeOverlayWindow {
+    public static final int RESULT_OK = 0;
+    public static final int RESULT_UNSUPPORTED_SDK = -1;
+    public static final int RESULT_MISSING_MANIFEST_PERMISSION = -2;
+    public static final int RESULT_MISSING_RUNTIME_PERMISSION = -3;
+    public static final int RESULT_ALREADY_VISIBLE = -4;
+    public static final int RESULT_CREATE_FAILED = -5;
+    public static final int RESULT_NOT_VISIBLE = -6;
+
+    private static volatile SurfaceView surfaceView;
+
+    private CranposeOverlayWindow() {
+    }
+
+    public static int show(
+            Activity activity,
+            int widthPx,
+            int heightPx,
+            int xPx,
+            int yPx,
+            boolean focusable
+    ) {
+        if (surfaceView != null) {
+            return RESULT_ALREADY_VISIBLE;
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return RESULT_UNSUPPORTED_SDK;
+        }
+        if (!declaresOverlayPermission(activity)) {
+            return RESULT_MISSING_MANIFEST_PERMISSION;
+        }
+        if (!Settings.canDrawOverlays(activity)) {
+            return RESULT_MISSING_RUNTIME_PERMISSION;
+        }
+
+        activity.runOnUiThread(() -> {
+            if (surfaceView != null) {
+                return;
+            }
+
+            WindowManager windowManager =
+                    (WindowManager) activity.getSystemService(Context.WINDOW_SERVICE);
+            if (windowManager == null) {
+                nativeOverlayCreateFailed("Android WindowManager is unavailable");
+                return;
+            }
+
+            SurfaceView view = new SurfaceView(activity);
+            view.setZOrderOnTop(true);
+            view.getHolder().setFormat(PixelFormat.TRANSLUCENT);
+            view.getHolder().addCallback(new SurfaceHolder.Callback() {
+                @Override
+                public void surfaceCreated(SurfaceHolder holder) {
+                    Surface surface = holder.getSurface();
+                    nativeOverlaySurfaceChanged(
+                            surface,
+                            Math.max(view.getWidth(), 1),
+                            Math.max(view.getHeight(), 1)
+                    );
+                }
+
+                @Override
+                public void surfaceChanged(
+                        SurfaceHolder holder,
+                        int format,
+                        int width,
+                        int height
+                ) {
+                    nativeOverlaySurfaceChanged(holder.getSurface(), width, height);
+                }
+
+                @Override
+                public void surfaceDestroyed(SurfaceHolder holder) {
+                    nativeOverlaySurfaceDestroyed();
+                }
+            });
+            view.setOnTouchListener((View touched, MotionEvent event) -> {
+                nativeOverlayPointer(event.getActionMasked(), event.getX(), event.getY());
+                return true;
+            });
+
+            int flags = WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS;
+            if (!focusable) {
+                flags |= WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE;
+            }
+
+            WindowManager.LayoutParams params = new WindowManager.LayoutParams(
+                    widthPx,
+                    heightPx,
+                    WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
+                    flags,
+                    PixelFormat.TRANSLUCENT
+            );
+            params.gravity = Gravity.TOP | Gravity.START;
+            params.x = xPx;
+            params.y = yPx;
+
+            try {
+                windowManager.addView(view, params);
+                surfaceView = view;
+            } catch (RuntimeException error) {
+                nativeOverlayCreateFailed(error.toString());
+            }
+        });
+
+        return RESULT_OK;
+    }
+
+    public static int updateBounds(
+            Activity activity,
+            int widthPx,
+            int heightPx,
+            int xPx,
+            int yPx
+    ) {
+        if (surfaceView == null) {
+            return RESULT_NOT_VISIBLE;
+        }
+
+        activity.runOnUiThread(() -> {
+            SurfaceView view = surfaceView;
+            if (view == null) {
+                return;
+            }
+
+            WindowManager windowManager =
+                    (WindowManager) activity.getSystemService(Context.WINDOW_SERVICE);
+            if (windowManager == null) {
+                nativeOverlayCreateFailed("Android WindowManager is unavailable");
+                return;
+            }
+
+            try {
+                WindowManager.LayoutParams params =
+                        (WindowManager.LayoutParams) view.getLayoutParams();
+                params.width = widthPx;
+                params.height = heightPx;
+                params.x = xPx;
+                params.y = yPx;
+                windowManager.updateViewLayout(view, params);
+            } catch (RuntimeException error) {
+                nativeOverlayCreateFailed(error.toString());
+            }
+        });
+
+        return RESULT_OK;
+    }
+
+    public static void hide(Activity activity) {
+        activity.runOnUiThread(() -> {
+            SurfaceView view = surfaceView;
+            if (view == null) {
+                return;
+            }
+            surfaceView = null;
+            WindowManager windowManager =
+                    (WindowManager) activity.getSystemService(Context.WINDOW_SERVICE);
+            if (windowManager != null) {
+                windowManager.removeViewImmediate(view);
+            }
+            nativeOverlaySurfaceDestroyed();
+        });
+    }
+
+    private static boolean declaresOverlayPermission(Activity activity) {
+        try {
+            PackageInfo info = activity
+                    .getPackageManager()
+                    .getPackageInfo(activity.getPackageName(), PackageManager.GET_PERMISSIONS);
+            if (info.requestedPermissions == null) {
+                return false;
+            }
+            for (String permission : info.requestedPermissions) {
+                if (Manifest.permission.SYSTEM_ALERT_WINDOW.equals(permission)) {
+                    return true;
+                }
+            }
+        } catch (PackageManager.NameNotFoundException ignored) {
+        }
+        return false;
+    }
+
+    private static native void nativeOverlayCreateFailed(String message);
+
+    private static native void nativeOverlaySurfaceChanged(Surface surface, int width, int height);
+
+    private static native void nativeOverlaySurfaceDestroyed();
+
+    private static native void nativeOverlayPointer(int action, float x, float y);
+}

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -3,22 +3,35 @@
 //! This module provides the Android event loop implementation with proper
 //! lifecycle management, input handling, and rendering coordination.
 
-use crate::{android_host_window, launcher::AppSettings};
+use crate::{
+    android_host_window,
+    android_jni::{clear_pending_android_jni_exception, with_android_activity_env},
+    android_overlay_window,
+    launcher::{AndroidOverlayWindowOptions, AppSettings},
+};
 use cranpose_app_shell::{default_root_key, AppShell};
 use cranpose_platform_android::AndroidPlatform;
 use cranpose_render_wgpu::WgpuRenderer;
 use cranpose_ui::Size;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+use ndk::native_window::NativeWindow;
 use std::time::Instant;
+use std::{
+    cell::RefCell,
+    ffi::c_void,
+    ptr::NonNull,
+    rc::Rc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 /// GPU resources for the surface (recreated when window is destroyed/created).
 struct GpuResources {
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
     config: wgpu::SurfaceConfiguration,
+    _native_window: Option<NativeWindow>,
 }
 
 /// Pending input event to be processed outside poll_events callback.
@@ -128,21 +141,196 @@ fn render_once(resources: &mut GpuResources, shell: &mut AppShell<WgpuRenderer>)
     }
 }
 
-fn dispatch_android_host_window_size_request(
+struct AndroidGpuSetup {
+    resources: GpuResources,
+    queue: Arc<wgpu::Queue>,
+    surface_format: wgpu::TextureFormat,
+    backend: wgpu::Backend,
+}
+
+fn initialize_android_rendering<F>(
+    instance: &wgpu::Instance,
+    app_shell: &mut Option<AppShell<WgpuRenderer>>,
+    content: &Rc<RefCell<F>>,
+    settings: &AppSettings,
+    need_frame: &Arc<AtomicBool>,
+    native_window_ptr: NonNull<c_void>,
+    native_window_owner: Option<NativeWindow>,
+    width: u32,
+    height: u32,
+    density: f32,
+) -> (GpuResources, Option<Size>)
+where
+    F: FnMut() + 'static,
+{
+    let setup = create_android_gpu_resources(
+        instance,
+        native_window_ptr,
+        native_window_owner,
+        width,
+        height,
+    );
+
+    if app_shell.is_none() {
+        let fonts: &[&[u8]] = settings.fonts.unwrap_or(&[]);
+        let mut renderer = WgpuRenderer::new(fonts);
+        renderer.init_gpu(
+            setup.resources.device.clone(),
+            setup.queue.clone(),
+            setup.surface_format,
+            setup.backend,
+        );
+        renderer.set_root_scale(density);
+
+        let content_clone = content.clone();
+        let shell = AppShell::new(renderer, default_root_key(), move || {
+            content_clone.borrow_mut()()
+        });
+
+        *app_shell = Some(shell);
+
+        if let Some(shell) = app_shell {
+            let need_frame = need_frame.clone();
+            shell.set_frame_waker(move || {
+                need_frame.store(true, Ordering::Relaxed);
+            });
+        }
+
+        log::info!("App shell created");
+    } else if let Some(shell) = app_shell {
+        shell.renderer().init_gpu(
+            setup.resources.device.clone(),
+            setup.queue.clone(),
+            setup.surface_format,
+            setup.backend,
+        );
+        shell.renderer().set_root_scale(density);
+        cranpose_ui::set_density(density);
+        log::info!("Renderer reinitialized with new GPU resources");
+    }
+
+    let actual_size = app_shell.as_mut().and_then(|shell| {
+        shell.set_buffer_size(width, height);
+        update_android_shell_geometry(shell, density)
+    });
+
+    (setup.resources, actual_size)
+}
+
+fn create_android_gpu_resources(
+    instance: &wgpu::Instance,
+    native_window_ptr: NonNull<c_void>,
+    native_window_owner: Option<NativeWindow>,
+    width: u32,
+    height: u32,
+) -> AndroidGpuSetup {
+    let surface = create_android_wgpu_surface(instance, native_window_ptr);
+
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        compatible_surface: Some(&surface),
+        force_fallback_adapter: false,
+    }))
+    .expect("Failed to find suitable adapter");
+
+    let adapter_info = adapter.get_info();
+    log::info!("Found adapter: {:?}", adapter_info.backend);
+
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("Android Device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
+        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        memory_hints: wgpu::MemoryHints::default(),
+        trace: wgpu::Trace::Off,
+    }))
+    .expect("Failed to create device");
+
+    let device = Arc::new(device);
+    let queue = Arc::new(queue);
+
+    let surface_caps = surface.get_capabilities(&adapter);
+    let surface_format = surface_caps
+        .formats
+        .iter()
+        .copied()
+        .find(|f| f.is_srgb())
+        .unwrap_or(surface_caps.formats[0]);
+    let present_mode = crate::present_mode::select_present_mode(&surface_caps);
+    let config = wgpu::SurfaceConfiguration {
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        format: surface_format,
+        width,
+        height,
+        present_mode,
+        alpha_mode: surface_caps.alpha_modes[0],
+        view_formats: vec![],
+        desired_maximum_frame_latency: 2,
+    };
+
+    surface.configure(&device, &config);
+
+    AndroidGpuSetup {
+        resources: GpuResources {
+            surface,
+            device,
+            config,
+            _native_window: native_window_owner,
+        },
+        queue,
+        surface_format,
+        backend: adapter_info.backend,
+    }
+}
+
+fn create_android_wgpu_surface(
+    instance: &wgpu::Instance,
+    native_window_ptr: NonNull<c_void>,
+) -> wgpu::Surface<'static> {
+    unsafe {
+        use raw_window_handle::{
+            AndroidDisplayHandle, AndroidNdkWindowHandle, RawDisplayHandle, RawWindowHandle,
+        };
+
+        let window_handle = AndroidNdkWindowHandle::new(native_window_ptr);
+        let raw_window_handle = RawWindowHandle::AndroidNdk(window_handle);
+        let display_handle = AndroidDisplayHandle::new();
+        let raw_display_handle = RawDisplayHandle::Android(display_handle);
+
+        let target = wgpu::SurfaceTargetUnsafe::RawHandle {
+            raw_display_handle,
+            raw_window_handle,
+        };
+
+        instance
+            .create_surface_unsafe(target)
+            .expect("Failed to create WGPU surface")
+    }
+}
+
+fn dispatch_android_surface_size_request(
     app: &android_activity::AndroidApp,
     requested: Size,
     density: f32,
+    overlay_options: Option<AndroidOverlayWindowOptions>,
 ) -> Result<(), String> {
     let requested =
         android_host_window::validate_logical_size(requested).map_err(|error| error.to_string())?;
+    if let Some(options) = overlay_options {
+        return android_overlay_window::update_android_overlay_window_bounds(
+            app, options, requested, density,
+        );
+    }
+
     let (width_px, height_px) =
         android_host_window::logical_to_physical_window_size(requested, density);
     set_android_window_layout_px(app, width_px, height_px)
 }
 
-fn dispatch_registered_android_host_window_request(
+fn dispatch_registered_android_surface_size_request(
     app: &android_activity::AndroidApp,
     density: f32,
+    overlay_options: Option<AndroidOverlayWindowOptions>,
     last_dispatched: &mut Option<(android_host_window::AndroidHostWindowState, u64)>,
     pending_confirmation: &mut Option<PendingHostWindowSizeRequest>,
 ) {
@@ -155,7 +343,7 @@ fn dispatch_registered_android_host_window_request(
     }
 
     request.state.mark_pending(request.size);
-    match dispatch_android_host_window_size_request(app, request.size, density) {
+    match dispatch_android_surface_size_request(app, request.size, density, overlay_options) {
         Ok(()) => {
             *last_dispatched = Some(dispatch_key);
             *pending_confirmation = Some(PendingHostWindowSizeRequest {
@@ -163,8 +351,13 @@ fn dispatch_registered_android_host_window_request(
                 requested: request.size,
                 requested_at: Instant::now(),
             });
+            let target = if overlay_options.is_some() {
+                "Android overlay surface"
+            } else {
+                "Android host-window"
+            };
             log::info!(
-                "Requested Android host-window size {:.1}x{:.1} dp",
+                "Requested {target} size {:.1}x{:.1} dp",
                 request.size.width,
                 request.size.height
             );
@@ -197,7 +390,7 @@ fn confirm_android_host_window_request(
             state.mark_unsupported(pending.requested, actual_size);
         }
         log::info!(
-            "Android host-window size request {:.1}x{:.1} dp was not honored; actual is {:.1}x{:.1} dp",
+            "Android surface size request {:.1}x{:.1} dp was not honored; actual is {:.1}x{:.1} dp",
             pending.requested.width,
             pending.requested.height,
             actual_size.width,
@@ -212,43 +405,28 @@ fn set_android_window_layout_px(
     width_px: i32,
     height_px: i32,
 ) -> Result<(), String> {
-    use jni::{objects::JValue, JavaVM};
+    use jni::objects::JValue;
 
-    // SAFETY: android-activity owns a valid JavaVM pointer for the lifetime of AndroidApp.
-    let vm = unsafe { JavaVM::from_raw(app.vm_as_ptr().cast()) }
-        .map_err(|error| format!("failed to access Android Java VM: {error}"))?;
-    let mut env = vm
-        .attach_current_thread()
-        .map_err(|error| format!("failed to attach Android JNI thread: {error}"))?;
-
-    // SAFETY: activity_as_ptr returns a JNI global Activity reference owned by android-activity.
-    // JObject does not delete this reference on drop; it is used only for this JNI call chain.
-    let activity = unsafe { jni::objects::JObject::from_raw(app.activity_as_ptr().cast()) };
-    let window = env
-        .call_method(&activity, "getWindow", "()Landroid/view/Window;", &[])
-        .and_then(|value| value.l())
+    with_android_activity_env(app, |env, activity| {
+        let window = env
+            .call_method(&activity, "getWindow", "()Landroid/view/Window;", &[])
+            .and_then(|value| value.l())
+            .map_err(|error| {
+                clear_pending_android_jni_exception(env);
+                format!("failed to access Android Activity window: {error}")
+            })?;
+        env.call_method(
+            &window,
+            "setLayout",
+            "(II)V",
+            &[JValue::Int(width_px), JValue::Int(height_px)],
+        )
         .map_err(|error| {
-            clear_pending_android_jni_exception(&mut env);
-            format!("failed to access Android Activity window: {error}")
+            clear_pending_android_jni_exception(env);
+            format!("failed to request Android window layout: {error}")
         })?;
-    env.call_method(
-        &window,
-        "setLayout",
-        "(II)V",
-        &[JValue::Int(width_px), JValue::Int(height_px)],
-    )
-    .map_err(|error| {
-        clear_pending_android_jni_exception(&mut env);
-        format!("failed to request Android window layout: {error}")
-    })?;
-    Ok(())
-}
-
-fn clear_pending_android_jni_exception(env: &mut jni::JNIEnv<'_>) {
-    if matches!(env.exception_check(), Ok(true)) {
-        let _ = env.exception_describe();
-        let _ = env.exception_clear();
-    }
+        Ok(())
+    })
 }
 
 /// Runs an Android Compose application with wgpu rendering.
@@ -336,6 +514,8 @@ pub fn run(
     let mut last_dispatched_host_window_request =
         None::<(android_host_window::AndroidHostWindowState, u64)>;
     let mut pending_host_window_confirmation = None::<PendingHostWindowSizeRequest>;
+    let mut overlay_window_options = settings.android_overlay_window;
+    let mut overlay_window_requested = false;
 
     // GPU resources (recreated when window is destroyed/created)
     let mut gpu_resources: Option<GpuResources> = None;
@@ -369,156 +549,62 @@ pub fn run(
                     MainEvent::InitWindow { .. } => {
                         log::info!("Window initialized, setting up rendering");
 
-                        if let Some(native_window) = app.native_window() {
-                            // Get actual window dimensions
-                            let width = native_window.width() as u32;
-                            let height = native_window.height() as u32;
-
-                            // Create surface using raw window handle from NativeWindow
-                            let surface = unsafe {
-                                use raw_window_handle::{
-                                    AndroidDisplayHandle, AndroidNdkWindowHandle, RawDisplayHandle,
-                                    RawWindowHandle,
-                                };
-
-                                let window_handle = AndroidNdkWindowHandle::new(
-                                    std::ptr::NonNull::new(native_window.ptr().as_ptr() as *mut _)
-                                        .expect("NativeWindow pointer is null"),
-                                );
-                                let raw_window_handle = RawWindowHandle::AndroidNdk(window_handle);
-
-                                let display_handle = AndroidDisplayHandle::new();
-                                let raw_display_handle = RawDisplayHandle::Android(display_handle);
-
-                                let target = wgpu::SurfaceTargetUnsafe::RawHandle {
-                                    raw_display_handle,
-                                    raw_window_handle,
-                                };
-
-                                instance
-                                    .create_surface_unsafe(target)
-                                    .expect("Failed to create WGPU surface")
-                            };
-
-                            // Request adapter
-                            let adapter = pollster::block_on(instance.request_adapter(
-                                &wgpu::RequestAdapterOptions {
-                                    power_preference: wgpu::PowerPreference::HighPerformance,
-                                    compatible_surface: Some(&surface),
-                                    force_fallback_adapter: false,
-                                },
-                            ))
-                            .expect("Failed to find suitable adapter");
-
-                            let adapter_info = adapter.get_info();
-                            log::info!("Found adapter: {:?}", adapter_info.backend);
-
-                            // Request device and queue
-                            // Use downlevel limits for broad compatibility, with adapter's actual limits
-                            let (device, queue) = pollster::block_on(
-                                adapter.request_device(&wgpu::DeviceDescriptor {
-                                    label: Some("Android Device"),
-                                    required_features: wgpu::Features::empty(),
-                                    required_limits: wgpu::Limits::downlevel_defaults()
-                                        .using_resolution(adapter.limits()),
-                                    experimental_features: wgpu::ExperimentalFeatures::disabled(),
-                                    memory_hints: wgpu::MemoryHints::default(),
-                                    trace: wgpu::Trace::Off,
-                                }),
-                            )
-                            .expect("Failed to create device");
-
-                            let device = Arc::new(device);
-                            let queue = Arc::new(queue);
-
-                            // Get surface capabilities and format
-                            let surface_caps = surface.get_capabilities(&adapter);
-                            let surface_format = surface_caps
-                                .formats
-                                .iter()
-                                .copied()
-                                .find(|f| f.is_srgb())
-                                .unwrap_or(surface_caps.formats[0]);
-
-                            // Configure surface
-                            let present_mode =
-                                crate::present_mode::select_present_mode(&surface_caps);
-                            let surface_config = wgpu::SurfaceConfiguration {
-                                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                                format: surface_format,
-                                width,
-                                height,
-                                present_mode,
-                                alpha_mode: surface_caps.alpha_modes[0],
-                                view_formats: vec![],
-                                desired_maximum_frame_latency: 2,
-                            };
-
-                            surface.configure(&device, &surface_config);
-
+                        if let Some(options) = overlay_window_options {
                             let density =
                                 update_android_platform_geometry(&app, &mut android_platform);
-                            let (input_offset_x, input_offset_y) =
-                                android_platform.input_surface_offset_px();
-                            log::info!(
-                                "Display density: {:.2}x, input surface offset: ({:.1}, {:.1}) px",
-                                density,
-                                input_offset_x,
-                                input_offset_y
-                            );
-
-                            // Create or reuse app shell
-                            if app_shell.is_none() {
-                                // First initialization - create renderer and app shell
-                                let fonts: &[&[u8]] = settings.fonts.unwrap_or(&[]);
-                                let mut renderer = WgpuRenderer::new(fonts);
-                                renderer.init_gpu(
-                                    device.clone(),
-                                    queue.clone(),
-                                    surface_format,
-                                    adapter_info.backend,
-                                );
-                                renderer.set_root_scale(density);
-
-                                // Create app shell with content closure
-                                let content_clone = content.clone();
-                                let shell =
-                                    AppShell::new(renderer, default_root_key(), move || {
-                                        content_clone.borrow_mut()()
-                                    });
-
-                                app_shell = Some(shell);
-
-                                // Wire frame waker for event-driven rendering
-                                if let Some(shell) = &mut app_shell {
-                                    let need_frame = need_frame.clone();
-                                    shell.set_frame_waker(move || {
-                                        need_frame.store(true, Ordering::Relaxed);
-                                    });
-                                }
-
-                                log::info!("App shell created");
-                            } else {
-                                // Window recreated - reinitialize GPU resources
-                                if let Some(shell) = &mut app_shell {
-                                    shell.renderer().init_gpu(
-                                        device.clone(),
-                                        queue.clone(),
-                                        surface_format,
-                                        adapter_info.backend,
-                                    );
-                                    shell.renderer().set_root_scale(density);
-                                    cranpose_ui::set_density(density);
-                                    log::info!("Renderer reinitialized with new GPU resources");
+                            android_platform.set_input_surface_offset_px(0.0, 0.0);
+                            if !overlay_window_requested {
+                                match android_overlay_window::show_android_overlay_window(
+                                    &app, options, density,
+                                ) {
+                                    Ok(()) => {
+                                        overlay_window_requested = true;
+                                        log::info!(
+                                            "Requested Android overlay surface {}x{} dp at ({}, {})",
+                                            options.width,
+                                            options.height,
+                                            options.x,
+                                            options.y
+                                        );
+                                    }
+                                    Err(error) => {
+                                        overlay_window_options = None;
+                                        log::warn!(
+                                            "Android overlay surface unavailable; waiting for activity surface fallback: {error}"
+                                        );
+                                    }
                                 }
                             }
+                        }
 
-                            // Set buffer_size and viewport
-                            if let Some(shell) = &mut app_shell {
-                                shell.set_buffer_size(width, height);
-                                if let Some(actual_size) =
-                                    update_android_shell_geometry(shell, density)
-                                {
+                        if overlay_window_options.is_none() {
+                            if let Some(native_window) = app.native_window() {
+                                let width = native_window.width() as u32;
+                                let height = native_window.height() as u32;
+                                let density =
+                                    update_android_platform_geometry(&app, &mut android_platform);
+                                let (input_offset_x, input_offset_y) =
+                                    android_platform.input_surface_offset_px();
+                                log::info!(
+                                    "Display density: {:.2}x, input surface offset: ({:.1}, {:.1}) px",
+                                    density,
+                                    input_offset_x,
+                                    input_offset_y
+                                );
+
+                                let (resources, actual_size) = initialize_android_rendering(
+                                    &instance,
+                                    &mut app_shell,
+                                    &content,
+                                    &settings,
+                                    &need_frame,
+                                    native_window.ptr().cast(),
+                                    None,
+                                    width,
+                                    height,
+                                    density,
+                                );
+                                if let Some(actual_size) = actual_size {
                                     current_host_window_size = actual_size;
                                 }
                                 let width_dp = current_host_window_size.width;
@@ -531,82 +617,80 @@ pub fn run(
                                     height,
                                     density
                                 );
-                            }
 
-                            if let Some(requested) = initial_host_window_size.take() {
-                                match dispatch_android_host_window_size_request(
-                                    &app, requested, density,
-                                ) {
-                                    Ok(()) => {
-                                        pending_host_window_confirmation =
-                                            Some(PendingHostWindowSizeRequest {
-                                                state: None,
-                                                requested,
-                                                requested_at: Instant::now(),
-                                            });
-                                        log::info!(
-                                            "Requested initial Android host-window size {:.1}x{:.1} dp",
-                                            requested.width,
-                                            requested.height
-                                        );
-                                    }
-                                    Err(error) => {
-                                        log::warn!(
-                                            "Initial Android host-window size request failed: {error}"
-                                        );
+                                if let Some(requested) = initial_host_window_size.take() {
+                                    match dispatch_android_surface_size_request(
+                                        &app, requested, density, None,
+                                    ) {
+                                        Ok(()) => {
+                                            pending_host_window_confirmation =
+                                                Some(PendingHostWindowSizeRequest {
+                                                    state: None,
+                                                    requested,
+                                                    requested_at: Instant::now(),
+                                                });
+                                            log::info!(
+                                                "Requested initial Android host-window size {:.1}x{:.1} dp",
+                                                requested.width,
+                                                requested.height
+                                            );
+                                        }
+                                        Err(error) => {
+                                            log::warn!(
+                                                "Initial Android host-window size request failed: {error}"
+                                            );
+                                        }
                                     }
                                 }
+
+                                gpu_resources = Some(resources);
+                                log::info!("Rendering initialized successfully");
                             }
-
-                            // Store GPU resources
-                            gpu_resources = Some(GpuResources {
-                                surface,
-                                device,
-                                config: surface_config,
-                            });
-
-                            log::info!("Rendering initialized successfully");
                         }
                     }
                     MainEvent::TerminateWindow { .. } => {
                         log::info!("Window terminated");
-                        gpu_resources = None;
+                        if overlay_window_options.is_none() {
+                            gpu_resources = None;
+                        }
                     }
                     MainEvent::WindowResized { .. } => {
-                        if let Some(native_window) = app.native_window() {
-                            let width = native_window.width() as u32;
-                            let height = native_window.height() as u32;
+                        if overlay_window_options.is_none() {
+                            if let Some(native_window) = app.native_window() {
+                                let width = native_window.width() as u32;
+                                let height = native_window.height() as u32;
 
-                            let density =
-                                update_android_platform_geometry(&app, &mut android_platform);
-                            let (input_offset_x, input_offset_y) =
-                                android_platform.input_surface_offset_px();
-                            log::info!(
-                                "Window resized to {}x{} at {:.2}x density with input surface offset ({:.1}, {:.1}) px",
-                                width,
-                                height,
-                                density,
-                                input_offset_x,
-                                input_offset_y
-                            );
+                                let density =
+                                    update_android_platform_geometry(&app, &mut android_platform);
+                                let (input_offset_x, input_offset_y) =
+                                    android_platform.input_surface_offset_px();
+                                log::info!(
+                                    "Window resized to {}x{} at {:.2}x density with input surface offset ({:.1}, {:.1}) px",
+                                    width,
+                                    height,
+                                    density,
+                                    input_offset_x,
+                                    input_offset_y
+                                );
 
-                            if let (Some(resources), Some(shell)) =
-                                (&mut gpu_resources, &mut app_shell)
-                            {
-                                if width > 0 && height > 0 {
-                                    resources.config.width = width;
-                                    resources.config.height = height;
-                                    resources
-                                        .surface
-                                        .configure(&resources.device, &resources.config);
+                                if let (Some(resources), Some(shell)) =
+                                    (&mut gpu_resources, &mut app_shell)
+                                {
+                                    if width > 0 && height > 0 {
+                                        resources.config.width = width;
+                                        resources.config.height = height;
+                                        resources
+                                            .surface
+                                            .configure(&resources.device, &resources.config);
 
-                                    // Set buffer_size to physical pixels
-                                    shell.set_buffer_size(width, height);
+                                        // Set buffer_size to physical pixels
+                                        shell.set_buffer_size(width, height);
 
-                                    if let Some(actual_size) =
-                                        update_android_shell_geometry(shell, density)
-                                    {
-                                        current_host_window_size = actual_size;
+                                        if let Some(actual_size) =
+                                            update_android_shell_geometry(shell, density)
+                                        {
+                                            current_host_window_size = actual_size;
+                                        }
                                     }
                                 }
                             }
@@ -614,6 +698,9 @@ pub fn run(
                     }
                     MainEvent::ContentRectChanged { .. } => {
                         let density = update_android_platform_geometry(&app, &mut android_platform);
+                        if overlay_window_options.is_some() {
+                            android_platform.set_input_surface_offset_px(0.0, 0.0);
+                        }
                         let (input_offset_x, input_offset_y) =
                             android_platform.input_surface_offset_px();
                         log::info!(
@@ -652,6 +739,9 @@ pub fn run(
                     }
                     MainEvent::Destroy => {
                         log::info!("App destroy requested, will exit after this event");
+                        if overlay_window_options.is_some() {
+                            android_overlay_window::hide_android_overlay_window(&app);
+                        }
                         should_exit.store(true, Ordering::Relaxed);
                     }
                     _ => {}
@@ -735,6 +825,103 @@ pub fn run(
             }
         });
 
+        for event in android_overlay_window::drain_android_overlay_window_events() {
+            match event {
+                android_overlay_window::AndroidOverlayWindowEvent::CreateFailed(message) => {
+                    log::warn!("Android overlay surface failed: {message}");
+                    overlay_window_options = None;
+
+                    if let Some(native_window) = app.native_window() {
+                        let width = native_window.width() as u32;
+                        let height = native_window.height() as u32;
+                        if width > 0 && height > 0 {
+                            let density =
+                                update_android_platform_geometry(&app, &mut android_platform);
+                            let (resources, actual_size) = initialize_android_rendering(
+                                &instance,
+                                &mut app_shell,
+                                &content,
+                                &settings,
+                                &need_frame,
+                                native_window.ptr().cast(),
+                                None,
+                                width,
+                                height,
+                                density,
+                            );
+                            if let Some(actual_size) = actual_size {
+                                current_host_window_size = actual_size;
+                            }
+                            gpu_resources = Some(resources);
+                        }
+                    }
+                }
+                android_overlay_window::AndroidOverlayWindowEvent::SurfaceChanged {
+                    native_window,
+                    width,
+                    height,
+                } => {
+                    if width > 0 && height > 0 {
+                        let density = get_display_density(&app);
+                        android_platform.set_scale_factor(density as f64);
+                        android_platform.set_input_surface_offset_px(0.0, 0.0);
+                        cranpose_ui::set_density(density);
+
+                        let native_window_ptr = native_window.ptr().cast();
+                        let (resources, actual_size) = initialize_android_rendering(
+                            &instance,
+                            &mut app_shell,
+                            &content,
+                            &settings,
+                            &need_frame,
+                            native_window_ptr,
+                            Some(native_window),
+                            width,
+                            height,
+                            density,
+                        );
+                        if let Some(actual_size) = actual_size {
+                            current_host_window_size = actual_size;
+                        }
+                        gpu_resources = Some(resources);
+                        log::info!(
+                            "Android overlay surface ready at {}x{} px ({:.2}x density)",
+                            width,
+                            height,
+                            density
+                        );
+                    }
+                }
+                android_overlay_window::AndroidOverlayWindowEvent::SurfaceDestroyed => {
+                    if overlay_window_options.is_some() {
+                        gpu_resources = None;
+                    }
+                }
+                android_overlay_window::AndroidOverlayWindowEvent::Pointer { action, x, y } => {
+                    let logical = android_platform.pointer_position(x as f64, y as f64);
+                    match action {
+                        android_overlay_window::AndroidOverlayPointerAction::Down => {
+                            pending_inputs.push(PendingInput::PointerDown(
+                                logical.x as f32,
+                                logical.y as f32,
+                            ));
+                        }
+                        android_overlay_window::AndroidOverlayPointerAction::Up
+                        | android_overlay_window::AndroidOverlayPointerAction::Cancel => {
+                            pending_inputs
+                                .push(PendingInput::PointerUp(logical.x as f32, logical.y as f32));
+                        }
+                        android_overlay_window::AndroidOverlayPointerAction::Move => {
+                            pending_inputs.push(PendingInput::PointerMove(
+                                logical.x as f32,
+                                logical.y as f32,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
         // Process pending input events outside poll_events to prevent ANR
         if !pending_inputs.is_empty() {
             if let Some(shell) = &mut app_shell {
@@ -778,9 +965,10 @@ pub fn run(
         if let (Some(resources), Some(shell)) = (&mut gpu_resources, &mut app_shell) {
             if shell.needs_redraw() {
                 shell.update();
-                dispatch_registered_android_host_window_request(
+                dispatch_registered_android_surface_size_request(
                     &app,
                     android_platform.scale_factor(),
+                    overlay_window_options,
                     &mut last_dispatched_host_window_request,
                     &mut pending_host_window_confirmation,
                 );

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -26,10 +26,15 @@ use std::{
     },
 };
 
-/// GPU resources for the surface (recreated when window is destroyed/created).
+/// GPU resources for the current Android surface and its reusable WGPU device.
 struct GpuResources {
     surface: wgpu::Surface<'static>,
+    native_window_ptr: NonNull<c_void>,
+    adapter: Arc<wgpu::Adapter>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    surface_format: wgpu::TextureFormat,
+    backend: wgpu::Backend,
     config: wgpu::SurfaceConfiguration,
     _native_window: Option<NativeWindow>,
 }
@@ -143,13 +148,12 @@ fn render_once(resources: &mut GpuResources, shell: &mut AppShell<WgpuRenderer>)
 
 struct AndroidGpuSetup {
     resources: GpuResources,
-    queue: Arc<wgpu::Queue>,
-    surface_format: wgpu::TextureFormat,
-    backend: wgpu::Backend,
+    renderer_needs_init: bool,
 }
 
 fn initialize_android_rendering<F>(
     instance: &wgpu::Instance,
+    existing_resources: Option<GpuResources>,
     app_shell: &mut Option<AppShell<WgpuRenderer>>,
     content: &Rc<RefCell<F>>,
     settings: &AppSettings,
@@ -165,6 +169,7 @@ where
 {
     let setup = create_android_gpu_resources(
         instance,
+        existing_resources,
         native_window_ptr,
         native_window_owner,
         width,
@@ -176,11 +181,10 @@ where
         let mut renderer = WgpuRenderer::new(fonts);
         renderer.init_gpu(
             setup.resources.device.clone(),
-            setup.queue.clone(),
-            setup.surface_format,
-            setup.backend,
+            setup.resources.queue.clone(),
+            setup.resources.surface_format,
+            setup.resources.backend,
         );
-        renderer.set_root_scale(density);
 
         let content_clone = content.clone();
         let shell = AppShell::new(renderer, default_root_key(), move || {
@@ -197,17 +201,24 @@ where
         }
 
         log::info!("App shell created");
-    } else if let Some(shell) = app_shell {
-        shell.renderer().init_gpu(
-            setup.resources.device.clone(),
-            setup.queue.clone(),
-            setup.surface_format,
-            setup.backend,
-        );
-        shell.renderer().set_root_scale(density);
-        cranpose_ui::set_density(density);
-        log::info!("Renderer reinitialized with new GPU resources");
+    } else if setup.renderer_needs_init {
+        if let Some(shell) = app_shell {
+            shell.renderer().init_gpu(
+                setup.resources.device.clone(),
+                setup.resources.queue.clone(),
+                setup.resources.surface_format,
+                setup.resources.backend,
+            );
+            log::info!("Renderer reinitialized with new Android GPU pipeline resources");
+        }
+    } else {
+        log::debug!("Reused Android WGPU device and renderer resources for surface update");
     }
+
+    if let Some(shell) = app_shell {
+        shell.renderer().set_root_scale(density);
+    }
+    cranpose_ui::set_density(density);
 
     let actual_size = app_shell.as_mut().and_then(|shell| {
         shell.set_buffer_size(width, height);
@@ -219,11 +230,38 @@ where
 
 fn create_android_gpu_resources(
     instance: &wgpu::Instance,
+    existing_resources: Option<GpuResources>,
     native_window_ptr: NonNull<c_void>,
     native_window_owner: Option<NativeWindow>,
     width: u32,
     height: u32,
 ) -> AndroidGpuSetup {
+    if let Some(mut resources) = existing_resources {
+        if resources.native_window_ptr == native_window_ptr {
+            resources.config.width = width;
+            resources.config.height = height;
+            resources
+                .surface
+                .configure(&resources.device, &resources.config);
+            if let Some(native_window_owner) = native_window_owner {
+                resources._native_window = Some(native_window_owner);
+            }
+            return AndroidGpuSetup {
+                resources,
+                renderer_needs_init: false,
+            };
+        }
+
+        return create_android_gpu_resources_for_existing_device(
+            instance,
+            &resources,
+            native_window_ptr,
+            native_window_owner,
+            width,
+            height,
+        );
+    }
+
     let surface = create_android_wgpu_surface(instance, native_window_ptr);
 
     let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
@@ -235,6 +273,7 @@ fn create_android_gpu_resources(
 
     let adapter_info = adapter.get_info();
     log::info!("Found adapter: {:?}", adapter_info.backend);
+    let adapter = Arc::new(adapter);
 
     let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
         label: Some("Android Device"),
@@ -248,7 +287,60 @@ fn create_android_gpu_resources(
 
     let device = Arc::new(device);
     let queue = Arc::new(queue);
+    let config = create_android_surface_config(&surface, &adapter, width, height);
+    surface.configure(&device, &config);
 
+    AndroidGpuSetup {
+        resources: GpuResources {
+            surface,
+            native_window_ptr,
+            adapter,
+            device,
+            queue,
+            surface_format: config.format,
+            backend: adapter_info.backend,
+            config,
+            _native_window: native_window_owner,
+        },
+        renderer_needs_init: true,
+    }
+}
+
+fn create_android_gpu_resources_for_existing_device(
+    instance: &wgpu::Instance,
+    existing: &GpuResources,
+    native_window_ptr: NonNull<c_void>,
+    native_window_owner: Option<NativeWindow>,
+    width: u32,
+    height: u32,
+) -> AndroidGpuSetup {
+    let surface = create_android_wgpu_surface(instance, native_window_ptr);
+    let config = create_android_surface_config(&surface, &existing.adapter, width, height);
+    surface.configure(&existing.device, &config);
+    let renderer_needs_init = config.format != existing.surface_format;
+
+    AndroidGpuSetup {
+        resources: GpuResources {
+            surface,
+            native_window_ptr,
+            adapter: existing.adapter.clone(),
+            device: existing.device.clone(),
+            queue: existing.queue.clone(),
+            surface_format: config.format,
+            backend: existing.backend,
+            config,
+            _native_window: native_window_owner,
+        },
+        renderer_needs_init,
+    }
+}
+
+fn create_android_surface_config(
+    surface: &wgpu::Surface<'static>,
+    adapter: &wgpu::Adapter,
+    width: u32,
+    height: u32,
+) -> wgpu::SurfaceConfiguration {
     let surface_caps = surface.get_capabilities(&adapter);
     let surface_format = surface_caps
         .formats
@@ -257,7 +349,7 @@ fn create_android_gpu_resources(
         .find(|f| f.is_srgb())
         .unwrap_or(surface_caps.formats[0]);
     let present_mode = crate::present_mode::select_present_mode(&surface_caps);
-    let config = wgpu::SurfaceConfiguration {
+    wgpu::SurfaceConfiguration {
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         format: surface_format,
         width,
@@ -266,20 +358,6 @@ fn create_android_gpu_resources(
         alpha_mode: surface_caps.alpha_modes[0],
         view_formats: vec![],
         desired_maximum_frame_latency: 2,
-    };
-
-    surface.configure(&device, &config);
-
-    AndroidGpuSetup {
-        resources: GpuResources {
-            surface,
-            device,
-            config,
-            _native_window: native_window_owner,
-        },
-        queue,
-        surface_format,
-        backend: adapter_info.backend,
     }
 }
 
@@ -594,6 +672,7 @@ pub fn run(
 
                                 let (resources, actual_size) = initialize_android_rendering(
                                     &instance,
+                                    gpu_resources.take(),
                                     &mut app_shell,
                                     &content,
                                     &settings,
@@ -839,6 +918,7 @@ pub fn run(
                                 update_android_platform_geometry(&app, &mut android_platform);
                             let (resources, actual_size) = initialize_android_rendering(
                                 &instance,
+                                gpu_resources.take(),
                                 &mut app_shell,
                                 &content,
                                 &settings,
@@ -870,6 +950,7 @@ pub fn run(
                         let native_window_ptr = native_window.ptr().cast();
                         let (resources, actual_size) = initialize_android_rendering(
                             &instance,
+                            gpu_resources.take(),
                             &mut app_shell,
                             &content,
                             &settings,

--- a/crates/cranpose/src/android_host_window.rs
+++ b/crates/cranpose/src/android_host_window.rs
@@ -189,8 +189,9 @@ impl AndroidHostWindowState {
 /// usually keep the system-managed bounds and report
 /// [`AndroidHostWindowSizeStatus::Unsupported`].
 ///
-/// Overlay windows are a separate Android surface and permission model; this
-/// state targets only the current `NativeActivity` host window.
+/// In normal Android activity mode this state targets the current
+/// `NativeActivity` host window. In Android overlay mode it resizes the active
+/// overlay surface through `WindowManager.updateViewLayout`.
 #[allow(non_snake_case)]
 #[composable]
 pub fn rememberAndroidHostWindowState(width: f32, height: f32) -> AndroidHostWindowState {

--- a/crates/cranpose/src/android_jni.rs
+++ b/crates/cranpose/src/android_jni.rs
@@ -1,0 +1,30 @@
+//! Shared Android JNI helpers.
+
+use jni::{objects::JObject, JNIEnv, JavaVM};
+
+pub(crate) fn with_android_activity_env<T, F>(
+    app: &android_activity::AndroidApp,
+    f: F,
+) -> Result<T, String>
+where
+    F: for<'local> FnOnce(&mut JNIEnv<'local>, JObject<'local>) -> Result<T, String>,
+{
+    // SAFETY: android-activity owns a valid JavaVM pointer for the lifetime of AndroidApp.
+    let vm = unsafe { JavaVM::from_raw(app.vm_as_ptr().cast()) }
+        .map_err(|error| format!("failed to access Android Java VM: {error}"))?;
+    let mut env = vm
+        .attach_current_thread()
+        .map_err(|error| format!("failed to attach Android JNI thread: {error}"))?;
+
+    // SAFETY: activity_as_ptr returns a JNI global Activity reference owned by android-activity.
+    // JObject does not delete this reference on drop; it is used only for this JNI call chain.
+    let activity = unsafe { JObject::from_raw(app.activity_as_ptr().cast()) };
+    f(&mut env, activity)
+}
+
+pub(crate) fn clear_pending_android_jni_exception(env: &mut JNIEnv<'_>) {
+    if matches!(env.exception_check(), Ok(true)) {
+        let _ = env.exception_describe();
+        let _ = env.exception_clear();
+    }
+}

--- a/crates/cranpose/src/android_overlay_window.rs
+++ b/crates/cranpose/src/android_overlay_window.rs
@@ -1,0 +1,389 @@
+//! Android floating overlay window bridge.
+
+use crate::{
+    android_host_window,
+    android_jni::{clear_pending_android_jni_exception, with_android_activity_env},
+    launcher::AndroidOverlayWindowOptions,
+};
+use cranpose_ui::Size;
+use jni::{
+    objects::{JClass, JObject, JString, JValue},
+    sys::{jfloat, jint},
+    JNIEnv,
+};
+use ndk::native_window::NativeWindow;
+use std::{
+    collections::VecDeque,
+    sync::{Mutex, OnceLock},
+};
+
+const OVERLAY_CLASS: &str = "dev/cranpose/android/CranposeOverlayWindow";
+const RESULT_OK: i32 = 0;
+const RESULT_ALREADY_VISIBLE: i32 = -4;
+const RESULT_NOT_VISIBLE: i32 = -6;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct AndroidOverlayWindowBounds {
+    width_px: i32,
+    height_px: i32,
+    x_px: i32,
+    y_px: i32,
+}
+
+#[derive(Debug)]
+pub(crate) enum AndroidOverlayWindowEvent {
+    CreateFailed(String),
+    SurfaceChanged {
+        native_window: NativeWindow,
+        width: u32,
+        height: u32,
+    },
+    SurfaceDestroyed,
+    Pointer {
+        action: AndroidOverlayPointerAction,
+        x: f32,
+        y: f32,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AndroidOverlayPointerAction {
+    Down,
+    Up,
+    Move,
+    Cancel,
+}
+
+pub(crate) fn show_android_overlay_window(
+    app: &android_activity::AndroidApp,
+    options: AndroidOverlayWindowOptions,
+    density: f32,
+) -> Result<(), String> {
+    let bounds = overlay_options_to_physical_bounds(options, density)?;
+
+    with_android_activity_env(app, |env, activity| {
+        let class = find_overlay_class(env, &activity)?;
+        let result = env
+            .call_static_method(
+                class,
+                "show",
+                "(Landroid/app/Activity;IIIIZ)I",
+                &[
+                    JValue::Object(&activity),
+                    JValue::Int(bounds.width_px),
+                    JValue::Int(bounds.height_px),
+                    JValue::Int(bounds.x_px),
+                    JValue::Int(bounds.y_px),
+                    JValue::Bool(u8::from(options.focusable)),
+                ],
+            )
+            .and_then(|value| value.i())
+            .map_err(|error| {
+                clear_pending_android_jni_exception(env);
+                format!("failed to show Android overlay window: {error}")
+            })?;
+
+        match result {
+            RESULT_OK | RESULT_ALREADY_VISIBLE => Ok(()),
+            code => Err(format_android_overlay_result(code)),
+        }
+    })
+}
+
+pub(crate) fn update_android_overlay_window_bounds(
+    app: &android_activity::AndroidApp,
+    options: AndroidOverlayWindowOptions,
+    size: Size,
+    density: f32,
+) -> Result<(), String> {
+    let bounds = overlay_size_to_physical_bounds(options, size, density)?;
+
+    with_android_activity_env(app, |env, activity| {
+        let class = find_overlay_class(env, &activity)?;
+        let result = env
+            .call_static_method(
+                class,
+                "updateBounds",
+                "(Landroid/app/Activity;IIII)I",
+                &[
+                    JValue::Object(&activity),
+                    JValue::Int(bounds.width_px),
+                    JValue::Int(bounds.height_px),
+                    JValue::Int(bounds.x_px),
+                    JValue::Int(bounds.y_px),
+                ],
+            )
+            .and_then(|value| value.i())
+            .map_err(|error| {
+                clear_pending_android_jni_exception(env);
+                format!("failed to update Android overlay window bounds: {error}")
+            })?;
+
+        match result {
+            RESULT_OK => Ok(()),
+            code => Err(format_android_overlay_result(code)),
+        }
+    })
+}
+
+pub(crate) fn hide_android_overlay_window(app: &android_activity::AndroidApp) {
+    let _ = with_android_activity_env(app, |env, activity| {
+        let class = find_overlay_class(env, &activity)?;
+        env.call_static_method(
+            class,
+            "hide",
+            "(Landroid/app/Activity;)V",
+            &[JValue::Object(&activity)],
+        )
+        .map_err(|error| {
+            clear_pending_android_jni_exception(env);
+            format!("failed to hide Android overlay window: {error}")
+        })?;
+        Ok(())
+    });
+}
+
+pub(crate) fn drain_android_overlay_window_events() -> Vec<AndroidOverlayWindowEvent> {
+    let mut events = overlay_events()
+        .lock()
+        .expect("overlay event queue poisoned");
+    events.drain(..).collect()
+}
+
+fn find_overlay_class<'local>(
+    env: &mut JNIEnv<'local>,
+    activity: &JObject<'local>,
+) -> Result<JClass<'local>, String> {
+    let class_name = env
+        .new_string(OVERLAY_CLASS.replace('/', "."))
+        .map_err(|error| format!("failed to create Android overlay helper class name: {error}"))?;
+    let class_name = JObject::from(class_name);
+
+    let class = env
+        .call_method(activity, "getClass", "()Ljava/lang/Class;", &[])
+        .and_then(|value| value.l())
+        .and_then(|class| {
+            env.call_method(
+                &class,
+                "getClassLoader",
+                "()Ljava/lang/ClassLoader;",
+                &[],
+            )
+            .and_then(|value| value.l())
+        })
+        .and_then(|class_loader| {
+            env.call_method(
+                &class_loader,
+                "loadClass",
+                "(Ljava/lang/String;)Ljava/lang/Class;",
+                &[JValue::Object(&class_name)],
+            )
+            .and_then(|value| value.l())
+        })
+        .map_err(|error| {
+            clear_pending_android_jni_exception(env);
+            format!(
+                "failed to load Android overlay helper class {}; include cranpose/android/java in the Android source set: {error}",
+                OVERLAY_CLASS
+            )
+        })?;
+
+    Ok(JClass::from(class))
+}
+
+fn overlay_options_to_physical_bounds(
+    options: AndroidOverlayWindowOptions,
+    density: f32,
+) -> Result<AndroidOverlayWindowBounds, String> {
+    if !options.is_valid() {
+        return Err("Android overlay window dimensions must be greater than zero".to_string());
+    }
+    overlay_size_to_physical_bounds(
+        options,
+        Size::new(options.width as f32, options.height as f32),
+        density,
+    )
+}
+
+fn overlay_size_to_physical_bounds(
+    options: AndroidOverlayWindowOptions,
+    size: Size,
+    density: f32,
+) -> Result<AndroidOverlayWindowBounds, String> {
+    let size =
+        android_host_window::validate_logical_size(size).map_err(|error| error.to_string())?;
+    Ok(AndroidOverlayWindowBounds {
+        width_px: logical_dimension_to_physical_px(size.width, density)?,
+        height_px: logical_dimension_to_physical_px(size.height, density)?,
+        x_px: logical_to_physical_px(options.x as f32, density)?,
+        y_px: logical_to_physical_px(options.y as f32, density)?,
+    })
+}
+
+fn logical_dimension_to_physical_px(value: f32, density: f32) -> Result<i32, String> {
+    Ok(logical_to_physical_px(value, density)?.max(1))
+}
+
+fn logical_to_physical_px(value: f32, density: f32) -> Result<i32, String> {
+    if !value.is_finite() {
+        return Err("Android overlay dimensions and coordinates must be finite".to_string());
+    }
+    if !density.is_finite() || density <= 0.0 {
+        return Err("Android display density must be positive and finite".to_string());
+    }
+    let rounded = (value * density).round();
+    if rounded < i32::MIN as f32 || rounded > i32::MAX as f32 {
+        return Err("Android overlay physical coordinate is outside i32 range".to_string());
+    }
+    Ok(rounded as i32)
+}
+
+fn format_android_overlay_result(code: i32) -> String {
+    match code {
+        -1 => "Android overlay windows require Android 8.0/API 26 or newer".to_string(),
+        -2 => {
+            "Android overlay window requires android.permission.SYSTEM_ALERT_WINDOW in the manifest"
+                .to_string()
+        }
+        -3 => "Android overlay window permission is not granted by the user".to_string(),
+        -5 => "Android overlay window creation failed on the Java UI thread".to_string(),
+        RESULT_NOT_VISIBLE => "Android overlay window is not visible".to_string(),
+        _ => format!("Android overlay window helper returned error code {code}"),
+    }
+}
+
+fn push_overlay_event(event: AndroidOverlayWindowEvent) {
+    overlay_events()
+        .lock()
+        .expect("overlay event queue poisoned")
+        .push_back(event);
+}
+
+fn overlay_events() -> &'static Mutex<VecDeque<AndroidOverlayWindowEvent>> {
+    static EVENTS: OnceLock<Mutex<VecDeque<AndroidOverlayWindowEvent>>> = OnceLock::new();
+    EVENTS.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+fn native_window_from_surface(
+    env: &mut JNIEnv<'_>,
+    surface: JObject<'_>,
+) -> Result<NativeWindow, String> {
+    // SAFETY: The callback is invoked by the Java helper with the current JNI
+    // environment and a live android.view.Surface from SurfaceHolder.
+    unsafe { NativeWindow::from_surface(env.get_native_interface(), surface.as_raw()) }.ok_or_else(
+        || {
+            clear_pending_android_jni_exception(env);
+            "Android overlay Surface did not provide an ANativeWindow".to_string()
+        },
+    )
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeOverlayWindow_nativeOverlayCreateFailed(
+    mut env: JNIEnv<'_>,
+    _class: JClass<'_>,
+    message: JString<'_>,
+) {
+    let message = env
+        .get_string(&message)
+        .map(|value| value.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| "Android overlay window creation failed".to_string());
+    push_overlay_event(AndroidOverlayWindowEvent::CreateFailed(message));
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeOverlayWindow_nativeOverlaySurfaceChanged(
+    mut env: JNIEnv<'_>,
+    _class: JClass<'_>,
+    surface: JObject<'_>,
+    width: jint,
+    height: jint,
+) {
+    match native_window_from_surface(&mut env, surface) {
+        Ok(native_window) if width > 0 && height > 0 => {
+            push_overlay_event(AndroidOverlayWindowEvent::SurfaceChanged {
+                native_window,
+                width: width as u32,
+                height: height as u32,
+            });
+        }
+        Ok(_) => {}
+        Err(message) => push_overlay_event(AndroidOverlayWindowEvent::CreateFailed(message)),
+    }
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeOverlayWindow_nativeOverlaySurfaceDestroyed(
+    _env: JNIEnv<'_>,
+    _class: JClass<'_>,
+) {
+    push_overlay_event(AndroidOverlayWindowEvent::SurfaceDestroyed);
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeOverlayWindow_nativeOverlayPointer(
+    _env: JNIEnv<'_>,
+    _class: JClass<'_>,
+    action: jint,
+    x: jfloat,
+    y: jfloat,
+) {
+    let action = match action {
+        0 | 5 => AndroidOverlayPointerAction::Down,
+        1 | 6 => AndroidOverlayPointerAction::Up,
+        2 => AndroidOverlayPointerAction::Move,
+        3 => AndroidOverlayPointerAction::Cancel,
+        _ => return,
+    };
+    push_overlay_event(AndroidOverlayWindowEvent::Pointer { action, x, y });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logical_to_physical_rounds_by_density() {
+        assert_eq!(logical_to_physical_px(10.4, 2.0), Ok(21));
+        assert_eq!(logical_to_physical_px(-3.0, 3.0), Ok(-9));
+    }
+
+    #[test]
+    fn logical_to_physical_rejects_non_finite() {
+        assert!(logical_to_physical_px(f32::NAN, 2.0).is_err());
+        assert!(logical_to_physical_px(12.0, f32::INFINITY).is_err());
+        assert!(logical_to_physical_px(12.0, 0.0).is_err());
+    }
+
+    #[test]
+    fn logical_dimension_to_physical_clamps_to_visible_pixel() {
+        assert_eq!(logical_dimension_to_physical_px(0.1, 1.0), Ok(1));
+    }
+
+    #[test]
+    fn overlay_options_validate_positive_size() {
+        assert!(AndroidOverlayWindowOptions::new(100, 50).is_valid());
+        assert!(!AndroidOverlayWindowOptions::new(0, 50).is_valid());
+        assert!(!AndroidOverlayWindowOptions::new(100, 0).is_valid());
+    }
+
+    #[test]
+    fn overlay_size_to_physical_bounds_uses_requested_size_and_initial_position() {
+        let options = AndroidOverlayWindowOptions::new(100, 50).with_position(-4, 8);
+        let bounds = overlay_size_to_physical_bounds(options, Size::new(200.0, 80.0), 2.0).unwrap();
+
+        assert_eq!(
+            bounds,
+            AndroidOverlayWindowBounds {
+                width_px: 400,
+                height_px: 160,
+                x_px: -8,
+                y_px: 16,
+            }
+        );
+    }
+}

--- a/crates/cranpose/src/android_overlay_window.rs
+++ b/crates/cranpose/src/android_overlay_window.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use cranpose_ui::Size;
 use jni::{
-    objects::{JClass, JObject, JString, JValue},
+    objects::{GlobalRef, JClass, JObject, JString, JValue},
     sys::{jfloat, jint},
     JNIEnv,
 };
@@ -153,10 +153,35 @@ pub(crate) fn drain_android_overlay_window_events() -> Vec<AndroidOverlayWindowE
 fn find_overlay_class<'local>(
     env: &mut JNIEnv<'local>,
     activity: &JObject<'local>,
+) -> Result<&'static GlobalRef, String> {
+    static OVERLAY_CLASS_REF: OnceLock<GlobalRef> = OnceLock::new();
+
+    if let Some(class) = OVERLAY_CLASS_REF.get() {
+        return Ok(class);
+    }
+
+    let class = load_overlay_class(env, activity)?;
+    let global_class = env.new_global_ref(class).map_err(|error| {
+        clear_pending_android_jni_exception(env);
+        format!("failed to cache Android overlay helper class: {error}")
+    })?;
+
+    let _ = OVERLAY_CLASS_REF.set(global_class);
+    OVERLAY_CLASS_REF.get().ok_or_else(|| {
+        "failed to cache Android overlay helper class in process-global storage".to_string()
+    })
+}
+
+fn load_overlay_class<'local>(
+    env: &mut JNIEnv<'local>,
+    activity: &JObject<'local>,
 ) -> Result<JClass<'local>, String> {
     let class_name = env
         .new_string(OVERLAY_CLASS.replace('/', "."))
-        .map_err(|error| format!("failed to create Android overlay helper class name: {error}"))?;
+        .map_err(|error| {
+            clear_pending_android_jni_exception(env);
+            format!("failed to create Android overlay helper class name: {error}")
+        })?;
     let class_name = JObject::from(class_name);
 
     let class = env

--- a/crates/cranpose/src/launcher.rs
+++ b/crates/cranpose/src/launcher.rs
@@ -24,6 +24,8 @@ pub struct AppSettings {
     pub fonts: Option<&'static [&'static [u8]]>,
     /// Whether to load system fonts on Android (default: false)
     pub android_use_system_fonts: bool,
+    /// Optional Android overlay surface configuration.
+    pub android_overlay_window: Option<AndroidOverlayWindowOptions>,
     /// Run in headless mode (window hidden, for robot testing)
     ///
     /// When enabled, the window is created but not shown. This allows
@@ -61,6 +63,7 @@ impl Default for AppSettings {
             initial_size_explicit: false,
             fonts: None,
             android_use_system_fonts: false,
+            android_overlay_window: None,
             headless: false,
             primary_window_visible: true,
             #[cfg(all(feature = "desktop", feature = "renderer-wgpu"))]
@@ -74,6 +77,52 @@ impl Default for AppSettings {
             #[cfg(all(feature = "desktop", feature = "renderer-wgpu"))]
             record_to: None,
         }
+    }
+}
+
+/// Android floating overlay window configuration.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AndroidOverlayWindowOptions {
+    /// Requested overlay width in logical pixels.
+    pub width: u32,
+    /// Requested overlay height in logical pixels.
+    pub height: u32,
+    /// Requested screen X position in logical pixels.
+    pub x: i32,
+    /// Requested screen Y position in logical pixels.
+    pub y: i32,
+    /// Whether the overlay can receive keyboard focus.
+    pub focusable: bool,
+}
+
+impl AndroidOverlayWindowOptions {
+    /// Creates an overlay window request with top-left origin and touch-only focus behavior.
+    pub fn new(width: u32, height: u32) -> Self {
+        Self {
+            width,
+            height,
+            x: 0,
+            y: 0,
+            focusable: false,
+        }
+    }
+
+    /// Sets the initial overlay position in logical pixels.
+    pub fn with_position(mut self, x: i32, y: i32) -> Self {
+        self.x = x;
+        self.y = y;
+        self
+    }
+
+    /// Sets whether the overlay should receive keyboard focus.
+    pub fn with_focusable(mut self, focusable: bool) -> Self {
+        self.focusable = focusable;
+        self
+    }
+
+    /// Returns whether this request can create a non-empty overlay surface.
+    pub fn is_valid(self) -> bool {
+        self.width > 0 && self.height > 0
     }
 }
 
@@ -224,6 +273,17 @@ impl AppLauncher {
     /// Use static fonts via `with_fonts()` for reliable rendering.
     pub fn with_android_use_system_fonts(mut self, use_system_fonts: bool) -> Self {
         self.settings.android_use_system_fonts = use_system_fonts;
+        self
+    }
+
+    /// Render the Android root into a floating `TYPE_APPLICATION_OVERLAY` surface.
+    ///
+    /// This Android-only mode requires the host app to declare
+    /// `android.permission.SYSTEM_ALERT_WINDOW`, include Cranpose's Android Java
+    /// helper sources, and obtain overlay permission before launch. Other
+    /// platforms ignore this setting and keep their normal primary surface.
+    pub fn with_android_overlay_window(mut self, options: AndroidOverlayWindowOptions) -> Self {
+        self.settings.android_overlay_window = Some(options);
         self
     }
 
@@ -524,5 +584,39 @@ impl AppLauncher {
 impl Default for AppLauncher {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn android_overlay_options_default_to_touch_only_top_left_window() {
+        let options = AndroidOverlayWindowOptions::new(320, 180);
+
+        assert_eq!(options.width, 320);
+        assert_eq!(options.height, 180);
+        assert_eq!(options.x, 0);
+        assert_eq!(options.y, 0);
+        assert!(!options.focusable);
+        assert!(options.is_valid());
+    }
+
+    #[test]
+    fn android_overlay_options_apply_position_and_focus() {
+        let options = AndroidOverlayWindowOptions::new(320, 180)
+            .with_position(12, 34)
+            .with_focusable(true);
+
+        assert_eq!(options.x, 12);
+        assert_eq!(options.y, 34);
+        assert!(options.focusable);
+    }
+
+    #[test]
+    fn android_overlay_options_reject_zero_size() {
+        assert!(!AndroidOverlayWindowOptions::new(0, 180).is_valid());
+        assert!(!AndroidOverlayWindowOptions::new(320, 0).is_valid());
     }
 }

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -17,6 +17,10 @@ compile_error!("cranpose requires either `renderer-pixels` or `renderer-wgpu` fe
 
 #[cfg_attr(not(all(feature = "android", target_os = "android")), allow(dead_code))]
 mod android_host_window;
+#[cfg(all(feature = "android", target_os = "android"))]
+mod android_jni;
+#[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
+mod android_overlay_window;
 mod launcher;
 mod native_window;
 #[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
@@ -26,7 +30,7 @@ pub use android_host_window::{
 };
 #[cfg(all(feature = "desktop", feature = "renderer-wgpu"))]
 pub use launcher::LaunchError;
-pub use launcher::{AppLauncher, AppSettings};
+pub use launcher::{AndroidOverlayWindowOptions, AppLauncher, AppSettings};
 pub use native_window::{
     current_native_window_surface_origin, rememberWindowState, Window, WindowAttachPolicy,
     WindowConfig, WindowGroup, WindowId, WindowModifierExt, WindowMoveMode, WindowNode,
@@ -61,9 +65,9 @@ pub mod prelude {
         AndroidHostWindowState,
     };
     pub use crate::{
-        rememberWindowState, AppLauncher, AppSettings, Window, WindowAttachPolicy, WindowConfig,
-        WindowGroup, WindowId, WindowModifierExt, WindowMoveMode, WindowNode,
-        WindowResizeDirection, WindowState,
+        rememberWindowState, AndroidOverlayWindowOptions, AppLauncher, AppSettings, Window,
+        WindowAttachPolicy, WindowConfig, WindowGroup, WindowId, WindowModifierExt, WindowMoveMode,
+        WindowNode, WindowResizeDirection, WindowState,
     };
     pub use cranpose_core::{mutableStateOf, remember, rememberUpdatedState, useState};
     pub use cranpose_services::*;


### PR DESCRIPTION
## Summary

- Add an Android overlay backend that renders Cranpose into a `TYPE_APPLICATION_OVERLAY` `SurfaceView` via a packaged Java helper.
- Bridge overlay `Surface` lifecycle events into Rust, keep the `ANativeWindow` alive while WGPU owns the surface, and route overlay pointer events through the normal Cranpose input path.
- Reuse `rememberAndroidHostWindowState` for runtime overlay resizing through `WindowManager.updateViewLayout`, and document permission, API-level, fallback, and Play policy constraints.
- Wire the Android demo to package the helper Java source and declare `SYSTEM_ALERT_WINDOW`.

Closes #232.

## Validation

- `cargo fmt`
- `env CARGO_BUILD_JOBS=1 cargo test > 1.tmp 2>&1`
- `env CARGO_BUILD_JOBS=1 cargo clippy > 2.tmp 2>&1`
- `cargo tree --target all -i ndk`
- `cargo tree --target all -i ndk-sys@0.6.0`
- `cargo tree --target all --duplicates > duplicates.tmp 2>&1`
- `env CARGO_BUILD_JOBS=1 ./gradlew :app:assembleRelease > ../../../android-build.tmp 2>&1`
- `env CARGO_BUILD_JOBS=1 ./build-web.sh > ../../wasm-build.tmp 2>&1`
- `env CARGO_BUILD_JOBS=1 CRANPOSE_USE_SCCACHE=0 ./run_robot_test.sh --sequential > robot.tmp 2>&1`