### PR TITLE
Add a cross-platform writable-folder capability and release 0.1.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cranpose"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "android-activity",
  "android_logger",
@@ -574,14 +574,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-animation"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "cranpose-core",
 ]
 
 [[package]]
 name = "cranpose-app-shell"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "arboard",
  "cranpose-core",
@@ -597,11 +597,11 @@ dependencies = [
 
 [[package]]
 name = "cranpose-assets"
-version = "0.1.23"
+version = "0.1.24"
 
 [[package]]
 name = "cranpose-core"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "ahash",
  "cranpose-macros",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-foundation"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-macros"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -638,14 +638,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-android"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "cranpose-ui-graphics",
 ]
 
 [[package]]
 name = "cranpose-platform-desktop-winit"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-web"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-common"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-pixels"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "cranpose-core",
  "cranpose-foundation",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-wgpu"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "bytemuck",
  "cranpose-app-shell",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-runtime-std"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "cranpose-core",
  "web-time",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-services"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-testing"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "cranpose",
  "cranpose-app-shell",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -770,14 +770,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui-graphics"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cranpose-ui-layout"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.23"
+version = "0.1.24"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/samoylenkodmitry/cranpose"
@@ -39,25 +39,25 @@ categories = ["gui"]
 [workspace.dependencies]
 # Force android-activity to use native-activity feature across all workspace crates
 android-activity = { version = "0.6", features = ["native-activity"] }
-cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.23" }
-cranpose = { path = "crates/cranpose", version = "0.1.23", default-features = false }
-cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.23" }
-cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.23" }
-cranpose-core = { path = "crates/cranpose-core", version = "0.1.23" }
-cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.23" }
-cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.23" }
-cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.23" }
-cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.23" }
-cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.23" }
-cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.23" }
-cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.23" }
-cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.23" }
-cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.23" }
-cranpose-services = { path = "crates/cranpose-services", version = "0.1.23", default-features = false }
-cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.23" }
-cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.23" }
-cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.23" }
-cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.23" }
+cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.24" }
+cranpose = { path = "crates/cranpose", version = "0.1.24", default-features = false }
+cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.24" }
+cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.24" }
+cranpose-core = { path = "crates/cranpose-core", version = "0.1.24" }
+cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.24" }
+cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.24" }
+cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.24" }
+cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.24" }
+cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.24" }
+cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.24" }
+cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.24" }
+cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.24" }
+cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.24" }
+cranpose-services = { path = "crates/cranpose-services", version = "0.1.24", default-features = false }
+cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.24" }
+cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.24" }
+cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.24" }
+cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.24" }
 web-time = "1.1"
 
 [patch.crates-io]

--- a/apps/isolated-demo/Cargo.toml
+++ b/apps/isolated-demo/Cargo.toml
@@ -29,11 +29,11 @@ web = ["cranpose/web", "dep:wasm-bindgen", "dep:wasm-logger"]
 logging = ["dep:env_logger"]
 
 [dependencies]
-cranpose = { version = "0.1.23", default-features = false }
+cranpose = { version = "0.1.24", default-features = false }
 log = "0.4"
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-logger = { version = "0.2", optional = true }
-cranpose-core = "0.1.23"
+cranpose-core = "0.1.24"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = { version = "0.11", optional = true }

--- a/crates/cranpose-services/src/lib.rs
+++ b/crates/cranpose-services/src/lib.rs
@@ -9,6 +9,7 @@ pub mod file_picker;
 pub mod http;
 pub mod theme;
 pub mod uri_handler;
