### PR TITLE
fix(swipe): follow finger during drag; hide background reveal at rest

### DIFF
--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -284,5 +284,9 @@ mod lazy_list_viewport_tests;
 mod swipe_to_dismiss_lazy_tests;
 
 #[cfg(test)]
+#[path = "tests/swipe_to_dismiss_render_tests.rs"]
+mod swipe_to_dismiss_render_tests;
+
+#[cfg(test)]
 #[path = "tests/lazy_list_recompose_tests.rs"]
 mod lazy_list_recompose_tests;

--- a/crates/cranpose-ui/src/tests/swipe_to_dismiss_render_tests.rs
+++ b/crates/cranpose-ui/src/tests/swipe_to_dismiss_render_tests.rs
@@ -1,0 +1,220 @@
+//! Full-pipeline render tests for `SwipeToDismiss`.
+//!
+//! Regression coverage for two device-confirmed bugs:
+//!
+//! 1. **Live drag follow** — the content must translate under the finger while
+//!    dragging, not stay put and snap on release. The offset is applied as a
+//!    graphics-layer translation resolved on every draw pass, so pumping
+//!    pointer-move events must move the applied content offset 1:1 with the
+//!    accumulated drag (without any recomposition/re-measure).
+//!
+//! 2. **Background reveal gating** — the `with_background` content must not draw
+//!    at rest (offset 0), so it cannot flash through content that fades in with
+//!    alpha < 1 during an entrance animation. It must draw once displaced.
+
+use super::*;
+use crate::modifier::ModifierNodeSlices;
+use crate::modifier::{Color, PointerEvent, PointerEventKind};
+use cranpose_core::NodeId;
+use cranpose_ui_graphics::{DrawPrimitive, Point, Size as ViewportSize, Size as PrimSize};
+use std::rc::Rc;
+
+const BIN_RED: Color = Color(1.0, 0.0, 0.0, 1.0);
+
+fn compose_row(with_background: bool) -> TestComposition {
+    run_test_composition(move || {
+        let mut spec = SwipeToDismissSpec::default();
+        if with_background {
+            spec = spec.with_background(|| {
+                Box(
+                    Modifier::empty().fill_max_size().background(BIN_RED),
+                    BoxSpec::new(),
+                    || {},
+                );
+            });
+        }
+        SwipeToDismiss(
+            Modifier::empty().fill_max_width().height(48.0),
+            spec,
+            || {},
+            || {
+                Text(
+                    "CONTENT".to_string(),
+                    Modifier::empty(),
+                    TextStyle::default(),
+                );
+            },
+        );
+    })
+}
+
+fn measure_row(composition: &mut TestComposition, root: NodeId) {
+    let handle = composition.runtime_handle();
+    let mut applier = composition.applier_mut();
+    applier.set_runtime_handle(handle);
+    crate::measure_layout(
+        &mut applier,
+        root,
+        ViewportSize {
+            width: 320.0,
+            height: 480.0,
+        },
+    )
+    .expect("layout measurement");
+    applier.clear_runtime_handle();
+}
+
+fn layout_tree(composition: &mut TestComposition, root: NodeId) -> crate::LayoutTree {
+    let handle = composition.runtime_handle();
+    let mut applier = composition.applier_mut();
+    applier.set_runtime_handle(handle);
+    let tree = crate::build_layout_tree_from_applier(&mut applier, root)
+        .expect("layout tree build")
+        .expect("layout tree present");
+    applier.clear_runtime_handle();
+    tree
+}
+
+fn pointer_handler(tree: &crate::LayoutTree) -> Rc<dyn Fn(PointerEvent)> {
+    fn walk(node: &crate::LayoutBox) -> Option<Rc<dyn Fn(PointerEvent)>> {
+        if let Some(handler) = node.node_data.modifier_slices().pointer_inputs().first() {
+            return Some(Rc::clone(handler));
+        }
+        node.children.iter().find_map(walk)
+    }
+    walk(tree.root()).expect("swipe pointer handler")
+}
+
+/// The single node carrying the content's graphics-layer resolver (the content
+/// wrapper). Returned as an owned `Rc` so the resolver can be re-queried after
+/// drags without rebuilding the tree.
+fn content_layer_slices(tree: &crate::LayoutTree) -> Rc<ModifierNodeSlices> {
+    fn walk(node: &crate::LayoutBox) -> Option<Rc<ModifierNodeSlices>> {
+        if node.node_data.modifier_slices().graphics_layer().is_some() {
+            return Some(Rc::clone(&node.node_data.modifier_slices));
+        }
+        node.children.iter().find_map(walk)
+    }
+    walk(tree.root()).expect("content graphics-layer node")
+}
+
+fn applied_translation_x(slices: &ModifierNodeSlices) -> f32 {
+    slices
+        .graphics_layer()
+        .expect("content graphics layer")
+        .translation_x
+}
+
+fn count_bin_primitives(tree: &crate::LayoutTree) -> usize {
+    fn walk(node: &crate::LayoutBox, count: &mut usize) {
+        let size = PrimSize {
+            width: node.rect.width,
+            height: node.rect.height,
+        };
+        for primitive in
+            crate::execute_draw_commands(node.node_data.modifier_slices().draw_commands(), size)
+        {
+            if let DrawPrimitive::Rect { brush, .. } = primitive {
+                if format!("{brush:?}").contains("1.0, 0.0, 0.0") {
+                    *count += 1;
+                }
+            }
+        }
+        for child in &node.children {
+            walk(child, count);
+        }
+    }
+    let mut count = 0;
+    walk(tree.root(), &mut count);
+    count
+}
+
+fn down(x: f32) -> PointerEvent {
+    let p = Point { x, y: 24.0 };
+    PointerEvent::new(PointerEventKind::Down, p, p)
+}
+
+fn move_to(x: f32) -> PointerEvent {
+    let p = Point { x, y: 24.0 };
+    PointerEvent::new(PointerEventKind::Move, p, p)
+}
+
+/// Bug 1: pumping pointer-move events moves the applied content offset 1:1 with
+/// the accumulated drag, in real time, before release — with no recomposition.
+#[test]
+fn dragging_translates_content_with_the_finger() {
+    let mut composition = compose_row(false);
+    let root = composition.root().expect("root");
+    measure_row(&mut composition, root);
+    let tree = layout_tree(&mut composition, root);
+
+    let handler = pointer_handler(&tree);
+    let content = content_layer_slices(&tree);
+
+    // At rest, nothing is translated.
+    assert_eq!(applied_translation_x(&content), 0.0);
+
+    handler(down(10.0));
+
+    // Within the drag slop: no capture yet, still no translation.
+    handler(move_to(14.0));
+    assert_eq!(applied_translation_x(&content), 0.0);
+
+    // Crossing the slop captures the gesture; the content follows immediately.
+    handler(move_to(30.0));
+    assert!(
+        (applied_translation_x(&content) - 20.0).abs() < 1e-3,
+        "content should track the finger (dx=20), got {}",
+        applied_translation_x(&content)
+    );
+
+    // Each subsequent move tracks the accumulated drag 1:1.
+    handler(move_to(130.0));
+    assert!(
+        (applied_translation_x(&content) - 120.0).abs() < 1e-3,
+        "content should track the finger (dx=120), got {}",
+        applied_translation_x(&content)
+    );
+
+    handler(move_to(90.0));
+    assert!(
+        (applied_translation_x(&content) - 80.0).abs() < 1e-3,
+        "content should track the finger back (dx=80), got {}",
+        applied_translation_x(&content)
+    );
+}
+
+/// Bug 2: the background produces no draw primitives at rest (offset 0) and
+/// does once the row is displaced.
+#[test]
+fn background_only_draws_while_displaced() {
+    let mut composition = compose_row(true);
+    let root = composition.root().expect("root");
+    measure_row(&mut composition, root);
+
+    // At rest: the background is not composed, so it emits nothing — even
+    // though the content behind/over it would (this is the entrance-flash bug).
+    let tree = layout_tree(&mut composition, root);
+    assert_eq!(
+        count_bin_primitives(&tree),
+        0,
+        "background must not draw at offset 0"
+    );
+
+    // Displace the row past the slop.
+    let handler = pointer_handler(&tree);
+    handler(down(10.0));
+    handler(move_to(80.0)); // dx = 70 -> revealed
+
+    // Reading the reveal flag inside the subcompose subscribes the slot, so the
+    // write recomposes it and the background is now composed and drawn.
+    composition
+        .process_invalid_scopes()
+        .expect("recompose after reveal");
+    measure_row(&mut composition, root);
+    let displaced = layout_tree(&mut composition, root);
+    assert!(
+        count_bin_primitives(&displaced) > 0,
+        "background must draw while the row is displaced"
+    );
+}

