### PR TITLE
Fix SwipeToDismiss red strip, Android touch handles, caret blink on cursor scrub

### DIFF
--- a/crates/cranpose-ui/src/tests/swipe_to_dismiss_render_tests.rs
+++ b/crates/cranpose-ui/src/tests/swipe_to_dismiss_render_tests.rs
@@ -139,6 +139,15 @@ fn move_to(x: f32) -> PointerEvent {
     PointerEvent::new(PointerEventKind::Move, p, p)
 }
 
+fn up(x: f32) -> PointerEvent {
+    let p = Point { x, y: 24.0 };
+    PointerEvent::new(PointerEventKind::Up, p, p)
+}
+
+fn root_height(composition: &mut TestComposition, root: NodeId) -> f32 {
+    layout_tree(composition, root).root().rect.height
+}
+
 /// Bug 1: pumping pointer-move events moves the applied content offset 1:1 with
 /// the accumulated drag, in real time, before release — with no recomposition.
 #[test]
@@ -216,5 +225,52 @@ fn background_only_draws_while_displaced() {
     assert!(
         count_bin_primitives(&displaced) > 0,
         "background must draw while the row is displaced"
+    );
+}
+
+/// Bug 3: after a dismiss settles nothing may linger — no red "move to bin"
+/// strip and no empty row — regardless of when the host removes the item. The
+/// background stops drawing and the row collapses to zero height.
+#[test]
+fn dismissed_row_hides_background_and_collapses_to_zero_height() {
+    let mut composition = compose_row(true);
+    let root = composition.root().expect("root");
+    measure_row(&mut composition, root);
+    assert!(
+        (root_height(&mut composition, root) - 48.0).abs() < 1e-3,
+        "row starts at its natural 48px height"
+    );
+
+    let tree = layout_tree(&mut composition, root);
+    let handler = pointer_handler(&tree);
+
+    // Swipe past the dismiss threshold (0.5 * 320px width = 160px) and release.
+    handler(down(10.0));
+    handler(move_to(30.0)); // capture
+    handler(move_to(210.0)); // dx = 200 >= threshold
+    handler(up(210.0));
+
+    // Settle the fling and run the collapse animation to completion.
+    let handle = composition.runtime_handle();
+    let mut frame_time = 0u64;
+    for _ in 0..600 {
+        frame_time += 16_666_667;
+        composition.with_app_context(|| handle.drain_frame_callbacks(frame_time));
+    }
+    composition
+        .process_invalid_scopes()
+        .expect("recompose after the dismiss settles");
+    measure_row(&mut composition, root);
+
+    let settled = layout_tree(&mut composition, root);
+    assert_eq!(
+        count_bin_primitives(&settled),
+        0,
+        "no red background strip may linger after a dismiss"
+    );
+    assert!(
+        settled.root().rect.height <= 0.5,
+        "the dismissed row must collapse to zero height, got {}",
+        settled.root().rect.height
     );
 }

