### PR TITLE
Resilient folder walk for flaky providers (cranpose 0.1.22)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cranpose"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "android-activity",
  "android_logger",
@@ -574,14 +574,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-animation"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "cranpose-core",
 ]
 
 [[package]]
 name = "cranpose-app-shell"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "arboard",
  "cranpose-core",
@@ -597,11 +597,11 @@ dependencies = [
 
 [[package]]
 name = "cranpose-assets"
-version = "0.1.21"
+version = "0.1.22"
 
 [[package]]
 name = "cranpose-core"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "ahash",
  "cranpose-macros",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-foundation"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-macros"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -638,14 +638,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-android"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "cranpose-ui-graphics",
 ]
 
 [[package]]
 name = "cranpose-platform-desktop-winit"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-web"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-common"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-pixels"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "cranpose-core",
  "cranpose-foundation",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-wgpu"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "bytemuck",
  "cranpose-app-shell",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-runtime-std"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "cranpose-core",
  "web-time",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-services"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-testing"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "cranpose",
  "cranpose-app-shell",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -770,14 +770,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui-graphics"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cranpose-ui-layout"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/samoylenkodmitry/cranpose"
@@ -39,25 +39,25 @@ categories = ["gui"]
 [workspace.dependencies]
 # Force android-activity to use native-activity feature across all workspace crates
 android-activity = { version = "0.6", features = ["native-activity"] }
-cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.21" }
-cranpose = { path = "crates/cranpose", version = "0.1.21", default-features = false }
-cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.21" }
-cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.21" }
-cranpose-core = { path = "crates/cranpose-core", version = "0.1.21" }
-cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.21" }
-cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.21" }
-cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.21" }
-cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.21" }
-cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.21" }
-cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.21" }
-cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.21" }
-cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.21" }
-cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.21" }
-cranpose-services = { path = "crates/cranpose-services", version = "0.1.21", default-features = false }
-cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.21" }
-cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.21" }
-cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.21" }
-cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.21" }
+cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.22" }
+cranpose = { path = "crates/cranpose", version = "0.1.22", default-features = false }
+cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.22" }
+cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.22" }
+cranpose-core = { path = "crates/cranpose-core", version = "0.1.22" }
+cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.22" }
+cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.22" }
+cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.22" }
+cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.22" }
+cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.22" }
+cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.22" }
+cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.22" }
+cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.22" }
+cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.22" }
+cranpose-services = { path = "crates/cranpose-services", version = "0.1.22", default-features = false }
+cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.22" }
+cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.22" }
+cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.22" }
+cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.22" }
 web-time = "1.1"
 
 [patch.crates-io]

--- a/apps/isolated-demo/Cargo.toml
+++ b/apps/isolated-demo/Cargo.toml
@@ -29,11 +29,11 @@ web = ["cranpose/web", "dep:wasm-bindgen", "dep:wasm-logger"]
 logging = ["dep:env_logger"]
 
 [dependencies]
