### PR TITLE
Fix draw-only infinite transition invalidation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -214,7 +214,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-1
-          path: target/robot-artifacts/robot-examples-1.tar
+          path: target/robot-artifacts/robot-examples-1.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -222,7 +222,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-2
-          path: target/robot-artifacts/robot-examples-2.tar
+          path: target/robot-artifacts/robot-examples-2.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -230,7 +230,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-3
-          path: target/robot-artifacts/robot-examples-3.tar
+          path: target/robot-artifacts/robot-examples-3.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -238,7 +238,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-4
-          path: target/robot-artifacts/robot-examples-4.tar
+          path: target/robot-artifacts/robot-examples-4.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -246,7 +246,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-5
-          path: target/robot-artifacts/robot-examples-5.tar
+          path: target/robot-artifacts/robot-examples-5.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -254,7 +254,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-6
-          path: target/robot-artifacts/robot-examples-6.tar
+          path: target/robot-artifacts/robot-examples-6.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -262,7 +262,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-7
-          path: target/robot-artifacts/robot-examples-7.tar
+          path: target/robot-artifacts/robot-examples-7.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -270,7 +270,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-8
-          path: target/robot-artifacts/robot-examples-8.tar
+          path: target/robot-artifacts/robot-examples-8.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -278,7 +278,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-9
-          path: target/robot-artifacts/robot-examples-9.tar
+          path: target/robot-artifacts/robot-examples-9.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -286,7 +286,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-10
-          path: target/robot-artifacts/robot-examples-10.tar
+          path: target/robot-artifacts/robot-examples-10.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -294,7 +294,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-11
-          path: target/robot-artifacts/robot-examples-11.tar
+          path: target/robot-artifacts/robot-examples-11.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -302,7 +302,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-12
-          path: target/robot-artifacts/robot-examples-12.tar
+          path: target/robot-artifacts/robot-examples-12.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -310,7 +310,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-13
-          path: target/robot-artifacts/robot-examples-13.tar
+          path: target/robot-artifacts/robot-examples-13.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -318,7 +318,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-14
-          path: target/robot-artifacts/robot-examples-14.tar
+          path: target/robot-artifacts/robot-examples-14.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -326,7 +326,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-15
-          path: target/robot-artifacts/robot-examples-15.tar
+          path: target/robot-artifacts/robot-examples-15.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -334,7 +334,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: robot-examples-16
-          path: target/robot-artifacts/robot-examples-16.tar
+          path: target/robot-artifacts/robot-examples-16.tar.gz
           compression-level: 0
           if-no-files-found: error
 
@@ -371,7 +371,7 @@ jobs:
       - name: Extract robot examples
         run: |
           mkdir -p target/robot/examples
-          tar -C target/robot/examples -xf target/robot-artifacts/robot-examples-${{ matrix.shard_index }}.tar
+          tar -C target/robot/examples -xzf target/robot-artifacts/robot-examples-${{ matrix.shard_index }}.tar.gz
 
       - name: Run robot shard
         env:

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -204,6 +204,11 @@ path = "robot-runners/robot_async_progress_after_animations.rs"
 required-features = ["robot-app"]
 
 [[example]]
+name = "robot_conditional_infinite_transition_busy"
+path = "robot-runners/robot_conditional_infinite_transition_busy.rs"
+required-features = ["robot-app"]
+
+[[example]]
 name = "robot_text_input"
 path = "robot-runners/robot_text_input.rs"
 required-features = ["robot-app"]