+pub mod writable_folder;
 
 pub use file_picker::{
     clear_platform_file_picker, default_file_picker, local_file_picker, set_platform_file_picker,
@@ -25,6 +26,11 @@ pub use theme::{
 pub use uri_handler::{
     default_uri_handler, local_uri_handler, ProvideUriHandler, UriHandler, UriHandlerError,
     UriHandlerRef,
+};
+pub use writable_folder::{
+    clear_platform_writable_folder_picker, open_writable_folder, pick_writable_folder,
+    set_platform_writable_folder_picker, set_writable_folder_store_factory, FolderError,
+    WritableFolderPicker, WritableFolderPickerRef, WritableFolderStore, WritableFolderStoreRef,
 };
 
 /// Convenience alias used in unit tests.

--- a/crates/cranpose-services/src/writable_folder.rs
+++ b/crates/cranpose-services/src/writable_folder.rs
@@ -1,0 +1,205 @@
+//! Cross-platform access to a user-chosen **writable** folder.
+//!
+//! This is the write-side complement of [`crate::file_picker`]: where the picker
+//! *reads* files the user selects, this lets an app persist its own data into a
+//! folder the user grants — a local directory on desktop, a Storage Access
+//! Framework tree on Android — and read it back on later runs. The motivating
+//! use is cross-device sync, where each device writes a small document into a
+//! shared folder (e.g. on a Tailnet/WebDAV mount) and reads its peers'.
+//!
+//! Two halves, mirroring the picker:
+//! - [`pick_writable_folder`] — asynchronous, UI-thread. Presents the system
+//!   folder picker with a *persistent read/write* grant and resolves to an
+//!   opaque, durable **handle** string the app stores.
+//! - [`open_writable_folder`] — synchronous and thread-safe. Rebuilds a
+//!   [`WritableFolderStore`] from a stored handle. Its I/O methods are
+//!   synchronous and `Send + Sync`, so a background worker can call them without
+//!   touching the UI thread.
+//!
+//! Read-only or unreachable folders surface as [`FolderError::ReadOnly`] /
+//! [`FolderError::Io`] so callers can degrade gracefully. iOS (security-scoped
+//! bookmarks) and the web are not supported yet and return
+//! [`FolderError::Unsupported`].
+
+use crate::file_picker::{FilePickerError, PickerFuture};
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::{Arc, OnceLock};
+
+/// Errors produced by writable-folder I/O.
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum FolderError {
+    /// The folder (or backing store) is read-only.
+    #[error("writable folder is read-only")]
+    ReadOnly,
+    /// The named file does not exist.
+    #[error("file not found: {0}")]
+    NotFound(String),
+    /// Writable folders are not available on this platform/build.
+    #[error("writable folders are not supported on this platform")]
+    Unsupported,
+    /// Any other I/O failure.
+    #[error("{0}")]
+    Io(String),
+}
+
+/// Synchronous, thread-safe access to a user-chosen writable folder.
+///
+/// Implementations are `Send + Sync` so a background thread can read and write
+/// without involving the UI thread. Treat it as a flat store of named files
+/// (directories are not exposed by [`list`](WritableFolderStore::list)).
+pub trait WritableFolderStore: Send + Sync {
+    /// Writes (overwriting) the file `name` with `contents`.
+    fn write(&self, name: &str, contents: &[u8]) -> Result<(), FolderError>;
+
+    /// Reads the file `name`.
+    fn read(&self, name: &str) -> Result<Vec<u8>, FolderError>;
+
+    /// Lists the immediate child *file* names (directories excluded).
+    fn list(&self) -> Result<Vec<String>, FolderError>;
+
+    /// Removes the file `name`. Succeeds if it is already absent.
+    fn remove(&self, name: &str) -> Result<(), FolderError>;
+
+    /// Cheaply probes whether the folder is writable right now (e.g. detects a
+    /// read-only WebDAV mount that still granted a write permission).
+    fn is_writable(&self) -> bool;
+
+    /// The durable handle (filesystem path / SAF tree URI) used to reopen this
+    /// folder with [`open_writable_folder`] on a later run.
+    fn handle(&self) -> String;
+}
+
+/// Shared handle to a [`WritableFolderStore`].
+pub type WritableFolderStoreRef = Arc<dyn WritableFolderStore>;
+
+/// Presents the system "pick a writable folder" UI. Platform-provided (Android);
+/// desktop/web use the built-in backend.
+pub trait WritableFolderPicker {
+    /// Resolves to the durable handle string, or `None` if the user cancelled.
+    fn pick(&self) -> PickerFuture<Result<Option<String>, FilePickerError>>;
+}
+
+/// Shared handle to a [`WritableFolderPicker`].
+pub type WritableFolderPickerRef = Rc<dyn WritableFolderPicker>;
+
+thread_local! {
+    static PLATFORM_PICKER: RefCell<Option<WritableFolderPickerRef>> = const { RefCell::new(None) };
+}
+
+/// Registers the platform writable-folder picker (Android SAF). The cranpose
+/// crate's backend calls this during startup; once registered it takes
+/// precedence over the built-in desktop picker.
+pub fn set_platform_writable_folder_picker(picker: WritableFolderPickerRef) {
+    PLATFORM_PICKER.with(|cell| *cell.borrow_mut() = Some(picker));
+}
+
+/// Removes any registered platform picker (tests/teardown).
+pub fn clear_platform_writable_folder_picker() {
+    PLATFORM_PICKER.with(|cell| *cell.borrow_mut() = None);
+}
+
+fn registered_picker() -> Option<WritableFolderPickerRef> {
+    PLATFORM_PICKER.with(|cell| cell.borrow().clone())
+}
+
+/// Factory turning a stored handle into a [`WritableFolderStore`]. Unlike the
+/// picker this is thread-safe, so a worker thread can reopen the folder.
+type StoreFactory = Box<dyn Fn(&str) -> Option<WritableFolderStoreRef> + Send + Sync>;
+static STORE_FACTORY: OnceLock<StoreFactory> = OnceLock::new();
+
+/// Registers the platform store factory (Android). Called once at startup. No-op
+/// if already set.
+pub fn set_writable_folder_store_factory(factory: StoreFactory) {
+    let _ = STORE_FACTORY.set(factory);
+}
+
+/// Presents the writable-folder picker and resolves to a durable handle (or
+/// `None` if cancelled). Async; drive it from `LaunchedEffectAsync`.
+pub fn pick_writable_folder() -> PickerFuture<Result<Option<String>, FilePickerError>> {
+    if let Some(picker) = registered_picker() {
+        return picker.pick();
+    }
+    builtin_pick()
+}
+
+/// Reopens a writable folder from a stored handle. Synchronous and callable from
+/// any thread; returns `None` only when writable folders are unsupported here.
+pub fn open_writable_folder(handle: &str) -> Option<WritableFolderStoreRef> {
+    if let Some(factory) = STORE_FACTORY.get() {
+        return factory(handle);
+    }
+    builtin_open(handle)
+}
+
+fn builtin_pick() -> PickerFuture<Result<Option<String>, FilePickerError>> {
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        not(target_os = "android"),
+        not(target_os = "ios"),
+        feature = "file-picker-native"
+    ))]
+    {
+        return desktop::pick();
+    }
+    #[allow(unreachable_code)]
+    Box::pin(async { Err(FilePickerError::UnsupportedPlatform) })
+}
+
+fn builtin_open(handle: &str) -> Option<WritableFolderStoreRef> {
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        not(target_os = "android"),
+        not(target_os = "ios"),
+        feature = "file-picker-native"
+    ))]
+    {
+        return Some(desktop::open(handle));
+    }
+    #[allow(unreachable_code)]
+    {
+        let _ = handle;
+        None
+    }
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "android"),
+    not(target_os = "ios"),
+    feature = "file-picker-native"
+))]
+mod desktop;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folder_error_messages_are_distinct() {
+        assert_eq!(
+            FolderError::ReadOnly.to_string(),
+            "writable folder is read-only"
+        );
+        assert!(FolderError::NotFound("a.txt".into())
+            .to_string()
+            .contains("a.txt"));
+    }
+
+    #[test]
+    fn picker_registration_round_trips() {
+        struct Marker;
+        impl WritableFolderPicker for Marker {
+            fn pick(&self) -> PickerFuture<Result<Option<String>, FilePickerError>> {
+                Box::pin(async { Ok(Some("handle".to_string())) })
+            }
+        }
+        clear_platform_writable_folder_picker();
+        assert!(registered_picker().is_none());
+        set_platform_writable_folder_picker(Rc::new(Marker));
+        assert!(registered_picker().is_some());
+        let result = pollster::block_on(pick_writable_folder());
+        assert!(matches!(result, Ok(Some(handle)) if handle == "handle"));
+        clear_platform_writable_folder_picker();
+    }
+}