-cranpose = { version = "0.1.21", default-features = false }
+cranpose = { version = "0.1.22", default-features = false }
 log = "0.4"
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-logger = { version = "0.2", optional = true }
-cranpose-core = "0.1.21"
+cranpose-core = "0.1.22"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = { version = "0.11", optional = true }

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeFilePickerActivity.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeFilePickerActivity.java
@@ -44,6 +44,13 @@ public class CranposeFilePickerActivity extends NativeActivity {
     /** Number of files to accumulate before flushing a streaming batch. */
     private static final int FOLDER_BATCH_SIZE = 32;
 
+    /** How many times to try listing a folder before skipping it (slow cloud /
+     * WebDAV shares fail transiently). */
+    private static final int FOLDER_QUERY_ATTEMPTS = 4;
+
+    /** Base backoff between folder-listing retries, in ms (grows per attempt). */
+    private static final int FOLDER_QUERY_RETRY_MS = 250;
+
     /** Implemented in the Rust cdylib. {@code entries} is newline-separated
      * {@code uri\tname} rows (one for a file, every descendant for a folder). */
     private static native void nativeOnFilePicked(
@@ -180,12 +187,10 @@ public class CranposeFilePickerActivity extends NativeActivity {
 
     private void collectTree(Uri treeUri, String documentId, StringBuilder out) {
         Uri childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, documentId);
-        String[] columns = {
-                DocumentsContract.Document.COLUMN_DOCUMENT_ID,
-                DocumentsContract.Document.COLUMN_DISPLAY_NAME,
-                DocumentsContract.Document.COLUMN_MIME_TYPE,
-        };
-        try (Cursor cursor = getContentResolver().query(childrenUri, columns, null, null, null)) {
+        // Same resilience as the streaming walk: retry a slow provider and skip a
+        // folder that stays unreadable rather than aborting the whole enumeration.
+        Cursor cursor = queryChildrenWithRetry(childrenUri);
+        try {
             if (cursor == null) {
                 return;
             }
@@ -202,6 +207,10 @@ public class CranposeFilePickerActivity extends NativeActivity {
                     }
                     out.append(childUri.toString()).append('\t').append(sanitize(name));
                 }
+            }
+        } finally {
+            if (cursor != null) {
+                cursor.close();
             }
         }
     }
@@ -222,16 +231,20 @@ public class CranposeFilePickerActivity extends NativeActivity {
     /** Returns {@code false} once the consumer has gone away, so recursion can
      * unwind without finishing the walk. */
     private boolean collectTreeStreaming(Uri treeUri, String documentId, Batch batch) {
+        if (batch.stopped()) {
+            return false;
+        }
         Uri childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, documentId);
-        String[] columns = {
-                DocumentsContract.Document.COLUMN_DOCUMENT_ID,
-                DocumentsContract.Document.COLUMN_DISPLAY_NAME,
-                DocumentsContract.Document.COLUMN_MIME_TYPE,
-        };
-        try (Cursor cursor = getContentResolver().query(childrenUri, columns, null, null, null)) {
-            if (cursor == null) {
-                return !batch.stopped();
-            }
+        // Query this folder with retries. A slow document provider (a mounted
+        // WebDAV / cloud share) transiently fails requests; without this, one
+        // failed query would throw and abort the ENTIRE walk, so a big library
+        // over a flaky link could end up adding nothing. On persistent failure we
+        // skip just this folder and let the rest of the tree keep streaming in.
+        Cursor cursor = queryChildrenWithRetry(childrenUri);
+        if (cursor == null) {
+            return !batch.stopped();
+        }
+        try {
             while (cursor.moveToNext()) {
                 if (batch.stopped()) {
                     return false;
@@ -248,8 +261,41 @@ public class CranposeFilePickerActivity extends NativeActivity {
                     batch.add(childUri, name);
                 }
             }
+        } finally {
+            cursor.close();
         }
         return !batch.stopped();
+    }
+
+    /** Lists a folder's children, retrying transient provider failures (a slow
+     * cloud/WebDAV share throws intermittently). Returns {@code null} if the
+     * folder cannot be read after {@link #FOLDER_QUERY_ATTEMPTS} tries, so the
+     * caller skips just that folder instead of aborting the whole walk. */
+    private Cursor queryChildrenWithRetry(Uri childrenUri) {
+        String[] columns = {
+                DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                DocumentsContract.Document.COLUMN_MIME_TYPE,
+        };
+        for (int attempt = 1; ; attempt++) {
+            try {
+                return getContentResolver().query(childrenUri, columns, null, null, null);
+            } catch (Exception error) {
+                if (attempt >= FOLDER_QUERY_ATTEMPTS) {
+                    android.util.Log.w(
+                            "Cranpose",
+                            "skipping unreadable folder after " + attempt + " tries: "
+                                    + childrenUri + " (" + error + ")");
+                    return null;
+                }
+                try {
+                    Thread.sleep((long) FOLDER_QUERY_RETRY_MS * attempt);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    return null;
+                }
+            }
+        }
     }
 
     /** Accumulates {@code uri\tname} rows and flushes them to Rust every


### PR DESCRIPTION
## Folder picks added nothing over a flaky/slow provider

Picking a folder served by a slow document provider — a mounted **WebDAV / cloud share over a high-latency link (e.g. Tailscale Taildrive)** — could add **nothing**. The recursive tree walk lists one folder per `ContentResolver.query`; if a single listing **threw** (a transient network failure, common over a slow relay), the exception unwound the whole recursion and the **entire scan was abandoned**. On a fast/local provider this never happens, which is why it only bit large libraries over slow links.

## Fix

Both the streaming (`collectTreeStreaming`) and eager (`collectTree`) walks now list each folder through a new `queryChildrenWithRetry`, which:
- retries a transient failure up to `FOLDER_QUERY_ATTEMPTS` (4) times with linear backoff, and
- if the folder still can't be read, **logs and skips just that folder** instead of aborting the whole walk.

A flaky link now yields everything that responds rather than nothing.

## Validation
Reproduced the full path on an emulator with **RoundSync** (rclone SAF provider) → WebDAV serving the real 2095-track library: cranamp discovers **2095/2095** and starts playback. The resilient build keeps that happy path intact (no regression); the retry/skip path activates only when a folder listing persistently fails.

Bumps the workspace to **0.1.22**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)