### PR TITLE
Stream folder picks incrementally (cranpose 0.1.21)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cranpose"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "android-activity",
  "android_logger",
@@ -574,14 +574,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-animation"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "cranpose-core",
 ]
 
 [[package]]
 name = "cranpose-app-shell"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "arboard",
  "cranpose-core",
@@ -597,11 +597,11 @@ dependencies = [
 
 [[package]]
 name = "cranpose-assets"
-version = "0.1.20"
+version = "0.1.21"
 
 [[package]]
 name = "cranpose-core"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "ahash",
  "cranpose-macros",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-foundation"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-macros"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -638,14 +638,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-android"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "cranpose-ui-graphics",
 ]
 
 [[package]]
 name = "cranpose-platform-desktop-winit"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-web"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-common"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-pixels"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "cranpose-core",
  "cranpose-foundation",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-wgpu"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "bytemuck",
  "cranpose-app-shell",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-runtime-std"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "cranpose-core",
  "web-time",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-services"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-testing"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "cranpose",
  "cranpose-app-shell",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -770,14 +770,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui-graphics"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cranpose-ui-layout"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/samoylenkodmitry/cranpose"
@@ -39,25 +39,25 @@ categories = ["gui"]
 [workspace.dependencies]
 # Force android-activity to use native-activity feature across all workspace crates
 android-activity = { version = "0.6", features = ["native-activity"] }
-cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.20" }
-cranpose = { path = "crates/cranpose", version = "0.1.20", default-features = false }
-cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.20" }
-cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.20" }
-cranpose-core = { path = "crates/cranpose-core", version = "0.1.20" }
-cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.20" }
-cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.20" }
-cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.20" }
-cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.20" }
-cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.20" }
-cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.20" }
-cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.20" }
-cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.20" }
-cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.20" }
-cranpose-services = { path = "crates/cranpose-services", version = "0.1.20", default-features = false }
-cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.20" }
-cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.20" }
-cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.20" }
-cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.20" }
+cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.21" }
+cranpose = { path = "crates/cranpose", version = "0.1.21", default-features = false }
+cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.21" }
+cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.21" }
+cranpose-core = { path = "crates/cranpose-core", version = "0.1.21" }
+cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.21" }
+cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.21" }
+cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.21" }
+cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.21" }
+cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.21" }
+cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.21" }
+cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.21" }
+cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.21" }
+cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.21" }
+cranpose-services = { path = "crates/cranpose-services", version = "0.1.21", default-features = false }
+cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.21" }
+cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.21" }
+cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.21" }
+cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.21" }
 web-time = "1.1"
 
 [patch.crates-io]

--- a/apps/isolated-demo/Cargo.toml
+++ b/apps/isolated-demo/Cargo.toml
@@ -29,11 +29,11 @@ web = ["cranpose/web", "dep:wasm-bindgen", "dep:wasm-logger"]
 logging = ["dep:env_logger"]
 
 [dependencies]
-cranpose = { version = "0.1.20", default-features = false }
+cranpose = { version = "0.1.21", default-features = false }
 log = "0.4"
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-logger = { version = "0.2", optional = true }
-cranpose-core = "0.1.20"
+cranpose-core = "0.1.21"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = { version = "0.11", optional = true }

