### PR TITLE
Add Compose-parity animation APIs: animateColorAsState, Crossfade, AnimatedVisibility, collectIsPressedAsState

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ name = "cranpose-animation"
 version = "0.1.30"
 dependencies = [
  "cranpose-core",
+ "cranpose-ui-graphics",
 ]
 
 [[package]]

--- a/crates/cranpose-animation/Cargo.toml
+++ b/crates/cranpose-animation/Cargo.toml
@@ -13,6 +13,7 @@ description = "Animation system for Cranpose"
 
 [dependencies]
 cranpose-core = { workspace = true, features = ["internal"] }
+cranpose-ui-graphics = { workspace = true }
 
 [features]
 default = []

--- a/crates/cranpose-animation/src/color.rs
+++ b/crates/cranpose-animation/src/color.rs
@@ -1,0 +1,105 @@
+//! Color animation for Cranpose
+//!
+//! Mirrors Jetpack Compose's `animateColorAsState` from
+//! `androidx.compose.animation.SingleValueAnimation` by layering a [`Lerp`]
+//! implementation for [`Color`] over the generic [`Animatable`] machinery.
+//!
+//! Note: This module uses camelCase for function names to maintain 1:1 API
+//! parity with Jetpack Compose.
+
+#![allow(non_snake_case)]
+
+use crate::animation::{Animatable, AnimationType, Lerp, SpringScalar};
+use cranpose_core::{with_current_composer, Owned, State};
+use cranpose_ui_graphics::Color;
+
+impl Lerp for Color {
+    /// Linearly interpolate each RGBA channel, including alpha.
+    ///
+    /// Jetpack Compose's default `Color` lerp converts through the Oklab
+    /// color space before interpolating. Cranpose colors carry no color-space
+    /// information, so this implementation interpolates each channel linearly
+    /// in the color's own (linear RGBA) space instead. For typical UI fades
+    /// between colors in the same space this closely matches Compose's
+    /// behavior; the results are clamped to `[0.0, 1.0]` per channel so
+    /// overshooting springs still produce valid colors, matching Compose's
+    /// gamut coercion.
+    fn lerp(&self, target: &Self, fraction: f32) -> Self {
+        Color(
+            self.0.lerp(&target.0, fraction).clamp(0.0, 1.0),
+            self.1.lerp(&target.1, fraction).clamp(0.0, 1.0),
+            self.2.lerp(&target.2, fraction).clamp(0.0, 1.0),
+            self.3.lerp(&target.3, fraction).clamp(0.0, 1.0),
+        )
+    }
+}
+
+impl SpringScalar for Color {
+    /// Magnitude of the RGBA vector.
+    ///
+    /// Only a coarse scalar view: spring progress and settling for colors use
+    /// the 4-channel overrides below, mirroring how Compose animates colors
+    /// as `AnimationVector4D`.
+    fn to_f32(&self) -> f32 {
+        (self.0 * self.0 + self.1 * self.1 + self.2 * self.2 + self.3 * self.3).sqrt()
+    }
+
+    /// Progress of `current` along the 4D line from `start` to `target`,
+    /// computed as a vector projection so all channels contribute.
+    fn spring_progress(start: &Self, target: &Self, current: &Self) -> f32 {
+        let delta = [
+            target.0 - start.0,
+            target.1 - start.1,
+            target.2 - start.2,
+            target.3 - start.3,
+        ];
+        let len_sq: f32 = delta.iter().map(|d| d * d).sum();
+        if len_sq < f32::EPSILON {
+            1.0
+        } else {
+            let travelled = (current.0 - start.0) * delta[0]
+                + (current.1 - start.1) * delta[1]
+                + (current.2 - start.2) * delta[2]
+                + (current.3 - start.3) * delta[3];
+            travelled / len_sq
+        }
+    }
+
+    /// Euclidean distance across all four channels.
+    fn is_near_target(current: &Self, target: &Self, threshold: f32) -> bool {
+        let dr = current.0 - target.0;
+        let dg = current.1 - target.1;
+        let db = current.2 - target.2;
+        let da = current.3 - target.3;
+        (dr * dr + dg * dg + db * db + da * da).sqrt() < threshold
+    }
+}
+
+/// Fire-and-forget color animation. Returns a [`State`] whose value is
+/// updated by animations towards the provided `target` whenever `target`
+/// changes.
+///
+/// Mirrors Jetpack Compose:
+/// `animateColorAsState(targetValue, animationSpec, label)`.
+///
+/// The interpolation happens linearly per RGBA channel, including alpha (see
+/// [`Lerp`] for [`Color`] for how this relates to Compose's Oklab lerp).
+pub fn animateColorAsState(target: Color, animation: AnimationType, label: &str) -> State<Color> {
+    let _ = label;
+    with_current_composer(|composer| {
+        let runtime = composer.runtime_handle();
+        let anim: Owned<Animatable<Color>> = composer.remember(|| Animatable::new(target, runtime));
+        anim.update(|animatable| {
+            let is_new_target = animatable.target() != target;
+            let is_new_animation = animatable.animation_type() != animation;
+            if is_new_target || is_new_animation {
+                animatable.animateTo(target, animation);
+            }
+        });
+        anim.with(|animatable| animatable.state())
+    })
+}
+
+#[cfg(test)]
+#[path = "tests/color_tests.rs"]
+mod tests;

--- a/crates/cranpose-animation/src/lib.rs
+++ b/crates/cranpose-animation/src/lib.rs
@@ -6,10 +6,12 @@
 #![allow(non_snake_case)]
 
 pub mod animation;
+pub mod color;
 pub mod decay_spec;
 
 // Re-export animation system
 pub use animation::*;
+pub use color::animateColorAsState;
 pub use decay_spec::{FlingCalculator, FlingInfo, FloatDecayAnimationSpec, SplineBasedDecaySpec};
 
 pub mod prelude {
@@ -18,5 +20,6 @@ pub mod prelude {
         Animatable, AnimationSpec, AnimationType, Easing, InfiniteRepeatableSpec,
         InfiniteTransition, Lerp, RepeatMode, Spring, SpringSpec, StartOffset, StartOffsetType,
     };
+    pub use crate::color::animateColorAsState;
     pub use crate::decay_spec::{FlingCalculator, FloatDecayAnimationSpec, SplineBasedDecaySpec};
 }

