### PR TITLE
Proper IME text input on all platforms + SwipeToDismiss

### DIFF
--- a/crates/cranpose-app-shell/src/lib.rs
+++ b/crates/cranpose-app-shell/src/lib.rs
@@ -45,6 +45,8 @@ use std::collections::HashSet;
 pub use cranpose_ui::{KeyCode, KeyEvent, KeyEventType, Modifiers};
 // Re-export the platform soft-keyboard hook so runtimes only depend on the shell
 pub use cranpose_ui::PlatformTextInputHandler;
+// Re-export the IME editable-state snapshot for platform text-input bridges
+pub use cranpose_ui::ImeEditorState;
 
 #[cfg(any(test, feature = "test-support"))]
 use cranpose_core::{

--- a/crates/cranpose-app-shell/src/shell_input.rs
+++ b/crates/cranpose-app-shell/src/shell_input.rs
@@ -845,6 +845,70 @@ where
         handled
     }
 
+    /// Finishes the active IME composition, keeping the composed text as
+    /// committed text (Android `finishComposingText` semantics).
+    /// Returns `true` if a text field consumed the event.
+    pub fn on_ime_finish_composing(&mut self) -> bool {
+        let _event_handler = enter_event_handler_scope();
+        let app_context = Rc::clone(&self.app_context);
+        app_context.enter(|| self.on_ime_finish_composing_inner())
+    }
+
+    fn on_ime_finish_composing_inner(&mut self) -> bool {
+        let handled =
+            run_in_mutable_snapshot(cranpose_ui::text_field_focus::dispatch_ime_finish_composing)
+                .unwrap_or(false);
+
+        if handled {
+            self.mark_dirty();
+            self.request_layout_pass();
+        }
+
+        handled
+    }
+
+    /// Marks existing text in the focused field as the composing region
+    /// without changing it (Android `setComposingRegion` semantics). Offsets
+    /// are UTF-8 bytes. Returns `true` if a text field consumed the event.
+    pub fn on_ime_set_composing_region(&mut self, start_bytes: usize, end_bytes: usize) -> bool {
+        let _event_handler = enter_event_handler_scope();
+        let app_context = Rc::clone(&self.app_context);
+        app_context.enter(|| {
+            let handled = run_in_mutable_snapshot(|| {
+                cranpose_ui::text_field_focus::dispatch_ime_set_composing_region(
+                    start_bytes,
+                    end_bytes,
+                )
+            })
+            .unwrap_or(false);
+
+            if handled {
+                self.mark_dirty();
+                self.request_layout_pass();
+            }
+
+            handled
+        })
+    }
+
+    /// Returns a snapshot of the focused text field's editable state for
+    /// platform IMEs (text, selection and composition in UTF-8 bytes), or
+    /// `None` when no text field is focused.
+    pub fn ime_editor_state(&mut self) -> Option<cranpose_ui::text_field_focus::ImeEditorState> {
+        let app_context = Rc::clone(&self.app_context);
+        app_context.enter(cranpose_ui::text_field_focus::focused_editor_state)
+    }
+
+    /// Clears text-field focus (used by platform IME actions such as
+    /// Android's Done). The focus-loss notification hides the soft keyboard.
+    pub fn clear_text_field_focus(&mut self) {
+        let _event_handler = enter_event_handler_scope();
+        let app_context = Rc::clone(&self.app_context);
+        app_context.enter(cranpose_ui::text_field_focus::clear_focus);
+        self.mark_dirty();
+        self.request_layout_pass();
+    }
+
     /// Handles IME delete-surrounding events.
     /// Returns `true` if a text field consumed the event.
     pub fn on_ime_delete_surrounding(&mut self, before_bytes: usize, after_bytes: usize) -> bool {

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -2348,6 +2348,8 @@ struct TextFieldDispatchProbe {
     last_delete: Cell<Option<(usize, usize)>>,
     delete_in_event_handler: Cell<bool>,
     delete_in_applied_snapshot: Cell<bool>,
+    finish_composition_count: Cell<usize>,
+    last_composing_region: Cell<Option<(usize, usize)>>,
 }
 
 impl cranpose_ui::text_field_focus::FocusedTextFieldHandler for TextFieldDispatchProbe {
@@ -2389,6 +2391,26 @@ impl cranpose_ui::text_field_focus::FocusedTextFieldHandler for TextFieldDispatc
             .set(cranpose_core::in_event_handler());
         self.preedit_in_applied_snapshot
             .set(cranpose_core::in_applied_snapshot());
+    }
+
+    fn finish_composition(&self) {
+        self.finish_composition_count
+            .set(self.finish_composition_count.get() + 1);
+    }
+
+    fn set_composing_region(&self, start_bytes: usize, end_bytes: usize) {
+        self.last_composing_region
+            .set(Some((start_bytes, end_bytes)));
+    }
+
+    fn editor_state(&self) -> Option<cranpose_ui::ImeEditorState> {
+        Some(cranpose_ui::ImeEditorState {
+            text: "probe".to_string(),
+            selection_start: 1,
+            selection_end: 2,
+            composition: Some((0, 3)),
+            single_line: true,
+        })
     }
 }
 
@@ -2530,6 +2552,50 @@ fn ime_delete_surrounding_marks_dirty() {
     assert_eq!(handler.last_delete.get(), Some((2, 1)));
     assert!(shell.needs_redraw());
     shell.debug_enter_app_context(cranpose_ui::text_field_focus::clear_focus);
+}
+
+/// The InputConnection-facing shell methods (finish-composing, composing
+/// region, editor-state snapshot, focus clearing for the Done action) must
+/// dispatch to the focused field and drive the platform keyboard.
+#[test]
+fn ime_session_shell_methods_dispatch_to_focused_field() {
+    let _guard = test_guard();
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(TestRenderer::default(), root_key, empty_content);
+    shell.update();
+
+    let keyboard = Rc::new(SoftKeyboardProbe::default());
+    shell.set_platform_text_input(keyboard.clone());
+
+    // Without a focused field nothing dispatches.
+    assert!(!shell.on_ime_finish_composing());
+    assert!(!shell.on_ime_set_composing_region(0, 1));
+    assert!(shell.ime_editor_state().is_none());
+
+    let focus_flag = Rc::new(RefCell::new(false));
+    let handler = Rc::new(TextFieldDispatchProbe::default());
+    shell.debug_enter_app_context(|| {
+        cranpose_ui::text_field_focus::request_focus(Rc::clone(&focus_flag), handler.clone());
+    });
+    assert_eq!(*keyboard.calls.borrow(), vec!["show"]);
+
+    assert!(shell.on_ime_finish_composing());
+    assert_eq!(handler.finish_composition_count.get(), 1);
+
+    assert!(shell.on_ime_set_composing_region(2, 5));
+    assert_eq!(handler.last_composing_region.get(), Some((2, 5)));
+
+    let state = shell.ime_editor_state().expect("focused editor state");
+    assert_eq!(state.text, "probe");
+    assert_eq!((state.selection_start, state.selection_end), (1, 2));
+    assert_eq!(state.composition, Some((0, 3)));
+    assert!(state.single_line);
+
+    // The IME Done action clears focus, which hides the soft keyboard.
+    shell.clear_text_field_focus();
+    assert!(!*focus_flag.borrow());
+    assert_eq!(*keyboard.calls.borrow(), vec!["show", "hide"]);
+    assert!(shell.ime_editor_state().is_none());
 }
 
 #[test]

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -39,6 +39,9 @@ pub mod zoom;
 
 // Export for cursor blink animation - AppShell checks this to continuously redraw
 pub use text_field_focus::has_focused_field;
+// Editable-state snapshot for platform IMEs (Android InputConnection, web
+// composition) - platform runtimes read it through the shell
+pub use text_field_focus::ImeEditorState;
 // Platform soft-keyboard bridge - platform runtimes install a handler so text
 // field focus changes can show/hide the on-screen keyboard
 pub use text_input_session::PlatformTextInputHandler;

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -148,6 +148,7 @@ pub use text_modifier_node::{TextModifierElement, TextModifierNode};
 pub use widgets::clickable_text::ClickableText;
 pub use widgets::lazy_list::{LazyColumn, LazyColumnSpec, LazyRow, LazyRowSpec};
 pub use widgets::linked_text::LinkedText;