--- a/crates/cranpose-services/src/file_picker.rs
+++ b/crates/cranpose-services/src/file_picker.rs
@@ -135,6 +135,89 @@ pub trait PickedEntry {
 /// Shared handle to a [`PickedEntry`].
 pub type PickedEntryRef = Rc<dyn PickedEntry>;
 
+/// A folder being enumerated, yielding its files as the provider discovers
+/// them.
+///
+/// Walking a deep tree from a slow provider (cloud storage, a mounted WebDAV
+/// share) can take a long time, so the files are delivered incrementally rather
+/// than all at once: poll [`take_ready`] each frame to drain newly-found files,
+/// and [`is_finished`] to know when the walk is done. Callers can show the
+/// running count and start playing the first file without waiting for the rest.
+///
+/// [`take_ready`]: FolderStream::take_ready
+/// [`is_finished`]: FolderStream::is_finished
+pub trait FolderStream {
+    /// Files discovered since the previous call (drains the ready queue).
+    fn take_ready(&self) -> Vec<PickedEntryRef>;
+
+    /// Whether enumeration has finished (no more files will be discovered).
+    fn is_finished(&self) -> bool;
+
+    /// Takes the error that ended enumeration early, if any.
+    fn take_error(&self) -> Option<FilePickerError>;
+}
+
+/// Shared handle to a [`FolderStream`].
+pub type FolderStreamRef = Rc<dyn FolderStream>;
+
+/// Recursively collects every [`PickedKind::File`] under `entry`.
+fn collect_files(entry: PickedEntryRef) -> PickerFuture<Vec<PickedEntryRef>> {
+    Box::pin(async move {
+        match entry.kind() {
+            PickedKind::File => vec![entry],
+            PickedKind::Folder => {
+                let mut files = Vec::new();
+                if let Ok(children) = entry.list().await {
+                    for child in children {
+                        files.extend(collect_files(child).await);
+                    }
+                }
+                files
+            }
+        }
+    })
+}
+
+/// A [`FolderStream`] whose files were all gathered up front (the default for
+/// providers that enumerate eagerly, e.g. the local filesystem). It yields
+/// everything on the first poll and is immediately finished.
+struct ReadyFolderStream {
+    ready: RefCell<Vec<PickedEntryRef>>,
+}
+
+impl FolderStream for ReadyFolderStream {
+    fn take_ready(&self) -> Vec<PickedEntryRef> {
+        std::mem::take(&mut self.ready.borrow_mut())
+    }
+
+    fn is_finished(&self) -> bool {
+        true
+    }
+
+    fn take_error(&self) -> Option<FilePickerError> {
+        None
+    }
+}
+
+/// Wraps an eager [`FilePicker::pick_folder`] as a [`FolderStream`] by walking
+/// the whole tree up front. Used as the default for every backend that does not
+/// stream natively.
+fn eager_folder_stream(
+    folder: PickerFuture<Result<Option<PickedEntryRef>, FilePickerError>>,
+) -> PickerFuture<Result<Option<FolderStreamRef>, FilePickerError>> {
+    Box::pin(async move {
+        match folder.await? {
+            None => Ok(None),
+            Some(entry) => {
+                let files = collect_files(entry).await;
+                Ok(Some(Rc::new(ReadyFolderStream {
+                    ready: RefCell::new(files),
+                }) as FolderStreamRef))
+            }
+        }
+    })
+}
+
 /// Presents native file and folder pickers.
 pub trait FilePicker {
     /// Presents a single-file picker. Resolves to `None` if cancelled.
@@ -148,6 +231,22 @@ pub trait FilePicker {
         &self,
         options: FilePickerOptions,
     ) -> PickerFuture<Result<Option<PickedEntryRef>, FilePickerError>>;
+
+    /// Presents a folder picker and streams the tree's files as they are
+    /// discovered (see [`FolderStream`]).
+    ///
+    /// The default walks the picked folder eagerly via [`pick_folder`] and
+    /// yields every file at once; backends served by a slow provider (Android's
+    /// Storage Access Framework) override this to stream during the walk.
+    /// Resolves to `None` if cancelled.
+    ///
+    /// [`pick_folder`]: FilePicker::pick_folder
+    fn pick_folder_streaming(
+        &self,
+        options: FilePickerOptions,
+    ) -> PickerFuture<Result<Option<FolderStreamRef>, FilePickerError>> {
+        eager_folder_stream(self.pick_folder(options))
+    }
 }
 
 /// Shared handle to a [`FilePicker`].
@@ -198,6 +297,16 @@ impl FilePicker for PlatformFilePicker {
             return picker.pick_folder(options);
         }
         builtin_pick(options, PickedKind::Folder)
+    }
+
+    fn pick_folder_streaming(
+        &self,
+        options: FilePickerOptions,
+    ) -> PickerFuture<Result<Option<FolderStreamRef>, FilePickerError>> {
+        if let Some(picker) = registered_platform_file_picker() {
+            return picker.pick_folder_streaming(options);
+        }
+        eager_folder_stream(builtin_pick(options, PickedKind::Folder))
     }
 }
 