--- a/crates/cranpose-animation/src/tests/color_tests.rs
+++ b/crates/cranpose-animation/src/tests/color_tests.rs
@@ -1,0 +1,163 @@
+use super::*;
+
+use crate::animation::{AnimationSpec, AnimationType, Lerp, SpringSpec};
+use cranpose_core::{location_key, with_current_composer, Composition, MemoryApplier, State};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+fn assert_color_near(actual: Color, expected: Color, tolerance: f32) {
+    let channels = [
+        (actual.0, expected.0, "r"),
+        (actual.1, expected.1, "g"),
+        (actual.2, expected.2, "b"),
+        (actual.3, expected.3, "a"),
+    ];
+    for (actual, expected, name) in channels {
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "channel {name} should be near {expected}, got {actual}"
+        );
+    }
+}
+
+#[test]
+fn color_lerp_interpolates_each_channel_including_alpha() {
+    let start = Color(0.0, 0.2, 0.4, 0.0);
+    let end = Color(1.0, 0.6, 0.8, 1.0);
+
+    assert_color_near(start.lerp(&end, 0.5), Color(0.5, 0.4, 0.6, 0.5), 1e-6);
+    assert_color_near(start.lerp(&end, 0.25), Color(0.25, 0.3, 0.5, 0.25), 1e-6);
+}
+
+#[test]
+fn color_lerp_endpoints_match_inputs() {
+    let start = Color(0.1, 0.2, 0.3, 0.4);
+    let end = Color(0.9, 0.8, 0.7, 0.6);
+
+    assert_color_near(start.lerp(&end, 0.0), start, 1e-6);
+    assert_color_near(start.lerp(&end, 1.0), end, 1e-6);
+}
+
+#[test]
+fn color_lerp_clamps_overshoot_to_valid_range() {
+    let start = Color(0.0, 0.0, 0.0, 0.0);
+    let end = Color(1.0, 1.0, 1.0, 1.0);
+
+    // Springs can overshoot the target fraction; the result must stay a
+    // valid color.
+    assert_color_near(start.lerp(&end, 1.5), Color(1.0, 1.0, 1.0, 1.0), 1e-6);
+    assert_color_near(end.lerp(&start, 1.5), Color(0.0, 0.0, 0.0, 0.0), 1e-6);
+}
+
+#[test]
+fn color_spring_progress_projects_across_all_channels() {
+    let start = Color(0.0, 0.0, 0.0, 0.0);
+    let target = Color(1.0, 1.0, 1.0, 1.0);
+    let halfway = Color(0.5, 0.5, 0.5, 0.5);
+
+    let progress = <Color as SpringScalar>::spring_progress(&start, &target, &halfway);
+    assert!(
+        (progress - 0.5).abs() < 1e-6,
+        "expected 0.5, got {progress}"
+    );
+
+    // Degenerate span reports finished.
+    let same = <Color as SpringScalar>::spring_progress(&start, &start, &start);
+    assert!((same - 1.0).abs() < 1e-6, "expected 1.0, got {same}");
+}
+
+#[test]
+fn animate_color_as_state_interpolates_over_time() {
+    let mut composition = Composition::new(MemoryApplier::new());
+    let runtime = composition.runtime_handle();
+    let root_key = location_key(file!(), line!(), column!());
+    let group_key = location_key(file!(), line!(), column!());
+    let state_slot = Rc::new(RefCell::new(None::<State<Color>>));
+    let target = Rc::new(RefCell::new(Color(0.0, 0.0, 0.0, 0.0)));
+
+    let render = |composition: &mut Composition<MemoryApplier>,
+                  state_slot: &Rc<RefCell<Option<State<Color>>>>,
+                  target: &Rc<RefCell<Color>>| {
+        let state_slot = Rc::clone(state_slot);
+        let target = Rc::clone(target);
+        composition
+            .render(root_key, move || {
+                let state_slot = Rc::clone(&state_slot);
+                let target = Rc::clone(&target);
+                with_current_composer(|composer| {
+                    composer.with_group(group_key, |_| {
+                        let state = animateColorAsState(
+                            *target.borrow(),
+                            AnimationType::Tween(AnimationSpec::linear(300)),
+                            "background_color",
+                        );
+                        state_slot.borrow_mut().replace(state);
+                    });
+                });
+            })
+            .expect("render succeeds");
+    };
+
+    render(&mut composition, &state_slot, &target);
+    let initial = state_slot.borrow().as_ref().expect("state available").get();
+    assert_color_near(initial, Color(0.0, 0.0, 0.0, 0.0), 1e-6);
+
+    *target.borrow_mut() = Color(1.0, 0.5, 0.25, 1.0);
+    render(&mut composition, &state_slot, &target);
+    assert!(composition.should_render());
+
+    let mut frame_time = 0u64;
+    let mut saw_midpoint = false;
+    for _ in 0..64 {
+        if !composition.should_render() {
+            break;
+        }
+        frame_time += 16_666_667; // ~60 FPS
+        runtime.drain_frame_callbacks(frame_time);
+        let _ = composition
+            .process_invalid_scopes()
+            .expect("process invalid scopes succeeds");
+        if let Some(state) = state_slot.borrow().as_ref() {
+            let value = state.get();
+            if value.0 > 0.0 && value.0 < 1.0 && value.3 > 0.0 && value.3 < 1.0 {
+                saw_midpoint = true;
+            }
+        }
+    }
+
+    assert!(
+        saw_midpoint,
+        "color animation should report intermediate values incl. alpha"
+    );
+    let last = state_slot.borrow().as_ref().expect("state available").get();
+    assert_color_near(last, Color(1.0, 0.5, 0.25, 1.0), 1e-4);
+    assert!(!composition.should_render());
+}
+
+#[test]
+fn animatable_color_spring_settles_at_target() {
+    let composition = Composition::new(MemoryApplier::new());
+    let runtime = composition.runtime_handle();
+    let mut animatable = Animatable::new(Color(0.0, 0.0, 0.0, 0.0), runtime.clone());
+    let state = animatable.state();
+
+    animatable.animateTo(
+        Color(1.0, 0.5, 0.25, 1.0),
+        AnimationType::Spring(SpringSpec::default_spring()),
+    );
+
+    let mut frame_time = 0u64;
+    for _ in 0..600 {
+        frame_time += 16_666_667;
+        runtime.drain_frame_callbacks(frame_time);
+        if !runtime.has_frame_callbacks() {
+            break;
+        }
+    }
+
+    assert!(
+        !runtime.has_frame_callbacks(),
+        "spring should settle within the frame budget"
+    );
+    assert_color_near(state.get(), Color(1.0, 0.5, 0.25, 1.0), 1e-3);
+}

--- a/crates/cranpose-ui/src/interaction.rs
+++ b/crates/cranpose-ui/src/interaction.rs
@@ -120,6 +120,16 @@ impl MutableInteractionSource {
         }
     }
 
+    /// Returns whether the interaction source is currently pressed as a
+    /// reactive [`State`].
+    ///
+    /// Mirrors Jetpack Compose: `InteractionSource.collectIsPressedAsState()`.
+    ///
+    /// The value flips to `true` when a `PressInteraction::Press` is emitted
+    /// and back to `false` once every active press has seen a matching
+    /// `PressInteraction::Release` or `PressInteraction::Cancel`. Reading the
+    /// returned state inside a composable subscribes the enclosing recompose
+    /// scope, so the composable recomposes whenever the pressed state changes.
     pub fn collectIsPressedAsState(&self) -> State<bool> {
         self.inner.pressed.as_state()
     }