--- a/apps/desktop-demo/robot-runners/robot_conditional_infinite_transition_busy.rs
+++ b/apps/desktop-demo/robot-runners/robot_conditional_infinite_transition_busy.rs
@@ -1,0 +1,169 @@
+//! Robot regression for conditionally inserted infinite transitions.
+//!
+//! The busy indicator is absent on the first composition. Clicking the button
+//! inserts a draw-only consumer of `rememberInfiniteTransition`; screenshots
+//! must keep changing after the first painted frame.
+
+use cranpose::{AppLauncher, Robot, RobotScreenshot};
+use cranpose_animation::{
+    infiniteRepeatable, rememberInfiniteTransition, AnimationSpec, Easing, RepeatMode, StartOffset,
+};
+use cranpose_core::useState;
+use cranpose_testing::{
+    changed_pixel_count_in_region, find_button_in_semantics, find_text_in_semantics,
+};
+use cranpose_ui::{
+    Brush, Button, ButtonSpec, Color, Column, ColumnSpec, LinearArrangement, Modifier, Rect, Row,
+    RowSpec, Text, TextStyle,
+};
+use std::time::{Duration, Instant};
+
+fn fail(robot: &Robot, message: &str) -> ! {
+    println!("FAIL: {message}");
+    robot.exit().ok();
+    std::process::exit(1);
+}
+
+fn capture(robot: &Robot, label: &str) -> RobotScreenshot {
+    robot
+        .screenshot()
+        .unwrap_or_else(|err| fail(robot, &format!("{label} screenshot failed: {err}")))
+}
+
+fn wait_for_text(robot: &Robot, text: &str, timeout: Duration) -> (f32, f32, f32, f32) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Some(bounds) = find_text_in_semantics(robot, text) {
+            return bounds;
+        }
+        std::thread::sleep(Duration::from_millis(30));
+    }
+    fail(robot, &format!("timed out waiting for text {text:?}"));
+}
+
+fn click_button(robot: &Robot, label: &str) {
+    let Some((x, y, w, h)) = find_button_in_semantics(robot, label) else {
+        fail(robot, &format!("button {label:?} not found"));
+    };
+    robot
+        .click(x + w * 0.5, y + h * 0.5)
+        .unwrap_or_else(|err| fail(robot, &format!("click {label:?} failed: {err}")));
+}
+
+fn test_app() {
+    let busy = useState(|| false);
+
+    Column(
+        Modifier::empty()
+            .fill_max_size()
+            .background(Color(0.07, 0.08, 0.10, 1.0))
+            .padding(24.0),
+        ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(14.0)),
+        move || {
+            Text(
+                "Conditional Infinite Transition",
+                Modifier::empty(),
+                TextStyle::default(),
+            );
+            Button(
+                Modifier::empty(),
+                ButtonSpec::default(),
+                move || {
+                    busy.set(true);
+                },
+                move || {
+                    let label = if busy.get() { "Busy" } else { "Start busy" };
+                    Text(label, Modifier::empty().padding(8.0), TextStyle::default());
+                },
+            );
+
+            if busy.get() {
+                busy_indicator();
+            }
+        },
+    );
+}
+
+fn busy_indicator() {
+    let transition = rememberInfiniteTransition("conditional_busy_indicator");
+    let phase = transition.animateFloat(
+        0.0,
+        1.0,
+        infiniteRepeatable(
+            AnimationSpec::tween(700, Easing::LinearEasing),
+            RepeatMode::Restart,
+            StartOffset::default(),
+        ),
+        "conditional_busy_indicator_phase",
+    );
+
+    Row(
+        Modifier::empty()
+            .width(360.0)
+            .height(48.0)
+            .rounded_corners(8.0)
+            .clip_to_bounds()
+            .draw_behind(move |scope| {
+                let size = scope.size();
+                let band_width = 96.0;
+                let x = phase.get() * (size.width + band_width) - band_width;
+                scope.draw_rect(Brush::solid(Color(0.16, 0.18, 0.22, 1.0)));
+                scope.draw_rect_at(
+                    Rect {
+                        x,
+                        y: 0.0,
+                        width: band_width,
+                        height: size.height,
+                    },
+                    Brush::solid(Color(0.20, 0.58, 0.90, 1.0)),
+                );
+            })
+            .padding(14.0),
+        RowSpec::default(),
+        || {
+            Text("Busy indicator", Modifier::empty(), TextStyle::default());
+        },
+    );
+}
+
+fn main() {
+    env_logger::init();
+    println!("=== Conditional Infinite Transition Busy Robot Test ===");
+
+    AppLauncher::new()
+        .with_title("Conditional Infinite Transition Busy")
+        .with_size(800, 500)
+        .with_headless(true)
+        .with_test_driver(|robot| {
+            wait_for_text(
+                &robot,
+                "Conditional Infinite Transition",
+                Duration::from_secs(5),
+            );
+            click_button(&robot, "Start busy");
+            let (text_x, text_y, _, _) =
+                wait_for_text(&robot, "Busy indicator", Duration::from_secs(5));
+            let indicator_region = (text_x - 16.0, text_y - 14.0, 360.0, 52.0);
+
+            robot
+                .pump_frames(2)
+                .unwrap_or_else(|err| fail(&robot, &format!("initial pump failed: {err}")));
+            let first = capture(&robot, "first busy frame");
+            robot
+                .pump_frames(16)
+                .unwrap_or_else(|err| fail(&robot, &format!("animation pump failed: {err}")));
+            let later = capture(&robot, "later busy frame");
+
+            let changed = changed_pixel_count_in_region(&first, &later, indicator_region, 8);
+            if changed < 80 {
+                fail(
+                    &robot,
+                    &format!("busy indicator painted once but did not advance; changed={changed}"),
+                );
+            }
+
+            println!("PASS: conditional busy animation advanced; changed={changed}");
+            robot.exit().ok();
+        })
+        .run(test_app);
+}

