### PR TITLE
Align facade release with split crates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to publish, for example v0.0.67"
+        description: "Release tag to publish, for example v0.1.0"
         required: true
         type: string
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+      - name: Check Cranpose package versions
+        run: python3 scripts/check_cranpose_versions.py
+
       - name: Run workspace tests
         run: cargo test --profile ci --workspace --verbose
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "android-activity",
  "android_logger",
@@ -970,14 +970,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-animation"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "cranpose-core",
 ]
 
 [[package]]
 name = "cranpose-app-shell"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "arboard",
  "cranpose-core",
@@ -993,11 +993,11 @@ dependencies = [
 
 [[package]]
 name = "cranpose-assets"
-version = "0.0.67"
+version = "0.1.0"
 
 [[package]]
 name = "cranpose-core"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "ahash",
  "cranpose-macros",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-foundation"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-macros"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1035,14 +1035,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-android"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "cranpose-ui-graphics",
 ]
 
 [[package]]
 name = "cranpose-platform-desktop-winit"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-web"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-common"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-pixels"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-wgpu"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "bytemuck",
  "cranpose-app-shell",
@@ -1108,14 +1108,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-runtime-std"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "cranpose-core",
 ]
 
 [[package]]
 name = "cranpose-services"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-testing"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "cranpose",
  "cranpose-app-shell",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -1169,14 +1169,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui-graphics"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cranpose-ui-layout"
-version = "0.0.67"
+version = "0.1.0"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.67"
+version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/samoylenkodmitry/cranpose"
@@ -37,25 +37,25 @@ categories = ["gui"]
 [workspace.dependencies]
 # Force android-activity to use native-activity feature across all workspace crates
 android-activity = { version = "0.6", features = ["native-activity"] }
-cranpose-animation = { path = "crates/cranpose-animation", version = "0.0.67" }
-cranpose = { path = "crates/cranpose", version = "0.0.67" }
-cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.0.67" }
-cranpose-assets = { path = "crates/cranpose-assets", version = "0.0.67" }
-cranpose-core = { path = "crates/cranpose-core", version = "0.0.67" }
-cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.0.67" }
-cranpose-macros = { path = "crates/cranpose-macros", version = "0.0.67" }
-cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.0.67" }
-cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.0.67" }
-cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.0.67" }
-cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.0.67" }
-cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.0.67" }
-cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.0.67" }
-cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.0.67" }
-cranpose-services = { path = "crates/cranpose-services", version = "0.0.67" }
-cranpose-testing = { path = "crates/cranpose-testing", version = "0.0.67" }
-cranpose-ui = { path = "crates/cranpose-ui", version = "0.0.67" }
-cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.0.67" }
-cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.0.67" }
+cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.0" }
+cranpose = { path = "crates/cranpose", version = "0.1.0" }
+cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.0" }
+cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.0" }
+cranpose-core = { path = "crates/cranpose-core", version = "0.1.0" }
+cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.0" }
+cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.0" }
+cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.0" }
+cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.0" }
+cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.0" }
+cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.0" }
+cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.0" }
+cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.0" }
+cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.0" }
+cranpose-services = { path = "crates/cranpose-services", version = "0.1.0" }
+cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.0" }
+cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.0" }
+cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.0" }
+cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.0" }
 
 # Faster local debug builds while preserving useful panic locations.
 [profile.dev]

--- a/apps/isolated-demo/Cargo.toml
+++ b/apps/isolated-demo/Cargo.toml
@@ -30,11 +30,11 @@ web = ["cranpose/web", "dep:wasm-bindgen", "dep:wasm-logger"]
 logging = ["dep:env_logger"]
 
 [dependencies]
-cranpose = { version = "0.0.67", default-features = false }
+cranpose = { version = "0.1.0", default-features = false }
 log = "0.4"
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-logger = { version = "0.2", optional = true }
-cranpose-core = "0.0.67"
+cranpose-core = "0.1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = { version = "0.10", optional = true }

