### PR TITLE
[codex] Fix returned composable animation invalidation

### DIFF
--- a/apps/desktop-demo/tests/counter_tab_roundtrip_regression.rs
+++ b/apps/desktop-demo/tests/counter_tab_roundtrip_regression.rs
@@ -132,19 +132,19 @@ fn max_layer_translation_y(layer: &LayerNode) -> f32 {
 fn returned_press_lift(press_tick: MutableState<u64>) -> f32 {
     let press_target = cranpose_core::useState(|| 0.0_f32);
     cranpose_core::LaunchedEffect!(press_tick.value(), {
-        let press_target = press_target;
-        let press_tick = press_tick;
+        let target_state = press_target;
+        let tick_state = press_tick;
         move |scope| {
-            if press_tick.value() == 0 {
+            if tick_state.value() == 0 {
                 return;
             }
-            press_target.set(1.0);
-            let press_target = press_target;
+            target_state.set(1.0);
+            let reset_target_state = target_state;
             scope.launch_background(
                 move |_| async move {
                     std::thread::sleep(Duration::from_millis(120));
                 },
-                move |_| press_target.set(0.0),
+                move |_| reset_target_state.set(0.0),
             );
         }
     });

--- a/apps/desktop-demo/tests/counter_tab_roundtrip_regression.rs
+++ b/apps/desktop-demo/tests/counter_tab_roundtrip_regression.rs
@@ -1,19 +1,26 @@
 pub mod tab_switch_regression_support;
 
+use cranpose_animation::{animateFloatAsStateWithSpec, AnimationSpec, AnimationType};
 use cranpose_app_shell::AppShell;
 use cranpose_core::{location_key, MutableState};
 use cranpose_foundation::PointerEvent;
+use cranpose_macros::composable;
 use cranpose_render_common::graph::ProjectiveTransform;
+use cranpose_render_common::graph::{LayerNode, RenderNode};
 use cranpose_render_common::graph_scene::{ClickAction, HitGeometry, Scene};
 use cranpose_render_common::hit_graph::{collect_hits_from_graph, HitGraphSink};
 use cranpose_render_common::{RenderScene, Renderer};
-use cranpose_ui::{LayoutTree, SemanticsAction, SemanticsNode, SemanticsRole, Size};
+use cranpose_ui::{
+    Button, LayoutTree, Modifier, SemanticsAction, SemanticsNode, SemanticsRole, Size, Text,
+    TextStyle,
+};
 use cranpose_ui_graphics::{Point, Rect, RoundedCornerShape};
 use desktop_app::app::{
     combined_app, DemoTab, TEST_ACTIVE_TAB_STATE, TEST_COUNTER_APP_COUNTER_STATE,
     TEST_LAZY_LIST_STATE, TEST_RECURSIVE_LAYOUT_DEPTH_STATE,
 };
 use std::rc::Rc;
+use std::time::Duration;
 use tab_switch_regression_support::{active_tab_state, pump_shell_until_stable};
 
 #[derive(Default)]
@@ -106,6 +113,111 @@ impl Renderer for HitGraphRenderer {
         }
         Ok(())
     }
+}
+
+fn max_layer_translation_y(layer: &LayerNode) -> f32 {
+    layer.children.iter().fold(
+        layer.graphics_layer.translation_y.abs(),
+        |max_value, child| {
+            let child_value = match child {
+                RenderNode::Layer(child_layer) => max_layer_translation_y(child_layer),
+                RenderNode::Primitive(_) => 0.0,
+            };
+            max_value.max(child_value)
+        },
+    )
+}
+
+#[composable]
+fn returned_press_lift(press_tick: MutableState<u64>) -> f32 {
+    let press_target = cranpose_core::useState(|| 0.0_f32);
+    cranpose_core::LaunchedEffect!(press_tick.value(), {
+        let press_target = press_target;
+        let press_tick = press_tick;
+        move |scope| {
+            if press_tick.value() == 0 {
+                return;
+            }
+            press_target.set(1.0);
+            let press_target = press_target;
+            scope.launch_background(
+                move |_| async move {
+                    std::thread::sleep(Duration::from_millis(120));
+                },
+                move |_| press_target.set(0.0),
+            );
+        }
+    });
+
+    animateFloatAsStateWithSpec(
+        press_target.value(),
+        AnimationType::Tween(AnimationSpec::linear(240)),
+        "returned_button_graphics_layer_probe",
+    )
+    .value()
+}
+
+#[composable]
+fn animate_float_returned_button_graphics_layer_probe() {
+    let press_tick = cranpose_core::useState(|| 0_u64);
+    let lift = returned_press_lift(press_tick);
+
+    Button(
+        Modifier::empty()
+            .graphics_layer_block(move |layer| {
+                layer.translation_y = lift * 32.0;
+                layer.scale_x = 1.0 - lift * 0.05;
+                layer.scale_y = 1.0 - lift * 0.05;
+            })
+            .height(48.0)
+            .padding_symmetric(12.0, 8.0),
+        move || {
+            press_tick.set(press_tick.value().wrapping_add(1));
+        },
+        move || {
+            Text("Press probe", Modifier::empty(), TextStyle::default());
+        },
+    );
+}
+
+#[test]
+fn animate_float_as_state_returned_value_updates_parent_graphics_layer_after_click() {
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(
+        HitGraphRenderer::default(),
+        root_key,
+        animate_float_returned_button_graphics_layer_probe,
+    );
+    shell.set_buffer_size(320, 180);
+    shell.set_viewport(320.0, 180.0);
+    pump_shell_until_stable(&mut shell);
+
+    shell.set_cursor(32.0, 24.0);
+    shell.pointer_pressed();
+    shell.pointer_released();
+
+    let mut saw_intermediate_layer = false;
+    let mut last_translation = 0.0;
+    for _ in 0..24 {
+        std::thread::sleep(Duration::from_millis(16));
+        shell.update();
+        let translation = shell
+            .scene()
+            .graph
+            .as_ref()
+            .map(|graph| max_layer_translation_y(&graph.root))
+            .expect("graph available after returned animation frame");
+        last_translation = translation;
+        if translation > 1.0 && translation < 31.0 {
+            saw_intermediate_layer = true;
+            break;
+        }
+    }
+
+    assert!(
+        saw_intermediate_layer,
+        "animateFloatAsState returned from a child composable did not update the parent graphics_layer_block; last translation_y={last_translation}"
+    );
 }
 
 fn semantics_text(node: &SemanticsNode) -> Option<&str> {

--- a/crates/cranpose-animation/src/tests/animation_tests.rs
+++ b/crates/cranpose-animation/src/tests/animation_tests.rs
@@ -1,8 +1,16 @@
 use super::*;
 
-use cranpose_core::{location_key, with_current_composer, Composition, MemoryApplier, State};
+use cranpose_core::{
+    location_key, with_current_composer, Composer, Composition, MemoryApplier, MutableState, Node,
+    State,
+};
 use std::cell::RefCell;
 use std::rc::Rc;
+
+#[derive(Default)]
+struct DummyNode;
+
+impl Node for DummyNode {}
 
 #[test]
 fn animate_float_as_state_interpolates_over_time() {
@@ -87,6 +95,97 @@ fn animate_float_as_state_interpolates_over_time() {
         "animation should end at target"
     );
     assert!(!composition.should_render());
+}
+
+#[test]
+fn animate_float_as_state_invalidates_composition_time_readers() {
+    fn render_animation_reader(
+        composer: &Composer,
+        target: MutableState<f32>,
+        rendered_values: Rc<RefCell<Vec<f32>>>,
+    ) {
+        {
+            let rendered_values = Rc::clone(&rendered_values);
+            composer.set_recranpose_callback(move |composer| {
+                render_animation_reader(composer, target, Rc::clone(&rendered_values));
+            });
+        }
+
+        let value = animateFloatAsStateWithSpec(
+            target.value(),
+            AnimationType::Tween(AnimationSpec::linear(240)),
+            "alpha",
+        )
+        .value();
+        rendered_values.borrow_mut().push(value);
+        composer.emit_node(|| DummyNode);
+    }
+
+    let mut composition = Composition::new(MemoryApplier::new());
+    let runtime = composition.runtime_handle();
+    let root_key = location_key(file!(), line!(), column!());
+    let group_key = location_key(file!(), line!(), column!());
+    let target = MutableState::with_runtime(0.0f32, runtime.clone());
+    let rendered_values = Rc::new(RefCell::new(Vec::<f32>::new()));
+
+    {
+        let rendered_values = Rc::clone(&rendered_values);
+        composition
+            .render(root_key, move || {
+                let rendered_values = Rc::clone(&rendered_values);
+                with_current_composer(|composer| {
+                    composer.with_group(group_key, |composer| {
+                        render_animation_reader(composer, target, rendered_values);
+                    });
+                });
+            })
+            .expect("initial render succeeds");
+    }
+
+    assert_eq!(rendered_values.borrow().as_slice(), &[0.0]);
+
+    target.set_value(1.0);
+    while composition
+        .process_invalid_scopes()
+        .expect("process target invalidation")
+    {}
+
+    assert!(
+        runtime.has_frame_callbacks(),
+        "target change should enqueue animation frames"
+    );
+    assert!(
+        composition.should_render(),
+        "queued animation frames should keep the composition active"
+    );
+
+    let mut frame_time = 0u64;
+    for _ in 0..32 {
+        if !composition.should_render() {
+            break;
+        }
+        frame_time += 16_666_667;
+        runtime.drain_frame_callbacks(frame_time);
+        runtime.drain_ui();
+        while composition
+            .process_invalid_scopes()
+            .expect("process invalid scopes succeeds")
+        {}
+    }
+
+    let rendered = rendered_values.borrow();
+    assert!(
+        rendered.iter().any(|value| *value > 0.0 && *value < 1.0),
+        "composition-time readers should observe intermediate values, got {rendered:?}",
+    );
+    assert!(
+        rendered.len() > 3,
+        "animation should invalidate composition readers across frames, got {rendered:?}",
+    );
+    assert!(
+        (*rendered.last().expect("rendered values") - 1.0).abs() < f32::EPSILON,
+        "animation should finish at target, got {rendered:?}",
+    );
 }
 
 #[test]

--- a/crates/cranpose-core/src/composer.rs
+++ b/crates/cranpose-core/src/composer.rs
@@ -1187,6 +1187,20 @@ impl Composer {
         ValueSlotHandle::new(slot)
     }
 
+    #[doc(hidden)]
+    pub fn __invalidate_return_consumer_scope(&self) {
+        let Some(scope) = self.current_recranpose_scope() else {
+            self.request_root_render();
+            return;
+        };
+
+        if let Some(target) = scope.callback_promotion_target() {
+            target.invalidate();
+        } else {
+            self.request_root_render();
+        }
+    }
+
     pub fn with_slot_value<'pass, T: 'static, R>(
         &'pass self,
         handle: ValueSlotHandle<'pass, T>,

--- a/crates/cranpose-core/src/tests/recompose_and_diff_tests.rs
+++ b/crates/cranpose-core/src/tests/recompose_and_diff_tests.rs
@@ -45,6 +45,44 @@ fn state_update_schedules_render() {
 }
 
 #[test]
+fn returned_composable_state_change_recomposes_parent_consumer() {
+    thread_local! {
+        static OBSERVED_RETURNS: RefCell<Vec<i32>> = const { RefCell::new(Vec::new()) };
+    }
+
+    #[composable]
+    fn child_value(state: MutableState<i32>) -> i32 {
+        state.value()
+    }
+
+    #[composable]
+    fn parent(state: MutableState<i32>) {
+        let value = child_value(state);
+        OBSERVED_RETURNS.with(|values| values.borrow_mut().push(value));
+    }
+
+    OBSERVED_RETURNS.with(|values| values.borrow_mut().clear());
+
+    let mut composition = test_composition();
+    let runtime = composition.runtime_handle();
+    let state = MutableState::with_runtime(0, runtime.clone());
+
+    composition
+        .render(location_key(file!(), line!(), column!()), || parent(state))
+        .expect("initial composition");
+
+    state.set_value(1);
+    while composition
+        .process_invalid_scopes()
+        .expect("returned value recomposition")
+    {}
+
+    OBSERVED_RETURNS.with(|values| {
+        assert_eq!(values.borrow().as_slice(), &[0, 1]);
+    });
+}
+
+#[test]
 fn recranpose_does_not_use_stale_indices_when_prior_scope_changes_length() {
     thread_local! {
         static STABLE_RECOMPOSE_A: Cell<usize> = const { Cell::new(0) };

--- a/crates/cranpose-macros/src/lib.rs
+++ b/crates/cranpose-macros/src/lib.rs
@@ -138,6 +138,18 @@ fn is_zero_arg_fn_impl_trait(ty: &Type) -> bool {
     }
 }
 
+fn is_node_id_return(ty: &Type) -> bool {
+    matches!(
+        ty,
+        Type::Path(type_path)
+            if type_path
+                .path
+                .segments
+                .last()
+                .is_some_and(|segment| segment.ident == "NodeId")
+    )
+}
+
 fn core_crate_path() -> TokenStream2 {
     let crate_name = crate_name("cranpose")
         .ok()
@@ -251,6 +263,11 @@ pub fn composable(attr: TokenStream, item: TokenStream) -> TokenStream {
         ReturnType::Type(_, ty) => {
             matches!(ty.as_ref(), Type::Tuple(tuple) if tuple.elems.is_empty())
         }
+    };
+    let invalidate_return_consumer = if returns_unit || is_node_id_return(&return_ty) {
+        quote! {}
+    } else {
+        quote! { __composer.__invalidate_return_consumer_scope(); }
     };
     let _helper_ident = Ident::new(
         &format!("__cranpose_impl_{}", func.sig.ident),
@@ -553,6 +570,7 @@ pub fn composable(attr: TokenStream, item: TokenStream) -> TokenStream {
                     },
                 );
                 #recranpose_setter
+                #invalidate_return_consumer
                 __value
             }
         };


### PR DESCRIPTION
## Summary

Fixes #249.

`animateFloatAsState(...).value()` could animate correctly inside the child composable that produced it, but if that value was returned to a parent and then captured into a parent modifier, the parent was never invalidated when the child return slot changed. That left parent-side `graphics_layer_block` closures with stale values, so press animations such as leetcodedaily's button lift never became visible.

This change makes non-`NodeId` return-value recomposition invalidate the nearest parent consumer scope after the return slot is updated. `NodeId`-returning widget composables keep the existing scoped recomposition behavior so ordinary UI node updates still avoid unnecessary parent recomposition.

## Validation

- `cargo fmt`
- `CARGO_BUILD_JOBS=1 cargo test > 1.tmp 2>&1`
- `CARGO_BUILD_JOBS=1 cargo clippy > 2.tmp 2>&1`
- `./build-web.sh` from `apps/desktop-demo`
- `./gradlew :app:assembleRelease` from `apps/android-demo/android`
- `CRANPOSE_USE_SCCACHE=0 ./run_robot_test.sh --sequential` (97/97 passed)