@@ -162,6 +172,18 @@ pub fn rememberMutableInteractionSource() -> MutableInteractionSource {
     let runtime = with_current_composer(|composer| composer.runtime_handle());
     remember(move || MutableInteractionSource::with_runtime(runtime.clone()))
         .with(|source| source.clone())
+}
+
+/// Free-function form of
+/// [`MutableInteractionSource::collectIsPressedAsState`].
+///
+/// Mirrors Jetpack Compose: `InteractionSource.collectIsPressedAsState()`.
+///
+/// Returns a reactive [`State`] derived from the press interactions emitted
+/// by `interaction_source`: `true` between `PressInteraction::Press` and the
+/// matching `PressInteraction::Release`/`PressInteraction::Cancel`.
+pub fn collect_is_pressed_as_state(interaction_source: &MutableInteractionSource) -> State<bool> {
+    interaction_source.collectIsPressedAsState()
 }
 
 impl Modifier {
@@ -389,6 +411,89 @@ mod tests {
         assert_eq!(first.press(Point { x: 0.0, y: 0.0 }).id(), 1);
         assert_eq!(first.press(Point { x: 1.0, y: 1.0 }).id(), 2);
         assert_eq!(second.press(Point { x: 0.0, y: 0.0 }).id(), 1);
+    }
+
+    #[test]
+    fn collect_is_pressed_as_state_tracks_press_emissions() {
+        let composition = Composition::new(MemoryApplier::new());
+        let source = MutableInteractionSource::with_runtime(composition.runtime_handle());
+        let pressed = collect_is_pressed_as_state(&source);
+
+        assert!(!pressed.get());
+
+        let press = PressInteractionPress {
+            id: 7,
+            press_position: Point { x: 4.0, y: 5.0 },
+        };
+        source.emit(Interaction::Press(PressInteraction::Press(press)));
+        assert!(pressed.get(), "pressed after a Press emission");
+
+        source.emit(Interaction::Press(PressInteraction::Release(
+            PressInteractionRelease { press },
+        )));
+        assert!(!pressed.get(), "released after a Release emission");
+
+        source.emit(Interaction::Press(PressInteraction::Press(press)));
+        assert!(pressed.get(), "pressed again after a new Press emission");
+
+        source.emit(Interaction::Press(PressInteraction::Cancel(
+            PressInteractionCancel { press },
+        )));
+        assert!(!pressed.get(), "released after a Cancel emission");
+    }
+
+    #[composable]
+    fn PressedReader(
+        observed: Rc<RefCell<Vec<bool>>>,
+        source_slot: Rc<RefCell<Option<MutableInteractionSource>>>,
+    ) {
+        let source = rememberMutableInteractionSource();
+        source_slot.borrow_mut().replace(source.clone());
+        let pressed = collect_is_pressed_as_state(&source);
+        observed.borrow_mut().push(pressed.value());
+    }
+
+    #[test]
+    fn collect_is_pressed_as_state_recomposes_readers() {
+        let observed = Rc::new(RefCell::new(Vec::<bool>::new()));
+        let source_slot = Rc::new(RefCell::new(None::<MutableInteractionSource>));
+
+        let mut composition = {
+            let observed = Rc::clone(&observed);
+            let source_slot = Rc::clone(&source_slot);
+            crate::run_test_composition(move || {
+                PressedReader(Rc::clone(&observed), Rc::clone(&source_slot));
+            })
+        };
+
+        assert_eq!(observed.borrow().as_slice(), &[false]);
+
+        let source = source_slot
+            .borrow()
+            .as_ref()
+            .expect("interaction source captured")
+            .clone();
+        let press = composition.with_app_context(|| source.press(Point { x: 1.0, y: 1.0 }));
+        while composition
+            .process_invalid_scopes()
+            .expect("process press invalidation")
+        {}
+        assert_eq!(
+            observed.borrow().last(),
+            Some(&true),
+            "press emission should recompose readers with pressed=true"
+        );
+
+        composition.with_app_context(|| source.release(press));
+        while composition
+            .process_invalid_scopes()
+            .expect("process release invalidation")
+        {}
+        assert_eq!(
+            observed.borrow().last(),
+            Some(&false),
+            "release emission should recompose readers with pressed=false"
+        );
     }
 
     #[test]

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -56,8 +56,9 @@ pub use focus_dispatch::{
     process_focus_invalidations, schedule_focus_invalidation, set_active_focus_target,
 };
 pub use interaction::{
-    rememberMutableInteractionSource, Interaction, MutableInteractionSource, PressInteraction,
-    PressInteractionCancel, PressInteractionPress, PressInteractionRelease,
+    collect_is_pressed_as_state, rememberMutableInteractionSource, Interaction,
+    MutableInteractionSource, PressInteraction, PressInteractionCancel, PressInteractionPress,
+    PressInteractionRelease,
 };
 pub use safe_area::local_safe_area_insets;
 // Re-export FocusManager from cranpose-foundation to avoid duplication
@@ -87,19 +88,21 @@ pub use modifier::{
 };
 pub use modifier_nodes::{
     AlphaElement, AlphaNode, BackgroundElement, BackgroundNode, ClickableElement, ClickableNode,
-    CornerShapeElement, CornerShapeNode, FillDirection, FillElement, FillNode, OffsetElement,
-    OffsetNode, PaddingElement, PaddingNode, SizeElement, SizeNode,
+    CornerShapeElement, CornerShapeNode, FillDirection, FillElement, FillNode,
+    FractionalOffsetElement, FractionalOffsetNode, OffsetElement, OffsetNode, PaddingElement,
+    PaddingNode, SizeElement, SizeNode,
 };
 pub use pointer_dispatch::{
     clear_pointer_repasses, has_pending_pointer_repasses, process_pointer_repasses,
     schedule_pointer_repass,
 };
 pub use primitives::{
-    remember_svg, BasicText, BasicTextField, BasicTextFieldOptions, BasicTextWithOptions,
-    BitmapPainter, Box, BoxScope, BoxSpec, BoxWithConstraints, BoxWithConstraintsScope,
-    BoxWithConstraintsScopeImpl, Button, ButtonSpec, Canvas, Column, ColumnSpec, ContentScale,
-    ForEach, Image, Layout, LayoutNode, Painter, Row, RowSpec, Spacer, SubcomposeLayout,
-    SvgPainter, SvgPainterError, Text, TextWithOptions, DEFAULT_ALPHA,
+    fade_in, fade_out, remember_svg, slide_in_vertically, slide_out_vertically, AnimatedVisibility,
+    BasicText, BasicTextField, BasicTextFieldOptions, BasicTextWithOptions, BitmapPainter, Box,
+    BoxScope, BoxSpec, BoxWithConstraints, BoxWithConstraintsScope, BoxWithConstraintsScopeImpl,
+    Button, ButtonSpec, Canvas, Column, ColumnSpec, ContentScale, Crossfade, EnterTransition,
+    ExitTransition, ForEach, Image, Layout, LayoutNode, Painter, Row, RowSpec, Spacer,
+    SubcomposeLayout, SvgPainter, SvgPainterError, Text, TextWithOptions, DEFAULT_ALPHA,
 };
 // Lazy list exports - single source from cranpose-foundation
 pub use cranpose_foundation::lazy::{LazyListItemInfo, LazyListLayoutInfo, LazyListState};
@@ -246,6 +249,14 @@ pub use cranpose_core::MutableState as SnapshotState;
 #[cfg(test)]
 #[path = "tests/anchor_async_tests.rs"]
 mod anchor_async_tests;
+
+#[cfg(test)]
+#[path = "tests/animated_visibility_tests.rs"]
+mod animated_visibility_tests;
+
+#[cfg(test)]
+#[path = "tests/crossfade_tests.rs"]
+mod crossfade_tests;
 
 #[cfg(test)]
 #[path = "tests/async_runtime_full_layout_test.rs"]

--- a/crates/cranpose-ui/src/modifier/offset.rs
+++ b/crates/cranpose-ui/src/modifier/offset.rs
@@ -3,7 +3,7 @@
 //! Reference: /media/huge/composerepo/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/Offset.kt
 
 use super::{inspector_metadata, Modifier, Point};
-use crate::modifier_nodes::OffsetElement;
+use crate::modifier_nodes::{FractionalOffsetElement, OffsetElement};
 
 impl Modifier {
     /// Offset the content by (x, y). The offsets can be positive or negative.
@@ -36,6 +36,28 @@ impl Modifier {
                 info.add_offset_components("absoluteOffsetX", "absoluteOffsetY", Point { x, y });
             }),
         );
+        self.then(modifier)
+    }
+
+    /// Offset the content by a fraction of its own measured size.
+    ///
+    /// `x_fraction` / `y_fraction` are multiplied by the measured width /
+    /// height of the content when it is placed, so `offset_fraction(0.0,
+    /// -0.5)` moves the content up by half its own height. Like
+    /// [`Modifier::offset`], this only affects placement, not measurement.
+    ///
+    /// There is no direct Jetpack Compose equivalent; Compose's
+    /// `slideInVertically`/`slideOutVertically` receive the measured size via
+    /// a lambda instead. This modifier backs `slide_in_vertically` /
+    /// `slide_out_vertically` in `AnimatedVisibility`.
+    ///
+    /// Example: `Modifier::empty().offset_fraction(0.0, -0.5)`
+    pub fn offset_fraction(self, x_fraction: f32, y_fraction: f32) -> Self {
+        let modifier = Self::with_element(FractionalOffsetElement::new(x_fraction, y_fraction))
+            .with_inspector_metadata(inspector_metadata("offsetFraction", move |info| {
+                info.add_property("offsetFractionX", x_fraction.to_string());
+                info.add_property("offsetFractionY", y_fraction.to_string());
+            }));
         self.then(modifier)
     }
 }

--- a/crates/cranpose-ui/src/modifier_nodes.rs
+++ b/crates/cranpose-ui/src/modifier_nodes.rs
@@ -1819,6 +1819,146 @@ impl ModifierNodeElement for OffsetElement {
 }
 
 // ============================================================================
