### PR TITLE
Fix robot shard 6: screenshot dump defaults to a temp shot dir

### DIFF
--- a/apps/desktop-demo/examples/robot_tab_screenshot_dump.rs
+++ b/apps/desktop-demo/examples/robot_tab_screenshot_dump.rs
@@ -148,9 +148,11 @@ fn set_tab_hook(name: String, argument: String) -> Result<Option<String>, String
 }
 
 fn shot_dir() -> PathBuf {
+    // Default to a temp directory so the example runs unconfigured (CI robot
+    // shards); set ROBOT_SHOT_DIR to keep the screenshots somewhere useful.
     std::env::var_os(SHOT_DIR_ENV)
         .map(PathBuf::from)
-        .unwrap_or_else(|| panic!("{SHOT_DIR_ENV} must be set to a writable directory"))
+        .unwrap_or_else(|| std::env::temp_dir().join("cranpose-robot-shots"))
 }
 
 fn headless() -> bool {


### PR DESCRIPTION
`robot_tab_screenshot_dump` panicked when `ROBOT_SHOT_DIR` was unset, which is exactly how the CI robot shards run it — shard 6 has been red for multiple releases. Unconfigured runs now write into `$TMPDIR/cranpose-robot-shots`; the env var still overrides. Verified green locally via `./run_robot_test.sh --example robot_tab_screenshot_dump` under Xvfb with no `ROBOT_SHOT_DIR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKmJDd6pG9opQHr7btBMke