--- a/crates/cranpose-animation/tests/infinite_transition_tests.rs
+++ b/crates/cranpose-animation/tests/infinite_transition_tests.rs
@@ -2,7 +2,8 @@ use cranpose_animation::{
     infiniteRepeatable, rememberInfiniteTransition, AnimationSpec, RepeatMode, StartOffset,
 };
 use cranpose_core::{
-    location_key, with_current_composer, Composition, MemoryApplier, Node, NodeError, State,
+    location_key, with_current_composer, Composition, MemoryApplier, MutableState, Node, NodeError,
+    State,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -148,6 +149,153 @@ fn infinite_transition_survives_conditional_cycle() {
     assert!(
         saw_forward_after_reverse,
         "transition should keep cycling when a conditional child collapses and restores",
+    );
+}
+
+#[test]
+fn infinite_transition_inserted_after_state_change_advances() {
+    let mut composition = Composition::new(MemoryApplier::new());
+    let runtime = composition.runtime_handle();
+    let root_key = location_key(file!(), line!(), column!());
+    let busy = MutableState::with_runtime(false, runtime.clone());
+    let state_slot = Rc::new(RefCell::new(None::<State<f32>>));
+
+    let mut render = {
+        let state_slot = Rc::clone(&state_slot);
+        move || {
+            let state_slot = Rc::clone(&state_slot);
+            with_current_composer(|composer| {
+                composer.with_group(location_key(file!(), line!(), column!()), |composer| {
+                    if busy.value() {
+                        let state_slot = Rc::clone(&state_slot);
+                        composer.with_group(
+                            location_key(file!(), line!(), column!()),
+                            |composer| {
+                                let transition = rememberInfiniteTransition("inserted_busy_pulse");
+                                let state = transition.animateFloat(
+                                    0.0,
+                                    1.0,
+                                    infiniteRepeatable(
+                                        AnimationSpec::linear(600),
+                                        RepeatMode::Restart,
+                                        StartOffset::default(),
+                                    ),
+                                    "inserted_busy_pulse",
+                                );
+                                state_slot.borrow_mut().replace(state);
+                                composer.emit_node(|| DummyNode);
+                            },
+                        );
+                    }
+                });
+            });
+        }
+    };
+
+    composition
+        .render(root_key, &mut render)
+        .expect("initial render");
+
+    drain_all(&mut composition).expect("initial drain");
+    assert!(
+        state_slot.borrow().is_none(),
+        "transition should be absent before busy state starts"
+    );
+
+    busy.set_value(true);
+    composition
+        .reconcile(root_key, &mut render)
+        .expect("reconcile after busy state update");
+
+    let initial = state_slot.borrow().as_ref().expect("state available").get();
+    assert_eq!(initial, 0.0);
+
+    let mut time = 0u64;
+    let mut last_value = initial;
+    for _ in 0..40 {
+        time += 16_666_667;
+        runtime.drain_frame_callbacks(time);
+        composition
+            .reconcile(root_key, &mut render)
+            .expect("reconcile after frame");
+        last_value = state_slot.borrow().as_ref().expect("state available").get();
+        if (last_value - initial).abs() > 0.0001 {
+            return;
+        }
+    }
+
+    panic!("inserted infinite transition stayed frozen: initial={initial} last={last_value}");
+}
+
+#[test]
+fn infinite_transition_restarts_when_first_animation_is_inserted_later() {
+    let mut composition = Composition::new(MemoryApplier::new());
+    let runtime = composition.runtime_handle();
+    let root_key = location_key(file!(), line!(), column!());
+    let busy = MutableState::with_runtime(false, runtime.clone());
+    let state_slot = Rc::new(RefCell::new(None::<State<f32>>));
+
+    let mut render = {
+        let state_slot = Rc::clone(&state_slot);
+        move || {
+            with_current_composer(|composer| {
+                composer.with_group(location_key(file!(), line!(), column!()), |composer| {
+                    let transition = rememberInfiniteTransition("late_child_pulse");
+                    if busy.value() {
+                        let state_slot = Rc::clone(&state_slot);
+                        composer.with_group(location_key(file!(), line!(), column!()), |_| {
+                            let state = transition.animateFloat(
+                                0.0,
+                                1.0,
+                                infiniteRepeatable(
+                                    AnimationSpec::linear(600),
+                                    RepeatMode::Restart,
+                                    StartOffset::default(),
+                                ),
+                                "late_child_pulse",
+                            );
+                            state_slot.borrow_mut().replace(state);
+                        });
+                    }
+                });
+            });
+        }
+    };
+
+    composition
+        .render(root_key, &mut render)
+        .expect("initial render");
+    drain_all(&mut composition).expect("initial drain");
+
+    runtime.drain_frame_callbacks(16_666_667);
+    composition
+        .reconcile(root_key, &mut render)
+        .expect("reconcile empty transition frame");
+
+    busy.set_value(true);
+    composition
+        .reconcile(root_key, &mut render)
+        .expect("reconcile after animation insertion");
+
+    let initial = state_slot.borrow().as_ref().expect("state available").get();
+    assert_eq!(initial, 0.0);
+
+    let mut time = 16_666_667u64;
+    let mut last_value = initial;
+    for _ in 0..40 {
+        time += 16_666_667;
+        runtime.drain_frame_callbacks(time);
+        composition
+            .reconcile(root_key, &mut render)
+            .expect("reconcile after frame");
+        last_value = state_slot.borrow().as_ref().expect("state available").get();
+        if (last_value - initial).abs() > 0.0001 {
+            return;
+        }
+    }
+
+    panic!(
+        "infinite transition did not restart after first animation insertion: initial={initial} last={last_value}"
     );
 }
 

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -1083,6 +1083,31 @@ fn draw_width_app(width_state: cranpose_core::MutableState<f32>) {
     );
 }
 