--- a/crates/cranpose-ui/src/tests/swipe_to_dismiss_tests.rs
+++ b/crates/cranpose-ui/src/tests/swipe_to_dismiss_tests.rs
@@ -41,6 +41,9 @@ fn cancel() -> PointerEvent {
 }
 
 struct Harness {
+    // The collapse watcher requests render/layout invalidation, which needs an
+    // active app context; keep one alive for the whole harness.
+    _app_context: crate::render_state::TestAppContextScope,
     _runtime: Runtime,
     controller: Rc<SwipeToDismissController>,
     dismiss_count: Rc<Cell<usize>>,
@@ -49,6 +52,7 @@ struct Harness {
 
 impl Harness {
     fn new(width: f32, threshold_fraction: f32) -> Self {
+        let app_context = crate::render_state::app_context_test_scope();
         let runtime = Runtime::new(std::sync::Arc::new(DefaultScheduler));
         let controller = SwipeToDismissController::new(runtime.handle());
         controller.width_px.set(width);
@@ -61,6 +65,7 @@ impl Harness {
         }));
 
         Self {
+            _app_context: app_context,
             _runtime: runtime,
             controller,
             dismiss_count,
@@ -79,6 +84,11 @@ impl Harness {
     /// Non-reactive read of the background-reveal flag driven by the gesture.
     fn revealed(&self) -> bool {
         self.controller.revealed.get_non_reactive()
+    }
+
+    /// Current row height scale (`1.0` at rest, `0.0` fully collapsed).
+    fn collapse(&self) -> f32 {
+        self.controller.collapse_fraction()
     }
 
     /// Advances the frame clock, driving springs and the settle watcher.
@@ -307,18 +317,30 @@ fn background_reveal_tracks_displacement() {
 }
 
 #[test]
-fn background_reveal_stays_on_through_dismissal() {
+fn dismiss_hides_background_and_collapses_row() {
     let mut harness = Harness::new(200.0, 0.5);
+    assert_eq!(harness.collapse(), 1.0, "row starts at full height");
+
     harness.send(&down(10.0, 10.0));
     harness.send(&move_to(30.0, 10.0));
     harness.send(&move_to(140.0, 10.0)); // offset 130 >= threshold 100
+    assert!(harness.revealed(), "background revealed while displaced");
     harness.send(&up(140.0, 10.0));
     harness.pump_frames(300);
 
+    // The dismiss fired exactly once and the row has fully settled: the
+    // background is no longer drawn (nothing to leave a red strip) and the row
+    // has collapsed to zero height (no lingering gap) regardless of when the
+    // host removes the item.
     assert_eq!(harness.dismiss_count.get(), 1);
     assert!(
-        harness.revealed(),
-        "background stays revealed while the dismissed row rests off-screen"
+        !harness.revealed(),
+        "background must be hidden after a dismiss settles, not left as a strip"
+    );
+    assert!(
+        harness.collapse() <= 0.01,
+        "row must collapse to zero height after a dismiss, got scale {}",
+        harness.collapse()
     );
 }
 

--- a/crates/cranpose-ui/src/text_field_handler.rs
+++ b/crates/cranpose-ui/src/text_field_handler.rs
@@ -206,6 +206,13 @@ impl crate::text_field_focus::FocusedTextFieldHandler for TextFieldHandler {
         let end = floor_char_boundary(&text, start_bytes.max(end_bytes));
         self.state
             .set_selection(cranpose_foundation::text::TextRange::new(start, end));
+        // Moving the caret counts as activity: snap it solid and restart the
+        // blink timer so the caret stays visible while it is actively scrubbing
+        // (spacebar-swipe / arrow scrub) and only resumes blinking once the
+        // movement stops (standard IME behavior). The key-driven scrub path
+        // already resets via `on_text_mutated`; this covers the IME
+        // `setSelection` path that never touches the text.
+        crate::cursor_animation::reset_cursor_blink();
         crate::request_render_invalidation();
     }
 
@@ -381,6 +388,38 @@ mod tests {
 
             // Scrubbing the cursor must never change the text.
             assert_eq!(state.text(), "hello");
+            text_field_focus::clear_focus();
+        });
+    }
+
+    /// A cursor move via `setSelection` (Gboard spacebar-swipe / arrow scrub)
+    /// must snap the blinking caret solid and restart the blink timer, so the
+    /// caret stays visible while the cursor is actively moving and only resumes
+    /// blinking once movement stops. Without this the caret keeps blinking
+    /// mid-scrub.
+    #[test]
+    fn cursor_move_via_set_selection_resets_blink_to_solid() {
+        use crate::cursor_animation::{is_cursor_visible, start_cursor_blink, BLINK_INTERVAL_MS};
+        let _app_context = crate::render_state::app_context_test_scope();
+        with_test_runtime(|| {
+            let (state, _focus) = focused_state("hello world", TextFieldLineLimits::SingleLine);
+            state.edit(|buffer| buffer.place_cursor_at_end());
+
+            // Start blinking, then advance one full interval so the caret is in
+            // its hidden phase (actively blinking).
+            start_cursor_blink();
+            let hidden_at =
+                web_time::Instant::now() + std::time::Duration::from_millis(BLINK_INTERVAL_MS + 1);
+            crate::render_state::with_cursor_animation(|state| state.tick(hidden_at));
+            assert!(!is_cursor_visible(), "caret should be hidden mid-blink");
+
+            // Scrub the caret via the IME setSelection path.
+            assert!(text_field_focus::dispatch_ime_set_selection(2, 2));
+            assert!(
+                is_cursor_visible(),
+                "a cursor-move must reset the blink phase to solid (visible)"
+            );
+
             text_field_focus::clear_focus();
         });
     }

--- a/crates/cranpose-ui/src/text_field_modifier_node.rs
+++ b/crates/cranpose-ui/src/text_field_modifier_node.rs
@@ -1320,6 +1320,76 @@ mod tests {
         });
     }
 
+    /// End-to-end guard for the touch-vs-mouse finger-handle pipeline through
+    /// the real pointer handler and draw closure: a Touch-source press makes the
+    /// focused field publish `touch = true` (so `SelectionHandles` shows the
+    /// finger cursor/selection handles and the Copy/Cut/Paste popup), while a
+    /// Mouse-source press publishes `touch = false` (a clean caret, no handles).
+    /// The published `touch` flag is exactly what the overlay is gated on, so
+    /// this pins the source → `last_pointer_source` → metrics link the Android
+    /// touch handles depend on.
+    #[test]
+    fn touch_press_publishes_touch_handle_metrics_but_mouse_does_not() {
+        use cranpose_foundation::{PointerEvent, PointerEventKind, PointerSource};
+        use cranpose_ui_graphics::Point;
+
+        let _app_context = crate::render_state::app_context_test_scope();
+        with_test_runtime(|| {
+            let state = TextFieldState::new("hello world");
+            let controller = TextFieldHandleController::new();
+            let node = TextFieldModifierNode::new(state.clone(), TextStyle::default())
+                .with_handle_controller(controller.clone());
+            // Give the field a measured size so the draw closure has geometry.
+            node.measured_size.set(Size {
+                width: 120.0,
+                height: 20.0,
+            });
+
+            let handler = node
+                .pointer_input_handler()
+                .expect("field exposes a pointer handler");
+            let draw = node
+                .create_draw_closure()
+                .expect("field exposes a draw closure");
+            let at = Point { x: 12.0, y: 8.0 };
+            let size = Size {
+                width: 120.0,
+                height: 20.0,
+            };
+
+            // Touch tap: the field focuses and remembers the touch source, so
+            // its draw closure publishes touch = true.
+            handler(
+                PointerEvent::new(PointerEventKind::Down, at, at).with_source(PointerSource::Touch),
+            );
+            let _ = draw(size);
+            let metrics = controller
+                .metrics()
+                .expect("focused field publishes handle metrics");
+            assert!(metrics.focused, "a tap focuses the field");
+            assert!(
+                metrics.touch,
+                "a touch tap must publish touch = true so the finger handles show"
+            );
+
+            // Mouse tap on the same field: the source flips to mouse, so the
+            // field publishes touch = false (clean caret, no finger handles).
+            handler(
+                PointerEvent::new(PointerEventKind::Down, at, at).with_source(PointerSource::Mouse),
+            );
+            let _ = draw(size);
+            let metrics = controller
+                .metrics()
+                .expect("focused field publishes handle metrics");
+            assert!(
+                !metrics.touch,
+                "a mouse tap must publish touch = false (clean caret, no finger handle)"
+            );
+
+            crate::text_field_focus::clear_focus();
+        });
+    }
+
     #[test]
     fn text_field_element_equality() {
         let _app_context = crate::render_state::app_context_test_scope();

--- a/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
+++ b/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
@@ -23,19 +23,27 @@
 
 use crate::composable;
 use crate::modifier::{GraphicsLayer, Modifier, PointerEvent, PointerEventKind};
+use crate::subcompose_layout::{Constraints, SubcomposeLayoutScope, SubcomposeMeasureScope};
 use crate::widgets::box_widget::{Box, BoxSpec};
-use crate::widgets::layout::BoxWithConstraints;
+use crate::widgets::layout::{BoxWithConstraints, SubcomposeLayout};
 use crate::widgets::scopes::BoxWithConstraintsScope;
 use cranpose_animation::{spring, Animatable, AnimationType, Spring};
 use cranpose_core::internal::FrameCallbackRegistration;
-use cranpose_core::{with_current_composer, Owned, OwnedMutableState, RuntimeHandle};
+use cranpose_core::{
+    with_current_composer, NodeId, Owned, OwnedMutableState, RuntimeHandle, SlotId,
+};
 use cranpose_foundation::DRAG_THRESHOLD;
+use cranpose_ui_layout::Placement;
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Offset (logical px) within which a dismiss animation counts as settled.
 const DISMISS_SETTLE_EPSILON: f32 = 0.5;
+
+/// Height-scale (fraction of the natural height) at or below which the
+/// post-dismiss collapse is considered complete.
+const COLLAPSE_SETTLE_EPSILON: f32 = 0.01;
 
 /// Spring used both for the dismissal fling and the spring-back.
 fn swipe_spring() -> AnimationType {
@@ -159,6 +167,11 @@ struct SwipeToDismissController {
     /// than on every drag frame. Without gating, the always-composed background
     /// flashes through content that fades in with alpha < 1 during an entrance.
     revealed: OwnedMutableState<bool>,
+    /// Height scale of the row (fraction of its natural height). `1.0` at rest;
+    /// after a successful dismiss it animates to `0.0` so the row collapses and
+    /// leaves no gap — and no red background strip — even if the host removes
+    /// the item a few frames later.
+    collapse: RefCell<Animatable<f32>>,
     phase: Cell<SwipePhase>,
     /// Content width in logical px, refreshed from the incoming constraints.
     width_px: Cell<f32>,
@@ -167,8 +180,13 @@ struct SwipeToDismissController {
     on_dismiss: RefCell<Option<Rc<dyn Fn()>>>,
     /// `on_dismiss` fired for the current dismissal (fires at most once).
     dismissed: Cell<bool>,
+    /// The row's layout node, so the collapse watcher can force a re-measure
+    /// each frame as the height shrinks. Set on every recomposition.
+    node_id: Cell<Option<NodeId>>,
     /// Frame callback watching the dismiss animation for completion.
     settle_watcher: RefCell<Option<FrameCallbackRegistration>>,
+    /// Frame callback driving the post-dismiss height collapse.
+    collapse_watcher: RefCell<Option<FrameCallbackRegistration>>,
 }
 
 impl SwipeToDismissController {
@@ -177,18 +195,26 @@ impl SwipeToDismissController {
             id: NEXT_SWIPE_ID.fetch_add(1, Ordering::Relaxed),
             offset: RefCell::new(Animatable::new(0.0, runtime.clone())),
             revealed: OwnedMutableState::with_runtime(false, runtime.clone()),
+            collapse: RefCell::new(Animatable::new(1.0, runtime.clone())),
             runtime,
             phase: Cell::new(SwipePhase::Idle),
             width_px: Cell::new(f32::NAN),
             threshold_fraction: Cell::new(0.5),
             on_dismiss: RefCell::new(None),
             dismissed: Cell::new(false),
+            node_id: Cell::new(None),
             settle_watcher: RefCell::new(None),
+            collapse_watcher: RefCell::new(None),
         })
     }
 
     fn current_offset(&self) -> f32 {
         self.offset.borrow().state().value()
+    }
+
+    /// Current row height scale (`1.0` at rest, `0.0` fully collapsed).
+    fn collapse_fraction(&self) -> f32 {
+        self.collapse.borrow().state().value()
     }
 
     /// Reactive read of the revealed flag; subscribes the reading scope (the
@@ -386,11 +412,17 @@ fn watch_settle(controller: &Rc<SwipeToDismissController>, dismissing: bool) {
                 let target = controller.offset.borrow().target();
                 let value = controller.current_offset();
                 if (value - target).abs() <= DISMISS_SETTLE_EPSILON {
-                    // The row has settled: reveal iff it rests displaced (a
-                    // dismissal rests off-screen, a spring-back rests at 0).
-                    controller.set_revealed(target != 0.0);
+                    // The row has settled. Stop drawing the background in every
+                    // case: a spring-back rests at 0 (nothing revealed), and a
+                    // dismissal must *not* leave the red strip behind while it
+                    // waits for the host to drop the item.
+                    controller.set_revealed(false);
                     if dismissing && !controller.dismissed.get() {
                         controller.dismissed.set(true);
+                        // Collapse the row to zero height so no empty gap (or
+                        // background strip) lingers if the host removes the item
+                        // a frame or two later, then notify the host.
+                        start_collapse(&controller);
                         let on_dismiss = controller.on_dismiss.borrow().clone();
                         if let Some(on_dismiss) = on_dismiss {
                             on_dismiss();
@@ -401,6 +433,42 @@ fn watch_settle(controller: &Rc<SwipeToDismissController>, dismissing: bool) {
                 }
             });
     *controller.settle_watcher.borrow_mut() = Some(registration);
+}
+
+/// Animates the row's height scale to `0.0` and watches the animation so the
+/// list re-measures the shrinking row each frame. Runs after a dismiss settles.
+fn start_collapse(controller: &Rc<SwipeToDismissController>) {
+    controller
+        .collapse
+        .borrow_mut()
+        .animateTo(0.0, swipe_spring());
+    watch_collapse(controller);
+}
+
+/// Frame-by-frame watcher for the post-dismiss collapse: the row height is a
+/// layout output, so a plain animated value would not reach the parent list on
+/// its own — each frame this forces a scoped re-measure of the row and a redraw
+/// until the height scale reaches zero.
+fn watch_collapse(controller: &Rc<SwipeToDismissController>) {
+    let weak = Rc::downgrade(controller);
+    let registration =
+        controller
+            .runtime
+            .frame_clock()
+            .with_frame_nanos(move |_frame_time_nanos| {
+                let Some(controller) = weak.upgrade() else {
+                    return;
+                };
+                controller.collapse_watcher.borrow_mut().take();
+                if let Some(node_id) = controller.node_id.get() {
+                    crate::schedule_layout_repass(node_id);
+                }
+                crate::request_render_invalidation();
+                if controller.collapse_fraction() > COLLAPSE_SETTLE_EPSILON {
+                    watch_collapse(&controller);
+                }
+            });
+    *controller.collapse_watcher.borrow_mut() = Some(registration);
 }
 
 /// Wraps `content` so it can be swiped away horizontally.
@@ -449,45 +517,96 @@ where
     // content slides away.
     let gesture_modifier = swipe_gesture_modifier(modifier, Rc::clone(&controller));
 
+    // Outer collapsing layout: it measures the row and reports the row's height
+    // scaled by the collapse fraction, so a dismissed row shrinks to nothing —
+    // even when the row has a fixed height. It carries no user modifier: the
+    // user modifier, the gesture handler and any fixed size stay on the *row*
+    // (below), so the hit region and layout still belong to the row while only
+    // the reported height is scaled here.
     let controller_for_layout = Rc::clone(&controller);
-    BoxWithConstraints(gesture_modifier, move |scope| {
-        controller_for_layout
-            .width_px
-            .set(scope.constraints().max_width);
+    let node = SubcomposeLayout(Modifier::empty(), move |scope, constraints| {
+        // Height scale for the post-dismiss collapse (1.0 until dismissed), read
+        // before measuring so the reported height tracks the animation.
+        let collapse = controller_for_layout.collapse_fraction().clamp(0.0, 1.0);
 
-        // Only draw the background while the row is displaced. Reading the
-        // reveal flag inside the subcompose subscribes this slot, so it
-        // recomposes when the row leaves/returns to rest. At rest (offset 0)
-        // the background is not composed at all, so it cannot flash through
-        // content that fades in with alpha < 1 during an entrance animation.
-        let revealed = controller_for_layout.revealed();
-        if revealed {
-            if let Some(background) = &background {
-                let background = Rc::clone(background);
-                Box(Modifier::empty(), BoxSpec::new(), move || {
-                    (background.borrow_mut())();
-                });
-            }
-        }
-
-        // Translate the content with the finger via a graphics-layer resolver.
-        // The resolver re-reads the live offset on every draw pass, and an
-        // offset write schedules a draw repass for this node, so the content
-        // follows the finger 1:1 in real time and settles with the spring on
-        // release — without needing a re-measure of the subcompose each frame.
+        let gesture_modifier = gesture_modifier.clone();
+        let background = background.clone();
         let content = Rc::clone(&content);
-        let controller_for_layer = Rc::clone(&controller_for_layout);
-        Box(
-            Modifier::empty().graphics_layer(move || GraphicsLayer {
-                translation_x: controller_for_layer.current_offset(),
-                ..GraphicsLayer::default()
-            }),
-            BoxSpec::new(),
-            move || {
-                (content.borrow_mut())();
-            },
-        );
-    })
+        let controller_for_row = Rc::clone(&controller_for_layout);
+        let measurables = scope.subcompose(SlotId::new(0), move || {
+            // The row itself: a `BoxWithConstraints` (so it can read its own
+            // width for the dismiss threshold) carrying the user modifier + the
+            // swipe pointer handler, overlaying the optional background and the
+            // finger-translated content.
+            let background = background.clone();
+            let content = Rc::clone(&content);
+            let controller_for_row = Rc::clone(&controller_for_row);
+            BoxWithConstraints(gesture_modifier.clone(), move |row_scope| {
+                controller_for_row
+                    .width_px
+                    .set(row_scope.constraints().max_width);
+
+                // Only compose the background while the row is displaced (and
+                // never once dismissed — the reveal flag is cleared on settle).
+                // Reading it inside the subcompose subscribes this slot, so it
+                // recomposes when the row leaves/returns to rest. At rest the
+                // background is not composed at all, so it cannot flash through
+                // content that fades in with alpha < 1 during an entrance.
+                if controller_for_row.revealed() {
+                    if let Some(background) = &background {
+                        let background = Rc::clone(background);
+                        Box(Modifier::empty(), BoxSpec::new(), move || {
+                            (background.borrow_mut())();
+                        });
+                    }
+                }
+
+                // Translate the content with the finger via a graphics-layer
+                // resolver. The resolver re-reads the live offset on every draw
+                // pass, and an offset write schedules a draw repass for this
+                // node, so the content follows the finger 1:1 in real time and
+                // settles with the spring on release — without re-measuring the
+                // subcompose each frame.
+                let content = Rc::clone(&content);
+                let controller_for_layer = Rc::clone(&controller_for_row);
+                Box(
+                    Modifier::empty().graphics_layer(move || GraphicsLayer {
+                        translation_x: controller_for_layer.current_offset(),
+                        ..GraphicsLayer::default()
+                    }),
+                    BoxSpec::new(),
+                    move || {
+                        (content.borrow_mut())();
+                    },
+                );
+            });
+        });
+
+        let child_constraints = Constraints {
+            min_width: constraints.min_width,
+            max_width: constraints.max_width,
+            min_height: 0.0,
+            max_height: constraints.max_height,
+        };
+        let mut width = 0.0_f32;
+        let mut natural_height = 0.0_f32;
+        let mut placements = Vec::with_capacity(measurables.len());
+        for measurable in measurables {
+            let placeable = scope.measure(measurable, child_constraints);
+            width = width.max(placeable.width());
+            natural_height = natural_height.max(placeable.height());
+            placeable.place(0.0, 0.0);
+            placements.push(Placement::new(placeable.node_id(), 0.0, 0.0, 0));
+        }
+        width = width.clamp(constraints.min_width, constraints.max_width);
+        // Collapse the row height after a dismiss so the slot shrinks to
+        // nothing: the content is already translated off-screen and the
+        // background hidden, so scaling the reported height just closes the gap.
+        let height = (natural_height * collapse).clamp(0.0, constraints.max_height);
+        scope.layout(width, height, placements)
+    });
+    controller.node_id.set(Some(node));
+    node
 }
 
 #[cfg(test)]

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -78,16 +78,34 @@ fn android_event_time_ms(event_time_ns: i64) -> i64 {
     event_time_ns / 1_000_000
 }
 
-/// Maps an Android `MotionEvent` pointer tool type onto the framework
-/// [`PointerSource`] so text fields can show finger handles only for touch.
-fn android_pointer_source(pointer: &android_activity::input::Pointer<'_>) -> PointerSource {
-    use android_activity::input::ToolType;
-    match pointer.tool_type() {
-        ToolType::Finger => PointerSource::Touch,
-        ToolType::Mouse => PointerSource::Mouse,
-        ToolType::Stylus | ToolType::Eraser => PointerSource::Stylus,
-        _ => PointerSource::Unknown,
-    }
+/// Maps an Android `MotionEvent` pointer onto the framework [`PointerSource`]
+/// so text fields can show finger handles only for touch/stylus input.
+///
+/// The per-pointer tool type is the most specific signal, but many devices and
+/// the Android emulator report `TOOL_TYPE_UNKNOWN` for genuine finger touches;
+/// in that case the whole-event input source class (`getSource`) is consulted
+/// so a touchscreen press is still stamped [`PointerSource::Touch`]. Without
+/// this fallback the finger selection/cursor handles (touch-only) never appear.
+fn android_pointer_source(
+    pointer: &android_activity::input::Pointer<'_>,
+    event_source: android_activity::input::Source,
+) -> PointerSource {
+    use crate::android_input::{resolve_pointer_source, AndroidSourceKind, AndroidToolKind};
+    use android_activity::input::{Source, ToolType};
+
+    let tool = match pointer.tool_type() {
+        ToolType::Finger => AndroidToolKind::Finger,
+        ToolType::Mouse => AndroidToolKind::Mouse,
+        ToolType::Stylus | ToolType::Eraser => AndroidToolKind::Stylus,
+        _ => AndroidToolKind::Indeterminate,
+    };
+    let source = match event_source {
+        Source::Touchscreen => AndroidSourceKind::Touchscreen,
+        Source::Stylus | Source::BluetoothStylus => AndroidSourceKind::Stylus,
+        Source::Mouse | Source::MouseRelative => AndroidSourceKind::Mouse,
+        _ => AndroidSourceKind::Other,
+    };
+    resolve_pointer_source(tool, source)
 }
 
 /// Translates one Android `KeyEvent` into a pending framework key event.
@@ -230,6 +248,9 @@ fn push_pending_inputs_from_android_event(
     };
 
     let time_ms = Some(android_event_time_ms(motion_event.event_time()));
+    // The whole-event input source class; used to recover a touch classification
+    // when the per-pointer tool type is unreported (see `android_pointer_source`).
+    let event_source = motion_event.source();
     let logical_of = |x: f32, y: f32| {
         let logical = android_platform.pointer_position(x as f64, y as f64);
         (logical.x as f32, logical.y as f32)
@@ -244,7 +265,7 @@ fn push_pending_inputs_from_android_event(
                 x,
                 y,
                 time_ms,
-                android_pointer_source(&pointer),
+                android_pointer_source(&pointer, event_source),
             ));
             true
         }
@@ -283,7 +304,7 @@ fn push_pending_inputs_from_android_event(
                 x,
                 y,
                 time_ms,
-                android_pointer_source(&pointer),
+                android_pointer_source(&pointer, event_source),
             ));
             *primary_pointer_id = None;
             true
@@ -315,7 +336,7 @@ fn push_pending_inputs_from_android_event(
                     x,
                     y,
                     time_ms,
-                    android_pointer_source(&pointer),
+                    android_pointer_source(&pointer, event_source),
                 ));
                 *primary_pointer_id = None;
             } else {
@@ -332,7 +353,7 @@ fn push_pending_inputs_from_android_event(
             let primary = *primary_pointer_id;
             for pointer in motion_event.pointers() {
                 let is_primary = primary == Some(pointer.pointer_id());
-                let source = android_pointer_source(&pointer);
+                let source = android_pointer_source(&pointer, event_source);
                 if is_primary {
                     for historical in pointer.history() {
                         let (hx, hy) = logical_of(historical.x(), historical.y());

--- a/crates/cranpose/src/android_input.rs
+++ b/crates/cranpose/src/android_input.rs
@@ -1,0 +1,117 @@
+//! Host-testable classification of Android pointer device sources.
+//!
+//! An Android `MotionEvent` exposes both a per-pointer *tool type*
+//! (`getToolType`) and a whole-event input *source* class (`getSource`). The
+//! tool type is the most specific signal, but a number of devices and the
+//! Android emulator report `TOOL_TYPE_UNKNOWN` for genuine finger touches. When
+//! that happens the pointer must still be classified as touch (from the
+//! touchscreen source class) or the finger selection/cursor handles — which are
+//! only shown for touch/stylus input — never appear.
+//!
+//! The real `android_activity` `ToolType`/`Source` enums only exist on the
+//! android target, so this module works on small host-visible mirror enums and
+//! is exercised by ordinary unit tests. `android.rs` maps the platform enums
+//! onto these kinds at the boundary.
+
+use cranpose_app_shell::PointerSource;
+
+/// Per-pointer tool category, mirroring the `android_activity` `ToolType`
+/// variants that matter for source classification.
+#[cfg_attr(not(all(feature = "android", target_os = "android")), allow(dead_code))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AndroidToolKind {
+    Finger,
+    Mouse,
+    Stylus,
+    /// A tool type that does not by itself identify the device (Unknown, Palm,
+    /// or a variant added by a newer Android version).
+    Indeterminate,
+}
+
+/// Whole-event input source class, mirroring the `android_activity` `Source`
+/// variants that matter for source classification.
+#[cfg_attr(not(all(feature = "android", target_os = "android")), allow(dead_code))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AndroidSourceKind {
+    Touchscreen,
+    Stylus,
+    Mouse,
+    /// A source class that does not identify a direct pointing device.
+    Other,
+}
+
+/// Resolves an Android pointer's [`PointerSource`] from its tool type and the
+/// event's input source class.
+///
+/// The tool type wins when it identifies the device; otherwise the source class
+/// is consulted so a touchscreen press whose tool type is unreported is still
+/// treated as touch (the finger selection/cursor handles depend on it).
+#[cfg_attr(not(all(feature = "android", target_os = "android")), allow(dead_code))]
+pub(crate) fn resolve_pointer_source(
+    tool: AndroidToolKind,
+    source: AndroidSourceKind,
+) -> PointerSource {
+    match tool {
+        AndroidToolKind::Finger => PointerSource::Touch,
+        AndroidToolKind::Mouse => PointerSource::Mouse,
+        AndroidToolKind::Stylus => PointerSource::Stylus,
+        AndroidToolKind::Indeterminate => match source {
+            AndroidSourceKind::Touchscreen => PointerSource::Touch,
+            AndroidSourceKind::Stylus => PointerSource::Stylus,
+            AndroidSourceKind::Mouse => PointerSource::Mouse,
+            AndroidSourceKind::Other => PointerSource::Unknown,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_type_wins_when_it_identifies_the_device() {
+        assert_eq!(
+            resolve_pointer_source(AndroidToolKind::Finger, AndroidSourceKind::Mouse),
+            PointerSource::Touch
+        );
+        assert_eq!(
+            resolve_pointer_source(AndroidToolKind::Mouse, AndroidSourceKind::Touchscreen),
+            PointerSource::Mouse
+        );
+        assert_eq!(
+            resolve_pointer_source(AndroidToolKind::Stylus, AndroidSourceKind::Other),
+            PointerSource::Stylus
+        );
+    }
+
+    #[test]
+    fn unreported_tool_type_falls_back_to_touchscreen_source() {
+        // Regression guard: devices/emulators that report an unknown tool type
+        // for a finger must still classify as touch, or the finger
+        // selection/cursor handles (touch-only) never appear.
+        assert_eq!(
+            resolve_pointer_source(
+                AndroidToolKind::Indeterminate,
+                AndroidSourceKind::Touchscreen
+            ),
+            PointerSource::Touch
+        );
+        assert!(PointerSource::Touch.is_touch_like());
+    }
+
+    #[test]
+    fn unreported_tool_type_uses_the_source_class() {
+        assert_eq!(
+            resolve_pointer_source(AndroidToolKind::Indeterminate, AndroidSourceKind::Stylus),
+            PointerSource::Stylus
+        );
+        assert_eq!(
+            resolve_pointer_source(AndroidToolKind::Indeterminate, AndroidSourceKind::Mouse),
+            PointerSource::Mouse
+        );
+        assert_eq!(
+            resolve_pointer_source(AndroidToolKind::Indeterminate, AndroidSourceKind::Other),
+            PointerSource::Unknown
+        );
+    }
+}

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -9,6 +9,7 @@ mod android_file_picker;
 pub use android_file_picker::open_content_uri;
 #[cfg_attr(not(all(feature = "android", target_os = "android")), allow(dead_code))]
 mod android_host_window;
+mod android_input;
 #[cfg(all(feature = "android", target_os = "android"))]
 mod android_jni;
 #[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]


### PR DESCRIPTION
Three bugs the user found while testing the real Android app built on 0.1.36. Root-caused by code reading + headless/unit tests (no on-device testing). All framework-side.

## Bug 1 — SwipeToDismiss leaves a red "Move to bin" strip after dismissal
**Root cause:** After a successful dismiss the content animates off past the threshold, so `offset` rests at its dismissed extreme (`±width`), not 0. The recently-added `revealed` flag (background drawn while `|offset| > 0`) therefore stayed `true`, so the red background kept drawing as a strip until the host removed the item — and the emptied row also kept its full height, leaving a gap if the removal lagged a frame.

**Fix** (`crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs`):
- On settle, always clear the reveal flag (`set_revealed(false)`) — a dismissed row no longer leaves a strip, a spring-back still hides at rest.
- On dismiss completion, animate a new `collapse` height-scale (`1.0 → 0.0`) and report the row's height scaled by it, so the slot shrinks to nothing even if the host drops the item a few frames later. The scaling happens in an **outer** subcompose layer wrapping the row, so it also collapses **fixed-height** rows (an `.height(..)` on the row's own modifier can't defeat it). A frame-callback watcher forces a scoped re-measure each frame as the height shrinks.

**Test evidence:**
- `swipe_to_dismiss_tests::dismiss_hides_background_and_collapses_row` — after a dismiss settles, `revealed == false` and the collapse fraction reaches ~0.
- `swipe_to_dismiss_render_tests::dismissed_row_hides_background_and_collapses_to_zero_height` — full render pipeline: **zero** red background draw primitives remain and the row's laid-out height collapses to ~0.

## Bug 2 (most important) — selection handles + Copy/Cut/Paste menu invisible on Android
**Root cause — NOT the task's prime suspect.** The touch-source → handle pipeline is correct and already shipped in 0.1.36 (commit `31b7b938`, part of #309). Verified end-to-end in code: Android stamps the source, the shell threads it into the `Down` event (`.with_source`), the field records `last_pointer_source` on `Down` and its draw closure publishes `touch = last_pointer_source.is_touch_like()`, `PopupHost` is installed at the AppShell root (and the Android entry builds the shell via `AppShell::new_with_size_and_density`), and `SelectionHandles` renders the cursor/selection handles + menu when `focused && touch`. A **new end-to-end test proves this path passes** (`text_field_modifier_node::tests::touch_press_publishes_touch_handle_metrics_but_mouse_does_not`): a real Touch `Down` through the real pointer handler + draw closure publishes `touch = true`; a Mouse `Down` publishes `touch = false`.

**The real bug** is in the touch-source **classification**: `android_pointer_source` classified purely from the per-pointer `MotionEvent.getToolType()`. Many devices and the Android emulator report `TOOL_TYPE_UNKNOWN` for genuine finger touches → `PointerSource::Unknown` → `is_touch_like() == false` → the touch-only handles never appear. `getToolType()`'s effective "never stamps Touch" matches the reported symptom.

**Fix** (`crates/cranpose/src/android.rs` + new `crates/cranpose/src/android_input.rs`): when the tool type is indeterminate, fall back to the whole-event input source class (`MotionEvent.getSource()` — `SOURCE_TOUCHSCREEN` → `Touch`, stylus/mouse handled too). The decision is factored into a pure, host-testable `android_input::resolve_pointer_source` (the real `android_activity` enums only exist on the android target).

**Is the fix in-framework?** Yes — **fully in-framework**, no cranscan change required (cranscan uses `BasicTextField`, which gets the handles + `PopupHost` for free). Caveat: if a device/emulator genuinely reports the pointer as **mouse** (some emulators simulate touch as a mouse), the finger handles stay hidden **by design** (mouse keeps a clean caret) — that is an emulator/device input-source limitation, not a framework or app bug.

**Test evidence:**
- `android_input::tests::unreported_tool_type_falls_back_to_touchscreen_source` (+ `tool_type_wins_when_it_identifies_the_device`, `unreported_tool_type_uses_the_source_class`).
- `text_field_modifier_node::tests::touch_press_publishes_touch_handle_metrics_but_mouse_does_not` (end-to-end handle metrics).
- Existing `basic_text_field` render tests already prove `touch = true` → handle/menu draws, `touch = false` → none.

## Bug 3 — caret blinks during spacebar-swipe cursor scrub
**Root cause** (`crates/cranpose-ui/src/text_field_handler.rs`): the key-driven scrub path (arrow / `KEYCODE_DPAD_*`) already reset the blink via `on_text_mutated → reset_cursor_blink`, but the modern Gboard spacebar-swipe path — IME `setSelection` → `TextFieldHandler::set_selection` — only invalidated render and never reset the blink, so the caret kept blinking mid-scrub.

**Fix:** `set_selection` now calls `reset_cursor_blink()`, snapping the caret solid and restarting the timer, so it stays visible while actively moving and resumes blinking shortly after movement stops (standard IME behavior).

**Test evidence:** `text_field_handler::tests::cursor_move_via_set_selection_resets_blink_to_solid` — after ticking the caret into its hidden phase, an IME `setSelection` cursor-move flips it back to visible.

## Verification
- `cargo fmt --check` clean.
- `cargo test -p cranpose-ui -p cranpose-foundation -p cranpose -p cranpose-app-shell` green, including the **48 static guards** (`platform_scheduling_static.rs`).
- `cargo check --workspace` clean.
- Android: `RUSTUP_TOOLCHAIN=stable cargo ndk --platform 26 -t arm64-v8a check -p cranpose --features android,renderer-wgpu` (NDK 28.2.13676358) — passes (compiles the `android.rs` + `android_input` changes for `aarch64-linux-android`).
- wasm: `cranpose-ui` (holds the swipe + text-field changes) checks clean for `wasm32-unknown-unknown`. The full `cargo check -p cranpose --target wasm32-unknown-unknown` is blocked by a **pre-existing** `getrandom 0.3.4` `wasm_js`-feature config gap that fails **identically on unmodified `origin/main` HEAD** — unrelated to this change (my diff adds no wasm/getrandom code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKmJDd6pG9opQHr7btBMke