--- a/crates/cranpose-ui/src/tests/swipe_to_dismiss_tests.rs
+++ b/crates/cranpose-ui/src/tests/swipe_to_dismiss_tests.rs
@@ -76,6 +76,11 @@ impl Harness {
         self.controller.current_offset()
     }
 
+    /// Non-reactive read of the background-reveal flag driven by the gesture.
+    fn revealed(&self) -> bool {
+        self.controller.revealed.get_non_reactive()
+    }
+
     /// Advances the frame clock, driving springs and the settle watcher.
     fn pump_frames(&mut self, frames: usize) {
         let handle = self._runtime.handle();
@@ -274,6 +279,47 @@ fn consumed_move_abandons_the_gesture_and_restores() {
     harness.pump_frames(300);
     assert_eq!(harness.dismiss_count.get(), 0);
     assert!(harness.offset().abs() <= 0.5);
+}
+
+#[test]
+fn background_reveal_tracks_displacement() {
+    let mut harness = Harness::new(200.0, 0.5);
+    assert!(!harness.revealed(), "background hidden at rest");
+
+    harness.send(&down(10.0, 10.0));
+    assert!(
+        !harness.revealed(),
+        "still hidden before the swipe captures"
+    );
+
+    harness.send(&move_to(30.0, 10.0)); // captured, offset 20
+    assert!(harness.revealed(), "revealed once the row is displaced");
+
+    // Below threshold: springs back and the reveal turns off at rest so the
+    // background cannot flash while the row sits still.
+    harness.send(&up(30.0, 10.0));
+    harness.pump_frames(300);
+    assert!(harness.offset().abs() <= 0.5);
+    assert!(
+        !harness.revealed(),
+        "background hidden again after springing back to rest"
+    );
+}
+
+#[test]
+fn background_reveal_stays_on_through_dismissal() {
+    let mut harness = Harness::new(200.0, 0.5);
+    harness.send(&down(10.0, 10.0));
+    harness.send(&move_to(30.0, 10.0));
+    harness.send(&move_to(140.0, 10.0)); // offset 130 >= threshold 100
+    harness.send(&up(140.0, 10.0));
+    harness.pump_frames(300);
+
+    assert_eq!(harness.dismiss_count.get(), 1);
+    assert!(
+        harness.revealed(),
+        "background stays revealed while the dismissed row rests off-screen"
+    );
 }
 
 #[test]

--- a/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
+++ b/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
@@ -22,13 +22,13 @@
 #![allow(non_snake_case)]
 
 use crate::composable;
-use crate::modifier::{Modifier, PointerEvent, PointerEventKind};
+use crate::modifier::{GraphicsLayer, Modifier, PointerEvent, PointerEventKind};
 use crate::widgets::box_widget::{Box, BoxSpec};
 use crate::widgets::layout::BoxWithConstraints;
 use crate::widgets::scopes::BoxWithConstraintsScope;
 use cranpose_animation::{spring, Animatable, AnimationType, Spring};
 use cranpose_core::internal::FrameCallbackRegistration;
-use cranpose_core::{with_current_composer, Owned, RuntimeHandle};
+use cranpose_core::{with_current_composer, Owned, OwnedMutableState, RuntimeHandle};
 use cranpose_foundation::DRAG_THRESHOLD;
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -150,6 +150,15 @@ struct SwipeToDismissController {
     runtime: RuntimeHandle,
     /// Animated horizontal offset of the content in logical px.
     offset: RefCell<Animatable<f32>>,
+    /// Reactive flag mirroring `|offset| > 0`, read inside the subcompose so
+    /// the row's background is *composed* only while the row is displaced.
+    /// Conditional composition (adding/removing the background node) re-applies
+    /// when the slot recomposes, unlike a layout-offset value change which is
+    /// placement-cached — so this bool, not the raw offset, gates the reveal.
+    /// A plain bool also recomposes only on rest/displaced transitions rather
+    /// than on every drag frame. Without gating, the always-composed background
+    /// flashes through content that fades in with alpha < 1 during an entrance.
+    revealed: OwnedMutableState<bool>,
     phase: Cell<SwipePhase>,
     /// Content width in logical px, refreshed from the incoming constraints.
     width_px: Cell<f32>,
@@ -167,6 +176,7 @@ impl SwipeToDismissController {
         Rc::new(Self {
             id: NEXT_SWIPE_ID.fetch_add(1, Ordering::Relaxed),
             offset: RefCell::new(Animatable::new(0.0, runtime.clone())),
+            revealed: OwnedMutableState::with_runtime(false, runtime.clone()),
             runtime,
             phase: Cell::new(SwipePhase::Idle),
             width_px: Cell::new(f32::NAN),
@@ -181,12 +191,36 @@ impl SwipeToDismissController {
         self.offset.borrow().state().value()
     }
 
+    /// Reactive read of the revealed flag; subscribes the reading scope (the
+    /// subcompose slot) so it recomposes when the background reveal toggles.
+    fn revealed(&self) -> bool {
+        self.revealed.value()
+    }
+
+    /// Updates the revealed flag (only writes on change, to avoid needless
+    /// recompositions each drag frame while already displaced).
+    fn set_revealed(&self, revealed: bool) {
+        if self.revealed.get_non_reactive() != revealed {
+            self.revealed.set_value(revealed);
+        }
+    }
+
     fn snap_to(&self, offset: f32) {
         self.offset.borrow_mut().snapTo(offset);
+        // A live drag frame: the background is revealed exactly while the row
+        // is displaced. Rest (offset 0) hides it, even mid-entrance.
+        self.set_revealed(offset != 0.0);
     }
 
     fn animate_to(&self, target: f32) {
         self.offset.borrow_mut().animateTo(target, swipe_spring());
+        // A dismissal fling keeps the row displaced, so reveal immediately.
+        // A spring-back keeps the reveal on until the settle watcher observes
+        // the row return to rest (so the background does not vanish out from
+        // under the still-sliding content).
+        if target != 0.0 {
+            self.set_revealed(true);
+        }
     }
 }
 
@@ -240,7 +274,7 @@ fn handle_swipe_event(controller: &Rc<SwipeToDismissController>, event: &Pointer
                 // Another handler owns this sequence (parent scroll started,
                 // or a sibling captured); abandon and rest.
                 if matches!(controller.phase.get(), SwipePhase::Dragging { .. }) {
-                    controller.animate_to(0.0);
+                    animate_spring_back(controller);
                 }
                 controller.phase.set(SwipePhase::Idle);
                 return;
@@ -291,7 +325,7 @@ fn handle_swipe_event(controller: &Rc<SwipeToDismissController>, event: &Pointer
         }
         PointerEventKind::Cancel => {
             if matches!(controller.phase.get(), SwipePhase::Dragging { .. }) {
-                controller.animate_to(0.0);
+                animate_spring_back(controller);
             }
             controller.phase.set(SwipePhase::Idle);
         }
@@ -308,20 +342,29 @@ fn settle_release(controller: &Rc<SwipeToDismissController>) {
     let offset = controller.current_offset();
     let width = controller.width_px.get();
     match dismissal_target(offset, width, controller.threshold_fraction.get()) {
-        Some(target) => {
-            controller.animate_to(target);
-            watch_dismiss_settle(controller);
-        }
-        None => {
-            controller.animate_to(0.0);
-        }
+        Some(target) => animate_dismiss(controller, target),
+        None => animate_spring_back(controller),
     }
 }
 
-/// Watches the dismiss animation frame-by-frame; once the offset settles at
-/// the off-screen target, fires `on_dismiss` exactly once. Runs in frame
-/// callbacks (outside composition), so the callback may freely mutate state.
-fn watch_dismiss_settle(controller: &Rc<SwipeToDismissController>) {
+/// Flings the row off-screen and watches for `on_dismiss` to fire once settled.
+fn animate_dismiss(controller: &Rc<SwipeToDismissController>, target: f32) {
+    controller.animate_to(target);
+    watch_settle(controller, true);
+}
+
+/// Springs the row back to rest and watches so the reveal is hidden again once
+/// the content actually returns to offset 0.
+fn animate_spring_back(controller: &Rc<SwipeToDismissController>) {
+    controller.animate_to(0.0);
+    watch_settle(controller, false);
+}
+
+/// Watches the settle animation frame-by-frame. Once the offset reaches its
+/// target it syncs the reveal flag to the resting displacement and, for a
+/// dismissal, fires `on_dismiss` exactly once. Runs in frame callbacks
+/// (outside composition), so the callback may freely mutate state.
+fn watch_settle(controller: &Rc<SwipeToDismissController>, dismissing: bool) {
     let weak = Rc::downgrade(controller);
     let registration =
         controller
@@ -332,23 +375,29 @@ fn watch_dismiss_settle(controller: &Rc<SwipeToDismissController>) {
                     return;
                 };
                 controller.settle_watcher.borrow_mut().take();
-                if controller.dismissed.get() {
+                if dismissing && controller.dismissed.get() {
                     return;
                 }
-                // A new gesture retargeted the animation; stop watching.
+                // A new gesture retargeted the animation; a fresh snap already
+                // owns the reveal flag, so stop watching.
                 if matches!(controller.phase.get(), SwipePhase::Dragging { .. }) {
                     return;
                 }
                 let target = controller.offset.borrow().target();
                 let value = controller.current_offset();
                 if (value - target).abs() <= DISMISS_SETTLE_EPSILON {
-                    controller.dismissed.set(true);
-                    let on_dismiss = controller.on_dismiss.borrow().clone();
-                    if let Some(on_dismiss) = on_dismiss {
-                        on_dismiss();
+                    // The row has settled: reveal iff it rests displaced (a
+                    // dismissal rests off-screen, a spring-back rests at 0).
+                    controller.set_revealed(target != 0.0);
+                    if dismissing && !controller.dismissed.get() {
+                        controller.dismissed.set(true);
+                        let on_dismiss = controller.on_dismiss.borrow().clone();
+                        if let Some(on_dismiss) = on_dismiss {
+                            on_dismiss();
+                        }
                     }
                 } else {
-                    watch_dismiss_settle(&controller);
+                    watch_settle(&controller, dismissing);
                 }
             });
     *controller.settle_watcher.borrow_mut() = Some(registration);
@@ -406,19 +455,33 @@ where
             .width_px
             .set(scope.constraints().max_width);
 
-        if let Some(background) = &background {
-            let background = Rc::clone(background);
-            Box(Modifier::empty(), BoxSpec::new(), move || {
-                (background.borrow_mut())();
-            });
+        // Only draw the background while the row is displaced. Reading the
+        // reveal flag inside the subcompose subscribes this slot, so it
+        // recomposes when the row leaves/returns to rest. At rest (offset 0)
+        // the background is not composed at all, so it cannot flash through
+        // content that fades in with alpha < 1 during an entrance animation.
+        let revealed = controller_for_layout.revealed();
+        if revealed {
+            if let Some(background) = &background {
+                let background = Rc::clone(background);
+                Box(Modifier::empty(), BoxSpec::new(), move || {
+                    (background.borrow_mut())();
+                });
+            }
         }
 
-        // Reading the animated offset subscribes this scope: every spring
-        // frame recomposes and re-places the content at the new offset.
-        let offset_x = controller_for_layout.current_offset();
+        // Translate the content with the finger via a graphics-layer resolver.
+        // The resolver re-reads the live offset on every draw pass, and an
+        // offset write schedules a draw repass for this node, so the content
+        // follows the finger 1:1 in real time and settles with the spring on
+        // release — without needing a re-measure of the subcompose each frame.
         let content = Rc::clone(&content);
+        let controller_for_layer = Rc::clone(&controller_for_layout);
         Box(
-            Modifier::empty().offset(offset_x, 0.0),
+            Modifier::empty().graphics_layer(move || GraphicsLayer {
+                translation_x: controller_for_layer.current_offset(),
+                ..GraphicsLayer::default()
+            }),
             BoxSpec::new(),
             move || {
                 (content.borrow_mut())();


### PR DESCRIPTION
Two device-confirmed `SwipeToDismiss` bugs, both rooted in how the animated offset drives rendering.

## Bug 1 — content did not translate under the finger during the drag
The gesture recognized and dismiss fired at threshold, but the row stayed put mid-drag and snapped on release.

**Root cause** (`crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs`, old line 468): the content offset was applied with a layout `Modifier::empty().offset(offset_x, 0.0)` baked at composition time *inside the `BoxWithConstraints` subcompose closure*. Writing the offset (`snapTo`/spring) schedules a **draw** repass but never a **layout** repass for the subcompose slot, and a layout-modifier value change is placement-cached — so the placement never updated. Empirically confirmed headlessly: after a drag + `process_invalid_scopes()` + re-measure, `pending_layout=false`, `pending_draw=true`, and the content rect stayed at `x=0`.

**Fix**: translate the content via a `graphics_layer` resolver that re-reads the live offset on every draw pass — the same reactive channel zoom uses to follow the finger:
```rust
Modifier::empty().graphics_layer(move || GraphicsLayer {
    translation_x: controller.current_offset(),
    ..GraphicsLayer::default()
})
```
The content now follows 1:1 in real time; the existing spring settles on release (dismiss past threshold, spring back otherwise).

## Bug 2 — background reveal shown when it shouldn't
Library rows wrapped in `SwipeToDismiss` flashed the red "Move to bin" background during the row's entrance animation (content fades in with alpha < 1, revealing the always-drawn background).

**Root cause** (same file, old lines 456–461): the `with_background` content was composed and drawn unconditionally, regardless of offset or content alpha.

**Fix**: gate the background on a reactive `revealed` flag (`|offset| > 0`) **read inside the subcompose**. Conditional composition re-applies when the slot recomposes (unlike the placement-cached layout-offset), so at rest the background node is not composed at all and produces zero draw primitives. A plain bool recomposes only on rest↔displaced transitions rather than every drag frame; the settle watcher clears it once a spring-back returns to rest and keeps it set through a dismissal.

## Test evidence
- `crates/cranpose-ui/src/tests/swipe_to_dismiss_render_tests.rs` (new, full composition pipeline):
  - `dragging_translates_content_with_the_finger` — pumps pointer-move events and asserts the applied content offset (graphics-layer `translation_x`) tracks the accumulated drag 1:1 (0 → 20 → 120 → 80) before release, with no recomposition.
  - `background_only_draws_while_displaced` — asserts the background produces **no** draw primitives at offset 0 and **does** once displaced.
- `crates/cranpose-ui/src/tests/swipe_to_dismiss_tests.rs` (added): `background_reveal_tracks_displacement` (hides on spring-back to rest) and `background_reveal_stays_on_through_dismissal`.

Verification (all green):
- `cargo fmt --check` clean
- `cargo test -p cranpose-ui` (186) + `-p cranpose-foundation` (570); existing `swipe_to_dismiss_lazy` tests still pass
- `cargo test -p cranpose` incl. the 48 static guards
- `cargo check --workspace`
- `RUSTUP_TOOLCHAIN=stable cargo ndk --platform 26 -t arm64-v8a check -p cranpose --features android,renderer-wgpu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKmJDd6pG9opQHr7btBMke