+#[composable]
+fn draw_observed_width_app(width_state: cranpose_core::MutableState<f32>) {
+    Box(
+        Modifier::empty()
+            .size(Size {
+                width: 200.0,
+                height: 40.0,
+            })
+            .draw_behind(move |scope| {
+                let width = width_state.get();
+                scope.draw_rect_at(
+                    Rect {
+                        x: 0.0,
+                        y: 0.0,
+                        width,
+                        height: 10.0,
+                    },
+                    Brush::solid(Color(0.2, 0.7, 0.3, 1.0)),
+                );
+            }),
+        BoxSpec::default(),
+        || {},
+    );
+}
+
 struct DeleteSurroundingHandler {
     last_delete: Cell<Option<(usize, usize)>>,
 }
@@ -1725,6 +1750,56 @@ fn draw_repass_updates_render_data_without_layout() {
     assert!(
         (updated_width - 120.0).abs() < 0.1,
         "updated width should reflect latest state"
+    );
+}
+
+#[test]
+fn draw_state_reads_schedule_draw_repass_without_composition_read() {
+    let _guard = test_guard();
+    let root_key = location_key(file!(), line!(), column!());
+    let state_holder: Rc<RefCell<Option<cranpose_core::MutableState<f32>>>> =
+        Rc::new(RefCell::new(None));
+    let state_holder_for_app = Rc::clone(&state_holder);
+
+    let mut shell = AppShell::new(RecordingRenderer::default(), root_key, move || {
+        let width_state = useState(|| 24.0f32);
+        *state_holder_for_app.borrow_mut() = Some(width_state);
+        draw_observed_width_app(width_state);
+    });
+
+    shell.update();
+    let initial_scene = shell
+        .renderer
+        .last_scene
+        .as_ref()
+        .expect("expected initial render scene");
+    let initial_width = find_rect_width(initial_scene, Color(0.2, 0.7, 0.3, 1.0))
+        .expect("expected initial observed draw rect");
+
+    let width_state = state_holder
+        .borrow()
+        .as_ref()
+        .cloned()
+        .expect("width state should be captured");
+    width_state.set(120.0);
+
+    shell.update();
+
+    let updated_scene = shell
+        .renderer
+        .last_scene
+        .as_ref()
+        .expect("expected updated render scene");
+    let updated_width = find_rect_width(updated_scene, Color(0.2, 0.7, 0.3, 1.0))
+        .expect("expected updated observed draw rect");
+
+    assert_ne!(
+        initial_width, updated_width,
+        "state reads inside draw closures must invalidate draw output"
+    );
+    assert!(
+        (updated_width - 120.0).abs() < 0.1,
+        "updated draw width should reflect latest state-only read"
     );
 }
 