+// Fractional Offset Modifier Node
+// ============================================================================
+
+/// Node that offsets its content by a fraction of its own measured size.
+///
+/// There is no direct Jetpack Compose modifier equivalent; Compose's slide
+/// transitions receive the measured size through a lambda instead. This node
+/// backs `slide_in_vertically` / `slide_out_vertically` in
+/// `AnimatedVisibility`, where the offset is expressed as a fraction of the
+/// content height.
+#[derive(Debug)]
+pub struct FractionalOffsetNode {
+    x_fraction: f32,
+    y_fraction: f32,
+    state: NodeState,
+}
+
+impl FractionalOffsetNode {
+    pub fn new(x_fraction: f32, y_fraction: f32) -> Self {
+        Self {
+            x_fraction,
+            y_fraction,
+            state: NodeState::new(),
+        }
+    }
+
+    pub fn fractions(&self) -> Point {
+        Point {
+            x: self.x_fraction,
+            y: self.y_fraction,
+        }
+    }
+}
+
+impl DelegatableNode for FractionalOffsetNode {
+    fn node_state(&self) -> &NodeState {
+        &self.state
+    }
+}
+
+impl ModifierNode for FractionalOffsetNode {
+    fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
+        context.invalidate(cranpose_foundation::InvalidationKind::Layout);
+    }
+
+    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
+        Some(self)
+    }
+
+    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
+        Some(self)
+    }
+}
+
+impl LayoutModifierNode for FractionalOffsetNode {
+    fn measure(
+        &self,
+        _context: &mut dyn ModifierNodeContext,
+        measurable: &dyn Measurable,
+        constraints: Constraints,
+    ) -> cranpose_ui_layout::LayoutModifierMeasureResult {
+        // Offset doesn't affect measurement, just placement. The placement
+        // offset is resolved against the measured content size.
+        let placeable = measurable.measure(constraints);
+
+        cranpose_ui_layout::LayoutModifierMeasureResult::new(
+            Size {
+                width: placeable.width(),
+                height: placeable.height(),
+            },
+            self.x_fraction * placeable.width(),
+            self.y_fraction * placeable.height(),
+        )
+    }
+
+    fn min_intrinsic_width(&self, measurable: &dyn Measurable, height: f32) -> f32 {
+        measurable.min_intrinsic_width(height)
+    }
+
+    fn max_intrinsic_width(&self, measurable: &dyn Measurable, height: f32) -> f32 {
+        measurable.max_intrinsic_width(height)
+    }
+
+    fn min_intrinsic_height(&self, measurable: &dyn Measurable, width: f32) -> f32 {
+        measurable.min_intrinsic_height(width)
+    }
+
+    fn max_intrinsic_height(&self, measurable: &dyn Measurable, width: f32) -> f32 {
+        measurable.max_intrinsic_height(width)
+    }
+}
+
+/// Element that creates and updates fractional offset nodes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FractionalOffsetElement {
+    x_fraction: f32,
+    y_fraction: f32,
+}
+
+impl FractionalOffsetElement {
+    pub fn new(x_fraction: f32, y_fraction: f32) -> Self {
+        Self {
+            x_fraction,
+            y_fraction,
+        }
+    }
+}
+
+impl Hash for FractionalOffsetElement {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        "fractional_offset".hash(state);
+        hash_f32_value(state, self.x_fraction);
+        hash_f32_value(state, self.y_fraction);
+    }
+}
+
+impl ModifierNodeElement for FractionalOffsetElement {
+    type Node = FractionalOffsetNode;
+
+    fn create(&self) -> Self::Node {
+        FractionalOffsetNode::new(self.x_fraction, self.y_fraction)
+    }
+
+    fn update(&self, node: &mut Self::Node) {
+        if node.x_fraction != self.x_fraction || node.y_fraction != self.y_fraction {
+            node.x_fraction = self.x_fraction;
+            node.y_fraction = self.y_fraction;
+        }
+    }
+
+    fn capabilities(&self) -> NodeCapabilities {
+        NodeCapabilities::LAYOUT
+    }
+
+    fn update_invalidation_kind(&self) -> Option<InvalidationKind> {
+        Some(InvalidationKind::Layout)
+    }
+}
+
+// ============================================================================
 // Fill Modifier Node
 // ============================================================================
 

--- a/crates/cranpose-ui/src/tests/animated_visibility_tests.rs
+++ b/crates/cranpose-ui/src/tests/animated_visibility_tests.rs
@@ -1,0 +1,211 @@
+use crate::{
+    fade_in, fade_out, run_test_composition, slide_in_vertically, slide_out_vertically,
+    AnimatedVisibility, EnterTransition, ExitTransition, TestComposition,
+};
+use cranpose_animation::{tween, AnimationType, Easing};
+use cranpose_core::{DisposableEffectResult, MutableState};
+use cranpose_macros::composable;
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+const FRAME_NANOS: u64 = 16_666_667; // ~60 FPS
+const TRANSITION_MILLIS: u64 = 160;
+
+fn transition_spec() -> AnimationType {
+    tween(TRANSITION_MILLIS, Easing::LinearEasing)
+}
+
+fn drain(composition: &mut TestComposition) {
+    while composition
+        .process_invalid_scopes()
+        .expect("process invalid scopes")
+    {}
+}
+
+fn pump_frames(composition: &mut TestComposition, frame_time: &mut u64, frames: usize) {
+    let runtime = composition.runtime_handle();
+    for _ in 0..frames {
+        *frame_time += FRAME_NANOS;
+        composition.with_app_context(|| {
+            runtime.drain_frame_callbacks(*frame_time);
+            runtime.drain_ui();
+        });
+        drain(composition);
+    }
+}
+
+fn settle(composition: &mut TestComposition, frame_time: &mut u64) {
+    for _ in 0..120 {
+        if !composition.should_render() {
+            break;
+        }
+        pump_frames(composition, frame_time, 1);
+    }
+}
+
+#[composable]
+fn VisibilityHost(visible: MutableState<bool>, alive: Rc<Cell<bool>>) {
+    let is_visible = visible.value();
+    let alive_for_content = Rc::clone(&alive);
+    AnimatedVisibility(
+        is_visible,
+        (fade_in() + slide_in_vertically(-0.5)).with_animation(transition_spec()),
+        (fade_out() + slide_out_vertically(0.5)).with_animation(transition_spec()),
+        move || {
+            let alive = Rc::clone(&alive_for_content);
+            cranpose_core::DisposableEffect!((), move |_scope| {
+                alive.set(true);
+                let alive = Rc::clone(&alive);
+                DisposableEffectResult::new(move || {
+                    alive.set(false);
+                })
+            });
+        },
+    );
+}
+
+fn visibility_composition(initial: bool) -> (TestComposition, MutableState<bool>, Rc<Cell<bool>>) {
+    let alive = Rc::new(Cell::new(false));
+    let visible_slot = Rc::new(RefCell::new(None::<MutableState<bool>>));
+
+    let composition = {
+        let alive = Rc::clone(&alive);
+        let visible_slot = Rc::clone(&visible_slot);
+        run_test_composition(move || {
+            let visible = cranpose_core::useState(move || initial);
+            visible_slot.borrow_mut().replace(visible);
+            VisibilityHost(visible, Rc::clone(&alive));
+        })
+    };
+
+    let visible = visible_slot
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("visible state captured");
+    (composition, visible, alive)
+}
+
+#[test]
+fn initially_hidden_content_is_never_composed() {
+    let (mut composition, _visible, alive) = visibility_composition(false);
+    let mut frame_time = 0u64;
+
+    assert!(!alive.get(), "hidden content must not be composed");
+    settle(&mut composition, &mut frame_time);
+    assert!(
+        !alive.get(),
+        "hidden content must stay out of the composition"
+    );
+}
+
+#[test]
+fn initially_visible_content_appears_without_animation() {
+    let (mut composition, _visible, alive) = visibility_composition(true);
+    let mut frame_time = 0u64;
+
+    assert!(alive.get(), "visible content should be composed right away");
+    settle(&mut composition, &mut frame_time);
+    assert!(alive.get());
+    assert!(!composition.should_render());
+}
+
+#[test]
+fn content_stays_composed_during_exit_and_leaves_after_it_completes() {
+    let (mut composition, visible, alive) = visibility_composition(true);
+    let mut frame_time = 0u64;
+    settle(&mut composition, &mut frame_time);
+
+    composition.with_app_context(|| visible.set_value(false));
+    drain(&mut composition);
+    assert!(
+        alive.get(),
+        "content must stay composed when the exit transition starts"
+    );
+
+    pump_frames(&mut composition, &mut frame_time, 3);
+    assert!(
+        alive.get(),
+        "content must stay composed while the exit transition runs"
+    );
+
+    settle(&mut composition, &mut frame_time);
+    assert!(
+        !alive.get(),
+        "content must leave the composition after the exit transition completes"
+    );
+    assert!(
+        !composition.should_render(),
+        "exit should settle with no pending animation frames"
+    );
+}
+
+#[test]
+fn becoming_visible_mid_exit_keeps_content_composed() {
+    let (mut composition, visible, alive) = visibility_composition(true);
+    let mut frame_time = 0u64;
+    settle(&mut composition, &mut frame_time);
+
+    composition.with_app_context(|| visible.set_value(false));
+    drain(&mut composition);
+    pump_frames(&mut composition, &mut frame_time, 2);
+    assert!(alive.get(), "content composed mid-exit");
+
+    // Toggle back to visible before the exit finishes: the enter transition
+    // retargets the running animation and the content never leaves.
+    composition.with_app_context(|| visible.set_value(true));
+    drain(&mut composition);
+    settle(&mut composition, &mut frame_time);
+    assert!(
+        alive.get(),
+        "content must remain composed after re-entering mid-exit"
+    );
+}
+
+#[test]
+fn hidden_then_shown_content_enters_the_composition() {
+    let (mut composition, visible, alive) = visibility_composition(false);
+    let mut frame_time = 0u64;
+    settle(&mut composition, &mut frame_time);
+    assert!(!alive.get());
+
+    composition.with_app_context(|| visible.set_value(true));
+    drain(&mut composition);
+    assert!(
+        alive.get(),
+        "content should be composed as soon as the enter transition starts"
+    );
+
+    settle(&mut composition, &mut frame_time);
+    assert!(alive.get());
+}
+
+#[test]
+fn enter_and_exit_transitions_combine_with_plus() {
+    let enter = fade_in() + slide_in_vertically(-0.5);
+    assert!(enter.has_fade());
+    assert_eq!(enter.slide_vertical_fraction(), Some(-0.5));
+    assert_eq!(enter.animation(), AnimationType::default());
+
+    let enter = enter.with_animation(transition_spec());
+    assert_eq!(enter.animation(), transition_spec());
+
+    let exit = slide_out_vertically(0.25) + fade_out();
+    assert!(exit.has_fade());
+    assert_eq!(exit.slide_vertical_fraction(), Some(0.25));
+
+    // `+` keeps the left-hand animation spec when both sides carry one, like
+    // effect order in Compose is preserved.
+    let spec_a = tween(100, Easing::LinearEasing);
+    let spec_b = tween(200, Easing::EaseIn);
+    let combined =
+        fade_in().with_animation(spec_a) + slide_in_vertically(-1.0).with_animation(spec_b);
+    assert_eq!(combined.animation(), spec_a);
+
+    let none = EnterTransition::none();
+    assert!(!none.has_fade());
+    assert_eq!(none.slide_vertical_fraction(), None);
+    let none = ExitTransition::none();
+    assert!(!none.has_fade());
+    assert_eq!(none.slide_vertical_fraction(), None);
+}

