### PR TITLE
Fix DeX/freeform touch offset and wait out loading folder cursors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cranpose"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "android-activity",
  "android_logger",
@@ -574,14 +574,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-animation"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "cranpose-core",
 ]
 
 [[package]]
 name = "cranpose-app-shell"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "arboard",
  "cranpose-core",
@@ -597,11 +597,11 @@ dependencies = [
 
 [[package]]
 name = "cranpose-assets"
-version = "0.1.22"
+version = "0.1.23"
 
 [[package]]
 name = "cranpose-core"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "ahash",
  "cranpose-macros",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-foundation"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-macros"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -638,14 +638,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-android"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "cranpose-ui-graphics",
 ]
 
 [[package]]
 name = "cranpose-platform-desktop-winit"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-web"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-common"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-pixels"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "cranpose-core",
  "cranpose-foundation",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-wgpu"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "bytemuck",
  "cranpose-app-shell",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-runtime-std"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "cranpose-core",
  "web-time",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-services"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-testing"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "cranpose",
  "cranpose-app-shell",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -770,14 +770,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui-graphics"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cranpose-ui-layout"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/samoylenkodmitry/cranpose"
@@ -39,25 +39,25 @@ categories = ["gui"]
 [workspace.dependencies]
 # Force android-activity to use native-activity feature across all workspace crates
 android-activity = { version = "0.6", features = ["native-activity"] }
-cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.22" }
-cranpose = { path = "crates/cranpose", version = "0.1.22", default-features = false }
-cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.22" }
-cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.22" }
-cranpose-core = { path = "crates/cranpose-core", version = "0.1.22" }
-cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.22" }
-cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.22" }
-cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.22" }
-cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.22" }
-cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.22" }
-cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.22" }
-cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.22" }
-cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.22" }
-cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.22" }
-cranpose-services = { path = "crates/cranpose-services", version = "0.1.22", default-features = false }
-cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.22" }
-cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.22" }
-cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.22" }
-cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.22" }
+cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.23" }
+cranpose = { path = "crates/cranpose", version = "0.1.23", default-features = false }
+cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.23" }
+cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.23" }
+cranpose-core = { path = "crates/cranpose-core", version = "0.1.23" }
+cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.23" }
+cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.23" }
+cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.23" }
+cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.23" }
+cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.23" }
+cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.23" }
+cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.23" }
+cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.23" }
+cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.23" }
+cranpose-services = { path = "crates/cranpose-services", version = "0.1.23", default-features = false }
+cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.23" }
+cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.23" }
+cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.23" }
+cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.23" }
 web-time = "1.1"
 
 [patch.crates-io]

--- a/apps/isolated-demo/Cargo.toml
+++ b/apps/isolated-demo/Cargo.toml
@@ -29,11 +29,11 @@ web = ["cranpose/web", "dep:wasm-bindgen", "dep:wasm-logger"]
 logging = ["dep:env_logger"]
 
 [dependencies]
-cranpose = { version = "0.1.22", default-features = false }
+cranpose = { version = "0.1.23", default-features = false }
 log = "0.4"
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-logger = { version = "0.2", optional = true }
-cranpose-core = "0.1.22"
+cranpose-core = "0.1.23"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = { version = "0.11", optional = true }

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeFilePickerActivity.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeFilePickerActivity.java
@@ -4,6 +4,7 @@ import android.app.NativeActivity;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Bundle;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
 import android.provider.OpenableColumns;