--- a/crates/cranpose-ui/src/modifier/slices.rs
+++ b/crates/cranpose-ui/src/modifier/slices.rs
@@ -408,9 +408,7 @@ pub fn collect_modifier_slices_into(chain: &ModifierNodeChain, slices: &mut Modi
                 }
 
                 if let Some(commands) = any.downcast_ref::<DrawCommandNode>() {
-                    slices
-                        .draw_commands
-                        .extend(commands.commands().iter().cloned());
+                    slices.draw_commands.extend(commands.observed_commands());
                 }
 
                 if let Some(draw_node) = node.as_draw_node() {

--- a/crates/cranpose-ui/src/modifier_nodes.rs
+++ b/crates/cranpose-ui/src/modifier_nodes.rs
@@ -60,6 +60,7 @@
 //! these nodes. The system achieves complete 1:1 parity with Jetpack Compose's modifier
 //! architecture.
 
+use cranpose_core::NodeId;
 use cranpose_foundation::{
     Constraints, DelegatableNode, DrawModifierNode, DrawScope, LayoutModifierNode, Measurable,
     MeasurementProxy, ModifierNode, ModifierNodeContext, ModifierNodeElement, NodeCapabilities,
@@ -67,6 +68,7 @@ use cranpose_foundation::{
 };
 use cranpose_ui_layout::{Alignment, HorizontalAlignment, IntrinsicSize, VerticalAlignment};
 
+use std::cell::Cell;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1827,6 +1829,7 @@ impl ModifierNodeElement for ClipToBoundsElement {
 /// Node that stores draw commands emitted by draw modifiers.
 pub struct DrawCommandNode {
     commands: Vec<DrawCommand>,
+    node_id: Cell<Option<NodeId>>,
     state: NodeState,
 }
 
@@ -1834,12 +1837,24 @@ impl DrawCommandNode {
     pub fn new(commands: Vec<DrawCommand>) -> Self {
         Self {
             commands,
+            node_id: Cell::new(None),
             state: NodeState::new(),
         }
     }
 
+    #[cfg(test)]
     pub fn commands(&self) -> &[DrawCommand] {
         &self.commands
+    }
+
+    pub(crate) fn observed_commands(&self) -> Vec<DrawCommand> {
+        let node_id = self.node_id.get();
+        self.commands
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(index, command)| observe_draw_command(command, node_id, index))
+            .collect()
     }
 }
 
@@ -1851,7 +1866,14 @@ impl DelegatableNode for DrawCommandNode {
 
 impl ModifierNode for DrawCommandNode {
     fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
+        self.node_id.set(context.node_id());
         context.invalidate(cranpose_foundation::InvalidationKind::Draw);
+    }
+
+    fn on_detach(&mut self) {
+        if let Some(node_id) = self.node_id.replace(None) {
+            crate::render_state::clear_draw_observations_for_node(node_id);
+        }
     }
 
     fn as_draw_node(&self) -> Option<&dyn DrawModifierNode> {
@@ -1865,6 +1887,28 @@ impl ModifierNode for DrawCommandNode {
 
 impl DrawModifierNode for DrawCommandNode {
     fn draw(&self, _draw_scope: &mut dyn DrawScope) {}
+}
+
+fn observe_draw_command(
+    command: DrawCommand,
+    node_id: Option<NodeId>,
+    command_index: usize,
+) -> DrawCommand {
+    let Some(node_id) = node_id else {
+        return command;
+    };
+    let scope = crate::render_state::DrawObservationScope::new(node_id, command_index);
+    match command {
+        DrawCommand::Behind(draw) => DrawCommand::Behind(Rc::new(move |size| {
+            crate::render_state::observe_draw_reads(scope, || draw(size))
+        })),
+        DrawCommand::WithContent(draw) => DrawCommand::WithContent(Rc::new(move |size| {
+            crate::render_state::observe_draw_reads(scope, || draw(size))
+        })),
+        DrawCommand::Overlay(draw) => DrawCommand::Overlay(Rc::new(move |size| {
+            crate::render_state::observe_draw_reads(scope, || draw(size))
+        })),
+    }
 }
 
 fn draw_command_tag(cmd: &DrawCommand) -> u8 {

--- a/crates/cranpose-ui/src/render_state.rs
+++ b/crates/cranpose-ui/src/render_state.rs
@@ -1,4 +1,4 @@
-use cranpose_core::NodeId;
+use cranpose_core::{current_runtime_handle, NodeId, SnapshotStateObserver};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Mutex;
@@ -15,6 +15,57 @@ struct RenderState {
     focus_invalidated: AtomicBool,
     layout_invalidated: AtomicBool,
     density_bits: AtomicU32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct DrawObservationScope {
+    node_id: NodeId,
+    command_index: usize,
+}
+
+impl DrawObservationScope {
+    pub(crate) fn new(node_id: NodeId, command_index: usize) -> Self {
+        Self {
+            node_id,
+            command_index,
+        }
+    }
+}
+
+std::thread_local! {
+    static DRAW_OBSERVER: SnapshotStateObserver = {
+        let observer = SnapshotStateObserver::new(|callback| {
+            if let Some(runtime) = current_runtime_handle() {
+                runtime.enqueue_ui_task(callback);
+            } else {
+                callback();
+            }
+        });
+        observer.start();
+        observer
+    };
+}
+
+pub(crate) fn observe_draw_reads<R>(scope: DrawObservationScope, block: impl FnOnce() -> R) -> R {
+    DRAW_OBSERVER.with(|observer| {
+        observer.observe_reads(
+            scope,
+            |scope| {
+                schedule_draw_repass(scope.node_id);
+            },
+            block,
+        )
+    })
+}
+
+pub(crate) fn clear_draw_observations_for_node(node_id: NodeId) {
+    DRAW_OBSERVER.with(|observer| {
+        observer.clear_if(|scope| {
+            scope
+                .downcast_ref::<DrawObservationScope>()
+                .is_some_and(|scope| scope.node_id == node_id)
+        });
+    });
 }
 
 impl RenderState {
@@ -146,6 +197,7 @@ pub fn schedule_draw_repass(node_id: NodeId) {
             .expect("draw repass manager poisoned")
             .schedule_repass(node_id);
     });
+    request_render_invalidation();
 }
 
 /// Returns true if any draw repasses are pending.

--- a/crates/cranpose-ui/src/subcompose_layout.rs
+++ b/crates/cranpose-ui/src/subcompose_layout.rs
@@ -826,6 +826,7 @@ impl cranpose_core::Node for SubcomposeLayoutNode {
     fn set_node_id(&mut self, id: NodeId) {
         self.id.set(Some(id));
         self.inner.borrow_mut().modifier_chain.set_node_id(Some(id));
+        self.update_modifier_slices_cache();
     }
 
     fn on_attached_to_parent(&mut self, parent: NodeId) {

--- a/crates/cranpose-ui/src/widgets/nodes/layout_node.rs
+++ b/crates/cranpose-ui/src/widgets/nodes/layout_node.rs
@@ -540,6 +540,7 @@ impl LayoutNode {
         // Propagate the ID to the modifier chain. This triggers a lifecycle update
         // for nodes that depend on the node ID for invalidation (e.g., ScrollNode).
         self.modifier_chain.set_node_id(Some(id));
+        self.update_modifier_slices_cache();
     }
 
     /// Get this node's ID.

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -298,7 +298,11 @@ stage_robot_artifacts() {
 
     mkdir -p "$output_dir"
     for shard in $(seq 1 "$shard_count"); do
-        tar -C "$stage_root/$shard" -cf "$output_dir/robot-examples-$shard.tar" .
+        local archive="$output_dir/robot-examples-$shard.tar.gz"
+        if ! tar -C "$stage_root/$shard" -I "gzip -1" -cf "$archive" .; then
+            echo "Cannot stage robot artifact: $archive" | tee -a "$LOG_FILE"
+            exit 1
+        fi
     done
     rm -r -- "$stage_root"
 }


### PR DESCRIPTION
## Summary
- observe snapshot state reads made by deferred draw commands and schedule scoped draw repasses
- refresh modifier slice caches after node ids are assigned so draw commands are tagged with their layout node
- add unit, app-shell, and robot regressions for conditionally inserted infinite transitions

Fixes #262

## Verification
- cargo fmt --check
- cargo test > 1.tmp 2>&1
- cargo clippy > 2.tmp 2>&1
- CRANPOSE_USE_SCCACHE=0 ./build-web.sh > ../../web-build.tmp 2>&1
- ./gradlew :app:assembleRelease > ../../../android-build.tmp 2>&1
- CRANPOSE_USE_SCCACHE=0 ./run_robot_test.sh --sequential > robot_all.tmp 2>&1