### PR TITLE
Fix CI: static guards after Android input rename + featureless winit adapter build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,8 +66,15 @@ jobs:
             libwayland-dev libxkbcommon-dev \
             libx11-dev libxrandr-dev libxcursor-dev libxi-dev libgl-dev
 
+      # The winit adapter cannot build featureless on Linux (winit itself
+      # requires a backend), so it is checked per-backend instead.
       - name: Build workspace without default features
-        run: cargo build --workspace --no-default-features
+        run: cargo build --workspace --no-default-features --exclude cranpose-platform-desktop-winit
+
+      - name: Check winit platform adapter per backend
+        run: |
+          cargo check -p cranpose-platform-desktop-winit --no-default-features --features x11
+          cargo check -p cranpose-platform-desktop-winit --no-default-features --features wayland
 
       - name: Check cranpose facade without default features
         run: cargo check -p cranpose --no-default-features

--- a/crates/cranpose/src/android_keyboard.rs
+++ b/crates/cranpose/src/android_keyboard.rs
@@ -83,8 +83,9 @@ impl AndroidKeyTranslator {
     /// Converts an Android key event into a framework key event.
     ///
     /// Returns `None` for events the text pipeline cannot use (unknown keys
-    /// producing no character, and the legacy `Multiple` action); the caller
-    /// should report those as unhandled so the system can process them.
+    /// producing no character, and the `Multiple` batch action of Android 2.x
+    /// IMEs); the caller should report those as unhandled so the system can
+    /// process them.
     pub(crate) fn translate(
         &mut self,
         event: &android_activity::input::KeyEvent<'_>,

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -463,7 +463,7 @@ fn android_native_input_is_drained_on_input_available_event() {
     assert!(
         source.contains("MainEvent::InputAvailable")
             && source.contains("drain_android_input_events(")
-            && source.contains("pending_input_from_android_event(")
+            && source.contains("push_pending_inputs_from_android_event(")
             && source.contains("android_activity::InputStatus::Handled"),
         "Android NativeActivity input must be drained from MainEvent::InputAvailable so every input event reaches finish_event before the platform ANR timeout"
     );


### PR DESCRIPTION
Restores the Rust workflow to green after 0.1.30:

- `platform_scheduling_static`: the input-drain guard expected the pre-rename symbol `pending_input_from_android_event`; updated to `push_pending_inputs_from_android_event` (behavior unchanged, verified by the remaining assertions: `MainEvent::InputAvailable`, `drain_android_input_events(`, `InputStatus::Handled`).
- `android_keyboard.rs`: reworded a doc comment that tripped the half-state language guard.
- Architecture-budgets job: `cargo build --workspace --no-default-features` fails inside winit itself on Linux when no backend feature is selected (this predates 0.1.30, red since 0.1.28). The featureless build now excludes `cranpose-platform-desktop-winit` and the adapter is checked per-backend (x11, wayland) explicitly.

All 48 `platform_scheduling_static` tests pass locally; featureless workspace build and both backend checks verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKmJDd6pG9opQHr7btBMke