+pub use widgets::swipe_to_dismiss::{SwipeToDismiss, SwipeToDismissSpec};
 
 // Debug utilities
 pub use debug::{

--- a/crates/cranpose-ui/src/tests/swipe_to_dismiss_tests.rs
+++ b/crates/cranpose-ui/src/tests/swipe_to_dismiss_tests.rs
@@ -1,0 +1,436 @@
+//! Headless tests for the SwipeToDismiss gesture math and dismiss/restore
+//! behavior. The controller state machine is driven with synthetic pointer
+//! events; spring animations advance through manual frame-clock pumps.
+
+use super::*;
+use crate::collect_modifier_slices;
+use crate::scroll::ScrollState;
+use cranpose_core::{DefaultScheduler, Runtime};
+use cranpose_foundation::{
+    BasicModifierNodeContext, ModifierNodeChain, PointerButton, PointerButtons,
+};
+use cranpose_ui_graphics::Point;
+
+const FRAME_NANOS: u64 = 16_666_667; // ~60 FPS
+
+fn point(x: f32, y: f32) -> Point {
+    Point { x, y }
+}
+
+fn primary_buttons() -> PointerButtons {
+    PointerButtons::new().with(PointerButton::Primary)
+}
+
+fn down(x: f32, y: f32) -> PointerEvent {
+    PointerEvent::new(PointerEventKind::Down, point(x, y), point(x, y))
+        .with_buttons(primary_buttons())
+}
+
+fn move_to(x: f32, y: f32) -> PointerEvent {
+    PointerEvent::new(PointerEventKind::Move, point(x, y), point(x, y))
+        .with_buttons(primary_buttons())
+}
+
+fn up(x: f32, y: f32) -> PointerEvent {
+    PointerEvent::new(PointerEventKind::Up, point(x, y), point(x, y))
+        .with_buttons(primary_buttons())
+}
+
+fn cancel() -> PointerEvent {
+    PointerEvent::new(PointerEventKind::Cancel, point(0.0, 0.0), point(0.0, 0.0))
+}
+
+struct Harness {
+    _runtime: Runtime,
+    controller: Rc<SwipeToDismissController>,
+    dismiss_count: Rc<Cell<usize>>,
+    frame_time: u64,
+}
+
+impl Harness {
+    fn new(width: f32, threshold_fraction: f32) -> Self {
+        let runtime = Runtime::new(std::sync::Arc::new(DefaultScheduler));
+        let controller = SwipeToDismissController::new(runtime.handle());
+        controller.width_px.set(width);
+        controller.threshold_fraction.set(threshold_fraction);
+
+        let dismiss_count = Rc::new(Cell::new(0usize));
+        let count = Rc::clone(&dismiss_count);
+        *controller.on_dismiss.borrow_mut() = Some(Rc::new(move || {
+            count.set(count.get() + 1);
+        }));
+
+        Self {
+            _runtime: runtime,
+            controller,
+            dismiss_count,
+            frame_time: 0,
+        }
+    }
+
+    fn send(&self, event: &PointerEvent) {
+        handle_swipe_event(&self.controller, event);
+    }
+
+    fn offset(&self) -> f32 {
+        self.controller.current_offset()
+    }
+
+    /// Advances the frame clock, driving springs and the settle watcher.
+    fn pump_frames(&mut self, frames: usize) {
+        let handle = self._runtime.handle();
+        for _ in 0..frames {
+            self.frame_time += FRAME_NANOS;
+            handle.drain_frame_callbacks(self.frame_time);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure gesture math
+// ---------------------------------------------------------------------------
+
+#[test]
+fn axis_stays_undecided_within_slop() {
+    assert_eq!(decide_axis(0.0, 0.0, 8.0), SwipeAxisDecision::Undecided);
+    assert_eq!(decide_axis(8.0, 0.0, 8.0), SwipeAxisDecision::Undecided);
+    assert_eq!(decide_axis(-7.9, 5.0, 8.0), SwipeAxisDecision::Undecided);
+    assert_eq!(decide_axis(0.0, -8.0, 8.0), SwipeAxisDecision::Undecided);
+}
+
+#[test]
+fn axis_capture_requires_horizontal_dominance() {
+    assert_eq!(decide_axis(9.0, 0.0, 8.0), SwipeAxisDecision::Horizontal);
+    assert_eq!(decide_axis(-9.0, 4.0, 8.0), SwipeAxisDecision::Horizontal);
+    // Ties go to the swipe (main axis wins on >=, like the scroll modifier).
+    assert_eq!(decide_axis(9.0, 9.0, 8.0), SwipeAxisDecision::Horizontal);
+}
+
+#[test]
+fn axis_locks_out_on_decisive_vertical_travel() {
+    assert_eq!(decide_axis(0.0, 9.0, 8.0), SwipeAxisDecision::Vertical);
+    assert_eq!(decide_axis(4.0, -12.0, 8.0), SwipeAxisDecision::Vertical);
+}
+
+#[test]
+fn dismissal_target_uses_threshold_fraction_and_sign() {
+    assert_eq!(dismissal_target(99.0, 200.0, 0.5), None);
+    assert_eq!(dismissal_target(100.0, 200.0, 0.5), Some(200.0));
+    assert_eq!(dismissal_target(-150.0, 200.0, 0.5), Some(-200.0));
+    assert_eq!(dismissal_target(30.0, 200.0, 0.1), Some(200.0));
+    // Unknown or degenerate widths never dismiss.
+    assert_eq!(dismissal_target(500.0, f32::NAN, 0.5), None);
+    assert_eq!(dismissal_target(500.0, 0.0, 0.5), None);
+}
+
+#[test]
+fn clamp_offset_limits_travel_to_one_width() {
+    assert_eq!(clamp_offset(250.0, 200.0), 200.0);
+    assert_eq!(clamp_offset(-250.0, 200.0), -200.0);
+    assert_eq!(clamp_offset(50.0, 200.0), 50.0);
+    // Unknown width leaves the offset untouched.
+    assert_eq!(clamp_offset(250.0, f32::NAN), 250.0);
+}
+
+// ---------------------------------------------------------------------------
+// Gesture state machine
+// ---------------------------------------------------------------------------
+
+#[test]
+fn horizontal_drag_captures_and_follows_the_finger() {
+    let harness = Harness::new(200.0, 0.5);
+
+    harness.send(&down(10.0, 10.0));
+
+    // Within the slop: no capture, no consumption.
+    let small = move_to(14.0, 10.0);
+    harness.send(&small);
+    assert!(!small.is_consumed());
+    assert_eq!(harness.offset(), 0.0);
+
+    // Crossing the slop horizontally captures and consumes.
+    let capture = move_to(30.0, 12.0);
+    harness.send(&capture);
+    assert!(capture.is_consumed());
+    assert_eq!(harness.offset(), 20.0);
+
+    // Subsequent moves track the finger relative to the down position.
+    let drag = move_to(140.0, 12.0);
+    harness.send(&drag);
+    assert!(drag.is_consumed());
+    assert_eq!(harness.offset(), 130.0);
+
+    // The offset clamps at one content width.
+    let far = move_to(500.0, 12.0);
+    harness.send(&far);
+    assert_eq!(harness.offset(), 200.0);
+}
+
+#[test]
+fn vertical_drag_locks_out_and_leaves_events_for_the_parent() {
+    let harness = Harness::new(200.0, 0.5);
+
+    harness.send(&down(10.0, 10.0));
+
+    // Decisively vertical: the parent (LazyColumn) must win.
+    let vertical = move_to(12.0, 40.0);
+    harness.send(&vertical);
+    assert!(!vertical.is_consumed());
+
+    // Even large horizontal travel later in the gesture stays unconsumed.
+    let late_horizontal = move_to(80.0, 40.0);
+    harness.send(&late_horizontal);
+    assert!(!late_horizontal.is_consumed());
+    assert_eq!(harness.offset(), 0.0);
+
+    let release = up(80.0, 40.0);
+    harness.send(&release);
+    assert!(!release.is_consumed());
+}
+
+#[test]
+fn tap_consumes_nothing() {
+    let harness = Harness::new(200.0, 0.5);
+
+    let press = down(10.0, 10.0);
+    harness.send(&press);
+    assert!(!press.is_consumed());
+
+    let release = up(11.0, 10.0);
+    harness.send(&release);
+    assert!(!release.is_consumed());
+    assert_eq!(harness.offset(), 0.0);
+}
+
+#[test]
+fn release_past_threshold_animates_out_and_fires_on_dismiss_once() {
+    let mut harness = Harness::new(200.0, 0.5);
+
+    harness.send(&down(10.0, 10.0));
+    harness.send(&move_to(30.0, 10.0));
+    harness.send(&move_to(140.0, 10.0)); // offset 130 >= threshold 100
+
+    let release = up(140.0, 10.0);
+    harness.send(&release);
+    assert!(release.is_consumed());
+    assert_eq!(harness.dismiss_count.get(), 0, "fires only after settling");
+
+    harness.pump_frames(300);
+    assert_eq!(harness.dismiss_count.get(), 1);
+    assert!(
+        (harness.offset() - 200.0).abs() <= 0.5,
+        "content settles off-screen, got offset {}",
+        harness.offset()
+    );
+
+    // Further frames never re-fire the callback.
+    harness.pump_frames(60);
+    assert_eq!(harness.dismiss_count.get(), 1);
+}
+
+#[test]
+fn release_below_threshold_springs_back_without_dismissing() {
+    let mut harness = Harness::new(200.0, 0.5);
+
+    harness.send(&down(10.0, 10.0));
+    harness.send(&move_to(30.0, 10.0));
+    harness.send(&move_to(70.0, 10.0)); // offset 60 < threshold 100
+    harness.send(&up(70.0, 10.0));
+
+    harness.pump_frames(300);
+    assert_eq!(harness.dismiss_count.get(), 0);
+    assert!(
+        harness.offset().abs() <= 0.5,
+        "content springs back to rest, got offset {}",
+        harness.offset()
+    );
+}
+
+#[test]
+fn leftward_swipe_dismisses_to_the_left() {
+    let mut harness = Harness::new(200.0, 0.5);
+
+    harness.send(&down(150.0, 10.0));
+    harness.send(&move_to(30.0, 10.0)); // offset -120
+
+    harness.send(&up(30.0, 10.0));
+    harness.pump_frames(300);
+    assert_eq!(harness.dismiss_count.get(), 1);
+    assert!((harness.offset() + 200.0).abs() <= 0.5);
+}
+
+#[test]
+fn consumed_move_abandons_the_gesture_and_restores() {
+    let mut harness = Harness::new(200.0, 0.5);
+
+    harness.send(&down(10.0, 10.0));
+    harness.send(&move_to(60.0, 10.0)); // captured, offset 50
+
+    // A foreign handler consumed this sequence; the swipe must let go.
+    let foreign = move_to(80.0, 10.0);
+    foreign.consume();
+    harness.send(&foreign);
+
+    harness.pump_frames(300);
+    assert_eq!(harness.dismiss_count.get(), 0);
+    assert!(harness.offset().abs() <= 0.5);
+}
+
+#[test]
+fn cancel_springs_back() {
+    let mut harness = Harness::new(200.0, 0.5);
+
+    harness.send(&down(10.0, 10.0));
+    harness.send(&move_to(90.0, 10.0)); // captured, offset 80
+    harness.send(&cancel());
+
+    harness.pump_frames(300);
+    assert_eq!(harness.dismiss_count.get(), 0);
+    assert!(harness.offset().abs() <= 0.5);
+}
+
+// ---------------------------------------------------------------------------
+// Nested with a vertical scroll parent (modifier-chain dispatch, mirroring
+// the shell's leaf-first hit-path order like the nested scroll tests)
+// ---------------------------------------------------------------------------
+
+/// Builds the production pointer handler for a modifier by driving it
+/// through a real modifier-node chain (same approach as zoom/scroll tests).
+fn pointer_handler_for(modifier: crate::Modifier) -> (Rc<dyn Fn(PointerEvent)>, ModifierNodeChain) {
+    let elements = modifier.elements();
+    let mut chain = ModifierNodeChain::new();
+    let mut context = BasicModifierNodeContext::new();
+    chain.update_from_slice(&elements, &mut context);
+    let slices = collect_modifier_slices(&chain);
+    let handler = slices
+        .pointer_inputs()
+        .first()
+        .cloned()
+        .expect("swipe modifier should provide a pointer input handler");
+    (handler, chain)
+}
+
+/// Dispatches an event leaf-first (swipe child, then scroll parent),
+/// mirroring the shell's hit-path dispatch order.
+fn dispatch_nested(
+    child: &Rc<dyn Fn(PointerEvent)>,
+    parent: &Rc<dyn Fn(PointerEvent)>,
+    event: PointerEvent,
+) -> PointerEvent {
+    child(event.clone());
+    parent(event.clone());
+    event
+}
+
+struct NestedHarness {
+    harness: Harness,
+    swipe: Rc<dyn Fn(PointerEvent)>,
+    _swipe_chain: ModifierNodeChain,
+    scroll_state: ScrollState,
+    scroll: Rc<dyn Fn(PointerEvent)>,
+    _scroll_chain: ModifierNodeChain,
+    _app_context: crate::render_state::TestAppContextScope,
+}
+
+impl NestedHarness {
+    /// A swipeable row nested in a vertical scroll container.
+    fn new() -> Self {
+        let app_context = crate::render_state::app_context_test_scope();
+        let harness = Harness::new(200.0, 0.5);
+
+        let (swipe, swipe_chain) = pointer_handler_for(swipe_gesture_modifier(
+            crate::Modifier::empty(),
+            Rc::clone(&harness.controller),
+        ));
+
+        let scroll_state = ScrollState::new(100.0);
+        scroll_state.set_max_value(400.0);
+        let (scroll, scroll_chain) = pointer_handler_for(
+            crate::Modifier::empty().vertical_scroll(scroll_state.clone(), false),
+        );
+
+        Self {
+            harness,
+            swipe,
+            _swipe_chain: swipe_chain,
+            scroll_state,
+            scroll,
+            _scroll_chain: scroll_chain,
+            _app_context: app_context,
+        }
+    }
+
+    fn send(&self, event: PointerEvent) -> PointerEvent {
+        dispatch_nested(&self.swipe, &self.scroll, event)
+    }
+}
+
+#[test]
+fn vertical_drag_on_row_scrolls_parent_list() {
+    let nested = NestedHarness::new();
+
+    nested.send(down(100.0, 100.0));
+    // Decisively vertical: the swipe locks itself out, the parent scrolls.
+    nested.send(move_to(102.0, 60.0));
+    nested.send(move_to(104.0, 20.0));
+    nested.send(up(104.0, 20.0));
+
+    assert_eq!(nested.harness.offset(), 0.0, "row must not move sideways");
+    assert_eq!(nested.harness.dismiss_count.get(), 0);
+    assert!(
+        (nested.scroll_state.value_non_reactive() - 180.0).abs() < 1.0,
+        "vertical drag must scroll the parent list (finger up 80 => offset +80), got {}",
+        nested.scroll_state.value_non_reactive()
+    );
+}
+
+#[test]
+fn horizontal_swipe_on_row_does_not_scroll_parent_list() {
+    let mut nested = NestedHarness::new();
+
+    nested.send(down(20.0, 100.0));
+    // Mostly horizontal with vertical jitter: the swipe captures, so the
+    // consumed moves never scroll the parent.
+    let capture = nested.send(move_to(40.0, 104.0));
+    assert!(capture.is_consumed(), "swipe must capture horizontal drags");
+    nested.send(move_to(160.0, 98.0));
+    let release = nested.send(up(160.0, 98.0));
+    assert!(release.is_consumed());
+
+    assert_eq!(
+        nested.scroll_state.value_non_reactive(),
+        100.0,
+        "parent list must not scroll during a captured swipe"
+    );
+
+    nested.harness.pump_frames(300);
+    assert_eq!(
+        nested.harness.dismiss_count.get(),
+        1,
+        "the released swipe crossed the threshold and must dismiss"
+    );
+}
+
+#[test]
+fn pressing_mid_flight_pins_the_content() {
+    let mut harness = Harness::new(200.0, 0.5);
+
+    // Swipe below threshold and release: spring-back starts.
+    harness.send(&down(10.0, 10.0));
+    harness.send(&move_to(90.0, 10.0));
+    harness.send(&up(90.0, 10.0));
+    harness.pump_frames(3);
+    let mid_flight = harness.offset();
+    assert!(mid_flight > 0.0 && mid_flight < 80.0);
+
+    // Pressing again stops the animation where it is.
+    harness.send(&down(50.0, 10.0));
+    harness.pump_frames(5);
+    assert_eq!(harness.offset(), mid_flight);
+
+    // And the new drag continues from the pinned offset.
+    let drag = move_to(70.0, 10.0);
+    harness.send(&drag);
+    assert!(drag.is_consumed());
+    assert_eq!(harness.offset(), mid_flight + 20.0);
+}

--- a/crates/cranpose-ui/src/text_field_focus.rs
+++ b/crates/cranpose-ui/src/text_field_focus.rs
@@ -12,6 +12,26 @@ use std::rc::{Rc, Weak};
 
 use crate::key_event::KeyEvent;
 
+/// Snapshot of the focused text field's editable state for platform IMEs.
+///
+/// All offsets are UTF-8 byte offsets into `text`. Platform layers that talk
+/// to UTF-16 based IMEs (Android's `InputConnection`, web composition events)
+/// convert on their side of the boundary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ImeEditorState {
+    /// Full text content of the field.
+    pub text: String,
+    /// Selection start (min) in bytes. Equal to `selection_end` for a caret.
+    pub selection_start: usize,
+    /// Selection end (max) in bytes.
+    pub selection_end: usize,
+    /// Active composing (preedit) region in bytes, if any.
+    pub composition: Option<(usize, usize)>,
+    /// Whether the field is single-line (platforms use this to pick the
+    /// keyboard action, e.g. Android `IME_ACTION_DONE` vs newline).
+    pub single_line: bool,
+}
+
 /// Handler trait for focused text field operations.
 /// Stored in focus module for O(1) key/clipboard dispatch.
 pub trait FocusedTextFieldHandler {
@@ -26,9 +46,27 @@ pub trait FocusedTextFieldHandler {
     /// Cut current selection (copy + delete). Returns None if nothing selected.
     fn cut_selection(&self) -> Option<String>;
     /// Set IME composition (preedit) state.
-    /// - `text`: The composition text being typed (empty string to clear)
+    /// - `text`: The composition text being typed (empty string to clear,
+    ///   which *deletes* the preedit text)
     /// - `cursor`: Optional cursor position within composition (start, end)
     fn set_composition(&self, text: &str, cursor: Option<(usize, usize)>);
+    /// Finish the active composition, keeping the composed text as regular
+    /// committed text (Android `finishComposingText` semantics). No-op when
+    /// no composition is active.
+    fn finish_composition(&self) {}
+    /// Mark existing text as the composing region without changing it
+    /// (Android `setComposingRegion` semantics, used by autocorrect to
+    /// re-compose an already committed word). Offsets are UTF-8 bytes;
+    /// implementations clamp them to valid character boundaries.
+    fn set_composing_region(&self, start_bytes: usize, end_bytes: usize) {
+        let _ = (start_bytes, end_bytes);
+    }
+    /// Snapshot of the current editable state for platform IMEs
+    /// (`InputConnection` text queries, session seeding). `None` when the
+    /// handler cannot expose its state.
+    fn editor_state(&self) -> Option<ImeEditorState> {
+        None
+    }
 }
 
 pub(crate) struct TextFieldFocusState {
@@ -139,6 +177,29 @@ impl TextFieldFocusState {
             false
         }
     }
+
+    fn dispatch_ime_finish_composing(&self) -> bool {
+        if let Some(handler) = self.focused_handler() {
+            handler.finish_composition();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn dispatch_ime_set_composing_region(&self, start_bytes: usize, end_bytes: usize) -> bool {
+        if let Some(handler) = self.focused_handler() {
+            handler.set_composing_region(start_bytes, end_bytes);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn focused_editor_state(&self) -> Option<ImeEditorState> {
+        self.focused_handler()
+            .and_then(|handler| handler.editor_state())
+    }
 }
 
 /// Requests focus for a text field.
@@ -228,6 +289,29 @@ pub fn dispatch_cut() -> Option<String> {
 /// Returns true if a text field was focused and received the event.
 pub fn dispatch_ime_preedit(text: &str, cursor: Option<(usize, usize)>) -> bool {
     crate::render_state::with_text_field_focus(|state| state.dispatch_ime_preedit(text, cursor))
+}
+
+/// Finishes the active composition in the focused text field, keeping the
+/// composed text (Android `finishComposingText` semantics).
+/// Returns true if a text field was focused and received the event.
+pub fn dispatch_ime_finish_composing() -> bool {
+    crate::render_state::with_text_field_focus(|state| state.dispatch_ime_finish_composing())
+}
+
+/// Marks existing text in the focused field as the composing region without
+/// changing it (Android `setComposingRegion` semantics).
+/// Returns true if a text field was focused and received the event.
+pub fn dispatch_ime_set_composing_region(start_bytes: usize, end_bytes: usize) -> bool {
+    crate::render_state::with_text_field_focus(|state| {
+        state.dispatch_ime_set_composing_region(start_bytes, end_bytes)
+    })
+}
+
+/// Returns a snapshot of the focused text field's editable state for
+/// platform IMEs, or `None` when no field is focused (or the handler does
+/// not expose its state).
+pub fn focused_editor_state() -> Option<ImeEditorState> {
+    crate::render_state::with_text_field_focus(|state| state.focused_editor_state())
 }
 
 #[cfg(test)]

--- a/crates/cranpose-ui/src/text_field_handler.rs
+++ b/crates/cranpose-ui/src/text_field_handler.rs
@@ -132,13 +132,16 @@ impl crate::text_field_focus::FocusedTextFieldHandler for TextFieldHandler {
                 }
                 buffer.set_composition(None);
             } else {
-                // Set composition text and range
-                // The composition range is relative to where the IME text will be inserted
-                let insert_pos = buffer.selection().min();
+                // Successive preedit updates must *replace* the previous
+                // composing text (IMEs resend the whole preedit on every
+                // keystroke); without an active composition the preedit
+                // replaces the current selection, like Android's
+                // `setComposingText` and winit's `Ime::Preedit`.
+                let target = buffer.composition().unwrap_or_else(|| buffer.selection());
+                let insert_pos = target.min();
                 let comp_end = insert_pos + text.len();
 
-                // Replace current selection with composition text
-                buffer.replace(buffer.selection(), text);
+                buffer.replace(target, text);
 
                 // Set composition range to highlight the preedit text
                 let comp_range = cranpose_foundation::text::TextRange::new(insert_pos, comp_end);
@@ -155,6 +158,55 @@ impl crate::text_field_focus::FocusedTextFieldHandler for TextFieldHandler {
         // Request redraw for composition underline
         crate::request_render_invalidation();
     }
+
+    fn finish_composition(&self) {
+        // Android `finishComposingText`: keep the composed text as committed
+        // text, only drop the composing region (unlike `set_composition("")`,
+        // which deletes the preedit text).
+        if self.state.composition().is_none() {
+            return;
+        }
+        self.state.edit(|buffer| {
+            buffer.set_composition(None);
+        });
+        crate::request_render_invalidation();
+    }
+
+    fn set_composing_region(&self, start_bytes: usize, end_bytes: usize) {
+        self.state.edit(|buffer| {
+            let text = buffer.text();
+            let start = floor_char_boundary(text, start_bytes.min(end_bytes));
+            let end = floor_char_boundary(text, start_bytes.max(end_bytes));
+            if start == end {
+                // An empty region clears the composing state (keeping the
+                // text), matching Android's setComposingRegion contract.
+                buffer.set_composition(None);
+            } else {
+                buffer.set_composition(Some(cranpose_foundation::text::TextRange::new(start, end)));
+            }
+        });
+        crate::request_render_invalidation();
+    }
+
+    fn editor_state(&self) -> Option<crate::text_field_focus::ImeEditorState> {
+        let value = self.state.value();
+        Some(crate::text_field_focus::ImeEditorState {
+            text: value.text.clone(),
+            selection_start: value.selection.min(),
+            selection_end: value.selection.max(),
+            composition: value.composition.map(|range| (range.min(), range.max())),
+            single_line: matches!(self.line_limits, TextFieldLineLimits::SingleLine),
+        })
+    }
+}
+
+/// Largest byte index `<= index` that lies on a `char` boundary of `text`.
+fn floor_char_boundary(text: &str, index: usize) -> usize {
+    let mut index = index.min(text.len());
+    while index > 0 && !text.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
 }
 
 #[cfg(test)]
@@ -243,6 +295,125 @@ mod tests {
             assert_eq!(state.text(), "hi\n");
 
             text_field_focus::clear_focus();
+        });
+    }
+
+    /// IMEs resend the whole preedit on every keystroke; successive preedit
+    /// updates must replace the previous composing text, not accumulate.
+    #[test]
+    fn successive_preedit_updates_replace_previous_composition() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        with_test_runtime(|| {
+            let (state, _focus) = focused_state("ab", TextFieldLineLimits::SingleLine);
+            state.edit(|buffer| buffer.place_cursor_at_end());
+
+            assert!(text_field_focus::dispatch_ime_preedit("k", Some((1, 1))));
+            assert_eq!(state.text(), "abk");
+            assert!(text_field_focus::dispatch_ime_preedit("ka", Some((2, 2))));
+            assert_eq!(state.text(), "abka");
+            assert!(text_field_focus::dispatch_ime_preedit(
+                "\u{304b}",
+                Some((3, 3))
+            ));
+            assert_eq!(state.text(), "ab\u{304b}");
+            let comp = state.composition().expect("composition active");
+            assert_eq!((comp.min(), comp.max()), (2, 2 + "\u{304b}".len()));
+
+            // Commit path: clear preedit (deletes it), then insert the final text.
+            assert!(text_field_focus::dispatch_ime_preedit("", None));
+            assert_eq!(state.text(), "ab");
+            assert!(text_field_focus::dispatch_paste("\u{304b}\u{306a}"));
+            assert_eq!(state.text(), "ab\u{304b}\u{306a}");
+            assert_eq!(state.composition(), None);
+
+            text_field_focus::clear_focus();
+        });
+    }
+
+    /// `finishComposingText` keeps the composed text and only clears the
+    /// composing region, unlike an empty preedit which deletes the text.
+    #[test]
+    fn finish_composition_keeps_text() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        with_test_runtime(|| {
+            let (state, _focus) = focused_state("", TextFieldLineLimits::SingleLine);
+
+            assert!(text_field_focus::dispatch_ime_preedit("hello", None));
+            assert_eq!(state.text(), "hello");
+            assert!(state.composition().is_some());
+
+            assert!(text_field_focus::dispatch_ime_finish_composing());
+            assert_eq!(state.text(), "hello");
+            assert_eq!(state.composition(), None);
+
+            // Finishing again is a no-op.
+            assert!(text_field_focus::dispatch_ime_finish_composing());
+            assert_eq!(state.text(), "hello");
+
+            text_field_focus::clear_focus();
+        });
+    }
+
+    /// Autocorrect re-composes an already committed word via
+    /// `setComposingRegion`; the text must not change, only the region.
+    #[test]
+    fn set_composing_region_marks_text_without_changing_it() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        with_test_runtime(|| {
+            let (state, _focus) = focused_state("hello world", TextFieldLineLimits::SingleLine);
+
+            assert!(text_field_focus::dispatch_ime_set_composing_region(0, 5));
+            assert_eq!(state.text(), "hello world");
+            let comp = state.composition().expect("composition active");
+            assert_eq!((comp.min(), comp.max()), (0, 5));
+
+            // Replacing the composing region rewrites the marked word.
+            assert!(text_field_focus::dispatch_ime_preedit("Hello", None));
+            assert_eq!(state.text(), "Hello world");
+
+            // Offsets that fall inside a multi-byte character are clamped to
+            // the previous boundary instead of panicking.
+            assert!(text_field_focus::dispatch_ime_preedit("", None));
+            state.edit(|buffer| {
+                buffer.clear();
+                buffer.insert("\u{00e9}x");
+            });
+            assert!(text_field_focus::dispatch_ime_set_composing_region(1, 3));
+            let comp = state.composition().expect("composition active");
+            assert_eq!((comp.min(), comp.max()), (0, 3));
+
+            // An empty region clears composing state but keeps the text.
+            assert!(text_field_focus::dispatch_ime_set_composing_region(1, 1));
+            assert_eq!(state.composition(), None);
+            assert_eq!(state.text(), "\u{00e9}x");
+
+            text_field_focus::clear_focus();
+        });
+    }
+
+    #[test]
+    fn editor_state_reflects_text_selection_and_composition() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        with_test_runtime(|| {
+            let (state, _focus) = focused_state("hi", TextFieldLineLimits::SingleLine);
+            state.edit(|buffer| buffer.place_cursor_at_end());
+
+            let snapshot = text_field_focus::focused_editor_state().expect("focused field");
+            assert_eq!(snapshot.text, "hi");
+            assert_eq!(
+                (snapshot.selection_start, snapshot.selection_end),
+                (2usize, 2usize)
+            );
+            assert_eq!(snapshot.composition, None);
+            assert!(snapshot.single_line);
+
+            assert!(text_field_focus::dispatch_ime_preedit("ab", None));
+            let snapshot = text_field_focus::focused_editor_state().expect("focused field");
+            assert_eq!(snapshot.text, "hiab");
+            assert_eq!(snapshot.composition, Some((2, 4)));
+
+            text_field_focus::clear_focus();
+            assert_eq!(text_field_focus::focused_editor_state(), None);
         });
     }
 

--- a/crates/cranpose-ui/src/widgets/mod.rs
+++ b/crates/cranpose-ui/src/widgets/mod.rs
@@ -19,6 +19,7 @@ pub mod progress_indicator;
 pub mod row;
 pub mod scopes;
 pub mod spacer;
+pub mod swipe_to_dismiss;
 pub mod text;
 
 pub use animated_visibility::*;

--- a/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
+++ b/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
@@ -1,0 +1,432 @@
+//! SwipeToDismiss composable
+//!
+//! Mirrors Jetpack Compose's `SwipeToDismissBox` (Material) in spirit: wraps
+//! content that can be dragged horizontally; releasing past a threshold
+//! animates the content off-screen and fires `on_dismiss`, otherwise the
+//! content springs back into place.
+//!
+//! # Gesture disambiguation
+//!
+//! The drag capture mirrors the axis-locking rules of the scroll modifier so
+//! a `SwipeToDismiss` row inside a vertical `LazyColumn` coexists with the
+//! list scroll (children receive pointer events before ancestors):
+//!
+//! - the swipe captures the gesture only once the *horizontal* travel exceeds
+//!   the drag slop while dominating the vertical travel; from then on events
+//!   are consumed so the parent scroll abandons the gesture;
+//! - a decisively *vertical* start locks the swipe out for the rest of the
+//!   gesture, leaving every event unconsumed for the parent to scroll;
+//! - taps (no travel beyond the slop) consume nothing, so clickable rows
+//!   keep working.
+
+#![allow(non_snake_case)]
+
+use crate::composable;
+use crate::modifier::{Modifier, PointerEvent, PointerEventKind};
+use crate::widgets::box_widget::{Box, BoxSpec};
+use crate::widgets::layout::BoxWithConstraints;
+use crate::widgets::scopes::BoxWithConstraintsScope;
+use cranpose_animation::{spring, Animatable, AnimationType, Spring};
+use cranpose_core::internal::FrameCallbackRegistration;
+use cranpose_core::{with_current_composer, Owned, RuntimeHandle};
+use cranpose_foundation::DRAG_THRESHOLD;
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Offset (logical px) within which a dismiss animation counts as settled.
+const DISMISS_SETTLE_EPSILON: f32 = 0.5;
+
+/// Spring used both for the dismissal fling and the spring-back.
+fn swipe_spring() -> AnimationType {
+    spring(Spring::DampingRatioNoBouncy, Spring::StiffnessMediumLow)
+}
+
+/// Configuration for [`SwipeToDismiss`].
+#[derive(Clone)]
+pub struct SwipeToDismissSpec {
+    /// Fraction of the content width the offset must exceed on release for
+    /// the row to dismiss (default `0.5`). Clamped to `(0, 1]`.
+    pub threshold_fraction: f32,
+    /// Optional content drawn behind the swiped row (e.g. a delete bin),
+    /// revealed as the row slides away.
+    background: Option<Rc<RefCell<dyn FnMut()>>>,
+}
+
+impl SwipeToDismissSpec {
+    pub fn new() -> Self {
+        Self {
+            threshold_fraction: 0.5,
+            background: None,
+        }
+    }
+
+    /// Sets the dismiss threshold as a fraction of the content width.
+    pub fn with_threshold_fraction(mut self, fraction: f32) -> Self {
+        self.threshold_fraction = fraction;
+        self
+    }
+
+    /// Sets the background content revealed behind the swiped row.
+    pub fn with_background(mut self, background: impl FnMut() + 'static) -> Self {
+        self.background = Some(Rc::new(RefCell::new(background)));
+        self
+    }
+}
+
+impl Default for SwipeToDismissSpec {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Phase of the swipe gesture state machine.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum SwipePhase {
+    /// No active pointer sequence.
+    Idle,
+    /// Pointer down, axis not decided yet.
+    Tracking {
+        down_x: f32,
+        down_y: f32,
+        start_offset: f32,
+    },
+    /// Horizontal axis won: the swipe owns the gesture and consumes events.
+    Dragging { down_x: f32, start_offset: f32 },
+    /// Vertical axis won decisively: never capture for this gesture.
+    LockedOut,
+}
+
+/// Axis decision for the initial slop check. Mirrors the scroll modifier:
+/// the main axis captures when it exceeds the slop *and* dominates; the
+/// cross axis locks out when it exceeds the slop and strictly dominates.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SwipeAxisDecision {
+    Undecided,
+    Horizontal,
+    Vertical,
+}
+
+/// Decides the gesture axis from the total travel since pointer down.
+pub(crate) fn decide_axis(total_dx: f32, total_dy: f32, slop: f32) -> SwipeAxisDecision {
+    let horizontal = total_dx.abs();
+    let vertical = total_dy.abs();
+    if horizontal > slop && horizontal >= vertical {
+        SwipeAxisDecision::Horizontal
+    } else if vertical > slop && vertical > horizontal {
+        SwipeAxisDecision::Vertical
+    } else {
+        SwipeAxisDecision::Undecided
+    }
+}
+
+/// Where the released row should animate to: `Some(±width)` when the offset
+/// crossed the dismiss threshold, `None` to spring back to rest.
+pub(crate) fn dismissal_target(offset: f32, width: f32, threshold_fraction: f32) -> Option<f32> {
+    if !width.is_finite() || width <= 0.0 {
+        return None;
+    }
+    let threshold = width * threshold_fraction.clamp(f32::EPSILON, 1.0);
+    (offset.abs() >= threshold).then(|| width * offset.signum())
+}
+
+/// Clamps the dragged offset so the content cannot travel further than one
+/// full width in either direction.
+pub(crate) fn clamp_offset(offset: f32, width: f32) -> f32 {
+    if width.is_finite() && width > 0.0 {
+        offset.clamp(-width, width)
+    } else {
+        offset
+    }
+}
+
+static NEXT_SWIPE_ID: AtomicU64 = AtomicU64::new(0);
+
+/// State shared between the composable (which reads the animated offset) and
+/// the pointer-input handler (which drives it). Main-thread only.
+struct SwipeToDismissController {
+    /// Stable key for the pointer-input modifier.
+    id: u64,
+    runtime: RuntimeHandle,
+    /// Animated horizontal offset of the content in logical px.
+    offset: RefCell<Animatable<f32>>,
+    phase: Cell<SwipePhase>,
+    /// Content width in logical px, refreshed from the incoming constraints.
+    width_px: Cell<f32>,
+    threshold_fraction: Cell<f32>,
+    /// Refreshed every recomposition so the latest captured environment runs.
+    on_dismiss: RefCell<Option<Rc<dyn Fn()>>>,
+    /// `on_dismiss` fired for the current dismissal (fires at most once).
+    dismissed: Cell<bool>,
+    /// Frame callback watching the dismiss animation for completion.
+    settle_watcher: RefCell<Option<FrameCallbackRegistration>>,
+}
+
+impl SwipeToDismissController {
+    fn new(runtime: RuntimeHandle) -> Rc<Self> {
+        Rc::new(Self {
+            id: NEXT_SWIPE_ID.fetch_add(1, Ordering::Relaxed),
+            offset: RefCell::new(Animatable::new(0.0, runtime.clone())),
+            runtime,
+            phase: Cell::new(SwipePhase::Idle),
+            width_px: Cell::new(f32::NAN),
+            threshold_fraction: Cell::new(0.5),
+            on_dismiss: RefCell::new(None),
+            dismissed: Cell::new(false),
+            settle_watcher: RefCell::new(None),
+        })
+    }
+
+    fn current_offset(&self) -> f32 {
+        self.offset.borrow().state().value()
+    }
+
+    fn snap_to(&self, offset: f32) {
+        self.offset.borrow_mut().snapTo(offset);
+    }
+
+    fn animate_to(&self, target: f32) {
+        self.offset.borrow_mut().animateTo(target, swipe_spring());
+    }
+}
+
+/// Appends the swipe pointer-input handler to `base`. Split out of the
+/// composable so headless tests can drive the exact production modifier
+/// through a manually built modifier chain.
+fn swipe_gesture_modifier(base: Modifier, controller: Rc<SwipeToDismissController>) -> Modifier {
+    let key = controller.id;
+    base.pointer_input(key, move |scope| {
+        let controller = Rc::clone(&controller);
+        async move {
+            scope
+                .await_pointer_event_scope(|await_scope| async move {
+                    loop {
+                        let event = await_scope.await_pointer_event().await;
+                        handle_swipe_event(&controller, &event);
+                    }
+                })
+                .await;
+        }
+    })
+}
+
+/// Handles one pointer event for the swipe gesture. Returns nothing; event
+/// consumption communicates ownership to sibling/ancestor handlers.
+fn handle_swipe_event(controller: &Rc<SwipeToDismissController>, event: &PointerEvent) {
+    // Secondary fingers never participate: the swipe is a one-finger gesture
+    // and multi-touch handlers (zoom) key off the extra pointers themselves.
+    if event.id != 0 && event.kind != PointerEventKind::Cancel {
+        return;
+    }
+
+    match event.kind {
+        PointerEventKind::Down => {
+            if event.is_consumed() {
+                return;
+            }
+            // Catch an in-flight spring: pressing pins the content where it
+            // currently is, like Compose's swipeable.
+            let current = controller.current_offset();
+            controller.snap_to(current);
+            controller.phase.set(SwipePhase::Tracking {
+                down_x: event.global_position.x,
+                down_y: event.global_position.y,
+                start_offset: current,
+            });
+            // Down is never consumed: taps must keep reaching clickables.
+        }
+        PointerEventKind::Move => {
+            if event.is_consumed() {
+                // Another handler owns this sequence (parent scroll started,
+                // or a sibling captured); abandon and rest.
+                if matches!(controller.phase.get(), SwipePhase::Dragging { .. }) {
+                    controller.animate_to(0.0);
+                }
+                controller.phase.set(SwipePhase::Idle);
+                return;
+            }
+            match controller.phase.get() {
+                SwipePhase::Tracking {
+                    down_x,
+                    down_y,
+                    start_offset,
+                } => {
+                    let total_dx = event.global_position.x - down_x;
+                    let total_dy = event.global_position.y - down_y;
+                    match decide_axis(total_dx, total_dy, DRAG_THRESHOLD) {
+                        SwipeAxisDecision::Horizontal => {
+                            controller.phase.set(SwipePhase::Dragging {
+                                down_x,
+                                start_offset,
+                            });
+                            let width = controller.width_px.get();
+                            controller.snap_to(clamp_offset(start_offset + total_dx, width));
+                            event.consume();
+                        }
+                        SwipeAxisDecision::Vertical => {
+                            controller.phase.set(SwipePhase::LockedOut);
+                        }
+                        SwipeAxisDecision::Undecided => {}
+                    }
+                }
+                SwipePhase::Dragging {
+                    down_x,
+                    start_offset,
+                } => {
+                    let total_dx = event.global_position.x - down_x;
+                    let width = controller.width_px.get();
+                    controller.snap_to(clamp_offset(start_offset + total_dx, width));
+                    event.consume();
+                }
+                SwipePhase::Idle | SwipePhase::LockedOut => {}
+            }
+        }
+        PointerEventKind::Up => {
+            let phase = controller.phase.get();
+            controller.phase.set(SwipePhase::Idle);
+            if let SwipePhase::Dragging { .. } = phase {
+                settle_release(controller);
+                event.consume();
+            }
+        }
+        PointerEventKind::Cancel => {
+            if matches!(controller.phase.get(), SwipePhase::Dragging { .. }) {
+                controller.animate_to(0.0);
+            }
+            controller.phase.set(SwipePhase::Idle);
+        }
+        PointerEventKind::Scroll
+        | PointerEventKind::Zoom
+        | PointerEventKind::Enter
+        | PointerEventKind::Exit => {}
+    }
+}
+
+/// Applies the release decision: animate off-screen and watch for completion
+/// (firing `on_dismiss`), or spring back to rest.
+fn settle_release(controller: &Rc<SwipeToDismissController>) {
+    let offset = controller.current_offset();
+    let width = controller.width_px.get();
+    match dismissal_target(offset, width, controller.threshold_fraction.get()) {
+        Some(target) => {
+            controller.animate_to(target);
+            watch_dismiss_settle(controller);
+        }
+        None => {
+            controller.animate_to(0.0);
+        }
+    }
+}
+
+/// Watches the dismiss animation frame-by-frame; once the offset settles at
+/// the off-screen target, fires `on_dismiss` exactly once. Runs in frame
+/// callbacks (outside composition), so the callback may freely mutate state.
+fn watch_dismiss_settle(controller: &Rc<SwipeToDismissController>) {
+    let weak = Rc::downgrade(controller);
+    let registration =
+        controller
+            .runtime
+            .frame_clock()
+            .with_frame_nanos(move |_frame_time_nanos| {
+                let Some(controller) = weak.upgrade() else {
+                    return;
+                };
+                controller.settle_watcher.borrow_mut().take();
+                if controller.dismissed.get() {
+                    return;
+                }
+                // A new gesture retargeted the animation; stop watching.
+                if matches!(controller.phase.get(), SwipePhase::Dragging { .. }) {
+                    return;
+                }
+                let target = controller.offset.borrow().target();
+                let value = controller.current_offset();
+                if (value - target).abs() <= DISMISS_SETTLE_EPSILON {
+                    controller.dismissed.set(true);
+                    let on_dismiss = controller.on_dismiss.borrow().clone();
+                    if let Some(on_dismiss) = on_dismiss {
+                        on_dismiss();
+                    }
+                } else {
+                    watch_dismiss_settle(&controller);
+                }
+            });
+    *controller.settle_watcher.borrow_mut() = Some(registration);
+}
+
+/// Wraps `content` so it can be swiped away horizontally.
+///
+/// Dragging moves the content with the finger (clamped to one content width
+/// in either direction). Releasing past `spec.threshold_fraction` of the
+/// width animates the content off-screen with a spring and then fires
+/// `on_dismiss` (exactly once); releasing earlier springs the content back.
+/// An optional [`SwipeToDismissSpec::with_background`] content (delete bin,
+/// archive icon, ...) is revealed behind the row while it is displaced.
+///
+/// Vertical drags are handed to ancestor scroll containers untouched, so
+/// rows inside a `LazyColumn` still scroll the list (see the module docs for
+/// the axis-locking rules).
+#[composable(no_skip)]
+pub fn SwipeToDismiss<D, F>(
+    modifier: Modifier,
+    spec: SwipeToDismissSpec,
+    on_dismiss: D,
+    content: F,
+) -> cranpose_core::NodeId
+where
+    D: Fn() + 'static,
+    F: FnMut() + 'static,
+{
+    let controller: Rc<SwipeToDismissController> = with_current_composer(|composer| {
+        let runtime = composer.runtime_handle();
+        let owned: Owned<Rc<SwipeToDismissController>> =
+            composer.remember(|| SwipeToDismissController::new(runtime));
+        owned.with(Rc::clone)
+    });
+
+    // Refresh the per-recomposition inputs so the pointer handler (which
+    // lives across recompositions) observes the latest values.
+    controller
+        .threshold_fraction
+        .set(spec.threshold_fraction.clamp(f32::EPSILON, 1.0));
+    *controller.on_dismiss.borrow_mut() = Some(Rc::new(on_dismiss));
+
+    let background = spec.background.clone();
+    let content = Rc::new(RefCell::new(content));
+
+    // The gesture area is the whole (un-offset) row: like a scroll
+    // container, the handler sits on the ancestor node so descendants
+    // (clickables) see events first, and the hit region stays put while the
+    // content slides away.
+    let gesture_modifier = swipe_gesture_modifier(modifier, Rc::clone(&controller));
+
+    let controller_for_layout = Rc::clone(&controller);
+    BoxWithConstraints(gesture_modifier, move |scope| {
+        controller_for_layout
+            .width_px
+            .set(scope.constraints().max_width);
+
+        if let Some(background) = &background {
+            let background = Rc::clone(background);
+            Box(Modifier::empty(), BoxSpec::new(), move || {
+                (background.borrow_mut())();
+            });
+        }
+
+        // Reading the animated offset subscribes this scope: every spring
+        // frame recomposes and re-places the content at the new offset.
+        let offset_x = controller_for_layout.current_offset();
+        let content = Rc::clone(&content);
+        Box(
+            Modifier::empty().offset(offset_x, 0.0),
+            BoxSpec::new(),
+            move || {
+                (content.borrow_mut())();
+            },
+        );
+    })
+}
+
+#[cfg(test)]
+#[path = "../tests/swipe_to_dismiss_tests.rs"]
+mod tests;

--- a/crates/cranpose/Cargo.toml
+++ b/crates/cranpose/Cargo.toml
@@ -107,6 +107,10 @@ web-sys = { version = "0.3", optional = true, features = [
     "Clipboard",
     "ClipboardEvent",
     "DataTransfer",
+    # IME composition support (hidden textarea + composition events)
+    "CompositionEvent",
+    "HtmlTextAreaElement",
+    "Node",
 ] }
 log = "0.4"
 cranpose-services = { workspace = true, default-features = false }

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeTextInput.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeTextInput.java
@@ -1,0 +1,437 @@
+package dev.cranpose.android;
+
+import android.app.Activity;
+import android.content.Context;
+import android.text.Editable;
+import android.text.InputType;
+import android.text.Selection;
+import android.text.SpannableStringBuilder;
+import android.util.Log;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.inputmethod.BaseInputConnection;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputMethodManager;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Invisible editor view giving cranpose text fields a real {@link InputConnection}.
+ *
+ * <p>A {@code NativeActivity} has no Java view overriding
+ * {@code onCreateInputConnection}, so IMEs fall back to raw key events and
+ * features that need a real editor - autocorrect/suggestions, swipe typing,
+ * voice input and composing scripts such as CJK - do not work. This helper
+ * attaches a focusable 1x1 view to the activity content view whenever a
+ * cranpose text field gains focus; its {@link InputConnection} forwards
+ * editing operations (commit, compose, delete-surrounding, key events,
+ * editor actions) through JNI into the native text pipeline.
+ *
+ * <p>The Java side keeps an {@link Editable} mirror of the field so the IME's
+ * synchronous text queries ({@code getTextBeforeCursor} and friends, served
+ * by {@link BaseInputConnection}) never have to block on the native thread.
+ * The native side owns the truth: it pushes state back via
+ * {@link #updateState} after applying the forwarded operations, restarting
+ * the input session whenever the two sides diverge (for example when the app
+ * rejects or transforms input).
+ *
+ * <p>All methods are called from native code; view and IME operations are
+ * posted to the UI thread. Include this source (and the {@code cranpose}
+ * native library) in the Android app build - see
+ * {@code cranpose/android/java}.
+ */
+public final class CranposeTextInput {
+    private static final String TAG = "CranposeTextInput";
+
+    private static volatile SessionState current;
+
+    private CranposeTextInput() {
+    }
+
+    /**
+     * Opens (or refreshes) the text-input session: attaches the editor view,
+     * seeds the {@link Editable} mirror, focuses the view and asks the IME to
+     * show. Selection offsets are UTF-16 code units into {@code text}.
+     *
+     * <p>{@code queueHandle} transfers ownership of one native queue
+     * reference to this class; it is released when the session is hidden (or
+     * immediately when a session already owns a handle).
+     */
+    public static int show(
+            Activity activity,
+            long queueHandle,
+            String text,
+            int selStart,
+            int selEnd,
+            boolean singleLine
+    ) {
+        try {
+            activity.runOnUiThread(() -> {
+                SessionState state = current;
+                if (state == null) {
+                    state = new SessionState(queueHandle);
+                    state.editable = new SpannableStringBuilder(text);
+                    state.singleLine = singleLine;
+                    EditorView view = new EditorView(activity, state);
+                    state.view = view;
+                    setSelectionClamped(state.editable, selStart, selEnd);
+
+                    ViewGroup content = activity.findViewById(android.R.id.content);
+                    if (content == null) {
+                        Log.w(TAG, "Activity has no content view; cannot install IME editor");
+                        state.release();
+                        return;
+                    }
+                    content.addView(view, new ViewGroup.LayoutParams(1, 1));
+                    current = state;
+                } else {
+                    // The session already owns a queue handle; drop the new one.
+                    nativeImeReleaseQueue(queueHandle);
+                    state.singleLine = singleLine;
+                    state.editable.replace(0, state.editable.length(), text);
+                    BaseInputConnection.removeComposingSpans(state.editable);
+                    setSelectionClamped(state.editable, selStart, selEnd);
+                    InputMethodManager imm = inputMethodManager(activity);
+                    if (imm != null) {
+                        // Re-seeding always restarts: the previous session's
+                        // composition state is no longer meaningful (and the
+                        // editor options may have changed).
+                        imm.restartInput(state.view);
+                    }
+                }
+
+                SessionState active = current;
+                if (active == null || active.view == null) {
+                    return;
+                }
+                active.view.requestFocus();
+                InputMethodManager imm = inputMethodManager(activity);
+                if (imm != null) {
+                    imm.showSoftInput(active.view, 0);
+                }
+            });
+            return 0;
+        } catch (RuntimeException error) {
+            Log.w(TAG, "Failed to show cranpose text input", error);
+            return -1;
+        }
+    }
+
+    /** Closes the session: hides the IME, detaches the editor view. */
+    public static void hide(Activity activity) {
+        try {
+            activity.runOnUiThread(() -> {
+                SessionState state = current;
+                if (state == null) {
+                    return;
+                }
+                current = null;
+                InputMethodManager imm = inputMethodManager(activity);
+                if (imm != null && state.view != null) {
+                    imm.hideSoftInputFromWindow(state.view.getWindowToken(), 0);
+                }
+                if (state.view != null && state.view.getParent() instanceof ViewGroup) {
+                    ((ViewGroup) state.view.getParent()).removeView(state.view);
+                }
+                state.release();
+            });
+        } catch (RuntimeException error) {
+            Log.w(TAG, "Failed to hide cranpose text input", error);
+        }
+    }
+
+    /**
+     * Pushes the native editor state into the mirror. Selection/composition
+     * offsets are UTF-16 code units; composition -1/-1 means none.
+     *
+     * <p>If the text content already matches, only the selection (and the
+     * IME's view of it via {@code updateSelection}) is refreshed - this is
+     * the common case after the native side applied a forwarded operation
+     * verbatim. A content mismatch means the two sides diverged, so the
+     * whole input session is restarted.
+     */
+    public static void updateState(
+            Activity activity,
+            String text,
+            int selStart,
+            int selEnd,
+            int compStart,
+            int compEnd
+    ) {
+        try {
+            activity.runOnUiThread(() -> {
+                SessionState state = current;
+                if (state == null || state.disposed || state.view == null) {
+                    return;
+                }
+                boolean textChanged = !contentEquals(state.editable, text);
+                if (textChanged) {
+                    state.editable.replace(0, state.editable.length(), text);
+                    BaseInputConnection.removeComposingSpans(state.editable);
+                }
+                setSelectionClamped(state.editable, selStart, selEnd);
+                InputMethodManager imm = inputMethodManager(activity);
+                if (imm == null) {
+                    return;
+                }
+                if (textChanged) {
+                    imm.restartInput(state.view);
+                } else {
+                    int length = state.editable.length();
+                    int candStart = compStart >= 0 ? Math.min(compStart, length) : -1;
+                    int candEnd = compEnd >= 0 ? Math.min(compEnd, length) : -1;
+                    imm.updateSelection(
+                            state.view,
+                            Selection.getSelectionStart(state.editable),
+                            Selection.getSelectionEnd(state.editable),
+                            candStart,
+                            candEnd
+                    );
+                }
+            });
+        } catch (RuntimeException error) {
+            Log.w(TAG, "Failed to update cranpose text input state", error);
+        }
+    }
+
+    private static InputMethodManager inputMethodManager(Context context) {
+        return (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+    }
+
+    private static boolean contentEquals(Editable editable, String text) {
+        int length = editable.length();
+        if (length != text.length()) {
+            return false;
+        }
+        for (int i = 0; i < length; i++) {
+            if (editable.charAt(i) != text.charAt(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void setSelectionClamped(Editable editable, int start, int end) {
+        int length = editable.length();
+        int clampedStart = Math.max(0, Math.min(start, length));
+        int clampedEnd = Math.max(0, Math.min(end, length));
+        Selection.setSelection(editable, clampedStart, clampedEnd);
+    }
+
+    private static int utf8Length(CharSequence text) {
+        return text.toString().getBytes(StandardCharsets.UTF_8).length;
+    }
+
+    /** Session state shared between the editor view and its InputConnection. */
+    private static final class SessionState {
+        final long queueHandle;
+        volatile View view;
+        volatile boolean disposed;
+        volatile boolean singleLine;
+        Editable editable;
+
+        SessionState(long queueHandle) {
+            this.queueHandle = queueHandle;
+        }
+
+        void release() {
+            if (!disposed) {
+                disposed = true;
+                view = null;
+                nativeImeReleaseQueue(queueHandle);
+            }
+        }
+    }
+
+    /** Invisible focusable view whose InputConnection feeds the native pipeline. */
+    private static final class EditorView extends View {
+        private final SessionState state;
+
+        EditorView(Context context, SessionState state) {
+            super(context);
+            this.state = state;
+            setFocusable(true);
+            setFocusableInTouchMode(true);
+        }
+
+        @Override
+        public boolean onCheckIsTextEditor() {
+            return true;
+        }
+
+        @Override
+        public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+            if (state.disposed) {
+                return null;
+            }
+            outAttrs.inputType = state.singleLine
+                    ? InputType.TYPE_CLASS_TEXT
+                    : InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
+            // NO_EXTRACT_UI/NO_FULLSCREEN: the fullscreen extract editor would
+            // hide the composed UI entirely.
+            outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_FULLSCREEN
+                    | EditorInfo.IME_FLAG_NO_EXTRACT_UI
+                    | (state.singleLine ? EditorInfo.IME_ACTION_DONE : EditorInfo.IME_ACTION_NONE);
+            outAttrs.initialSelStart = Selection.getSelectionStart(state.editable);
+            outAttrs.initialSelEnd = Selection.getSelectionEnd(state.editable);
+            return new Connection(this, state);
+        }
+    }
+
+    /**
+     * Forwards IME editing operations to native code while keeping the local
+     * {@link Editable} mirror in sync via {@link BaseInputConnection}'s
+     * full-editor implementation (which also serves all text queries).
+     */
+    private static final class Connection extends BaseInputConnection {
+        private final SessionState state;
+
+        Connection(View view, SessionState state) {
+            super(view, true);
+            this.state = state;
+        }
+
+        @Override
+        public Editable getEditable() {
+            return state.editable;
+        }
+
+        @Override
+        public boolean commitText(CharSequence text, int newCursorPosition) {
+            if (!state.disposed) {
+                nativeImeCommitText(state.queueHandle, text.toString(), newCursorPosition);
+            }
+            return super.commitText(text, newCursorPosition);
+        }
+
+        @Override
+        public boolean setComposingText(CharSequence text, int newCursorPosition) {
+            if (!state.disposed) {
+                // The native side positions the cursor inside the preedit in
+                // UTF-8 bytes. IMEs practically always pass 1 (cursor after
+                // the composed text); other offsets degrade to the ends.
+                int cursorBytes = newCursorPosition > 0 ? utf8Length(text) : 0;
+                nativeImeSetComposingText(state.queueHandle, text.toString(), cursorBytes);
+            }
+            return super.setComposingText(text, newCursorPosition);
+        }
+
+        @Override
+        public boolean setComposingRegion(int start, int end) {
+            if (!state.disposed) {
+                Editable editable = getEditable();
+                int length = editable.length();
+                int clampedStart = Math.max(0, Math.min(Math.min(start, end), length));
+                int clampedEnd = Math.max(0, Math.min(Math.max(start, end), length));
+                int startBytes = utf8Length(editable.subSequence(0, clampedStart));
+                int endBytes =
+                        startBytes + utf8Length(editable.subSequence(clampedStart, clampedEnd));
+                nativeImeSetComposingRegion(state.queueHandle, startBytes, endBytes);
+            }
+            return super.setComposingRegion(start, end);
+        }
+
+        @Override
+        public boolean finishComposingText() {
+            if (!state.disposed) {
+                nativeImeFinishComposing(state.queueHandle);
+            }
+            return super.finishComposingText();
+        }
+
+        @Override
+        public boolean deleteSurroundingText(int beforeLength, int afterLength) {
+            if (!state.disposed) {
+                // Convert the UTF-16 char counts into UTF-8 byte counts using
+                // the mirror (the native side counts bytes).
+                Editable editable = getEditable();
+                int selStart = Selection.getSelectionStart(editable);
+                int selEnd = Selection.getSelectionEnd(editable);
+                if (selStart >= 0 && selEnd >= 0) {
+                    int start = Math.min(selStart, selEnd);
+                    int end = Math.max(selStart, selEnd);
+                    int beforeChars = Math.max(0, Math.min(beforeLength, start));
+                    int afterChars = Math.max(0, Math.min(afterLength, editable.length() - end));
+                    int beforeBytes = utf8Length(editable.subSequence(start - beforeChars, start));
+                    int afterBytes = utf8Length(editable.subSequence(end, end + afterChars));
+                    nativeImeDeleteSurrounding(state.queueHandle, beforeBytes, afterBytes);
+                }
+            }
+            return super.deleteSurroundingText(beforeLength, afterLength);
+        }
+
+        @Override
+        public boolean sendKeyEvent(KeyEvent event) {
+            if (state.disposed) {
+                return false;
+            }
+            // Forward through the IME queue instead of super (which would
+            // inject into the window input queue and double-deliver through
+            // the native key path).
+            nativeImeSendKeyEvent(
+                    state.queueHandle,
+                    event.getAction(),
+                    event.getKeyCode(),
+                    event.getMetaState(),
+                    event.getUnicodeChar()
+            );
+            // Mirror the common editing keys BaseInputConnection would have
+            // delivered so the Editable stays in sync until the next native
+            // state push.
+            if (event.getAction() == KeyEvent.ACTION_DOWN
+                    && event.getKeyCode() == KeyEvent.KEYCODE_DEL) {
+                Editable editable = getEditable();
+                int selStart = Selection.getSelectionStart(editable);
+                int selEnd = Selection.getSelectionEnd(editable);
+                if (selStart >= 0 && selEnd >= 0) {
+                    int start = Math.min(selStart, selEnd);
+                    int end = Math.max(selStart, selEnd);
+                    if (start != end) {
+                        editable.delete(start, end);
+                    } else if (start > 0) {
+                        int deleteFrom = start - 1;
+                        // Keep surrogate pairs intact.
+                        if (deleteFrom > 0
+                                && Character.isLowSurrogate(editable.charAt(deleteFrom))
+                                && Character.isHighSurrogate(editable.charAt(deleteFrom - 1))) {
+                            deleteFrom -= 1;
+                        }
+                        editable.delete(deleteFrom, start);
+                    }
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public boolean performEditorAction(int actionCode) {
+            if (!state.disposed) {
+                nativeImePerformEditorAction(state.queueHandle, actionCode);
+            }
+            return true;
+        }
+    }
+
+    private static native void nativeImeCommitText(
+            long queueHandle, String text, int newCursorPosition);
+
+    private static native void nativeImeSetComposingText(
+            long queueHandle, String text, int cursorBytes);
+
+    private static native void nativeImeSetComposingRegion(
+            long queueHandle, int startBytes, int endBytes);
+
+    private static native void nativeImeFinishComposing(long queueHandle);
+
+    private static native void nativeImeDeleteSurrounding(
+            long queueHandle, int beforeBytes, int afterBytes);
+
+    private static native void nativeImeSendKeyEvent(
+            long queueHandle, int action, int keyCode, int metaState, int unicodeChar);
+
+    private static native void nativeImePerformEditorAction(long queueHandle, int actionCode);
+
+    private static native void nativeImeReleaseQueue(long queueHandle);
+}

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -6,9 +6,10 @@
 use crate::{
     android_host_window,
     android_jni::{clear_pending_android_jni_exception, with_android_activity_env},
-    android_keyboard::{is_system_key, AndroidKeyTranslator, AndroidSoftKeyboard},
+    android_keyboard::{self, is_system_key, AndroidKeyTranslator, AndroidSoftKeyboard},
     android_overlay_window,
     android_surface::{create_android_wgpu_surface, AndroidSurfaceError},
+    android_text_input::{self, AndroidImeEvent},
     launcher::{AndroidOverlayWindowOptions, AppSettings},
     wgpu_surface::surface_present_required,
     wgpu_surface::{current_surface_texture, SurfaceFrame},
@@ -92,6 +93,80 @@ fn push_pending_input_from_android_key_event(
     };
     pending_inputs.push(PendingInput::Key(event));
     true
+}
+
+/// `EditorInfo.IME_ACTION_DONE`: the user tapped the keyboard's Done action.
+const IME_ACTION_DONE: i32 = 6;
+
+/// Applies one editing operation forwarded by the Java `InputConnection`
+/// (see [`crate::android_text_input`]) to the focused text field.
+fn dispatch_android_ime_event(shell: &mut AppShell<WgpuRenderer>, event: AndroidImeEvent) {
+    match event {
+        AndroidImeEvent::CommitText { text, .. } => {
+            // commitText replaces the composing text (if any); clearing the
+            // preedit first deletes it, then the final text is inserted.
+            // `new_cursor_position` values other than 1 are not honored yet;
+            // the editor-state sync restarts the IME session if the cursor
+            // ends up somewhere the IME did not expect.
+            let _ = shell.on_ime_preedit("", None);
+            let _ = shell.on_paste(&text);
+        }
+        AndroidImeEvent::SetComposingText { text, cursor_bytes } => {
+            let _ = shell.on_ime_preedit(&text, Some((cursor_bytes, cursor_bytes)));
+        }
+        AndroidImeEvent::SetComposingRegion {
+            start_bytes,
+            end_bytes,
+        } => {
+            let _ = shell.on_ime_set_composing_region(start_bytes, end_bytes);
+        }
+        AndroidImeEvent::FinishComposing => {
+            let _ = shell.on_ime_finish_composing();
+        }
+        AndroidImeEvent::DeleteSurrounding {
+            before_bytes,
+            after_bytes,
+        } => {
+            let _ = shell.on_ime_delete_surrounding(before_bytes, after_bytes);
+        }
+        AndroidImeEvent::Key {
+            action,
+            key_code,
+            meta_state,
+            unicode_char,
+        } => {
+            if let Some(event) =
+                android_keyboard::ime_key_event(action, key_code, meta_state, unicode_char)
+            {
+                let _ = shell.on_key_event(&event);
+            }
+        }
+        AndroidImeEvent::EditorAction { action } => {
+            // Done follows the platform convention of dismissing the
+            // keyboard (focus stays in the field). Other actions are
+            // surfaced as an Enter key press: single-line fields ignore it
+            // and apps can react through their key handlers. A dedicated
+            // per-field ime-action callback (Compose `KeyboardActions`) is
+            // not modeled yet.
+            if action == IME_ACTION_DONE {
+                let _ = shell.on_ime_finish_composing();
+                shell.clear_text_field_focus();
+            } else {
+                for event_type in [
+                    cranpose_app_shell::KeyEventType::KeyDown,
+                    cranpose_app_shell::KeyEventType::KeyUp,
+                ] {
+                    let key = KeyEvent::new(
+                        cranpose_app_shell::KeyCode::Enter,
+                        "",
+                        cranpose_app_shell::Modifiers::NONE,
+                        event_type,
+                    );
+                    let _ = shell.on_key_event(&key);
+                }
+            }
+        }
+    }
 }
 
 /// Maps an Android pointer id to the shell's pointer id space: the finger
@@ -980,6 +1055,13 @@ pub fn run(
     let host_window_registry = Rc::new(android_host_window::AndroidHostWindowRegistry::default());
     let overlay_event_queue = Arc::new(android_overlay_window::AndroidOverlayEventQueue::default());
 
+    // IME editor bridge (InputConnection-backed text input). The queue crosses
+    // the JNI/UI-thread boundary; the session state stays on this thread.
+    let ime_event_queue = Arc::new(android_text_input::AndroidImeEventQueue::new());
+    ime_event_queue.set_waker(app.create_waker());
+    let ime_session =
+        android_keyboard::AndroidImeSession::new(app.clone(), Arc::clone(&ime_event_queue));
+
     // Exit flag for Destroy event (can't break from inside poll_events closure)
     let should_exit = Arc::new(AtomicBool::new(false));
 
@@ -1435,9 +1517,19 @@ pub fn run(
         // the first tap on a text field already opens the keyboard.
         if !soft_keyboard_installed {
             if let Some(shell) = &mut app_shell {
-                shell.set_platform_text_input(Rc::new(AndroidSoftKeyboard::new(app.clone())));
+                shell.set_platform_text_input(Rc::new(AndroidSoftKeyboard::new(Rc::clone(
+                    &ime_session,
+                ))));
                 soft_keyboard_installed = true;
                 log::info!("Android soft keyboard focus hook installed");
+            }
+        }
+
+        // Apply editing operations forwarded by the IME InputConnection
+        // (commit/compose/delete/key/editor-action), in arrival order.
+        if let Some(shell) = &mut app_shell {
+            for event in ime_event_queue.drain() {
+                dispatch_android_ime_event(shell, event);
             }
         }
 
@@ -1474,6 +1566,16 @@ pub fn run(
                         }
                     }
                 }
+            }
+        }
+
+        // Mirror the editor state back to the Java InputConnection after
+        // input handling: refreshes the IME's selection view and restarts
+        // the input session when the field content diverged from the mirror
+        // (e.g. the app transformed or rejected input).
+        if ime_session.is_active() {
+            if let Some(shell) = &mut app_shell {
+                ime_session.sync_editor_state(shell.ime_editor_state());
             }
         }
 

--- a/crates/cranpose/src/android_jni.rs
+++ b/crates/cranpose/src/android_jni.rs
@@ -46,6 +46,58 @@ pub(crate) fn clear_pending_android_jni_exception(env: &mut Env<'_>) {
     }
 }
 
+/// Loads a cranpose Java helper class (`dev.cranpose.android.*`) through the
+/// activity's class loader.
+///
+/// `FindClass` cannot be used from native (non-Java) threads because they have
+/// no application class loader; going through the Activity works everywhere.
+/// `class_name` uses JNI slash notation (`dev/cranpose/android/Foo`).
+pub(crate) fn load_cranpose_java_class<'local>(
+    env: &mut Env<'local>,
+    activity: &jni::objects::JObject<'local>,
+    class_name: &str,
+) -> Result<JClass<'local>, String> {
+    use jni::{jni_sig, jni_str, objects::JValue};
+
+    let class_name_string = env
+        .new_string(class_name.replace('/', "."))
+        .map_err(|error| {
+            clear_pending_android_jni_exception(env);
+            format!("failed to create Java class name for {class_name}: {error}")
+        })?;
+    let class_name_string = JObject::from(class_name_string);
+
+    let class = env
+        .call_method(
+            activity,
+            jni_str!("getClassLoader"),
+            jni_sig!("()Ljava/lang/ClassLoader;"),
+            &[],
+        )
+        .and_then(|value| value.l())
+        .and_then(|class_loader| {
+            env.call_method(
+                &class_loader,
+                jni_str!("loadClass"),
+                jni_sig!("(Ljava/lang/String;)Ljava/lang/Class;"),
+                &[JValue::Object(&class_name_string)],
+            )
+            .and_then(|value| value.l())
+        })
+        .map_err(|error| {
+            clear_pending_android_jni_exception(env);
+            format!(
+                "failed to load Android helper class {}; include cranpose/android/java in the Android source set: {error}",
+                class_name
+            )
+        })?;
+
+    env.cast_local::<JClass>(class).map_err(|error| {
+        clear_pending_android_jni_exception(env);
+        format!("Android helper {class_name} did not resolve to a Java class: {error}")
+    })
+}
+
 pub(crate) fn native_window_from_surface(
     env: &mut Env<'_>,
     surface: JObject<'_>,

--- a/crates/cranpose/src/android_keyboard.rs
+++ b/crates/cranpose/src/android_keyboard.rs
@@ -4,57 +4,221 @@
 //!
 //! 1. [`AndroidSoftKeyboard`] implements the framework's
 //!    [`PlatformTextInputHandler`] hook: when a `BasicTextField` gains focus
-//!    the framework calls `show_keyboard` and we ask the platform to show the
-//!    soft keyboard via [`AndroidApp::show_soft_input`]; when text-field focus
-//!    is cleared (or goes stale) we hide it again.
+//!    the framework calls `show_keyboard` and we open an IME editor session
+//!    through the `CranposeTextInput` Java helper (a real `InputConnection`,
+//!    see [`crate::android_text_input`]); when text-field focus is cleared
+//!    (or goes stale) the session is closed again. Apps that do not compile
+//!    the `cranpose/android/java` sources fall back to the plain
+//!    [`AndroidApp::show_soft_input`] path.
 //!
 //! 2. [`AndroidKeyTranslator`] converts [`android_activity`] `KeyEvent`s into
 //!    the framework [`KeyEvent`] consumed by the focused text field. Printable
 //!    characters are resolved through the device [`KeyCharacterMap`]
 //!    (including dead-key/combining-accent composition), while editing keys
 //!    (backspace, enter, arrows, ...) are mapped to framework [`KeyCode`]s.
-//!
-//! # Limitation: KeyCharacterMap path, not a full IME `InputConnection`
-//!
-//! A `NativeActivity` has no Java `View` overriding `onCreateInputConnection`,
-//! so IMEs run in their fallback mode and deliver input as plain key events.
-//! Simple keyboards (and Gboard's basic Latin layouts) work fine through the
-//! `KeyCharacterMap` path implemented here, but anything that needs a real
-//! `InputConnection` - autocorrect/suggestions, swipe typing, voice input,
-//! and composing-text scripts such as CJK or Indic - cannot be delivered as
-//! key events by the IME. Supporting those requires a Java editor overlay
-//! providing an `InputConnection` (the framework side is already prepared:
-//! see `AppShell::on_ime_preedit` / `on_paste` for committed text).
+//!    This remains the path for hardware keyboards, and the whole-app
+//!    fallback when the Java IME helper is unavailable.
 
+use crate::android_text_input::{
+    hide_android_text_input, show_android_text_input, update_android_text_input_state,
+    AndroidImeEventQueue,
+};
 use android_activity::input::{KeyAction, KeyCharacterMap, KeyMapChar, Keycode, MetaState};
 use android_activity::AndroidApp;
-use cranpose_app_shell::{KeyCode, KeyEvent, KeyEventType, Modifiers, PlatformTextInputHandler};
+use cranpose_app_shell::{
+    ImeEditorState, KeyCode, KeyEvent, KeyEventType, Modifiers, PlatformTextInputHandler,
+};
+use std::cell::{Cell, RefCell};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// Android `KeyEvent` action constants (`ACTION_DOWN` / `ACTION_UP`).
+const ANDROID_KEY_ACTION_DOWN: i32 = 0;
+const ANDROID_KEY_ACTION_UP: i32 = 1;
+
+/// State of the IME editor session shared between the focus-driven
+/// [`AndroidSoftKeyboard`] handler and the main loop (which drains IME events
+/// and pushes editor-state updates back to the Java mirror).
+///
+/// Main-thread only (`Rc`); the cross-thread part is the event queue.
+pub(crate) struct AndroidImeSession {
+    app: AndroidApp,
+    queue: Arc<AndroidImeEventQueue>,
+    /// A Java editor session is currently open.
+    active: Cell<bool>,
+    /// The Java helper class could not be used; stick to the plain
+    /// `show_soft_input` path for the rest of the process lifetime.
+    bridge_failed: Cell<bool>,
+    /// Editor state last pushed to (or seeded into) the Java mirror. Used to
+    /// skip redundant JNI round-trips on every frame.
+    last_synced: RefCell<Option<ImeEditorState>>,
+}
+
+impl AndroidImeSession {
+    pub(crate) fn new(app: AndroidApp, queue: Arc<AndroidImeEventQueue>) -> Rc<Self> {
+        Rc::new(Self {
+            app,
+            queue,
+            active: Cell::new(false),
+            bridge_failed: Cell::new(false),
+            last_synced: RefCell::new(None),
+        })
+    }
+
+    /// Whether the Java editor session is open (and therefore editor-state
+    /// syncing is worthwhile).
+    pub(crate) fn is_active(&self) -> bool {
+        self.active.get() && !self.bridge_failed.get()
+    }
+
+    /// Pushes the current editor state to the Java mirror when it changed
+    /// since the last push. Called from the main loop after input handling.
+    pub(crate) fn sync_editor_state(&self, state: Option<ImeEditorState>) {
+        if !self.is_active() {
+            return;
+        }
+        let Some(state) = state else {
+            // No focused field: the session is about to be closed by the
+            // focus-loss notification; nothing to sync.
+            return;
+        };
+        if self.last_synced.borrow().as_ref() == Some(&state) {
+            return;
+        }
+        match update_android_text_input_state(&self.app, &state) {
+            Ok(()) => {
+                *self.last_synced.borrow_mut() = Some(state);
+            }
+            Err(error) => {
+                log::warn!("Android IME state sync failed: {error}");
+            }
+        }
+    }
+
+    fn show(&self) {
+        if self.bridge_failed.get() {
+            self.show_soft_input_only();
+            return;
+        }
+
+        // Seed the Java mirror with the focused field's state. This runs
+        // inside the app context (the focus manager invokes the platform
+        // handler synchronously), so the focused handler is accessible.
+        let state = cranpose_ui::text_field_focus::focused_editor_state().unwrap_or_else(|| {
+            // Focus notifications only fire for text fields; an absent state
+            // still opens a session so the keyboard appears.
+            ImeEditorState {
+                text: String::new(),
+                selection_start: 0,
+                selection_end: 0,
+                composition: None,
+                single_line: true,
+            }
+        });
+
+        match show_android_text_input(&self.app, &self.queue, &state) {
+            Ok(()) => {
+                self.active.set(true);
+                *self.last_synced.borrow_mut() = Some(state);
+            }
+            Err(error) => {
+                log::warn!(
+                    "Android IME editor bridge unavailable, falling back to key-event input \
+                     (include cranpose/android/java sources for full IME support): {error}"
+                );
+                self.bridge_failed.set(true);
+                self.show_soft_input_only();
+            }
+        }
+    }
+
+    fn hide(&self) {
+        if self.bridge_failed.get() {
+            // `false` = do not restrict to implicitly-shown keyboards; always hide.
+            self.app.hide_soft_input(false);
+            return;
+        }
+        self.active.set(false);
+        *self.last_synced.borrow_mut() = None;
+        if let Err(error) = hide_android_text_input(&self.app) {
+            log::warn!("Android IME editor hide failed: {error}");
+            self.app.hide_soft_input(false);
+        }
+    }
+
+    fn show_soft_input_only(&self) {
+        // `true` requests SHOW_IMPLICIT: the system may coordinate visibility
+        // with hardware keyboards / display modes instead of forcing the IME.
+        self.app.show_soft_input(true);
+    }
+}
 
 /// Shows/hides the Android soft keyboard in response to text-field focus
 /// changes. Installed on the `AppShell` via `set_platform_text_input`.
 pub(crate) struct AndroidSoftKeyboard {
-    app: AndroidApp,
+    session: Rc<AndroidImeSession>,
 }
 
 impl AndroidSoftKeyboard {
-    pub(crate) fn new(app: AndroidApp) -> Self {
-        Self { app }
+    pub(crate) fn new(session: Rc<AndroidImeSession>) -> Self {
+        Self { session }
     }
 }
 
 impl PlatformTextInputHandler for AndroidSoftKeyboard {
     fn show_keyboard(&self) {
-        // `true` requests SHOW_IMPLICIT: the system may coordinate visibility
-        // with hardware keyboards / display modes instead of forcing the IME.
-        self.app.show_soft_input(true);
+        self.session.show();
     }
 
     fn hide_keyboard(&self) {
-        // `false` = do not restrict to implicitly-shown keyboards; always hide.
-        self.app.hide_soft_input(false);
+        self.session.hide();
     }
+}
+
+/// Translates a raw key event forwarded by the IME through
+/// `InputConnection.sendKeyEvent` (some keyboards deliver backspace/enter
+/// this way even with a real editor attached) into a framework [`KeyEvent`].
+///
+/// Returns `None` for events the text pipeline cannot use; system keys are
+/// never expected through this path and are dropped defensively.
+pub(crate) fn ime_key_event(
+    action: i32,
+    key_code: i32,
+    meta_state: i32,
+    unicode_char: i32,
+) -> Option<KeyEvent> {
+    let event_type = match action {
+        ANDROID_KEY_ACTION_DOWN => KeyEventType::KeyDown,
+        ANDROID_KEY_ACTION_UP => KeyEventType::KeyUp,
+        _ => return None,
+    };
+
+    let keycode = Keycode::from(key_code.max(0) as u32);
+    if is_system_key(keycode) {
+        return None;
+    }
+    let key_code = map_keycode(keycode);
+    let modifiers = map_modifiers(MetaState(meta_state.max(0) as u32));
+
+    // Characters commit on key-down only, mirroring the hardware-key path.
+    let text = if event_type == KeyEventType::KeyDown {
+        u32::try_from(unicode_char)
+            .ok()
+            .and_then(char::from_u32)
+            .filter(|ch| *ch != '\0' && !ch.is_control())
+            .map(|ch| ch.to_string())
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    if key_code == KeyCode::Unknown && text.is_empty() {
+        return None;
+    }
+
+    Some(KeyEvent::new(key_code, text, modifiers, event_type))
 }
 
 /// Translates Android key events into framework [`KeyEvent`]s.

--- a/crates/cranpose/src/android_overlay_window.rs
+++ b/crates/cranpose/src/android_overlay_window.rs
@@ -207,50 +207,7 @@ pub(crate) fn find_android_overlay_class<'local>(
     env: &mut Env<'local>,
     activity: &JObject<'local>,
 ) -> Result<JClass<'local>, String> {
-    load_overlay_class(env, activity)
-}
-
-fn load_overlay_class<'local>(
-    env: &mut Env<'local>,
-    activity: &JObject<'local>,
-) -> Result<JClass<'local>, String> {
-    let class_name = env
-        .new_string(OVERLAY_CLASS.replace('/', "."))
-        .map_err(|error| {
-            clear_pending_android_jni_exception(env);
-            format!("failed to create Android overlay helper class name: {error}")
-        })?;
-    let class_name = JObject::from(class_name);
-
-    let class = env
-        .call_method(
-            activity,
-            jni_str!("getClassLoader"),
-            jni_sig!("()Ljava/lang/ClassLoader;"),
-            &[],
-        )
-        .and_then(|value| value.l())
-        .and_then(|class_loader| {
-            env.call_method(
-                &class_loader,
-                jni_str!("loadClass"),
-                jni_sig!("(Ljava/lang/String;)Ljava/lang/Class;"),
-                &[JValue::Object(&class_name)],
-            )
-            .and_then(|value| value.l())
-        })
-        .map_err(|error| {
-            clear_pending_android_jni_exception(env);
-            format!(
-                "failed to load Android overlay helper class {}; include cranpose/android/java in the Android source set: {error}",
-                OVERLAY_CLASS
-            )
-        })?;
-
-    env.cast_local::<JClass>(class).map_err(|error| {
-        clear_pending_android_jni_exception(env);
-        format!("Android overlay helper did not resolve to a Java class: {error}")
-    })
+    crate::android_jni::load_cranpose_java_class(env, activity, OVERLAY_CLASS)
 }
 
 fn overlay_options_to_physical_bounds(

--- a/crates/cranpose/src/android_text_input.rs
+++ b/crates/cranpose/src/android_text_input.rs
@@ -1,0 +1,490 @@
+//! Android IME bridge: real `InputConnection` support for text fields.
+//!
+//! A `NativeActivity` has no Java view overriding `onCreateInputConnection`,
+//! so IMEs run in fallback mode and can only deliver plain key events (the
+//! [`crate::android_keyboard`] `KeyCharacterMap` path). This module drives the
+//! `dev.cranpose.android.CranposeTextInput` Java helper, which attaches an
+//! invisible focusable view to the activity and returns a
+//! `BaseInputConnection` subclass when the soft keyboard opens. Editing
+//! operations flow back through the JNI callbacks below into an event queue
+//! drained by the Android main loop:
+//!
+//! - `commitText` → [`AndroidImeEvent::CommitText`] → `AppShell::on_paste`
+//! - `setComposingText` → [`AndroidImeEvent::SetComposingText`] →
+//!   `AppShell::on_ime_preedit`
+//! - `setComposingRegion` → [`AndroidImeEvent::SetComposingRegion`] →
+//!   `AppShell::on_ime_set_composing_region`
+//! - `finishComposingText` → [`AndroidImeEvent::FinishComposing`] →
+//!   `AppShell::on_ime_finish_composing`
+//! - `deleteSurroundingText` → [`AndroidImeEvent::DeleteSurrounding`] →
+//!   `AppShell::on_ime_delete_surrounding`
+//! - `sendKeyEvent` → [`AndroidImeEvent::Key`] → `AppShell::on_key_event`
+//! - `performEditorAction` → [`AndroidImeEvent::EditorAction`]
+//!
+//! The Java side keeps a UTF-16 `Editable` mirror so IME text queries are
+//! answered synchronously; the Rust text field remains the source of truth
+//! and pushes its state back through [`update_android_text_input_state`]
+//! (selection updates, or an input-session restart when the contents
+//! diverged). All boundary offsets are converted at this JNI layer: Rust
+//! works in UTF-8 bytes, Java in UTF-16 code units.
+#![allow(unsafe_code)]
+
+use crate::android_jni::{
+    clear_pending_android_jni_exception, load_cranpose_java_class, with_android_activity_env,
+};
+use android_activity::AndroidAppWaker;
+use cranpose_app_shell::ImeEditorState;
+use jni::{
+    jni_sig, jni_str,
+    objects::{JClass, JObject, JString, JValue},
+    sys::{jint, jlong},
+    EnvUnowned, Outcome,
+};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+
+const TEXT_INPUT_CLASS: &str = "dev/cranpose/android/CranposeTextInput";
+
+/// One editing operation forwarded from the Java `InputConnection`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum AndroidImeEvent {
+    /// `commitText`: replace the composing text (if any) with `text` and move
+    /// the cursor after it. `new_cursor_position` follows the Android
+    /// contract; values other than 1 are currently treated as 1 (cursor
+    /// after the committed text) and self-correct through the state sync.
+    CommitText {
+        text: String,
+        new_cursor_position: i32,
+    },
+    /// `setComposingText`: replace the current preedit with `text`;
+    /// `cursor_bytes` is the caret offset inside `text` in UTF-8 bytes.
+    SetComposingText { text: String, cursor_bytes: usize },
+    /// `setComposingRegion`: mark existing text as composing (UTF-8 bytes).
+    SetComposingRegion {
+        start_bytes: usize,
+        end_bytes: usize,
+    },
+    /// `finishComposingText`: keep the composed text, clear the region.
+    FinishComposing,
+    /// `deleteSurroundingText`, already converted to UTF-8 byte counts.
+    DeleteSurrounding {
+        before_bytes: usize,
+        after_bytes: usize,
+    },
+    /// `sendKeyEvent`: editing keys some IMEs deliver as key events
+    /// (backspace, enter). Raw Android values; translated by
+    /// [`crate::android_keyboard::ime_key_event`].
+    Key {
+        action: i32,
+        key_code: i32,
+        meta_state: i32,
+        unicode_char: i32,
+    },
+    /// `performEditorAction` with an `EditorInfo.IME_ACTION_*` code.
+    EditorAction { action: i32 },
+}
+
+/// Cross-thread queue for IME events (pushed on the Android UI thread,
+/// drained by the native main loop). Pushes wake the main-loop looper so
+/// events are handled without waiting for the next frame.
+pub(crate) struct AndroidImeEventQueue {
+    events: Mutex<Vec<AndroidImeEvent>>,
+    waker: OnceLock<AndroidAppWaker>,
+}
+
+impl AndroidImeEventQueue {
+    pub(crate) fn new() -> Self {
+        Self {
+            events: Mutex::new(Vec::new()),
+            waker: OnceLock::new(),
+        }
+    }
+
+    /// Installs the main-loop waker. Events pushed before this are delivered
+    /// on the next natural poll.
+    pub(crate) fn set_waker(&self, waker: AndroidAppWaker) {
+        let _ = self.waker.set(waker);
+    }
+
+    pub(crate) fn push(&self, event: AndroidImeEvent) {
+        self.lock_events().push(event);
+        if let Some(waker) = self.waker.get() {
+            waker.wake();
+        }
+    }
+
+    pub(crate) fn drain(&self) -> Vec<AndroidImeEvent> {
+        std::mem::take(&mut *self.lock_events())
+    }
+
+    fn lock_events(&self) -> MutexGuard<'_, Vec<AndroidImeEvent>> {
+        self.events
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+/// Opaque `jlong` wrapper over a retained `Arc<AndroidImeEventQueue>`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct AndroidImeQueueHandle(jlong);
+
+impl AndroidImeQueueHandle {
+    fn raw(self) -> jlong {
+        self.0
+    }
+}
+
+fn retain_ime_queue_handle(queue: &Arc<AndroidImeEventQueue>) -> AndroidImeQueueHandle {
+    let pointer = Arc::into_raw(Arc::clone(queue));
+    AndroidImeQueueHandle(pointer as usize as jlong)
+}
+
+fn release_ime_queue_handle_raw(handle: jlong) {
+    if handle == 0 {
+        return;
+    }
+    // SAFETY: handles are created by `retain_ime_queue_handle` (Arc::into_raw)
+    // and released exactly once: by the Java helper when the session is
+    // disposed, or by Rust when `show` failed to transfer ownership.
+    unsafe {
+        drop(Arc::from_raw(
+            handle as usize as *const AndroidImeEventQueue,
+        ));
+    }
+}
+
+fn push_ime_event_for_handle(handle: jlong, event: AndroidImeEvent) {
+    if handle == 0 {
+        log::warn!("dropped Android IME event because the Java callback carried no queue handle");
+        return;
+    }
+    // SAFETY: the Java helper stores a handle retained from an
+    // Arc<AndroidImeEventQueue> and releases it only when the session is
+    // disposed on the Android UI thread; callbacks check `disposed` first.
+    let Some(queue) = (unsafe { (handle as usize as *const AndroidImeEventQueue).as_ref() }) else {
+        log::warn!("dropped Android IME event because the queue handle was invalid");
+        return;
+    };
+    queue.push(event);
+}
+
+/// Converts a UTF-8 byte offset into `text` to UTF-16 code units, clamping
+/// into the valid range (and down to a character boundary).
+fn utf16_offset(text: &str, byte_offset: usize) -> i32 {
+    let mut offset = byte_offset.min(text.len());
+    while offset > 0 && !text.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    text[..offset].encode_utf16().count() as i32
+}
+
+/// Opens (or reseeds) the Java text-input session for the focused field.
+///
+/// Transfers one retained queue handle to Java on success; on failure the
+/// handle is released here. Errors are returned so the caller can fall back
+/// to the plain `show_soft_input` path (for apps that do not ship the
+/// `cranpose/android/java` sources).
+pub(crate) fn show_android_text_input(
+    app: &android_activity::AndroidApp,
+    queue: &Arc<AndroidImeEventQueue>,
+    state: &ImeEditorState,
+) -> Result<(), String> {
+    let handle = retain_ime_queue_handle(queue);
+    let sel_start = utf16_offset(&state.text, state.selection_start);
+    let sel_end = utf16_offset(&state.text, state.selection_end);
+
+    let result = with_android_activity_env(app, |env, activity| {
+        let class = load_cranpose_java_class(env, &activity, TEXT_INPUT_CLASS)?;
+        let text = env.new_string(&state.text).map_err(|error| {
+            clear_pending_android_jni_exception(env);
+            format!("failed to create Android IME text string: {error}")
+        })?;
+        let text = JObject::from(text);
+        env.call_static_method(
+            class,
+            jni_str!("show"),
+            jni_sig!("(Landroid/app/Activity;JLjava/lang/String;IIZ)I"),
+            &[
+                JValue::Object(&activity),
+                JValue::Long(handle.raw()),
+                JValue::Object(&text),
+                JValue::Int(sel_start),
+                JValue::Int(sel_end),
+                JValue::Bool(state.single_line),
+            ],
+        )
+        .and_then(|value| value.i())
+        .map_err(|error| {
+            clear_pending_android_jni_exception(env);
+            format!("failed to show Android text input: {error}")
+        })
+    });
+
+    match result {
+        Ok(0) => Ok(()),
+        Ok(code) => {
+            release_ime_queue_handle_raw(handle.raw());
+            Err(format!("Android text input helper returned {code}"))
+        }
+        Err(error) => {
+            release_ime_queue_handle_raw(handle.raw());
+            Err(error)
+        }
+    }
+}
+
+/// Closes the Java text-input session (hides the IME, detaches the editor
+/// view, releases the queue handle owned by the session).
+pub(crate) fn hide_android_text_input(app: &android_activity::AndroidApp) -> Result<(), String> {
+    with_android_activity_env(app, |env, activity| {
+        let class = load_cranpose_java_class(env, &activity, TEXT_INPUT_CLASS)?;
+        env.call_static_method(
+            class,
+            jni_str!("hide"),
+            jni_sig!("(Landroid/app/Activity;)V"),
+            &[JValue::Object(&activity)],
+        )
+        .map_err(|error| {
+            clear_pending_android_jni_exception(env);
+            format!("failed to hide Android text input: {error}")
+        })?;
+        Ok(())
+    })
+}
+
+/// Pushes the Rust-side editor state into the Java mirror. Java refreshes the
+/// IME's selection view, or restarts the input session when the text content
+/// diverged from the mirror.
+pub(crate) fn update_android_text_input_state(
+    app: &android_activity::AndroidApp,
+    state: &ImeEditorState,
+) -> Result<(), String> {
+    let sel_start = utf16_offset(&state.text, state.selection_start);
+    let sel_end = utf16_offset(&state.text, state.selection_end);
+    let (comp_start, comp_end) = match state.composition {
+        Some((start, end)) => (
+            utf16_offset(&state.text, start),
+            utf16_offset(&state.text, end),
+        ),
+        None => (-1, -1),
+    };
+
+    with_android_activity_env(app, |env, activity| {
+        let class = load_cranpose_java_class(env, &activity, TEXT_INPUT_CLASS)?;
+        let text = env.new_string(&state.text).map_err(|error| {
+            clear_pending_android_jni_exception(env);
+            format!("failed to create Android IME text string: {error}")
+        })?;
+        let text = JObject::from(text);
+        env.call_static_method(
+            class,
+            jni_str!("updateState"),
+            jni_sig!("(Landroid/app/Activity;Ljava/lang/String;IIII)V"),
+            &[
+                JValue::Object(&activity),
+                JValue::Object(&text),
+                JValue::Int(sel_start),
+                JValue::Int(sel_end),
+                JValue::Int(comp_start),
+                JValue::Int(comp_end),
+            ],
+        )
+        .map_err(|error| {
+            clear_pending_android_jni_exception(env);
+            format!("failed to update Android text input state: {error}")
+        })?;
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// JNI callbacks from dev.cranpose.android.CranposeTextInput (UI thread)
+// ---------------------------------------------------------------------------
+
+fn jstring_to_string(env: &mut EnvUnowned<'_>, text: JString<'_>) -> Option<String> {
+    match env
+        .with_env(|env| -> jni::errors::Result<String> { text.try_to_string(env) })
+        .into_outcome()
+    {
+        Outcome::Ok(text) => Some(text),
+        Outcome::Err(_) | Outcome::Panic(_) => {
+            log::warn!("failed to read Android IME text from JNI");
+            None
+        }
+    }
+}
+
+fn non_negative(value: jint) -> usize {
+    value.max(0) as usize
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeTextInput_nativeImeCommitText<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    queue_handle: jlong,
+    text: JString<'local>,
+    new_cursor_position: jint,
+) {
+    let Some(text) = jstring_to_string(&mut env, text) else {
+        return;
+    };
+    push_ime_event_for_handle(
+        queue_handle,
+        AndroidImeEvent::CommitText {
+            text,
+            new_cursor_position,
+        },
+    );
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeTextInput_nativeImeSetComposingText<
+    'local,
+>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    queue_handle: jlong,
+    text: JString<'local>,
+    cursor_bytes: jint,
+) {
+    let Some(text) = jstring_to_string(&mut env, text) else {
+        return;
+    };
+    push_ime_event_for_handle(
+        queue_handle,
+        AndroidImeEvent::SetComposingText {
+            text,
+            cursor_bytes: non_negative(cursor_bytes),
+        },
+    );
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeTextInput_nativeImeSetComposingRegion(
+    _env: EnvUnowned<'_>,
+    _class: JClass<'_>,
+    queue_handle: jlong,
+    start_bytes: jint,
+    end_bytes: jint,
+) {
+    push_ime_event_for_handle(
+        queue_handle,
+        AndroidImeEvent::SetComposingRegion {
+            start_bytes: non_negative(start_bytes),
+            end_bytes: non_negative(end_bytes),
+        },
+    );
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeTextInput_nativeImeFinishComposing(
+    _env: EnvUnowned<'_>,
+    _class: JClass<'_>,
+    queue_handle: jlong,
+) {
+    push_ime_event_for_handle(queue_handle, AndroidImeEvent::FinishComposing);
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeTextInput_nativeImeDeleteSurrounding(
+    _env: EnvUnowned<'_>,
+    _class: JClass<'_>,
+    queue_handle: jlong,
+    before_bytes: jint,
+    after_bytes: jint,
+) {
+    push_ime_event_for_handle(
+        queue_handle,
+        AndroidImeEvent::DeleteSurrounding {
+            before_bytes: non_negative(before_bytes),
+            after_bytes: non_negative(after_bytes),
+        },
+    );
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeTextInput_nativeImeSendKeyEvent(
+    _env: EnvUnowned<'_>,
+    _class: JClass<'_>,
+    queue_handle: jlong,
+    action: jint,
+    key_code: jint,
+    meta_state: jint,
+    unicode_char: jint,
+) {
+    push_ime_event_for_handle(
+        queue_handle,
+        AndroidImeEvent::Key {
+            action,
+            key_code,
+            meta_state,
+            unicode_char,
+        },
+    );
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeTextInput_nativeImePerformEditorAction(
+    _env: EnvUnowned<'_>,
+    _class: JClass<'_>,
+    queue_handle: jlong,
+    action: jint,
+) {
+    push_ime_event_for_handle(queue_handle, AndroidImeEvent::EditorAction { action });
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeTextInput_nativeImeReleaseQueue(
+    _env: EnvUnowned<'_>,
+    _class: JClass<'_>,
+    queue_handle: jlong,
+) {
+    release_ime_queue_handle_raw(queue_handle);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn utf16_offset_converts_and_clamps() {
+        // "aé漢x" - 'a'=1 byte/1 unit, 'é'=2 bytes/1 unit, '漢'=3 bytes/1 unit.
+        let text = "a\u{00e9}\u{6f22}x";
+        assert_eq!(utf16_offset(text, 0), 0);
+        assert_eq!(utf16_offset(text, 1), 1);
+        assert_eq!(utf16_offset(text, 3), 2);
+        assert_eq!(utf16_offset(text, 6), 3);
+        assert_eq!(utf16_offset(text, 7), 4);
+        // Past the end clamps to the full length.
+        assert_eq!(utf16_offset(text, 100), 4);
+        // Mid-character offsets clamp down to the previous boundary.
+        assert_eq!(utf16_offset(text, 2), 1);
+        assert_eq!(utf16_offset(text, 4), 2);
+        // Supplementary-plane characters count as two UTF-16 units.
+        let emoji = "\u{1f600}b";
+        assert_eq!(utf16_offset(emoji, 4), 2);
+        assert_eq!(utf16_offset(emoji, 5), 3);
+    }
+
+    #[test]
+    fn queue_push_and_drain() {
+        let queue = AndroidImeEventQueue::new();
+        queue.push(AndroidImeEvent::FinishComposing);
+        queue.push(AndroidImeEvent::CommitText {
+            text: "hi".to_string(),
+            new_cursor_position: 1,
+        });
+        let events = queue.drain();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0], AndroidImeEvent::FinishComposing);
+        assert!(queue.drain().is_empty());
+    }
+}

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -1319,6 +1319,9 @@ impl App {
         dev_options.frame_pacing_mode = self.frame_pacing_mode;
         dev_options.frame_pacing_controls = false;
         app.set_dev_options(dev_options);
+        // Enable/disable the platform IME with text-field focus so composing
+        // input methods (CJK, dead keys via IME) work in native windows.
+        DesktopTextInput::install(&mut app, &window);
         trace_native_window_timing(format_args!(
             "{} app_shell {}ms",
             options.title,
@@ -3636,7 +3639,73 @@ fn dispatch_ime_event(app: &mut AppShell<WgpuRenderer>, ime_event: winit::event:
         Ime::Disabled => {
             app.on_ime_preedit("", None);
         }
-        Ime::DeleteSurrounding { .. } => {}
+        Ime::DeleteSurrounding {
+            before_bytes,
+            after_bytes,
+        } => {
+            // winit guarantees byte-wise UTF-8 counts, matching the shell API.
+            // The buffer implementation already preserves any active preedit
+            // region, as this event requires.
+            let _ = app.on_ime_delete_surrounding(before_bytes, after_bytes);
+        }
+    }
+}
+
+/// Text-input focus hook for desktop: enables the platform IME on the window
+/// while a text field is focused and disables it when focus is lost.
+///
+/// winit only delivers [`winit::event::Ime`] events (preedit/commit for CJK
+/// and other composing input methods) while the IME is enabled via
+/// [`winit::window::ImeRequest::Enable`], so without this hook the
+/// `dispatch_ime_event` path never fires.
+///
+/// The candidate-window cursor area (`ImeCapabilities::with_cursor_area`) is
+/// not reported yet: the framework does not currently expose the focused
+/// field's caret rectangle to the platform layer. Until it does, IME popups
+/// may appear at a default position instead of next to the caret.
+struct DesktopTextInput {
+    window: std::sync::Weak<dyn Window>,
+}
+
+impl DesktopTextInput {
+    fn install(app: &mut AppShell<WgpuRenderer>, window: &Arc<dyn Window>) {
+        app.set_platform_text_input(Rc::new(DesktopTextInput {
+            window: Arc::downgrade(window),
+        }));
+    }
+}
+
+impl cranpose_app_shell::PlatformTextInputHandler for DesktopTextInput {
+    fn show_keyboard(&self) {
+        use winit::window::{ImeCapabilities, ImeEnableRequest, ImeRequest, ImeRequestData};
+
+        let Some(window) = self.window.upgrade() else {
+            return;
+        };
+        // No optional capabilities requested, so the enable request is always
+        // well-formed.
+        let Some(enable) = ImeEnableRequest::new(ImeCapabilities::new(), ImeRequestData::default())
+        else {
+            return;
+        };
+        match window.request_ime_update(ImeRequest::Enable(enable)) {
+            // `show_keyboard` intentionally fires on every focus request;
+            // an already enabled IME stays enabled.
+            Ok(()) | Err(winit::window::ImeRequestError::AlreadyEnabled) => {}
+            Err(error) => log::debug!("winit IME enable failed: {error}"),
+        }
+    }
+
+    fn hide_keyboard(&self) {
+        use winit::window::{ImeRequest, ImeRequestError};
+
+        let Some(window) = self.window.upgrade() else {
+            return;
+        };
+        match window.request_ime_update(ImeRequest::Disable) {
+            Ok(()) | Err(ImeRequestError::NotEnabled) => {}
+            Err(error) => log::debug!("winit IME disable failed: {error}"),
+        }
     }
 }
 
@@ -3791,6 +3860,10 @@ impl ApplicationHandler for App {
         let mut dev_options = self.settings.dev_options.clone();
         dev_options.frame_pacing_mode = self.frame_pacing_mode;
         app.set_dev_options(dev_options);
+
+        // Enable/disable the platform IME with text-field focus so composing
+        // input methods (CJK, dead keys via IME) work on desktop.
+        DesktopTextInput::install(&mut app, &window);
 
         // Runtime-driven frame scheduling: Compose invalidations and animations
         // request frames via the runtime waker, not per-input host redraw forcing.

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -17,6 +17,8 @@ mod android_keyboard;
 mod android_overlay_window;
 #[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
 mod android_surface;
+#[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
+mod android_text_input;
 #[cfg(all(feature = "android", target_os = "android"))]
 mod android_writable_folder;
 mod launcher;

--- a/crates/cranpose/src/web.rs
+++ b/crates/cranpose/src/web.rs
@@ -265,6 +265,17 @@ pub async fn run(
         move || request_frame()
     });
 
+    // Hidden editable element backing IME composition. Browsers only start
+    // IME composition sessions (and mobile browsers only show their virtual
+    // keyboard) when an editable element is focused, so text-field focus
+    // moves DOM focus onto this textarea; its composition events feed the
+    // shared preedit/commit pipeline below.
+    let ime_textarea = create_ime_textarea(&document)?;
+    app.borrow_mut()
+        .set_platform_text_input(Rc::new(WebTextInput {
+            textarea: ime_textarea.clone(),
+        }));
+
     // Set up mouse event handlers
     {
         let app = app.clone();
@@ -465,6 +476,15 @@ pub async fn run(
         let closure = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
             use cranpose_app_shell::{KeyCode, KeyEvent, KeyEventType, Modifiers};
 
+            // During IME composition the browser owns text input: key events
+            // arrive with `isComposing` (or the synthetic 229 keyCode) and the
+            // composition listeners deliver the text. Dispatching them (or
+            // calling prevent_default) would double-commit characters and can
+            // break the composition session.
+            if event.is_composing() || event.key_code() == 229 {
+                return;
+            }
+
             // Convert web key code to our KeyCode
             let key_code = match event.code().as_str() {
                 // Letters
@@ -577,6 +597,11 @@ pub async fn run(
         let request_frame = request_frame.clone();
         let closure = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
             use cranpose_app_shell::{KeyCode, KeyEvent, KeyEventType, Modifiers};
+
+            // Skip IME-composition key events (see the keydown handler).
+            if event.is_composing() || event.key_code() == 229 {
+                return;
+            }
 
             // Similar conversion for keyup
             let key_code = match event.code().as_str() {
@@ -714,6 +739,50 @@ pub async fn run(
         closure.forget();
     }
 
+    // IME composition: the browser resends the whole preedit on every update,
+    // so `compositionupdate` maps 1:1 onto the framework preedit hook.
+    {
+        let app = app.clone();
+        let request_frame = request_frame.clone();
+        let closure = Closure::wrap(Box::new(move |event: web_sys::CompositionEvent| {
+            let text = event.data().unwrap_or_default();
+            if let Ok(mut app_mut) = app.try_borrow_mut() {
+                app_mut.on_ime_preedit(&text, None);
+                request_frame();
+            }
+        }) as Box<dyn FnMut(_)>);
+        ime_textarea.add_event_listener_with_callback(
+            "compositionupdate",
+            closure.as_ref().unchecked_ref(),
+        )?;
+        closure.forget();
+    }
+
+    // Composition finished: clear the preedit (which deletes the composing
+    // text) and commit the final string, mirroring the desktop
+    // `Ime::Commit` flow.
+    {
+        let app = app.clone();
+        let request_frame = request_frame.clone();
+        let textarea = ime_textarea.clone();
+        let closure = Closure::wrap(Box::new(move |event: web_sys::CompositionEvent| {
+            let text = event.data().unwrap_or_default();
+            if let Ok(mut app_mut) = app.try_borrow_mut() {
+                let _ = app_mut.on_ime_preedit("", None);
+                if !text.is_empty() {
+                    app_mut.on_paste(&text);
+                }
+                request_frame();
+            }
+            // Drop the composed text from the hidden textarea so the next
+            // composition session starts from an empty mirror.
+            textarea.set_value("");
+        }) as Box<dyn FnMut(_)>);
+        ime_textarea
+            .add_event_listener_with_callback("compositionend", closure.as_ref().unchecked_ref())?;
+        closure.forget();
+    }
+
     let frame_pending_for_loop = frame_pending.clone();
     let frame_timer_for_loop = frame_timer.clone();
     let render_loop_for_deadline = render_loop.clone();
@@ -792,6 +861,70 @@ pub async fn run(
     request_frame();
 
     Ok(())
+}
+
+/// Web text-input focus hook: moves DOM focus onto the hidden IME textarea
+/// while a cranpose text field is focused, and releases it when text-field
+/// focus is lost.
+///
+/// The browser only starts IME composition sessions for editable elements
+/// (and mobile browsers only show their virtual keyboard for them), so the
+/// canvas alone can never receive composition events.
+struct WebTextInput {
+    textarea: web_sys::HtmlTextAreaElement,
+}
+
+impl cranpose_app_shell::PlatformTextInputHandler for WebTextInput {
+    fn show_keyboard(&self) {
+        let _ = self.textarea.focus();
+    }
+
+    fn hide_keyboard(&self) {
+        self.textarea.set_value("");
+        let _ = self.textarea.blur();
+    }
+}
+
+/// Creates the visually hidden, focusable textarea that backs IME
+/// composition and appends it to the document body.
+fn create_ime_textarea(
+    document: &web_sys::Document,
+) -> Result<web_sys::HtmlTextAreaElement, JsValue> {
+    let textarea: web_sys::HtmlTextAreaElement = document.create_element("textarea")?.dyn_into()?;
+
+    // The composed text is delivered through composition events; browser
+    // assistance on the mirror itself would only interfere.
+    textarea.set_attribute("autocomplete", "off")?;
+    textarea.set_attribute("autocorrect", "off")?;
+    textarea.set_attribute("autocapitalize", "off")?;
+    textarea.set_attribute("spellcheck", "false")?;
+    // Programmatic focus only - the textarea must never be tab-reachable.
+    textarea.set_attribute("tabindex", "-1")?;
+    textarea.set_attribute("aria-hidden", "true")?;
+
+    // Visually hidden but still focusable: `display:none`/`visibility:hidden`
+    // elements refuse focus, so shrink to a transparent 1x1 point instead.
+    let style = textarea.style();
+    style.set_property("position", "fixed")?;
+    style.set_property("top", "0")?;
+    style.set_property("left", "0")?;
+    style.set_property("width", "1px")?;
+    style.set_property("height", "1px")?;
+    style.set_property("opacity", "0")?;
+    style.set_property("border", "0")?;
+    style.set_property("padding", "0")?;
+    style.set_property("margin", "0")?;
+    style.set_property("outline", "none")?;
+    style.set_property("resize", "none")?;
+    style.set_property("overflow", "hidden")?;
+    style.set_property("background", "transparent")?;
+    style.set_property("pointer-events", "none")?;
+
+    let body = document
+        .body()
+        .ok_or_else(|| JsValue::from_str("document has no body for the IME textarea"))?;
+    body.append_child(&textarea)?;
+    Ok(textarea)
 }
 
 fn request_animation_frame(f: &Closure<dyn FnMut()>) -> bool {

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -433,9 +433,13 @@ fn android_overlay_events_are_runtime_owned() {
         "Android runtime should own and explicitly drain overlay events"
     );
     assert!(
-        overlay_source.contains("jni_str!(\"getClassLoader\")")
+        jni_source.contains("jni_str!(\"getClassLoader\")")
+            && !jni_source.contains("jni_str!(\"getClass\")")
+            && overlay_source.contains("load_cranpose_java_class")
             && !overlay_source.contains("jni_str!(\"getClass\")"),
-        "Android Java bridge loading must use the Activity context classloader; android.app.NativeActivity itself is framework-loaded by the boot classloader"
+        "Android Java bridge loading must use the Activity context classloader (via the shared \
+         android_jni helper); android.app.NativeActivity itself is framework-loaded by the boot \
+         classloader"
     );
 }
 
@@ -997,6 +1001,7 @@ fn unsafe_code_stays_in_android_boundary_modules() {
         "android_jni.rs",
         "android_surface.rs",
         "android_file_picker.rs",
+        "android_text_input.rs",
         "android_writable_folder.rs",
         "ios_file_picker.rs",
     ];
@@ -1161,6 +1166,7 @@ fn workspace_ffi_boundaries_are_explicit() {
         "crates/cranpose/src/android_jni.rs",
         "crates/cranpose/src/android_surface.rs",
         "crates/cranpose/src/android_file_picker.rs",
+        "crates/cranpose/src/android_text_input.rs",
         "crates/cranpose/src/android_writable_folder.rs",
         "crates/cranpose/src/ios_file_picker.rs",
         "apps/desktop-demo-platform/src/android_entry.rs",


### PR DESCRIPTION
## What

Three pieces, per platform-parity text input ("IME actions on text, but not with scratches") plus a new gesture widget:

### 1. Framework IME core (`cranpose-ui`, `cranpose-app-shell`)
- **Bugfix**: `set_composition` now *replaces* the active composing region on successive preedit updates. IMEs resend the whole preedit on every keystroke; previously each update was inserted at the cursor, so composing `k → ka → か` produced `kkaか`.
- New `FocusedTextFieldHandler` operations (default-implemented, non-breaking):
  - `finish_composition` — Android `finishComposingText` semantics: keep the composed text, clear the region (distinct from the empty-preedit path, which deletes it);
  - `set_composing_region` — mark committed text as composing (autocorrect re-composes words this way), char-boundary clamped.
- New `ImeEditorState` snapshot (text, selection, composition — UTF-8 byte offsets — plus a single-line flag) via `focused_editor_state()`, so platform IMEs can seed sessions and answer `getTextBeforeCursor`-style queries.
- `AppShell`: `on_ime_finish_composing`, `on_ime_set_composing_region`, `ime_editor_state`, `clear_text_field_focus` (IME Done action).

### 2. Desktop + web IME parity
- **Desktop (winit 0.31)**: each window now installs a `PlatformTextInputHandler` that enables/disables the IME with text-field focus via `request_ime_update(Enable/Disable)`. winit only delivers `Ime::*` events while enabled, so the existing `dispatch_ime_event` path was dormant — CJK input never composed. `Ime::DeleteSurrounding` is now wired to `on_ime_delete_surrounding` too.
- **Web**: a hidden 1×1 textarea takes DOM focus while a text field is focused (browsers only start IME composition — and mobile browsers only show the virtual keyboard — for editable elements). `compositionupdate`/`compositionend` feed the shared preedit/commit pipeline; `keydown`/`keyup` skip `isComposing`/keyCode-229 events so composition isn't double-committed.

### 3. Android: real IME via `InputConnection` (replaces the KeyCharacterMap-only path)
`NativeActivity` has no Java view overriding `onCreateInputConnection`, so IMEs ran in fallback mode — no autocorrect, swipe typing, voice input, or composing scripts.

- **`CranposeTextInput.java`** (ships in `cranpose/android/java` like the overlay/file-picker helpers): on text-field focus an invisible focusable view attaches to the activity content view; its `BaseInputConnection` subclass answers IME text queries from a UTF-16 `Editable` mirror and forwards `commitText` / `setComposingText` / `setComposingRegion` / `finishComposingText` / `deleteSurroundingText` / `sendKeyEvent` / `performEditorAction` through JNI.
- **`android_text_input.rs`**: looper-waking event queue + JNI natives; `AndroidImeSession` opens/closes the session from the focus hooks, seeds it with `ImeEditorState`, and syncs the editor state back each loop iteration — `updateSelection` when the mirror matches, `restartInput` when the sides diverge (e.g. the app rejected input), so divergences self-heal.
- Offset conversion at the boundary that owns the text: UTF-16 char counts → UTF-8 bytes in Java; UTF-8 byte offsets → UTF-16 in Rust.
- Apps that don't compile the Java helper keep the previous `show_soft_input` + `KeyCharacterMap` behavior (detected once, logged).
- Editor actions: `IME_ACTION_DONE` clears focus (hides the keyboard); others surface as an Enter key press.

### 4. `SwipeToDismiss` composable (`cranpose-ui`)
```rust
SwipeToDismiss(modifier, SwipeToDismissSpec::new().with_threshold_fraction(0.5).with_background(|| { ... }), on_dismiss, content)
```
Spring-driven horizontal drag (clamped to one width); release past the threshold animates out and fires `on_dismiss` exactly once after settling; otherwise springs back; pressing mid-flight pins the content. Axis-locking mirrors the scroll modifier (capture on dominant horizontal travel past the slop; decisive vertical start locks the swipe out) so rows in a vertical `LazyColumn` still scroll the list, and taps consume nothing.

## Test evidence
- `cargo test -p cranpose-ui -p cranpose-foundation -p cranpose` — green (incl. 48 static guard tests; new: preedit replacement, finish-composition, composing-region, editor-state, 16 SwipeToDismiss tests covering gesture math, the controller state machine with frame-pumped springs, and nested dispatch against a real `vertical_scroll` parent).
- `cargo test -p cranpose-app-shell -p cranpose-testing` — green (new AppShell IME-dispatch test).
- `cargo fmt --check`, `cargo check --workspace` — clean.
- Android: `RUSTUP_TOOLCHAIN=stable cargo ndk --platform 26 -t arm64-v8a check -p cranpose --features android,renderer-wgpu` — clean; `CranposeTextInput.java` + `CranposeOverlayWindow.java` compile against android-35 `android.jar`.
- Web: `cargo check -p desktop-app-platform --target wasm32-unknown-unknown --no-default-features --features web,renderer-wgpu` — clean.

## Deferred (documented in-code)
- Android: `commitText` `newCursorPosition` values other than 1 (degrade to cursor-after-text and self-correct via the state sync); `CursorAnchorInfo` for floating candidate windows; per-field keyboard options / ime-action callbacks (Compose `KeyboardOptions`/`KeyboardActions` parity); extract-mode editing; **on-device verification of the bridge** (compile-checked + headless-tested only so far).
- Desktop: IME candidate-window positioning (`ImeCapabilities::cursor_area`) needs the focused field's caret rect exposed to the platform layer.
- Web: `beforeinput`-based input path for Android-Chrome-style virtual keyboards that never send real key events; composition-cursor offsets within the preedit.
- Composing-region underline rendering already existed and is exercised by the now-live preedit paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKmJDd6pG9opQHr7btBMke