### PR TITLE
Release 0.1.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cranpose"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "android-activity",
  "android_logger",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-animation"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-app-shell"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "arboard",
  "cranpose-core",
@@ -599,11 +599,11 @@ dependencies = [
 
 [[package]]
 name = "cranpose-assets"
-version = "0.1.35"
+version = "0.1.36"
 
 [[package]]
 name = "cranpose-core"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "ahash",
  "cranpose-macros",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-foundation"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-macros"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -640,14 +640,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-android"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "cranpose-ui-graphics",
 ]
 
 [[package]]
 name = "cranpose-platform-desktop-winit"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-web"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-common"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-pixels"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "cranpose-core",
  "cranpose-foundation",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-wgpu"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "bytemuck",
  "cranpose-app-shell",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-runtime-std"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "cranpose-core",
  "web-time",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-services"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-testing"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "cranpose",
  "cranpose-app-shell",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -772,14 +772,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui-graphics"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cranpose-ui-layout"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.35"
+version = "0.1.36"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/samoylenkodmitry/cranpose"
@@ -39,25 +39,25 @@ categories = ["gui"]
 [workspace.dependencies]
 # Force android-activity to use native-activity feature across all workspace crates
 android-activity = { version = "0.6", features = ["native-activity"] }
-cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.35" }
-cranpose = { path = "crates/cranpose", version = "0.1.35", default-features = false }
-cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.35" }
-cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.35" }
-cranpose-core = { path = "crates/cranpose-core", version = "0.1.35" }
-cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.35" }
-cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.35" }
-cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.35" }
-cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.35", default-features = false }
-cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.35" }
-cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.35", default-features = false }
-cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.35" }
-cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.35" }
-cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.35" }
-cranpose-services = { path = "crates/cranpose-services", version = "0.1.35", default-features = false }
-cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.35" }
-cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.35" }
-cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.35" }
-cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.35" }
+cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.36" }
+cranpose = { path = "crates/cranpose", version = "0.1.36", default-features = false }
+cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.36" }
+cranpose-assets = { path = "crates/cranpose-assets", version = "0.1.36" }
+cranpose-core = { path = "crates/cranpose-core", version = "0.1.36" }
+cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.36" }
+cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.36" }
+cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.36" }
+cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.36", default-features = false }
+cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.36" }
+cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.36", default-features = false }
+cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.36" }
+cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.36" }
+cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.36" }
+cranpose-services = { path = "crates/cranpose-services", version = "0.1.36", default-features = false }
+cranpose-testing = { path = "crates/cranpose-testing", version = "0.1.36" }
+cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.36" }
+cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.36" }
+cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.36" }
 web-time = "1.1"
 
 [patch.crates-io]

--- a/apps/isolated-demo/Cargo.toml
+++ b/apps/isolated-demo/Cargo.toml
@@ -31,11 +31,11 @@ logging = ["dep:env_logger"]
 [dependencies]
 # Default features stay on: the isolated demo ships no fonts of its own and
 # renders text through the framework's embedded fallback font.
-cranpose = { version = "0.1.35" }
+cranpose = { version = "0.1.36" }
 log = "0.4"
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-logger = { version = "0.2", optional = true }
-cranpose-core = "0.1.35"
+cranpose-core = "0.1.36"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = { version = "0.11", optional = true }


### PR DESCRIPTION
Version bump to 0.1.36.

Carries:
- #308 SwipeToDismiss drag-follow + background fix (already on main)
- #309 native text selection: overlay Popup, touch cursor/selection handles, contextual Copy/Cut/Paste/Select-all menu, IME setSelection

Bump: workspace.package + all `cranpose*` workspace.dependencies + all `cranpose*` in Cargo.lock + apps/isolated-demo (cranpose, cranpose-core) → 0.1.36. `check_cranpose_versions.py` aligned at 0.1.36; `cargo check --workspace` clean.