--- a/crates/cranpose-ui/src/tests/crossfade_tests.rs
+++ b/crates/cranpose-ui/src/tests/crossfade_tests.rs
@@ -1,0 +1,166 @@
+use crate::{run_test_composition, Crossfade, TestComposition};
+use cranpose_animation::{tween, Easing};
+use cranpose_core::{DisposableEffectResult, MutableState};
+use cranpose_macros::composable;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+const FRAME_NANOS: u64 = 16_666_667; // ~60 FPS
+const CROSSFADE_MILLIS: u64 = 160;
+
+fn drain(composition: &mut TestComposition) {
+    while composition
+        .process_invalid_scopes()
+        .expect("process invalid scopes")
+    {}
+}
+
+fn pump_frames(composition: &mut TestComposition, frame_time: &mut u64, frames: usize) {
+    let runtime = composition.runtime_handle();
+    for _ in 0..frames {
+        *frame_time += FRAME_NANOS;
+        composition.with_app_context(|| {
+            runtime.drain_frame_callbacks(*frame_time);
+            runtime.drain_ui();
+        });
+        drain(composition);
+    }
+}
+
+fn settle(composition: &mut TestComposition, frame_time: &mut u64) {
+    for _ in 0..120 {
+        if !composition.should_render() {
+            break;
+        }
+        pump_frames(composition, frame_time, 1);
+    }
+}
+
+#[composable]
+fn CrossfadeHost(target: MutableState<u32>, alive: Rc<RefCell<Vec<u32>>>) {
+    let current = target.value();
+    let alive_for_content = Rc::clone(&alive);
+    Crossfade(
+        current,
+        tween(CROSSFADE_MILLIS, Easing::LinearEasing),
+        move |value: u32| {
+            let alive = Rc::clone(&alive_for_content);
+            cranpose_core::DisposableEffect!(value, move |_scope| {
+                alive.borrow_mut().push(value);
+                let alive = Rc::clone(&alive);
+                DisposableEffectResult::new(move || {
+                    alive.borrow_mut().retain(|item| *item != value);
+                })
+            });
+        },
+    );
+}
+
+fn crossfade_composition(
+    initial: u32,
+) -> (TestComposition, MutableState<u32>, Rc<RefCell<Vec<u32>>>) {
+    let alive = Rc::new(RefCell::new(Vec::<u32>::new()));
+    let target_slot = Rc::new(RefCell::new(None::<MutableState<u32>>));
+
+    let composition = {
+        let alive = Rc::clone(&alive);
+        let target_slot = Rc::clone(&target_slot);
+        run_test_composition(move || {
+            let target = cranpose_core::useState(move || initial);
+            target_slot.borrow_mut().replace(target);
+            CrossfadeHost(target, Rc::clone(&alive));
+        })
+    };
+
+    let target = target_slot
+        .borrow()
+        .as_ref()
+        .copied()
+        .expect("target state captured");
+    (composition, target, alive)
+}
+
+#[test]
+fn crossfade_shows_initial_content_immediately() {
+    let (mut composition, _target, alive) = crossfade_composition(1);
+    let mut frame_time = 0u64;
+
+    assert_eq!(
+        alive.borrow().as_slice(),
+        &[1],
+        "initial content should be composed right away"
+    );
+
+    settle(&mut composition, &mut frame_time);
+    assert_eq!(
+        alive.borrow().as_slice(),
+        &[1],
+        "initial content should stay composed with no transition running"
+    );
+    assert!(!composition.should_render());
+}
+
+#[test]
+fn crossfade_keeps_both_contents_during_transition_and_removes_old_after() {
+    let (mut composition, target, alive) = crossfade_composition(1);
+    let mut frame_time = 0u64;
+    settle(&mut composition, &mut frame_time);
+
+    composition.with_app_context(|| target.set_value(2));
+    drain(&mut composition);
+    assert_eq!(
+        alive.borrow().as_slice(),
+        &[1, 2],
+        "both contents should be composed as soon as the transition starts"
+    );
+
+    // A few frames into the crossfade both compositions must still exist.
+    pump_frames(&mut composition, &mut frame_time, 3);
+    assert_eq!(
+        alive.borrow().as_slice(),
+        &[1, 2],
+        "both contents should stay composed mid-transition"
+    );
+
+    // Run well past the crossfade duration: the old content must leave the
+    // composition once its fade-out completes.
+    settle(&mut composition, &mut frame_time);
+    assert_eq!(
+        alive.borrow().as_slice(),
+        &[2],
+        "old content should be removed after its fade-out completes"
+    );
+    assert!(
+        !composition.should_render(),
+        "crossfade should settle with no pending animation frames"
+    );
+}
+
+#[test]
+fn crossfade_retargeting_mid_transition_restores_previous_content() {
+    let (mut composition, target, alive) = crossfade_composition(1);
+    let mut frame_time = 0u64;
+    settle(&mut composition, &mut frame_time);
+
+    composition.with_app_context(|| target.set_value(2));
+    drain(&mut composition);
+    pump_frames(&mut composition, &mut frame_time, 2);
+    assert_eq!(alive.borrow().as_slice(), &[1, 2]);
+
+    // Flip back to the original state while the crossfade is still running:
+    // the original content fades back in, the interrupted one fades out.
+    composition.with_app_context(|| target.set_value(1));
+    drain(&mut composition);
+    assert_eq!(
+        alive.borrow().as_slice(),
+        &[1, 2],
+        "both contents remain composed after retargeting mid-transition"
+    );
+
+    settle(&mut composition, &mut frame_time);
+    assert_eq!(
+        alive.borrow().as_slice(),
+        &[1],
+        "interrupted content should be removed once its fade-out completes"
+    );
+}