--- a/crates/cranpose-services/src/lib.rs
+++ b/crates/cranpose-services/src/lib.rs
@@ -12,8 +12,8 @@ pub mod uri_handler;
 
 pub use file_picker::{
     clear_platform_file_picker, default_file_picker, local_file_picker, set_platform_file_picker,
-    FileFilter, FilePicker, FilePickerError, FilePickerOptions, FilePickerRef, PickedEntry,
-    PickedEntryRef, PickedKind, PickerFuture, ProvideFilePicker,
+    FileFilter, FilePicker, FilePickerError, FilePickerOptions, FilePickerRef, FolderStream,
+    FolderStreamRef, PickedEntry, PickedEntryRef, PickedKind, PickerFuture, ProvideFilePicker,
 };
 pub use http::{
     default_http_client, local_http_client, map_ordered_concurrent, HttpClient, HttpClientRef,

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeFilePickerActivity.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeFilePickerActivity.java
@@ -16,26 +16,48 @@ import java.io.IOException;
  *
  * <p>Apps that want {@code cranpose_services::file_picker} on Android declare
  * this class (or a subclass) as their launcher activity. The Rust backend calls
- * {@link #cranposePickFile(long)} / {@link #cranposePickFolder(long)} over JNI;
- * the chosen {@code content://} document URIs are reported back through
- * {@link #nativeOnFilePicked} <em>without copying any data</em>. A picked file is
- * later opened on demand through {@link #cranposeOpenUri(String)}, which hands
- * the provider's descriptor to Rust, so even a multi-gigabyte folder is selected
- * instantly and each file is streamed only when it is actually read.
+ * {@link #cranposePickFile(long)} / {@link #cranposePickFolder(long)} /
+ * {@link #cranposePickFolderStreaming(long)} over JNI; the chosen
+ * {@code content://} document URIs are reported back <em>without copying any
+ * data</em>. A picked file is later opened on demand through
+ * {@link #cranposeOpenUri(String)}, which hands the provider's descriptor to
+ * Rust, so even a multi-gigabyte folder is selected instantly and each file is
+ * streamed only when it is actually read.
  *
  * <p>The folder picker uses {@code ACTION_OPEN_DOCUMENT_TREE}, so the user can
  * choose a folder served by any document provider the device exposes — local
  * storage, cloud, or a mounted WebDAV share — rather than a private path.
+ *
+ * <p>{@link #cranposePickFolderStreaming(long)} resolves the selection at once
+ * and then walks the tree on a worker thread, reporting files in batches as it
+ * finds them ({@link #nativeOnFolderEntries}). A slow provider (a mounted WebDAV
+ * share with thousands of files) therefore no longer freezes the app: the first
+ * tracks appear and can be played while the rest keep streaming in.
  */
 public class CranposeFilePickerActivity extends NativeActivity {
     private static final int REQUEST_BASE = 0x0C9A0000;
+    private static final int FLAG_FOLDER = 1;
+    private static final int FLAG_STREAMING = 2;
 
     private long pendingToken;
+
+    /** Number of files to accumulate before flushing a streaming batch. */
+    private static final int FOLDER_BATCH_SIZE = 32;
 
     /** Implemented in the Rust cdylib. {@code entries} is newline-separated
      * {@code uri\tname} rows (one for a file, every descendant for a folder). */
     private static native void nativeOnFilePicked(
             long token, boolean folder, String entries, boolean cancelled, String error);
+
+    /** A folder was selected (or cancelled/failed); streaming may now begin. */
+    private static native void nativeOnFolderPicked(long token, boolean cancelled, String error);
+
+    /** A streaming batch of discovered files ({@code uri\tname} rows). Returns
+     * {@code false} once the consumer has gone away, so enumeration can stop. */
+    private static native boolean nativeOnFolderEntries(long token, String entries);
+
+    /** Folder enumeration finished, with an optional error. */
+    private static native void nativeOnFolderFinished(long token, String error);
 
     /** Opens the document picker for a single file. Called from Rust over JNI. */
     public void cranposePickFile(long token) {
@@ -43,14 +65,23 @@ public class CranposeFilePickerActivity extends NativeActivity {
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("*/*");
-        launch(intent, token, false);
+        launch(intent, token, 0);
     }
 
-    /** Opens the document tree picker for a folder. Called from Rust over JNI. */
+    /** Opens the document tree picker for a folder, delivered all at once.
+     * Called from Rust over JNI. */
     public void cranposePickFolder(long token) {
         pendingToken = token;
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
-        launch(intent, token, true);
+        launch(intent, token, FLAG_FOLDER);
+    }
+
+    /** Opens the document tree picker for a folder whose files stream back as
+     * they are discovered. Called from Rust over JNI. */
+    public void cranposePickFolderStreaming(long token) {
+        pendingToken = token;
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+        launch(intent, token, FLAG_FOLDER | FLAG_STREAMING);
     }
 
     /**
@@ -67,16 +98,16 @@ public class CranposeFilePickerActivity extends NativeActivity {
         return descriptor.detachFd();
     }
 
-    private void launch(Intent intent, long token, boolean folder) {
+    private void launch(Intent intent, long token, int flags) {
         try {
-            startActivityForResult(intent, requestCode(token, folder));
+            startActivityForResult(intent, REQUEST_BASE | flags);
         } catch (Exception error) {
-            nativeOnFilePicked(token, folder, null, false, error.toString());
+            if ((flags & FLAG_STREAMING) != 0) {
+                nativeOnFolderPicked(token, false, error.toString());
+            } else {
+                nativeOnFilePicked(token, (flags & FLAG_FOLDER) != 0, null, false, error.toString());
+            }
         }
-    }
-
-    private int requestCode(long token, boolean folder) {
-        return REQUEST_BASE | (folder ? 1 : 0);
     }
 
     @Override
@@ -86,8 +117,35 @@ public class CranposeFilePickerActivity extends NativeActivity {
             return;
         }
         final long token = pendingToken;
-        final boolean folder = (requestCode & 1) != 0;
-        if (resultCode != RESULT_OK || data == null || data.getData() == null) {
+        final int flags = requestCode & 0x0000FFFF;
+        final boolean folder = (flags & FLAG_FOLDER) != 0;
+        final boolean streaming = (flags & FLAG_STREAMING) != 0;
+        final boolean ok = resultCode == RESULT_OK && data != null && data.getData() != null;
+
+        if (streaming) {
+            if (!ok) {
+                nativeOnFolderPicked(token, true, null);
+                return;
+            }
+            final Uri uri = data.getData();
+            // Resolve the selection immediately so the UI stays responsive, then
+            // walk the (possibly slow) tree off the main thread, streaming files
+            // back in batches. This is what keeps a huge WebDAV folder from
+            // freezing the app — the first tracks play while the rest arrive.
+            nativeOnFolderPicked(token, false, null);
+            new Thread(() -> {
+                String error = null;
+                try {
+                    streamTree(uri, token);
+                } catch (Exception failure) {
+                    error = failure.toString();
+                }
+                nativeOnFolderFinished(token, error);
+            }, "cranpose-folder-stream").start();
+            return;
+        }
+
+        if (!ok) {
             nativeOnFilePicked(token, folder, null, true, null);
             return;
         }
@@ -145,6 +203,95 @@ public class CranposeFilePickerActivity extends NativeActivity {
                     out.append(childUri.toString()).append('\t').append(sanitize(name));
                 }
             }
+        }
+    }
+
+    /** Walks {@code treeUri} depth-first, flushing files to Rust in batches as
+     * they are found. Stops early if the consumer drops the stream. */
+    private void streamTree(Uri treeUri, long token) {
+        try {
+            getContentResolver().takePersistableUriPermission(
+                    treeUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        } catch (SecurityException ignored) {
+        }
+        Batch batch = new Batch(token);
+        collectTreeStreaming(treeUri, DocumentsContract.getTreeDocumentId(treeUri), batch);
+        batch.flush();
+    }
+
+    /** Returns {@code false} once the consumer has gone away, so recursion can
+     * unwind without finishing the walk. */
+    private boolean collectTreeStreaming(Uri treeUri, String documentId, Batch batch) {
+        Uri childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, documentId);
+        String[] columns = {
+                DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                DocumentsContract.Document.COLUMN_MIME_TYPE,
+        };
+        try (Cursor cursor = getContentResolver().query(childrenUri, columns, null, null, null)) {
+            if (cursor == null) {
+                return !batch.stopped();
+            }
+            while (cursor.moveToNext()) {
+                if (batch.stopped()) {
+                    return false;
+                }
+                String childId = cursor.getString(0);
+                String name = cursor.getString(1);
+                String mime = cursor.getString(2);
+                if (DocumentsContract.Document.MIME_TYPE_DIR.equals(mime)) {
+                    if (!collectTreeStreaming(treeUri, childId, batch)) {
+                        return false;
+                    }
+                } else {
+                    Uri childUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, childId);
+                    batch.add(childUri, name);
+                }
+            }
+        }
+        return !batch.stopped();
+    }
+
+    /** Accumulates {@code uri\tname} rows and flushes them to Rust every
+     * {@link #FOLDER_BATCH_SIZE} files, recording when the consumer stops. */
+    private final class Batch {
+        private final long token;
+        private final StringBuilder rows = new StringBuilder();
+        private int count;
+        private boolean stopped;
+
+        Batch(long token) {
+            this.token = token;
+        }
+
+        void add(Uri uri, String name) {
+            if (stopped) {
+                return;
+            }
+            if (rows.length() > 0) {
+                rows.append('\n');
+            }
+            rows.append(uri.toString()).append('\t').append(sanitize(name));
+            count++;
+            if (count >= FOLDER_BATCH_SIZE) {
+                flush();
+            }
+        }
+
+        void flush() {
+            if (stopped || rows.length() == 0) {
+                return;
+            }
+            boolean keepGoing = nativeOnFolderEntries(token, rows.toString());
+            rows.setLength(0);
+            count = 0;
+            if (!keepGoing) {
+                stopped = true;
+            }
+        }
+
+        boolean stopped() {
+            return stopped;
         }
     }
 

--- a/crates/cranpose/src/android_file_picker.rs
+++ b/crates/cranpose/src/android_file_picker.rs
@@ -17,8 +17,8 @@
 #![allow(unsafe_code)]
 
 use cranpose_services::{
-    set_platform_file_picker, FilePicker, FilePickerError, FilePickerOptions, PickedEntry,
-    PickedEntryRef, PickedKind, PickerFuture,
+    set_platform_file_picker, FilePicker, FilePickerError, FilePickerOptions, FolderStream,
+    FolderStreamRef, PickedEntry, PickedEntryRef, PickedKind, PickerFuture,
 };
 use jni::objects::{JClass, JObject, JString, JValue};
 use jni::sys::{jboolean, jlong};
@@ -80,6 +80,25 @@ impl FilePicker for AndroidFilePicker {
     fn pick_folder(&self, _options: FilePickerOptions) -> PickerFuture<PickResult> {
         present(true)
     }
+
+    fn pick_folder_streaming(
+        &self,
+        _options: FilePickerOptions,
+    ) -> PickerFuture<Result<Option<FolderStreamRef>, FilePickerError>> {
+        present_folder_stream()
+    }
+}
+
+/// Which Android picker entry point to launch for a request.
+#[derive(Clone, Copy)]
+enum PickKind {
+    /// `cranposePickFile` — a single document.
+    File,
+    /// `cranposePickFolder` — a tree, enumerated fully before delivery.
+    Folder,
+    /// `cranposePickFolderStreaming` — a tree whose files stream in as the
+    /// provider discovers them.
+    FolderStreaming,
 }
 
 fn present(folder: bool) -> PickerFuture<PickResult> {
@@ -89,7 +108,12 @@ fn present(folder: bool) -> PickerFuture<PickResult> {
         .expect("file picker registry poisoned")
         .insert(token, Pending::default());
 
-    if let Err(error) = call_activity(folder, token) {
+    let kind = if folder {
+        PickKind::Folder
+    } else {
+        PickKind::File
+    };
+    if let Err(error) = call_activity(kind, token) {
         pending()
             .lock()
             .expect("file picker registry poisoned")
@@ -100,15 +124,15 @@ fn present(folder: bool) -> PickerFuture<PickResult> {
     Box::pin(PickFuture { token })
 }
 
-fn call_activity(folder: bool, token: i64) -> Result<(), String> {
+fn call_activity(kind: PickKind, token: i64) -> Result<(), String> {
     let app = APP
         .get()
         .ok_or_else(|| "Android file picker was not registered".to_string())?;
     crate::android_jni::with_android_activity_env(app, |env, activity| {
-        let method = if folder {
-            jni_str!("cranposePickFolder")
-        } else {
-            jni_str!("cranposePickFile")
+        let method = match kind {
+            PickKind::File => jni_str!("cranposePickFile"),
+            PickKind::Folder => jni_str!("cranposePickFolder"),
+            PickKind::FolderStreaming => jni_str!("cranposePickFolderStreaming"),
         };
         env.call_method(&activity, method, jni_sig!("(J)V"), &[JValue::Long(token)])
             .map(|_| ())
@@ -246,6 +270,214 @@ impl PickedEntry for FolderEntry {
     fn list(&self) -> PickerFuture<Result<Vec<PickedEntryRef>, FilePickerError>> {
         let children = self.children.clone();
         Box::pin(async move { Ok(children) })
+    }
+}
+
+// ---- Streaming folder discovery ------------------------------------------
+//
+// `enumerateTree` on the Java side walks the picked tree on a worker thread and
+// reports audio files in batches as it finds them. That matters for a slow
+// provider (a mounted WebDAV share): instead of blocking until the whole tree
+// is walked, the folder selection resolves immediately and files arrive
+// incrementally, so the app can show progress and play the first track at once.
+
+/// Per-token state for a streaming folder pick, written by the Java callbacks
+/// and drained by the [`AndroidFolderStream`] on the UI thread.
+#[derive(Default)]
+struct FolderStreaming {
+    documents: Vec<PickedDocument>,
+    picked: bool,
+    cancelled: bool,
+    pick_error: Option<String>,
+    finished: bool,
+    stream_error: Option<String>,
+    waker: Option<Waker>,
+}
+
+fn folder_streaming() -> &'static Mutex<HashMap<i64, FolderStreaming>> {
+    static FOLDER_STREAMING: OnceLock<Mutex<HashMap<i64, FolderStreaming>>> = OnceLock::new();
+    FOLDER_STREAMING.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn present_folder_stream() -> PickerFuture<Result<Option<FolderStreamRef>, FilePickerError>> {
+    let token = NEXT_TOKEN.fetch_add(1, Ordering::Relaxed);
+    folder_streaming()
+        .lock()
+        .expect("folder picker registry poisoned")
+        .insert(token, FolderStreaming::default());
+
+    if let Err(error) = call_activity(PickKind::FolderStreaming, token) {
+        folder_streaming()
+            .lock()
+            .expect("folder picker registry poisoned")
+            .remove(&token);
+        return Box::pin(async move { Err(FilePickerError::Failed(error)) });
+    }
+
+    Box::pin(FolderPickFuture { token })
+}
+
+/// Resolves once the user has selected (or cancelled) the folder; the returned
+/// [`AndroidFolderStream`] then yields files as enumeration continues.
+struct FolderPickFuture {
+    token: i64,
+}
+
+impl Future for FolderPickFuture {
+    type Output = Result<Option<FolderStreamRef>, FilePickerError>;
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut registry = folder_streaming()
+            .lock()
+            .expect("folder picker registry poisoned");
+        let Some(slot) = registry.get_mut(&self.token) else {
+            return Poll::Ready(Ok(None));
+        };
+        if slot.cancelled {
+            registry.remove(&self.token);
+            return Poll::Ready(Ok(None));
+        }
+        if let Some(error) = slot.pick_error.take() {
+            registry.remove(&self.token);
+            return Poll::Ready(Err(FilePickerError::Failed(error)));
+        }
+        if slot.picked {
+            return Poll::Ready(Ok(Some(
+                Rc::new(AndroidFolderStream { token: self.token }) as FolderStreamRef
+            )));
+        }
+        slot.waker = Some(context.waker().clone());
+        Poll::Pending
+    }
+}
+
+/// Streams files discovered under a picked folder. Dropping it discards the
+/// registry slot (the Java enumeration thread checks the slot and stops).
+struct AndroidFolderStream {
+    token: i64,
+}
+
+impl FolderStream for AndroidFolderStream {
+    fn take_ready(&self) -> Vec<PickedEntryRef> {
+        let mut registry = folder_streaming()
+            .lock()
+            .expect("folder picker registry poisoned");
+        let Some(slot) = registry.get_mut(&self.token) else {
+            return Vec::new();
+        };
+        std::mem::take(&mut slot.documents)
+            .into_iter()
+            .map(|document| Rc::new(UriEntry::from(document)) as PickedEntryRef)
+            .collect()
+    }
+
+    fn is_finished(&self) -> bool {
+        let registry = folder_streaming()
+            .lock()
+            .expect("folder picker registry poisoned");
+        registry
+            .get(&self.token)
+            .map(|slot| slot.finished && slot.documents.is_empty())
+            .unwrap_or(true)
+    }
+
+    fn take_error(&self) -> Option<FilePickerError> {
+        let mut registry = folder_streaming()
+            .lock()
+            .expect("folder picker registry poisoned");
+        registry
+            .get_mut(&self.token)
+            .and_then(|slot| slot.stream_error.take())
+            .map(FilePickerError::Failed)
+    }
+}
+
+impl Drop for AndroidFolderStream {
+    fn drop(&mut self) {
+        folder_streaming()
+            .lock()
+            .expect("folder picker registry poisoned")
+            .remove(&self.token);
+    }
+}
+
+/// Java callback: the user picked a folder (or cancelled/failed). Resolves the
+/// [`FolderPickFuture`] so streaming can begin.
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeFilePickerActivity_nativeOnFolderPicked<
+    'local,
+>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    token: jlong,
+    cancelled: jboolean,
+    error: JString<'local>,
+) {
+    let error = read_optional_jstring(&mut env, error);
+    let mut registry = folder_streaming()
+        .lock()
+        .expect("folder picker registry poisoned");
+    if let Some(slot) = registry.get_mut(&token) {
+        if cancelled {
+            slot.cancelled = true;
+        } else if let Some(error) = error {
+            slot.pick_error = Some(error);
+        } else {
+            slot.picked = true;
+        }
+        if let Some(waker) = slot.waker.take() {
+            waker.wake();
+        }
+    }
+}
+
+/// Java callback: a batch of newly-discovered files (`uri\tname` rows). Returns
+/// `false` (0) once the consumer has dropped the stream, so the Java
+/// enumeration thread can stop walking a huge tree it no longer needs.
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeFilePickerActivity_nativeOnFolderEntries<
+    'local,
+>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    token: jlong,
+    entries: JString<'local>,
+) -> jboolean {
+    let documents = read_optional_jstring(&mut env, entries)
+        .map(parse_documents)
+        .unwrap_or_default();
+    let mut registry = folder_streaming()
+        .lock()
+        .expect("folder picker registry poisoned");
+    match registry.get_mut(&token) {
+        Some(slot) => {
+            slot.documents.extend(documents);
+            true
+        }
+        None => false,
+    }
+}
+
+/// Java callback: enumeration finished (with an optional error).
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeFilePickerActivity_nativeOnFolderFinished<
+    'local,
+>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    token: jlong,
+    error: JString<'local>,
+) {
+    let error = read_optional_jstring(&mut env, error);
+    let mut registry = folder_streaming()
+        .lock()
+        .expect("folder picker registry poisoned");
+    if let Some(slot) = registry.get_mut(&token) {
+        slot.finished = true;
+        slot.stream_error = error;
     }
 }
 


### PR DESCRIPTION
## What

Walking a deep tree from a slow document provider (cloud storage, a mounted WebDAV share) could take a long time, and the folder picker blocked until the **whole** tree was enumerated — which froze the app on large folders. This adds a streaming folder API so files arrive as the provider discovers them.

### `cranpose-services`
- New `FolderStream` trait (`take_ready` / `is_finished` / `take_error`) and `FolderStreamRef`.
- New `FilePicker::pick_folder_streaming`, with a **default** implementation that walks the picked folder eagerly and yields everything at once — so every existing backend (desktop, web, iOS) keeps working unchanged.

### `cranpose` (Android / SAF)
- Overrides `pick_folder_streaming` to enumerate the picked tree on a worker thread, reporting files in batches as they are found.
- New Java entry point `cranposePickFolderStreaming` resolves the folder selection immediately, then `nativeOnFolderEntries` streams `uri\tname` rows. The callback returns `false` once the consumer drops the stream, so a huge tree the app no longer needs stops being walked.
- Selection no longer blocks the UI; the first tracks are available right away.

### Release
- Bumps the workspace to **0.1.21**.

## Validation
- `cargo check -p cranpose --target x86_64-linux-android --features android,renderer-wgpu` ✅
- `cargo test -p cranpose-services` ✅ (19 passed)
- End-to-end on an Android emulator via the downstream Cranamp app: picked a 60-file folder, files streamed into the playlist incrementally, the first track played immediately, the UI never froze, and all 60 tracks loaded with no drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)