--- a/crates/cranpose-services/src/writable_folder/desktop.rs
+++ b/crates/cranpose-services/src/writable_folder/desktop.rs
@@ -1,0 +1,178 @@
+//! Desktop writable-folder backend: `rfd` folder picker + `std::fs` I/O.
+//!
+//! The chosen directory may be a plain folder or a mounted network share
+//! (GVFS/rclone/davfs over the same WebDAV the app already reads). Writes use
+//! temp-file-then-rename for atomicity and fall back to a direct write when the
+//! backing filesystem rejects rename. A permission/EROFS failure maps to
+//! [`FolderError::ReadOnly`] so the caller can degrade to receive-only.
+
+use super::{FolderError, WritableFolderStore, WritableFolderStoreRef};
+use crate::file_picker::{FilePickerError, PickerFuture};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Fixed-name probe used by [`is_writable`](WritableFolderStore::is_writable);
+/// created and immediately deleted, so it never accumulates.
+const PROBE_NAME: &str = ".cranpose-write-probe";
+
+pub(super) fn pick() -> PickerFuture<Result<Option<String>, FilePickerError>> {
+    Box::pin(async move {
+        let handle = rfd::AsyncFileDialog::new().pick_folder().await;
+        Ok(handle.map(|handle| handle.path().to_string_lossy().into_owned()))
+    })
+}
+
+pub(super) fn open(handle: &str) -> WritableFolderStoreRef {
+    Arc::new(DesktopWritableFolder {
+        dir: PathBuf::from(handle),
+    })
+}
+
+struct DesktopWritableFolder {
+    dir: PathBuf,
+}
+
+impl WritableFolderStore for DesktopWritableFolder {
+    fn write(&self, name: &str, contents: &[u8]) -> Result<(), FolderError> {
+        ensure_dir(&self.dir)?;
+        let target = self.dir.join(name);
+        let temp = self.dir.join(format!("{name}.tmp"));
+        if std::fs::write(&temp, contents).is_ok() && std::fs::rename(&temp, &target).is_ok() {
+            return Ok(());
+        }
+        let _ = std::fs::remove_file(&temp);
+        std::fs::write(&target, contents).map_err(map_err)
+    }
+
+    fn read(&self, name: &str) -> Result<Vec<u8>, FolderError> {
+        match std::fs::read(self.dir.join(name)) {
+            Ok(bytes) => Ok(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                Err(FolderError::NotFound(name.to_string()))
+            }
+            Err(error) => Err(map_err(error)),
+        }
+    }
+
+    fn list(&self) -> Result<Vec<String>, FolderError> {
+        let entries = match std::fs::read_dir(&self.dir) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(map_err(error)),
+        };
+        let mut names = Vec::new();
+        for entry in entries.flatten() {
+            if entry
+                .file_type()
+                .map(|kind| kind.is_file())
+                .unwrap_or(false)
+            {
+                if let Some(name) = entry.file_name().to_str() {
+                    names.push(name.to_string());
+                }
+            }
+        }
+        Ok(names)
+    }
+
+    fn remove(&self, name: &str) -> Result<(), FolderError> {
+        match std::fs::remove_file(self.dir.join(name)) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(map_err(error)),
+        }
+    }
+
+    fn is_writable(&self) -> bool {
+        if ensure_dir(&self.dir).is_err() {
+            return false;
+        }
+        let probe = self.dir.join(PROBE_NAME);
+        let ok = std::fs::write(&probe, b"ok").is_ok();
+        let _ = std::fs::remove_file(&probe);
+        ok
+    }
+
+    fn handle(&self) -> String {
+        self.dir.to_string_lossy().into_owned()
+    }
+}
+
+fn ensure_dir(dir: &Path) -> Result<(), FolderError> {
+    std::fs::create_dir_all(dir).map_err(map_err)
+}
+
+fn map_err(error: std::io::Error) -> FolderError {
+    if error.kind() == std::io::ErrorKind::PermissionDenied {
+        return FolderError::ReadOnly;
+    }
+    // EACCES (13) / EROFS (30) cover read-only or unwritable mounts on
+    // Linux/Android without depending on the newer `ReadOnlyFilesystem` variant.
+    #[cfg(unix)]
+    if matches!(error.raw_os_error(), Some(13) | Some(30)) {
+        return FolderError::ReadOnly;
+    }
+    FolderError::Io(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    // Tests write under the workspace `target/test-output` (never tmpfs), per
+    // the workspace source-hygiene policy.
+    fn unique_dir(tag: &str) -> PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../target/test-output/cranpose-wfolder");
+        let _ = std::fs::create_dir_all(&root);
+        root.join(format!("{tag}-{nanos}-{n}"))
+    }
+
+    #[test]
+    fn round_trips_write_list_read_remove() {
+        let dir = unique_dir("rw");
+        let store = open(dir.to_string_lossy().as_ref());
+        assert!(store.is_writable());
+
+        store.write("a.bin", b"hello").expect("write");
+        store.write("b.bin", b"world").expect("write");
+
+        let mut names = store.list().expect("list");
+        names.sort();
+        assert_eq!(names, vec!["a.bin".to_string(), "b.bin".to_string()]);
+
+        assert_eq!(store.read("a.bin").expect("read"), b"hello");
+        assert_eq!(store.handle(), dir.to_string_lossy());
+
+        store.remove("a.bin").expect("remove");
+        assert_eq!(store.list().expect("list"), vec!["b.bin".to_string()]);
+
+        // No probe/temp files left behind.
+        let leftover: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.ends_with(".tmp") || n.contains("write-probe"))
+            .collect();
+        assert!(leftover.is_empty(), "stray files: {leftover:?}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_missing_is_not_found() {
+        let dir = unique_dir("missing");
+        let store = open(dir.to_string_lossy().as_ref());
+        assert!(matches!(store.read("nope"), Err(FolderError::NotFound(_))));
+        assert!(store.list().expect("list").is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeFilePickerActivity.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeFilePickerActivity.java
@@ -2,6 +2,7 @@ package dev.cranpose.android;
 
 import android.app.NativeActivity;
 import android.content.Intent;
+import android.content.UriPermission;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
@@ -9,7 +10,10 @@ import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
 import android.provider.OpenableColumns;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * A {@link NativeActivity} that exposes the Storage Access Framework to
@@ -39,6 +43,11 @@ public class CranposeFilePickerActivity extends NativeActivity {
     private static final int REQUEST_BASE = 0x0C9A0000;
     private static final int FLAG_FOLDER = 1;
     private static final int FLAG_STREAMING = 2;
+    private static final int FLAG_WRITABLE = 4;
+
+    /** A fixed-name probe used by {@link #cranposeFolderWritable}; created and
+     * deleted immediately, and ignored by listings. */
+    private static final String WRITABLE_PROBE_NAME = ".cranpose-write-probe";
 
     private long pendingToken;
 
@@ -78,6 +87,11 @@ public class CranposeFilePickerActivity extends NativeActivity {
     /** Folder enumeration finished, with an optional error. */
     private static native void nativeOnFolderFinished(long token, String error);
 
+    /** A writable folder was picked (or cancelled/failed). {@code uri} is the
+     * persisted SAF tree URI on success. */
+    private static native void nativeOnWritableFolderPicked(
+            long token, String uri, boolean cancelled, String error);
+
     /** Opens the document picker for a single file. Called from Rust over JNI. */
     public void cranposePickFile(long token) {
         pendingToken = token;
@@ -103,6 +117,22 @@ public class CranposeFilePickerActivity extends NativeActivity {
         launch(intent, token, FLAG_FOLDER | FLAG_STREAMING);
     }
 
+    /** Opens the document tree picker for a <em>writable</em> folder, taking a
+     * persistent read/write grant. The chosen tree URI is reported back through
+     * {@link #nativeOnWritableFolderPicked}. Called from Rust over JNI. */
+    public void cranposePickWritableFolder(long token) {
+        pendingToken = token;
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION
+                | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+        try {
+            startActivityForResult(intent, REQUEST_BASE | FLAG_WRITABLE);
+        } catch (Exception error) {
+            nativeOnWritableFolderPicked(token, null, false, error.toString());
+        }
+    }
+
     /**
      * Opens a picked {@code content://} document for reading and returns a
      * detached file descriptor. The Rust caller owns and closes it. Called over
@@ -115,6 +145,170 @@ public class CranposeFilePickerActivity extends NativeActivity {
             throw new IOException("no descriptor for " + uriString);
         }
         return descriptor.detachFd();
+    }
+
+    /** Writes (overwriting) {@code contents} to a file named {@code name} in the
+     * writable tree. Returns 0 on success, 1 on permission failure (read-only),
+     * 2 on any other error. Called from the Rust sync worker thread over JNI. */
+    public int cranposeFolderWrite(String treeUriString, String name, byte[] contents) {
+        try {
+            Uri tree = Uri.parse(treeUriString);
+            String treeDocId = DocumentsContract.getTreeDocumentId(tree);
+            Uri parent = DocumentsContract.buildDocumentUriUsingTree(tree, treeDocId);
+            String docId = findWritableChildId(tree, treeDocId, name);
+            Uri docUri;
+            if (docId != null) {
+                docUri = DocumentsContract.buildDocumentUriUsingTree(tree, docId);
+            } else {
+                docUri = DocumentsContract.createDocument(
+                        getContentResolver(), parent, "application/octet-stream", name);
+                if (docUri == null) {
+                    return 2;
+                }
+            }
+            try (OutputStream output = getContentResolver().openOutputStream(docUri, "wt")) {
+                if (output == null) {
+                    return 2;
+                }
+                output.write(contents);
+            }
+            return 0;
+        } catch (SecurityException error) {
+            return 1;
+        } catch (Exception error) {
+            return 2;
+        }
+    }
+
+    /** Lists immediate child file names (directories excluded), newline-joined.
+     * Returns {@code null} only on a hard read failure (an empty folder is ""). */
+    public String cranposeFolderList(String treeUriString) {
+        try {
+            Uri tree = Uri.parse(treeUriString);
+            String treeDocId = DocumentsContract.getTreeDocumentId(tree);
+            Uri childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(tree, treeDocId);
+            Cursor cursor = queryChildrenWithRetry(childrenUri);
+            if (cursor == null) {
+                return null;
+            }
+            StringBuilder out = new StringBuilder();
+            try {
+                while (cursor.moveToNext()) {
+                    String name = cursor.getString(1);
+                    String mime = cursor.getString(2);
+                    if (name == null || DocumentsContract.Document.MIME_TYPE_DIR.equals(mime)) {
+                        continue;
+                    }
+                    if (out.length() > 0) {
+                        out.append('\n');
+                    }
+                    out.append(sanitize(name));
+                }
+            } finally {
+                cursor.close();
+            }
+            return out.toString();
+        } catch (Exception error) {
+            return null;
+        }
+    }
+
+    /** Reads the file {@code name} as bytes, or {@code null} if absent/unreadable. */
+    public byte[] cranposeFolderRead(String treeUriString, String name) {
+        try {
+            Uri tree = Uri.parse(treeUriString);
+            String treeDocId = DocumentsContract.getTreeDocumentId(tree);
+            String docId = findWritableChildId(tree, treeDocId, name);
+            if (docId == null) {
+                return null;
+            }
+            Uri docUri = DocumentsContract.buildDocumentUriUsingTree(tree, docId);
+            try (InputStream input = getContentResolver().openInputStream(docUri)) {
+                if (input == null) {
+                    return null;
+                }
+                ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                byte[] chunk = new byte[8192];
+                int read;
+                while ((read = input.read(chunk)) >= 0) {
+                    buffer.write(chunk, 0, read);
+                }
+                return buffer.toByteArray();
+            }
+        } catch (Exception error) {
+            return null;
+        }
+    }
+
+    /** Deletes the file {@code name}. Returns 0 on success (or already gone), 2 otherwise. */
+    public int cranposeFolderRemove(String treeUriString, String name) {
+        try {
+            Uri tree = Uri.parse(treeUriString);
+            String treeDocId = DocumentsContract.getTreeDocumentId(tree);
+            String docId = findWritableChildId(tree, treeDocId, name);
+            if (docId == null) {
+                return 0;
+            }
+            Uri docUri = DocumentsContract.buildDocumentUriUsingTree(tree, docId);
+            return DocumentsContract.deleteDocument(getContentResolver(), docUri) ? 0 : 2;
+        } catch (Exception error) {
+            return 2;
+        }
+    }
+
+    /** Whether the tree is writable now: a persisted write grant exists AND a
+     * probe document can be created and deleted (catching a read-only backing
+     * store such as a read-only WebDAV mount). */
+    public boolean cranposeFolderWritable(String treeUriString) {
+        try {
+            Uri tree = Uri.parse(treeUriString);
+            boolean granted = false;
+            for (UriPermission permission : getContentResolver().getPersistedUriPermissions()) {
+                if (permission.getUri().equals(tree) && permission.isWritePermission()) {
+                    granted = true;
+                    break;
+                }
+            }
+            if (!granted) {
+                return false;
+            }
+            String treeDocId = DocumentsContract.getTreeDocumentId(tree);
+            Uri parent = DocumentsContract.buildDocumentUriUsingTree(tree, treeDocId);
+            String existing = findWritableChildId(tree, treeDocId, WRITABLE_PROBE_NAME);
+            if (existing != null) {
+                DocumentsContract.deleteDocument(
+                        getContentResolver(),
+                        DocumentsContract.buildDocumentUriUsingTree(tree, existing));
+            }
+            Uri probe = DocumentsContract.createDocument(
+                    getContentResolver(), parent, "application/octet-stream", WRITABLE_PROBE_NAME);
+            if (probe == null) {
+                return false;
+            }
+            DocumentsContract.deleteDocument(getContentResolver(), probe);
+            return true;
+        } catch (Exception error) {
+            return false;
+        }
+    }
+
+    /** Finds the document id of a direct child by display name, or {@code null}. */
+    private String findWritableChildId(Uri treeUri, String treeDocId, String name) {
+        Uri childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, treeDocId);
+        Cursor cursor = queryChildrenWithRetry(childrenUri);
+        if (cursor == null) {
+            return null;
+        }
+        try {
+            while (cursor.moveToNext()) {
+                if (name.equals(cursor.getString(1))) {
+                    return cursor.getString(0);
+                }
+            }
+        } finally {
+            cursor.close();
+        }
+        return null;
     }
 
     private void launch(Intent intent, long token, int flags) {
@@ -140,6 +334,23 @@ public class CranposeFilePickerActivity extends NativeActivity {
         final boolean folder = (flags & FLAG_FOLDER) != 0;
         final boolean streaming = (flags & FLAG_STREAMING) != 0;
         final boolean ok = resultCode == RESULT_OK && data != null && data.getData() != null;
+
+        if ((flags & FLAG_WRITABLE) != 0) {
+            if (!ok) {
+                nativeOnWritableFolderPicked(token, null, true, null);
+                return;
+            }
+            final Uri tree = data.getData();
+            try {
+                getContentResolver().takePersistableUriPermission(tree,
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION
+                                | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                nativeOnWritableFolderPicked(token, tree.toString(), false, null);
+            } catch (Exception error) {
+                nativeOnWritableFolderPicked(token, null, false, error.toString());
+            }
+            return;
+        }
 
         if (streaming) {
             if (!ok) {

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -712,6 +712,9 @@ pub fn run(
     // Register the SAF document picker as the platform file picker. Requires the
     // app's activity to be `dev.cranpose.android.CranposeFilePickerActivity`.
     crate::android_file_picker::register(app.clone());
+    // Register the SAF writable-folder backend (write-side complement, used for
+    // cross-device sync into a user-granted folder).
+    crate::android_writable_folder::register(app.clone());
 
     // Install panic hook for better crash logging in Logcat
     std::panic::set_hook(Box::new(|panic_info| {

--- a/crates/cranpose/src/android_writable_folder.rs
+++ b/crates/cranpose/src/android_writable_folder.rs
@@ -1,0 +1,339 @@
+//! Android writable-folder backend built on the Storage Access Framework.
+//!
+//! The write-side complement of [`crate::android_file_picker`]. The user grants a
+//! persistent read/write tree via `cranposePickWritableFolder` on
+//! [`CranposeFilePickerActivity`]; the chosen tree URI comes back through
+//! [`Java_dev_cranpose_android_CranposeFilePickerActivity_nativeOnWritableFolderPicked`].
+//! Document I/O (`cranposeFolderWrite`/`List`/`Read`/`Remove`/`Writable`) runs
+//! synchronously over JNI and is safe to call from a background worker thread —
+//! [`crate::android_jni::with_android_activity_env`] attaches the calling thread.
+#![allow(unsafe_code)]
+
+use android_activity::AndroidApp;
+use cranpose_services::{
+    set_platform_writable_folder_picker, set_writable_folder_store_factory, FilePickerError,
+    FolderError, PickerFuture, WritableFolderPicker, WritableFolderStore, WritableFolderStoreRef,
+};
+use jni::objects::{JByteArray, JClass, JObject, JString, JValue};
+use jni::sys::{jboolean, jlong};
+use jni::{jni_sig, jni_str, Env, EnvUnowned, Outcome};
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::task::{Context, Poll, Waker};
+
+static APP: OnceLock<AndroidApp> = OnceLock::new();
+static NEXT_TOKEN: AtomicI64 = AtomicI64::new(1);
+
+/// Registers the Android writable-folder picker and store factory. Called once
+/// at startup from [`crate::android::run`].
+pub(crate) fn register(app: AndroidApp) {
+    let _ = APP.set(app);
+    set_platform_writable_folder_picker(Rc::new(AndroidWritableFolderPicker));
+    set_writable_folder_store_factory(Box::new(|handle| {
+        Some(Arc::new(AndroidWritableFolder {
+            tree: handle.to_string(),
+        }) as WritableFolderStoreRef)
+    }));
+}
+
+fn app() -> Result<&'static AndroidApp, String> {
+    APP.get()
+        .ok_or_else(|| "Android writable folder backend is not registered".to_string())
+}
+
+fn with_env<T, F>(f: F) -> Result<T, String>
+where
+    F: for<'local> FnOnce(&mut Env<'local>, JObject<'local>) -> Result<T, String>,
+{
+    crate::android_jni::with_android_activity_env(app()?, f)
+}
+
+fn string_err(error: impl std::fmt::Display) -> String {
+    error.to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Store: synchronous SAF document I/O over JNI
+// ---------------------------------------------------------------------------
+
+struct AndroidWritableFolder {
+    /// The persisted SAF tree URI (`content://…`).
+    tree: String,
+}
+
+impl WritableFolderStore for AndroidWritableFolder {
+    fn write(&self, name: &str, contents: &[u8]) -> Result<(), FolderError> {
+        match call_folder_write(&self.tree, name, contents).map_err(FolderError::Io)? {
+            0 => Ok(()),
+            1 => Err(FolderError::ReadOnly),
+            _ => Err(FolderError::Io("SAF write failed".to_string())),
+        }
+    }
+
+    fn read(&self, name: &str) -> Result<Vec<u8>, FolderError> {
+        match call_folder_read(&self.tree, name).map_err(FolderError::Io)? {
+            Some(bytes) => Ok(bytes),
+            None => Err(FolderError::NotFound(name.to_string())),
+        }
+    }
+
+    fn list(&self) -> Result<Vec<String>, FolderError> {
+        match call_folder_list(&self.tree).map_err(FolderError::Io)? {
+            Some(text) => Ok(text
+                .lines()
+                .filter(|line| !line.is_empty())
+                .map(|line| line.to_string())
+                .collect()),
+            None => Err(FolderError::Io("SAF list failed".to_string())),
+        }
+    }
+
+    fn remove(&self, name: &str) -> Result<(), FolderError> {
+        match call_folder_remove(&self.tree, name).map_err(FolderError::Io)? {
+            0 => Ok(()),
+            _ => Err(FolderError::Io("SAF remove failed".to_string())),
+        }
+    }
+
+    fn is_writable(&self) -> bool {
+        call_folder_writable(&self.tree).unwrap_or(false)
+    }
+
+    fn handle(&self) -> String {
+        self.tree.clone()
+    }
+}
+
+fn call_folder_write(tree: &str, name: &str, contents: &[u8]) -> Result<i32, String> {
+    with_env(|env, activity| {
+        let tree = env.new_string(tree).map_err(string_err)?;
+        let name = env.new_string(name).map_err(string_err)?;
+        let bytes = env.byte_array_from_slice(contents).map_err(string_err)?;
+        let tree_obj: &JObject = tree.as_ref();
+        let name_obj: &JObject = name.as_ref();
+        let bytes_obj: &JObject = bytes.as_ref();
+        env.call_method(
+            &activity,
+            jni_str!("cranposeFolderWrite"),
+            jni_sig!("(Ljava/lang/String;Ljava/lang/String;[B)I"),
+            &[
+                JValue::Object(tree_obj),
+                JValue::Object(name_obj),
+                JValue::Object(bytes_obj),
+            ],
+        )
+        .and_then(|value| value.i())
+        .map_err(string_err)
+    })
+}
+
+fn call_folder_read(tree: &str, name: &str) -> Result<Option<Vec<u8>>, String> {
+    with_env(|env, activity| {
+        let tree = env.new_string(tree).map_err(string_err)?;
+        let name = env.new_string(name).map_err(string_err)?;
+        let tree_obj: &JObject = tree.as_ref();
+        let name_obj: &JObject = name.as_ref();
+        let result = env
+            .call_method(
+                &activity,
+                jni_str!("cranposeFolderRead"),
+                jni_sig!("(Ljava/lang/String;Ljava/lang/String;)[B"),
+                &[JValue::Object(tree_obj), JValue::Object(name_obj)],
+            )
+            .and_then(|value| value.l())
+            .map_err(string_err)?;
+        if result.is_null() {
+            return Ok(None);
+        }
+        let array = JByteArray::cast_local(env, result).map_err(string_err)?;
+        Ok(Some(env.convert_byte_array(&array).map_err(string_err)?))
+    })
+}
+
+fn call_folder_list(tree: &str) -> Result<Option<String>, String> {
+    with_env(|env, activity| {
+        let tree = env.new_string(tree).map_err(string_err)?;
+        let tree_obj: &JObject = tree.as_ref();
+        let result = env
+            .call_method(
+                &activity,
+                jni_str!("cranposeFolderList"),
+                jni_sig!("(Ljava/lang/String;)Ljava/lang/String;"),
+                &[JValue::Object(tree_obj)],
+            )
+            .and_then(|value| value.l())
+            .map_err(string_err)?;
+        if result.is_null() {
+            return Ok(None);
+        }
+        let text = JString::cast_local(env, result)
+            .map_err(string_err)?
+            .try_to_string(env)
+            .map_err(string_err)?;
+        Ok(Some(text))
+    })
+}
+
+fn call_folder_remove(tree: &str, name: &str) -> Result<i32, String> {
+    with_env(|env, activity| {
+        let tree = env.new_string(tree).map_err(string_err)?;
+        let name = env.new_string(name).map_err(string_err)?;
+        let tree_obj: &JObject = tree.as_ref();
+        let name_obj: &JObject = name.as_ref();
+        env.call_method(
+            &activity,
+            jni_str!("cranposeFolderRemove"),
+            jni_sig!("(Ljava/lang/String;Ljava/lang/String;)I"),
+            &[JValue::Object(tree_obj), JValue::Object(name_obj)],
+        )
+        .and_then(|value| value.i())
+        .map_err(string_err)
+    })
+}
+
+fn call_folder_writable(tree: &str) -> Result<bool, String> {
+    with_env(|env, activity| {
+        let tree = env.new_string(tree).map_err(string_err)?;
+        let tree_obj: &JObject = tree.as_ref();
+        env.call_method(
+            &activity,
+            jni_str!("cranposeFolderWritable"),
+            jni_sig!("(Ljava/lang/String;)Z"),
+            &[JValue::Object(tree_obj)],
+        )
+        .and_then(|value| value.z())
+        .map_err(string_err)
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Picker: async folder pick, token registry + JNI callback (mirrors the file
+// picker). The Java callback runs on the UI thread; the future is polled on the
+// android_main thread, so results travel through a `Send` global.
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct PickPending {
+    result: Option<Result<Option<String>, String>>,
+    waker: Option<Waker>,
+}
+
+fn pick_pending() -> &'static Mutex<HashMap<i64, PickPending>> {
+    static PENDING: OnceLock<Mutex<HashMap<i64, PickPending>>> = OnceLock::new();
+    PENDING.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+struct AndroidWritableFolderPicker;
+
+impl WritableFolderPicker for AndroidWritableFolderPicker {
+    fn pick(&self) -> PickerFuture<Result<Option<String>, FilePickerError>> {
+        let token = NEXT_TOKEN.fetch_add(1, Ordering::Relaxed);
+        pick_pending()
+            .lock()
+            .expect("writable folder registry poisoned")
+            .insert(token, PickPending::default());
+
+        if let Err(error) = call_pick_writable(token) {
+            pick_pending()
+                .lock()
+                .expect("writable folder registry poisoned")
+                .remove(&token);
+            return Box::pin(async move { Err(FilePickerError::Failed(error)) });
+        }
+        Box::pin(PickFuture { token })
+    }
+}
+
+fn call_pick_writable(token: i64) -> Result<(), String> {
+    with_env(|env, activity| {
+        env.call_method(
+            &activity,
+            jni_str!("cranposePickWritableFolder"),
+            jni_sig!("(J)V"),
+            &[JValue::Long(token)],
+        )
+        .map(|_| ())
+        .map_err(string_err)
+    })
+}
+
+struct PickFuture {
+    token: i64,
+}
+
+impl Future for PickFuture {
+    type Output = Result<Option<String>, FilePickerError>;
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut registry = pick_pending()
+            .lock()
+            .expect("writable folder registry poisoned");
+        let Some(slot) = registry.get_mut(&self.token) else {
+            return Poll::Ready(Ok(None));
+        };
+        match slot.result.take() {
+            Some(Ok(handle)) => {
+                registry.remove(&self.token);
+                Poll::Ready(Ok(handle))
+            }
+            Some(Err(message)) => {
+                registry.remove(&self.token);
+                Poll::Ready(Err(FilePickerError::Failed(message)))
+            }
+            None => {
+                slot.waker = Some(context.waker().clone());
+                Poll::Pending
+            }
+        }
+    }
+}
+
+/// Java callback delivering the picked writable tree URI (or cancellation/error).
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeFilePickerActivity_nativeOnWritableFolderPicked<
+    'local,
+>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    token: jlong,
+    uri: JString<'local>,
+    cancelled: jboolean,
+    error: JString<'local>,
+) {
+    let uri = read_optional_jstring(&mut env, uri);
+    let error = read_optional_jstring(&mut env, error);
+    let result = if cancelled {
+        Ok(None)
+    } else if let Some(error) = error {
+        Err(error)
+    } else {
+        Ok(uri)
+    };
+    let mut registry = pick_pending()
+        .lock()
+        .expect("writable folder registry poisoned");
+    if let Some(slot) = registry.get_mut(&token) {
+        slot.result = Some(result);
+        if let Some(waker) = slot.waker.take() {
+            waker.wake();
+        }
+    }
+}
+
+fn read_optional_jstring(env: &mut EnvUnowned<'_>, value: JString<'_>) -> Option<String> {
+    if value.is_null() {
+        return None;
+    }
+    match env
+        .with_env(|env| -> jni::errors::Result<String> { value.try_to_string(env) })
+        .into_outcome()
+    {
+        Outcome::Ok(text) if !text.is_empty() => Some(text),
+        _ => None,
+    }
+}

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -15,6 +15,8 @@ mod android_jni;
 mod android_overlay_window;
 #[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
 mod android_surface;
+#[cfg(all(feature = "android", target_os = "android"))]
+mod android_writable_folder;
 mod launcher;
 mod native_window;
 #[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -961,6 +961,7 @@ fn unsafe_code_stays_in_android_boundary_modules() {
         "android_jni.rs",
         "android_surface.rs",
         "android_file_picker.rs",
+        "android_writable_folder.rs",
         "ios_file_picker.rs",
     ];
     let mut offenders = Vec::new();
@@ -1124,6 +1125,7 @@ fn workspace_ffi_boundaries_are_explicit() {
         "crates/cranpose/src/android_jni.rs",
         "crates/cranpose/src/android_surface.rs",
         "crates/cranpose/src/android_file_picker.rs",
+        "crates/cranpose/src/android_writable_folder.rs",
         "crates/cranpose/src/ios_file_picker.rs",
         "apps/desktop-demo-platform/src/android_entry.rs",
         "apps/isolated-demo/src/native_entry.rs",


### PR DESCRIPTION
## What

Adds `cranpose_services::writable_folder` — the **write-side complement** of the read-only file picker. Cross-device features (sync, export-to-folder) need to persist app data into a folder the user grants and read it back later; until now apps had to reimplement the SAF writable-tree picker + `DocumentsContract` document I/O themselves, duplicating the framework's read-only SAF code.

## API (cranpose-services)

- **`WritableFolderStore`** — synchronous, `Send + Sync`: `write` / `read` / `list` / `remove` / `is_writable` / `handle`. Safe to call from a background worker thread (unlike the async, UI-thread file picker).
- **`pick_writable_folder()`** — async picker resolving to a durable handle string; **`open_writable_folder(handle)`** rebuilds a store from it.
- Same registration shape as the file picker: thread-local `set_platform_writable_folder_picker` + a thread-safe `set_writable_folder_store_factory`.

## Platforms

- **Desktop**: `std::fs` backend (rfd folder pick; atomic temp+rename; EROFS/EACCES → `ReadOnly`).
- **Android**: `cranposePickWritableFolder` + `cranposeFolderWrite/List/Read/Remove/Writable` on `CranposeFilePickerActivity`, reusing the resilient `queryChildrenWithRetry` walk (EXTRA_LOADING + retries for slow WebDAV/cloud providers), behind a JNI-backed `AndroidWritableFolder`. No new manifest permission (SAF grants are runtime).
- **iOS** (security-scoped bookmarks) and **web** return `FolderError::Unsupported` for now.

Bumps the workspace to **0.1.24**.

## Verification

- `cargo test -p cranpose-services --features file-picker-native` — 23 pass (4 new for the desktop store + registration).
- `cargo ndk -t arm64-v8a check/clippy -p cranpose --features android,renderer-wgpu` — clean (no warnings in new files).
- `javac` of `CranposeFilePickerActivity.java` against `android.jar` — clean.
- `scripts/check_cranpose_versions.py` — aligned at 0.1.24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)