### PR TITLE
[codex] fix text field style refresh

### DIFF
--- a/crates/cranpose-ui/src/text_field_modifier_node.rs
+++ b/crates/cranpose-ui/src/text_field_modifier_node.rs
@@ -857,6 +857,7 @@ impl ModifierNodeElement for TextFieldElement {
     fn update(&self, node: &mut Self::Node) {
         // Update the state reference
         node.state = self.state.clone();
+        node.style = self.style.clone();
         node.cursor_brush = Brush::solid(self.cursor_color);
         node.line_limits = self.line_limits;
 
@@ -865,7 +866,7 @@ impl ModifierNodeElement for TextFieldElement {
             node.state.clone(),
             node.refs.clone(),
             node.line_limits,
-            node.style.clone(),
+            self.style.clone(),
         );
 
         // Check if content changed and update cache
@@ -951,6 +952,29 @@ mod tests {
             // This ensures proper Eq/Hash contract compliance
             assert_eq!(elem1, elem2, "Same state should be equal");
             assert_ne!(elem1, elem3, "Different states should not be equal");
+        });
+    }
+
+    #[test]
+    fn text_field_element_update_refreshes_existing_node_style() {
+        with_test_runtime(|| {
+            let state = TextFieldState::new("themed text");
+            let dark_style = TextStyle::from_span_style(crate::text::SpanStyle {
+                color: Some(Color::from_rgba_u8(228, 240, 252, 255)),
+                ..crate::text::SpanStyle::default()
+            });
+            let light_style = TextStyle::from_span_style(crate::text::SpanStyle {
+                color: Some(Color::from_rgba_u8(14, 58, 96, 255)),
+                ..crate::text::SpanStyle::default()
+            });
+            let initial = TextFieldElement::new(state.clone(), dark_style);
+            let updated = TextFieldElement::new(state, light_style.clone());
+            let mut node = initial.create();
+
+            updated.update(&mut node);
+
+            assert_eq!(node.text(), "themed text");
+            assert_eq!(node.style(), &light_style);
         });
     }
 

--- a/crates/cranpose-ui/tests/basic_text_field_style_integration.rs
+++ b/crates/cranpose-ui/tests/basic_text_field_style_integration.rs
@@ -1,0 +1,41 @@
+use cranpose_foundation::text::TextFieldState;
+use cranpose_foundation::{modifier_element, BasicModifierNodeContext, ModifierNodeChain};
+use cranpose_ui::{collect_modifier_slices, Color, SpanStyle, TextFieldElement, TextStyle};
+use std::sync::Arc;
+
+fn colored_style(color: Color) -> TextStyle {
+    TextStyle::from_span_style(SpanStyle {
+        color: Some(color),
+        ..SpanStyle::default()
+    })
+}
+
+#[test]
+fn text_field_modifier_slices_refresh_style_when_state_identity_is_reused() {
+    let _runtime = cranpose_core::Runtime::new(Arc::new(cranpose_core::DefaultScheduler));
+    let state = TextFieldState::new("hello world");
+    let dark_style = colored_style(Color::from_rgba_u8(228, 240, 252, 255));
+    let light_style = colored_style(Color::from_rgba_u8(14, 58, 96, 255));
+    let mut chain = ModifierNodeChain::new();
+    let mut context = BasicModifierNodeContext::new();
+
+    chain.update_from_slice(
+        &[modifier_element(TextFieldElement::new(
+            state.clone(),
+            dark_style,
+        ))],
+        &mut context,
+    );
+    chain.update_from_slice(
+        &[modifier_element(TextFieldElement::new(
+            state.clone(),
+            light_style.clone(),
+        ))],
+        &mut context,
+    );
+
+    let slices = collect_modifier_slices(&chain);
+
+    assert_eq!(slices.text_content(), Some("hello world"));
+    assert_eq!(slices.text_style(), Some(&light_style));
+}


### PR DESCRIPTION
## Summary

Fixes #248.

`TextFieldElement::update` now refreshes the reused `TextFieldModifierNode` style before rebuilding its pointer handler, so an existing `TextFieldState` receives new visual styling when theme-dependent `BasicTextFieldWithOptions` parameters change.

## Validation

- `cargo test > 1.tmp 2>&1`
- `cargo clippy > 2.tmp 2>&1`
- `cargo fmt`
- `apps/android-demo/android/./gradlew :app:assembleRelease > android-build.tmp 2>&1`
- `apps/desktop-demo/./build-web.sh > web-build.tmp 2>&1`
- `./run_robot_test.sh --sequential > robot.tmp 2>&1` reached 95/96; `robot_shadow_fields` failed once, then `./run_robot_test.sh --sequential --example robot_shadow_fields > robot_shadow_fields.tmp 2>&1` passed. A full retry was stopped by the local host temperature guard before `robot_lazy_recursive_composition` (`host_not_ready` at ~93-95C).