### PR TITLE
Prepare Cranpose 0.1.1 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to publish, for example v0.1.0"
+        description: "Release tag to publish, for example v0.1.1"
         required: true
         type: string
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "android-activity",
  "android_logger",
@@ -970,14 +970,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-animation"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cranpose-core",
 ]
 
 [[package]]
 name = "cranpose-app-shell"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arboard",
  "cranpose-core",
@@ -993,11 +993,11 @@ dependencies = [
 
 [[package]]
 name = "cranpose-assets"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "cranpose-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ahash",
  "cranpose-macros",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-foundation"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1035,14 +1035,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-android"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cranpose-ui-graphics",
 ]
 
 [[package]]
 name = "cranpose-platform-desktop-winit"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-web"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-common"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-pixels"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-wgpu"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytemuck",
  "cranpose-app-shell",
@@ -1108,14 +1108,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-runtime-std"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cranpose-core",
 ]
 
 [[package]]
 name = "cranpose-services"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-testing"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cranpose",
  "cranpose-app-shell",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -1169,14 +1169,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui-graphics"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cranpose-ui-layout"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/samoylenkodmitry/cranpose"
@@ -37,25 +37,25 @@ categories = ["gui"]
 [workspace.dependencies]
 # Force android-activity to use native-activity feature across all workspace crates
 android-activity = { version = "0.6", features = ["native-activity"] }
-cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.0" }
-cranpose = { path = "crates/cranpose", version = "0.1.0" }
-cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.0" }
-cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.0" }
-cranpose-core = { path = "crates/cranpose-core", version = "0.1.0" }
-cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.0" }
-cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.0" }
-cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.0" }
-cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.0" }
-cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.0" }
-cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.0" }
-cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.0" }
-cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.0" }
-cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.0" }
-cranpose-services = { path = "crates/cranpose-services", version = "0.1.0" }
-cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.0" }
-cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.0" }
-cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.0" }
-cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.0" }
+cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.1" }
+cranpose = { path = "crates/cranpose", version = "0.1.1" }
+cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.1" }
+cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.1" }
+cranpose-core = { path = "crates/cranpose-core", version = "0.1.1" }
+cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.1" }
+cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.1" }
+cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.1" }
+cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.1" }
+cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.1" }
+cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.1" }
+cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.1" }
+cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.1" }
+cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.1" }
+cranpose-services = { path = "crates/cranpose-services", version = "0.1.1" }
+cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.1" }
+cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.1" }
+cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.1" }
+cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.1" }
 
 # Faster local debug builds while preserving useful panic locations.
 [profile.dev]

--- a/apps/isolated-demo/Cargo.toml
+++ b/apps/isolated-demo/Cargo.toml
@@ -30,11 +30,11 @@ web = ["cranpose/web", "dep:wasm-bindgen", "dep:wasm-logger"]
 logging = ["dep:env_logger"]
 
 [dependencies]
-cranpose = { version = "0.1.0", default-features = false }
+cranpose = { version = "0.1.1", default-features = false }
 log = "0.4"
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-logger = { version = "0.2", optional = true }
-cranpose-core = "0.1.0"
+cranpose-core = "0.1.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = { version = "0.10", optional = true }

--- a/crates/cranpose-services/Cargo.toml
+++ b/crates/cranpose-services/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 description = "Multiplatform system services for Cranpose (HTTP, URI, and OS integrations)"
 
 [dependencies]
-cranpose-core = { workspace = true, features = ["internal"] }
+cranpose-core = { workspace = true }
 cranpose-macros = { workspace = true }
 thiserror = "2.0.18"
 


### PR DESCRIPTION
## Summary
- bump the Cranpose workspace and split-crate dependency matrix to 0.1.1
- point the isolated crates.io smoke demo at the same 0.1.1 facade/core versions
- remove the unused `cranpose-core/internal` feature from `cranpose-services`

## Why
The v0.1.0 publish run failed after crates.io rejected `cranpose-services` against the already-published immutable `cranpose-core 0.1.0`, which does not expose the `internal` feature. A clean 0.1.1 workspace release publishes `cranpose-core` with the current feature metadata before dependent crates resolve it.

## Verification
- `python3 scripts/check_cranpose_versions.py`
- `cargo fmt --check`
- `cargo test > 1.tmp 2>&1`
- `cargo clippy > 2.tmp 2>&1`
- `cargo clippy --workspace --all-targets -- -D warnings > 2.tmp 2>&1`
- `apps/desktop-demo/build-web.sh`
- `apps/android-demo/android: ./gradlew :app:assembleRelease`
- `./run_robot_test.sh --sequential`