### PR TITLE
Attach the current thread in with_android_activity_env

### DIFF
--- a/crates/cranpose/src/android_jni.rs
+++ b/crates/cranpose/src/android_jni.rs
@@ -22,7 +22,12 @@ where
 {
     let vm = JavaVM::singleton()
         .map_err(|error| format!("Android JavaVM is not available on android_main: {error}"))?;
-    vm.with_local_frame(16, |env| -> jni::errors::Result<Result<T, String>> {
+    // Attach the current thread to the JVM rather than assuming it already is:
+    // callers such as the audio engine reach this from worker threads they
+    // spawned, where `with_local_frame` would fail with `ThreadDetached`.
+    // `attach_current_thread` is cheap when the thread is already attached and
+    // pushes a local frame for us, so scoped local references are still released.
+    vm.attach_current_thread(|env| -> jni::errors::Result<Result<T, String>> {
         let raw_activity_global = app.activity_as_ptr() as jni::sys::jobject;
         // SAFETY: android-activity owns this unowned global Activity reference for the
         // AndroidApp lifetime. The cast borrows it without taking deletion ownership;

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -439,20 +439,19 @@ fn android_overlay_events_are_runtime_owned() {
 }
 
 #[test]
-fn android_activity_jni_uses_existing_android_main_attachment() {
+fn android_activity_jni_attaches_the_caller_without_recreating_the_vm() {
     let jni_source = crate_source("src/android_jni.rs");
 
     assert!(
         jni_source.contains("JavaVM::singleton()")
-            && jni_source.contains("vm.with_local_frame")
+            && jni_source.contains("vm.attach_current_thread")
             && jni_source.contains("env.as_cast_raw::<JObject>")
             && jni_source.contains("env.new_local_ref"),
-        "Android activity JNI access must use android-activity's existing android_main attachment and create a scoped local Activity reference from the global Activity handle"
+        "Android activity JNI access must reach the activity through the process JavaVM singleton and attach the calling thread (cheap when android_main is already attached, required when called from a worker thread such as audio playback opening a content:// document), creating a scoped local Activity reference from the global Activity handle"
     );
     assert!(
-        !jni_source.contains("attach_current_thread(|env|")
-            && !jni_source.contains("JavaVM::from_raw(app.vm_as_ptr"),
-        "Android activity JNI access must not reattach android_main or recreate JavaVM from AndroidApp"
+        !jni_source.contains("JavaVM::from_raw(app.vm_as_ptr"),
+        "Android activity JNI access must not recreate the JavaVM from AndroidApp; it must reuse the JavaVM singleton"
     );
 }
 


### PR DESCRIPTION
## Problem

`with_android_activity_env` resolves the activity through `JavaVM::with_local_frame`, which **requires the calling thread to already be attached to the JVM** — jni 0.22 returns `JniError::ThreadDetached` otherwise.

Callers that reach this from a thread they spawned themselves fail with `JNI call failed`. The concrete symptom: `open_content_uri` is called by an audio engine from a playback **worker thread**, so a picked `content://` document can never be opened off the UI thread — the track "loads" but never plays.

## Fix

Use `JavaVM::attach_current_thread` instead. It attaches the thread when needed (and is cheap when it already is — just a TLS check), and pushes a local frame so scoped local references are still released. One-line change, same callback shape.

Verified: `cargo check -p cranpose --target x86_64-linux-android --features android,renderer-wgpu` passes. The same attach mechanism is already used successfully elsewhere for JNI calls from worker threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)