### PR TITLE
Prepare Cranpose 0.1.7 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "android-activity",
  "android_logger",
@@ -848,14 +848,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-animation"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "cranpose-core",
 ]
 
 [[package]]
 name = "cranpose-app-shell"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "arboard",
  "cranpose-core",
@@ -871,11 +871,11 @@ dependencies = [
 
 [[package]]
 name = "cranpose-assets"
-version = "0.1.6"
+version = "0.1.7"
 
 [[package]]
 name = "cranpose-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "ahash",
  "cranpose-macros",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-foundation"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-macros"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -913,14 +913,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-android"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "cranpose-ui-graphics",
 ]
 
 [[package]]
 name = "cranpose-platform-desktop-winit"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-web"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-common"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-pixels"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-wgpu"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bytemuck",
  "cranpose-app-shell",
@@ -986,14 +986,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-runtime-std"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "cranpose-core",
 ]
 
 [[package]]
 name = "cranpose-services"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-testing"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "cranpose",
  "cranpose-app-shell",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -1047,14 +1047,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui-graphics"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cranpose-ui-layout"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/samoylenkodmitry/cranpose"
@@ -37,25 +37,25 @@ categories = ["gui"]
 [workspace.dependencies]
 # Force android-activity to use native-activity feature across all workspace crates
 android-activity = { version = "0.6", features = ["native-activity"] }
-cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.6" }
-cranpose = { path = "crates/cranpose", version = "0.1.6" }
-cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.6" }
-cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.6" }
-cranpose-core = { path = "crates/cranpose-core", version = "0.1.6" }
-cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.6" }
-cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.6" }
-cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.6" }
-cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.6" }
-cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.6" }
-cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.6" }
-cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.6" }
-cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.6" }
-cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.6" }
-cranpose-services = { path = "crates/cranpose-services", version = "0.1.6" }
-cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.6" }
-cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.6" }
-cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.6" }
-cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.6" }
+cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.7" }
+cranpose = { path = "crates/cranpose", version = "0.1.7" }
+cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.7" }
+cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.7" }
+cranpose-core = { path = "crates/cranpose-core", version = "0.1.7" }
+cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.7" }
+cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.7" }
+cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.7" }
+cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.7" }
+cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.7" }
+cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.7" }
+cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.7" }
+cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.7" }
+cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.7" }
+cranpose-services = { path = "crates/cranpose-services", version = "0.1.7" }
+cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.7" }
+cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.7" }
+cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.7" }
+cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.7" }
 
 # Faster local debug builds while preserving useful panic locations.
 [profile.dev]

--- a/apps/isolated-demo/Cargo.toml
+++ b/apps/isolated-demo/Cargo.toml
@@ -30,11 +30,11 @@ web = ["cranpose/web", "dep:wasm-bindgen", "dep:wasm-logger"]
 logging = ["dep:env_logger"]
 
 [dependencies]
-cranpose = { version = "0.1.6", default-features = false }
+cranpose = { version = "0.1.7", default-features = false }
 log = "0.4"
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-logger = { version = "0.2", optional = true }
-cranpose-core = "0.1.6"
+cranpose-core = "0.1.7"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = { version = "0.11", optional = true }

--- a/crates/cranpose/src/web.rs
+++ b/crates/cranpose/src/web.rs
@@ -25,6 +25,15 @@ enum WebBackendPreference {
     Gl,
 }
 
+#[derive(Debug)]
+struct BrowserDisplayHandle;
+
+impl wgpu::rwh::HasDisplayHandle for BrowserDisplayHandle {
+    fn display_handle(&self) -> Result<wgpu::rwh::DisplayHandle<'_>, wgpu::rwh::HandleError> {
+        Ok(wgpu::rwh::DisplayHandle::web())
+    }
+}
+
 /// Runs a web Compose application with wgpu rendering.
 ///
 /// Called by `AppLauncher::run_web()`. This is the framework-level
@@ -70,7 +79,8 @@ pub async fn run(
     }
 
     let backend_preference = requested_web_backend(&window);
-    let mut instance_desc = wgpu::InstanceDescriptor::new_without_display_handle();
+    let mut instance_desc =
+        wgpu::InstanceDescriptor::new_with_display_handle(Box::new(BrowserDisplayHandle));
     instance_desc.backends = instance_backends(backend_preference);
     let instance = match backend_preference {
         WebBackendPreference::Auto => {


### PR DESCRIPTION
## Summary

- Fix browser surface creation by giving the web `wgpu::InstanceDescriptor` a browser display handle before creating the canvas surface.
- Bump Cranpose workspace crates and isolated-demo dependency references from `0.1.6` to `0.1.7`.

## Root Cause

After the `wgpu 29` upgrade, `SurfaceTarget::Canvas` still supplies the canvas window handle, but `wgpu-core` now also requires a display handle. The web runtime was creating the instance with `new_without_display_handle()`, so browser startup failed with `CreateSurfaceError { inner: Hal(MissingDisplayHandle) }`.

## Validation

- `cargo check`
- `cargo fmt`
- `cargo test > 1.tmp 2>&1`
- `cargo clippy > 2.tmp 2>&1`
- `apps/desktop-demo/build-web.sh`
- Chromium headless smoke test against `http://127.0.0.1:8080/?backend=gl`: reached `phase=running`, `error=null`, WebGL2 active
- Earlier full validation for the web fix before the release bump: Android `:app:assembleRelease` and `./run_robot_test.sh --sequential` passed with 100/100 robot tests