### PR TITLE
[codex] Add absolute-offset text redraw regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,7 @@ name = "cranpose-render-wgpu"
 version = "0.0.65"
 dependencies = [
  "bytemuck",
+ "cranpose-app-shell",
  "cranpose-core",
  "cranpose-foundation",
  "cranpose-render-common",

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -1727,6 +1727,87 @@ fn draw_repass_updates_render_data_without_layout() {
     );
 }
 
+#[composable]
+#[allow(non_snake_case)]
+fn AbsoluteOffsetStackedTextRows(start: MutableState<i32>) {
+    Box(
+        Modifier::empty()
+            .size_points(260.0, 220.0)
+            .background(Color(0.02, 0.03, 0.05, 1.0)),
+        BoxSpec::default(),
+        move || {
+            for row in 0..14 {
+                Text(
+                    format!("Row {:02}", start.get() + row),
+                    Modifier::empty()
+                        .size_points(220.0, 14.0)
+                        .absolute_offset(12.0, 10.0 + row as f32 * 14.0),
+                    TextStyle::default(),
+                );
+            }
+        },
+    );
+}
+
+fn rendered_text_values(scene: &cranpose_ui::RecordedRenderScene) -> Vec<String> {
+    scene
+        .operations()
+        .iter()
+        .filter_map(|op| match op {
+            RenderOp::Text { value, .. } => Some(value.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn absolute_offset_text_rows_redraw_after_state_only_change() {
+    let _guard = test_guard();
+    let root_key = location_key(file!(), line!(), column!());
+    let state_holder: Rc<RefCell<Option<MutableState<i32>>>> = Rc::new(RefCell::new(None));
+    let state_holder_for_app = Rc::clone(&state_holder);
+
+    let mut shell = AppShell::new(RecordingRenderer::default(), root_key, move || {
+        let start = useState(|| 0i32);
+        *state_holder_for_app.borrow_mut() = Some(start);
+        AbsoluteOffsetStackedTextRows(start);
+    });
+
+    shell.update();
+    let initial_scene = shell
+        .renderer
+        .last_scene
+        .as_ref()
+        .expect("expected initial render scene");
+    let initial_texts = rendered_text_values(initial_scene);
+    assert!(initial_texts.iter().any(|text| text == "Row 00"));
+    assert!(!initial_texts.iter().any(|text| text == "Row 30"));
+
+    let start = state_holder
+        .borrow()
+        .as_ref()
+        .cloned()
+        .expect("start state should be captured");
+    start.set(30);
+    shell.update();
+
+    let updated_scene = shell
+        .renderer
+        .last_scene
+        .as_ref()
+        .expect("expected updated render scene");
+    let updated_texts = rendered_text_values(updated_scene);
+
+    assert!(
+        updated_texts.iter().any(|text| text == "Row 30"),
+        "render scene should contain recomposed absolute-offset text rows, got {updated_texts:?}"
+    );
+    assert!(
+        !updated_texts.iter().any(|text| text == "Row 00"),
+        "render scene must not keep stale absolute-offset text rows, got {updated_texts:?}"
+    );
+}
+
 #[test]
 fn app_shell_new_drains_root_render_requests_before_first_frame() {
     let _guard = test_guard();

--- a/crates/cranpose-render/wgpu/Cargo.toml
+++ b/crates/cranpose-render/wgpu/Cargo.toml
@@ -29,4 +29,5 @@ naga = { version = "28.0.0", features = ["glsl-out", "wgsl-in"] }
 ttf-parser = "0.25.1"
 
 [dev-dependencies]
+cranpose-app-shell = { workspace = true }
 pollster = "0.4.0"

--- a/crates/cranpose-render/wgpu/tests/absolute_offset_text_redraw.rs
+++ b/crates/cranpose-render/wgpu/tests/absolute_offset_text_redraw.rs
@@ -1,0 +1,126 @@
+mod support;
+
+use cranpose_app_shell::AppShell;
+use cranpose_core::{location_key, MutableState};
+use cranpose_render_wgpu::CapturedFrame;
+use cranpose_ui::text::{SpanStyle, TextUnit};
+use cranpose_ui::{composable, Box, BoxSpec, Color, Modifier, Text, TextStyle};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+const FRAME_WIDTH: u32 = 400;
+const FRAME_HEIGHT: u32 = 300;
+
+#[composable]
+#[allow(non_snake_case)]
+fn AbsoluteOffsetTextRedrawProbe(start: MutableState<i32>) {
+    let style = TextStyle::from_span_style(SpanStyle {
+        color: Some(Color(1.0, 0.78, 0.42, 1.0)),
+        font_size: TextUnit::Sp(11.0),
+        ..Default::default()
+    });
+    let pattern = if start.get() == 0 {
+        "IIIIIIIIIIII"
+    } else {
+        "WWWWWWWWWWWW"
+    };
+
+    Box(
+        Modifier::empty()
+            .size_points(FRAME_WIDTH as f32, FRAME_HEIGHT as f32)
+            .background(Color(0.015, 0.02, 0.03, 1.0)),
+        BoxSpec::default(),
+        move || {
+            for row in 0..14 {
+                Text(
+                    format!("{pattern} row {:02}", start.get() + row),
+                    Modifier::empty()
+                        .size_points(380.0, 16.0)
+                        .absolute_offset(8.0, row as f32 * 16.0),
+                    style.clone(),
+                );
+            }
+        },
+    );
+}
+
+fn bright_pixel_count(frame: &CapturedFrame) -> usize {
+    frame
+        .pixels
+        .chunks_exact(4)
+        .filter(|pixel| pixel[0] > 120 && pixel[1] > 80 && pixel[2] > 35)
+        .count()
+}
+
+fn changed_pixel_count(before: &CapturedFrame, after: &CapturedFrame, threshold: u8) -> usize {
+    assert_eq!(before.width, after.width);
+    assert_eq!(before.height, after.height);
+    before
+        .pixels
+        .chunks_exact(4)
+        .zip(after.pixels.chunks_exact(4))
+        .filter(|(before, after)| {
+            before[0].abs_diff(after[0]) > threshold
+                || before[1].abs_diff(after[1]) > threshold
+                || before[2].abs_diff(after[2]) > threshold
+                || before[3].abs_diff(after[3]) > threshold
+        })
+        .count()
+}
+
+#[test]
+fn absolute_offset_text_pixels_redraw_after_state_only_change() {
+    let (_lock, renderer) = match support::headless_renderer_parts() {
+        Ok(parts) => parts,
+        Err(err) => {
+            eprintln!("skipping absolute-offset text redraw assertion because headless WGPU init failed: {err}");
+            return;
+        }
+    };
+
+    let root_key = location_key(file!(), line!(), column!());
+    let state_holder: Rc<RefCell<Option<MutableState<i32>>>> = Rc::new(RefCell::new(None));
+    let state_holder_for_app = Rc::clone(&state_holder);
+    let mut shell = AppShell::new(renderer, root_key, move || {
+        let start = cranpose_core::useState(|| 0i32);
+        *state_holder_for_app.borrow_mut() = Some(start);
+        AbsoluteOffsetTextRedrawProbe(start);
+    });
+    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
+    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+    shell.update();
+
+    let before = shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("initial frame capture should succeed");
+    let before_bright = bright_pixel_count(&before);
+    assert!(
+        before_bright > 250,
+        "initial absolute-offset text should render visibly, bright pixels={before_bright}"
+    );
+
+    let start = state_holder
+        .borrow()
+        .as_ref()
+        .cloned()
+        .expect("start state should be captured");
+    start.set(30);
+    shell.update();
+
+    let after = shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("updated frame capture should succeed");
+    let after_bright = bright_pixel_count(&after);
+    assert!(
+        after_bright > 250,
+        "updated absolute-offset text should remain visibly rendered, bright pixels={after_bright}"
+    );
+
+    let changed_pixels = changed_pixel_count(&before, &after, 24);
+    assert!(
+        changed_pixels > 300,
+        "state-only text recomposition should change the rasterized text without waiting for input, changed pixels={changed_pixels}"
+    );
+}

--- a/crates/cranpose-render/wgpu/tests/support.rs
+++ b/crates/cranpose-render/wgpu/tests/support.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -29,6 +31,20 @@ impl DerefMut for LockedRenderer {
 
 pub fn headless_renderer() -> Result<LockedRenderer, String> {
     let lock = GPU_TEST_LOCK.lock().expect("GPU test lock poisoned");
+    let renderer = create_headless_renderer()?;
+    Ok(LockedRenderer {
+        _lock: lock,
+        renderer,
+    })
+}
+
+pub fn headless_renderer_parts() -> Result<(MutexGuard<'static, ()>, WgpuRenderer), String> {
+    let lock = GPU_TEST_LOCK.lock().expect("GPU test lock poisoned");
+    let renderer = create_headless_renderer()?;
+    Ok((lock, renderer))
+}
+
+fn create_headless_renderer() -> Result<WgpuRenderer, String> {
     let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
         backends: wgpu::Backends::all(),
         ..Default::default()
@@ -56,8 +72,5 @@ pub fn headless_renderer() -> Result<LockedRenderer, String> {
         wgpu::TextureFormat::Bgra8UnormSrgb,
         adapter.get_info().backend,
     );
-    Ok(LockedRenderer {
-        _lock: lock,
-        renderer,
-    })
+    Ok(renderer)
 }


### PR DESCRIPTION
## Summary
- add an app-shell regression that verifies absolute-offset Text rows update the retained render scene after a state-only change
- add a headless WGPU capture regression that verifies the same scenario remains visibly rasterized and changes pixels without waiting for input
- share the WGPU test renderer setup so app-shell capture tests can reuse the locked headless renderer

Fixes #250

## Verification
- cargo test > 1.tmp 2>&1
- cargo clippy > 2.tmp 2>&1
- cargo fmt
- cargo test -p cranpose-app-shell absolute_offset_text_rows_redraw_after_state_only_change
- cargo test -p cranpose-render-wgpu absolute_offset_text_pixels_redraw_after_state_only_change
- cargo clippy -p cranpose-render-wgpu --tests
- apps/desktop-demo/build-web.sh
- apps/android-demo/android ./gradlew :app:assembleRelease
- CRANPOSE_USE_SCCACHE=0 ./run_robot_test.sh --sequential