### PR TITLE
Text field: live-edit wrapping relayout, native selection foundation, nested-subcompose placement (#305)

### DIFF
--- a/crates/cranpose-render/wgpu/Cargo.toml
+++ b/crates/cranpose-render/wgpu/Cargo.toml
@@ -83,7 +83,7 @@ wgpu = { version = "29.0", default-features = false, features = [
 naga = { version = "29.0.3", features = ["wgsl-in", "glsl-out"] }
 
 [dev-dependencies]
-cranpose-app-shell = { workspace = true }
+cranpose-app-shell = { workspace = true, features = ["test-support"] }
 # Unit tests exercise the embedded fallback font and GL portability validation
 # on every platform, independent of the production feature set.
 cranpose-render-common = { workspace = true, features = ["embedded-default-font"] }

--- a/crates/cranpose-render/wgpu/tests/swipe_to_dismiss_lazy.rs
+++ b/crates/cranpose-render/wgpu/tests/swipe_to_dismiss_lazy.rs
@@ -1,0 +1,115 @@
+mod support;
+
+use cranpose_core::location_key;
+use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope};
+use cranpose_ui::text::{SpanStyle, TextUnit};
+use cranpose_ui::{
+    composable, Color, LayoutBox, LazyColumn, LazyColumnSpec, Modifier, SwipeToDismiss,
+    SwipeToDismissSpec, Text, TextStyle,
+};
+
+const FRAME_WIDTH: u32 = 320;
+const FRAME_HEIGHT: u32 = 480;
+
+fn bright_text_pixels(pixels: &[u8]) -> usize {
+    pixels
+        .chunks_exact(4)
+        .filter(|pixel| pixel[0] > 120 && pixel[1] > 90 && pixel[2] > 40)
+        .count()
+}
+
+fn layout_texts(root: &LayoutBox) -> Vec<String> {
+    fn walk(node: &LayoutBox, out: &mut Vec<String>) {
+        if let Some(text) = node.node_data.modifier_slices().text_content() {
+            out.push(text.to_string());
+        }
+        for child in &node.children {
+            walk(child, out);
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, &mut out);
+    out
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn SwipeRows() {
+    let style = TextStyle::from_span_style(SpanStyle {
+        color: Some(Color(1.0, 0.85, 0.4, 1.0)),
+        font_size: TextUnit::Sp(16.0),
+        ..Default::default()
+    });
+    let list_state = remember_lazy_list_state();
+    LazyColumn(
+        Modifier::empty()
+            .size_points(FRAME_WIDTH as f32, FRAME_HEIGHT as f32)
+            .background(Color(0.02, 0.03, 0.05, 1.0)),
+        list_state,
+        LazyColumnSpec::default(),
+        move |scope| {
+            let style = style.clone();
+            scope.items(
+                5,
+                None::<fn(usize) -> u64>,
+                None::<fn(usize) -> u64>,
+                move |index| {
+                    let style = style.clone();
+                    SwipeToDismiss(
+                        Modifier::empty().fill_max_width().height(56.0),
+                        SwipeToDismissSpec::default(),
+                        || {},
+                        move || {
+                            Text(
+                                format!("Row {index}"),
+                                Modifier::empty().padding(16.0),
+                                style.clone(),
+                            );
+                        },
+                    );
+                },
+            );
+        },
+    );
+}
+
+/// Regression for issue #305: a `SwipeToDismiss` row inside a `LazyColumn` item
+/// slot must both compose (layout/semantics) and rasterize its content. Before
+/// the fix these rows vanished entirely inside lazy slots.
+#[test]
+fn swipe_to_dismiss_rows_render_inside_lazy_column() {
+    let (_lock, renderer) = match support::headless_renderer_parts() {
+        Ok(parts) => parts,
+        Err(err) => {
+            eprintln!("skipping (headless WGPU init failed): {err}");
+            return;
+        }
+    };
+
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = cranpose_app_shell::AppShell::new(renderer, root_key, SwipeRows);
+    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
+    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+    shell.update();
+
+    // Composition/layout: the row content must be present in the layout tree.
+    let texts = shell
+        .layout_tree()
+        .map(|tree| layout_texts(tree.root()))
+        .unwrap_or_default();
+    assert!(
+        texts.iter().any(|text| text == "Row 0"),
+        "SwipeToDismiss content must compose inside a LazyColumn item, got {texts:?}"
+    );
+
+    // Scene/render: the content must actually rasterize.
+    let frame = shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("frame capture");
+    let bright = bright_text_pixels(&frame.pixels);
+    assert!(
+        bright > 200,
+        "SwipeToDismiss rows must rasterize glyphs inside a LazyColumn, bright pixels={bright}"
+    );
+}

--- a/crates/cranpose-render/wgpu/tests/text_field_live_edit.rs
+++ b/crates/cranpose-render/wgpu/tests/text_field_live_edit.rs
@@ -1,0 +1,209 @@
+mod support;
+
+use cranpose_core::location_key;
+use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope};
+use cranpose_foundation::text::TextFieldState;
+use cranpose_render_wgpu::CapturedFrame;
+use cranpose_ui::text::{SpanStyle, TextUnit};
+use cranpose_ui::text_field_focus::{clear_focus, dispatch_ime_preedit};
+use cranpose_ui::{
+    composable, Color, Column, ColumnSpec, LayoutBox, LazyColumn, LazyColumnSpec, Modifier,
+    TextStyle,
+};
+
+const FRAME_WIDTH: u32 = 400;
+const FRAME_HEIGHT: u32 = 500;
+
+fn newline_preedit() -> String {
+    // Explicit newlines so the field's line count (and measured height) grows.
+    (0..8)
+        .map(|i| format!("composed line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn wrapping_transcript() -> String {
+    // ~260 chars, no newlines: must wrap to many lines inside the field width.
+    "the quick brown fox jumps over the lazy dog ".repeat(6)
+}
+
+fn field_style() -> TextStyle {
+    TextStyle::from_span_style(SpanStyle {
+        color: Some(Color(1.0, 0.85, 0.4, 1.0)),
+        font_size: TextUnit::Sp(13.0),
+        ..Default::default()
+    })
+}
+
+fn deepest_text_field_height(root: &LayoutBox) -> Option<f32> {
+    fn walk(node: &LayoutBox, found: &mut Option<f32>) {
+        if node.node_data.modifier_slices().text_content().is_some() {
+            *found = Some(node.rect.height);
+        }
+        for child in &node.children {
+            walk(child, found);
+        }
+    }
+    let mut found = None;
+    walk(root, &mut found);
+    found
+}
+
+/// Bright glyph pixels (the field text is a bright warm color on a dark field).
+fn bright_pixels_below(frame: &CapturedFrame, min_y: u32) -> usize {
+    let width = frame.width as usize;
+    frame
+        .pixels
+        .chunks_exact(4)
+        .enumerate()
+        .filter(|(idx, pixel)| {
+            let y = (*idx / width) as u32;
+            y >= min_y && pixel[0] > 120 && pixel[1] > 90 && pixel[2] > 40
+        })
+        .count()
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn Field(state: TextFieldState, style: TextStyle) {
+    cranpose_ui::BasicTextField(
+        state,
+        Modifier::empty()
+            .fill_max_width()
+            .padding(12.0)
+            .background(Color(0.06, 0.08, 0.11, 1.0))
+            .rounded_corners(10.0),
+        style,
+    );
+}
+
+type Shell = cranpose_app_shell::AppShell<cranpose_render_wgpu::WgpuRenderer>;
+
+/// Holds the GPU test lock alongside the shell so the serialized GPU access
+/// stays live for the whole test.
+struct TestApp {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    shell: Shell,
+}
+
+fn build_shell(lazy: bool, seed: String) -> Option<TestApp> {
+    let (lock, renderer) = match support::headless_renderer_parts() {
+        Ok(parts) => parts,
+        Err(err) => {
+            eprintln!("skipping (headless WGPU init failed): {err}");
+            return None;
+        }
+    };
+
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = cranpose_app_shell::AppShell::new(renderer, root_key, move || {
+        let seed = seed.clone();
+        let state = cranpose_core::remember(move || TextFieldState::new(&seed)).with(|s| s.clone());
+        let style = field_style();
+        let root_mod = Modifier::empty()
+            .size_points(FRAME_WIDTH as f32, FRAME_HEIGHT as f32)
+            .background(Color(0.02, 0.03, 0.05, 1.0));
+        if lazy {
+            let list_state = remember_lazy_list_state();
+            LazyColumn(root_mod, list_state, LazyColumnSpec::new(), move |scope| {
+                let state = state.clone();
+                let style = style.clone();
+                scope.item(None, None, move || Field(state.clone(), style.clone()));
+            });
+        } else {
+            Column(root_mod, ColumnSpec::default(), move || {
+                Field(state.clone(), style.clone());
+            });
+        }
+    });
+    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
+    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+    shell.update();
+    Some(TestApp { _lock: lock, shell })
+}
+
+fn focus_field(shell: &mut Shell) {
+    assert!(shell.set_cursor(40.0, 20.0), "click should hit the field");
+    shell.update();
+    assert!(shell.pointer_pressed(), "pointer down should hit the field");
+    shell.update();
+    let _ = shell.pointer_released();
+    shell.update();
+}
+
+/// Regression: composing text into a focused multi-line field (via the IME
+/// path used by both desktop winit and the Android InputConnection) must grow
+/// and relayout the field on the next frame, not only after the field blurs.
+fn assert_typing_grows_field(lazy: bool) {
+    let Some(mut app) = build_shell(lazy, String::new()) else {
+        return;
+    };
+    let shell = &mut app.shell;
+    focus_field(shell);
+
+    let before = shell
+        .layout_tree()
+        .and_then(|tree| deepest_text_field_height(tree.root()))
+        .expect("field height before");
+
+    shell.debug_enter_app_context(|| {
+        assert!(
+            dispatch_ime_preedit(&newline_preedit(), None),
+            "preedit routed"
+        );
+    });
+    shell.update();
+
+    let after = shell
+        .layout_tree()
+        .and_then(|tree| deepest_text_field_height(tree.root()))
+        .expect("field height after");
+    shell.debug_enter_app_context(clear_focus);
+
+    assert!(
+        after > before + 60.0,
+        "lazy={lazy}: composed multi-line text must grow the field (before={before:.1}, after={after:.1})"
+    );
+}
+
+#[test]
+fn typing_grows_multiline_text_field_in_plain_column() {
+    assert_typing_grows_field(false);
+}
+
+#[test]
+fn typing_grows_multiline_text_field_in_lazy_item() {
+    assert_typing_grows_field(true);
+}
+
+/// Regression: a long single-paragraph transcript (no newlines) seeded into a
+/// multi-line field must wrap to many lines and render them all, not clip
+/// everything past the first line. Before the fix the field measured a single
+/// line tall and the wrapped glyphs were clipped away.
+#[test]
+fn seeded_wrapping_transcript_renders_all_lines() {
+    let Some(mut app) = build_shell(false, wrapping_transcript()) else {
+        return;
+    };
+    let shell = &mut app.shell;
+
+    let height = shell
+        .layout_tree()
+        .and_then(|tree| deepest_text_field_height(tree.root()))
+        .expect("field height");
+    assert!(
+        height > 90.0,
+        "wrapping transcript must measure several lines tall, got {height:.1}"
+    );
+
+    // Text must actually be rasterized well below the first line.
+    let frame = shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("frame capture");
+    let bright_below_first_line = bright_pixels_below(&frame, 60);
+    assert!(
+        bright_below_first_line > 200,
+        "wrapped lines below the first must render, bright pixels below y=60 = {bright_below_first_line}"
+    );
+}

--- a/crates/cranpose-ui/src/layout/mod.rs
+++ b/crates/cranpose-ui/src/layout/mod.rs
@@ -1570,13 +1570,25 @@ impl LayoutBuilderState {
                 y: padding.top + placement.y,
             };
 
-            // Critical: Update the child LayoutNode's retained state.
-            // Standard layouts do this via Placeable::place(), but SubcomposeLayout logic
-            // bypasses Placeables and returns raw Placements.
+            // Critical: Update the child's retained placement state.
+            // Standard layouts do this via Placeable::place(), but SubcomposeLayout
+            // logic bypasses Placeables and returns raw Placements. A subcomposed
+            // child can itself be a SubcomposeLayout (e.g. a `BoxWithConstraints`
+            // inside a `LazyColumn` item), so both node kinds must be positioned
+            // and marked placed; otherwise the applier-traversal render, layout,
+            // and semantics builds cull the child's whole subtree (issue #305).
             if let Ok(mut applier) = applier_host.try_borrow_typed() {
-                let _ = applier.with_node::<LayoutNode, _>(placement.node_id, |node| {
-                    node.set_position(position);
-                });
+                if applier
+                    .with_node::<LayoutNode, _>(placement.node_id, |node| {
+                        node.set_position(position);
+                    })
+                    .is_err()
+                {
+                    let _ =
+                        applier.with_node::<SubcomposeLayoutNode, _>(placement.node_id, |node| {
+                            node.set_position(position);
+                        });
+                }
             }
 
             children.push(MeasuredChild {

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -33,6 +33,7 @@ mod text_field_modifier_node;
 pub mod text_input_session;
 pub mod text_layout_result;
 mod text_modifier_node;
+pub mod text_selection;
 pub mod widgets;
 mod word_boundaries;
 pub mod zoom;
@@ -277,6 +278,10 @@ mod tab_switching_tests;
 #[cfg(test)]
 #[path = "tests/lazy_list_viewport_tests.rs"]
 mod lazy_list_viewport_tests;
+
+#[cfg(test)]
+#[path = "tests/swipe_to_dismiss_lazy_tests.rs"]
+mod swipe_to_dismiss_lazy_tests;
 
 #[cfg(test)]
 #[path = "tests/lazy_list_recompose_tests.rs"]

--- a/crates/cranpose-ui/src/tests/cursor_position_tests.rs
+++ b/crates/cranpose-ui/src/tests/cursor_position_tests.rs
@@ -297,6 +297,60 @@ fn focused_single_line_chain(state: TextFieldState, style: TextStyle) -> Modifie
     chain
 }
 
+/// Tap-count classification drives the selection through the real pointer
+/// handler: one tap places the cursor, two select the word under the tap, and
+/// three select its line/paragraph.
+#[test]
+fn tap_count_selects_cursor_word_and_line() {
+    use cranpose_foundation::nodes::input::{PointerEvent, PointerEventKind};
+    use cranpose_foundation::PointerInputNode;
+    use cranpose_ui_graphics::Point;
+
+    let _app_context = crate::render_state::app_context_test_scope();
+    with_test_runtime(|| {
+        let style = TextStyle::default();
+        let state = TextFieldState::new("hello world\nsecond line");
+        let chain = focused_text_field_chain(state.clone(), style.clone());
+        let handler = chain
+            .node::<TextFieldModifierNode>(0)
+            .expect("text field node")
+            .pointer_input_handler()
+            .expect("pointer handler");
+
+        // Tap at the x of the middle of "world" so the offset lands inside it.
+        let tap_x =
+            crate::text::measure_text(&crate::text::AnnotatedString::from("hello wor"), &style)
+                .width;
+        let tap = || {
+            let position = Point { x: tap_x, y: 0.0 };
+            handler(PointerEvent::new(
+                PointerEventKind::Down,
+                position,
+                position,
+            ));
+        };
+
+        // Single tap: collapsed cursor inside "world".
+        tap();
+        let single = state.selection();
+        assert!(single.collapsed(), "single tap must collapse the selection");
+        assert!(
+            (6..=11).contains(&single.start),
+            "single tap must land inside 'world', got {single:?}"
+        );
+
+        // Second tap (same spot, immediately): selects the word "world".
+        tap();
+        assert_eq!(state.selection(), TextRange::new(6, 11));
+
+        // Third tap: selects the whole first line (up to the newline).
+        tap();
+        assert_eq!(state.selection(), TextRange::new(0, 11));
+
+        crate::text_field_focus::clear_focus();
+    });
+}
+
 fn run_field_draw(
     chain: &ModifierNodeChain,
     size: crate::modifier::Size,
@@ -359,6 +413,38 @@ fn horizontal_scroll_offset_math_keeps_cursor_visible() {
     assert_eq!(
         compute_horizontal_scroll_offset(10.0, 50.0, 400.0, 0.0),
         0.0
+    );
+}
+
+/// Dragging a selection handle past the visible window auto-pans the field so
+/// the dragged edge stays in view, reusing the same cursor-follow pan resolver.
+#[test]
+fn handle_drag_auto_pans_to_keep_dragged_edge_visible() {
+    use crate::text_selection::{selection_after_handle_drag, HandleKind};
+
+    let viewport = 100.0;
+    let text_width = 400.0;
+
+    // Drag the end handle to a text offset whose x sits well past the right
+    // edge: the pan advances so the dragged edge lands at the right edge.
+    let dragged_edge_x = 360.0;
+    let panned = compute_horizontal_scroll_offset(0.0, dragged_edge_x, text_width, viewport);
+    let edge_in_viewport = dragged_edge_x - panned;
+    assert!(
+        edge_in_viewport >= 0.0 && edge_in_viewport + CURSOR_WIDTH <= viewport + 0.01,
+        "dragged edge must be visible after auto-pan, got {edge_in_viewport}"
+    );
+
+    // The selection math keeps the fixed (start) edge and extends to the drag.
+    let (min, max) = selection_after_handle_drag(HandleKind::SelectionEnd, 2, 40, 64);
+    assert_eq!((min, max), (2, 40));
+
+    // Dragging the same handle back before the visible window pans back to it.
+    let back_edge_x = 20.0;
+    let panned_back = compute_horizontal_scroll_offset(panned, back_edge_x, text_width, viewport);
+    assert!(
+        (back_edge_x - panned_back) >= 0.0,
+        "dragging the edge back must pan back to keep it visible"
     );
 }
 

--- a/crates/cranpose-ui/src/tests/swipe_to_dismiss_lazy_tests.rs
+++ b/crates/cranpose-ui/src/tests/swipe_to_dismiss_lazy_tests.rs
@@ -1,0 +1,141 @@
+//! Composition tests for `SwipeToDismiss` inside lazy list item slots.
+//!
+//! Regression coverage for issue #305: a `SwipeToDismiss` row rendered nothing
+//! (no content, no semantics) when placed in a `LazyColumn` item, even though
+//! the same row worked standalone or inside a `vertical_scroll` column.
+//!
+//! `SwipeToDismiss` is a `BoxWithConstraints` (a `SubcomposeLayout`), so a row
+//! inside a `LazyColumn` item nests one subcompose inside another. The nested
+//! subcompose child was measured but never marked placed by the outer
+//! subcompose's raw placement path, so the on-demand applier-traversal builds
+//! (which the app shell renderer and semantics use) culled its whole subtree.
+//! These tests exercise those applier-traversal builds specifically.
+
+use super::*;
+use cranpose_core::NodeId;
+use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope};
+use cranpose_ui_graphics::Size as ViewportSize;
+
+fn compose_lazy_swipe_rows() -> TestComposition {
+    run_test_composition(|| {
+        let list_state = remember_lazy_list_state();
+        LazyColumn(
+            Modifier::empty().fill_max_size(),
+            list_state,
+            LazyColumnSpec::default(),
+            |scope| {
+                scope.items(
+                    5,
+                    None::<fn(usize) -> u64>,
+                    None::<fn(usize) -> u64>,
+                    |index| {
+                        SwipeToDismiss(
+                            Modifier::empty().fill_max_width().height(48.0),
+                            SwipeToDismissSpec::default(),
+                            || {},
+                            move || {
+                                Text(
+                                    format!("Row {index}"),
+                                    Modifier::empty(),
+                                    TextStyle::default(),
+                                );
+                            },
+                        );
+                    },
+                );
+            },
+        );
+    })
+}
+
+fn measure(composition: &mut TestComposition, root: NodeId) {
+    let handle = composition.runtime_handle();
+    let mut applier = composition.applier_mut();
+    applier.set_runtime_handle(handle);
+    measure_layout(
+        &mut applier,
+        root,
+        ViewportSize {
+            width: 320.0,
+            height: 480.0,
+        },
+    )
+    .expect("layout measurement");
+    applier.clear_runtime_handle();
+}
+
+fn layout_texts(tree: &crate::LayoutTree) -> Vec<String> {
+    fn walk(node: &crate::LayoutBox, out: &mut Vec<String>) {
+        if let Some(text) = node.node_data.modifier_slices().text_content() {
+            out.push(text.to_string());
+        }
+        for child in &node.children {
+            walk(child, out);
+        }
+    }
+    let mut out = Vec::new();
+    walk(tree.root(), &mut out);
+    out
+}
+
+fn semantics_descriptions(tree: &crate::SemanticsTree) -> Vec<String> {
+    fn walk(node: &crate::SemanticsNode, out: &mut Vec<String>) {
+        if let Some(description) = &node.description {
+            out.push(description.clone());
+        }
+        for child in &node.children {
+            walk(child, out);
+        }
+    }
+    let mut out = Vec::new();
+    walk(tree.root(), &mut out);
+    out
+}
+
+/// The applier-traversal layout build (used by the app shell renderer) must
+/// include the `SwipeToDismiss` content nested in a lazy item slot.
+#[test]
+fn swipe_to_dismiss_renders_content_inside_lazy_column_item() {
+    let mut composition = compose_lazy_swipe_rows();
+    let root = composition.root().expect("lazy column root");
+    measure(&mut composition, root);
+
+    let handle = composition.runtime_handle();
+    let mut applier = composition.applier_mut();
+    applier.set_runtime_handle(handle);
+    let tree = crate::build_layout_tree_from_applier(&mut applier, root)
+        .expect("layout tree build")
+        .expect("layout tree present");
+    applier.clear_runtime_handle();
+
+    let texts = layout_texts(&tree);
+    assert!(
+        texts.iter().any(|text| text == "Row 0"),
+        "SwipeToDismiss content must appear in the applier-traversal layout build, got {texts:?}"
+    );
+}
+
+/// The applier-traversal semantics build (used by accessibility / robot tests)
+/// must also expose the nested `SwipeToDismiss` content.
+#[test]
+fn swipe_to_dismiss_exposes_semantics_inside_lazy_column_item() {
+    let mut composition = compose_lazy_swipe_rows();
+    let root = composition.root().expect("lazy column root");
+    measure(&mut composition, root);
+
+    let handle = composition.runtime_handle();
+    let mut applier = composition.applier_mut();
+    applier.set_runtime_handle(handle);
+    let tree = crate::build_semantics_tree_from_applier(&mut applier, root)
+        .expect("semantics tree build")
+        .expect("semantics tree present");
+    applier.clear_runtime_handle();
+
+    let descriptions = semantics_descriptions(&tree);
+    assert!(
+        descriptions
+            .iter()
+            .any(|description| description == "Row 0"),
+        "SwipeToDismiss semantics must appear in the applier-traversal build, got {descriptions:?}"
+    );
+}

--- a/crates/cranpose-ui/src/text_field_handler.rs
+++ b/crates/cranpose-ui/src/text_field_handler.rs
@@ -31,6 +31,23 @@ impl TextFieldHandler {
             line_limits,
         })
     }
+
+    /// Invalidations every text mutation needs.
+    ///
+    /// A text change can grow or shrink the field (wrapped lines added/removed),
+    /// so the field must re-measure, not just redraw. The scoped
+    /// `schedule_layout_repass` re-measures the field's subtree on the same
+    /// frame the input is dispatched; without it a field only relayouts when
+    /// something else forces a full rebuild (e.g. focus loss), which is why
+    /// IME-composed edits appeared to "stick" until the field was blurred.
+    fn on_text_mutated(&self) {
+        crate::cursor_animation::reset_cursor_blink();
+        // Scoped O(subtree) relayout instead of O(app size) global invalidation.
+        if let Some(node_id) = self.node_id {
+            crate::schedule_layout_repass(node_id);
+        }
+        crate::request_render_invalidation();
+    }
 }
 
 impl crate::text_field_focus::FocusedTextFieldHandler for TextFieldHandler {
@@ -46,12 +63,7 @@ impl crate::text_field_focus::FocusedTextFieldHandler for TextFieldHandler {
         let consumed = handle_key_event_impl(&self.state, event, self.line_limits);
 
         if consumed {
-            crate::cursor_animation::reset_cursor_blink();
-            // Use scoped invalidation for O(subtree) instead of O(app size)
-            if let Some(node_id) = self.node_id {
-                crate::schedule_layout_repass(node_id);
-            }
-            crate::request_render_invalidation();
+            self.on_text_mutated();
         }
 
         consumed
@@ -61,12 +73,7 @@ impl crate::text_field_focus::FocusedTextFieldHandler for TextFieldHandler {
         self.state.edit(|buffer| {
             buffer.insert(text);
         });
-        crate::cursor_animation::reset_cursor_blink();
-        // Text content changed - use scoped invalidation for O(subtree)
-        if let Some(node_id) = self.node_id {
-            crate::schedule_layout_repass(node_id);
-        }
-        crate::request_render_invalidation();
+        self.on_text_mutated();
     }
 
     fn delete_surrounding(&self, before_bytes: usize, after_bytes: usize) {
@@ -78,11 +85,7 @@ impl crate::text_field_focus::FocusedTextFieldHandler for TextFieldHandler {
             buffer.delete_surrounding(before_bytes, after_bytes);
         });
         self.state.set_desired_column(None);
-        crate::cursor_animation::reset_cursor_blink();
-        if let Some(node_id) = self.node_id {
-            crate::schedule_layout_repass(node_id);
-        }
-        crate::request_render_invalidation();
+        self.on_text_mutated();
     }
 
     fn copy_selection(&self) -> Option<String> {
@@ -118,8 +121,7 @@ impl crate::text_field_focus::FocusedTextFieldHandler for TextFieldHandler {
         self.state.edit(|buffer| {
             buffer.delete(selection);
         });
-        crate::cursor_animation::reset_cursor_blink();
-        crate::request_render_invalidation();
+        self.on_text_mutated();
         Some(text)
     }
 
@@ -155,8 +157,9 @@ impl crate::text_field_focus::FocusedTextFieldHandler for TextFieldHandler {
             }
         });
 
-        // Request redraw for composition underline
-        crate::request_render_invalidation();
+        // Preedit changes the text (grows/shrinks the field), so it needs a
+        // relayout, not just a redraw of the composition underline.
+        self.on_text_mutated();
     }
 
     fn finish_composition(&self) {

--- a/crates/cranpose-ui/src/text_field_modifier_node.rs
+++ b/crates/cranpose-ui/src/text_field_modifier_node.rs
@@ -34,9 +34,6 @@ const DEFAULT_CURSOR_COLOR: Color = Color(1.0, 1.0, 1.0, 1.0);
 /// Default selection highlight color (light blue with transparency)
 const DEFAULT_SELECTION_COLOR: Color = Color(0.0, 0.5, 1.0, 0.3);
 
-/// Double-click timeout in milliseconds
-const DOUBLE_CLICK_MS: u128 = 500;
-
 /// Default line height for empty text fields
 const DEFAULT_LINE_HEIGHT: f32 = 20.0;
 
@@ -116,6 +113,8 @@ pub(crate) struct TextFieldRefs {
     pub drag_anchor: Rc<Cell<Option<usize>>>,
     /// Last click time for double/triple-click detection
     pub last_click_time: Rc<Cell<Option<web_time::Instant>>>,
+    /// Last click screen position, for multi-tap slop gating
+    pub last_click_pos: Rc<Cell<Option<(f32, f32)>>>,
     /// Click count (1=single, 2=double, 3=triple)
     pub click_count: Rc<Cell<u8>>,
     /// Node ID for scoped layout invalidation
@@ -134,6 +133,7 @@ impl TextFieldRefs {
             content_y_offset: Rc::new(Cell::new(0.0_f32)),
             drag_anchor: Rc::new(Cell::new(None::<usize>)),
             last_click_time: Rc::new(Cell::new(None::<web_time::Instant>)),
+            last_click_pos: Rc::new(Cell::new(None::<(f32, f32)>)),
             click_count: Rc::new(Cell::new(0_u8)),
             node_id: Rc::new(Cell::new(None::<cranpose_core::NodeId>)),
             scroll_offset: Rc::new(Cell::new(0.0_f32)),
@@ -303,7 +303,11 @@ impl TextFieldModifierNode {
         line_limits: TextFieldLineLimits,
         style: TextStyle, // Add style
     ) -> Rc<dyn Fn(PointerEvent)> {
-        // Use word_boundaries module for double-click word selection
+        // Word boundaries for double-tap; selection classification/line
+        // boundaries for the tap-count-driven selection gestures.
+        use crate::text_selection::{
+            classify_tap, find_line_boundaries, TapCount, MULTI_TAP_SLOP_PX, MULTI_TAP_TIMEOUT_MS,
+        };
         use crate::word_boundaries::find_word_boundaries;
 
         Rc::new(move |event: PointerEvent| {
@@ -330,44 +334,58 @@ impl TextFieldModifierNode {
                         click_y,
                     );
 
-                    // Detect double-click
-                    let is_double_click = if let Some(last) = refs.last_click_time.get() {
-                        now.duration_since(last).as_millis() < DOUBLE_CLICK_MS
-                    } else {
-                        false
-                    };
+                    // Classify the press into single/double/triple by both the
+                    // time since and the distance from the previous press (a tap
+                    // far from the last one starts a fresh single tap, matching
+                    // Android's double-tap slop).
+                    let previous = refs.click_count.get().try_into().ok().and_then(|count| {
+                        let (px, py) = refs.last_click_pos.get()?;
+                        Some((count, px, py))
+                    });
+                    let elapsed_ms = refs
+                        .last_click_time
+                        .get()
+                        .map(|last| now.duration_since(last).as_millis())
+                        .unwrap_or(u128::MAX);
+                    let tap = classify_tap(
+                        previous,
+                        elapsed_ms,
+                        event.position.x,
+                        event.position.y,
+                        MULTI_TAP_TIMEOUT_MS,
+                        MULTI_TAP_SLOP_PX,
+                    );
 
-                    if is_double_click {
-                        // Increment click count for potential triple-click
-                        let count = refs.click_count.get() + 1;
-                        refs.click_count.set(count.min(3));
-
-                        if count >= 3 {
-                            // Triple-click: select all
+                    match tap {
+                        TapCount::Triple => {
+                            // Triple tap/click: select the line/paragraph.
+                            let (line_start, line_end) = find_line_boundaries(&text, pos);
                             state.edit(|buffer| {
-                                buffer.select_all();
+                                buffer.select(TextRange::new(line_start, line_end));
                             });
-                            // Set drag anchor to start for select-all drag
-                            refs.drag_anchor.set(Some(0));
-                        } else if count >= 2 {
-                            // Double-click: select word
+                            refs.drag_anchor.set(Some(line_start));
+                        }
+                        TapCount::Double => {
+                            // Double tap/click: select the word.
                             let (word_start, word_end) = find_word_boundaries(&text, pos);
                             state.edit(|buffer| {
                                 buffer.select(TextRange::new(word_start, word_end));
                             });
-                            // Set drag anchor to word boundaries for word-extend drag
                             refs.drag_anchor.set(Some(word_start));
                         }
-                    } else {
-                        // Single click: reset click count, place cursor
-                        refs.click_count.set(1);
-                        refs.drag_anchor.set(Some(pos));
-                        state.edit(|buffer| {
-                            buffer.place_cursor_before_char(pos);
-                        });
+                        TapCount::Single => {
+                            // Single tap/click: place the cursor.
+                            refs.drag_anchor.set(Some(pos));
+                            state.edit(|buffer| {
+                                buffer.place_cursor_before_char(pos);
+                            });
+                        }
                     }
 
+                    refs.click_count.set(tap.as_u8());
                     refs.last_click_time.set(Some(now));
+                    refs.last_click_pos
+                        .set(Some((event.position.x, event.position.y)));
                     event.consume();
                 }
                 PointerEventKind::Move => {
@@ -502,15 +520,36 @@ impl TextFieldModifierNode {
         self.refs.content_y_offset.set(offset);
     }
 
+    /// The wrap width a multi-line field lays its text out at, or `None` when
+    /// the text must not wrap (single-line fields pan horizontally instead).
+    ///
+    /// Multi-line fields wrap at the available content width exactly like the
+    /// render scene builder, so the measured height reflects every wrapped line
+    /// and the field grows to fit its content instead of clipping it.
+    fn wrap_width(&self, available_width: f32) -> Option<f32> {
+        (!self.line_limits.is_single_line() && available_width.is_finite() && available_width > 0.0)
+            .then_some(available_width)
+    }
+
     /// Measures the text content using node-identity-based caching.
-    fn measure_text_content(&self) -> Size {
+    ///
+    /// `wrap_width` bounds the layout width so multi-line text wraps; `None`
+    /// measures the natural single-line width (single-line fields, intrinsic
+    /// width queries).
+    fn measure_text_content(&self, wrap_width: Option<f32>) -> Size {
         let text = self.state.text();
         let node_id = self.refs.node_id.get();
-        let metrics = crate::text::measure_text_for_node(
-            node_id,
-            &crate::text::AnnotatedString::from(text.as_str()),
-            &self.style,
-        );
+        let annotated = crate::text::AnnotatedString::from(text.as_str());
+        let metrics = match wrap_width {
+            Some(max_width) => crate::text::measure_text_with_options_for_node(
+                node_id,
+                &annotated,
+                &self.style,
+                crate::text::TextLayoutOptions::default(),
+                Some(max_width),
+            ),
+            None => crate::text::measure_text_for_node(node_id, &annotated, &self.style),
+        };
         self.measured_line_height.set(metrics.line_height);
         Size {
             width: metrics.width,
@@ -620,8 +659,10 @@ impl LayoutModifierNode for TextFieldModifierNode {
         _measurable: &dyn Measurable,
         constraints: Constraints,
     ) -> cranpose_ui_layout::LayoutModifierMeasureResult {
-        // Measure the text content
-        let text_size = self.measure_text_content();
+        // Measure the text content, wrapping multi-line fields at the available
+        // width so the field grows to fit every wrapped line instead of
+        // clipping content past the first line.
+        let text_size = self.measure_text_content(self.wrap_width(constraints.max_width));
 
         // Add minimum height for empty text (cursor needs space)
         let min_height = if text_size.height < 1.0 {
@@ -650,19 +691,23 @@ impl LayoutModifierNode for TextFieldModifierNode {
     }
 
     fn min_intrinsic_width(&self, _measurable: &dyn Measurable, _height: f32) -> f32 {
-        self.measure_text_content().width
+        self.measure_text_content(None).width
     }
 
     fn max_intrinsic_width(&self, _measurable: &dyn Measurable, _height: f32) -> f32 {
-        self.measure_text_content().width
+        self.measure_text_content(None).width
     }
 
-    fn min_intrinsic_height(&self, _measurable: &dyn Measurable, _width: f32) -> f32 {
-        self.measure_text_content().height.max(DEFAULT_LINE_HEIGHT)
+    fn min_intrinsic_height(&self, _measurable: &dyn Measurable, width: f32) -> f32 {
+        self.measure_text_content(self.wrap_width(width))
+            .height
+            .max(DEFAULT_LINE_HEIGHT)
     }
 
-    fn max_intrinsic_height(&self, _measurable: &dyn Measurable, _width: f32) -> f32 {
-        self.measure_text_content().height.max(DEFAULT_LINE_HEIGHT)
+    fn max_intrinsic_height(&self, _measurable: &dyn Measurable, width: f32) -> f32 {
+        self.measure_text_content(self.wrap_width(width))
+            .height
+            .max(DEFAULT_LINE_HEIGHT)
     }
 }
 
@@ -1161,6 +1206,51 @@ mod tests {
 
             assert_eq!(node.text(), "themed text");
             assert_eq!(node.style(), &light_style);
+        });
+    }
+
+    /// A multi-line field must measure the *wrapped* height at the available
+    /// width, so a long transcript grows the field instead of being clipped to
+    /// a single line. Regression for the "edits only appear after focus loss"
+    /// bug where a wrapped OCR transcript rendered only its first line.
+    #[test]
+    fn multiline_field_measures_wrapped_height() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        with_test_runtime(|| {
+            let long = "abcd ".repeat(40); // ~200 chars, no explicit newlines
+            let state = TextFieldState::new(&long);
+            let node = TextFieldModifierNode::new(state, TextStyle::default());
+            assert!(
+                !node.line_limits().is_single_line(),
+                "default fields are multi-line"
+            );
+
+            let natural = node.measure_text_content(None);
+            let wrapped = node.measure_text_content(node.wrap_width(20.0));
+
+            assert!(
+                wrapped.height > natural.height,
+                "wrapped multi-line height {} must exceed the single-line height {}",
+                wrapped.height,
+                natural.height
+            );
+        });
+    }
+
+    /// Single-line fields pan horizontally instead of wrapping, so they never
+    /// derive a wrap width even under a narrow constraint.
+    #[test]
+    fn single_line_field_never_wraps() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        with_test_runtime(|| {
+            let state = TextFieldState::new("abcd ".repeat(40));
+            let node = TextFieldModifierNode::new(state, TextStyle::default())
+                .with_line_limits(TextFieldLineLimits::SingleLine);
+            assert_eq!(
+                node.wrap_width(20.0),
+                None,
+                "single-line fields must not wrap"
+            );
         });
     }
 

--- a/crates/cranpose-ui/src/text_selection.rs
+++ b/crates/cranpose-ui/src/text_selection.rs
@@ -1,0 +1,419 @@
+//! Native-grade text selection primitives for `BasicTextField`.
+//!
+//! This module holds the pure, unit-tested building blocks the text field uses
+//! to offer Android/iOS-style selection: tap-count classification, word and
+//! line/paragraph boundary detection, and the geometry of the draggable
+//! teardrop selection handles (their shapes, their hit regions, and the
+//! selection math that a handle drag produces).
+//!
+//! Keeping these as free functions makes the touch behavior testable without a
+//! renderer and keeps `TextFieldModifierNode` focused on wiring.
+
+use cranpose_ui_graphics::Rect;
+
+/// How many consecutive taps a press represents, mirroring the platform text
+/// selection gestures: one tap places the cursor, two select the word, three
+/// select the line/paragraph.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TapCount {
+    Single,
+    Double,
+    Triple,
+}
+
+impl TapCount {
+    /// The 1-based tap number, capped at three.
+    pub fn as_u8(self) -> u8 {
+        match self {
+            TapCount::Single => 1,
+            TapCount::Double => 2,
+            TapCount::Triple => 3,
+        }
+    }
+}
+
+impl TryFrom<u8> for TapCount {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(TapCount::Single),
+            2 => Ok(TapCount::Double),
+            3 => Ok(TapCount::Triple),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Maximum time between taps that still counts as a multi-tap, in milliseconds.
+pub const MULTI_TAP_TIMEOUT_MS: u128 = 500;
+
+/// Maximum distance (px) between consecutive taps that still counts as a
+/// multi-tap. A tap that lands far from the previous one starts a fresh
+/// single tap even if it arrives quickly, matching Android's `ViewConfiguration`
+/// double-tap slop behavior.
+pub const MULTI_TAP_SLOP_PX: f32 = 24.0;
+
+/// Classifies a press into a tap count from the previous tap's count, the time
+/// since it, and the distance from it.
+///
+/// `previous` is the last tap's `(count, x, y)` or `None` for the first tap.
+/// A tap escalates the count (single -> double -> triple, then wraps back to
+/// single) only when it lands within both the timeout and the slop radius;
+/// otherwise it restarts at a single tap.
+pub fn classify_tap(
+    previous: Option<(TapCount, f32, f32)>,
+    elapsed_ms: u128,
+    x: f32,
+    y: f32,
+    timeout_ms: u128,
+    slop_px: f32,
+) -> TapCount {
+    let Some((prev_count, prev_x, prev_y)) = previous else {
+        return TapCount::Single;
+    };
+    let within_time = elapsed_ms <= timeout_ms;
+    let dx = x - prev_x;
+    let dy = y - prev_y;
+    let within_slop = dx * dx + dy * dy <= slop_px * slop_px;
+    if !within_time || !within_slop {
+        return TapCount::Single;
+    }
+    match prev_count {
+        TapCount::Single => TapCount::Double,
+        TapCount::Double => TapCount::Triple,
+        // A fourth tap cycles back to a single cursor placement.
+        TapCount::Triple => TapCount::Single,
+    }
+}
+
+/// Returns the byte range `[start, end)` of the line/paragraph containing
+/// `pos`, delimited by `\n` (the newline itself is excluded from the range).
+///
+/// Used for triple-tap line/paragraph selection. Byte offsets always land on
+/// `char` boundaries because `\n` is a single-byte ASCII character.
+pub fn find_line_boundaries(text: &str, pos: usize) -> (usize, usize) {
+    let pos = pos.min(text.len());
+    let start = text[..pos].rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let end = text[pos..]
+        .find('\n')
+        .map(|i| pos + i)
+        .unwrap_or(text.len());
+    (start, end)
+}
+
+/// Which selection handle a teardrop represents.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HandleKind {
+    /// The blinking-cursor handle shown for a collapsed selection: a teardrop
+    /// whose tip points up at the cursor, centered under it.
+    Cursor,
+    /// The start (leftmost) selection handle: tip at the top-right, bulb below-left.
+    SelectionStart,
+    /// The end (rightmost) selection handle: tip at the top-left, bulb below-right.
+    SelectionEnd,
+}
+
+/// Radius of a selection/cursor handle bulb in px (Android uses ~11dp).
+pub const HANDLE_RADIUS: f32 = 8.0;
+
+/// Extra hit-test slop (px) around a handle so it is easy to grab with a finger.
+pub const HANDLE_TOUCH_SLOP: f32 = 12.0;
+
+/// SVG path data for a handle teardrop whose tip sits at `(tip_x, tip_y)`.
+///
+/// The tip is anchored at the text edge (the cursor position or a selection
+/// endpoint at the line's bottom) and the rounded bulb hangs below it, so the
+/// caller positions the handle by passing the on-screen anchor point.
+pub fn handle_path_data(kind: HandleKind, tip_x: f32, tip_y: f32, radius: f32) -> String {
+    let r = radius.max(0.0);
+    let cy = tip_y + r; // bulb center y
+    match kind {
+        HandleKind::Cursor => {
+            // Symmetric teardrop: tip up, full circular bulb below.
+            format!(
+                "M {tip_x} {tip_y} L {left} {cy} A {r} {r} 0 1 0 {right} {cy} Z",
+                left = tip_x - r,
+                right = tip_x + r,
+            )
+        }
+        HandleKind::SelectionStart => {
+            // Tip at the endpoint, bulb hanging down and to the LEFT.
+            format!(
+                "M {tip_x} {tip_y} L {tip_x} {cy} A {r} {r} 0 1 0 {left} {tip_y} Z",
+                left = tip_x - r,
+            )
+        }
+        HandleKind::SelectionEnd => {
+            // Tip at the endpoint, bulb hanging down and to the RIGHT.
+            format!(
+                "M {tip_x} {tip_y} L {right} {tip_y} A {r} {r} 0 1 0 {tip_x} {cy} Z",
+                right = tip_x + r,
+            )
+        }
+    }
+}
+
+/// The axis-aligned hit region for a handle, expanded by touch slop, used to
+/// decide whether a pointer-down grabbed a handle.
+pub fn handle_hit_rect(kind: HandleKind, tip_x: f32, tip_y: f32, radius: f32, slop: f32) -> Rect {
+    let r = radius.max(0.0);
+    let slop = slop.max(0.0);
+    // Horizontal span of the bulb relative to the tip depends on the handle side.
+    let (left, right) = match kind {
+        HandleKind::Cursor => (tip_x - r, tip_x + r),
+        HandleKind::SelectionStart => (tip_x - 2.0 * r, tip_x + r),
+        HandleKind::SelectionEnd => (tip_x - r, tip_x + 2.0 * r),
+    };
+    Rect {
+        x: left - slop,
+        y: tip_y - slop,
+        width: (right - left) + 2.0 * slop,
+        height: 2.0 * r + 2.0 * slop,
+    }
+}
+
+/// Returns the handle nearest to `(x, y)` whose slop-expanded hit region
+/// contains the point, or `None` when the point misses every handle.
+///
+/// `handles` lists the currently drawn handles as `(kind, tip_x, tip_y)`.
+pub fn hit_test_handles(
+    handles: &[(HandleKind, f32, f32)],
+    x: f32,
+    y: f32,
+    radius: f32,
+    slop: f32,
+) -> Option<HandleKind> {
+    let mut best: Option<(HandleKind, f32)> = None;
+    for &(kind, tip_x, tip_y) in handles {
+        let rect = handle_hit_rect(kind, tip_x, tip_y, radius, slop);
+        let inside =
+            x >= rect.x && x <= rect.x + rect.width && y >= rect.y && y <= rect.y + rect.height;
+        if !inside {
+            continue;
+        }
+        let cx = tip_x;
+        let cy = tip_y + radius;
+        let dist_sq = (x - cx) * (x - cx) + (y - cy) * (y - cy);
+        if best
+            .map(|(_, best_dist)| dist_sq < best_dist)
+            .unwrap_or(true)
+        {
+            best = Some((kind, dist_sq));
+        }
+    }
+    best.map(|(kind, _)| kind)
+}
+
+/// Computes the selection `(min, max)` that results from dragging one handle to
+/// a new text `offset`, keeping the opposite (fixed) edge anchored.
+///
+/// Dragging never lets the two edges cross: a dragged start clamps to just
+/// before the fixed end, and a dragged end clamps to just after the fixed
+/// start, so the selection keeps at least one selected unit.
+pub fn selection_after_handle_drag(
+    dragged: HandleKind,
+    fixed_edge: usize,
+    dragged_offset: usize,
+    text_len: usize,
+) -> (usize, usize) {
+    let fixed = fixed_edge.min(text_len);
+    let dragged_offset = dragged_offset.min(text_len);
+    match dragged {
+        HandleKind::SelectionStart => {
+            let start = dragged_offset.min(fixed.saturating_sub(1));
+            (start, fixed)
+        }
+        HandleKind::SelectionEnd => {
+            let end = dragged_offset.max(fixed + 1).min(text_len);
+            (fixed, end)
+        }
+        // The cursor handle just moves the collapsed caret.
+        HandleKind::Cursor => (dragged_offset, dragged_offset),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tap_classification_escalates_within_time_and_slop() {
+        assert_eq!(
+            classify_tap(None, 0, 10.0, 10.0, 500, 24.0),
+            TapCount::Single
+        );
+        assert_eq!(
+            classify_tap(
+                Some((TapCount::Single, 10.0, 10.0)),
+                100,
+                11.0,
+                12.0,
+                500,
+                24.0
+            ),
+            TapCount::Double
+        );
+        assert_eq!(
+            classify_tap(
+                Some((TapCount::Double, 10.0, 10.0)),
+                100,
+                11.0,
+                12.0,
+                500,
+                24.0
+            ),
+            TapCount::Triple
+        );
+        // A fourth quick tap wraps back to a single cursor placement.
+        assert_eq!(
+            classify_tap(
+                Some((TapCount::Triple, 10.0, 10.0)),
+                100,
+                11.0,
+                12.0,
+                500,
+                24.0
+            ),
+            TapCount::Single
+        );
+    }
+
+    #[test]
+    fn tap_classification_resets_past_timeout_or_slop() {
+        // Too slow: restarts.
+        assert_eq!(
+            classify_tap(
+                Some((TapCount::Single, 10.0, 10.0)),
+                600,
+                10.0,
+                10.0,
+                500,
+                24.0
+            ),
+            TapCount::Single
+        );
+        // Too far: restarts even though it is quick.
+        assert_eq!(
+            classify_tap(
+                Some((TapCount::Single, 10.0, 10.0)),
+                50,
+                100.0,
+                10.0,
+                500,
+                24.0
+            ),
+            TapCount::Single
+        );
+    }
+
+    #[test]
+    fn line_boundaries_span_between_newlines() {
+        let text = "first line\nsecond line\nthird";
+        // Inside the second line.
+        assert_eq!(find_line_boundaries(text, 15), (11, 22));
+        // Start of the first line.
+        assert_eq!(find_line_boundaries(text, 0), (0, 10));
+        // Inside the last (newline-terminated-absent) line.
+        assert_eq!(find_line_boundaries(text, 25), (23, text.len()));
+    }
+
+    #[test]
+    fn line_boundaries_handle_unicode_and_empty_lines() {
+        let text = "\u{00e9}\u{00e8}\n\n\u{4e2d}\u{6587}";
+        // Empty middle line: start == end at the byte after the first newline.
+        let (start, end) = find_line_boundaries(text, "\u{00e9}\u{00e8}\n".len());
+        assert_eq!(start, end);
+        // Last line spans the two CJK characters.
+        let last = find_line_boundaries(text, text.len());
+        assert_eq!(&text[last.0..last.1], "\u{4e2d}\u{6587}");
+    }
+
+    #[test]
+    fn handle_path_is_non_empty_and_contains_the_tip() {
+        for kind in [
+            HandleKind::Cursor,
+            HandleKind::SelectionStart,
+            HandleKind::SelectionEnd,
+        ] {
+            let data = handle_path_data(kind, 40.0, 20.0, HANDLE_RADIUS);
+            let path = cranpose_ui_graphics::VectorPath::parse(&data)
+                .expect("handle path must be valid SVG");
+            assert!(!path.is_empty(), "{kind:?} handle must have geometry");
+            let bounds = path.bounds();
+            // The tip (40, 20) must lie within the shape's bounds.
+            assert!(bounds.x <= 40.0 + 0.5 && bounds.x + bounds.width >= 40.0 - 0.5);
+            assert!(bounds.y <= 20.0 + 0.5);
+            // The bulb hangs below the tip.
+            assert!(bounds.y + bounds.height >= 20.0 + HANDLE_RADIUS);
+        }
+    }
+
+    #[test]
+    fn handle_hit_rect_covers_tip_and_bulb_with_slop() {
+        let rect = handle_hit_rect(
+            HandleKind::Cursor,
+            40.0,
+            20.0,
+            HANDLE_RADIUS,
+            HANDLE_TOUCH_SLOP,
+        );
+        // Tip and bulb center are inside.
+        assert!(rect.x <= 40.0 && 40.0 <= rect.x + rect.width);
+        assert!(rect.y <= 20.0 && 20.0 + HANDLE_RADIUS <= rect.y + rect.height);
+        // Slop widens the region beyond the bulb radius.
+        assert!(rect.width >= 2.0 * HANDLE_RADIUS + 2.0 * HANDLE_TOUCH_SLOP - 0.01);
+    }
+
+    #[test]
+    fn hit_test_prefers_the_nearest_handle() {
+        let handles = [
+            (HandleKind::SelectionStart, 20.0, 20.0),
+            (HandleKind::SelectionEnd, 120.0, 20.0),
+        ];
+        // Near the start handle bulb.
+        assert_eq!(
+            hit_test_handles(&handles, 20.0, 28.0, HANDLE_RADIUS, HANDLE_TOUCH_SLOP),
+            Some(HandleKind::SelectionStart)
+        );
+        // Near the end handle bulb.
+        assert_eq!(
+            hit_test_handles(&handles, 120.0, 28.0, HANDLE_RADIUS, HANDLE_TOUCH_SLOP),
+            Some(HandleKind::SelectionEnd)
+        );
+        // Far from both.
+        assert_eq!(
+            hit_test_handles(&handles, 300.0, 300.0, HANDLE_RADIUS, HANDLE_TOUCH_SLOP),
+            None
+        );
+    }
+
+    #[test]
+    fn handle_drag_keeps_edges_from_crossing() {
+        // Dragging the end handle left past the start clamps to start+1.
+        assert_eq!(
+            selection_after_handle_drag(HandleKind::SelectionEnd, 5, 2, 20),
+            (5, 6)
+        );
+        // Dragging the end handle right extends normally.
+        assert_eq!(
+            selection_after_handle_drag(HandleKind::SelectionEnd, 5, 12, 20),
+            (5, 12)
+        );
+        // Dragging the start handle right past the end clamps to end-1.
+        assert_eq!(
+            selection_after_handle_drag(HandleKind::SelectionStart, 8, 10, 20),
+            (7, 8)
+        );
+        // Dragging the start handle left extends normally.
+        assert_eq!(
+            selection_after_handle_drag(HandleKind::SelectionStart, 8, 3, 20),
+            (3, 8)
+        );
+        // The cursor handle moves a collapsed caret.
+        assert_eq!(
+            selection_after_handle_drag(HandleKind::Cursor, 4, 9, 20),
+            (9, 9)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Three fixes to the text-field foundation, rendering, and lazy layout, each root-caused and covered by a regression test that fails before the fix.

### 1. Live-edit rendering bug (multi-line `BasicTextField`) — user-reported
**Root cause:** `TextFieldModifierNode::measure` (`crates/cranpose-ui/src/text_field_modifier_node.rs`) measured its text with **no wrap width**, so a multi-line field seeded with a long OCR transcript measured a *single line tall* even though the scene builder wraps the glyphs at the content width. The wrapped continuation lines were then clipped to the field bounds and only reappeared once something forced a full scene rebuild (e.g. losing focus) — exactly the reported "edits only appear after the field loses focus" symptom. A second, related gap: the IME composition path (`set_composition`) and `cut` only requested a *redraw*, not a scoped relayout, so a growing field could lag a frame behind the input.

**Fix:**
- Multi-line fields now measure their **wrapped** height at the available width (single-line fields keep their natural width and pan, unchanged). `min/max_intrinsic_height(width)` wrap too.
- All focused-field text mutations flow through one `TextFieldHandler::on_text_mutated` helper (DRY) that schedules the scoped `schedule_layout_repass` + redraw, so composition/cut relayout on the same frame like key input already did.

**Evidence:** `crates/cranpose-render/wgpu/tests/text_field_live_edit.rs` (headless wgpu): a long no-newline transcript now measures ~7 wrapped lines (was 1) and rasterizes glyphs well below the first line; composing multi-line text into a focused field grows it on the next frame, in both a plain `Column` and a `LazyColumn` item. Plus non-GPU unit tests in `text_field_modifier_node.rs`.

### 2. Native-grade text selection foundation
New `crates/cranpose-ui/src/text_selection.rs` with the pure, unit-tested building blocks for Android/iOS-style selection, wired into the pointer handler:
- **Tap-count classification** gated by both time *and* slop (a tap far from the previous restarts the count).
- **Unicode-aware boundaries**: word (existing) + line/paragraph (new).
- **Teardrop selection-handle geometry** (`VectorPath` SVG builders) with slop hit-testing and nearest-handle resolution.
- **Handle-drag selection math** (edges never cross) + **auto-pan** on a dragged edge (reuses the cursor-follow pan resolver).

Wired behavior: single tap → cursor, double tap → word, triple tap → line/paragraph. Desktop mouse behavior (double-click word, drag-extend) is preserved.

**Deferred (precise follow-up), intentionally not half-implemented here since cranpose has no popup/overflow layer yet:** drawing the draggable teardrop handles into the live field, the long-press-to-select gesture, grabbing/dragging a handle to extend the selection, and the single-tap movable cursor handle. All the math/geometry those need is already implemented and tested in this PR; the remaining work is the interaction/rendering wiring (which needs an overflow layer so handles below the last line aren't clipped, plus a touch-vs-mouse source signal to keep desktop carets clean).

**Evidence:** unit tests in `text_selection.rs` (classification, boundaries, handle geometry/hit-test, drag math), and `cursor_position_tests.rs` (auto-pan-on-handle-drag; an end-to-end tap-count selection test through the real pointer handler).

### 3. Issue #305 — SwipeToDismiss composes to nothing inside LazyColumn items
**Root cause:** `SwipeToDismiss` is a `BoxWithConstraints` (a `SubcomposeLayout`), so a row inside a `LazyColumn` item nests one subcompose inside another. In `crates/cranpose-ui/src/layout/mod.rs`, the outer subcompose's raw placement loop set position / `is_placed` **only for `LayoutNode` children**. A nested `SubcomposeLayoutNode` child was measured but never marked placed, so the on-demand applier-traversal builds (`build_layout_tree_from_applier`, `build_semantics_tree_from_applier`, and the scene builder) culled its whole subtree via `if !state.is_placed { return None }` — the rows vanished from render *and* semantics. Standalone / `vertical_scroll` worked because a normal `LayoutNode` parent places children via `Placeable::place`, which handles both node kinds.

**Fix:** the placement path now positions and places both `LayoutNode` and `SubcomposeLayoutNode` children.

**Evidence:** `crates/cranpose-ui/src/tests/swipe_to_dismiss_lazy_tests.rs` (applier-traversal layout + semantics builds, non-GPU — both fail with `got []` before the fix) and `crates/cranpose-render/wgpu/tests/swipe_to_dismiss_lazy.rs` (end-to-end render).

## Verification
- `cargo fmt --check` clean
- `cargo test -p cranpose-ui -p cranpose-foundation -p cranpose -p cranpose-app-shell` green, incl. the 48 static guard tests
- `cargo check --workspace` clean; `cargo clippy` clean on touched crates
- Android: `RUSTUP_TOOLCHAIN=stable cargo ndk --platform 26 -t arm64-v8a check -p cranpose --features android,renderer-wgpu` (NDK 28.2.13676358) — Finished
- wasm: `cargo check -p desktop-app --target wasm32-unknown-unknown --no-default-features --features web,renderer-wgpu` — Finished

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKmJDd6pG9opQHr7btBMke
