### PR TITLE
Fix clippy: allow composable-style names on animation test hosts

### DIFF
--- a/crates/cranpose-ui/src/tests/animated_visibility_tests.rs
+++ b/crates/cranpose-ui/src/tests/animated_visibility_tests.rs
@@ -44,6 +44,7 @@ fn settle(composition: &mut TestComposition, frame_time: &mut u64) {
 }
 
 #[composable]
+#[allow(non_snake_case)]
 fn VisibilityHost(visible: MutableState<bool>, alive: Rc<Cell<bool>>) {
     let is_visible = visible.value();
     let alive_for_content = Rc::clone(&alive);

--- a/crates/cranpose-ui/src/tests/crossfade_tests.rs
+++ b/crates/cranpose-ui/src/tests/crossfade_tests.rs
@@ -37,6 +37,7 @@ fn settle(composition: &mut TestComposition, frame_time: &mut u64) {
 }
 
 #[composable]
+#[allow(non_snake_case)]
 fn CrossfadeHost(target: MutableState<u32>, alive: Rc<RefCell<Vec<u32>>>) {
     let current = target.value();
     let alive_for_content = Rc::clone(&alive);


### PR DESCRIPTION
The Crossfade/AnimatedVisibility test host composables use PascalCase (composable convention) which `clippy --all-targets -D warnings` rejects in test code; annotated with `#[allow(non_snake_case)]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKmJDd6pG9opQHr7btBMke