--- a/scripts/check_cranpose_versions.py
+++ b/scripts/check_cranpose_versions.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tomllib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_toml(path: Path) -> dict:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def dependency_version(spec: object) -> str | None:
+    if isinstance(spec, str):
+        return spec
+    if isinstance(spec, dict):
+        version = spec.get("version")
+        return version if isinstance(version, str) else None
+    return None
+
+
+def root_lock_versions(path: Path) -> dict[str, set[str]]:
+    versions: dict[str, set[str]] = {}
+    package_name: str | None = None
+
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped == "[[package]]":
+            package_name = None
+            continue
+        if stripped.startswith("name = "):
+            package_name = stripped.split("=", 1)[1].strip().strip('"')
+            continue
+        if package_name is None or not package_name.startswith("cranpose"):
+            continue
+        if stripped.startswith("version = "):
+            version = stripped.split("=", 1)[1].strip().strip('"')
+            versions.setdefault(package_name, set()).add(version)
+            package_name = None
+
+    return versions
+
+
+def dependency_tables(manifest: dict) -> list[dict]:
+    tables: list[dict] = []
+    dependencies = manifest.get("dependencies")
+    if isinstance(dependencies, dict):
+        tables.append(dependencies)
+
+    targets = manifest.get("target")
+    if isinstance(targets, dict):
+        for target in targets.values():
+            if isinstance(target, dict):
+                target_dependencies = target.get("dependencies")
+                if isinstance(target_dependencies, dict):
+                    tables.append(target_dependencies)
+
+    return tables
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    root_manifest = load_toml(ROOT / "Cargo.toml")
+    workspace = root_manifest["workspace"]
+    workspace_version = workspace["package"]["version"]
+
+    expected_package_names: set[str] = set()
+    workspace_dependencies = workspace.get("dependencies", {})
+    for name, spec in sorted(workspace_dependencies.items()):
+        if not name.startswith("cranpose"):
+            continue
+        expected_package_names.add(name)
+        version = dependency_version(spec)
+        if version != workspace_version:
+            failures.append(
+                f"workspace dependency {name} is {version}, expected {workspace_version}"
+            )
+
+    lock_versions = root_lock_versions(ROOT / "Cargo.lock")
+    for name in sorted(expected_package_names.difference(lock_versions)):
+        failures.append(f"Cargo.lock is missing workspace package {name}")
+
+    for name, versions in sorted(lock_versions.items()):
+        if versions != {workspace_version}:
+            found = ", ".join(sorted(versions))
+            failures.append(
+                f"Cargo.lock package {name} has {found}, expected {workspace_version}"
+            )
+
+    isolated_manifest = load_toml(ROOT / "apps/isolated-demo/Cargo.toml")
+    for table in dependency_tables(isolated_manifest):
+        for name, spec in sorted(table.items()):
+            if not name.startswith("cranpose"):
+                continue
+            version = dependency_version(spec)
+            if version != workspace_version:
+                failures.append(
+                    "apps/isolated-demo dependency "
+                    f"{name} is {version}, expected {workspace_version}"
+                )
+
+    if failures:
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+
+    print(f"cranpose package versions are aligned at {workspace_version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- bump all Cranpose workspace packages and workspace Cranpose dependency versions to 0.1.0
- update the isolated demo manifest to consume the 0.1.0 facade/core release line
- add a Rust CI guard that fails when workspace Cranpose dependency versions or root lockfile package versions drift from the workspace version

## Verification
- python3 scripts/check_cranpose_versions.py
- cargo fmt --check
- cargo test > 1.tmp 2>&1
- cargo clippy --workspace --all-targets -- -D warnings > 2.tmp 2>&1
- apps/desktop-demo/build-web.sh
- apps/android-demo/android: ./gradlew :app:assembleRelease
- ./run_robot_test.sh --sequential (99/99 passed)

Fixes #263