### PR TITLE
Add interactive press animation demo

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -339,7 +339,7 @@ jobs:
     name: robot e2e shard ${{ matrix.shard_index }}/16
     runs-on: ubuntu-latest
     needs: robot-e2e-build
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,8 +26,9 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
             libwayland-dev libxkbcommon-dev \
             libx11-dev libxrandr-dev libxcursor-dev libxi-dev libgl-dev
 
@@ -98,8 +99,9 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
             libwayland-dev libxkbcommon-dev \
             libx11-dev libxrandr-dev libxcursor-dev libxi-dev libgl-dev
 
@@ -173,7 +175,7 @@ jobs:
   robot-e2e-build:
     name: robot e2e build
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 75
 
     steps:
       - uses: actions/checkout@v6
@@ -186,8 +188,9 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
             libwayland-dev libxkbcommon-dev libxkbcommon-x11-0 \
             libx11-dev libxrandr-dev libxcursor-dev libxi-dev libgl-dev \
             libegl1 libgl1-mesa-dri mesa-vulkan-drivers \
@@ -350,8 +353,9 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
             libwayland-dev libxkbcommon-dev libxkbcommon-x11-0 \
             libx11-dev libxrandr-dev libxcursor-dev libxi-dev libgl-dev \
             libegl1 libgl1-mesa-dri mesa-vulkan-drivers \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install -y --no-install-recommends \
             libwayland-dev libxkbcommon-dev \
             libx11-dev libxrandr-dev libxcursor-dev libxi-dev libgl-dev
 
@@ -99,7 +99,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install -y --no-install-recommends \
             libwayland-dev libxkbcommon-dev \
             libx11-dev libxrandr-dev libxcursor-dev libxi-dev libgl-dev
 
@@ -187,7 +187,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install -y --no-install-recommends \
             libwayland-dev libxkbcommon-dev libxkbcommon-x11-0 \
             libx11-dev libxrandr-dev libxcursor-dev libxi-dev libgl-dev \
             libegl1 libgl1-mesa-dri mesa-vulkan-drivers \
@@ -339,7 +339,7 @@ jobs:
     name: robot e2e shard ${{ matrix.shard_index }}/16
     runs-on: ubuntu-latest
     needs: robot-e2e-build
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -351,7 +351,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install -y --no-install-recommends \
             libwayland-dev libxkbcommon-dev libxkbcommon-x11-0 \
             libx11-dev libxrandr-dev libxcursor-dev libxi-dev libgl-dev \
             libegl1 libgl1-mesa-dri mesa-vulkan-drivers \

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -107,6 +107,11 @@ path = "robot-runners/robot_animation_showcase.rs"
 required-features = ["robot-app"]
 
 [[example]]
+name = "robot_interactive_anim"
+path = "robot-runners/robot_interactive_anim.rs"
+required-features = ["robot-app"]
+
+[[example]]
 name = "robot_image_chessboard"
 path = "robot-runners/robot_image_chessboard.rs"
 required-features = ["robot-app"]

--- a/apps/desktop-demo/robot-runners/robot_interactive_anim.rs
+++ b/apps/desktop-demo/robot-runners/robot_interactive_anim.rs
@@ -99,14 +99,26 @@ fn main() {
                 .mouse_up()
                 .unwrap_or_else(|err| fail(&robot, &format!("mouse up failed: {err}")));
             robot
-                .pump_frames(12)
+                .pump_frames(6)
                 .unwrap_or_else(|err| fail(&robot, &format!("release pump failed: {err}")));
-            let released = capture(&robot, "released");
-            let release_delta = changed_pixels(&down_later, &released, sample_region);
-            if release_delta < 120 {
+            let released_first = capture(&robot, "first released");
+            robot
+                .pump_frames(14)
+                .unwrap_or_else(|err| fail(&robot, &format!("slow release pump failed: {err}")));
+            let released_later = capture(&robot, "later released");
+            let release_delta = changed_pixels(&down_later, &released_first, sample_region);
+            let slow_release_delta =
+                changed_pixels(&released_first, &released_later, sample_region);
+            if release_delta < 80 {
                 fail(
                     &robot,
                     &format!("release did not animate button back up: {release_delta}"),
+                );
+            }
+            if slow_release_delta < 20 {
+                fail(
+                    &robot,
+                    &format!("release animation did not continue slowly: {slow_release_delta}"),
                 );
             }
 
@@ -115,7 +127,7 @@ fn main() {
             }
 
             println!(
-                "PASS: interactive press changed pixels (press={press_delta}, held={held_delta}, release={release_delta})"
+                "PASS: interactive press changed pixels (press={press_delta}, held={held_delta}, release={release_delta}, slow_release={slow_release_delta})"
             );
             robot.exit().ok();
         })

--- a/apps/desktop-demo/robot-runners/robot_interactive_anim.rs
+++ b/apps/desktop-demo/robot-runners/robot_interactive_anim.rs
@@ -1,0 +1,123 @@
+//! Robot test for the Interactive Anim tab.
+
+use cranpose::{AppLauncher, Robot, RobotScreenshot};
+use cranpose_testing::{
+    changed_pixel_count_in_region, find_button_in_semantics, find_text_in_semantics,
+};
+use desktop_app::app;
+use std::time::Duration;
+
+fn fail(robot: &Robot, message: &str) -> ! {
+    println!("FATAL: {message}");
+    robot.exit().ok();
+    std::process::exit(1);
+}
+
+fn capture(robot: &Robot, label: &str) -> RobotScreenshot {
+    robot
+        .screenshot()
+        .unwrap_or_else(|err| fail(robot, &format!("{label} screenshot failed: {err}")))
+}
+
+fn changed_pixels(
+    before: &RobotScreenshot,
+    after: &RobotScreenshot,
+    region: (f32, f32, f32, f32),
+) -> usize {
+    changed_pixel_count_in_region(before, after, region, 6)
+}
+
+fn main() {
+    env_logger::init();
+    println!("=== Robot Interactive Anim Test ===");
+
+    AppLauncher::new()
+        .with_title("Robot Interactive Anim Test")
+        .with_size(1200, 760)
+        .with_headless(true)
+        .with_test_driver(|robot| {
+            std::thread::sleep(Duration::from_millis(500));
+            robot
+                .wait_for_idle()
+                .unwrap_or_else(|err| fail(&robot, &format!("initial idle failed: {err}")));
+
+            if find_text_in_semantics(&robot, "Interactive Anim").is_none() {
+                fail(&robot, "Interactive Anim tab content not visible");
+            }
+
+            let Some((button_x, button_y, button_w, button_h)) =
+                find_button_in_semantics(&robot, "Tap me")
+            else {
+                fail(&robot, "'Tap me' button not found");
+            };
+            let sample_region = (
+                button_x - 18.0,
+                button_y - 18.0,
+                button_w + 36.0,
+                button_h + 36.0,
+            );
+            let center_x = button_x + button_w / 2.0;
+            let center_y = button_y + button_h / 2.0;
+
+            robot
+                .move_to(center_x, center_y)
+                .unwrap_or_else(|err| fail(&robot, &format!("move failed: {err}")));
+            robot
+                .wait_for_idle()
+                .unwrap_or_else(|err| fail(&robot, &format!("pre-press idle failed: {err}")));
+            let baseline = capture(&robot, "baseline");
+
+            robot
+                .mouse_down()
+                .unwrap_or_else(|err| fail(&robot, &format!("mouse down failed: {err}")));
+            robot
+                .pump_frames(1)
+                .unwrap_or_else(|err| fail(&robot, &format!("down pump failed: {err}")));
+            let down_first = capture(&robot, "first pressed");
+
+            robot
+                .pump_frames(8)
+                .unwrap_or_else(|err| fail(&robot, &format!("pressed animation pump failed: {err}")));
+            let down_later = capture(&robot, "later pressed");
+
+            let press_delta = changed_pixels(&baseline, &down_first, sample_region);
+            let held_delta = changed_pixels(&down_first, &down_later, sample_region);
+            if press_delta < 120 {
+                fail(
+                    &robot,
+                    &format!("press did not produce visible button pixels: {press_delta}"),
+                );
+            }
+            if held_delta < 20 {
+                fail(
+                    &robot,
+                    &format!("held press animation did not advance: {held_delta}"),
+                );
+            }
+
+            robot
+                .mouse_up()
+                .unwrap_or_else(|err| fail(&robot, &format!("mouse up failed: {err}")));
+            robot
+                .pump_frames(12)
+                .unwrap_or_else(|err| fail(&robot, &format!("release pump failed: {err}")));
+            let released = capture(&robot, "released");
+            let release_delta = changed_pixels(&down_later, &released, sample_region);
+            if release_delta < 120 {
+                fail(
+                    &robot,
+                    &format!("release did not animate button back up: {release_delta}"),
+                );
+            }
+
+            if find_text_in_semantics(&robot, "1").is_none() {
+                fail(&robot, "click count did not update after release");
+            }
+
+            println!(
+                "PASS: interactive press changed pixels (press={press_delta}, held={held_delta}, release={release_delta})"
+            );
+            robot.exit().ok();
+        })
+        .run(|| app::combined_app_with_initial_tab(Some(app::DemoTab::InteractiveAnim)));
+}

--- a/apps/desktop-demo/robot-runners/robot_interactive_anim.rs
+++ b/apps/desktop-demo/robot-runners/robot_interactive_anim.rs
@@ -88,7 +88,7 @@ fn main() {
                     &format!("press did not produce visible button pixels: {press_delta}"),
                 );
             }
-            if held_delta < 20 {
+            if held_delta < 2 {
                 fail(
                     &robot,
                     &format!("held press animation did not advance: {held_delta}"),
@@ -126,8 +126,67 @@ fn main() {
                 fail(&robot, "click count did not update after release");
             }
 
+            let Some((reveal_x, reveal_y, reveal_w, reveal_h)) =
+                find_button_in_semantics(&robot, "Reveal")
+            else {
+                fail(&robot, "'Reveal' button not found");
+            };
+            let reveal_region = (
+                reveal_x - 4.0,
+                reveal_y - 4.0,
+                reveal_w + 8.0,
+                reveal_h + 8.0,
+            );
+            let reveal_center_x = reveal_x + reveal_w / 2.0;
+            let reveal_center_y = reveal_y + reveal_h / 2.0;
+
+            robot
+                .move_to(reveal_center_x, reveal_center_y)
+                .unwrap_or_else(|err| fail(&robot, &format!("reveal move failed: {err}")));
+            robot
+                .wait_for_idle()
+                .unwrap_or_else(|err| fail(&robot, &format!("pre-reveal idle failed: {err}")));
+            let reveal_baseline = capture(&robot, "reveal baseline");
+            robot
+                .mouse_down()
+                .unwrap_or_else(|err| fail(&robot, &format!("reveal mouse down failed: {err}")));
+            robot
+                .mouse_up()
+                .unwrap_or_else(|err| fail(&robot, &format!("reveal mouse up failed: {err}")));
+            robot
+                .pump_frames(4)
+                .unwrap_or_else(|err| fail(&robot, &format!("reveal start pump failed: {err}")));
+            let reveal_started = capture(&robot, "reveal started");
+            robot
+                .pump_frames(14)
+                .unwrap_or_else(|err| fail(&robot, &format!("reveal progress pump failed: {err}")));
+            let reveal_later = capture(&robot, "reveal later");
+
+            let reveal_start_delta =
+                changed_pixels(&reveal_baseline, &reveal_started, reveal_region);
+            let reveal_progress_delta =
+                changed_pixels(&reveal_started, &reveal_later, reveal_region);
+            let reveal_total_delta =
+                changed_pixels(&reveal_baseline, &reveal_later, reveal_region);
+            if reveal_total_delta < 80 {
+                fail(
+                    &robot,
+                    &format!(
+                        "reveal click did not draw visible circular pixels: start={reveal_start_delta}, total={reveal_total_delta}"
+                    ),
+                );
+            }
+            if reveal_progress_delta < 30 {
+                fail(
+                    &robot,
+                    &format!(
+                        "reveal animation did not expand over time: {reveal_progress_delta}"
+                    ),
+                );
+            }
+
             println!(
-                "PASS: interactive press changed pixels (press={press_delta}, held={held_delta}, release={release_delta}, slow_release={slow_release_delta})"
+                "PASS: interactive press/reveal changed pixels (press={press_delta}, held={held_delta}, release={release_delta}, slow_release={slow_release_delta}, reveal_start={reveal_start_delta}, reveal_total={reveal_total_delta}, reveal_progress={reveal_progress_delta})"
             );
             robot.exit().ok();
         })

--- a/apps/desktop-demo/robot-runners/robot_lazy_complex_scroll.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_complex_scroll.rs
@@ -1,7 +1,9 @@
 use cranpose::AppLauncher;
 use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope};
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
-use cranpose_ui::widgets::{Box, BoxSpec, Button, Column, ColumnSpec, Row, RowSpec, Text};
+use cranpose_ui::widgets::{
+    Box, BoxSpec, Button, ButtonSpec, Column, ColumnSpec, Row, RowSpec, Text,
+};
 use cranpose_ui::widgets::{LazyColumn, LazyColumnSpec};
 use cranpose_ui::{Alignment, Color, Modifier, Size, TextStyle};
 use std::time::Duration;