--- a/crates/cranpose-ui/src/tests/modifier_nodes_tests.rs
+++ b/crates/cranpose-ui/src/tests/modifier_nodes_tests.rs
@@ -120,6 +120,46 @@ fn padding_node_clamps_to_constraints() {
 }
 
 #[test]
+fn fractional_offset_node_places_content_by_fraction_of_measured_size() {
+    let _app_context = crate::render_state::app_context_test_scope();
+    let mut context = BasicModifierNodeContext::new();
+    let node = FractionalOffsetNode::new(0.25, -0.5);
+    let measurable = TestMeasurable {
+        intrinsic_width: 80.0,
+        intrinsic_height: 40.0,
+    };
+    let constraints = Constraints {
+        min_width: 0.0,
+        max_width: 200.0,
+        min_height: 0.0,
+        max_height: 200.0,
+    };
+
+    let result = node.measure(&mut context, &measurable, constraints);
+
+    // Offset never affects measurement, only placement.
+    assert_eq!(result.size.width, 80.0);
+    assert_eq!(result.size.height, 40.0);
+    // Placement offset resolves the fractions against the measured size.
+    assert_eq!(result.placement_offset_x, 0.25 * 80.0);
+    assert_eq!(result.placement_offset_y, -0.5 * 40.0);
+}
+
+#[test]
+fn fractional_offset_node_passes_intrinsics_through() {
+    let node = FractionalOffsetNode::new(0.0, 1.0);
+    let measurable = TestMeasurable {
+        intrinsic_width: 64.0,
+        intrinsic_height: 32.0,
+    };
+
+    assert_eq!(node.min_intrinsic_width(&measurable, 32.0), 64.0);
+    assert_eq!(node.max_intrinsic_width(&measurable, 32.0), 64.0);
+    assert_eq!(node.min_intrinsic_height(&measurable, 64.0), 32.0);
+    assert_eq!(node.max_intrinsic_height(&measurable, 64.0), 32.0);
+}
+
+#[test]
 fn padding_node_respects_intrinsics() {
     let _app_context = crate::render_state::app_context_test_scope();
     let padding = EdgeInsets::uniform(10.0);

--- a/crates/cranpose-ui/src/widgets/animated_visibility.rs
+++ b/crates/cranpose-ui/src/widgets/animated_visibility.rs
@@ -1,0 +1,256 @@
+//! AnimatedVisibility composable
+//!
+//! Mirrors Jetpack Compose's `AnimatedVisibility` from
+//! `androidx.compose.animation.AnimatedVisibility`, with a minimal set of
+//! enter/exit transitions: `fade_in`/`fade_out` and
+//! `slide_in_vertically`/`slide_out_vertically`.
+
+#![allow(non_snake_case)]
+
+use crate::composable;
+use crate::modifier::{GraphicsLayer, Modifier};
+use crate::widgets::box_widget::{Box, BoxSpec};
+use crate::widgets::crossfade::animate_float_with_initial;
+use cranpose_animation::AnimationType;
+
+/// Progress below which exiting content is considered fully hidden and can
+/// leave the composition.
+const VISIBILITY_PROGRESS_EPSILON: f32 = 0.001;
+
+/// Defines how an [`AnimatedVisibility`] content appears.
+///
+/// Mirrors Jetpack Compose's `EnterTransition`. Transitions are combined
+/// with `+`, like Compose's `fadeIn() + slideInVertically()`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EnterTransition {
+    fade: bool,
+    slide_vertical_fraction: Option<f32>,
+    animation: Option<AnimationType>,
+}
+
+impl EnterTransition {
+    /// An empty enter transition: content appears without any effect.
+    ///
+    /// Mirrors Jetpack Compose: `EnterTransition.None`.
+    pub fn none() -> Self {
+        Self {
+            fade: false,
+            slide_vertical_fraction: None,
+            animation: None,
+        }
+    }
+
+    /// Use a custom animation spec for this transition. In Compose the spec
+    /// is a parameter of each transition factory (e.g.
+    /// `fadeIn(animationSpec = tween(300))`); here it is a builder method:
+    /// `fade_in().with_animation(tween(300, Easing::LinearEasing))`.
+    pub fn with_animation(mut self, animation: AnimationType) -> Self {
+        self.animation = Some(animation);
+        self
+    }
+
+    pub(crate) fn has_fade(&self) -> bool {
+        self.fade
+    }
+
+    pub(crate) fn slide_vertical_fraction(&self) -> Option<f32> {
+        self.slide_vertical_fraction
+    }
+
+    pub(crate) fn animation(&self) -> AnimationType {
+        self.animation.unwrap_or_default()
+    }
+}
+
+impl std::ops::Add for EnterTransition {
+    type Output = Self;
+
+    /// Combines two enter transitions, mirroring Compose's
+    /// `EnterTransition.plus`: the resulting transition applies every effect
+    /// of both operands. The left-hand animation spec wins when both sides
+    /// carry one.
+    fn add(self, other: Self) -> Self {
+        Self {
+            fade: self.fade || other.fade,
+            slide_vertical_fraction: self
+                .slide_vertical_fraction
+                .or(other.slide_vertical_fraction),
+            animation: self.animation.or(other.animation),
+        }
+    }
+}
+
+/// Defines how an [`AnimatedVisibility`] content disappears.
+///
+/// Mirrors Jetpack Compose's `ExitTransition`. Transitions are combined
+/// with `+`, like Compose's `fadeOut() + slideOutVertically()`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ExitTransition {
+    fade: bool,
+    slide_vertical_fraction: Option<f32>,
+    animation: Option<AnimationType>,
+}
+
+impl ExitTransition {
+    /// An empty exit transition: content disappears without any effect.
+    ///
+    /// Mirrors Jetpack Compose: `ExitTransition.None`.
+    pub fn none() -> Self {
+        Self {
+            fade: false,
+            slide_vertical_fraction: None,
+            animation: None,
+        }
+    }
+
+    /// Use a custom animation spec for this transition (see
+    /// [`EnterTransition::with_animation`]).
+    pub fn with_animation(mut self, animation: AnimationType) -> Self {
+        self.animation = Some(animation);
+        self
+    }
+
+    pub(crate) fn has_fade(&self) -> bool {
+        self.fade
+    }
+
+    pub(crate) fn slide_vertical_fraction(&self) -> Option<f32> {
+        self.slide_vertical_fraction
+    }
+
+    pub(crate) fn animation(&self) -> AnimationType {
+        self.animation.unwrap_or_default()
+    }
+}
+
+impl std::ops::Add for ExitTransition {
+    type Output = Self;
+
+    /// Combines two exit transitions, mirroring Compose's
+    /// `ExitTransition.plus`: the resulting transition applies every effect
+    /// of both operands. The left-hand animation spec wins when both sides
+    /// carry one.
+    fn add(self, other: Self) -> Self {
+        Self {
+            fade: self.fade || other.fade,
+            slide_vertical_fraction: self
+                .slide_vertical_fraction
+                .or(other.slide_vertical_fraction),
+            animation: self.animation.or(other.animation),
+        }
+    }
+}
+
+/// Fades in the content of an [`AnimatedVisibility`], from transparent to
+/// fully opaque.
+///
+/// Mirrors Jetpack Compose: `fadeIn()`.
+pub fn fade_in() -> EnterTransition {
+    EnterTransition {
+        fade: true,
+        ..EnterTransition::none()
+    }
+}
+
+/// Fades out the content of an [`AnimatedVisibility`], from fully opaque to
+/// transparent.
+///
+/// Mirrors Jetpack Compose: `fadeOut()`.
+pub fn fade_out() -> ExitTransition {
+    ExitTransition {
+        fade: true,
+        ..ExitTransition::none()
+    }
+}
+
+/// Slides in the content vertically from `initial_offset_fraction` of its
+/// own height (negative values start above the resting position, mirroring
+/// Compose's default of `-fullHeight / 2`).
+///
+/// Mirrors Jetpack Compose: `slideInVertically { fullHeight -> ... }`, with
+/// the offset expressed as a fraction of the content height instead of a
+/// lambda over the measured height.
+pub fn slide_in_vertically(initial_offset_fraction: f32) -> EnterTransition {
+    EnterTransition {
+        slide_vertical_fraction: Some(initial_offset_fraction),
+        ..EnterTransition::none()
+    }
+}
+
+/// Slides out the content vertically towards `target_offset_fraction` of
+/// its own height.
+///
+/// Mirrors Jetpack Compose: `slideOutVertically { fullHeight -> ... }`, with
+/// the offset expressed as a fraction of the content height instead of a
+/// lambda over the measured height.
+pub fn slide_out_vertically(target_offset_fraction: f32) -> ExitTransition {
+    ExitTransition {
+        slide_vertical_fraction: Some(target_offset_fraction),
+        ..ExitTransition::none()
+    }
+}
+
+/// Animates the appearance and disappearance of its content when `visible`
+/// changes.
+///
+/// Mirrors Jetpack Compose:
+/// `AnimatedVisibility(visible, enter = ..., exit = ...) { ... }`.
+///
+/// Compose semantics: content that is visible on first composition appears
+/// without an animation; when `visible` turns `false` the content stays
+/// composed for the whole exit transition and leaves the composition once it
+/// completes; toggling `visible` mid-transition retargets the running
+/// animation from its current value.
+///
+/// Divergence from Compose: enter and exit each drive a single shared
+/// progress (instead of one `Transition` animation per effect), so all
+/// effects of a combined transition share one animation spec. Exiting with
+/// `ExitTransition::none()` still holds the content for the duration of the
+/// exit spec before removal.
+#[composable]
+pub fn AnimatedVisibility<F>(
+    visible: bool,
+    enter: EnterTransition,
+    exit: ExitTransition,
+    content: F,
+) where
+    F: FnMut() + 'static,
+{
+    let target = if visible { 1.0 } else { 0.0 };
+    let animation = if visible {
+        enter.animation()
+    } else {
+        exit.animation()
+    };
+    // First composition seeds the progress at the target so an initially
+    // visible content appears without an enter animation, like Compose.
+    let progress_state = animate_float_with_initial(target, target, animation);
+    // Reading here subscribes this recompose scope: each animation frame
+    // re-evaluates whether the exiting content can leave the composition.
+    let progress = progress_state.value();
+
+    let composed = visible || progress > VISIBILITY_PROGRESS_EPSILON;
+    if composed {
+        let fade = if visible {
+            enter.has_fade()
+        } else {
+            exit.has_fade()
+        };
+        let slide_fraction = if visible {
+            enter.slide_vertical_fraction()
+        } else {
+            exit.slide_vertical_fraction()
+        };
+
+        let alpha = if fade { progress.clamp(0.0, 1.0) } else { 1.0 };
+        let mut modifier = Modifier::empty().graphics_layer_value(GraphicsLayer {
+            alpha,
+            ..Default::default()
+        });
+        if let Some(fraction) = slide_fraction {
+            modifier = modifier.offset_fraction(0.0, fraction * (1.0 - progress));
+        }
+
+        Box(modifier, BoxSpec::new(), content);
+    }
+}

