### PR TITLE
Fix Android startup crash on 16 KiB uniform-binding devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cranpose"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "android-activity",
  "android_logger",
@@ -570,14 +570,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-animation"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "cranpose-core",
 ]
 
 [[package]]
 name = "cranpose-app-shell"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "arboard",
  "cranpose-core",
@@ -593,11 +593,11 @@ dependencies = [
 
 [[package]]
 name = "cranpose-assets"
-version = "0.1.14"
+version = "0.1.15"
 
 [[package]]
 name = "cranpose-core"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "ahash",
  "cranpose-macros",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-foundation"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-macros"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -634,14 +634,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-android"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "cranpose-ui-graphics",
 ]
 
 [[package]]
 name = "cranpose-platform-desktop-winit"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-web"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-common"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-pixels"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "cranpose-core",
  "cranpose-foundation",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-wgpu"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "bytemuck",
  "cranpose-app-shell",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-runtime-std"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "cranpose-core",
  "web-time",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-services"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-testing"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "cranpose",
  "cranpose-app-shell",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -765,14 +765,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui-graphics"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cranpose-ui-layout"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/samoylenkodmitry/cranpose"
@@ -39,25 +39,25 @@ categories = ["gui"]
 [workspace.dependencies]
 # Force android-activity to use native-activity feature across all workspace crates
 android-activity = { version = "0.6", features = ["native-activity"] }
-cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.14" }
-cranpose = { path = "crates/cranpose", version = "0.1.14", default-features = false }
-cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.14" }
-cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.14" }
-cranpose-core = { path = "crates/cranpose-core", version = "0.1.14" }
-cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.14" }
-cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.14" }
-cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.14" }
-cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.14" }
-cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.14" }
-cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.14" }
-cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.14" }
-cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.14" }
-cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.14" }
-cranpose-services = { path = "crates/cranpose-services", version = "0.1.14", default-features = false }
-cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.14" }
-cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.14" }
-cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.14" }
-cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.14" }
+cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.15" }
+cranpose = { path = "crates/cranpose", version = "0.1.15", default-features = false }
+cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.15" }
+cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.15" }
+cranpose-core = { path = "crates/cranpose-core", version = "0.1.15" }
+cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.15" }
+cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.15" }
+cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.15" }
+cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.15" }
+cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.15" }
+cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.15" }
+cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.15" }
+cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.15" }
+cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.15" }
+cranpose-services = { path = "crates/cranpose-services", version = "0.1.15", default-features = false }
+cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.15" }
+cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.15" }
+cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.15" }
+cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.15" }
 web-time = "1.1"
 
 [patch.crates-io]

--- a/apps/isolated-demo/Cargo.toml
+++ b/apps/isolated-demo/Cargo.toml
@@ -29,11 +29,11 @@ web = ["cranpose/web", "dep:wasm-bindgen", "dep:wasm-logger"]
 logging = ["dep:env_logger"]
 
 [dependencies]
-cranpose = { version = "0.1.14", default-features = false }
+cranpose = { version = "0.1.15", default-features = false }
 log = "0.4"
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-logger = { version = "0.2", optional = true }
-cranpose-core = "0.1.14"
+cranpose-core = "0.1.15"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = { version = "0.11", optional = true }

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -105,6 +105,40 @@ const MAX_SHAPES_PER_BATCH: usize = 768;
 const MAX_GRADIENT_STOPS: usize = 256;
 #[cfg(not(target_arch = "wasm32"))]
 const MAX_GRADIENT_STOPS: usize = 1024;
+
+/// Uniform batch capacities derived from the actual device limits.
+///
+/// The compile-time `MAX_*` constants assume desktop-class 64 KiB uniform
+/// bindings. Android downlevel and GLES-class devices may only offer the
+/// 16 KiB spec minimum; sizing the shape/gradient uniform buffers (and the
+/// matching WGSL array lengths) past `max_uniform_buffer_binding_size` makes
+/// the very first "Shape Bind Group" fail validation and aborts the app.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ShapeBatchLimits {
+    max_shapes_per_batch: usize,
+    max_gradient_stops: usize,
+}
+
+impl ShapeBatchLimits {
+    fn for_device(device: &wgpu::Device) -> Self {
+        Self::for_uniform_binding_size(device.limits().max_uniform_buffer_binding_size)
+    }
+
+    fn for_uniform_binding_size(max_uniform_buffer_binding_size: u64) -> Self {
+        let binding = max_uniform_buffer_binding_size as usize;
+        Self {
+            max_shapes_per_batch: (binding / std::mem::size_of::<ShapeData>())
+                .clamp(1, MAX_SHAPES_PER_BATCH),
+            max_gradient_stops: (binding / std::mem::size_of::<GradientStop>())
+                .clamp(1, MAX_GRADIENT_STOPS),
+        }
+    }
+
+    #[cfg(test)]
+    fn desktop() -> Self {
+        Self::for_uniform_binding_size(wgpu::Limits::default().max_uniform_buffer_binding_size)
+    }
+}
 const HARD_MAX_BUFFER_MB: usize = 64; // Maximum 64MB per buffer (vertex/index only)
 const MAX_SHADOW_SURFACE_CACHE_ITEMS: usize = 512;
 // Sized for HiDPI: a 4K fractional-scale screen full of shadowed panels needs