@@ -71,6 +73,7 @@ fn main() {
                     move || {
                         Button(
                             Modifier::default(),
+                            ButtonSpec::default(),
                             move || {
                                 // On Click
                                 state.scroll_to_item(50, 0.0);

--- a/apps/desktop-demo/robot-runners/robot_lazy_infinite_scroll.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_infinite_scroll.rs
@@ -1,7 +1,9 @@
 use cranpose::AppLauncher;
 use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope};
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
-use cranpose_ui::widgets::{Box, BoxSpec, Button, Column, ColumnSpec, Row, RowSpec, Text};
+use cranpose_ui::widgets::{
+    Box, BoxSpec, Button, ButtonSpec, Column, ColumnSpec, Row, RowSpec, Text,
+};
 use cranpose_ui::widgets::{LazyColumn, LazyColumnSpec};
 use cranpose_ui::{Alignment, Color, Modifier, Size, TextStyle};
 use std::time::Duration;
@@ -84,7 +86,7 @@ fn main() {
                 // Controls
                 Row(Modifier::default().fill_max_width().height(50.0), RowSpec::default(), move || {
                     Button(
-                        Modifier::default(),
+                        Modifier::default(), ButtonSpec::default(),
                         move || {
                             state.scroll_to_item(99_990, 0.0);
                         },

--- a/apps/desktop-demo/robot-runners/robot_lazy_max_jump.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_max_jump.rs
@@ -11,7 +11,8 @@ use cranpose::AppLauncher;
 use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope};
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
 use cranpose_ui::widgets::{
-    Box, BoxSpec, Button, Column, ColumnSpec, LazyColumn, LazyColumnSpec, Row, RowSpec, Text,
+    Box, BoxSpec, Button, ButtonSpec, Column, ColumnSpec, LazyColumn, LazyColumnSpec, Row, RowSpec,
+    Text,
 };
 use cranpose_ui::{Alignment, Color, Modifier, Size, TextStyle};
 use std::time::Duration;
@@ -146,6 +147,7 @@ fn main() {
                                     // Set MAX button
                                     Button(
                                         Modifier::default().background(Color::rgb(0.6, 0.3, 0.6)),
+                                        ButtonSpec::default(),
                                         move || {
                                             item_count.set(usize::MAX);
                                         },
@@ -161,6 +163,7 @@ fn main() {
                                     // Go Middle button
                                     Button(
                                         Modifier::default().background(Color::rgb(0.3, 0.4, 0.6)),
+                                        ButtonSpec::default(),
                                         move || {
                                             let c = item_count.get();
                                             let middle = c / 2;

--- a/apps/desktop-demo/robot-runners/robot_lazy_perf.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_perf.rs
@@ -100,6 +100,7 @@ fn test_app() {
                 Modifier::empty()
                     .padding(8.0)
                     .background(Color(0.3, 0.5, 0.8, 1.0)),
+                ButtonSpec::default(),
                 move || {
                     list_state.scroll_to_item(middle_index, 0.0);
                 },

--- a/apps/desktop-demo/robot-runners/robot_lazy_scroll_edge_cases.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_scroll_edge_cases.rs
@@ -14,7 +14,8 @@ use cranpose::AppLauncher;
 use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope};
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
 use cranpose_ui::widgets::{
-    Box, BoxSpec, Button, Column, ColumnSpec, LazyColumn, LazyColumnSpec, Row, RowSpec, Text,
+    Box, BoxSpec, Button, ButtonSpec, Column, ColumnSpec, LazyColumn, LazyColumnSpec, Row, RowSpec,
+    Text,
 };
 use cranpose_ui::{Alignment, Color, LinearArrangement, Modifier, Size, TextStyle};
 use std::time::Duration;
@@ -163,6 +164,7 @@ fn main() {
                     move || {
                         Button(
                             Modifier::default(),
+                            ButtonSpec::default(),
                             move || {
                                 state.scroll_to_item(50, 0.0);
                             },
@@ -172,6 +174,7 @@ fn main() {
                         );
                         Button(
                             Modifier::default(),
+                            ButtonSpec::default(),
                             move || {
                                 state.scroll_to_item(95, 0.0);
                             },

--- a/apps/desktop-demo/robot-runners/robot_leetcodedaily_code_scroll_pixel_drift.rs
+++ b/apps/desktop-demo/robot-runners/robot_leetcodedaily_code_scroll_pixel_drift.rs
@@ -14,9 +14,9 @@ use cranpose_ui::{
     composable,
     text::{FontFamily, FontWeight, SpanStyle, TextUnit},
     widgets::BasicTextFieldWithOptions,
-    Alignment, BasicTextFieldOptions, Box as ComposeBox, BoxSpec, Button, Color, Column,
-    ColumnSpec, ContentScale, CornerRadii, Image, ImageBitmap, LinearArrangement, Modifier, Row,
-    RowSpec, Size, Spacer, Text, TextStyle, VerticalAlignment,
+    Alignment, BasicTextFieldOptions, Box as ComposeBox, BoxSpec, Button, ButtonSpec, Color,
+    Column, ColumnSpec, ContentScale, CornerRadii, Image, ImageBitmap, LinearArrangement, Modifier,
+    Row, RowSpec, Size, Spacer, Text, TextStyle, VerticalAlignment,
 };
 use scroll_stability_external_helpers::{
     run_internal_scroll_stability_capture, ScrollStabilityConfig,
@@ -222,6 +222,7 @@ fn ActionButton(label: &'static str) {
             .background(Color(0.15, 0.20, 0.30, 0.96))
             .rounded_corners(12.0)
             .padding(8.0),
+        ButtonSpec::default(),
         || {},
         move || {
             Text(label, Modifier::empty(), label_style());

--- a/apps/desktop-demo/robot-runners/robot_progress_bar.rs
+++ b/apps/desktop-demo/robot-runners/robot_progress_bar.rs
@@ -11,7 +11,9 @@
 
 use cranpose::{AppLauncher, SemanticElement};
 use cranpose_testing::find_button_in_semantics;
-use cranpose_ui::{Button, Column, ColumnSpec, Modifier, Size, Spacer, Text, TextStyle};
+use cranpose_ui::{
+    Button, ButtonSpec, Column, ColumnSpec, Modifier, Size, Spacer, Text, TextStyle,
+};
 use desktop_app::app::{AnimationState, AsyncRuntimeTabContent, FrameStats};
 use std::time::Duration;
 
@@ -260,6 +262,7 @@ fn main() {
                     );
                     Button(
                         Modifier::empty().padding(6.0),
+                        ButtonSpec::default(),
                         move || {
                             let last = TEST_PCTS.len().saturating_sub(1);
                             let next = (step_state.get() + 1).min(last);

--- a/apps/desktop-demo/robot-runners/robot_scroll_to_item_redraw.rs
+++ b/apps/desktop-demo/robot-runners/robot_scroll_to_item_redraw.rs
@@ -10,7 +10,8 @@ use cranpose::AppLauncher;
 use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope};
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
 use cranpose_ui::widgets::{
-    Box, BoxSpec, Button, Column, ColumnSpec, LazyColumn, LazyColumnSpec, Row, RowSpec, Text,
+    Box, BoxSpec, Button, ButtonSpec, Column, ColumnSpec, LazyColumn, LazyColumnSpec, Row, RowSpec,
+    Text,
 };
 use cranpose_ui::{Alignment, Color, Modifier, Size, TextStyle};
 use std::time::Duration;
@@ -96,6 +97,7 @@ fn main() {
                         move || {
                             Button(
                                 Modifier::default().background(Color::rgb(0.3, 0.4, 0.6)),
+                                ButtonSpec::default(),
                                 move || {
                                     // This should immediately show Item 50 at the top
                                     state.scroll_to_item(50, 0.0);

--- a/apps/desktop-demo/robot-runners/robot_subcompose_invalidation.rs
+++ b/apps/desktop-demo/robot-runners/robot_subcompose_invalidation.rs
@@ -70,6 +70,7 @@ fn test_app() {
                         c.is_button = true;
                         c.content_description = Some("Change Colors".into());
                     }),
+                ButtonSpec::default(),
                 move || {
                     color_scheme.set((color_scheme.get() + 1) % 3);
                 },

--- a/apps/desktop-demo/robot-runners/robot_ui_breakage.rs
+++ b/apps/desktop-demo/robot-runners/robot_ui_breakage.rs
@@ -12,7 +12,8 @@
 
 use cranpose_core::useState;
 use cranpose_ui::{
-    composable, Box, BoxSpec, Button, Column, ColumnSpec, Modifier, Row, RowSpec, Text, TextStyle,
+    composable, Box, BoxSpec, Button, ButtonSpec, Column, ColumnSpec, Modifier, Row, RowSpec, Text,
+    TextStyle,
 };
 // use desktop_app::app;
 use cranpose::AppLauncher;
@@ -26,6 +27,7 @@ fn reproduction_app() {
     Column(Modifier::empty(), ColumnSpec::default(), move || {
         Button(
             Modifier::empty(),
+            ButtonSpec::default(),
             move || toggle.set(!toggle.get()),
             || {
                 Text("Toggle Parent", Modifier::empty(), TextStyle::default());

--- a/apps/desktop-demo/robot-runners/robot_winamp_native_window_geometry.rs
+++ b/apps/desktop-demo/robot-runners/robot_winamp_native_window_geometry.rs
@@ -199,12 +199,106 @@ fn arrange_origin(windows: WinampWindows) -> WindowGeometry {
     let margin_y = desired_margin_y.min(((monitor.height - total_height).max(0) / 2).max(8));
     let max_x = monitor.x + monitor.width - total_width - margin_x;
     let max_y = monitor.y + monitor.height - total_height - margin_y;
-    WindowGeometry {
+    let fallback = WindowGeometry {
         x: (monitor.x + margin_x).min(max_x.max(monitor.x)),
         y: (monitor.y + margin_y).min(max_y.max(monitor.y)),
         width: geometries.main.width,
         height: geometries.main.height,
+    };
+    unobstructed_origin(monitor, total_width, total_height, fallback)
+}
+
+fn unobstructed_origin(
+    monitor: WindowGeometry,
+    total_width: i32,
+    total_height: i32,
+    fallback: WindowGeometry,
+) -> WindowGeometry {
+    let obstacles = visible_window_obstacles();
+    if !intersects_any_obstacle(fallback, total_width, total_height, &obstacles) {
+        return fallback;
     }
+
+    let max_x = monitor.x + monitor.width - total_width;
+    let max_y = monitor.y + monitor.height - total_height;
+    let min_x = monitor.x + 8;
+    let min_y = monitor.y + 8;
+    if max_x < min_x || max_y < min_y {
+        return fallback;
+    }
+    let step = 96.max(total_height / 3);
+    let x_candidates = [
+        fallback.x,
+        min_x,
+        (monitor.x + monitor.width / 2 - total_width / 2).clamp(min_x, max_x),
+        max_x.saturating_sub(8),
+    ];
+
+    for x in x_candidates {
+        let x = x.clamp(min_x, max_x);
+        let mut y = min_y;
+        while y <= max_y {
+            let candidate = WindowGeometry {
+                x,
+                y,
+                width: fallback.width,
+                height: fallback.height,
+            };
+            if !intersects_any_obstacle(candidate, total_width, total_height, &obstacles) {
+                println!("arrange origin avoided occupied area: fallback={fallback:?} selected={candidate:?}");
+                return candidate;
+            }
+            y += step;
+        }
+    }
+
+    fallback
+}
+
+fn visible_window_obstacles() -> Vec<WindowGeometry> {
+    visible_windows_summary()
+        .into_iter()
+        .filter_map(|(_, title, geometry)| {
+            let title = title.as_deref();
+            if matches!(
+                title,
+                Some("Desktop")
+                    | Some("xfdesktop")
+                    | Some("Xfwm4")
+                    | Some(WINDOW_TITLE)
+                    | Some("Winamp")
+                    | Some("Winamp Equalizer")
+                    | Some("Winamp Playlist")
+            ) {
+                return None;
+            }
+            geometry.filter(|geometry| geometry.width > 1 && geometry.height > 1)
+        })
+        .collect()
+}
+
+fn intersects_any_obstacle(
+    origin: WindowGeometry,
+    total_width: i32,
+    total_height: i32,
+    obstacles: &[WindowGeometry],
+) -> bool {
+    let bounds = WindowGeometry {
+        x: origin.x,
+        y: origin.y,
+        width: total_width,
+        height: total_height,
+    };
+    obstacles
+        .iter()
+        .any(|obstacle| rectangles_intersect(bounds, *obstacle))
+}
+
+fn rectangles_intersect(first: WindowGeometry, second: WindowGeometry) -> bool {
+    first.x < second.x + second.width
+        && first.x + first.width > second.x
+        && first.y < second.y + second.height
+        && first.y + first.height > second.y
 }
 
 fn host_window_origin() -> WindowGeometry {

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -11,9 +11,10 @@ use cranpose_foundation::text::TextFieldState;
 use cranpose_foundation::PointerEventKind;
 use cranpose_foundation::SemanticsConfiguration;
 use cranpose_ui::{
-    composable, BasicTextField, BoxSpec, Brush, Button, Color, Column, ColumnSpec, CornerRadii,
-    GraphicsLayer, IntrinsicSize, LinearArrangement, Modifier, Point, PointerInputScope,
-    RoundedCornerShape, Row, RowSpec, Size, Spacer, Text, TextStyle, VerticalAlignment,
+    composable, BasicTextField, BoxSpec, Brush, Button, ButtonSpec, Color, Column, ColumnSpec,
+    CornerRadii, GraphicsLayer, IntrinsicSize, LinearArrangement, Modifier, Point,
+    PointerInputScope, RoundedCornerShape, Row, RowSpec, Size, Spacer, Text, TextStyle,
+    VerticalAlignment,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -339,6 +340,7 @@ fn TabButton(tab: DemoTab, active_tab: cranpose_core::MutableState<DemoTab>, pad
                 );
             })
             .padding(padding),
+        ButtonSpec::default(),
         {
             move || {
                 if active_tab.get() != tab {
@@ -631,6 +633,7 @@ fn text_input_example() {
                                         );
                                     })
                                     .padding(10.0),
+                                ButtonSpec::default(),
                                 move || {
                                     state.set_text("");
                                 },
@@ -657,6 +660,7 @@ fn text_input_example() {
                                         );
                                     })
                                     .padding(10.0),
+                                ButtonSpec::default(),
                                 move || {
                                     state.edit(|buffer| {
                                         buffer.place_cursor_at_end();
@@ -688,6 +692,7 @@ fn text_input_example() {
                                         );
                                     })
                                     .padding(10.0),
+                                ButtonSpec::default(),
                                 move || {
                                     let text = from.text();
                                     to.set_text(text);
@@ -751,6 +756,7 @@ fn recursive_layout_example() {
                                 .background(Color(0.35, 0.45, 0.85, 1.0))
                                 .rounded_corners(16.0)
                                 .padding(10.0),
+                            ButtonSpec::default(),
                             {
                                 move || {
                                     let next = (depth_state.get() + 1).min(96);
@@ -773,6 +779,7 @@ fn recursive_layout_example() {
                                 .background(Color(0.65, 0.35, 0.35, 1.0))
                                 .rounded_corners(16.0)
                                 .padding(10.0),
+                            ButtonSpec::default(),
                             {
                                 move || {
                                     let next = depth_state.get().saturating_sub(1).max(1);
@@ -950,6 +957,7 @@ pub fn composition_local_example() {
                         );
                     })
                     .padding(12.0),
+                ButtonSpec::default(),
                 {
                     move || {
                         let new_val = counter.get() + 1;
@@ -1182,6 +1190,7 @@ pub fn AsyncRuntimeTabContent(
                                     );
                                 })
                                 .padding(12.0),
+                            ButtonSpec::default(),
                             move || {
                                 is_running.set(!is_running.get());
                             },
@@ -1211,6 +1220,7 @@ pub fn AsyncRuntimeTabContent(
                                     );
                                 })
                                 .padding(12.0),
+                            ButtonSpec::default(),
                             move || {
                                 animation.set(AnimationState::default());
                                 stats.set(FrameStats::default());
@@ -1575,6 +1585,7 @@ fn counter_app() {
                                             );
                                         })
                                         .padding(10.0),
+                                    ButtonSpec::default(),
                                     || {},
                                     || {
                                         Text(
@@ -1600,6 +1611,7 @@ fn counter_app() {
                                             );
                                         })
                                         .padding(10.0),
+                                    ButtonSpec::default(),
                                     || {},
                                     || {
                                         Text(
@@ -1620,6 +1632,7 @@ fn counter_app() {
                                             );
                                         })
                                         .padding(10.0),
+                                    ButtonSpec::default(),
                                     || {},
                                     || {
                                         Text(
@@ -1657,6 +1670,7 @@ fn counter_app() {
                                             });
                                         })
                                         .padding(12.0),
+                                    ButtonSpec::default(),
                                     move || {
                                         println!("Incrementing counter to {}", counter.get() + 1);
                                         counter.set(counter.get() + 1)
@@ -1679,6 +1693,7 @@ fn counter_app() {
                                             );
                                         })
                                         .padding(12.0),
+                                    ButtonSpec::default(),
                                     move || counter.set(counter.get() - 1),
                                     || {
                                         Text(
@@ -1725,6 +1740,7 @@ fn counter_app() {
                                     });
                                 })
                                 .padding(12.0),
+                            ButtonSpec::default(),
                             {
                                 move || {
                                     async_message
@@ -1838,6 +1854,7 @@ fn modifier_showcase_tab() {
                                     );
                                 })
                                 .padding(10.0),
+                            ButtonSpec::default(),
                             {
                                 move || {
                                     if selected_showcase.get() != showcase_type {
@@ -2354,6 +2371,7 @@ pub fn dynamic_modifiers_showcase() {
                     );
                 })
                 .padding(10.0),
+            ButtonSpec::default(),
             move || {
                 frame.set(frame.get() + 1);
             },

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -1,6 +1,6 @@
 use cranpose_animation::{
-    animateFloatAsState, infiniteRepeatable, rememberInfiniteTransition, AnimationSpec, RepeatMode,
-    StartOffset,
+    animateFloatAsState, infiniteRepeatable, rememberInfiniteTransition, AnimationSpec,
+    AnimationType, RepeatMode, StartOffset,
 };
 use cranpose_core::{
     self, compositionLocalOf, CompositionLocal, CompositionLocalProvider, DisposableEffect,
@@ -21,6 +21,7 @@ use std::rc::Rc;
 mod animations;
 mod hacker_news;
 mod images;
+mod interactive_anim;
 pub mod lazy_list;
 mod lazy_scrollbar;
 mod markdown;
@@ -35,6 +36,7 @@ mod xkcd;
 use animations::AnimationsTab;
 use hacker_news::{HackerNewsScrollStabilityFixtureTab, HackerNewsTab};
 use images::images_tab;
+use interactive_anim::InteractiveAnimTab;
 use lazy_list::lazy_list_example;
 use markdown::{markdown_viewer_tab, MarkdownScrollStabilityFixtureTab};
 use shader_rect::ShaderRectTab;
@@ -65,6 +67,7 @@ pub enum DemoTab {
     CompositionLocal,
     Async,
     Animations,
+    InteractiveAnim,
     WebFetch,
     TextInput,
     Layout,
@@ -88,6 +91,7 @@ impl DemoTab {
             DemoTab::CompositionLocal => "CompositionLocal Test",
             DemoTab::Async => "Async Runtime",
             DemoTab::Animations => "Animations",
+            DemoTab::InteractiveAnim => "Interactive Anim",
             DemoTab::WebFetch => "Web Fetch",
             DemoTab::TextInput => "Text Input",
             DemoTab::Layout => "Recursive Layout",
@@ -117,6 +121,9 @@ impl DemoTab {
             "compositionlocal" | "compositionlocaltest" => Some(Self::CompositionLocal),
             "async" | "asyncruntime" => Some(Self::Async),
             "animations" => Some(Self::Animations),
+            "interactiveanim" | "interactiveanimation" | "interactiveanimations" => {
+                Some(Self::InteractiveAnim)
+            }
             "webfetch" => Some(Self::WebFetch),
             "textinput" => Some(Self::TextInput),
             "layout" | "recursivelayout" => Some(Self::Layout),
@@ -136,7 +143,7 @@ impl DemoTab {
     }
 }
 
-pub const DEMO_TABS: [DemoTab; 18] = [
+pub const DEMO_TABS: [DemoTab; 19] = [
     DemoTab::Counter,
     DemoTab::CompositionLocal,
     DemoTab::Async,
@@ -155,6 +162,7 @@ pub const DEMO_TABS: [DemoTab; 18] = [
     DemoTab::Shaders,
     DemoTab::ShaderRect,
     DemoTab::MarkdownViewer,
+    DemoTab::InteractiveAnim,
 ];
 
 pub fn demo_tab_labels() -> Vec<&'static str> {
@@ -462,6 +470,7 @@ fn render_active_tab(active: DemoTab, startup: StartupSelection, winamp_tab_stat
         DemoTab::CompositionLocal => composition_local_example(),
         DemoTab::Async => async_runtime_example(),
         DemoTab::Animations => AnimationsTab(),
+        DemoTab::InteractiveAnim => InteractiveAnimTab(),
         DemoTab::WebFetch => web_fetch_example(),
         DemoTab::TextInput => text_input_example(),
         DemoTab::Layout => recursive_layout_example(),
@@ -1313,7 +1322,7 @@ fn counter_app() {
     } else {
         pointer_wave * 0.6
     };
-    let wave_state = animateFloatAsState(target_wave, "wave");
+    let wave_state = animateFloatAsState(target_wave, AnimationType::default(), "wave");
     let fetch_key = fetch_request.get();
     LaunchedEffect!(fetch_key, move |_scope| {
         if fetch_key == 0 {

--- a/apps/desktop-demo/src/app/hacker_news.rs
+++ b/apps/desktop-demo/src/app/hacker_news.rs
@@ -12,7 +12,7 @@ use cranpose_ui::{
     composable,
     text::{FontWeight, SpanStyle},
     widgets::{BoxWithConstraints, BoxWithConstraintsScope, LazyColumn, LazyColumnSpec},
-    Brush, Button, Color, Column, ColumnSpec, CornerRadii, GraphicsLayer, LayerShape,
+    Brush, Button, ButtonSpec, Color, Column, ColumnSpec, CornerRadii, GraphicsLayer, LayerShape,
     LinearArrangement, Modifier, RoundedCornerShape, Row, RowSpec, Text, TextStyle,
     VerticalAlignment,
 };
@@ -989,6 +989,7 @@ where
     DebugScopeTag("ActionButton");
     Button(
         rounded_surface(Modifier::empty(), background, 8.0).padding_symmetric(10.0, 6.0),
+        ButtonSpec::default(),
         on_click,
         move || {
             Text(

--- a/apps/desktop-demo/src/app/interactive_anim.rs
+++ b/apps/desktop-demo/src/app/interactive_anim.rs
@@ -1,8 +1,6 @@
 #![allow(non_snake_case)]
 
-use cranpose_animation::{
-    animateFloatAsState, spring, AnimationSpec, AnimationType, Easing, Spring,
-};
+use cranpose_animation::{animateFloatAsState, spring, tween, Easing, Spring};
 use cranpose_ui::{
     composable, rememberMutableInteractionSource,
     text::{FontWeight, SpanStyle, TextUnit},
@@ -85,10 +83,7 @@ fn PressAnimatedButton(text: &'static str, modifier: Modifier, on_click: impl Fn
     let press_animation = if is_pressed {
         spring(Spring::DampingRatioMediumBouncy, Spring::StiffnessMedium)
     } else {
-        AnimationType::Tween(AnimationSpec::tween(
-            BUTTON_RELEASE_DURATION_MS,
-            Easing::FastOutSlowInEasing,
-        ))
+        tween(BUTTON_RELEASE_DURATION_MS, Easing::FastOutSlowInEasing)
     };
     let target_scale = if is_pressed { 0.94 } else { 1.0 };
     let scale = animateFloatAsState(
@@ -148,10 +143,7 @@ fn RevealAnimatedButton(text: &'static str, modifier: Modifier, on_click: impl F
     };
     let raw_progress = animateFloatAsState(
         target_progress,
-        AnimationType::Tween(AnimationSpec::tween(
-            REVEAL_DURATION_MS,
-            Easing::FastOutSlowInEasing,
-        )),
+        tween(REVEAL_DURATION_MS, Easing::FastOutSlowInEasing),
         "interactive_button_reveal_progress",
     );
     let progress = if trigger.generation == 0 {

--- a/apps/desktop-demo/src/app/interactive_anim.rs
+++ b/apps/desktop-demo/src/app/interactive_anim.rs
@@ -1,0 +1,149 @@
+#![allow(non_snake_case)]
+
+use cranpose_animation::{animateFloatAsState, spring, Spring};
+use cranpose_ui::{
+    composable, rememberMutableInteractionSource,
+    text::{FontWeight, SpanStyle, TextUnit},
+    Brush, ButtonWithInteractionSource, Color, Column, ColumnSpec, CornerRadii, GraphicsLayer,
+    LinearArrangement, Modifier, Row, RowSpec, Size, Spacer, Text, TextStyle, VerticalAlignment,
+};
+
+fn title_style() -> TextStyle {
+    TextStyle {
+        span_style: SpanStyle {
+            color: Some(Color(0.08, 0.10, 0.14, 1.0)),
+            font_size: TextUnit::Sp(22.0),
+            font_weight: Some(FontWeight::BOLD),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn body_style() -> TextStyle {
+    TextStyle {
+        span_style: SpanStyle {
+            color: Some(Color(0.20, 0.23, 0.28, 1.0)),
+            font_size: TextUnit::Sp(15.0),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn button_text_style() -> TextStyle {
+    TextStyle {
+        span_style: SpanStyle {
+            color: Some(Color(1.0, 1.0, 1.0, 1.0)),
+            font_size: TextUnit::Sp(18.0),
+            font_weight: Some(FontWeight::BOLD),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+#[composable]
+fn PressAnimatedButton(text: &'static str, modifier: Modifier, on_click: impl FnMut() + 'static) {
+    let interaction_source = rememberMutableInteractionSource();
+    let pressed = interaction_source.collectIsPressedAsState();
+    let target_scale = if pressed.value() { 0.94 } else { 1.0 };
+    let scale = animateFloatAsState(
+        target_scale,
+        spring(Spring::DampingRatioMediumBouncy, Spring::StiffnessMedium),
+        "interactive_button_press_scale",
+    );
+    let fill = if pressed.value() {
+        Color(0.03, 0.33, 0.64, 1.0)
+    } else {
+        Color(0.05, 0.42, 0.82, 1.0)
+    };
+    let shadow = if pressed.value() { 4.0 } else { 10.0 };
+
+    ButtonWithInteractionSource(
+        modifier
+            .graphics_layer_block(move |layer: &mut GraphicsLayer| {
+                let scale = scale.value();
+                layer.scale_x = scale;
+                layer.scale_y = scale;
+                layer.shadow_elevation = shadow;
+            })
+            .rounded_corners(20.0)
+            .draw_behind(move |scope| {
+                scope.draw_round_rect(Brush::solid(fill), CornerRadii::uniform(20.0));
+            })
+            .padding(18.0),
+        interaction_source,
+        on_click,
+        move || {
+            Text(text, Modifier::empty(), button_text_style());
+        },
+    );
+}
+
+#[composable]
+pub(crate) fn InteractiveAnimTab() {
+    let clicks = cranpose_core::useState(|| 0u32);
+    let click_count = clicks.get();
+
+    Column(
+        Modifier::empty()
+            .fill_max_width()
+            .padding(18.0)
+            .background(Color(0.96, 0.97, 0.98, 1.0))
+            .rounded_corners(18.0)
+            .padding(22.0),
+        ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(18.0)),
+        move || {
+            Text("Interactive Anim", Modifier::empty(), title_style());
+
+            Row(
+                Modifier::empty().fill_max_width(),
+                RowSpec::new()
+                    .horizontal_arrangement(LinearArrangement::SpacedBy(18.0))
+                    .vertical_alignment(VerticalAlignment::CenterVertically),
+                {
+                    move || {
+                        PressAnimatedButton(
+                            "Tap me",
+                            Modifier::empty().width(220.0).height(86.0),
+                            move || {
+                                clicks.update(|count| *count += 1);
+                            },
+                        );
+
+                        Column(
+                            Modifier::empty()
+                                .background(Color(1.0, 1.0, 1.0, 1.0))
+                                .rounded_corners(14.0)
+                                .padding(16.0),
+                            ColumnSpec::new()
+                                .vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
+                            move || {
+                                Text("Clicks", Modifier::empty(), body_style());
+                                Text(
+                                    click_count.to_string(),
+                                    Modifier::empty(),
+                                    TextStyle {
+                                        span_style: SpanStyle {
+                                            color: Some(Color(0.05, 0.42, 0.82, 1.0)),
+                                            font_size: TextUnit::Sp(30.0),
+                                            font_weight: Some(FontWeight::BOLD),
+                                            ..Default::default()
+                                        },
+                                        ..Default::default()
+                                    },
+                                );
+                            },
+                        );
+                    }
+                },
+            );
+
+            Spacer(Size {
+                width: 0.0,
+                height: 4.0,
+            });
+        },
+    );
+}

--- a/apps/desktop-demo/src/app/interactive_anim.rs
+++ b/apps/desktop-demo/src/app/interactive_anim.rs
@@ -4,9 +4,12 @@ use cranpose_animation::{animateFloatAsState, spring, Spring};
 use cranpose_ui::{
     composable, rememberMutableInteractionSource,
     text::{FontWeight, SpanStyle, TextUnit},
-    Brush, ButtonWithInteractionSource, Color, Column, ColumnSpec, CornerRadii, GraphicsLayer,
-    LinearArrangement, Modifier, Row, RowSpec, Size, Spacer, Text, TextStyle, VerticalAlignment,
+    Brush, Button, ButtonSpec, Color, Column, ColumnSpec, CornerRadii, GraphicsLayer, LayerShape,
+    LinearArrangement, Modifier, RoundedCornerShape, Row, RowSpec, Size, Spacer, Text, TextStyle,
+    VerticalAlignment,
 };
+
+const BUTTON_RADIUS: f32 = 20.0;
 
 fn title_style() -> TextStyle {
     TextStyle {
@@ -47,33 +50,47 @@ fn button_text_style() -> TextStyle {
 fn PressAnimatedButton(text: &'static str, modifier: Modifier, on_click: impl FnMut() + 'static) {
     let interaction_source = rememberMutableInteractionSource();
     let pressed = interaction_source.collectIsPressedAsState();
-    let target_scale = if pressed.value() { 0.94 } else { 1.0 };
+    let is_pressed = pressed.value();
+    let press_animation = if is_pressed {
+        spring(Spring::DampingRatioMediumBouncy, Spring::StiffnessMedium)
+    } else {
+        spring(Spring::DampingRatioNoBouncy, Spring::StiffnessLow)
+    };
+    let target_scale = if is_pressed { 0.94 } else { 1.0 };
     let scale = animateFloatAsState(
         target_scale,
-        spring(Spring::DampingRatioMediumBouncy, Spring::StiffnessMedium),
+        press_animation,
         "interactive_button_press_scale",
     );
-    let fill = if pressed.value() {
+    let target_shadow = if is_pressed { 4.0 } else { 10.0 };
+    let shadow = animateFloatAsState(
+        target_shadow,
+        press_animation,
+        "interactive_button_press_shadow",
+    );
+    let fill = if is_pressed {
         Color(0.03, 0.33, 0.64, 1.0)
     } else {
         Color(0.05, 0.42, 0.82, 1.0)
     };
-    let shadow = if pressed.value() { 4.0 } else { 10.0 };
 
-    ButtonWithInteractionSource(
-        modifier
-            .graphics_layer_block(move |layer: &mut GraphicsLayer| {
-                let scale = scale.value();
-                layer.scale_x = scale;
-                layer.scale_y = scale;
-                layer.shadow_elevation = shadow;
-            })
-            .rounded_corners(20.0)
-            .draw_behind(move |scope| {
-                scope.draw_round_rect(Brush::solid(fill), CornerRadii::uniform(20.0));
-            })
-            .padding(18.0),
-        interaction_source,
+    Button(
+        ButtonSpec::new(
+            modifier
+                .graphics_layer_block(move |layer: &mut GraphicsLayer| {
+                    let scale = scale.value();
+                    layer.scale_x = scale;
+                    layer.scale_y = scale;
+                    layer.shadow_elevation = shadow.value();
+                    layer.shape = LayerShape::Rounded(RoundedCornerShape::uniform(BUTTON_RADIUS));
+                })
+                .rounded_corners(BUTTON_RADIUS)
+                .draw_behind(move |scope| {
+                    scope.draw_round_rect(Brush::solid(fill), CornerRadii::uniform(BUTTON_RADIUS));
+                })
+                .padding(18.0),
+        )
+        .interaction_source(interaction_source),
         on_click,
         move || {
             Text(text, Modifier::empty(), button_text_style());

--- a/apps/desktop-demo/src/app/interactive_anim.rs
+++ b/apps/desktop-demo/src/app/interactive_anim.rs
@@ -1,16 +1,27 @@
 #![allow(non_snake_case)]
 
-use cranpose_animation::{animateFloatAsState, spring, Spring};
+use cranpose_animation::{
+    animateFloatAsState, spring, AnimationSpec, AnimationType, Easing, Spring,
+};
 use cranpose_ui::{
     composable, rememberMutableInteractionSource,
     text::{FontWeight, SpanStyle, TextUnit},
-    Brush, Button, ButtonSpec, Color, Column, ColumnSpec, CornerRadii, GraphicsLayer, LayerShape,
-    LinearArrangement, Modifier, RoundedCornerShape, Row, RowSpec, Size, Spacer, Text, TextStyle,
-    VerticalAlignment,
+    Brush, Button, ButtonSpec, Color, Column, ColumnSpec, CornerRadii, GraphicsLayer, Interaction,
+    LayerShape, LinearArrangement, Modifier, Point, PressInteraction, PressInteractionPress,
+    RoundedCornerShape, Row, RowSpec, Size, Spacer, Text, TextStyle, VerticalAlignment,
 };
 
 const BUTTON_RADIUS: f32 = 20.0;
-const BUTTON_RELEASE_STIFFNESS: f32 = Spring::StiffnessVeryLow / 4.0;
+const BUTTON_RELEASE_DURATION_MS: u64 = 1_000;
+const REVEAL_DURATION_MS: u64 = 850;
+const REVEAL_EXTRA_RADIUS: f32 = 10.0;
+const REVEAL_ALPHA: f32 = 0.28;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct RevealTrigger {
+    generation: u64,
+    origin: Point,
+}
 
 fn title_style() -> TextStyle {
     TextStyle {
@@ -47,6 +58,25 @@ fn button_text_style() -> TextStyle {
     }
 }
 
+fn press_interaction_press(interaction: Option<Interaction>) -> Option<PressInteractionPress> {
+    match interaction {
+        Some(Interaction::Press(PressInteraction::Press(press))) => Some(press),
+        Some(Interaction::Press(PressInteraction::Release(release))) => Some(release.press),
+        Some(Interaction::Press(PressInteraction::Cancel(cancel))) => Some(cancel.press),
+        None => None,
+    }
+}
+
+fn reveal_alpha(progress: f32) -> f32 {
+    let fade_in = (progress / 0.16).clamp(0.0, 1.0);
+    let fade_out = (1.0 - progress).clamp(0.0, 1.0);
+    REVEAL_ALPHA * fade_in * fade_out
+}
+
+fn reveal_end_radius(size: Size) -> f32 {
+    ((size.width * size.width + size.height * size.height).sqrt() * 0.5) + REVEAL_EXTRA_RADIUS
+}
+
 #[composable]
 fn PressAnimatedButton(text: &'static str, modifier: Modifier, on_click: impl FnMut() + 'static) {
     let interaction_source = rememberMutableInteractionSource();
@@ -55,7 +85,10 @@ fn PressAnimatedButton(text: &'static str, modifier: Modifier, on_click: impl Fn
     let press_animation = if is_pressed {
         spring(Spring::DampingRatioMediumBouncy, Spring::StiffnessMedium)
     } else {
-        spring(Spring::DampingRatioNoBouncy, BUTTON_RELEASE_STIFFNESS)
+        AnimationType::Tween(AnimationSpec::tween(
+            BUTTON_RELEASE_DURATION_MS,
+            Easing::FastOutSlowInEasing,
+        ))
     };
     let target_scale = if is_pressed { 0.94 } else { 1.0 };
     let scale = animateFloatAsState(
@@ -98,9 +131,80 @@ fn PressAnimatedButton(text: &'static str, modifier: Modifier, on_click: impl Fn
 }
 
 #[composable]
+fn RevealAnimatedButton(text: &'static str, modifier: Modifier, on_click: impl FnMut() + 'static) {
+    let interaction_source = rememberMutableInteractionSource();
+    let last_interaction = interaction_source.collectLastInteractionAsState();
+    let reveal_trigger = cranpose_core::useState(|| RevealTrigger {
+        generation: 0,
+        origin: Point::default(),
+    });
+    let on_click = on_click;
+
+    let trigger = reveal_trigger.value();
+    let target_progress = if trigger.generation % 2 == 0 {
+        0.0
+    } else {
+        1.0
+    };
+    let raw_progress = animateFloatAsState(
+        target_progress,
+        AnimationType::Tween(AnimationSpec::tween(
+            REVEAL_DURATION_MS,
+            Easing::FastOutSlowInEasing,
+        )),
+        "interactive_button_reveal_progress",
+    );
+    let progress = if trigger.generation == 0 {
+        1.0
+    } else if target_progress > 0.5 {
+        raw_progress.value()
+    } else {
+        1.0 - raw_progress.value()
+    };
+    let origin = trigger.origin;
+    Button(
+        modifier
+            .rounded_corners(BUTTON_RADIUS)
+            .clip_to_bounds()
+            .draw_behind(move |scope| {
+                scope.draw_round_rect(
+                    Brush::solid(Color(0.13, 0.14, 0.18, 1.0)),
+                    CornerRadii::uniform(BUTTON_RADIUS),
+                );
+
+                let alpha = reveal_alpha(progress);
+                if alpha > 0.001 {
+                    let size = scope.size();
+                    let start_radius = size.width.max(size.height) * 0.3;
+                    let end_radius = reveal_end_radius(size);
+                    let radius = start_radius + (end_radius - start_radius) * progress;
+                    scope.draw_circle(Brush::solid(Color(0.38, 0.78, 1.0, alpha)), origin, radius);
+                }
+            })
+            .padding(18.0),
+        ButtonSpec::new().interaction_source(interaction_source),
+        move || {
+            let press = press_interaction_press(last_interaction.get());
+            reveal_trigger.update(|trigger| {
+                trigger.generation = trigger.generation.wrapping_add(1);
+                if let Some(press) = press {
+                    trigger.origin = press.press_position;
+                }
+            });
+            on_click();
+        },
+        move || {
+            Text(text, Modifier::empty(), button_text_style());
+        },
+    );
+}
+
+#[composable]
 pub(crate) fn InteractiveAnimTab() {
     let clicks = cranpose_core::useState(|| 0u32);
+    let reveal_clicks = cranpose_core::useState(|| 0u32);
     let click_count = clicks.get();
+    let reveal_click_count = reveal_clicks.get();
 
     Column(
         Modifier::empty()
@@ -128,6 +232,14 @@ pub(crate) fn InteractiveAnimTab() {
                             },
                         );
 
+                        RevealAnimatedButton(
+                            "Reveal",
+                            Modifier::empty().width(220.0).height(86.0),
+                            move || {
+                                reveal_clicks.update(|count| *count += 1);
+                            },
+                        );
+
                         Column(
                             Modifier::empty()
                                 .background(Color(1.0, 1.0, 1.0, 1.0))
@@ -136,13 +248,27 @@ pub(crate) fn InteractiveAnimTab() {
                             ColumnSpec::new()
                                 .vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
                             move || {
-                                Text("Clicks", Modifier::empty(), body_style());
+                                Text("Press clicks", Modifier::empty(), body_style());
                                 Text(
                                     click_count.to_string(),
                                     Modifier::empty(),
                                     TextStyle {
                                         span_style: SpanStyle {
                                             color: Some(Color(0.05, 0.42, 0.82, 1.0)),
+                                            font_size: TextUnit::Sp(30.0),
+                                            font_weight: Some(FontWeight::BOLD),
+                                            ..Default::default()
+                                        },
+                                        ..Default::default()
+                                    },
+                                );
+                                Text("Reveal clicks", Modifier::empty(), body_style());
+                                Text(
+                                    reveal_click_count.to_string(),
+                                    Modifier::empty(),
+                                    TextStyle {
+                                        span_style: SpanStyle {
+                                            color: Some(Color(0.13, 0.14, 0.18, 1.0)),
                                             font_size: TextUnit::Sp(30.0),
                                             font_weight: Some(FontWeight::BOLD),
                                             ..Default::default()

--- a/apps/desktop-demo/src/app/interactive_anim.rs
+++ b/apps/desktop-demo/src/app/interactive_anim.rs
@@ -10,6 +10,7 @@ use cranpose_ui::{
 };
 
 const BUTTON_RADIUS: f32 = 20.0;
+const BUTTON_RELEASE_STIFFNESS: f32 = Spring::StiffnessVeryLow / 4.0;
 
 fn title_style() -> TextStyle {
     TextStyle {
@@ -54,7 +55,7 @@ fn PressAnimatedButton(text: &'static str, modifier: Modifier, on_click: impl Fn
     let press_animation = if is_pressed {
         spring(Spring::DampingRatioMediumBouncy, Spring::StiffnessMedium)
     } else {
-        spring(Spring::DampingRatioNoBouncy, Spring::StiffnessLow)
+        spring(Spring::DampingRatioNoBouncy, BUTTON_RELEASE_STIFFNESS)
     };
     let target_scale = if is_pressed { 0.94 } else { 1.0 };
     let scale = animateFloatAsState(
@@ -75,22 +76,20 @@ fn PressAnimatedButton(text: &'static str, modifier: Modifier, on_click: impl Fn
     };
 
     Button(
-        ButtonSpec::new(
-            modifier
-                .graphics_layer_block(move |layer: &mut GraphicsLayer| {
-                    let scale = scale.value();
-                    layer.scale_x = scale;
-                    layer.scale_y = scale;
-                    layer.shadow_elevation = shadow.value();
-                    layer.shape = LayerShape::Rounded(RoundedCornerShape::uniform(BUTTON_RADIUS));
-                })
-                .rounded_corners(BUTTON_RADIUS)
-                .draw_behind(move |scope| {
-                    scope.draw_round_rect(Brush::solid(fill), CornerRadii::uniform(BUTTON_RADIUS));
-                })
-                .padding(18.0),
-        )
-        .interaction_source(interaction_source),
+        modifier
+            .graphics_layer_block(move |layer: &mut GraphicsLayer| {
+                let scale = scale.value();
+                layer.scale_x = scale;
+                layer.scale_y = scale;
+                layer.shadow_elevation = shadow.value();
+                layer.shape = LayerShape::Rounded(RoundedCornerShape::uniform(BUTTON_RADIUS));
+            })
+            .rounded_corners(BUTTON_RADIUS)
+            .draw_behind(move |scope| {
+                scope.draw_round_rect(Brush::solid(fill), CornerRadii::uniform(BUTTON_RADIUS));
+            })
+            .padding(18.0),
+        ButtonSpec::new().interaction_source(interaction_source),
         on_click,
         move || {
             Text(text, Modifier::empty(), button_text_style());

--- a/apps/desktop-demo/src/app/lazy_list.rs
+++ b/apps/desktop-demo/src/app/lazy_list.rs
@@ -7,7 +7,7 @@ use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope, LazyLis
 use cranpose_foundation::SemanticsConfiguration;
 use cranpose_ui::widgets::{LazyColumn, LazyColumnSpec};
 use cranpose_ui::{
-    composable, Box, BoxSpec, Brush, Button, Color, Column, ColumnSpec, CornerRadii,
+    composable, Box, BoxSpec, Brush, Button, ButtonSpec, Color, Column, ColumnSpec, CornerRadii,
     LinearArrangement, Modifier, Row, RowSpec, Size, Spacer, Text, TextStyle, VerticalAlignment,
 };
 
@@ -135,6 +135,7 @@ where
                 scope.draw_round_rect(Brush::solid(background), CornerRadii::uniform(8.0));
             })
             .padding(8.0),
+        ButtonSpec::default(),
         on_click,
         move || {
             Text(label, Modifier::empty().padding(4.0), TextStyle::default());

--- a/apps/desktop-demo/src/app/markdown.rs
+++ b/apps/desktop-demo/src/app/markdown.rs
@@ -9,7 +9,7 @@ use cranpose_ui::{
         AnnotatedString, FontFamily, FontStyle, FontWeight, LinkAnnotation, ParagraphStyle,
         PlatformParagraphStyle, SpanStyle, TextDecoration, TextShaping, TextUnit,
     },
-    Brush, Button, Color, Column, ColumnSpec, CornerRadii, LazyColumn, LazyColumnSpec,
+    Brush, Button, ButtonSpec, Color, Column, ColumnSpec, CornerRadii, LazyColumn, LazyColumnSpec,
     LinearArrangement, LinkedText, Modifier, Row, RowSpec, Size, Spacer, Text, TextStyle,
     VerticalAlignment,
 };
@@ -478,6 +478,7 @@ pub fn markdown_viewer_tab() {
                                         );
                                     })
                                     .padding(10.0),
+                                ButtonSpec::default(),
                                 move || request_counter.update(|v| *v = v.wrapping_add(1)),
                                 || {
                                     Text(

--- a/apps/desktop-demo/src/app/mineswapper2.rs
+++ b/apps/desktop-demo/src/app/mineswapper2.rs
@@ -1,7 +1,7 @@
 use cranpose_core::useState;
 use cranpose_ui::{
-    composable, Brush, Button, Color, Column, ColumnSpec, CornerRadii, LinearArrangement, Modifier,
-    Row, RowSpec, Size, Spacer, Text, TextStyle, VerticalAlignment,
+    composable, Brush, Button, ButtonSpec, Color, Column, ColumnSpec, CornerRadii,
+    LinearArrangement, Modifier, Row, RowSpec, Size, Spacer, Text, TextStyle, VerticalAlignment,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -290,6 +290,7 @@ pub fn mineswapper2_tab() {
                                                 );
                                             })
                                             .padding(8.0),
+                                        ButtonSpec::default(),
                                         move || {
                                             preset_state.set(preset);
                                             game_state.set(MineswapperGame::new_from_preset(
@@ -323,6 +324,7 @@ pub fn mineswapper2_tab() {
                                 );
                             })
                             .padding(10.0),
+                        ButtonSpec::default(),
                         {
                             move || {
                                 let preset = preset_state.get();
@@ -348,6 +350,7 @@ pub fn mineswapper2_tab() {
                                 );
                             })
                             .padding(10.0),
+                        ButtonSpec::default(),
                         move || {
                             let next_mode = match flag_mode.get() {
                                 MineswapperTool::Reveal => MineswapperTool::Flag,
@@ -474,6 +477,7 @@ pub fn mineswapper2_tab() {
                                                     CornerRadii::uniform(8.0),
                                                 );
                                             }),
+                                        ButtonSpec::default(),
                                         move || match flag_mode.get() {
                                             MineswapperTool::Flag => {
                                                 game_state.update(|game| game.toggle_flag(x, y));

--- a/apps/desktop-demo/src/app/shader_rect.rs
+++ b/apps/desktop-demo/src/app/shader_rect.rs
@@ -7,9 +7,9 @@
 
 #![allow(non_snake_case)]
 
-use cranpose_animation::animateFloatAsState;
 use cranpose_animation::{
-    infiniteRepeatable, rememberInfiniteTransition, AnimationSpec, RepeatMode, StartOffset,
+    animateFloatAsState, infiniteRepeatable, rememberInfiniteTransition, AnimationSpec,
+    AnimationType, RepeatMode, StartOffset,
 };
 use cranpose_ui::{
     composable,
@@ -629,9 +629,10 @@ fn FireShaderBox(style: FireStyle) {
         style.base_core_scale
     };
 
-    let intensity_anim = animateFloatAsState(target_intensity, "fire_intensity");
-    let smoke_anim = animateFloatAsState(target_smoke, "fire_smoke");
-    let core_anim = animateFloatAsState(target_core, "fire_core");
+    let intensity_anim =
+        animateFloatAsState(target_intensity, AnimationType::default(), "fire_intensity");
+    let smoke_anim = animateFloatAsState(target_smoke, AnimationType::default(), "fire_smoke");
+    let core_anim = animateFloatAsState(target_core, AnimationType::default(), "fire_core");
 
     let effect = fire_shader_effect(&FireShaderParams {
         resolution_w: outer_width,
@@ -731,8 +732,9 @@ fn HaloBorderBox(color: Color, corner_radius: f32, max_halo_width: f32, label: &
     let target_press = if is_pressed.get() { 1.0f32 } else { 0.0f32 };
     let target_intensity = if is_pressed.get() { 1.6f32 } else { 1.0f32 };
 
-    let press_anim = animateFloatAsState(target_press, "halo_press");
-    let intensity_anim = animateFloatAsState(target_intensity, "halo_intensity");
+    let press_anim = animateFloatAsState(target_press, AnimationType::default(), "halo_press");
+    let intensity_anim =
+        animateFloatAsState(target_intensity, AnimationType::default(), "halo_intensity");
 
     let content_width = 280.0f32;
     let content_height = 120.0f32;

--- a/apps/desktop-demo/src/app/web_fetch.rs
+++ b/apps/desktop-demo/src/app/web_fetch.rs
@@ -2,8 +2,8 @@ use cranpose_services::{local_http_client, local_uri_handler, HttpClientRef};
 use cranpose_ui::{
     composable,
     text::{SpanStyle, TextDecoration},
-    Brush, Button, Color, Column, ColumnSpec, CornerRadii, LinearArrangement, Modifier, Row,
-    RowSpec, Size, Spacer, Text, TextStyle, VerticalAlignment,
+    Brush, Button, ButtonSpec, Color, Column, ColumnSpec, CornerRadii, LinearArrangement, Modifier,
+    Row, RowSpec, Size, Spacer, Text, TextStyle, VerticalAlignment,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -174,6 +174,7 @@ pub(crate) fn web_fetch_example() {
                                         );
                                     })
                                     .padding(10.0),
+                                ButtonSpec::default(),
                                 move || {
                                     fetch_status.set(FetchStatus::Loading);
                                     request_counter.update(|tick| *tick = tick.wrapping_add(1));

--- a/apps/desktop-demo/src/app/winamp/mod.rs
+++ b/apps/desktop-demo/src/app/winamp/mod.rs
@@ -18,8 +18,8 @@ use cranpose::{
 use cranpose_core::{self, MutableState};
 use cranpose_foundation::PointerButton;
 use cranpose_ui::{
-    composable, current_density, Box, BoxSpec, Button, Canvas, Color, Column, ColumnSpec, Modifier,
-    Point, PointerEventKind, PointerInputScope, Size, Text, TextStyle,
+    composable, current_density, Box, BoxSpec, Button, ButtonSpec, Canvas, Color, Column,
+    ColumnSpec, Modifier, Point, PointerEventKind, PointerInputScope, Size, Text, TextStyle,
 };
 use cranpose_ui_graphics::{ImageBitmap, Rect};
 
@@ -266,6 +266,7 @@ fn DockToggleButton(detached_state: MutableState<bool>, detached: bool) {
             .background(Color(0.18, 0.34, 0.58, 1.0))
             .rounded_corners(8.0)
             .padding(8.0),
+        ButtonSpec::default(),
         move || {
             detached_state.set(!detached_state.get_non_reactive());
         },

--- a/apps/desktop-demo/src/app/xkcd.rs
+++ b/apps/desktop-demo/src/app/xkcd.rs
@@ -1,8 +1,8 @@
 use anyhow::{anyhow, Context};
 use cranpose_services::{local_http_client, local_uri_handler, HttpClientRef, HttpError};
 use cranpose_ui::{
-    composable, Alignment, Box, BoxSpec, Color, Column, ColumnSpec, ContentScale, Image,
-    ImageBitmap, LinearArrangement, Modifier, Row, RowSpec, ScrollState, Size, Spacer, Text,
+    composable, Alignment, Box, BoxSpec, ButtonSpec, Color, Column, ColumnSpec, ContentScale,
+    Image, ImageBitmap, LinearArrangement, Modifier, Row, RowSpec, ScrollState, Size, Spacer, Text,
     TextStyle, VerticalAlignment,
 };
 use serde::Deserialize;
@@ -174,6 +174,7 @@ pub(crate) fn xkcd_tab() {
                             .padding(10.0)
                             .background(Color(0.21, 0.44, 0.83, 1.0))
                             .rounded_corners(12.0),
+                        ButtonSpec::default(),
                         {
                             move || {
                                 request_id.update(|value| *value = value.wrapping_add(1));

--- a/apps/desktop-demo/tests/counter_tab_roundtrip_regression.rs
+++ b/apps/desktop-demo/tests/counter_tab_roundtrip_regression.rs
@@ -11,8 +11,8 @@ use cranpose_render_common::graph_scene::{ClickAction, HitGeometry, Scene};
 use cranpose_render_common::hit_graph::{collect_hits_from_graph, HitGraphSink};
 use cranpose_render_common::{RenderScene, Renderer};
 use cranpose_ui::{
-    Button, LayoutTree, Modifier, SemanticsAction, SemanticsNode, SemanticsRole, Size, Text,
-    TextStyle,
+    Button, ButtonSpec, LayoutTree, Modifier, SemanticsAction, SemanticsNode, SemanticsRole, Size,
+    Text, TextStyle,
 };
 use cranpose_ui_graphics::{Point, Rect, RoundedCornerShape};
 use desktop_app::app::{
@@ -171,6 +171,7 @@ fn animate_float_returned_button_graphics_layer_probe() {
             })
             .height(48.0)
             .padding_symmetric(12.0, 8.0),
+        ButtonSpec::default(),
         move || {
             press_tick.set(press_tick.value().wrapping_add(1));
         },

--- a/apps/desktop-demo/tests/counter_tab_roundtrip_regression.rs
+++ b/apps/desktop-demo/tests/counter_tab_roundtrip_regression.rs
@@ -1,6 +1,6 @@
 pub mod tab_switch_regression_support;
 
-use cranpose_animation::{animateFloatAsState, AnimationSpec, AnimationType};
+use cranpose_animation::{animateFloatAsState, tween, Easing};
 use cranpose_app_shell::AppShell;
 use cranpose_core::{location_key, MutableState};
 use cranpose_foundation::PointerEvent;
@@ -151,7 +151,7 @@ fn returned_press_lift(press_tick: MutableState<u64>) -> f32 {
 
     animateFloatAsState(
         press_target.value(),
-        AnimationType::Tween(AnimationSpec::linear(240)),
+        tween(240, Easing::LinearEasing),
         "returned_button_graphics_layer_probe",
     )
     .value()

--- a/apps/desktop-demo/tests/counter_tab_roundtrip_regression.rs
+++ b/apps/desktop-demo/tests/counter_tab_roundtrip_regression.rs
@@ -1,6 +1,6 @@
 pub mod tab_switch_regression_support;
 
-use cranpose_animation::{animateFloatAsStateWithSpec, AnimationSpec, AnimationType};
+use cranpose_animation::{animateFloatAsState, AnimationSpec, AnimationType};
 use cranpose_app_shell::AppShell;
 use cranpose_core::{location_key, MutableState};
 use cranpose_foundation::PointerEvent;
@@ -149,7 +149,7 @@ fn returned_press_lift(press_tick: MutableState<u64>) -> f32 {
         }
     });
 
-    animateFloatAsStateWithSpec(
+    animateFloatAsState(
         press_target.value(),
         AnimationType::Tween(AnimationSpec::linear(240)),
         "returned_button_graphics_layer_probe",

--- a/apps/isolated-demo/src/app.rs
+++ b/apps/isolated-demo/src/app.rs
@@ -39,7 +39,7 @@ pub(crate) fn IsolatedDemoApp() {
                     Button(
                         Modifier::empty()
                             .padding(12.0)
-                            .background(Color::rgba(0.12, 0.16, 0.26, 1.0)),
+                            .background(Color::rgba(0.12, 0.16, 0.26, 1.0)), ButtonSpec::default(),
                         {
                             let counter = counter;
                             move || counter.set(counter.get() + 1)
@@ -55,7 +55,7 @@ pub(crate) fn IsolatedDemoApp() {
                     Button(
                         Modifier::empty()
                             .padding(12.0)
-                            .background(Color::rgba(0.2, 0.2, 0.2, 1.0)),
+                            .background(Color::rgba(0.2, 0.2, 0.2, 1.0)), ButtonSpec::default(),
                         {
                             let accent = accent;
                             move || accent.set(!accent.get())

--- a/crates/cranpose-animation/src/animation.rs
+++ b/crates/cranpose-animation/src/animation.rs
@@ -362,6 +362,11 @@ pub fn spring(damping_ratio: f32, stiffness: f32) -> AnimationType {
     AnimationType::Spring(SpringSpec::new(damping_ratio, stiffness))
 }
 
+/// Compose-style tween animation spec factory.
+pub fn tween(duration_millis: u64, easing: Easing) -> AnimationType {
+    AnimationType::Tween(AnimationSpec::tween(duration_millis, easing))
+}
+
 /// Animation type specification.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AnimationType {

--- a/crates/cranpose-animation/src/animation.rs
+++ b/crates/cranpose-animation/src/animation.rs
@@ -6,6 +6,7 @@
 //! 1:1 API parity with Jetpack Compose.
 
 #![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
 
 use std::cell::{Cell, RefCell};
 use std::marker::PhantomData;
@@ -293,6 +294,16 @@ pub struct SpringSpec {
 }
 
 impl SpringSpec {
+    /// Create a spring with explicit Compose-style physics constants.
+    pub fn new(damping_ratio: f32, stiffness: f32) -> Self {
+        Self {
+            damping_ratio,
+            stiffness,
+            velocity_threshold: 0.01,
+            position_threshold: 0.001,
+        }
+    }
+
     /// Create a spring with default material design values.
     pub fn default_spring() -> Self {
         Self {
@@ -328,6 +339,27 @@ impl Default for SpringSpec {
     fn default() -> Self {
         Self::default_spring()
     }
+}
+
+/// Compose-compatible spring constants.
+pub struct Spring;
+
+impl Spring {
+    pub const DampingRatioNoBouncy: f32 = 1.0;
+    pub const DampingRatioLowBouncy: f32 = 0.75;
+    pub const DampingRatioMediumBouncy: f32 = 0.5;
+    pub const DampingRatioHighBouncy: f32 = 0.2;
+
+    pub const StiffnessHigh: f32 = 10_000.0;
+    pub const StiffnessMedium: f32 = 1_500.0;
+    pub const StiffnessMediumLow: f32 = 400.0;
+    pub const StiffnessLow: f32 = 200.0;
+    pub const StiffnessVeryLow: f32 = 50.0;
+}
+
+/// Compose-style spring animation spec factory.
+pub fn spring(damping_ratio: f32, stiffness: f32) -> AnimationType {
+    AnimationType::Spring(SpringSpec::new(damping_ratio, stiffness))
 }
 
 /// Animation type specification.
@@ -849,16 +881,7 @@ impl<T: SpringScalar + 'static> Animatable<T> {
 }
 
 #[allow(non_snake_case)]
-pub fn animateFloatAsState(target: f32, label: &str) -> State<f32> {
-    animateFloatAsStateWithSpec(target, AnimationType::default(), label)
-}
-
-#[allow(non_snake_case)]
-pub fn animateFloatAsStateWithSpec(
-    target: f32,
-    animation: AnimationType,
-    label: &str,
-) -> State<f32> {
+pub fn animateFloatAsState(target: f32, animation: AnimationType, label: &str) -> State<f32> {
     let _ = label;
     with_current_composer(|composer| {
         let runtime = composer.runtime_handle();

--- a/crates/cranpose-animation/src/lib.rs
+++ b/crates/cranpose-animation/src/lib.rs
@@ -13,9 +13,9 @@ pub use decay_spec::{FlingCalculator, FlingInfo, FloatDecayAnimationSpec, Spline
 
 pub mod prelude {
     pub use crate::animation::{
-        animateFloatAsState, infiniteRepeatable, rememberInfiniteTransition, spring, Animatable,
-        AnimationSpec, AnimationType, Easing, InfiniteRepeatableSpec, InfiniteTransition, Lerp,
-        RepeatMode, Spring, SpringSpec, StartOffset, StartOffsetType,
+        animateFloatAsState, infiniteRepeatable, rememberInfiniteTransition, spring, tween,
+        Animatable, AnimationSpec, AnimationType, Easing, InfiniteRepeatableSpec,
+        InfiniteTransition, Lerp, RepeatMode, Spring, SpringSpec, StartOffset, StartOffsetType,
     };
     pub use crate::decay_spec::{FlingCalculator, FloatDecayAnimationSpec, SplineBasedDecaySpec};
 }

--- a/crates/cranpose-animation/src/lib.rs
+++ b/crates/cranpose-animation/src/lib.rs
@@ -13,10 +13,9 @@ pub use decay_spec::{FlingCalculator, FlingInfo, FloatDecayAnimationSpec, Spline
 
 pub mod prelude {
     pub use crate::animation::{
-        animateFloatAsState, animateFloatAsStateWithSpec, infiniteRepeatable,
-        rememberInfiniteTransition, Animatable, AnimationSpec, AnimationType, Easing,
-        InfiniteRepeatableSpec, InfiniteTransition, Lerp, RepeatMode, SpringSpec, StartOffset,
-        StartOffsetType,
+        animateFloatAsState, infiniteRepeatable, rememberInfiniteTransition, spring, Animatable,
+        AnimationSpec, AnimationType, Easing, InfiniteRepeatableSpec, InfiniteTransition, Lerp,
+        RepeatMode, Spring, SpringSpec, StartOffset, StartOffsetType,
     };
     pub use crate::decay_spec::{FlingCalculator, FloatDecayAnimationSpec, SplineBasedDecaySpec};
 }

--- a/crates/cranpose-animation/src/tests/animation_tests.rs
+++ b/crates/cranpose-animation/src/tests/animation_tests.rs
@@ -30,7 +30,11 @@ fn animate_float_as_state_interpolates_over_time() {
                 let target = Rc::clone(&target);
                 with_current_composer(|composer| {
                     composer.with_group(group_key, |_| {
-                        let state = animateFloatAsState(*target.borrow(), "alpha");
+                        let state = animateFloatAsState(
+                            *target.borrow(),
+                            AnimationType::default(),
+                            "alpha",
+                        );
                         state_slot.borrow_mut().replace(state);
                     });
                 });
@@ -55,7 +59,11 @@ fn animate_float_as_state_interpolates_over_time() {
                 let target = Rc::clone(&target);
                 with_current_composer(|composer| {
                     composer.with_group(group_key, |_| {
-                        let state = animateFloatAsState(*target.borrow(), "alpha");
+                        let state = animateFloatAsState(
+                            *target.borrow(),
+                            AnimationType::default(),
+                            "alpha",
+                        );
                         state_slot.borrow_mut().replace(state);
                     });
                 });
@@ -111,7 +119,7 @@ fn animate_float_as_state_invalidates_composition_time_readers() {
             });
         }
 
-        let value = animateFloatAsStateWithSpec(
+        let value = animateFloatAsState(
             target.value(),
             AnimationType::Tween(AnimationSpec::linear(240)),
             "alpha",

--- a/crates/cranpose-animation/src/tests/animation_tests.rs
+++ b/crates/cranpose-animation/src/tests/animation_tests.rs
@@ -358,3 +358,11 @@ fn spring_spec_stiff_has_high_stiffness() {
     assert_eq!(spec.stiffness, 3000.0);
     assert!(spec.stiffness > SpringSpec::default().stiffness);
 }
+
+#[test]
+fn tween_factory_creates_tween_animation_type() {
+    assert_eq!(
+        tween(450, Easing::FastOutSlowInEasing),
+        AnimationType::Tween(AnimationSpec::tween(450, Easing::FastOutSlowInEasing))
+    );
+}

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -7,7 +7,7 @@ use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope, LazyLis
 use cranpose_foundation::{PointerEvent, PointerEventKind};
 use cranpose_macros::composable;
 use cranpose_ui::{
-    BlendMode, Box, BoxSpec, Brush, Button, Color, Column, ColumnSpec, CornerRadii,
+    BlendMode, Box, BoxSpec, Brush, Button, ButtonSpec, Color, Column, ColumnSpec, CornerRadii,
     HeadlessRenderer, IntrinsicSize, LazyColumn, LazyColumnSpec, LinearArrangement, Modifier,
     PointerInputScope, Rect, RenderOp, Row, RowSpec, ScrollState, Size, Text, TextStyle,
     VerticalAlignment,
@@ -971,6 +971,7 @@ fn frame_stable_pointer_handler_content() {
     let pending_clicks_state = pending_clicks;
     Button(
         Modifier::empty().padding(8.0),
+        ButtonSpec::default(),
         move || {
             if pending_handler {
                 pending_clicks_state.set_value(pending_clicks_state.value() + 1);
@@ -2458,6 +2459,7 @@ fn app_shell_interactive_counter_test_tab(counter: MutableState<i32>) {
                             Modifier::empty()
                                 .background(Color(0.25, 0.45, 0.75, 1.0))
                                 .padding(12.0),
+                            ButtonSpec::default(),
                             move || {
                                 counter.set_value(counter.value() + 1);
                             },
@@ -2638,6 +2640,7 @@ fn app_shell_interactive_clickable_tab_host() {
             Row(Modifier::empty(), RowSpec::default(), move || {
                 Button(
                     Modifier::empty().padding(8.0),
+                    ButtonSpec::default(),
                     move || counter_tab.set_value(0),
                     || {
                         Text("Counter App", Modifier::empty(), TextStyle::default());
@@ -2645,6 +2648,7 @@ fn app_shell_interactive_clickable_tab_host() {
                 );
                 Button(
                     Modifier::empty().padding(8.0),
+                    ButtonSpec::default(),
                     move || composition_local_tab.set_value(1),
                     || {
                         Text(
@@ -2656,6 +2660,7 @@ fn app_shell_interactive_clickable_tab_host() {
                 );
                 Button(
                     Modifier::empty().padding(8.0),
+                    ButtonSpec::default(),
                     move || web_fetch_tab.set_value(2),
                     || {
                         Text("Web Fetch", Modifier::empty(), TextStyle::default());
@@ -2826,6 +2831,7 @@ fn app_shell_demo_like_counter_tab() {
                                                     });
                                                 })
                                                 .padding(12.0),
+                                            ButtonSpec::default(),
                                             move || counter.set(counter.get() + 1),
                                             || {
                                                 Text(
@@ -2859,6 +2865,7 @@ fn app_shell_demo_like_clickable_tab_host() {
             Row(Modifier::empty(), RowSpec::default(), move || {
                 Button(
                     Modifier::empty().padding(8.0),
+                    ButtonSpec::default(),
                     move || counter_tab.set_value(0),
                     || {
                         Text("Counter App", Modifier::empty(), TextStyle::default());
@@ -2866,6 +2873,7 @@ fn app_shell_demo_like_clickable_tab_host() {
                 );
                 Button(
                     Modifier::empty().padding(8.0),
+                    ButtonSpec::default(),
                     move || composition_local_tab.set_value(1),
                     || {
                         Text(
@@ -3075,6 +3083,7 @@ fn app_shell_actual_like_counter_tab() {
                                             );
                                         })
                                         .padding(10.0),
+                                    ButtonSpec::default(),
                                     || {},
                                     move || {
                                         Text(
@@ -3107,6 +3116,7 @@ fn app_shell_actual_like_counter_tab() {
                                         });
                                     })
                                     .padding(12.0),
+                                ButtonSpec::default(),
                                 move || counter.set(counter.get() + 1),
                                 || {
                                     Text(
@@ -3126,6 +3136,7 @@ fn app_shell_actual_like_counter_tab() {
                                         );
                                     })
                                     .padding(12.0),
+                                ButtonSpec::default(),
                                 move || counter.set(counter.get() - 1),
                                 || {
                                     Text(
@@ -3162,6 +3173,7 @@ fn app_shell_actual_like_counter_tab() {
                                 });
                             })
                             .padding(12.0),
+                        ButtonSpec::default(),
                         {
                             move || {
                                 async_message
@@ -3196,6 +3208,7 @@ fn app_shell_actual_like_clickable_tab_host() {
             Row(Modifier::empty(), RowSpec::default(), move || {
                 Button(
                     Modifier::empty().padding(8.0),
+                    ButtonSpec::default(),
                     move || counter_tab.set_value(0),
                     || {
                         Text("Counter App", Modifier::empty(), TextStyle::default());
@@ -3203,6 +3216,7 @@ fn app_shell_actual_like_clickable_tab_host() {
                 );
                 Button(
                     Modifier::empty().padding(8.0),
+                    ButtonSpec::default(),
                     move || composition_local_tab.set_value(1),
                     || {
                         Text(
@@ -3282,6 +3296,7 @@ fn app_shell_many_tabs_clickable_host() {
                     );
                 })
                 .padding(10.0),
+            ButtonSpec::default(),
             move || {
                 if active_tab.get() != index {
                     active_tab.set_value(index);
@@ -3363,6 +3378,7 @@ fn app_shell_many_tabs_precise_tab_button(
                 );
             })
             .padding(10.0),
+        ButtonSpec::default(),
         move || {
             if active_tab.get() != index {
                 active_tab.set_value(index);
@@ -3492,6 +3508,7 @@ fn app_shell_animated_draw_counter_tab() {
             );
             Button(
                 Modifier::empty().padding(8.0),
+                ButtonSpec::default(),
                 move || phase_state.set_value(0.8),
                 || {
                     Text("Drive wave", Modifier::empty(), TextStyle::default());

--- a/crates/cranpose-core/src/hooks.rs
+++ b/crates/cranpose-core/src/hooks.rs
@@ -192,7 +192,9 @@ where
 ///     let count = useState(|| 0);
 ///
 ///     Button(
-///         onClick = move || count.set(count.value() + 1),
+///         Modifier::empty(),
+///         ButtonSpec::default(),
+///         move || count.set(count.value() + 1),
 ///         || Text(format!("Count: {}", count.value()))
 ///     );
 /// }

--- a/crates/cranpose-testing/tests/button_clickable_test.rs
+++ b/crates/cranpose-testing/tests/button_clickable_test.rs
@@ -22,6 +22,7 @@ fn simple_button_app(clicked_count: MutableState<i32>) {
 
             Button(
                 Modifier::empty().padding(10.0),
+                ButtonSpec::default(),
                 {
                     let count = clicked_count;
                     move || {
@@ -67,11 +68,11 @@ fn test_button_creates_valid_composition() {
         "Button should not have been clicked yet"
     );
 
-    // The composition should have created nodes for Column, Text, Button, and Button's Text child
+    // The composition should have created nodes for Column, Text, Button, ButtonSpec, and Button's Text child
     let node_count = rule.applier_mut().len();
     assert!(
         node_count >= 4,
-        "Should have at least 4 nodes (Column, Text, Button, Button's Text)"
+        "Should have at least 4 nodes (Column, Text, Button, ButtonSpec, Button's Text)"
     );
 
     // In a real app, clicking would:
@@ -102,6 +103,7 @@ fn multi_button_app(button1_clicks: MutableState<i32>, button2_clicks: MutableSt
 
             Button(
                 Modifier::empty().padding(10.0),
+                ButtonSpec::default(),
                 {
                     let clicks = button1_clicks;
                     move || {
@@ -125,6 +127,7 @@ fn multi_button_app(button1_clicks: MutableState<i32>, button2_clicks: MutableSt
 
             Button(
                 Modifier::empty().padding(10.0),
+                ButtonSpec::default(),
                 {
                     let clicks = button2_clicks;
                     move || {

--- a/crates/cranpose-testing/tests/composition_switching_test.rs
+++ b/crates/cranpose-testing/tests/composition_switching_test.rs
@@ -26,6 +26,7 @@ fn counter_view(counter: MutableState<i32>, render_count: MutableState<i32>) {
 
             Button(
                 Modifier::empty().padding(10.0),
+                ButtonSpec::default(),
                 {
                     move || {
                         counter.set(counter.get() + 1);
@@ -61,6 +62,7 @@ fn alternative_view(counter: MutableState<i32>, render_count: MutableState<i32>)
 
             Button(
                 Modifier::empty().padding(10.0),
+                ButtonSpec::default(),
                 {
                     move || {
                         counter.set(counter.get() + 1);
@@ -102,6 +104,7 @@ fn combined_switching_app(
                 move || {
                     Button(
                         Modifier::empty().padding(10.0),
+                        ButtonSpec::default(),
                         {
                             let show_counter = show_counter_for_button1;
                             move || {
@@ -124,6 +127,7 @@ fn combined_switching_app(
 
                     Button(
                         Modifier::empty().padding(10.0),
+                        ButtonSpec::default(),
                         {
                             let show_counter = show_counter_for_button2;
                             move || {
@@ -398,6 +402,7 @@ fn test_multiple_switches_with_state_changes() {
                     );
                     Button(
                         Modifier::empty(),
+                        ButtonSpec::default(),
                         {
                             let counter_a = counter_a_inner;
                             move || counter_a.set(counter_a.get() + 1)
@@ -414,6 +419,7 @@ fn test_multiple_switches_with_state_changes() {
                     );
                     Button(
                         Modifier::empty(),
+                        ButtonSpec::default(),
                         {
                             let counter_b = counter_b_inner;
                             move || counter_b.set(counter_b.get() + 1)
@@ -655,6 +661,7 @@ fn test_conditional_with_complex_button_structure() {
                             Text("First View", Modifier::empty(), TextStyle::default());
                             Button(
                                 Modifier::empty(),
+                                ButtonSpec::default(),
                                 move || counter.set(counter.get() + 1),
                                 || {
                                     Text("Button 1", Modifier::empty(), TextStyle::default());
@@ -662,6 +669,7 @@ fn test_conditional_with_complex_button_structure() {
                             );
                             Button(
                                 Modifier::empty(),
+                                ButtonSpec::default(),
                                 move || counter.set(counter.get() + 10),
                                 || {
                                     Text("Button 2", Modifier::empty(), TextStyle::default());
@@ -674,6 +682,7 @@ fn test_conditional_with_complex_button_structure() {
                     Text("Second View", Modifier::empty(), TextStyle::default());
                     Button(
                         Modifier::empty(),
+                        ButtonSpec::default(),
                         {
                             let counter = counter_inner;
                             move || counter.set(counter.get() - 1)
@@ -752,6 +761,7 @@ fn test_clicking_same_switch_button_twice_no_duplication() {
 
                         Button(
                             Modifier::empty(),
+                            ButtonSpec::default(),
                             move || show_counter_for_btn1.set(true),
                             || {
                                 Text("Counter App", Modifier::empty(), TextStyle::default());
@@ -760,6 +770,7 @@ fn test_clicking_same_switch_button_twice_no_duplication() {
 
                         Button(
                             Modifier::empty(),
+                            ButtonSpec::default(),
                             move || show_counter_for_btn2.set(false),
                             || {
                                 Text(
@@ -926,6 +937,7 @@ fn test_composition_local_demo(
 
             Button(
                 Modifier::empty().padding(10.0),
+                ButtonSpec::default(),
                 {
                     move || {
                         counter.set(counter.get() + 1);
@@ -997,6 +1009,7 @@ fn composable_view_a() {
             Text("View A - Line 2", Modifier::empty(), TextStyle::default());
             Button(
                 Modifier::empty(),
+                ButtonSpec::default(),
                 || {},
                 || {
                     Text("Button A", Modifier::empty(), TextStyle::default());
@@ -1017,6 +1030,7 @@ fn composable_view_b() {
             Text("View B - Line 3", Modifier::empty(), TextStyle::default());
             Button(
                 Modifier::empty(),
+                ButtonSpec::default(),
                 || {},
                 || {
                     Text("Button B", Modifier::empty(), TextStyle::default());

--- a/crates/cranpose-testing/tests/intrinsics_test.rs
+++ b/crates/cranpose-testing/tests/intrinsics_test.rs
@@ -34,6 +34,7 @@ fn equal_width_buttons_api_demonstration() {
         Row(Modifier::empty(), RowSpec::default(), || {
             Button(
                 Modifier::empty().width_intrinsic(IntrinsicSize::Max),
+                ButtonSpec::default(),
                 || {},
                 || {
                     Text("OK", Modifier::empty(), TextStyle::default());
@@ -41,6 +42,7 @@ fn equal_width_buttons_api_demonstration() {
             );
             Button(
                 Modifier::empty().width_intrinsic(IntrinsicSize::Max),
+                ButtonSpec::default(),
                 || {},
                 || {
                     Text("Cancel", Modifier::empty(), TextStyle::default());
@@ -48,6 +50,7 @@ fn equal_width_buttons_api_demonstration() {
             );
             Button(
                 Modifier::empty().width_intrinsic(IntrinsicSize::Max),
+                ButtonSpec::default(),
                 || {},
                 || {
                     Text("Apply", Modifier::empty(), TextStyle::default());

--- a/crates/cranpose-testing/tests/pointer_input_end_to_end_test.rs
+++ b/crates/cranpose-testing/tests/pointer_input_end_to_end_test.rs
@@ -136,6 +136,7 @@ fn pause_button_app(is_running: MutableState<bool>, click_count: MutableState<i3
                             scope.draw_round_rect(Brush::solid(color), CornerRadii::uniform(16.0));
                         }
                     })),
+                ButtonSpec::default(),
                 {
                     move || {
                         is_running.set(!is_running.get());

--- a/crates/cranpose-testing/tests/pointer_input_integration_test.rs
+++ b/crates/cranpose-testing/tests/pointer_input_integration_test.rs
@@ -121,6 +121,7 @@ fn button_with_modifiers_app(click_count: MutableState<i32>) {
                             CornerRadii::uniform(12.0),
                         );
                     })),
+                ButtonSpec::default(),
                 {
                     let count = click_count;
                     move || {
@@ -186,6 +187,7 @@ fn dynamic_label_button_app(click_count: MutableState<i32>, is_active: MutableSt
 
             Button(
                 Modifier::empty().padding(10.0),
+                ButtonSpec::default(),
                 {
                     let count = click_count;
                     move || {

--- a/crates/cranpose-ui-graphics/src/geometry.rs
+++ b/crates/cranpose-ui-graphics/src/geometry.rs
@@ -443,6 +443,14 @@ pub trait DrawScope {
     fn draw_rect_at_blend(&mut self, rect: Rect, brush: Brush, blend_mode: BlendMode);
     fn draw_round_rect(&mut self, brush: Brush, radii: CornerRadii);
     fn draw_round_rect_blend(&mut self, brush: Brush, radii: CornerRadii, blend_mode: BlendMode);
+    fn draw_circle(&mut self, brush: Brush, center: Point, radius: f32);
+    fn draw_circle_blend(
+        &mut self,
+        brush: Brush,
+        center: Point,
+        radius: f32,
+        blend_mode: BlendMode,
+    );
     fn draw_image(&mut self, image: ImageBitmap);
     fn draw_image_blend(&mut self, image: ImageBitmap, blend_mode: BlendMode);
     fn draw_image_at(
@@ -566,6 +574,34 @@ impl DrawScope for DrawScopeDefault {
                 rect: Rect::from_size(self.size),
                 brush,
                 radii,
+            },
+            blend_mode,
+        );
+    }
+
+    fn draw_circle(&mut self, brush: Brush, center: Point, radius: f32) {
+        self.draw_circle_blend(brush, center, radius, BlendMode::SrcOver);
+    }
+
+    fn draw_circle_blend(
+        &mut self,
+        brush: Brush,
+        center: Point,
+        radius: f32,
+        blend_mode: BlendMode,
+    ) {
+        let radius = radius.max(0.0);
+        let diameter = radius * 2.0;
+        self.push_blended_primitive(
+            DrawPrimitive::RoundRect {
+                rect: Rect {
+                    x: center.x - radius,
+                    y: center.y - radius,
+                    width: diameter,
+                    height: diameter,
+                },
+                brush,
+                radii: CornerRadii::uniform(radius),
             },
             blend_mode,
         );
@@ -763,6 +799,54 @@ mod tests {
                 assert!(matches!(**primitive, DrawPrimitive::Rect { .. }));
             }
             other => panic!("expected blended primitive, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn draw_circle_records_centered_round_rect() {
+        let mut scope = DrawScopeDefault::new(Size::new(40.0, 40.0));
+        scope.draw_circle(Brush::solid(Color::BLUE), Point::new(12.0, 16.0), 5.0);
+
+        let primitives = scope.into_primitives();
+        assert_eq!(primitives.len(), 1);
+        match &primitives[0] {
+            DrawPrimitive::RoundRect { rect, radii, .. } => {
+                assert_eq!(
+                    *rect,
+                    Rect {
+                        x: 7.0,
+                        y: 11.0,
+                        width: 10.0,
+                        height: 10.0,
+                    }
+                );
+                assert_eq!(*radii, CornerRadii::uniform(5.0));
+            }
+            other => panic!("expected circular round rect, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn draw_circle_blend_wraps_non_default_modes() {
+        let mut scope = DrawScopeDefault::new(Size::new(10.0, 10.0));
+        scope.draw_circle_blend(
+            Brush::solid(Color::RED),
+            Point::new(5.0, 5.0),
+            3.0,
+            BlendMode::Plus,
+        );
+
+        let primitives = scope.into_primitives();
+        assert_eq!(primitives.len(), 1);
+        match &primitives[0] {
+            DrawPrimitive::Blend {
+                primitive,
+                blend_mode,
+            } => {
+                assert_eq!(*blend_mode, BlendMode::Plus);
+                assert!(matches!(**primitive, DrawPrimitive::RoundRect { .. }));
+            }
+            other => panic!("expected blended circle primitive, got {other:?}"),
         }
     }
 

--- a/crates/cranpose-ui/src/interaction.rs
+++ b/crates/cranpose-ui/src/interaction.rs
@@ -22,6 +22,7 @@ struct MutableInteractionSourceInner {
     id: u64,
     active_presses: RefCell<HashSet<u64>>,
     pressed: OwnedMutableState<bool>,
+    last_interaction: OwnedMutableState<Option<Interaction>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -64,7 +65,8 @@ impl MutableInteractionSource {
             inner: Rc::new(MutableInteractionSourceInner {
                 id: NEXT_SOURCE_ID.fetch_add(1, Ordering::Relaxed),
                 active_presses: RefCell::new(HashSet::new()),
-                pressed: OwnedMutableState::with_runtime(false, runtime),
+                pressed: OwnedMutableState::with_runtime(false, runtime.clone()),
+                last_interaction: OwnedMutableState::with_runtime(None, runtime),
             }),
         }
     }
@@ -96,6 +98,7 @@ impl MutableInteractionSource {
     }
 
     pub fn emit(&self, interaction: Interaction) {
+        self.inner.last_interaction.set(Some(interaction));
         let is_pressed = {
             let mut active_presses = self.inner.active_presses.borrow_mut();
             match interaction {
@@ -119,6 +122,16 @@ impl MutableInteractionSource {
 
     pub fn collectIsPressedAsState(&self) -> State<bool> {
         self.inner.pressed.as_state()
+    }
+
+    pub fn collectLastInteractionAsState(&self) -> State<Option<Interaction>> {
+        self.inner.last_interaction.as_state()
+    }
+}
+
+impl PressInteractionPress {
+    pub fn id(&self) -> u64 {
+        self.id
     }
 }
 
@@ -338,10 +351,35 @@ mod tests {
         assert!(pressed.get());
 
         let second = source.press(Point { x: 3.0, y: 4.0 });
+        assert_ne!(first.id(), second.id());
         source.release(first);
         assert!(pressed.get());
 
         source.cancel(second);
         assert!(!pressed.get());
+    }
+
+    #[test]
+    fn interaction_source_exposes_latest_interaction() {
+        let composition = Composition::new(MemoryApplier::new());
+        let source = MutableInteractionSource::with_runtime(composition.runtime_handle());
+        let last_interaction = source.collectLastInteractionAsState();
+
+        assert_eq!(last_interaction.get(), None);
+
+        let press = source.press(Point { x: 8.0, y: 12.0 });
+        assert_eq!(
+            last_interaction.get(),
+            Some(Interaction::Press(PressInteraction::Press(press)))
+        );
+        assert_eq!(press.press_position, Point { x: 8.0, y: 12.0 });
+
+        source.release(press);
+        assert_eq!(
+            last_interaction.get(),
+            Some(Interaction::Press(PressInteraction::Release(
+                PressInteractionRelease { press }
+            )))
+        );
     }
 }

--- a/crates/cranpose-ui/src/interaction.rs
+++ b/crates/cranpose-ui/src/interaction.rs
@@ -1,0 +1,347 @@
+#![allow(non_snake_case)]
+
+use crate::composable;
+use crate::modifier::{inspector_metadata, Modifier, Point, PointerEvent, PointerEventKind};
+use cranpose_core::{remember, with_current_composer, OwnedMutableState, RuntimeHandle, State};
+use cranpose_foundation::{
+    DelegatableNode, InvalidationKind, ModifierNode, ModifierNodeContext, ModifierNodeElement,
+    NodeCapabilities, NodeState, PointerInputNode,
+};
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Clone)]
+pub struct MutableInteractionSource {
+    inner: Rc<MutableInteractionSourceInner>,
+}
+
+struct MutableInteractionSourceInner {
+    id: u64,
+    active_presses: RefCell<HashSet<u64>>,
+    pressed: OwnedMutableState<bool>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Interaction {
+    Press(PressInteraction),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PressInteraction {
+    Press(PressInteractionPress),
+    Release(PressInteractionRelease),
+    Cancel(PressInteractionCancel),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PressInteractionPress {
+    id: u64,
+    pub press_position: Point,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PressInteractionRelease {
+    pub press: PressInteractionPress,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PressInteractionCancel {
+    pub press: PressInteractionPress,
+}
+
+impl MutableInteractionSource {
+    pub fn new() -> Self {
+        let runtime = with_current_composer(|composer| composer.runtime_handle());
+        Self::with_runtime(runtime)
+    }
+
+    pub fn with_runtime(runtime: RuntimeHandle) -> Self {
+        static NEXT_SOURCE_ID: AtomicU64 = AtomicU64::new(1);
+        Self {
+            inner: Rc::new(MutableInteractionSourceInner {
+                id: NEXT_SOURCE_ID.fetch_add(1, Ordering::Relaxed),
+                active_presses: RefCell::new(HashSet::new()),
+                pressed: OwnedMutableState::with_runtime(false, runtime),
+            }),
+        }
+    }
+
+    pub fn id(&self) -> u64 {
+        self.inner.id
+    }
+
+    pub fn press(&self, press_position: Point) -> PressInteractionPress {
+        static NEXT_PRESS_ID: AtomicU64 = AtomicU64::new(1);
+        let press = PressInteractionPress {
+            id: NEXT_PRESS_ID.fetch_add(1, Ordering::Relaxed),
+            press_position,
+        };
+        self.emit(Interaction::Press(PressInteraction::Press(press)));
+        press
+    }
+
+    pub fn release(&self, press: PressInteractionPress) {
+        self.emit(Interaction::Press(PressInteraction::Release(
+            PressInteractionRelease { press },
+        )));
+    }
+
+    pub fn cancel(&self, press: PressInteractionPress) {
+        self.emit(Interaction::Press(PressInteraction::Cancel(
+            PressInteractionCancel { press },
+        )));
+    }
+
+    pub fn emit(&self, interaction: Interaction) {
+        let is_pressed = {
+            let mut active_presses = self.inner.active_presses.borrow_mut();
+            match interaction {
+                Interaction::Press(PressInteraction::Press(press)) => {
+                    active_presses.insert(press.id);
+                }
+                Interaction::Press(PressInteraction::Release(release)) => {
+                    active_presses.remove(&release.press.id);
+                }
+                Interaction::Press(PressInteraction::Cancel(cancel)) => {
+                    active_presses.remove(&cancel.press.id);
+                }
+            }
+            !active_presses.is_empty()
+        };
+
+        if self.inner.pressed.get_non_reactive() != is_pressed {
+            self.inner.pressed.set(is_pressed);
+        }
+    }
+
+    pub fn collectIsPressedAsState(&self) -> State<bool> {
+        self.inner.pressed.as_state()
+    }
+}
+
+impl std::fmt::Debug for MutableInteractionSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MutableInteractionSource")
+            .field("id", &self.id())
+            .finish()
+    }
+}
+
+impl PartialEq for MutableInteractionSource {
+    fn eq(&self, other: &Self) -> bool {
+        self.id() == other.id()
+    }
+}
+
+impl Eq for MutableInteractionSource {}
+
+impl Default for MutableInteractionSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[composable]
+pub fn rememberMutableInteractionSource() -> MutableInteractionSource {
+    let runtime = with_current_composer(|composer| composer.runtime_handle());
+    remember(move || MutableInteractionSource::with_runtime(runtime.clone()))
+        .with(|source| source.clone())
+}
+
+impl Modifier {
+    pub fn press_interaction_source(self, interaction_source: MutableInteractionSource) -> Self {
+        let source_id = interaction_source.id();
+        let modifier = Self::with_element(PressInteractionElement::new(interaction_source))
+            .with_inspector_metadata(inspector_metadata("pressInteractionSource", move |info| {
+                info.add_property("sourceId", source_id.to_string());
+            }));
+        self.then(modifier)
+    }
+}
+
+#[derive(Clone)]
+struct PressInteractionElement {
+    interaction_source: MutableInteractionSource,
+}
+
+impl PressInteractionElement {
+    fn new(interaction_source: MutableInteractionSource) -> Self {
+        Self { interaction_source }
+    }
+}
+
+impl std::fmt::Debug for PressInteractionElement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PressInteractionElement")
+            .field("source_id", &self.interaction_source.id())
+            .finish()
+    }
+}
+
+impl PartialEq for PressInteractionElement {
+    fn eq(&self, other: &Self) -> bool {
+        self.interaction_source == other.interaction_source
+    }
+}
+
+impl Eq for PressInteractionElement {}
+
+impl Hash for PressInteractionElement {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        "pressInteractionSource".hash(state);
+        self.interaction_source.id().hash(state);
+    }
+}
+
+impl ModifierNodeElement for PressInteractionElement {
+    type Node = PressInteractionNode;
+
+    fn create(&self) -> Self::Node {
+        PressInteractionNode::new(self.interaction_source.clone())
+    }
+
+    fn update(&self, node: &mut Self::Node) {
+        node.update(self.interaction_source.clone());
+    }
+
+    fn capabilities(&self) -> NodeCapabilities {
+        NodeCapabilities::POINTER_INPUT
+    }
+}
+
+struct PressInteractionNode {
+    interaction_source: MutableInteractionSource,
+    active_press: Rc<RefCell<Option<PressInteractionPress>>>,
+    cached_handler: Rc<dyn Fn(PointerEvent)>,
+    state: NodeState,
+}
+
+impl PressInteractionNode {
+    fn new(interaction_source: MutableInteractionSource) -> Self {
+        let active_press = Rc::new(RefCell::new(None));
+        let cached_handler = Self::create_handler(interaction_source.clone(), active_press.clone());
+        Self {
+            interaction_source,
+            active_press,
+            cached_handler,
+            state: NodeState::new(),
+        }
+    }
+
+    fn update(&mut self, interaction_source: MutableInteractionSource) {
+        if self.interaction_source == interaction_source {
+            return;
+        }
+        if let Some(press) = self.active_press.borrow_mut().take() {
+            self.interaction_source.cancel(press);
+        }
+        self.interaction_source = interaction_source;
+        self.cached_handler =
+            Self::create_handler(self.interaction_source.clone(), self.active_press.clone());
+    }
+
+    fn create_handler(
+        interaction_source: MutableInteractionSource,
+        active_press: Rc<RefCell<Option<PressInteractionPress>>>,
+    ) -> Rc<dyn Fn(PointerEvent)> {
+        Rc::new(move |event: PointerEvent| {
+            if event.is_consumed() {
+                if let Some(press) = active_press.borrow_mut().take() {
+                    interaction_source.cancel(press);
+                }
+                return;
+            }
+
+            match event.kind {
+                PointerEventKind::Down => {
+                    if active_press.borrow().is_none() {
+                        let press = interaction_source.press(event.position);
+                        *active_press.borrow_mut() = Some(press);
+                    }
+                }
+                PointerEventKind::Up => {
+                    if let Some(press) = active_press.borrow_mut().take() {
+                        interaction_source.release(press);
+                    }
+                }
+                PointerEventKind::Cancel => {
+                    if let Some(press) = active_press.borrow_mut().take() {
+                        interaction_source.cancel(press);
+                    }
+                }
+                PointerEventKind::Move
+                | PointerEventKind::Scroll
+                | PointerEventKind::Enter
+                | PointerEventKind::Exit => {}
+            }
+        })
+    }
+}
+
+impl std::fmt::Debug for PressInteractionNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PressInteractionNode")
+            .field("source_id", &self.interaction_source.id())
+            .finish()
+    }
+}
+
+impl DelegatableNode for PressInteractionNode {
+    fn node_state(&self) -> &NodeState {
+        &self.state
+    }
+}
+
+impl ModifierNode for PressInteractionNode {
+    fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
+        context.invalidate(InvalidationKind::PointerInput);
+    }
+
+    fn as_pointer_input_node(&self) -> Option<&dyn PointerInputNode> {
+        Some(self)
+    }
+
+    fn as_pointer_input_node_mut(&mut self) -> Option<&mut dyn PointerInputNode> {
+        Some(self)
+    }
+
+    fn on_detach(&mut self) {
+        if let Some(press) = self.active_press.borrow_mut().take() {
+            self.interaction_source.cancel(press);
+        }
+    }
+}
+
+impl PointerInputNode for PressInteractionNode {
+    fn pointer_input_handler(&self) -> Option<Rc<dyn Fn(PointerEvent)>> {
+        Some(self.cached_handler.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cranpose_core::{Composition, MemoryApplier};
+
+    #[test]
+    fn interaction_source_tracks_active_press_state() {
+        let composition = Composition::new(MemoryApplier::new());
+        let source = MutableInteractionSource::with_runtime(composition.runtime_handle());
+        let pressed = source.collectIsPressedAsState();
+
+        assert!(!pressed.get());
+
+        let first = source.press(Point { x: 1.0, y: 2.0 });
+        assert!(pressed.get());
+
+        let second = source.press(Point { x: 3.0, y: 4.0 });
+        source.release(first);
+        assert!(pressed.get());
+
+        source.cancel(second);
+        assert!(!pressed.get());
+    }
+}

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -83,9 +83,9 @@ pub use pointer_dispatch::{
 pub use primitives::{
     remember_svg, BasicText, BasicTextField, BasicTextFieldOptions, BasicTextWithOptions,
     BitmapPainter, Box, BoxScope, BoxSpec, BoxWithConstraints, BoxWithConstraintsScope,
-    BoxWithConstraintsScopeImpl, Button, ButtonWithInteractionSource, Canvas, Column, ColumnSpec,
-    ContentScale, ForEach, Image, Layout, LayoutNode, Painter, Row, RowSpec, Spacer,
-    SubcomposeLayout, SvgPainter, SvgPainterError, Text, TextWithOptions, DEFAULT_ALPHA,
+    BoxWithConstraintsScopeImpl, Button, ButtonSpec, Canvas, Column, ColumnSpec, ContentScale,
+    ForEach, Image, Layout, LayoutNode, Painter, Row, RowSpec, Spacer, SubcomposeLayout,
+    SvgPainter, SvgPainterError, Text, TextWithOptions, DEFAULT_ALPHA,
 };
 // Lazy list exports - single source from cranpose-foundation
 pub use cranpose_foundation::lazy::{LazyListItemInfo, LazyListLayoutInfo, LazyListState};

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -9,6 +9,7 @@ mod debug;
 mod draw;
 pub mod fling_animation;
 mod focus_dispatch;
+mod interaction;
 mod key_event;
 pub mod layout;
 mod modifier;
@@ -44,6 +45,10 @@ pub use focus_dispatch::{
     active_focus_target, clear_focus_invalidations, has_pending_focus_invalidations,
     process_focus_invalidations, schedule_focus_invalidation, set_active_focus_target,
 };
+pub use interaction::{
+    rememberMutableInteractionSource, Interaction, MutableInteractionSource, PressInteraction,
+    PressInteractionCancel, PressInteractionPress, PressInteractionRelease,
+};
 // Re-export FocusManager from cranpose-foundation to avoid duplication
 pub use cranpose_foundation::nodes::input::focus::FocusManager;
 pub use layout::{
@@ -78,9 +83,9 @@ pub use pointer_dispatch::{
 pub use primitives::{
     remember_svg, BasicText, BasicTextField, BasicTextFieldOptions, BasicTextWithOptions,
     BitmapPainter, Box, BoxScope, BoxSpec, BoxWithConstraints, BoxWithConstraintsScope,
-    BoxWithConstraintsScopeImpl, Button, Canvas, Column, ColumnSpec, ContentScale, ForEach, Image,
-    Layout, LayoutNode, Painter, Row, RowSpec, Spacer, SubcomposeLayout, SvgPainter,
-    SvgPainterError, Text, TextWithOptions, DEFAULT_ALPHA,
+    BoxWithConstraintsScopeImpl, Button, ButtonWithInteractionSource, Canvas, Column, ColumnSpec,
+    ContentScale, ForEach, Image, Layout, LayoutNode, Painter, Row, RowSpec, Spacer,
+    SubcomposeLayout, SvgPainter, SvgPainterError, Text, TextWithOptions, DEFAULT_ALPHA,
 };
 // Lazy list exports - single source from cranpose-foundation
 pub use cranpose_foundation::lazy::{LazyListItemInfo, LazyListLayoutInfo, LazyListState};

--- a/crates/cranpose-ui/src/modifier/mod.rs
+++ b/crates/cranpose-ui/src/modifier/mod.rs
@@ -778,7 +778,7 @@ impl Modifier {
         handle.resolved_modifiers()
     }
 
-    fn with_element<E>(element: E) -> Self
+    pub(crate) fn with_element<E>(element: E) -> Self
     where
         E: ModifierNodeElement,
     {

--- a/crates/cranpose-ui/src/tests/async_runtime_full_layout_test.rs
+++ b/crates/cranpose-ui/src/tests/async_runtime_full_layout_test.rs
@@ -9,8 +9,8 @@
 // Root cause: Conditional rendering breaks RecomposeScope connections for sibling components
 
 use crate::{
-    Brush, Button, Color, Column, ColumnSpec, CornerRadii, Modifier, Row, RowSpec, Size, Spacer,
-    Text, TextStyle,
+    Brush, Button, ButtonSpec, Color, Column, ColumnSpec, CornerRadii, Modifier, Row, RowSpec,
+    Size, Spacer, Text, TextStyle,
 };
 use cranpose_core::{
     __launched_effect_async_impl as launched_effect_async_impl, location_key, Composition,
@@ -246,6 +246,7 @@ fn async_runtime_full_layout(
                         };
                         Button(
                             Modifier::empty().padding(12.0),
+                            ButtonSpec::default(),
                             {
                                 let toggle_state = is_running_for_button;
                                 move || toggle_state.set(!toggle_state.get())

--- a/crates/cranpose-ui/src/widgets/button.rs
+++ b/crates/cranpose-ui/src/widgets/button.rs
@@ -12,19 +12,50 @@ use cranpose_ui_layout::{HorizontalAlignment, LinearArrangement};
 use std::cell::RefCell;
 use std::rc::Rc;
 
-fn button_modifier<F>(
-    modifier: Modifier,
-    interaction_source: Option<MutableInteractionSource>,
-    on_click: F,
-) -> Modifier
+#[derive(Clone, Debug, PartialEq)]
+pub struct ButtonSpec {
+    pub modifier: Modifier,
+    pub interaction_source: Option<MutableInteractionSource>,
+}
+
+impl ButtonSpec {
+    pub fn new(modifier: Modifier) -> Self {
+        Self {
+            modifier,
+            ..Default::default()
+        }
+    }
+
+    pub fn interaction_source(mut self, interaction_source: MutableInteractionSource) -> Self {
+        self.interaction_source = Some(interaction_source);
+        self
+    }
+}
+
+impl Default for ButtonSpec {
+    fn default() -> Self {
+        Self {
+            modifier: Modifier::empty(),
+            interaction_source: None,
+        }
+    }
+}
+
+impl From<Modifier> for ButtonSpec {
+    fn from(modifier: Modifier) -> Self {
+        Self::new(modifier)
+    }
+}
+
+fn button_modifier<F>(spec: ButtonSpec, on_click: F) -> Modifier
 where
     F: FnMut() + 'static,
 {
     let on_click_rc: Rc<RefCell<dyn FnMut()>> = Rc::new(RefCell::new(on_click));
-    let modifier = if let Some(interaction_source) = interaction_source {
-        modifier.press_interaction_source(interaction_source)
+    let modifier = if let Some(interaction_source) = spec.interaction_source {
+        spec.modifier.press_interaction_source(interaction_source)
     } else {
-        modifier
+        spec.modifier
     };
 
     modifier.clickable(move |_point| {
@@ -40,7 +71,7 @@ where
 ///
 /// # Arguments
 ///
-/// * `modifier` - Modifiers to apply to the button container (e.g., size, padding).
+/// * `spec` - A `Modifier` or `ButtonSpec` for the button container.
 /// * `on_click` - The callback to execute when the button is clicked.
 /// * `content` - The content to display inside the button (e.g., `Text` or `Icon`).
 ///
@@ -54,13 +85,14 @@ where
 /// );
 /// ```
 #[composable]
-pub fn Button<F, G>(modifier: Modifier, on_click: F, content: G) -> NodeId
+pub fn Button<S, F, G>(spec: S, on_click: F, content: G) -> NodeId
 where
+    S: Into<ButtonSpec> + Clone + PartialEq + 'static,
     F: FnMut() + 'static,
     G: FnMut() + 'static,
 {
     Layout(
-        button_modifier(modifier, None, on_click),
+        button_modifier(spec.into(), on_click),
         FlexMeasurePolicy::column(
             LinearArrangement::Center,
             HorizontalAlignment::CenterHorizontally,
@@ -69,23 +101,34 @@ where
     )
 }
 
-#[composable]
-pub fn ButtonWithInteractionSource<F, G>(
-    modifier: Modifier,
-    interaction_source: MutableInteractionSource,
-    on_click: F,
-    content: G,
-) -> NodeId
-where
-    F: FnMut() + 'static,
-    G: FnMut() + 'static,
-{
-    Layout(
-        button_modifier(modifier, Some(interaction_source), on_click),
-        FlexMeasurePolicy::column(
-            LinearArrangement::Center,
-            HorizontalAlignment::CenterHorizontally,
-        ),
-        content,
-    )
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cranpose_core::{Composition, MemoryApplier};
+
+    #[test]
+    fn button_spec_from_modifier_preserves_modifier() {
+        let modifier = Modifier::empty().padding(8.0);
+        let spec = ButtonSpec::from(modifier.clone());
+
+        assert_eq!(spec.modifier, modifier);
+        assert!(spec.interaction_source.is_none());
+    }
+
+    #[test]
+    fn default_button_spec_has_empty_modifier() {
+        let spec = ButtonSpec::default();
+
+        assert_eq!(spec.modifier, Modifier::empty());
+        assert!(spec.interaction_source.is_none());
+    }
+
+    #[test]
+    fn button_spec_builder_preserves_interaction_source() {
+        let composition = Composition::new(MemoryApplier::new());
+        let source = MutableInteractionSource::with_runtime(composition.runtime_handle());
+        let spec = ButtonSpec::default().interaction_source(source.clone());
+
+        assert_eq!(spec.interaction_source, Some(source));
+    }
 }

--- a/crates/cranpose-ui/src/widgets/button.rs
+++ b/crates/cranpose-ui/src/widgets/button.rs
@@ -12,18 +12,14 @@ use cranpose_ui_layout::{HorizontalAlignment, LinearArrangement};
 use std::cell::RefCell;
 use std::rc::Rc;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ButtonSpec {
-    pub modifier: Modifier,
     pub interaction_source: Option<MutableInteractionSource>,
 }
 
 impl ButtonSpec {
-    pub fn new(modifier: Modifier) -> Self {
-        Self {
-            modifier,
-            ..Default::default()
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn interaction_source(mut self, interaction_source: MutableInteractionSource) -> Self {
@@ -32,30 +28,15 @@ impl ButtonSpec {
     }
 }
 
-impl Default for ButtonSpec {
-    fn default() -> Self {
-        Self {
-            modifier: Modifier::empty(),
-            interaction_source: None,
-        }
-    }
-}
-
-impl From<Modifier> for ButtonSpec {
-    fn from(modifier: Modifier) -> Self {
-        Self::new(modifier)
-    }
-}
-
-fn button_modifier<F>(spec: ButtonSpec, on_click: F) -> Modifier
+fn button_modifier<F>(modifier: Modifier, spec: ButtonSpec, on_click: F) -> Modifier
 where
     F: FnMut() + 'static,
 {
     let on_click_rc: Rc<RefCell<dyn FnMut()>> = Rc::new(RefCell::new(on_click));
     let modifier = if let Some(interaction_source) = spec.interaction_source {
-        spec.modifier.press_interaction_source(interaction_source)
+        modifier.press_interaction_source(interaction_source)
     } else {
-        spec.modifier
+        modifier
     };
 
     modifier.clickable(move |_point| {
@@ -71,7 +52,8 @@ where
 ///
 /// # Arguments
 ///
-/// * `spec` - A `Modifier` or `ButtonSpec` for the button container.
+/// * `modifier` - Modifiers to apply to the button container.
+/// * `spec` - Configuration for button behavior.
 /// * `on_click` - The callback to execute when the button is clicked.
 /// * `content` - The content to display inside the button (e.g., `Text` or `Icon`).
 ///
@@ -80,19 +62,19 @@ where
 /// ```rust,ignore
 /// Button(
 ///     Modifier::padding(8.0),
+///     ButtonSpec::default(),
 ///     || println!("Clicked!"),
 ///     || Text("Click Me", Modifier::empty())
 /// );
 /// ```
 #[composable]
-pub fn Button<S, F, G>(spec: S, on_click: F, content: G) -> NodeId
+pub fn Button<F, G>(modifier: Modifier, spec: ButtonSpec, on_click: F, content: G) -> NodeId
 where
-    S: Into<ButtonSpec> + Clone + PartialEq + 'static,
     F: FnMut() + 'static,
     G: FnMut() + 'static,
 {
     Layout(
-        button_modifier(spec.into(), on_click),
+        button_modifier(modifier, spec, on_click),
         FlexMeasurePolicy::column(
             LinearArrangement::Center,
             HorizontalAlignment::CenterHorizontally,
@@ -107,19 +89,9 @@ mod tests {
     use cranpose_core::{Composition, MemoryApplier};
 
     #[test]
-    fn button_spec_from_modifier_preserves_modifier() {
-        let modifier = Modifier::empty().padding(8.0);
-        let spec = ButtonSpec::from(modifier.clone());
-
-        assert_eq!(spec.modifier, modifier);
-        assert!(spec.interaction_source.is_none());
-    }
-
-    #[test]
-    fn default_button_spec_has_empty_modifier() {
+    fn default_button_spec_has_no_interaction_source() {
         let spec = ButtonSpec::default();
 
-        assert_eq!(spec.modifier, Modifier::empty());
         assert!(spec.interaction_source.is_none());
     }
 
@@ -127,7 +99,7 @@ mod tests {
     fn button_spec_builder_preserves_interaction_source() {
         let composition = Composition::new(MemoryApplier::new());
         let source = MutableInteractionSource::with_runtime(composition.runtime_handle());
-        let spec = ButtonSpec::default().interaction_source(source.clone());
+        let spec = ButtonSpec::new().interaction_source(source.clone());
 
         assert_eq!(spec.interaction_source, Some(source));
     }

--- a/crates/cranpose-ui/src/widgets/button.rs
+++ b/crates/cranpose-ui/src/widgets/button.rs
@@ -3,11 +3,34 @@
 #![allow(non_snake_case)]
 
 use crate::composable;
+use crate::interaction::MutableInteractionSource;
 use crate::layout::policies::FlexMeasurePolicy;
 use crate::modifier::Modifier;
 use crate::widgets::Layout;
 use cranpose_core::NodeId;
 use cranpose_ui_layout::{HorizontalAlignment, LinearArrangement};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+fn button_modifier<F>(
+    modifier: Modifier,
+    interaction_source: Option<MutableInteractionSource>,
+    on_click: F,
+) -> Modifier
+where
+    F: FnMut() + 'static,
+{
+    let on_click_rc: Rc<RefCell<dyn FnMut()>> = Rc::new(RefCell::new(on_click));
+    let modifier = if let Some(interaction_source) = interaction_source {
+        modifier.press_interaction_source(interaction_source)
+    } else {
+        modifier
+    };
+
+    modifier.clickable(move |_point| {
+        (on_click_rc.borrow_mut())();
+    })
+}
 
 /// A clickable button with a background and content.
 ///
@@ -36,21 +59,29 @@ where
     F: FnMut() + 'static,
     G: FnMut() + 'static,
 {
-    use std::cell::RefCell;
-    use std::rc::Rc;
-
-    // Wrap the on_click handler in Rc<RefCell<>> to make it callable from Fn closure
-    let on_click_rc: Rc<RefCell<dyn FnMut()>> = Rc::new(RefCell::new(on_click));
-
-    // Add clickable modifier to handle click events
-    let clickable_modifier = modifier.clickable(move |_point| {
-        (on_click_rc.borrow_mut())();
-    });
-
-    // Use Layout with FlexMeasurePolicy (column) to arrange button content
-    // This matches how Button is implemented in Jetpack Compose
     Layout(
-        clickable_modifier,
+        button_modifier(modifier, None, on_click),
+        FlexMeasurePolicy::column(
+            LinearArrangement::Center,
+            HorizontalAlignment::CenterHorizontally,
+        ),
+        content,
+    )
+}
+
+#[composable]
+pub fn ButtonWithInteractionSource<F, G>(
+    modifier: Modifier,
+    interaction_source: MutableInteractionSource,
+    on_click: F,
+    content: G,
+) -> NodeId
+where
+    F: FnMut() + 'static,
+    G: FnMut() + 'static,
+{
+    Layout(
+        button_modifier(modifier, Some(interaction_source), on_click),
         FlexMeasurePolicy::column(
             LinearArrangement::Center,
             HorizontalAlignment::CenterHorizontally,

--- a/crates/cranpose/README.md
+++ b/crates/cranpose/README.md
@@ -90,7 +90,9 @@ fn CounterApp() {
         Text(format!("Count: {}", count.value()));
         
         Button(
-            onClick = move || count.set(count.value() + 1), 
+            Modifier::empty(),
+            ButtonSpec::default(),
+            move || count.set(count.value() + 1),
             || Text("Increment")
         );
     });

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -1999,7 +1999,11 @@ impl App {
                 )
             });
         if handled {
-            native.window.request_redraw();
+            apply_pointer_button_frame_request(
+                &native.window,
+                &mut native.last_frame_start_time,
+                pointer_button_frame_request(handled),
+            );
             if drag_requested.get() {
                 trace_native_window(format_args!("drag requested key={:?}", native.key));
                 Self::sync_native_window_position_from_os(
@@ -2499,7 +2503,11 @@ impl App {
                         );
                         native.app.sync_selection_to_primary();
                         if handled {
-                            native.window.request_redraw();
+                            apply_pointer_button_frame_request(
+                                &native.window,
+                                &mut native.last_frame_start_time,
+                                pointer_button_frame_request(handled),
+                            );
                             sync_after_event = true;
                         }
                     }
@@ -3214,6 +3222,32 @@ fn primary_declaration_host_needs_direct_update(
         && !primary_surface_redraw_drives_app(primary_window_visible, headless)
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PointerButtonFrameRequest {
+    request_redraw: bool,
+    reset_frame_cap: bool,
+}
+
+fn pointer_button_frame_request(input_handled: bool) -> PointerButtonFrameRequest {
+    PointerButtonFrameRequest {
+        request_redraw: input_handled,
+        reset_frame_cap: input_handled,
+    }
+}
+
+fn apply_pointer_button_frame_request(
+    window: &Arc<dyn Window>,
+    last_frame_start_time: &mut Option<Instant>,
+    request: PointerButtonFrameRequest,
+) {
+    if request.reset_frame_cap {
+        *last_frame_start_time = None;
+    }
+    if request.request_redraw {
+        window.request_redraw();
+    }
+}
+
 fn configure_app_surface_size(
     app: &mut AppShell<WgpuRenderer>,
     surface: &wgpu::Surface<'static>,
@@ -3790,7 +3824,9 @@ impl ApplicationHandler for App {
                     logical.x,
                     logical.y
                 );
-                app.set_cursor(logical.x, logical.y);
+                if app.set_cursor(logical.x, logical.y) {
+                    window.request_redraw();
+                }
                 if let Some(recorder) = &mut self.recorder {
                     recorder.record_mouse_move(logical.x, logical.y);
                 }
@@ -3822,7 +3858,9 @@ impl ApplicationHandler for App {
                         x,
                         y
                     );
-                    app.set_cursor(x, y);
+                    if app.set_cursor(x, y) {
+                        window.request_redraw();
+                    }
                 }
                 match state {
                     ElementState::Pressed => {
@@ -3853,14 +3891,24 @@ impl ApplicationHandler for App {
                                 return;
                             }
                         }
-                        app.pointer_pressed();
+                        let request = pointer_button_frame_request(app.pointer_pressed());
+                        apply_pointer_button_frame_request(
+                            window,
+                            &mut self.last_frame_start_time,
+                            request,
+                        );
                         if let Some(recorder) = &mut self.recorder {
                             recorder.record_mouse_down();
                         }
                     }
                     ElementState::Released => {
-                        app.pointer_released();
+                        let request = pointer_button_frame_request(app.pointer_released());
                         app.sync_selection_to_primary();
+                        apply_pointer_button_frame_request(
+                            window,
+                            &mut self.last_frame_start_time,
+                            request,
+                        );
                         if let Some(recorder) = &mut self.recorder {
                             recorder.record_mouse_up();
                         }
@@ -4912,11 +4960,11 @@ fn char_to_key_code(ch: char) -> cranpose_app_shell::KeyCode {
 mod tests {
     use super::{
         clamp_rect_to_monitor_delta, native_window_graph_position, nearest_monitor_to_rect,
-        physical_surface_rect_contains_pointer, primary_declaration_host_needs_direct_update,
-        primary_frame_waker_uses_event_proxy, primary_surface_redraw_drives_app,
-        primary_viewport_for_surface_size, App, DesktopRect, NativeWindowDragSession,
-        NativeWindowGraphPositionSource, NativeWindowOptions, NativeWindowPollingDragSession,
-        NativeWindowPositionOrigin, PendingNativeWindowPositions,
+        physical_surface_rect_contains_pointer, pointer_button_frame_request,
+        primary_declaration_host_needs_direct_update, primary_frame_waker_uses_event_proxy,
+        primary_surface_redraw_drives_app, primary_viewport_for_surface_size, App, DesktopRect,
+        NativeWindowDragSession, NativeWindowGraphPositionSource, NativeWindowOptions,
+        NativeWindowPollingDragSession, NativeWindowPositionOrigin, PendingNativeWindowPositions,
     };
     use crate::launcher::AppSettings;
     use std::time::Instant;
@@ -5056,6 +5104,21 @@ mod tests {
         assert!(!primary_declaration_host_needs_direct_update(
             false, false, false, false
         ));
+    }
+
+    #[test]
+    fn pointer_button_input_requests_uncapped_frame_when_handled() {
+        let request = pointer_button_frame_request(true);
+
+        assert!(request.request_redraw);
+        assert!(request.reset_frame_cap);
+        assert_eq!(
+            pointer_button_frame_request(false),
+            super::PointerButtonFrameRequest {
+                request_redraw: false,
+                reset_frame_cap: false,
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- request uncapped redraws for handled primary pointer down/up events so press animations can run while the button is held
- add Compose-style animation helpers: `spring`, `Spring`, and `animateFloatAsState(target, animation, label)`
- add `MutableInteractionSource`, `collectIsPressedAsState`, and press interaction tracking
- align `Button` with the `Column`/`ColumnSpec` API shape: `Button(modifier, ButtonSpec, on_click, content)`
- add the desktop demo `Interactive Anim` tab with a press-scaled button driven by interaction state and a slower, visible release animation
- add `robot_interactive_anim` e2e coverage that checks press/hold/release screenshot pixel changes
- make the native Winamp window geometry robot fixture choose an unobstructed placement so local visible windows do not occlude the native test windows

Fixes #261

## Verification
- `cargo fmt --check`
- `cargo test --profile ci --workspace --verbose > 1.tmp 2>&1`
- `cargo clippy --workspace --all-targets -- -D warnings > 2.tmp 2>&1`
- `CRANPOSE_USE_SCCACHE=0 ./run_robot_test.sh --sequential --example robot_interactive_anim > robot_interactive_anim.tmp 2>&1`
- `CRANPOSE_USE_SCCACHE=0 ./run_robot_test.sh --sequential --example robot_winamp_native_window_geometry > robot_winamp.tmp 2>&1`
- `CRANPOSE_USE_SCCACHE=0 ./run_robot_test.sh --sequential > robot_all.tmp 2>&1` (98/98 passed)
- `CRANPOSE_USE_SCCACHE=0 ./build-web.sh > ../../web-build.tmp 2>&1`
- `./gradlew :app:assembleRelease > ../../../android-build.tmp 2>&1`