### PR TITLE
[codex] fix lazy list scroll snap stability

### DIFF
--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -579,6 +579,11 @@ path = "robot-runners/robot_text_scroll_exact_external_contract.rs"
 required-features = ["robot-app"]
 
 [[example]]
+name = "robot_leetcodedaily_code_scroll_pixel_drift"
+path = "robot-runners/robot_leetcodedaily_code_scroll_pixel_drift.rs"
+required-features = ["robot-app"]
+
+[[example]]
 name = "robot_hacker_news_scroll_exact_external_contract"
 path = "robot-runners/robot_hacker_news_scroll_exact_external_contract.rs"
 required-features = ["robot-app"]

--- a/apps/desktop-demo/robot-runners/robot_leetcodedaily_code_scroll_pixel_drift.rs
+++ b/apps/desktop-demo/robot-runners/robot_leetcodedaily_code_scroll_pixel_drift.rs
@@ -1,0 +1,566 @@
+//! Robot test: capture screenshots of a leetcodedaily-style Code layout while scrolling by
+//! exactly one logical pixel per step and require stable overlap inside the code workspace
+//! viewport.
+
+mod scroll_stability_external_helpers;
+mod text_showcase_external_helpers;
+
+use cranpose::AppLauncher;
+use cranpose_foundation::{
+    text::{TextFieldLineLimits, TextFieldState},
+    SemanticsConfiguration,
+};
+use cranpose_ui::{
+    composable,
+    text::{FontFamily, FontWeight, SpanStyle, TextUnit},
+    widgets::BasicTextFieldWithOptions,
+    Alignment, BasicTextFieldOptions, Box as ComposeBox, BoxSpec, Button, Color, Column,
+    ColumnSpec, ContentScale, CornerRadii, Image, ImageBitmap, LinearArrangement, Modifier, Row,
+    RowSpec, Size, Spacer, Text, TextStyle, VerticalAlignment,
+};
+use scroll_stability_external_helpers::{
+    run_internal_scroll_stability_capture, ScrollStabilityConfig,
+};
+use std::time::Duration;
+use text_showcase_external_helpers::scroll_text_into_view_between;
+
+const WINDOW_WIDTH: u32 = 980;
+const WINDOW_HEIGHT: u32 = 720;
+const WINDOW_TITLE: &str = "Robot LeetcodeDaily Code Scroll Pixel Drift";
+const VIEWPORT_TAG: &str = "LeetcodeDailyCodeViewport";
+const TARGET_TEXT: &str = "Rust Code";
+const SCROLL_STEPS: usize = 10;
+const SCROLL_DELTA_Y: f32 = -1.0;
+const STEP_EPSILON: f32 = 0.05;
+const COMPARE_SEARCH_OFFSET_PX: u32 = 32;
+const COMPARE_MAX_ADJACENT_SCORE: u32 = 8_192;
+const COMPARE_STABILIZED_GUARD_PX: u32 = 28;
+const COMPARE_VIEWPORT_INSET_PX: u32 = 36;
+const TARGET_MIN_CENTER_Y: f32 = 260.0;
+const TARGET_MAX_CENTER_Y: f32 = 430.0;
+const CAPTURE_SCALE: f32 = 1.0;
+const RENDER_STATS_ENV: &str = "CRANPOSE_LEETCODEDAILY_CODE_SCROLL_RENDER_STATS";
+
+const KOTLIN_CODE: &str = r#"class Solution {
+    fun countGood(nums: IntArray, k: Int): Long {
+        var left = 0
+        var pairs = 0L
+        var answer = 0L
+        val freq = HashMap<Int, Int>()
+
+        for (right in nums.indices) {
+            val value = nums[right]
+            val seen = freq.getOrDefault(value, 0)
+            pairs += seen.toLong()
+            freq[value] = seen + 1
+
+            while (pairs >= k) {
+                answer += (nums.size - right).toLong()
+                val remove = nums[left++]
+                val count = freq.getValue(remove)
+                pairs -= (count - 1).toLong()
+                if (count == 1) freq.remove(remove) else freq[remove] = count - 1
+            }
+        }
+
+        return answer
+    }
+}"#;
+
+const RUST_CODE: &str = r#"impl Solution {
+    pub fn count_good(nums: Vec<i32>, k: i32) -> i64 {
+        let mut left = 0usize;
+        let mut pairs = 0i64;
+        let mut answer = 0i64;
+        let mut freq = std::collections::HashMap::<i32, i64>::new();
+
+        for right in 0..nums.len() {
+            let value = nums[right];
+            let seen = *freq.get(&value).unwrap_or(&0);
+            pairs += seen;
+            freq.insert(value, seen + 1);
+
+            while pairs >= k as i64 {
+                answer += (nums.len() - right) as i64;
+                let remove = nums[left];
+                left += 1;
+                if let Some(count) = freq.get_mut(&remove) {
+                    pairs -= *count - 1;
+                    *count -= 1;
+                }
+            }
+        }
+
+        answer
+    }
+}"#;
+
+fn primary_text() -> Color {
+    Color::from_rgb_u8(236, 242, 255)
+}
+
+fn muted_text() -> Color {
+    Color::from_rgb_u8(148, 163, 184)
+}
+
+fn card_surface() -> Color {
+    Color(0.075, 0.090, 0.135, 0.96)
+}
+
+fn input_surface() -> Color {
+    Color(0.025, 0.035, 0.065, 1.0)
+}
+
+fn accent_color() -> Color {
+    Color::from_rgb_u8(87, 214, 255)
+}
+
+fn title_style(size: f32) -> TextStyle {
+    TextStyle::from_span_style(SpanStyle {
+        color: Some(primary_text()),
+        font_size: TextUnit::Sp(size),
+        font_weight: Some(FontWeight::BOLD),
+        ..SpanStyle::default()
+    })
+}
+
+fn label_style() -> TextStyle {
+    TextStyle::from_span_style(SpanStyle {
+        color: Some(accent_color()),
+        font_size: TextUnit::Sp(11.0),
+        font_weight: Some(FontWeight::SEMI_BOLD),
+        ..SpanStyle::default()
+    })
+}
+
+fn body_style() -> TextStyle {
+    TextStyle::from_span_style(SpanStyle {
+        color: Some(muted_text()),
+        font_size: TextUnit::Sp(13.0),
+        ..SpanStyle::default()
+    })
+}
+
+fn code_style() -> TextStyle {
+    TextStyle::from_span_style(SpanStyle {
+        color: Some(primary_text()),
+        font_family: Some(FontFamily::Monospace),
+        font_size: TextUnit::Sp(14.0),
+        ..SpanStyle::default()
+    })
+}
+
+fn glass_panel_modifier(modifier: Modifier, radius: f32) -> Modifier {
+    modifier
+        .background(card_surface())
+        .rounded_corners(radius)
+        .draw_behind(move |scope| {
+            scope.draw_round_rect(
+                cranpose_ui::Brush::solid(Color(1.0, 1.0, 1.0, 0.055)),
+                CornerRadii::uniform(radius),
+            );
+        })
+}
+
+fn code_icon_bitmap(kind: CodeLanguage) -> ImageBitmap {
+    const WIDTH: u32 = 24;
+    const HEIGHT: u32 = 24;
+    let mut pixels = vec![0u8; (WIDTH * HEIGHT * 4) as usize];
+    let (base, accent) = match kind {
+        CodeLanguage::Kotlin => ([107, 92, 255, 255], [255, 136, 87, 255]),
+        CodeLanguage::Rust => ([248, 113, 113, 255], [87, 214, 255, 255]),
+    };
+
+    for y in 0..HEIGHT {
+        for x in 0..WIDTH {
+            let border = x < 2 || y < 2 || x >= WIDTH - 2 || y >= HEIGHT - 2;
+            let diagonal = x + y >= 16 && x + y <= 20;
+            let bar = (14..=16).contains(&y) && (6..=18).contains(&x);
+            let rgba = if border {
+                [236, 242, 255, 255]
+            } else if diagonal || bar {
+                accent
+            } else if ((x / 4) + (y / 4)) % 2 == 0 {
+                base
+            } else {
+                [20, 28, 48, 255]
+            };
+            let index = ((y * WIDTH + x) * 4) as usize;
+            pixels[index..index + 4].copy_from_slice(&rgba);
+        }
+    }
+
+    ImageBitmap::from_rgba8(WIDTH, HEIGHT, pixels).expect("valid code icon bitmap")
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum CodeLanguage {
+    Kotlin,
+    Rust,
+}
+
+#[allow(non_snake_case)]
+#[composable]
+fn Pill(text: &'static str) {
+    Text(
+        text,
+        Modifier::empty()
+            .background(Color(0.12, 0.16, 0.24, 0.92))
+            .rounded_corners(999.0)
+            .padding_symmetric(12.0, 7.0),
+        body_style(),
+    );
+}
+
+#[allow(non_snake_case)]
+#[composable]
+fn ActionButton(label: &'static str) {
+    Button(
+        Modifier::empty()
+            .width(66.0)
+            .height(38.0)
+            .background(Color(0.15, 0.20, 0.30, 0.96))
+            .rounded_corners(12.0)
+            .padding(8.0),
+        || {},
+        move || {
+            Text(label, Modifier::empty(), label_style());
+        },
+    );
+}
+
+#[allow(non_snake_case)]
+#[composable]
+fn CodeField(
+    label: &'static str,
+    runtime: &'static str,
+    language: CodeLanguage,
+    state: TextFieldState,
+) {
+    let icon =
+        cranpose_core::remember(move || code_icon_bitmap(language)).with(|bitmap| bitmap.clone());
+    ComposeBox(
+        glass_panel_modifier(Modifier::empty().fill_max_width(), 12.0)
+            .padding_symmetric(12.0, 10.0),
+        BoxSpec::default(),
+        move || {
+            Row(
+                Modifier::empty().fill_max_width(),
+                RowSpec::default()
+                    .horizontal_arrangement(LinearArrangement::spaced_by(16.0))
+                    .vertical_alignment(VerticalAlignment::Top),
+                {
+                    let state = state.clone();
+                    let icon = icon.clone();
+                    move || {
+                        let icon_for_image = icon.clone();
+                        ComposeBox(
+                            Modifier::empty()
+                                .size(Size::new(44.0, 44.0))
+                                .background(Color(0.18, 0.23, 0.33, 0.96))
+                                .rounded_corners(12.0)
+                                .padding(9.0),
+                            BoxSpec::default().content_alignment(Alignment::CENTER),
+                            move || {
+                                Image(
+                                    icon_for_image.clone(),
+                                    Some(format!("{label} icon")),
+                                    Modifier::empty().fill_max_size(),
+                                    Alignment::CENTER,
+                                    ContentScale::Fit,
+                                    1.0,
+                                    None,
+                                );
+                            },
+                        );
+
+                        Column(
+                            Modifier::empty().weight(1.0),
+                            ColumnSpec::default()
+                                .vertical_arrangement(LinearArrangement::spaced_by(6.0)),
+                            {
+                                let state = state.clone();
+                                move || {
+                                    Row(
+                                        Modifier::empty().fill_max_width(),
+                                        RowSpec::default()
+                                            .horizontal_arrangement(LinearArrangement::SpaceBetween)
+                                            .vertical_alignment(
+                                                VerticalAlignment::CenterVertically,
+                                            ),
+                                        move || {
+                                            Text(label, Modifier::empty(), label_style());
+                                            Text(runtime, Modifier::empty(), body_style());
+                                        },
+                                    );
+                                    ComposeBox(
+                                        Modifier::empty()
+                                            .fill_max_width()
+                                            .background(input_surface())
+                                            .rounded_corners(8.0)
+                                            .padding(12.0),
+                                        BoxSpec::default(),
+                                        {
+                                            let state = state.clone();
+                                            move || {
+                                                BasicTextFieldWithOptions(
+                                                    state.clone(),
+                                                    Modifier::empty().fill_max_width(),
+                                                    BasicTextFieldOptions {
+                                                        text_style: code_style(),
+                                                        cursor_color: accent_color(),
+                                                        line_limits:
+                                                            TextFieldLineLimits::MultiLine {
+                                                                min_lines: 10,
+                                                                max_lines: 18,
+                                                            },
+                                                    },
+                                                );
+                                            }
+                                        },
+                                    );
+                                }
+                            },
+                        );
+
+                        Column(
+                            Modifier::empty(),
+                            ColumnSpec::default()
+                                .vertical_arrangement(LinearArrangement::spaced_by(8.0)),
+                            move || {
+                                ActionButton("Copy");
+                                ActionButton("Clear");
+                            },
+                        );
+                    }
+                },
+            );
+        },
+    );
+}
+
+#[allow(non_snake_case)]
+#[composable]
+fn SummaryCard() {
+    ComposeBox(
+        glass_panel_modifier(Modifier::empty().fill_max_width(), 16.0).padding(18.0),
+        BoxSpec::default(),
+        move || {
+            Column(
+                Modifier::empty().fill_max_width(),
+                ColumnSpec::default().vertical_arrangement(LinearArrangement::spaced_by(10.0)),
+                move || {
+                    Text("Daily Problem", Modifier::empty(), title_style(24.0));
+                    Text(
+                        "Count the Number of Good Subarrays",
+                        Modifier::empty(),
+                        title_style(18.0),
+                    );
+                    Text(
+                        "Sliding window with pair accounting, duplicate frequencies, and a shrinking left edge once the window reaches the requested pair threshold.",
+                        Modifier::empty(),
+                        body_style(),
+                    );
+                    Row(
+                        Modifier::empty().fill_max_width(),
+                        RowSpec::default()
+                            .horizontal_arrangement(LinearArrangement::spaced_by(10.0)),
+                        move || {
+                            Pill("Difficulty: Medium");
+                            Pill("Runtime notes ready");
+                            Pill("Cranpose preview");
+                        },
+                    );
+                },
+            );
+        },
+    );
+}
+
+#[allow(non_snake_case)]
+#[composable]
+fn WriteupCard() {
+    ComposeBox(
+        glass_panel_modifier(Modifier::empty().fill_max_width(), 16.0).padding(18.0),
+        BoxSpec::default(),
+        move || {
+            Column(
+                Modifier::empty().fill_max_width(),
+                ColumnSpec::default().vertical_arrangement(LinearArrangement::spaced_by(12.0)),
+                move || {
+                    Text("Writeup", Modifier::empty(), title_style(22.0));
+                    Text(
+                        "The queue keeps the author moving through preparation, writeup, code, review, and shipping while preserving the language-specific solution notes.",
+                        Modifier::empty(),
+                        body_style(),
+                    );
+                    Text(
+                        "Approach: expand right, count new equal pairs, and shrink left while the current window already satisfies the requested pair threshold.",
+                        Modifier::empty(),
+                        body_style(),
+                    );
+                },
+            );
+        },
+    );
+}
+
+#[allow(non_snake_case)]
+#[composable]
+fn CodeCard() {
+    let kotlin_state =
+        cranpose_core::remember(|| TextFieldState::new(KOTLIN_CODE)).with(|state| state.clone());
+    let rust_state =
+        cranpose_core::remember(|| TextFieldState::new(RUST_CODE)).with(|state| state.clone());
+
+    ComposeBox(
+        glass_panel_modifier(Modifier::empty().fill_max_width(), 18.0).padding(18.0),
+        BoxSpec::default(),
+        move || {
+            Column(
+                Modifier::empty().fill_max_width(),
+                ColumnSpec::default().vertical_arrangement(LinearArrangement::spaced_by(14.0)),
+                {
+                    let kotlin_state = kotlin_state.clone();
+                    let rust_state = rust_state.clone();
+                    move || {
+                        Text("Code Blocks", Modifier::empty(), title_style(28.0));
+                        CodeField(
+                            "Kotlin Code",
+                            "Runtime 146 ms",
+                            CodeLanguage::Kotlin,
+                            kotlin_state.clone(),
+                        );
+                        CodeField(
+                            TARGET_TEXT,
+                            "Runtime 0 ms",
+                            CodeLanguage::Rust,
+                            rust_state.clone(),
+                        );
+                    }
+                },
+            );
+        },
+    );
+}
+
+#[allow(non_snake_case)]
+#[composable]
+fn LeetcodeDailyCodeScrollApp() {
+    let scroll_state =
+        cranpose_core::remember(|| cranpose_ui::ScrollState::new(0.0)).with(|state| state.clone());
+
+    Column(
+        Modifier::empty()
+            .fill_max_size()
+            .background(Color(0.030, 0.040, 0.075, 1.0))
+            .padding(20.0),
+        ColumnSpec::default().vertical_arrangement(LinearArrangement::spaced_by(14.0)),
+        move || {
+            Text(
+                "LeetcodeDaily Code Layout",
+                Modifier::empty(),
+                title_style(26.0),
+            );
+            Row(
+                Modifier::empty().fill_max_width(),
+                RowSpec::default().horizontal_arrangement(LinearArrangement::spaced_by(10.0)),
+                move || {
+                    Pill("Prepare");
+                    Pill("Write");
+                    Pill("Code");
+                    Pill("Review");
+                    Pill("Ship");
+                },
+            );
+            ComposeBox(
+                glass_panel_modifier(
+                    Modifier::empty().fill_max_width().weight(1.0).semantics(
+                        |config: &mut SemanticsConfiguration| {
+                            config.content_description = Some(VIEWPORT_TAG.to_string());
+                        },
+                    ),
+                    20.0,
+                )
+                .clip_to_bounds(),
+                BoxSpec::default(),
+                {
+                    let scroll_state = scroll_state.clone();
+                    move || {
+                        Column(
+                            Modifier::empty()
+                                .fill_max_size()
+                                .vertical_scroll(scroll_state.clone(), false)
+                                .padding(22.0),
+                            ColumnSpec::default()
+                                .vertical_arrangement(LinearArrangement::spaced_by(22.0)),
+                            move || {
+                                SummaryCard();
+                                WriteupCard();
+                                Spacer(Size::new(0.0, 70.0));
+                                CodeCard();
+                                Spacer(Size::new(0.0, 96.0));
+                            },
+                        );
+                    }
+                },
+            );
+        },
+    );
+}
+
+fn main() {
+    env_logger::init();
+    println!("=== Robot LeetcodeDaily Code Scroll Pixel Drift ===");
+
+    AppLauncher::new()
+        .with_title(WINDOW_TITLE)
+        .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
+        .with_headless(true)
+        .with_test_driver(move |robot| {
+            std::thread::sleep(Duration::from_millis(1000));
+            let _ = robot.wait_for_idle();
+
+            scroll_text_into_view_between(
+                &robot,
+                TARGET_TEXT,
+                TARGET_MIN_CENTER_Y,
+                TARGET_MAX_CENTER_Y,
+                48,
+            );
+            std::thread::sleep(Duration::from_millis(500));
+            let _ = robot.wait_for_idle();
+
+            let compare_ok = run_internal_scroll_stability_capture(
+                &robot,
+                ScrollStabilityConfig {
+                    window_title: WINDOW_TITLE,
+                    output_name: "leetcodedaily_code_scroll_pixel_drift",
+                    file_prefix: "leetcodedaily_code_scroll",
+                    target_text: TARGET_TEXT,
+                    viewport_tag: Some(VIEWPORT_TAG),
+                    window_width: WINDOW_WIDTH,
+                    window_height: WINDOW_HEIGHT,
+                    scroll_steps: SCROLL_STEPS,
+                    scroll_delta_y: SCROLL_DELTA_Y,
+                    step_epsilon: STEP_EPSILON,
+                    fallback_trim_top_px: 112,
+                    fallback_trim_bottom_px: 88,
+                    compare_search_offset_px: COMPARE_SEARCH_OFFSET_PX,
+                    compare_max_adjacent_score: COMPARE_MAX_ADJACENT_SCORE,
+                    compare_stabilized_guard_px: COMPARE_STABILIZED_GUARD_PX,
+                    compare_viewport_inset_px: COMPARE_VIEWPORT_INSET_PX,
+                    render_stats_env: Some(RENDER_STATS_ENV),
+                },
+                CAPTURE_SCALE,
+            );
+            if !compare_ok {
+                std::process::exit(1);
+            }
+
+            println!("\n=== Test Summary ===");
+            println!("PASS: leetcodedaily Code layout stayed within the pixel-drift budget");
+            robot.exit().expect("exit");
+        })
+        .run(LeetcodeDailyCodeScrollApp);
+}

--- a/apps/desktop-demo/robot-runners/scroll_stability_external_helpers.rs
+++ b/apps/desktop-demo/robot-runners/scroll_stability_external_helpers.rs
@@ -36,11 +36,13 @@ struct CompareCrop {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub(crate) struct InternalDiagnostic {
     pub output_dir: PathBuf,
     pub capture_scale: f32,
 }
 
+#[allow(dead_code)]
 pub(crate) fn run_scroll_stability_capture(
     robot: &cranpose::Robot,
     config: ScrollStabilityConfig,
@@ -102,6 +104,57 @@ pub(crate) fn run_scroll_stability_capture(
     if let Some(paths) = internal_capture_paths.as_ref() {
         cleanup_capture_paths(paths);
     }
+    compare_ok
+}
+
+#[allow(dead_code)]
+pub(crate) fn run_internal_scroll_stability_capture(
+    robot: &cranpose::Robot,
+    config: ScrollStabilityConfig,
+    capture_scale: f32,
+) -> bool {
+    assert!(
+        config.scroll_steps >= 2,
+        "scroll stability capture needs at least two steps"
+    );
+    assert!(
+        capture_scale.is_finite() && capture_scale > 0.0,
+        "capture_scale must be positive and finite"
+    );
+
+    let output_dir = prepare_named_output_dir(config.output_name);
+    println!("Window title: {}", config.window_title);
+    println!("Output dir: {}", output_dir.display());
+    let crop = compare_crop(robot, config);
+    println!(
+        "compare crop: left={} right={} top={} bottom={}",
+        crop.trim_left_px, crop.trim_right_px, crop.trim_top_px, crop.trim_bottom_px
+    );
+
+    let mut previous_bounds = find_text_in_semantics(robot, config.target_text)
+        .unwrap_or_else(|| fail_with_semantics(robot, "target text must be visible"));
+
+    let mut capture_paths = Vec::with_capacity(config.scroll_steps);
+    for step in 0..config.scroll_steps {
+        previous_bounds =
+            scroll_once_and_expect_target_delta(robot, config, previous_bounds, step, "step");
+
+        let screenshot = robot
+            .screenshot_with_scale(capture_scale)
+            .expect("internal screenshot");
+        let screenshot_path = output_dir.join(format!("{}_step{step:02}.png", config.file_prefix));
+        save_robot_screenshot(&screenshot_path, &screenshot);
+        capture_paths.push(screenshot_path);
+
+        if let Some(env_name) = config.render_stats_env {
+            if std::env::var_os(env_name).is_some() {
+                log_render_stats(robot, step);
+            }
+        }
+    }
+
+    let compare_ok = run_compare_script(&capture_paths, crop, config);
+    cleanup_capture_paths(&capture_paths);
     compare_ok
 }
 

--- a/apps/desktop-demo/robot-runners/text_showcase_external_helpers.rs
+++ b/apps/desktop-demo/robot-runners/text_showcase_external_helpers.rs
@@ -4,6 +4,7 @@ use cranpose_testing::{
 use std::process::Command;
 use std::time::Duration;
 
+#[allow(dead_code)]
 pub(crate) fn find_window_id(title: &str) -> String {
     for _ in 0..20 {
         let output = Command::new("xdotool")
@@ -26,6 +27,7 @@ pub(crate) fn find_window_id(title: &str) -> String {
     panic!("window '{title}' not found via xdotool");
 }
 
+#[allow(dead_code)]
 pub(crate) fn take_x11_screenshot(window_id: &str, path: &str) {
     let status = Command::new("import")
         .args(["-window", window_id, path])

--- a/crates/cranpose-render/pixels/src/pipeline.rs
+++ b/crates/cranpose-render/pixels/src/pipeline.rs
@@ -61,12 +61,8 @@ fn graphics_layer_supports_rigid_snap(layer: &GraphicsLayer) -> bool {
         && layer.rotation_z.abs() <= f32::EPSILON
 }
 
-fn rigid_snap_anchor(
-    layer_bounds: Rect,
-    layer: &GraphicsLayer,
-    motion_context_animated: bool,
-) -> Option<Point> {
-    if motion_context_animated || !graphics_layer_supports_rigid_snap(layer) {
+fn rigid_snap_anchor(layer_bounds: Rect, layer: &GraphicsLayer) -> Option<Point> {
+    if !graphics_layer_supports_rigid_snap(layer) {
         return None;
     }
     let mapped = apply_layer_affine_to_rect(layer_bounds, layer_bounds, layer);
@@ -905,10 +901,10 @@ fn populate_draws_from_graph(
     );
     let effective_translated_content_context =
         inherited_translated_content_context || layer.translated_content_context;
-    let suppress_rigid_snap = effective_translated_content_context && layer.motion_context_animated;
+    let allow_rigid_snap = effective_translated_content_context || !layer.motion_context_animated;
     let boundary_snap_anchor = if !inherited_translated_content_context
         && layer.translated_content_context
-        && !suppress_rigid_snap
+        && allow_rigid_snap
     {
         rigid_snap_anchor(
             transform.bounds_for_rect(layer.local_bounds.translate(
@@ -916,31 +912,21 @@ fn populate_draws_from_graph(
                 layer.translated_content_offset.y,
             )),
             &mapping.raster_content_layer,
-            layer.motion_context_animated,
         )
     } else {
         None
     };
-    let translated_snap_anchor = if suppress_rigid_snap {
-        None
-    } else {
-        inherited_translated_snap_anchor.or(boundary_snap_anchor)
-    };
-    let layer_snap_anchor = if suppress_rigid_snap {
-        None
-    } else {
-        translated_snap_anchor.or_else(|| {
-            if layer_needs_rigid_snap(layer, effective_translated_content_context) {
-                rigid_snap_anchor(
-                    mapping.layer_bounds.raster_rect(),
-                    &mapping.raster_content_layer,
-                    layer.motion_context_animated,
-                )
-            } else {
-                None
-            }
-        })
-    };
+    let translated_snap_anchor = inherited_translated_snap_anchor.or(boundary_snap_anchor);
+    let layer_snap_anchor = translated_snap_anchor.or_else(|| {
+        if allow_rigid_snap && layer_needs_rigid_snap(layer, effective_translated_content_context) {
+            rigid_snap_anchor(
+                mapping.layer_bounds.raster_rect(),
+                &mapping.raster_content_layer,
+            )
+        } else {
+            None
+        }
+    });
 
     if content_clip_to_bounds && visual_clip.is_none() {
         return;
@@ -1268,7 +1254,7 @@ mod tests {
         PrimitivePhase, ProjectiveTransform, RenderGraph, RenderNode,
     };
     use cranpose_render_common::raster_cache::LayerRasterCacheHashes;
-    use cranpose_ui_graphics::CornerRadii;
+    use cranpose_ui_graphics::{CornerRadii, ImageBitmap, ImageSampling};
 
     fn snapped_text_leaf_root(animated: bool, translated_content_context: bool) -> RenderGraph {
         let text_leaf = LayerNode {
@@ -1305,6 +1291,33 @@ mod tests {
                             },
                             brush: Brush::solid(Color(0.28, 0.30, 0.46, 0.88)),
                             radii: CornerRadii::uniform(6.0),
+                        },
+                        clip: None,
+                    }),
+                }),
+                RenderNode::Primitive(PrimitiveEntry {
+                    phase: PrimitivePhase::BeforeChildren,
+                    node: PrimitiveNode::Draw(DrawPrimitiveNode {
+                        primitive: DrawPrimitive::Image {
+                            rect: Rect {
+                                x: 2.0,
+                                y: 2.0,
+                                width: 12.0,
+                                height: 12.0,
+                            },
+                            image: ImageBitmap::from_rgba8(
+                                2,
+                                2,
+                                vec![
+                                    255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255,
+                                    255,
+                                ],
+                            )
+                            .expect("image"),
+                            alpha: 1.0,
+                            color_filter: None,
+                            sampling: ImageSampling::Linear,
+                            src_rect: None,
                         },
                         clip: None,
                     }),
@@ -1535,25 +1548,33 @@ mod tests {
         let scene = build_raster_scene(&snapped_text_leaf_root(false, false));
 
         assert_eq!(scene.shapes.len(), 1);
+        assert_eq!(scene.images.len(), 1);
         assert_eq!(scene.texts.len(), 1);
         let expected_anchor = Some(Point::new(14.25, 16.5));
         assert_eq!(scene.shapes[0].snap_anchor, expected_anchor);
+        assert_eq!(scene.images[0].snap_anchor, expected_anchor);
         assert_eq!(scene.texts[0].snap_anchor, expected_anchor);
     }
 
     #[test]
-    fn translated_animated_text_leaf_disables_snap_for_smooth_scroll() {
+    fn animated_translated_content_text_leaf_keeps_shared_snap_anchor_for_inner_stability() {
         let scene = build_raster_scene(&snapped_text_leaf_root(true, true));
 
         assert_eq!(scene.shapes.len(), 1);
+        assert_eq!(scene.images.len(), 1);
         assert_eq!(scene.texts.len(), 1);
+        let expected_anchor = Some(Point::new(14.25, 16.5));
         assert_eq!(
-            scene.shapes[0].snap_anchor, None,
-            "active scroll content must not snap while motion is in progress"
+            scene.shapes[0].snap_anchor, expected_anchor,
+            "active scroll content should share one anchor so item internals stay pixel-stable"
         );
         assert_eq!(
-            scene.texts[0].snap_anchor, None,
-            "active scroll text must not snap while motion is in progress"
+            scene.images[0].snap_anchor, expected_anchor,
+            "active scroll images should share the item anchor instead of resampling independently"
+        );
+        assert_eq!(
+            scene.texts[0].snap_anchor, expected_anchor,
+            "active scroll text should share the item anchor instead of drifting independently"
         );
     }
 
@@ -1562,11 +1583,16 @@ mod tests {
         let scene = build_raster_scene(&snapped_text_leaf_root(false, true));
 
         assert_eq!(scene.shapes.len(), 1);
+        assert_eq!(scene.images.len(), 1);
         assert_eq!(scene.texts.len(), 1);
         let expected_anchor = Some(Point::new(14.25, 16.5));
         assert_eq!(
             scene.shapes[0].snap_anchor, expected_anchor,
             "rested scroll content should snap back to device pixels"
+        );
+        assert_eq!(
+            scene.images[0].snap_anchor, expected_anchor,
+            "rested scroll images should snap back to device pixels"
         );
         assert_eq!(
             scene.texts[0].snap_anchor, expected_anchor,

--- a/crates/cranpose-render/wgpu/src/normalized_scene.rs
+++ b/crates/cranpose-render/wgpu/src/normalized_scene.rs
@@ -246,12 +246,8 @@ fn graphics_layer_supports_rigid_snap(layer: &GraphicsLayer) -> bool {
         && layer.rotation_z.abs() <= NORMALIZED_SCENE_AFFINE_TOLERANCE
 }
 
-fn rigid_snap_anchor(
-    layer_bounds: Rect,
-    layer: &GraphicsLayer,
-    motion_context_animated: bool,
-) -> Option<SnapAnchor> {
-    if motion_context_animated || !graphics_layer_supports_rigid_snap(layer) {
+fn rigid_snap_anchor(layer_bounds: Rect, layer: &GraphicsLayer) -> Option<SnapAnchor> {
+    if !graphics_layer_supports_rigid_snap(layer) {
         return None;
     }
     let mapped = cranpose_render_common::layer_transform::apply_layer_affine_to_rect(
@@ -498,10 +494,10 @@ fn collect_layer_contents_into<'a>(
 
     let effective_translated_content_context =
         translation_context.inherited_content_translation || layer.translated_content_context;
-    let suppress_rigid_snap = effective_translated_content_context && layer.motion_context_animated;
+    let allow_rigid_snap = effective_translated_content_context || !layer.motion_context_animated;
     let boundary_snap_anchor = if !translation_context.inherited_content_translation
         && layer.translated_content_context
-        && !suppress_rigid_snap
+        && allow_rigid_snap
     {
         rigid_snap_anchor(
             layer_bounds.translate(
@@ -509,27 +505,18 @@ fn collect_layer_contents_into<'a>(
                 layer.translated_content_offset.y,
             ),
             &local_layer,
-            layer.motion_context_animated,
         )
     } else {
         None
     };
-    let translated_snap_anchor = if suppress_rigid_snap {
-        None
-    } else {
-        inherited_translated_snap_anchor.or(boundary_snap_anchor)
-    };
-    let layer_snap_anchor = if suppress_rigid_snap {
-        None
-    } else {
-        translated_snap_anchor.or_else(|| {
-            if layer_needs_rigid_snap(layer, effective_translated_content_context) {
-                rigid_snap_anchor(layer_bounds, &local_layer, layer.motion_context_animated)
-            } else {
-                None
-            }
-        })
-    };
+    let translated_snap_anchor = inherited_translated_snap_anchor.or(boundary_snap_anchor);
+    let layer_snap_anchor = translated_snap_anchor.or_else(|| {
+        if allow_rigid_snap && layer_needs_rigid_snap(layer, effective_translated_content_context) {
+            rigid_snap_anchor(layer_bounds, &local_layer)
+        } else {
+            None
+        }
+    });
     let translated_local_picture = layer.translated_content_context
         && layer.motion_context_animated
         && !translation_context.inherited_content_translation
@@ -590,11 +577,7 @@ fn collect_layer_contents_into<'a>(
                                 child_isolation.as_ref(),
                             );
                             let child_local_layer = local_content_layer(&child_content_layer);
-                            rigid_snap_anchor(
-                                child_bounds,
-                                &child_local_layer,
-                                child_layer.motion_context_animated,
-                            )
+                            rigid_snap_anchor(child_bounds, &child_local_layer)
                         } else {
                             None
                         }
@@ -665,11 +648,7 @@ fn collect_layer_contents_into<'a>(
                             child_isolation.as_ref(),
                         );
                         let child_local_layer = local_content_layer(&child_content_layer);
-                        rigid_snap_anchor(
-                            child_bounds,
-                            &child_local_layer,
-                            child_layer.motion_context_animated,
-                        )
+                        rigid_snap_anchor(child_bounds, &child_local_layer)
                     } else {
                         None
                     }

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -5071,6 +5071,33 @@ mod tests {
                 }),
                 RenderNode::Primitive(PrimitiveEntry {
                     phase: PrimitivePhase::BeforeChildren,
+                    node: PrimitiveNode::Draw(DrawPrimitiveNode {
+                        primitive: DrawPrimitive::Image {
+                            rect: Rect {
+                                x: 2.0,
+                                y: 2.0,
+                                width: 12.0,
+                                height: 12.0,
+                            },
+                            image: ImageBitmap::from_rgba8(
+                                2,
+                                2,
+                                vec![
+                                    255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255,
+                                    255,
+                                ],
+                            )
+                            .expect("image"),
+                            alpha: 1.0,
+                            color_filter: None,
+                            sampling: ImageSampling::Linear,
+                            src_rect: None,
+                        },
+                        clip: None,
+                    }),
+                }),
+                RenderNode::Primitive(PrimitiveEntry {
+                    phase: PrimitivePhase::BeforeChildren,
                     node: PrimitiveNode::Text(Box::new(TextPrimitiveNode {
                         node_id: 77,
                         rect: Rect {
@@ -6345,14 +6372,16 @@ mod tests {
             collect_layer_contents(&root, None, None, &mut rect_cache, &mut requirements_cache);
 
         assert_eq!(collected.scene.shapes.len(), 1);
+        assert_eq!(collected.scene.images.len(), 1);
         assert_eq!(collected.scene.texts.len(), 1);
         let expected_anchor = Some(SnapAnchor::rigid(Point::new(14.25, 16.5)));
         assert_eq!(collected.scene.shapes[0].snap_anchor, expected_anchor);
+        assert_eq!(collected.scene.images[0].snap_anchor, expected_anchor);
         assert_eq!(collected.scene.texts[0].snap_anchor, expected_anchor);
     }
 
     #[test]
-    fn translated_animated_text_leaf_disables_snap_for_smooth_scroll() {
+    fn animated_translated_content_text_leaf_keeps_shared_snap_anchor_for_inner_stability() {
         let root = snapped_text_leaf_root(true, true);
         let mut rect_cache = HashMap::new();
         let mut requirements_cache = HashMap::new();
@@ -6362,18 +6391,24 @@ mod tests {
 
         assert_eq!(collected.child_layers.len(), 0);
         assert_eq!(collected.scene.shapes.len(), 1);
+        assert_eq!(collected.scene.images.len(), 1);
         assert_eq!(collected.scene.texts.len(), 1);
         assert_eq!(collected.scene.effect_layers.len(), 1);
         assert!(collected.scene.effect_layers[0]
             .requirements
             .contains(SurfaceRequirement::MotionStableCapture));
+        let expected_anchor = Some(SnapAnchor::rigid(Point::new(14.25, 16.5)));
         assert_eq!(
-            collected.scene.shapes[0].snap_anchor, None,
-            "active scroll motion must not snap while the pointer-driven motion context is active"
+            collected.scene.shapes[0].snap_anchor, expected_anchor,
+            "active scroll content should share one anchor so item internals stay pixel-stable"
         );
         assert_eq!(
-            collected.scene.texts[0].snap_anchor, None,
-            "active scroll text must not snap while the pointer-driven motion context is active"
+            collected.scene.images[0].snap_anchor, expected_anchor,
+            "active scroll images should share the item anchor instead of resampling independently"
+        );
+        assert_eq!(
+            collected.scene.texts[0].snap_anchor, expected_anchor,
+            "active scroll text should share the item anchor instead of drifting independently"
         );
     }
 
@@ -6388,12 +6423,17 @@ mod tests {
 
         assert_eq!(collected.child_layers.len(), 0);
         assert_eq!(collected.scene.shapes.len(), 1);
+        assert_eq!(collected.scene.images.len(), 1);
         assert_eq!(collected.scene.texts.len(), 1);
         assert_eq!(collected.scene.effect_layers.len(), 0);
         let expected_anchor = Some(SnapAnchor::rigid(Point::new(14.25, 16.5)));
         assert_eq!(
             collected.scene.shapes[0].snap_anchor, expected_anchor,
             "rested scroll content should snap back to device pixels"
+        );
+        assert_eq!(
+            collected.scene.images[0].snap_anchor, expected_anchor,
+            "rested scroll images should snap back to device pixels"
         );
         assert_eq!(
             collected.scene.texts[0].snap_anchor, expected_anchor,

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -365,6 +365,9 @@ run_test() {
         robot_text_scroll_exact_external_contract)
             timeout_secs=180
             ;;
+        robot_leetcodedaily_code_scroll_pixel_drift)
+            timeout_secs=180
+            ;;
         robot_content_type_reuse|robot_lazy_perf_validation)
             timeout_secs=240
             ;;


### PR DESCRIPTION
## Summary

Fixes #247.

Active translated-content scroll now keeps a shared rigid snap anchor for item contents instead of suppressing snapping while the motion context is animated. This keeps LazyList item internals on the same pixel phase during scroll, including backgrounds, images, and text.

The change is applied to both render backends:
- WGPU normalized scene collection
- pixels raster scene collection

## Root Cause

The renderers explicitly disabled rigid snap anchors when a layer was both in a translated-content context and an active motion context. That made LazyList children fall back to independent fractional positioning during scroll, so images could be resampled and sibling content could drift by a pixel relative to each other.

## Validation

- `cargo fmt`
- `cargo test > 1.tmp 2>&1`
- `cargo clippy > 2.tmp 2>&1`
- `./gradlew :app:assembleRelease > android-build.tmp 2>&1`
- `./build-web.sh > web-build.tmp 2>&1`
- `CRANPOSE_USE_SCCACHE=0 ./run_robot_test.sh --sequential > robot.tmp 2>&1` attempted, but local host capacity guard timed out before robot build because CPU temperature stayed above 85C while other user processes were active; no robot test executed locally.