### PR TITLE
[codex] Add Android overlay position state

### DIFF
--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -12,7 +12,7 @@ use crate::{
 use cranpose_app_shell::{default_root_key, AppShell};
 use cranpose_platform_android::AndroidPlatform;
 use cranpose_render_wgpu::WgpuRenderer;
-use cranpose_ui::Size;
+use cranpose_ui::{Point, Size};
 use ndk::native_window::NativeWindow;
 use std::time::Instant;
 use std::{
@@ -389,14 +389,15 @@ fn create_android_wgpu_surface(
 fn dispatch_android_surface_size_request(
     app: &android_activity::AndroidApp,
     requested: Size,
+    position: Point,
     density: f32,
     overlay_options: Option<AndroidOverlayWindowOptions>,
 ) -> Result<(), String> {
     let requested =
         android_host_window::validate_logical_size(requested).map_err(|error| error.to_string())?;
-    if let Some(options) = overlay_options {
+    if overlay_options.is_some() {
         return android_overlay_window::update_android_overlay_window_bounds(
-            app, options, requested, density,
+            app, position, requested, density,
         );
     }
 
@@ -409,19 +410,37 @@ fn dispatch_registered_android_surface_size_request(
     app: &android_activity::AndroidApp,
     density: f32,
     overlay_options: Option<AndroidOverlayWindowOptions>,
-    last_dispatched: &mut Option<(android_host_window::AndroidHostWindowState, u64)>,
+    last_dispatched: &mut Option<(android_host_window::AndroidHostWindowState, u64, u64)>,
     pending_confirmation: &mut Option<PendingHostWindowSizeRequest>,
 ) {
     let Some(request) = android_host_window::latest_android_host_window_request() else {
         return;
     };
-    let dispatch_key = (request.state, request.revision);
+    let dispatch_key = (
+        request.state,
+        request.size_revision,
+        if overlay_options.is_some() {
+            request.position_revision
+        } else {
+            0
+        },
+    );
     if *last_dispatched == Some(dispatch_key) {
         return;
     }
 
+    let position = overlay_options
+        .filter(|_| request.position_revision == 0)
+        .map(|options| Point::new(options.x as f32, options.y as f32))
+        .unwrap_or(request.position);
     request.state.mark_pending(request.size);
-    match dispatch_android_surface_size_request(app, request.size, density, overlay_options) {
+    match dispatch_android_surface_size_request(
+        app,
+        request.size,
+        position,
+        density,
+        overlay_options,
+    ) {
         Ok(()) => {
             *last_dispatched = Some(dispatch_key);
             *pending_confirmation = Some(PendingHostWindowSizeRequest {
@@ -434,11 +453,21 @@ fn dispatch_registered_android_surface_size_request(
             } else {
                 "Android host-window"
             };
-            log::info!(
-                "Requested {target} size {:.1}x{:.1} dp",
-                request.size.width,
-                request.size.height
-            );
+            if overlay_options.is_some() {
+                log::info!(
+                    "Requested {target} bounds {:.1}x{:.1} dp at {:.1},{:.1} dp",
+                    request.size.width,
+                    request.size.height,
+                    position.x,
+                    position.y
+                );
+            } else {
+                log::info!(
+                    "Requested {target} size {:.1}x{:.1} dp",
+                    request.size.width,
+                    request.size.height
+                );
+            }
         }
         Err(message) => {
             *last_dispatched = Some(dispatch_key);
@@ -590,7 +619,7 @@ pub fn run(
         )
     });
     let mut last_dispatched_host_window_request =
-        None::<(android_host_window::AndroidHostWindowState, u64)>;
+        None::<(android_host_window::AndroidHostWindowState, u64, u64)>;
     let mut pending_host_window_confirmation = None::<PendingHostWindowSizeRequest>;
     let mut overlay_window_options = settings.android_overlay_window;
     let mut overlay_window_requested = false;
@@ -699,7 +728,11 @@ pub fn run(
 
                                 if let Some(requested) = initial_host_window_size.take() {
                                     match dispatch_android_surface_size_request(
-                                        &app, requested, density, None,
+                                        &app,
+                                        requested,
+                                        Point::ZERO,
+                                        density,
+                                        None,
                                     ) {
                                         Ok(()) => {
                                             pending_host_window_confirmation =

--- a/crates/cranpose/src/android_host_window.rs
+++ b/crates/cranpose/src/android_host_window.rs
@@ -1,7 +1,7 @@
 //! Android host-window size request state.
 
 use cranpose_core::MutableState;
-use cranpose_ui::{composable, Size};
+use cranpose_ui::{composable, Point, Size};
 use std::{
     cell::{Cell, RefCell},
     rc::Rc,
@@ -27,6 +27,14 @@ pub enum AndroidHostWindowSizeError {
     /// Width or height was zero or negative.
     #[error("Android host-window dimensions must be greater than zero")]
     NonPositive,
+}
+
+/// Validation error for an Android host-window position request.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum AndroidHostWindowPositionError {
+    /// X or Y was NaN or infinite.
+    #[error("Android host-window coordinates must be finite")]
+    NonFinite,
 }
 
 /// Result status for the latest Android host-window size request.
@@ -77,8 +85,10 @@ pub enum AndroidHostWindowSizeStatus {
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub struct AndroidHostWindowState {
     requested_size: MutableState<Size>,
+    requested_position: MutableState<Point>,
     actual_size: MutableState<Size>,
     request_revision: MutableState<u64>,
+    position_revision: MutableState<u64>,
     status: MutableState<AndroidHostWindowSizeStatus>,
 }
 
@@ -91,6 +101,19 @@ impl AndroidHostWindowState {
     /// Returns the requested host-window size without subscribing to changes.
     pub fn requested_size_non_reactive(self) -> Size {
         self.requested_size.get_non_reactive()
+    }
+
+    /// Returns the requested host-window position in logical pixels.
+    ///
+    /// Position requests are only applied when Android overlay-window mode is active.
+    /// Normal Activity windows keep Android-managed positioning and ignore this value.
+    pub fn requested_position(self) -> Point {
+        self.requested_position.get()
+    }
+
+    /// Returns the requested host-window position without subscribing to changes.
+    pub fn requested_position_non_reactive(self) -> Point {
+        self.requested_position.get_non_reactive()
     }
 
     /// Returns the actual host surface size last reported by Android in logical pixels.
@@ -141,8 +164,30 @@ impl AndroidHostWindowState {
         Ok(())
     }
 
+    /// Requests a new Android overlay-window position in logical pixels.
+    ///
+    /// This is meaningful only when the app is launched with
+    /// [`crate::AppLauncher::with_android_overlay_window`]. In overlay mode the
+    /// request is sent after the next successful composition pass and updates the
+    /// `WindowManager.LayoutParams` for the active overlay surface. In normal
+    /// Activity mode Android owns task/window placement, so position requests are
+    /// retained in state but not dispatched to the platform.
+    pub fn set_position(self, position: Point) -> Result<(), AndroidHostWindowPositionError> {
+        let requested = validate_logical_position(position)?;
+        if self.requested_position.get_non_reactive() != requested {
+            self.requested_position.set(requested);
+        }
+        self.position_revision
+            .set(self.position_revision.get_non_reactive().wrapping_add(1));
+        Ok(())
+    }
+
     pub(crate) fn request_revision_non_reactive(self) -> u64 {
         self.request_revision.get_non_reactive()
+    }
+
+    pub(crate) fn position_revision_non_reactive(self) -> u64 {
+        self.position_revision.get_non_reactive()
     }
 
     pub(crate) fn mark_pending(self, requested: Size) {
@@ -191,7 +236,7 @@ impl AndroidHostWindowState {
 ///
 /// In normal Android activity mode this state targets the current
 /// `NativeActivity` host window. In Android overlay mode it resizes the active
-/// overlay surface through `WindowManager.updateViewLayout`.
+/// overlay surface and can move it through `WindowManager.updateViewLayout`.
 #[allow(non_snake_case)]
 #[composable]
 pub fn rememberAndroidHostWindowState(width: f32, height: f32) -> AndroidHostWindowState {
@@ -212,8 +257,10 @@ pub fn rememberAndroidHostWindowState(width: f32, height: f32) -> AndroidHostWin
 
     let state = AndroidHostWindowState {
         requested_size: cranpose_core::useState(move || initial_requested),
+        requested_position: cranpose_core::useState(|| Point::ZERO),
         actual_size: cranpose_core::useState(|| Size::ZERO),
         request_revision: cranpose_core::useState(move || initial_revision),
+        position_revision: cranpose_core::useState(|| 0_u64),
         status: cranpose_core::useState(move || initial_status),
     };
 
@@ -238,7 +285,9 @@ pub fn rememberAndroidHostWindowState(width: f32, height: f32) -> AndroidHostWin
 pub(crate) struct AndroidHostWindowRequest {
     pub(crate) state: AndroidHostWindowState,
     pub(crate) size: Size,
-    pub(crate) revision: u64,
+    pub(crate) position: Point,
+    pub(crate) size_revision: u64,
+    pub(crate) position_revision: u64,
 }
 
 #[derive(Clone)]
@@ -264,7 +313,9 @@ pub(crate) fn latest_android_host_window_request() -> Option<AndroidHostWindowRe
             .map(|registration| AndroidHostWindowRequest {
                 state: registration.state,
                 size: registration.state.requested_size_non_reactive(),
-                revision: registration.state.request_revision_non_reactive(),
+                position: registration.state.requested_position_non_reactive(),
+                size_revision: registration.state.request_revision_non_reactive(),
+                position_revision: registration.state.position_revision_non_reactive(),
             })
     })
 }
@@ -285,6 +336,15 @@ pub(crate) fn validate_logical_size(size: Size) -> Result<Size, AndroidHostWindo
         return Err(AndroidHostWindowSizeError::NonPositive);
     }
     Ok(size)
+}
+
+pub(crate) fn validate_logical_position(
+    position: Point,
+) -> Result<Point, AndroidHostWindowPositionError> {
+    if !position.x.is_finite() || !position.y.is_finite() {
+        return Err(AndroidHostWindowPositionError::NonFinite);
+    }
+    Ok(position)
 }
 
 pub(crate) fn logical_to_physical_window_size(size: Size, density: f32) -> (i32, i32) {
@@ -350,36 +410,51 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
-    fn test_state(
-        width: f32,
-        height: f32,
-    ) -> (
-        cranpose_core::Runtime,
-        cranpose_core::OwnedMutableState<Size>,
-        cranpose_core::OwnedMutableState<Size>,
-        cranpose_core::OwnedMutableState<u64>,
-        cranpose_core::OwnedMutableState<AndroidHostWindowSizeStatus>,
-        AndroidHostWindowState,
-    ) {
+    struct TestState {
+        _runtime: cranpose_core::Runtime,
+        _requested: cranpose_core::OwnedMutableState<Size>,
+        _position: cranpose_core::OwnedMutableState<Point>,
+        _actual: cranpose_core::OwnedMutableState<Size>,
+        _revision: cranpose_core::OwnedMutableState<u64>,
+        _position_revision: cranpose_core::OwnedMutableState<u64>,
+        _status: cranpose_core::OwnedMutableState<AndroidHostWindowSizeStatus>,
+        state: AndroidHostWindowState,
+    }
+
+    fn test_state(width: f32, height: f32) -> TestState {
         let runtime = cranpose_core::Runtime::new(Arc::new(cranpose_core::DefaultScheduler));
         let handle = runtime.handle();
         let requested = cranpose_core::OwnedMutableState::with_runtime(
             Size::new(width, height),
             handle.clone(),
         );
+        let position = cranpose_core::OwnedMutableState::with_runtime(Point::ZERO, handle.clone());
         let actual = cranpose_core::OwnedMutableState::with_runtime(Size::ZERO, handle.clone());
         let revision = cranpose_core::OwnedMutableState::with_runtime(1_u64, handle.clone());
+        let position_revision =
+            cranpose_core::OwnedMutableState::with_runtime(0_u64, handle.clone());
         let status = cranpose_core::OwnedMutableState::with_runtime(
             AndroidHostWindowSizeStatus::Idle,
             handle,
         );
         let state = AndroidHostWindowState {
             requested_size: requested.handle(),
+            requested_position: position.handle(),
             actual_size: actual.handle(),
             request_revision: revision.handle(),
+            position_revision: position_revision.handle(),
             status: status.handle(),
         };
-        (runtime, requested, actual, revision, status, state)
+        TestState {
+            _runtime: runtime,
+            _requested: requested,
+            _position: position,
+            _actual: actual,
+            _revision: revision,
+            _position_revision: position_revision,
+            _status: status,
+            state,
+        }
     }
 
     #[test]
@@ -414,6 +489,25 @@ mod tests {
     }
 
     #[test]
+    fn validate_logical_position_accepts_finite_coordinates() {
+        let position = Point::new(-20.0, 48.5);
+
+        assert_eq!(validate_logical_position(position), Ok(position));
+    }
+
+    #[test]
+    fn validate_logical_position_rejects_non_finite_coordinates() {
+        assert_eq!(
+            validate_logical_position(Point::new(f32::NAN, 10.0)),
+            Err(AndroidHostWindowPositionError::NonFinite)
+        );
+        assert_eq!(
+            validate_logical_position(Point::new(10.0, f32::INFINITY)),
+            Err(AndroidHostWindowPositionError::NonFinite)
+        );
+    }
+
+    #[test]
     fn logical_to_physical_window_size_rounds_and_clamps() {
         assert_eq!(
             logical_to_physical_window_size(Size::new(10.4, 12.6), 2.0),
@@ -427,7 +521,8 @@ mod tests {
 
     #[test]
     fn state_set_size_updates_requested_size_and_revision() {
-        let (_runtime, _requested, _actual, _revision, _status, state) = test_state(100.0, 50.0);
+        let harness = test_state(100.0, 50.0);
+        let state = harness.state;
 
         state.set_size(Size::new(200.0, 75.0)).unwrap();
 
@@ -443,7 +538,8 @@ mod tests {
 
     #[test]
     fn state_set_size_rejects_invalid_size_without_changing_request() {
-        let (_runtime, _requested, _actual, _revision, _status, state) = test_state(100.0, 50.0);
+        let harness = test_state(100.0, 50.0);
+        let state = harness.state;
 
         let result = state.set_size(Size::new(f32::NAN, 75.0));
 
@@ -461,8 +557,37 @@ mod tests {
     }
 
     #[test]
+    fn state_set_position_updates_requested_position_and_revision() {
+        let harness = test_state(100.0, 50.0);
+        let state = harness.state;
+
+        state.set_position(Point::new(12.0, -4.0)).unwrap();
+
+        assert_eq!(
+            state.requested_position_non_reactive(),
+            Point::new(12.0, -4.0)
+        );
+        assert_eq!(state.request_revision_non_reactive(), 1);
+        assert_eq!(state.position_revision_non_reactive(), 1);
+    }
+
+    #[test]
+    fn state_set_position_rejects_invalid_position_without_changing_request() {
+        let harness = test_state(100.0, 50.0);
+        let state = harness.state;
+
+        let result = state.set_position(Point::new(f32::NAN, 4.0));
+
+        assert_eq!(result, Err(AndroidHostWindowPositionError::NonFinite));
+        assert_eq!(state.requested_position_non_reactive(), Point::ZERO);
+        assert_eq!(state.request_revision_non_reactive(), 1);
+        assert_eq!(state.position_revision_non_reactive(), 0);
+    }
+
+    #[test]
     fn state_tracks_actual_size_separately_from_requested_size() {
-        let (_runtime, _requested, _actual, _revision, _status, state) = test_state(100.0, 50.0);
+        let harness = test_state(100.0, 50.0);
+        let state = harness.state;
 
         state.set_size(Size::new(200.0, 75.0)).unwrap();
         state.set_actual_size(Size::new(120.0, 60.0));
@@ -475,5 +600,22 @@ mod tests {
     fn sizes_match_allows_half_logical_pixel_rounding_error() {
         assert!(sizes_match(Size::new(100.0, 50.0), Size::new(100.5, 49.5)));
         assert!(!sizes_match(Size::new(100.0, 50.0), Size::new(100.6, 50.0)));
+    }
+
+    #[test]
+    fn latest_request_includes_requested_position() {
+        let harness = test_state(100.0, 50.0);
+        let state = harness.state;
+        state.set_position(Point::new(24.0, 36.0)).unwrap();
+        let owner = Rc::new(());
+        register_android_host_window_state(state, Rc::clone(&owner));
+
+        let request = latest_android_host_window_request().expect("registered request");
+
+        assert_eq!(request.size, Size::new(100.0, 50.0));
+        assert_eq!(request.position, Point::new(24.0, 36.0));
+        assert_eq!(request.size_revision, 1);
+        assert_eq!(request.position_revision, 1);
+        unregister_android_host_window_state(state, owner);
     }
 }

--- a/crates/cranpose/src/android_overlay_window.rs
+++ b/crates/cranpose/src/android_overlay_window.rs
@@ -5,7 +5,7 @@ use crate::{
     android_jni::{clear_pending_android_jni_exception, with_android_activity_env},
     launcher::AndroidOverlayWindowOptions,
 };
-use cranpose_ui::Size;
+use cranpose_ui::{Point, Size};
 use jni::{
     objects::{GlobalRef, JClass, JObject, JString, JValue},
     sys::{jfloat, jint},
@@ -92,11 +92,11 @@ pub(crate) fn show_android_overlay_window(
 
 pub(crate) fn update_android_overlay_window_bounds(
     app: &android_activity::AndroidApp,
-    options: AndroidOverlayWindowOptions,
+    position: Point,
     size: Size,
     density: f32,
 ) -> Result<(), String> {
-    let bounds = overlay_size_to_physical_bounds(options, size, density)?;
+    let bounds = overlay_bounds_to_physical(position, size, density)?;
 
     with_android_activity_env(app, |env, activity| {
         let class = find_overlay_class(env, &activity)?;
@@ -223,15 +223,15 @@ fn overlay_options_to_physical_bounds(
     if !options.is_valid() {
         return Err("Android overlay window dimensions must be greater than zero".to_string());
     }
-    overlay_size_to_physical_bounds(
-        options,
+    overlay_bounds_to_physical(
+        Point::new(options.x as f32, options.y as f32),
         Size::new(options.width as f32, options.height as f32),
         density,
     )
 }
 
-fn overlay_size_to_physical_bounds(
-    options: AndroidOverlayWindowOptions,
+fn overlay_bounds_to_physical(
+    position: Point,
     size: Size,
     density: f32,
 ) -> Result<AndroidOverlayWindowBounds, String> {
@@ -240,8 +240,8 @@ fn overlay_size_to_physical_bounds(
     Ok(AndroidOverlayWindowBounds {
         width_px: logical_dimension_to_physical_px(size.width, density)?,
         height_px: logical_dimension_to_physical_px(size.height, density)?,
-        x_px: logical_to_physical_px(options.x as f32, density)?,
-        y_px: logical_to_physical_px(options.y as f32, density)?,
+        x_px: logical_to_physical_px(position.x, density)?,
+        y_px: logical_to_physical_px(position.y, density)?,
     })
 }
 
@@ -397,17 +397,34 @@ mod tests {
     }
 
     #[test]
-    fn overlay_size_to_physical_bounds_uses_requested_size_and_initial_position() {
+    fn overlay_options_to_physical_bounds_uses_initial_position_and_size() {
         let options = AndroidOverlayWindowOptions::new(100, 50).with_position(-4, 8);
-        let bounds = overlay_size_to_physical_bounds(options, Size::new(200.0, 80.0), 2.0).unwrap();
+        let bounds = overlay_options_to_physical_bounds(options, 2.0).unwrap();
+
+        assert_eq!(
+            bounds,
+            AndroidOverlayWindowBounds {
+                width_px: 200,
+                height_px: 100,
+                x_px: -8,
+                y_px: 16,
+            }
+        );
+    }
+
+    #[test]
+    fn overlay_bounds_to_physical_uses_runtime_position_and_size() {
+        let bounds =
+            overlay_bounds_to_physical(Point::new(12.25, -4.5), Size::new(200.0, 80.0), 2.0)
+                .unwrap();
 
         assert_eq!(
             bounds,
             AndroidOverlayWindowBounds {
                 width_px: 400,
                 height_px: 160,
-                x_px: -8,
-                y_px: 16,
+                x_px: 25,
+                y_px: -9,
             }
         );
     }

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -25,8 +25,8 @@ mod launcher;
 mod native_window;
 #[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
 pub use android_host_window::{
-    rememberAndroidHostWindowState, AndroidHostWindowSizeError, AndroidHostWindowSizeStatus,
-    AndroidHostWindowState,
+    rememberAndroidHostWindowState, AndroidHostWindowPositionError, AndroidHostWindowSizeError,
+    AndroidHostWindowSizeStatus, AndroidHostWindowState,
 };
 #[cfg(all(feature = "desktop", feature = "renderer-wgpu"))]
 pub use launcher::LaunchError;
@@ -61,8 +61,8 @@ pub type RobotAppHook = dyn FnMut(String, String) -> Result<Option<String>, Stri
 pub mod prelude {
     #[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
     pub use crate::{
-        rememberAndroidHostWindowState, AndroidHostWindowSizeError, AndroidHostWindowSizeStatus,
-        AndroidHostWindowState,
+        rememberAndroidHostWindowState, AndroidHostWindowPositionError, AndroidHostWindowSizeError,
+        AndroidHostWindowSizeStatus, AndroidHostWindowState,
     };
     pub use crate::{
         rememberWindowState, AndroidOverlayWindowOptions, AppLauncher, AppSettings, Window,


### PR DESCRIPTION
## Summary

Adds Android overlay-window position as first-class Cranpose host-window state so apps can move an active overlay surface from composition state instead of relying on app-specific JNI bridges.

## Changes

- Added `AndroidHostWindowState::set_position(Point)` plus requested-position accessors and validation.
- Split host-window size and position revisions so normal Activity windows ignore position-only updates while overlay windows dispatch them.
- Updated Android overlay dispatch to call `WindowManager.updateViewLayout` with runtime position and size.
- Preserved the launcher-provided initial overlay position until the app explicitly sends a position request.
- Exported `AndroidHostWindowPositionError` through the Android API and prelude.

Fixes #257

## Validation

- `cargo fmt`
- `cargo test > 1.tmp 2>&1` and inspected the log for failures/warnings
- `cargo clippy > 2.tmp 2>&1` and inspected the log for failures/warnings
- `apps/desktop-demo/build-web.sh`
- `apps/android-demo/android ./gradlew :app:assembleRelease`

Robot validation was attempted with `CRANPOSE_USE_SCCACHE=0 ./run_robot_test.sh --sequential`, but the local host capacity guard timed out before the robot build because the machine stayed above the configured resume temperature. CI needs to provide that signal.