@@ -1129,22 +1163,22 @@ fn gradient_tile_mode_value(tile_mode: TileMode) -> u32 {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn shape_shader_source() -> Cow<'static, str> {
+fn shape_shader_source(batch_limits: ShapeBatchLimits) -> Cow<'static, str> {
     Cow::Owned(
         shaders::SHADER
             .replace(
                 "array<ShapeData, 200>",
-                &format!("array<ShapeData, {MAX_SHAPES_PER_BATCH}>"),
+                &format!("array<ShapeData, {}>", batch_limits.max_shapes_per_batch),
             )
             .replace(
                 "array<GradientStop, 256>",
-                &format!("array<GradientStop, {MAX_GRADIENT_STOPS}>"),
+                &format!("array<GradientStop, {}>", batch_limits.max_gradient_stops),
             ),
     )
 }
 
 #[cfg(target_arch = "wasm32")]
-fn shape_shader_source() -> Cow<'static, str> {
+fn shape_shader_source(_batch_limits: ShapeBatchLimits) -> Cow<'static, str> {
     Cow::Borrowed(shaders::SHADER)
 }
 
@@ -1154,10 +1188,11 @@ fn create_shape_pipeline(
     uniform_layout: &wgpu::BindGroupLayout,
     shape_layout: &wgpu::BindGroupLayout,
     blend_mode: BlendMode,
+    batch_limits: ShapeBatchLimits,
 ) -> wgpu::RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("Shape Shader"),