@@ -50,6 +51,17 @@ public class CranposeFilePickerActivity extends NativeActivity {
 
     /** Base backoff between folder-listing retries, in ms (grows per attempt). */
     private static final int FOLDER_QUERY_RETRY_MS = 250;
+
+    /** How many times to re-query a folder whose cursor reports
+     * {@link DocumentsContract#EXTRA_LOADING} before giving up and using
+     * whatever it returns (a network provider keeps the listing "loading" while
+     * it fetches over the wire). */
+    private static final int FOLDER_LOADING_ATTEMPTS = 24;
+
+    /** Delay between {@link DocumentsContract#EXTRA_LOADING} re-queries, in ms
+     * ({@link #FOLDER_LOADING_ATTEMPTS} × this ≈ the time budget for one folder
+     * to finish loading). */
+    private static final int FOLDER_LOADING_POLL_MS = 250;
 
     /** Implemented in the Rust cdylib. {@code entries} is newline-separated
      * {@code uri\tname} rows (one for a file, every descendant for a folder). */
@@ -277,24 +289,62 @@ public class CranposeFilePickerActivity extends NativeActivity {
                 DocumentsContract.Document.COLUMN_DISPLAY_NAME,
                 DocumentsContract.Document.COLUMN_MIME_TYPE,
         };
-        for (int attempt = 1; ; attempt++) {
+        int errorAttempt = 0;
+        int loadingAttempt = 0;
+        while (true) {
+            Cursor cursor;
             try {
-                return getContentResolver().query(childrenUri, columns, null, null, null);
+                cursor = getContentResolver().query(childrenUri, columns, null, null, null);
             } catch (Exception error) {
-                if (attempt >= FOLDER_QUERY_ATTEMPTS) {
+                errorAttempt++;
+                if (errorAttempt >= FOLDER_QUERY_ATTEMPTS) {
                     android.util.Log.w(
                             "Cranpose",
-                            "skipping unreadable folder after " + attempt + " tries: "
+                            "skipping unreadable folder after " + errorAttempt + " tries: "
                                     + childrenUri + " (" + error + ")");
                     return null;
                 }
-                try {
-                    Thread.sleep((long) FOLDER_QUERY_RETRY_MS * attempt);
-                } catch (InterruptedException interrupted) {
-                    Thread.currentThread().interrupt();
+                if (!sleepQuietly((long) FOLDER_QUERY_RETRY_MS * errorAttempt)) {
                     return null;
                 }
+                continue;
             }
+            if (cursor == null) {
+                return null;
+            }
+            // A slow network document provider (RoundSync/rclone, a mounted WebDAV
+            // share) returns an EMPTY cursor immediately with EXTRA_LOADING=true
+            // while it fetches the real listing over the wire, then notifies and
+            // serves the cached result on the next query. Reading the cursor right
+            // now yields zero children, so the folder — even the picked root — looks
+            // empty ("adds nothing"). Re-query until it stops loading (or we run out
+            // of patience) instead of trusting the placeholder.
+            if (isLoading(cursor) && loadingAttempt < FOLDER_LOADING_ATTEMPTS) {
+                loadingAttempt++;
+                cursor.close();
+                if (!sleepQuietly(FOLDER_LOADING_POLL_MS)) {
+                    return null;
+                }
+                continue;
+            }
+            return cursor;
+        }
+    }
+
+    /** True if the provider flagged this cursor as still fetching its results. */
+    private static boolean isLoading(Cursor cursor) {
+        Bundle extras = cursor.getExtras();
+        return extras != null && extras.getBoolean(DocumentsContract.EXTRA_LOADING, false);
+    }
+
+    /** Sleeps, returning {@code false} (so callers can bail) if interrupted. */
+    private static boolean sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+            return true;
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            return false;
         }
     }
 

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -203,6 +203,31 @@ fn get_display_density(app: &android_activity::AndroidApp) -> f32 {
     density_dpi.map(|dpi| dpi as f32 / 160.0).unwrap_or(2.0) // Fallback to xhdpi (2.0) if density unavailable
 }
 
+/// The freeform/DeX shadow-margin inset (in physical px) between the render
+/// buffer and the on-screen frame. The native window buffer is enlarged by this
+/// margin on every side; the renderer fills the buffer from (0,0) while pointer
+/// events are frame-relative, so this is exactly the offset to add to pointers.
+/// Returns `(0, 0)` when there is no margin (fullscreen: buffer == frame).
+fn surface_inset_px(app: &android_activity::AndroidApp) -> (f64, f64) {
+    let Some(window) = app.native_window() else {
+        return (0.0, 0.0);
+    };
+    let buffer_w = window.width() as f64;
+    let buffer_h = window.height() as f64;
+    // `content_rect`'s right/bottom edges are the frame's size (the caption only
+    // insets the top, so the content still reaches the frame's right and bottom).
+    let content = app.content_rect();
+    let frame_w = content.right as f64;
+    let frame_h = content.bottom as f64;
+    if frame_w <= 0.0 || frame_h <= 0.0 || frame_w > buffer_w || frame_h > buffer_h {
+        return (0.0, 0.0);
+    }
+    (
+        ((buffer_w - frame_w) / 2.0).max(0.0),
+        ((buffer_h - frame_h) / 2.0).max(0.0),
+    )
+}
+
 fn update_android_platform_geometry(
     app: &android_activity::AndroidApp,
     android_platform: &mut AndroidPlatform,
@@ -210,13 +235,18 @@ fn update_android_platform_geometry(
     let density = get_display_density(app);
     android_platform.set_scale_factor(density as f64);
 
-    let content_rect = app.content_rect();
-    if content_rect.right > content_rect.left && content_rect.bottom > content_rect.top {
-        android_platform
-            .set_input_surface_offset_px(content_rect.left as f64, content_rect.top as f64);
-    } else {
-        android_platform.set_input_surface_offset_px(0.0, 0.0);
-    }
+    // A freeform/DeX window's render surface is LARGER than its on-screen frame:
+    // the system adds a shadow/resize margin (the window `surfaceInsets`), so the
+    // native buffer we draw into is e.g. 525x879 px while the visible frame is
+    // only 447x801. The renderer fills the whole buffer starting at (0,0), which
+    // lands at `frame_origin - inset` on screen — but pointer coordinates arrive
+    // relative to the *frame*. Without correction every touch is off by that inset
+    // (~39 px / 24 dp), so controls near the edges become unreachable. We recover
+    // the inset as half the difference between the buffer and the frame, and add
+    // it to incoming pointers so they map into the same surface space the renderer
+    // draws in. Fullscreen (phone) has buffer == frame, so this is a no-op there.
+    let (offset_x, offset_y) = surface_inset_px(app);
+    android_platform.set_input_surface_offset_px(offset_x, offset_y);
 
     density
 }


### PR DESCRIPTION
Two Android fixes, both validated on a Galaxy Tab (Samsung DeX) and a Huawei phone.

## DeX/freeform touch offset
A freeform window's render surface is larger than its on-screen frame — the system adds a ~39px shadow/resize margin (`surfaceInsets`), so the native buffer (e.g. 525×879) exceeds the frame (447×801). The renderer fills the buffer from (0,0) while pointer events arrive frame-relative, so every touch is off by the inset (~24dp) and edge controls become unreachable. `surface_inset_px` recovers the inset as `(buffer − frame)/2` and offsets incoming pointers by it. Fullscreen (phone) has `buffer == frame`, so it's a no-op there (verified no regression).

## Wait out loading folder cursors
The SAF walk treated a slow network DocumentsProvider's "still loading" placeholder as an empty folder. RoundSync/rclone over a flaky Taildrive link returns an empty cursor flagged `EXTRA_LOADING` while it fetches the listing, so a big WebDAV library could load nothing. `queryChildrenWithRetry` now re-queries while `EXTRA_LOADING` is set (in addition to the existing exception retries). Verified loading **2095 tracks** from `/huge/music` with zero unreadable-folder skips.

Bumps workspace version 0.1.22 → 0.1.23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)