--- a/crates/cranpose-ui/src/widgets/crossfade.rs
+++ b/crates/cranpose-ui/src/widgets/crossfade.rs
@@ -1,0 +1,214 @@
+//! Crossfade composable
+//!
+//! Mirrors Jetpack Compose's `Crossfade` from
+//! `androidx.compose.animation.Crossfade`.
+
+#![allow(non_snake_case)]
+
+use crate::composable;
+use crate::modifier::{GraphicsLayer, Modifier};
+use crate::widgets::box_widget::{Box, BoxSpec};
+use cranpose_animation::{Animatable, AnimationType};
+use cranpose_core::{remember, with_current_composer, Owned, State};
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+/// Alpha below which a fading-out content is considered fully transparent
+/// and can leave the composition.
+const CROSSFADE_ALPHA_EPSILON: f32 = 0.001;
+
+/// Animate a float towards `target`, starting from `initial` when the value
+/// is first composed.
+///
+/// This is `animateFloatAsState` with an explicit initial value, which lets
+/// newly appearing transition content fade in from 0 instead of snapping to
+/// its target. Internal building block for [`Crossfade`] and
+/// `AnimatedVisibility`.
+pub(crate) fn animate_float_with_initial(
+    initial: f32,
+    target: f32,
+    animation: AnimationType,
+) -> State<f32> {
+    with_current_composer(|composer| {
+        let runtime = composer.runtime_handle();
+        let anim: Owned<Animatable<f32>> = composer.remember(|| Animatable::new(initial, runtime));
+        anim.update(|animatable| {
+            let is_new_target = (animatable.target() - target).abs() > f32::EPSILON;
+            let is_new_animation = animatable.animation_type() != animation;
+            if is_new_target || is_new_animation {
+                animatable.animateTo(target, animation);
+            }
+        });
+        anim.with(|animatable| animatable.state())
+    })
+}
+
+struct CrossfadeEntry<T> {
+    /// Stable key for the composition group of this content.
+    id: u64,
+    value: T,
+    /// Alpha state produced the last time this entry was composed.
+    alpha: Option<State<f32>>,
+    /// Whether this entry should fade in from 0 when it first appears.
+    fade_in: bool,
+}
+
+type CrossfadeContentFn<T> = std::boxed::Box<dyn FnMut(T)>;
+
+struct CrossfadeStateInner<T> {
+    entries: RefCell<Vec<CrossfadeEntry<T>>>,
+    next_id: Cell<u64>,
+    content: RefCell<Option<CrossfadeContentFn<T>>>,
+}
+
+/// Shared, cheaply clonable holder for the in-flight crossfade contents.
+struct CrossfadeStateHandle<T> {
+    inner: Rc<CrossfadeStateInner<T>>,
+}
+
+impl<T> CrossfadeStateHandle<T> {
+    fn new() -> Self {
+        Self {
+            inner: Rc::new(CrossfadeStateInner {
+                entries: RefCell::new(Vec::new()),
+                next_id: Cell::new(0),
+                content: RefCell::new(None),
+            }),
+        }
+    }
+
+    fn allocate_id(&self) -> u64 {
+        let id = self.inner.next_id.get();
+        self.inner.next_id.set(id.wrapping_add(1));
+        id
+    }
+}
+
+impl<T> Clone for CrossfadeStateHandle<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Rc::clone(&self.inner),
+        }
+    }
+}
+
+impl<T> PartialEq for CrossfadeStateHandle<T> {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+/// Crossfade allows switching between two layouts with a crossfade
+/// animation.
+///
+/// Mirrors Jetpack Compose:
+/// `Crossfade(targetState, animationSpec) { state -> ... }`.
+///
+/// When `target_state` changes, the content for the previous state fades out
+/// while the content for the new state fades in. Compose semantics are
+/// preserved: both compositions stay alive during the transition, each
+/// wrapped in an alpha graphics layer, and the outgoing content leaves the
+/// composition once its fade-out completes. The content shown on first
+/// composition appears without an animation, and retargeting mid-transition
+/// keeps every in-flight content fading until it finishes.
+///
+/// `content` is invoked with each in-flight state, so it must not capture
+/// the current target; use the provided value instead.
+#[composable(no_skip)]
+pub fn Crossfade<T, F>(target_state: T, animation: AnimationType, content: F)
+where
+    T: Clone + PartialEq + 'static,
+    F: FnMut(T) + 'static,
+{
+    let handle = remember(|| CrossfadeStateHandle::<T>::new()).with(CrossfadeStateHandle::clone);
+    // Refresh the stored content closure so recompositions triggered by
+    // animation frames observe the latest captured environment.
+    *handle.inner.content.borrow_mut() = Some(std::boxed::Box::new(content));
+    CrossfadeContents(handle, target_state, animation);
+}
+
+/// Reactive part of [`Crossfade`]: reads the per-entry alpha states so each
+/// animation frame recomposes it, and drops entries whose fade-out finished.
+#[composable]
+fn CrossfadeContents<T>(state: CrossfadeStateHandle<T>, target_state: T, animation: AnimationType)
+where
+    T: Clone + PartialEq + 'static,
+{
+    {
+        let mut entries = state.inner.entries.borrow_mut();
+        if entries.is_empty() {
+            // First composition: the initial content appears without a fade,
+            // matching Compose (the transition starts at the target state).
+            let id = state.allocate_id();
+            entries.push(CrossfadeEntry {
+                id,
+                value: target_state.clone(),
+                alpha: None,
+                fade_in: false,
+            });
+        } else if !entries.iter().any(|entry| entry.value == target_state) {
+            let id = state.allocate_id();
+            entries.push(CrossfadeEntry {
+                id,
+                value: target_state.clone(),
+                alpha: None,
+                fade_in: true,
+            });
+        }
+
+        // Remove contents whose fade-out completed. Reading the alpha state
+        // here subscribes this recompose scope, so every animation frame
+        // re-evaluates the retention decision.
+        entries.retain(|entry| {
+            entry.value == target_state
+                || entry
+                    .alpha
+                    .is_none_or(|alpha| alpha.value() > CROSSFADE_ALPHA_EPSILON)
+        });
+    }
+
+    let state_for_items = state.clone();
+    Box(Modifier::empty(), BoxSpec::new(), move || {
+        let items: Vec<(u64, T, bool)> = state_for_items
+            .inner
+            .entries
+            .borrow()
+            .iter()
+            .map(|entry| (entry.id, entry.value.clone(), entry.fade_in))
+            .collect();
+        for (id, value, fade_in) in items {
+            let is_target = value == target_state;
+            let state_for_item = state_for_items.clone();
+            cranpose_core::with_key(&id, || {
+                let alpha_target = if is_target { 1.0 } else { 0.0 };
+                let initial_alpha = if fade_in { 0.0 } else { alpha_target };
+                let alpha = animate_float_with_initial(initial_alpha, alpha_target, animation);
+                if let Some(entry) = state_for_item
+                    .inner
+                    .entries
+                    .borrow_mut()
+                    .iter_mut()
+                    .find(|entry| entry.id == id)
+                {
+                    entry.alpha = Some(alpha);
+                }
+
+                let layer_alpha = alpha.value().clamp(0.0, 1.0);
+                let state_for_content = state_for_item.clone();
+                Box(
+                    Modifier::empty().graphics_layer_value(GraphicsLayer {
+                        alpha: layer_alpha,
+                        ..Default::default()
+                    }),
+                    BoxSpec::new(),
+                    move || {
+                        let mut content = state_for_content.inner.content.borrow_mut();
+                        if let Some(content) = content.as_mut() {
+                            content(value.clone());
+                        }
+                    },
+                );
+            });
+        }
+    });
+}

--- a/crates/cranpose-ui/src/widgets/mod.rs
+++ b/crates/cranpose-ui/src/widgets/mod.rs
@@ -1,11 +1,13 @@
 //! UI Widget components
 
+pub mod animated_visibility;
 pub mod basic_text_field;
 pub mod box_widget;
 pub mod button;
 pub mod canvas;
 pub mod clickable_text;
 pub mod column;
+pub mod crossfade;
 pub mod foreach;
 pub mod image;
 pub mod layout;
@@ -17,12 +19,14 @@ pub mod scopes;
 pub mod spacer;
 pub mod text;
 
+pub use animated_visibility::*;
 pub use basic_text_field::*;
 pub use box_widget::*;
 pub use button::*;
 pub use canvas::*;
 pub use clickable_text::*;
 pub use column::*;
+pub use crossfade::*;
 pub use foreach::*;
 pub use image::*;
 pub use layout::*;


### PR DESCRIPTION
## Summary

Adds four Jetpack-Compose-parity animation APIs on top of the existing `Animatable`/`animateFloatAsState` machinery and `MutableInteractionSource`.

### `animateColorAsState(target: Color, animation: AnimationType, label: &str) -> State<Color>` (cranpose-animation)
- New `crates/cranpose-animation/src/color.rs`; `cranpose-animation` now depends on `cranpose-ui-graphics` (which is dependency-free, so no cycle).
- `Lerp for Color`: linear per-channel interpolation **including alpha**, clamped to `[0, 1]` so overshooting springs still produce valid colors.
- `SpringScalar for Color`: spring progress via 4D vector projection and settling via 4D euclidean distance, mirroring Compose's `AnimationVector4D` treatment.
- **Divergence:** Compose lerps colors through the Oklab color space; Cranpose colors carry no color-space info, so interpolation is per-channel in the color's own linear RGBA space (documented on the impl).

### `collect_is_pressed_as_state(&MutableInteractionSource) -> State<bool>` (cranpose-ui)
- Free-function form of the existing `collectIsPressedAsState` method (Compose: `InteractionSource.collectIsPressedAsState()`), plus doc comments spelling out the Press → Release/Cancel semantics and reactivity guarantees.

### `Crossfade(target_state: T, animation: AnimationType, content: impl FnMut(T))` (cranpose-ui)
- Full Compose semantics: when `target_state` changes, **both compositions stay alive during the transition**, each wrapped in an alpha graphics layer; the outgoing content leaves the composition once its fade-out completes; retargeting mid-transition keeps every in-flight content fading; first composition appears without animation.
- Implementation note: the reactive part lives in an inner skippable composable (`no_skip` composables don't self-recompose), keyed per in-flight state with monotonic ids.

### `AnimatedVisibility(visible: bool, enter: EnterTransition, exit: ExitTransition, content: impl FnMut())` (cranpose-ui)
- `fade_in()`/`fade_out()` and `slide_in_vertically(fraction)`/`slide_out_vertically(fraction)`, combinable with `+` like Compose (`fade_in() + slide_in_vertically(-0.5)`); custom specs via `.with_animation(tween(...))`.
- Content stays composed for the whole exit transition and leaves the composition after it completes; initially visible content appears without an enter animation; toggling mid-transition retargets the running animation.
- New `Modifier::offset_fraction(x, y)` + `FractionalOffsetNode/Element` back the slide transitions (placement offset as a fraction of the measured content size — Compose passes the measured height to a lambda instead).
- **Divergences (documented on the composable):** enter/exit each drive a single shared progress instead of one `Transition` animation per effect, so combined effects share one spec; `ExitTransition::none()` still holds content for the exit spec duration before removal.

## Tests

- `cranpose-animation` (6 new): color lerp math incl. alpha and endpoints, overshoot clamping, 4D spring projection, `animateColorAsState` interpolating over frames and settling at the target, `Animatable<Color>` spring settling.
- `cranpose-ui` (14 new): pressed state through raw interaction emissions (Press/Release/Cancel) and recomposition of composable readers; Crossfade initial content, both-contents-alive mid-transition + old removed after completion (via `DisposableEffect` lifecycles), mid-transition retargeting; AnimatedVisibility hidden/visible initial states, content alive during exit and removed after completion, re-entry mid-exit, enter-after-hidden, `+` combination; fractional offset measurement/intrinsics.
- `cargo test -p cranpose-animation -p cranpose-ui`: **all suites green** (23 + 502 lib tests + integration suites, 0 failures).
- `cargo fmt --check` clean, `cargo check --workspace` clean, `cargo clippy -p cranpose-animation -p cranpose-ui` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKmJDd6pG9opQHr7btBMke