-        source: wgpu::ShaderSource::Wgsl(shape_shader_source()),
+        source: wgpu::ShaderSource::Wgsl(shape_shader_source(batch_limits)),
     });
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -1639,6 +1674,7 @@ struct ShapeBatchBuffers {
     index_capacity: usize,
     shape_capacity: usize,
     gradient_capacity: usize,
+    batch_limits: ShapeBatchLimits,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -1760,11 +1796,15 @@ impl StagedBufferUploads {
 }
 
 impl ShapeBatchBuffers {
-    fn new(device: &wgpu::Device, bind_group_layout: &wgpu::BindGroupLayout) -> Self {
-        let initial_vertex_cap = MAX_SHAPES_PER_BATCH * 4; // 4 vertices per shape
-        let initial_index_cap = MAX_SHAPES_PER_BATCH * 6; // 6 indices per shape
-        let initial_shape_cap = MAX_SHAPES_PER_BATCH;
-        let initial_gradient_cap = MAX_GRADIENT_STOPS;
+    fn new(
+        device: &wgpu::Device,
+        bind_group_layout: &wgpu::BindGroupLayout,
+        batch_limits: ShapeBatchLimits,
+    ) -> Self {
+        let initial_vertex_cap = batch_limits.max_shapes_per_batch * 4; // 4 vertices per shape
+        let initial_index_cap = batch_limits.max_shapes_per_batch * 6; // 6 indices per shape
+        let initial_shape_cap = batch_limits.max_shapes_per_batch;
+        let initial_gradient_cap = batch_limits.max_gradient_stops;
 
         let vertex_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Shape Vertex Buffer"),
@@ -1820,6 +1860,7 @@ impl ShapeBatchBuffers {
             index_capacity: initial_index_cap,
             shape_capacity: initial_shape_cap,
             gradient_capacity: initial_gradient_cap,
+            batch_limits,
         }
     }
 
@@ -1865,8 +1906,12 @@ impl ShapeBatchBuffers {
 
         // Shape and gradient buffers are uniform buffers whose size must match
         // the shader's fixed-size array declarations. Never grow beyond those.
-        if shapes_needed > self.shape_capacity && self.shape_capacity < MAX_SHAPES_PER_BATCH {
-            let new_cap = shapes_needed.next_power_of_two().min(MAX_SHAPES_PER_BATCH);
+        if shapes_needed > self.shape_capacity
+            && self.shape_capacity < self.batch_limits.max_shapes_per_batch
+        {
+            let new_cap = shapes_needed
+                .next_power_of_two()
+                .min(self.batch_limits.max_shapes_per_batch);
             self.shape_buffer = device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some("Shape Data Buffer"),
                 size: (std::mem::size_of::<ShapeData>() * new_cap) as u64,
@@ -1877,12 +1922,13 @@ impl ShapeBatchBuffers {
             need_bind_group_update = true;
         }
 
-        if gradients_needed > self.gradient_capacity && self.gradient_capacity < MAX_GRADIENT_STOPS
+        if gradients_needed > self.gradient_capacity
+            && self.gradient_capacity < self.batch_limits.max_gradient_stops
         {
             let new_cap = gradients_needed
                 .max(1)
                 .next_power_of_two()
-                .min(MAX_GRADIENT_STOPS);
+                .min(self.batch_limits.max_gradient_stops);
             self.gradient_buffer = device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some("Gradient Buffer"),
                 size: (std::mem::size_of::<GradientStop>() * new_cap) as u64,
@@ -1998,6 +2044,7 @@ pub struct GpuRenderer {
     pub(crate) device: Arc<wgpu::Device>,
     pub(crate) queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
+    shape_batch_limits: ShapeBatchLimits,
     pipeline: wgpu::RenderPipeline,
     pipeline_dst_out: wgpu::RenderPipeline,
     #[cfg(target_arch = "wasm32")]
@@ -2165,6 +2212,7 @@ impl GpuRenderer {
         adapter_backend: wgpu::Backend,
         text_fonts: SoftwareTextFontSet,
     ) -> Self {
+        let shape_batch_limits = ShapeBatchLimits::for_device(&device);
         let uniform_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 label: Some("Uniform Bind Group Layout"),
@@ -2232,6 +2280,7 @@ impl GpuRenderer {
             &uniform_bind_group_layout,
             &shape_bind_group_layout,
             BlendMode::SrcOver,
+            shape_batch_limits,
         );
         let pipeline_dst_out = create_shape_pipeline(
             &device,
@@ -2239,6 +2288,7 @@ impl GpuRenderer {
             &uniform_bind_group_layout,
             &shape_bind_group_layout,
             BlendMode::DstOut,
+            shape_batch_limits,
         );
 
         let image_bind_group_layout =
@@ -2319,7 +2369,8 @@ impl GpuRenderer {
         });
 
         #[cfg(not(target_arch = "wasm32"))]
-        let shape_buffers = ShapeBatchBuffers::new(&device, &shape_bind_group_layout);
+        let shape_buffers =
+            ShapeBatchBuffers::new(&device, &shape_bind_group_layout, shape_batch_limits);
 
         let image_nearest_sampler =
             device.create_sampler(&image_sampler_descriptor(ImageSampling::Nearest));
@@ -2379,6 +2430,7 @@ impl GpuRenderer {
             device,
             queue,
             surface_format,
+            shape_batch_limits,
             pipeline,
             pipeline_dst_out,
             #[cfg(target_arch = "wasm32")]
@@ -3738,6 +3790,7 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
                 composite_items: merged_composites.len(),
                 shader_composite_items: shader_composites.len(),
             },
+            self.renderer.shape_batch_limits,
         );
         let result = if ordered_items.is_empty() {
             Ok(SegmentCommandEncodeOutcome { first_batch: true })
@@ -4889,7 +4942,9 @@ impl GpuRenderer {
         root_scale: f32,
     ) -> Result<SegmentCommandEncodeOutcome, String> {
         let mut first_batch = true;
-        for command in SegmentCommandIter::new(ordered_items, shapes, images) {
+        for command in
+            SegmentCommandIter::new(ordered_items, shapes, images, self.shape_batch_limits)
+        {
             match command {
                 SegmentRenderCommand::DrawChunk(chunk) => {
                     let load_op = if first_batch {
@@ -4980,7 +5035,12 @@ impl GpuRenderer {
         root_scale: f32,
         load_op: wgpu::LoadOp<wgpu::Color>,
     ) -> Result<Option<SegmentRenderOutcome>, String> {
-        let Some(partitions) = native_segment_fusion_partitions(ordered_items, shapes, chunk)?
+        let Some(partitions) = native_segment_fusion_partitions(
+            ordered_items,
+            shapes,
+            chunk,
+            self.shape_batch_limits,
+        )?
         else {
             return Ok(None);
         };
@@ -5482,11 +5542,11 @@ impl GpuRenderer {
                         blend_mode,
                     } => {
                         let slice = &ordered_items[start..end];
-                        if slice.len() > MAX_SHAPES_PER_BATCH {
+                        if slice.len() > self.shape_batch_limits.max_shapes_per_batch {
                             return Err(format!(
                                 "shape batch contains {} shapes, exceeding the renderer limit of {}",
                                 slice.len(),
-                                MAX_SHAPES_PER_BATCH
+                                self.shape_batch_limits.max_shapes_per_batch
                             ));
                         }
                         let viewport = ViewportUniformParams {
@@ -5927,6 +5987,7 @@ impl GpuRenderer {
             self.wasm_shape_batches.push(ShapeBatchBuffers::new(
                 &self.device,
                 &self.shape_bind_group_layout,
+                self.shape_batch_limits,
             ));
         }
         slot
@@ -6431,7 +6492,7 @@ impl GpuRenderer {
             let blend_mode = supported_blend_mode(shapes[start].1);
             let mut end = start + 1;
             while end < shapes.len()
-                && end - start < MAX_SHAPES_PER_BATCH
+                && end - start < self.shape_batch_limits.max_shapes_per_batch
                 && supported_blend_mode(shapes[end].1) == blend_mode
             {
                 end += 1;
@@ -6686,7 +6747,7 @@ impl GpuRenderer {
 
         for (idx, shape) in layer_shapes
             .filter(|shape| shape_draw_is_visible_in_viewport(shape, viewport, root_scale))
-            .take(MAX_SHAPES_PER_BATCH)
+            .take(self.shape_batch_limits.max_shapes_per_batch)
             .enumerate()
         {
             let snap_delta = shape
@@ -9148,6 +9209,7 @@ struct SegmentCommandIter<'a> {
     shapes: &'a [DrawShape],
     images: &'a [ImageDraw],
     cursor: usize,
+    batch_limits: ShapeBatchLimits,
 }
 
 impl<'a> SegmentCommandIter<'a> {
@@ -9155,12 +9217,14 @@ impl<'a> SegmentCommandIter<'a> {
         ordered_items: &'a [(usize, SegmentDrawItem)],
         shapes: &'a [DrawShape],
         images: &'a [ImageDraw],
+        batch_limits: ShapeBatchLimits,
     ) -> Self {
         Self {
             ordered_items,
             shapes,
             images,
             cursor: 0,
+            batch_limits,
         }
     }
 }
@@ -9193,6 +9257,7 @@ impl Iterator for SegmentCommandIter<'_> {
                 self.shapes,
                 self.images,
                 self.cursor,
+                self.batch_limits,
             ) else {
                 break;
             };
@@ -9265,6 +9330,7 @@ fn native_segment_fusion_budget(
     ordered_items: &[(usize, SegmentDrawItem)],
     shapes: &[DrawShape],
     chunk: &SegmentDrawChunkPlan,
+    batch_limits: ShapeBatchLimits,
 ) -> Result<Option<NativeSegmentFusionBudget>, String> {
     let mut shape_count = 0usize;
     let mut gradient_stop_count = 0usize;
@@ -9286,7 +9352,9 @@ fn native_segment_fusion_budget(
         }
     }
 
-    if shape_count > MAX_SHAPES_PER_BATCH || gradient_stop_count > MAX_GRADIENT_STOPS {
+    if shape_count > batch_limits.max_shapes_per_batch
+        || gradient_stop_count > batch_limits.max_gradient_stops
+    {
         return Ok(None);
     }
 
@@ -9321,8 +9389,10 @@ fn native_segment_fusion_partitions(
     ordered_items: &[(usize, SegmentDrawItem)],
     shapes: &[DrawShape],
     chunk: &SegmentDrawChunkPlan,
+    batch_limits: ShapeBatchLimits,
 ) -> Result<Option<Vec<NativeSegmentFusionPartition>>, String> {
-    if let Some(budget) = native_segment_fusion_budget(ordered_items, shapes, chunk)? {
+    if let Some(budget) = native_segment_fusion_budget(ordered_items, shapes, chunk, batch_limits)?
+    {
         return Ok(Some(vec![NativeSegmentFusionPartition {
             chunk: chunk.clone(),
             budget,
@@ -9356,16 +9426,16 @@ fn native_segment_fusion_partitions(
                 ));
             };
             let gradient_stop_count = gradient_stop_count_for_shape(&shapes[shape_index]);
-            if gradient_stop_count > MAX_GRADIENT_STOPS {
+            if gradient_stop_count > batch_limits.max_gradient_stops {
                 return Ok(None);
             }
 
             let fits_shape_count =
-                current_budget.shape_count.saturating_add(1) <= MAX_SHAPES_PER_BATCH;
+                current_budget.shape_count.saturating_add(1) <= batch_limits.max_shapes_per_batch;
             let fits_gradient_count = current_budget
                 .gradient_stop_count
                 .saturating_add(gradient_stop_count)
-                <= MAX_GRADIENT_STOPS;
+                <= batch_limits.max_gradient_stops;
             if !fits_shape_count || !fits_gradient_count {
                 if run_start < item_cursor {
                     current.push(SegmentBatchPlan::Shape {
@@ -9406,12 +9476,13 @@ fn segment_batch_plan_at_cursor(
     shapes: &[DrawShape],
     images: &[ImageDraw],
     start: usize,
+    batch_limits: ShapeBatchLimits,
 ) -> Option<(SegmentBatchPlan, usize)> {
     match ordered_items[start].1 {
         SegmentDrawItem::Shape(index) => {
             let blend_mode = supported_blend_mode(shapes[index].blend_mode);
             let mut end = start + 1;
-            let shape_limit = (start + MAX_SHAPES_PER_BATCH).min(ordered_items.len());
+            let shape_limit = (start + batch_limits.max_shapes_per_batch).min(ordered_items.len());
             while end < shape_limit {
                 match ordered_items[end].1 {
                     SegmentDrawItem::Shape(next_index)
@@ -9570,6 +9641,7 @@ fn maybe_print_segment_diag(
     shapes: &[DrawShape],
     images: &[ImageDraw],
     counts: SegmentDiagCounts,
+    batch_limits: ShapeBatchLimits,
 ) {
     if std::env::var_os("CRANPOSE_SEGMENT_DIAG").is_none() {
         return;
@@ -9583,7 +9655,8 @@ fn maybe_print_segment_diag(
         .iter()
         .filter(|(_, item)| matches!(item, SegmentDrawItem::Shadow(_)))
         .count();
-    let commands: Vec<_> = SegmentCommandIter::new(ordered_items, shapes, images).collect();
+    let commands: Vec<_> =
+        SegmentCommandIter::new(ordered_items, shapes, images, batch_limits).collect();
     let draw_chunks = commands
         .iter()
         .filter(|command| matches!(command, SegmentRenderCommand::DrawChunk(_)))
@@ -9598,7 +9671,7 @@ fn maybe_print_segment_diag(
         let SegmentRenderCommand::DrawChunk(chunk) = command else {
             continue;
         };
-        match native_segment_fusion_partitions(ordered_items, shapes, chunk) {
+        match native_segment_fusion_partitions(ordered_items, shapes, chunk, batch_limits) {
             Ok(Some(partitions)) => native_partitions += partitions.len(),
             Ok(None) | Err(_) => native_unfused_chunks += 1,
         }
@@ -14310,7 +14383,13 @@ mod tests {
         let shapes = vec![test_shape(0, BlendMode::SrcOver)];
         let images = vec![test_image(1, BlendMode::DstOut)];
 
-        let commands: Vec<_> = SegmentCommandIter::new(&ordered_items, &shapes, &images).collect();
+        let commands: Vec<_> = SegmentCommandIter::new(
+            &ordered_items,
+            &shapes,
+            &images,
+            ShapeBatchLimits::desktop(),
+        )
+        .collect();
 
         assert_eq!(
             commands,
@@ -14342,7 +14421,13 @@ mod tests {
         let shapes = vec![test_shape(0, BlendMode::SrcOver)];
         let images = vec![test_image(2, BlendMode::SrcOver)];
 
-        let commands: Vec<_> = SegmentCommandIter::new(&ordered_items, &shapes, &images).collect();
+        let commands: Vec<_> = SegmentCommandIter::new(
+            &ordered_items,
+            &shapes,
+            &images,
+            ShapeBatchLimits::desktop(),
+        )
+        .collect();
 
         assert_eq!(
             commands,
@@ -14390,7 +14475,13 @@ mod tests {
 
         let culled =
             retain_renderable_shadow_items(&mut ordered_items, &shadow_draws, 100, 100, 1.0, 4096);
-        let commands: Vec<_> = SegmentCommandIter::new(&ordered_items, &shapes, &images).collect();
+        let commands: Vec<_> = SegmentCommandIter::new(
+            &ordered_items,
+            &shapes,
+            &images,
+            ShapeBatchLimits::desktop(),
+        )
+        .collect();
 
         assert_eq!(culled, 1);
         assert_eq!(
@@ -14437,8 +14528,33 @@ mod tests {
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
+    fn shape_batch_limits_follow_uniform_binding_size() {
+        // Desktop-class 64 KiB bindings keep the full compile-time capacities.
+        assert_eq!(
+            ShapeBatchLimits::desktop(),
+            ShapeBatchLimits {
+                max_shapes_per_batch: MAX_SHAPES_PER_BATCH,
+                max_gradient_stops: MAX_GRADIENT_STOPS,
+            }
+        );
+
+        // The 16 KiB downlevel/GLES minimum must shrink batches to fit:
+        // 16384 / 80-byte ShapeData = 204 shapes, 16384 / 32-byte stop = 512.
+        let downlevel = ShapeBatchLimits::for_uniform_binding_size(16384);
+        assert_eq!(downlevel.max_shapes_per_batch, 16384 / 80);
+        assert_eq!(downlevel.max_gradient_stops, 512.min(MAX_GRADIENT_STOPS));
+        assert!(downlevel.max_shapes_per_batch * std::mem::size_of::<ShapeData>() <= 16384);
+        assert!(downlevel.max_gradient_stops * std::mem::size_of::<GradientStop>() <= 16384);
+
+        // Degenerate limits must not produce zero-sized buffers.
+        let tiny = ShapeBatchLimits::for_uniform_binding_size(1);
+        assert_eq!(tiny.max_shapes_per_batch, 1);
+        assert_eq!(tiny.max_gradient_stops, 1);
+    }
+
+    #[test]
     fn native_shape_shader_source_uses_native_batch_limits() {
-        let source = shape_shader_source();
+        let source = shape_shader_source(ShapeBatchLimits::desktop());
 
         assert!(source.contains(&format!("array<ShapeData, {MAX_SHAPES_PER_BATCH}>")));
         assert!(source.contains(&format!("array<GradientStop, {MAX_GRADIENT_STOPS}>")));
@@ -14476,9 +14592,14 @@ mod tests {
             },
         ]);
 
-        let budget = native_segment_fusion_budget(&ordered_items, &shapes, &segment)
-            .expect("budget should be valid")
-            .expect("chunk should fit native fusion budget");
+        let budget = native_segment_fusion_budget(
+            &ordered_items,
+            &shapes,
+            &segment,
+            ShapeBatchLimits::desktop(),
+        )
+        .expect("budget should be valid")
+        .expect("chunk should fit native fusion budget");
 
         assert_eq!(
             budget,
@@ -14511,8 +14632,13 @@ mod tests {
             },
         ]);
 
-        let budget =
-            native_segment_fusion_budget(&ordered_items, &shapes, &segment).expect("valid plan");
+        let budget = native_segment_fusion_budget(
+            &ordered_items,
+            &shapes,
+            &segment,
+            ShapeBatchLimits::desktop(),
+        )
+        .expect("valid plan");
 
         assert_eq!(budget, None);
     }
@@ -14530,8 +14656,13 @@ mod tests {
             blend_mode: BlendMode::SrcOver,
         }]);
 
-        let budget =
-            native_segment_fusion_budget(&ordered_items, &shapes, &segment).expect("valid plan");
+        let budget = native_segment_fusion_budget(
+            &ordered_items,
+            &shapes,
+            &segment,
+            ShapeBatchLimits::desktop(),
+        )
+        .expect("valid plan");
 
         assert_eq!(budget, None);
     }
@@ -14558,9 +14689,14 @@ mod tests {
             },
         ]);
 
-        let partitions = native_segment_fusion_partitions(&ordered_items, &shapes, &segment)
-            .expect("valid plan")
-            .expect("overflowing segment should be partitionable");
+        let partitions = native_segment_fusion_partitions(
+            &ordered_items,
+            &shapes,
+            &segment,
+            ShapeBatchLimits::desktop(),
+        )
+        .expect("valid plan")
+        .expect("overflowing segment should be partitionable");
 
         assert_eq!(partitions.len(), 2);
         assert_eq!(
@@ -14614,9 +14750,14 @@ mod tests {
             blend_mode: BlendMode::SrcOver,
         }]);
 
-        let partitions = native_segment_fusion_partitions(&ordered_items, &shapes, &segment)
-            .expect("valid plan")
-            .expect("overflowing gradient segment should be partitionable");
+        let partitions = native_segment_fusion_partitions(
+            &ordered_items,
+            &shapes,
+            &segment,
+            ShapeBatchLimits::desktop(),
+        )
+        .expect("valid plan")
+        .expect("overflowing gradient segment should be partitionable");
 
         assert_eq!(partitions.len(), 2);
         assert_eq!(
@@ -14677,9 +14818,14 @@ mod tests {
             },
         ]);
 
-        let partitions = native_segment_fusion_partitions(&ordered_items, &shapes, &segment)
-            .expect("valid plan")
-            .expect("composites are drawable inside the native fused pass");
+        let partitions = native_segment_fusion_partitions(
+            &ordered_items,
+            &shapes,
+            &segment,
+            ShapeBatchLimits::desktop(),
+        )
+        .expect("valid plan")
+        .expect("composites are drawable inside the native fused pass");
 
         assert_eq!(
             partitions,
@@ -14728,9 +14874,14 @@ mod tests {
             },
         ]);
 
-        let partitions = native_segment_fusion_partitions(&ordered_items, &shapes, &segment)
-            .expect("valid plan")
-            .expect("overflowing segment should be partitionable");
+        let partitions = native_segment_fusion_partitions(
+            &ordered_items,
+            &shapes,
+            &segment,
+            ShapeBatchLimits::desktop(),
+        )
+        .expect("valid plan")
+        .expect("overflowing segment should be partitionable");
 
         assert_eq!(partitions.len(), 2);
         assert_eq!(
@@ -14771,7 +14922,13 @@ mod tests {
         ];
         let images = vec![test_image(1, BlendMode::SrcOver)];
 
-        let commands: Vec<_> = SegmentCommandIter::new(&ordered_items, &shapes, &images).collect();
+        let commands: Vec<_> = SegmentCommandIter::new(
+            &ordered_items,
+            &shapes,
+            &images,
+            ShapeBatchLimits::desktop(),
+        )
+        .collect();
 
         assert_eq!(
             commands,
@@ -14805,7 +14962,13 @@ mod tests {
             .collect();
         let images = Vec::new();
 
-        let commands: Vec<_> = SegmentCommandIter::new(&ordered_items, &shapes, &images).collect();
+        let commands: Vec<_> = SegmentCommandIter::new(
+            &ordered_items,
+            &shapes,
+            &images,
+            ShapeBatchLimits::desktop(),
+        )
+        .collect();
 
         assert_eq!(
             commands,
@@ -14835,7 +14998,13 @@ mod tests {
         let shapes = vec![test_shape(0, BlendMode::SrcOver)];
         let images = vec![test_image(2, BlendMode::SrcOver)];
 
-        let commands: Vec<_> = SegmentCommandIter::new(&ordered_items, &shapes, &images).collect();
+        let commands: Vec<_> = SegmentCommandIter::new(
+            &ordered_items,
+            &shapes,
+            &images,
+            ShapeBatchLimits::desktop(),
+        )
+        .collect();
 
         assert_eq!(
             commands,

--- a/crates/cranpose-render/wgpu/tests/device_limits.rs
+++ b/crates/cranpose-render/wgpu/tests/device_limits.rs
@@ -1,0 +1,143 @@
+//! Regression coverage for devices with small uniform-buffer binding limits.
+//!
+//! Android requests `wgpu::Limits::downlevel_defaults()`-shaped device limits,
+//! whose 16 KiB `max_uniform_buffer_binding_size` is below the desktop-sized
+//! shape batch uniform (768 shapes x 80 bytes = 60 KiB). The renderer must
+//! size its batch buffers and shader arrays from the actual device limits
+//! instead of compile-time desktop constants, or the very first
+//! "Shape Bind Group" raises a validation error and the app dies on launch.
+
+mod support;
+
+#[path = "../src/test_support.rs"]
+mod shared_test_support;
+
+use std::sync::Arc;
+
+use cranpose_render_common::graph::{
+    DrawPrimitiveNode, PrimitiveEntry, PrimitiveNode, PrimitivePhase, ProjectiveTransform,
+    RenderGraph, RenderNode,
+};
+use cranpose_render_common::Renderer;
+use cranpose_render_wgpu::WgpuRenderer;
+use cranpose_ui::AppContext;
+use cranpose_ui_graphics::{Brush, Color, DrawPrimitive, GraphicsLayer, Rect};
+
+fn downlevel_uniform_renderer() -> Result<(WgpuRenderer, Arc<wgpu::Device>), String> {
+    let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
+    instance_descriptor.backends = wgpu::Backends::all();
+    let instance = wgpu::Instance::new(instance_descriptor);
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::LowPower,
+        compatible_surface: None,
+        force_fallback_adapter: false,
+    }))
+    .map_err(|err| format!("adapter request failed: {err:?}"))?;
+    // The exact limits shape Android requests: downlevel defaults with texture
+    // resolution raised to the adapter's, leaving the 16 KiB uniform binding cap.
+    let required_limits = wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits());
+    assert_eq!(
+        required_limits.max_uniform_buffer_binding_size, 16384,
+        "test premise: downlevel uniform binding cap is 16 KiB"
+    );
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("Downlevel Uniform Limit Test Device"),
+        required_features: wgpu::Features::empty(),
+        required_limits,
+        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        memory_hints: wgpu::MemoryHints::default(),
+        trace: wgpu::Trace::Off,
+    }))
+    .map_err(|err| format!("device request failed: {err:?}"))?;
+
+    let device = Arc::new(device);
+    let mut renderer = WgpuRenderer::new(&[support::TEST_FONT]);
+    renderer.init_gpu(
+        Arc::clone(&device),
+        Arc::new(queue),
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+        adapter.get_info().backend,
+    );
+    Ok((renderer, device))
+}
+
+fn solid_rect(rect: Rect, color: Color) -> RenderNode {
+    RenderNode::Primitive(PrimitiveEntry {
+        phase: PrimitivePhase::BeforeChildren,
+        node: PrimitiveNode::Draw(DrawPrimitiveNode {
+            primitive: DrawPrimitive::Rect {
+                rect,
+                brush: Brush::solid(color),
+            },
+            clip: None,
+        }),
+    })
+}
+
+fn many_shapes_graph(shape_count: usize, width: f32, height: f32) -> RenderGraph {
+    let columns = 32usize;
+    let cell = width / columns as f32;
+    let children = (0..shape_count)
+        .map(|index| {
+            let col = index % columns;
+            let row = index / columns;
+            solid_rect(
+                Rect {
+                    x: col as f32 * cell,
+                    y: (row as f32 * 3.0) % height,
+                    width: cell.max(1.0) - 0.5,
+                    height: 2.5,
+                },
+                Color(
+                    0.2 + (index % 5) as f32 * 0.15,
+                    0.3,
+                    0.9 - (index % 7) as f32 * 0.1,
+                    1.0,
+                ),
+            )
+        })
+        .collect();
+    RenderGraph::new(shared_test_support::layer_node(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width,
+            height,
+        },
+        ProjectiveTransform::identity(),
+        GraphicsLayer::default(),
+        children,
+    ))
+}
+
+#[test]
+fn renderer_survives_downlevel_uniform_binding_limit() {
+    let _lock = support::gpu_test_lock();
+    let (mut renderer, device) = match downlevel_uniform_renderer() {
+        Ok(parts) => parts,
+        Err(err) => {
+            eprintln!("skipping downlevel uniform limit test, headless WGPU init failed: {err}");
+            return;
+        }
+    };
+
+    let error_scope = device.push_error_scope(wgpu::ErrorFilter::Validation);
+    // Force batch buffer/bind group creation plus a real multi-batch render:
+    // 300 shapes exceed the 16 KiB uniform budget (204 shapes) and must split.
+    let app_context = AppContext::new();
+    renderer.attach_app_context_services(&app_context);
+    renderer.scene_mut().graph = Some(many_shapes_graph(300, 256.0, 256.0));
+    let frame = app_context.enter(|| renderer.capture_frame(256, 256));
+    let validation = pollster::block_on(error_scope.pop());
+
+    assert!(
+        validation.is_none(),
+        "rendering on a 16 KiB uniform-binding device must not raise validation errors: {validation:?}"
+    );
+    let frame = frame.expect("capture should succeed on a downlevel-uniform device");
+    let index = ((128 * frame.width + 16) * 4) as usize;
+    assert!(
+        frame.pixels[index..index + 3].iter().any(|byte| *byte > 30),
+        "shapes should be visible in the captured frame"
+    );
+}

--- a/crates/cranpose-render/wgpu/tests/support.rs
+++ b/crates/cranpose-render/wgpu/tests/support.rs
@@ -13,6 +13,10 @@ pub static TEST_FONT: &[u8] = DEFAULT_SOFTWARE_TEXT_FONT_BYTES;
 
 static GPU_TEST_LOCK: Mutex<()> = Mutex::new(());
 
+pub fn gpu_test_lock() -> MutexGuard<'static, ()> {
+    lock_gpu_test()
+}
+
 fn lock_gpu_test() -> MutexGuard<'static, ()> {
     GPU_TEST_LOCK
         .lock()

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -417,7 +417,7 @@ fn create_android_gpu_resources(
     let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
         label: Some("Android Device"),
         required_features: wgpu::Features::empty(),
-        required_limits: wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
+        required_limits: crate::android_gpu_limits::android_device_limits(adapter.limits()),
         experimental_features: wgpu::ExperimentalFeatures::disabled(),
         memory_hints: wgpu::MemoryHints::default(),
         trace: wgpu::Trace::Off,

--- a/crates/cranpose/src/android_gpu_limits.rs
+++ b/crates/cranpose/src/android_gpu_limits.rs
@@ -1,0 +1,50 @@
+//! Device-limit policy for the Android GPU device request.
+//!
+//! Host-compilable so the policy stays unit-tested in regular CI even though
+//! the Android runtime module only builds for `target_os = "android"`.
+
+/// Device limits for the Android GPU device request.
+///
+/// `downlevel_defaults()` caps uniform bindings at 16 KiB and
+/// `using_resolution()` only raises texture limits, never buffer limits, while
+/// the renderer's desktop-sized shape batch uniform needs up to 60 KiB. Request
+/// the uniform binding size the adapter actually supports, up to the regular
+/// desktop default; the renderer derives its batch capacities from whatever is
+/// granted, so true 16 KiB-minimum devices still work with smaller batches.
+pub(crate) fn android_device_limits(adapter_limits: wgpu::Limits) -> wgpu::Limits {
+    let mut limits = wgpu::Limits::downlevel_defaults().using_resolution(adapter_limits.clone());
+    limits.max_uniform_buffer_binding_size = adapter_limits
+        .max_uniform_buffer_binding_size
+        .min(wgpu::Limits::default().max_uniform_buffer_binding_size);
+    limits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::android_device_limits;
+
+    #[test]
+    fn uniform_binding_size_follows_adapter_up_to_desktop_default() {
+        let desktop_binding = wgpu::Limits::default().max_uniform_buffer_binding_size;
+
+        // A capable adapter grants the full desktop-sized binding so shape
+        // batches keep their desktop capacity (the 0.1.13 Android crash was
+        // requesting only the 16 KiB downlevel cap on such devices).
+        let capable = android_device_limits(wgpu::Limits::default());
+        assert_eq!(capable.max_uniform_buffer_binding_size, desktop_binding);
+
+        // An adapter at the spec minimum is never asked for more than it has.
+        let mut minimal = wgpu::Limits::downlevel_defaults();
+        minimal.max_uniform_buffer_binding_size = 16384;
+        let limits = android_device_limits(minimal);
+        assert_eq!(limits.max_uniform_buffer_binding_size, 16384);
+
+        // Texture resolution still follows the adapter as before.
+        let big_textures = wgpu::Limits {
+            max_texture_dimension_2d: 16384,
+            ..wgpu::Limits::default()
+        };
+        let limits = android_device_limits(big_textures);
+        assert_eq!(limits.max_texture_dimension_2d, 16384);
+    }
+}

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -88,6 +88,9 @@ pub mod prelude {
 // Platform-specific runtime modules
 #[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
 pub mod android;
+#[cfg(feature = "renderer-wgpu")]
+#[cfg_attr(not(all(feature = "android", target_os = "android")), allow(dead_code))]
+pub(crate) mod android_gpu_limits;
 
 #[cfg(all(feature = "desktop", feature = "renderer-wgpu"))]
 pub mod desktop;


### PR DESCRIPTION
## Summary
- Android requested `downlevel_defaults()`-shaped device limits whose 16 KiB `max_uniform_buffer_binding_size` is below the desktop-sized shape batch uniform (768 shapes × 80 bytes = 60 KiB), so the very first "Shape Bind Group" raised a validation error and the app died on launch.
- The renderer now derives `ShapeBatchLimits` from the granted device limits and sizes its uniform buffers, WGSL array lengths, and batch partitioning from them — any spec-compliant device renders correctly with smaller batches.
- Android now requests the adapter's uniform binding size up to the desktop default (host-testable `android_gpu_limits` module), so capable devices keep full-size batches.
- Bumps version to 0.1.15.

## Test plan
- [x] New integration test `renderer_survives_downlevel_uniform_binding_limit`: renders 300 shapes on a real 16 KiB-binding device inside a validation error scope (reproduced the exact crash before the fix)
- [x] New unit tests: `shape_batch_limits_follow_uniform_binding_size`, `uniform_binding_size_follows_adapter_up_to_desktop_default`
- [x] `cargo test --workspace` (2575 passed), `cargo clippy --workspace --all-targets` (zero warnings), `cargo fmt`
- [x] wasm `apps/desktop-demo/build-web.sh`
- [x] Android `:app:assembleRelease`
- [x] Patched APK verified on emulator (AVD cranamp_api36) — app launches and renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)