### PR TITLE
Round 9 input fixes: subcompose CompositionLocals, IME insets, SwipeToDismiss direction+collapse

### DIFF
--- a/crates/cranpose-app-shell/src/lib.rs
+++ b/crates/cranpose-app-shell/src/lib.rs
@@ -642,6 +642,7 @@ where
             || peek_focus_invalidation()
             || peek_layout_invalidation()
             || cranpose_ui::has_pending_layout_repasses()
+            || cranpose_ui::has_pending_measure_repasses()
             || cranpose_ui::has_pending_draw_repasses()
             || has_pending_pointer_repasses()
             || has_pending_focus_invalidations()

--- a/crates/cranpose-app-shell/src/shell_frame.rs
+++ b/crates/cranpose-app-shell/src/shell_frame.rs
@@ -167,8 +167,11 @@ where
     }
 
     fn run_layout_phase_in_context(&mut self) {
-        let has_scoped_repasses = cranpose_ui::has_pending_layout_repasses();
-        let scoped_layout_nodes = if has_scoped_repasses {
+        // Both scoped layout repasses (re-placement) and scoped measure repasses
+        // (re-sizing, e.g. a collapsing swipe-dismissed row) drive a layout pass.
+        let has_scoped_repasses = cranpose_ui::has_pending_layout_repasses()
+            || cranpose_ui::has_pending_measure_repasses();
+        let scoped_layout_nodes = if cranpose_ui::has_pending_layout_repasses() {
             cranpose_ui::pending_layout_repass_nodes_snapshot()
         } else {
             Vec::new()

--- a/crates/cranpose-core/src/composer.rs
+++ b/crates/cranpose-core/src/composer.rs
@@ -457,6 +457,12 @@ pub(crate) struct ComposerCore {
     pub(crate) _not_send: PhantomData<*const ()>,
 }
 
+/// An opaque snapshot of the composition-local values in scope at the point it
+/// was captured (see [`Composer::capture_composition_locals`]). Cheap to clone
+/// (an `Rc` internally); replayed by [`Composer::subcompose_slot_with_locals`].
+#[derive(Clone)]
+pub struct CapturedCompositionLocals(LocalStackSnapshot);
+
 fn take_subcompose_frame(core: &ComposerCore, operation: &str) -> SubcomposeFrame {
     match core.subcompose_stack.borrow_mut().pop() {
         Some(frame) => frame,
@@ -1504,6 +1510,21 @@ impl Composer {
         Ok(result)
     }
 
+    /// Captures the composition-local values in scope at the current point of
+    /// composition, as an opaque snapshot that can later be replayed with
+    /// [`Composer::subcompose_slot_with_locals`].
+    ///
+    /// A `SubcomposeLayout` captures this while it is being composed and replays
+    /// it while subcomposing off the measure pass, so content that is
+    /// subcomposed during layout observes the same composition locals as the
+    /// `SubcomposeLayout` call site — matching Jetpack Compose, where a
+    /// subcomposition inherits the composition locals of the layout that
+    /// created it rather than whatever happens to be in scope during measure
+    /// (which, after composition unwinds, no longer carries ancestor providers).
+    pub fn capture_composition_locals(&self) -> CapturedCompositionLocals {
+        CapturedCompositionLocals(self.current_local_stack())
+    }
+
     /// Subcomposes content using an isolated SlotsHost without resetting it.
     /// Unlike `subcompose_in`, this preserves existing slot state across calls,
     /// allowing efficient reuse during measurement passes. This is critical for
@@ -1514,9 +1535,26 @@ impl Composer {
         root: Option<NodeId>,
         f: impl FnOnce(&Composer) -> R,
     ) -> Result<(R, Vec<RecomposeScope>), NodeError> {
+        self.subcompose_slot_with_locals(slots, root, None, f)
+    }
+
+    /// Like [`Composer::subcompose_slot`], but seeds the subcomposition with a
+    /// composition-local snapshot captured earlier (see
+    /// [`Composer::capture_composition_locals`]). When `locals` is `None` the
+    /// locals in scope right now are used, preserving the plain behavior.
+    pub fn subcompose_slot_with_locals<R>(
+        &self,
+        slots: &Rc<SlotsHost>,
+        root: Option<NodeId>,
+        locals: Option<&CapturedCompositionLocals>,
+        f: impl FnOnce(&Composer) -> R,
+    ) -> Result<(R, Vec<RecomposeScope>), NodeError> {
         let runtime_handle = self.runtime_handle();
         let phase = self.phase();
-        let locals = self.current_local_stack();
+        let locals = match locals {
+            Some(captured) => captured.0.clone(),
+            None => self.current_local_stack(),
+        };
         let shared_state = slots
             .runtime_state()
             .unwrap_or_else(|| Rc::clone(&self.core.shared_state));

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -35,7 +35,7 @@ pub mod internal {
     pub use crate::frame_clock::{FrameCallbackRegistration, FrameClock};
 }
 pub use callbacks::{CallbackHolder, CallbackHolder1, ParamSlot, ParamState, ReturnSlot};
-pub use composer::{Composer, ValueSlotHandle};
+pub use composer::{CapturedCompositionLocals, Composer, ValueSlotHandle};
 pub(crate) use composer::{ComposerCore, EmittedNode, ParentAttachMode, ParentFrame};
 pub use composition::{Composition, ROOT_RENDER_REPLAY_LIMIT};
 pub use composition_locals::{

--- a/crates/cranpose-ui/src/layout/mod.rs
+++ b/crates/cranpose-ui/src/layout/mod.rs
@@ -1068,9 +1068,15 @@ fn process_pending_layout_repasses(
             }
         }
     }
+    // Measure repasses re-*size* a subtree (and its ancestors), so an enclosing
+    // LazyColumn re-measures the node instead of reusing its cached item slot.
+    let measure_repass_nodes = crate::take_measure_repass_nodes();
     let repass_nodes = crate::take_layout_repass_nodes();
-    if repass_nodes.is_empty() {
+    if measure_repass_nodes.is_empty() && repass_nodes.is_empty() {
         return Ok(());
+    }
+    for node_id in measure_repass_nodes {
+        cranpose_core::bubble_measure_dirty(applier as &mut dyn Applier, node_id);
     }
     for node_id in repass_nodes {
         cranpose_core::bubble_layout_dirty(applier as &mut dyn Applier, node_id);

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -65,7 +65,7 @@ pub use interaction::{
     MutableInteractionSource, PressInteraction, PressInteractionCancel, PressInteractionPress,
     PressInteractionRelease,
 };
-pub use safe_area::local_safe_area_insets;
+pub use safe_area::{local_ime_insets, local_safe_area_insets};
 // Re-export FocusManager from cranpose-foundation to avoid duplication
 pub use cranpose_foundation::nodes::input::focus::FocusManager;
 pub use cranpose_foundation::{
@@ -118,12 +118,13 @@ pub use render_state::reset_render_state_for_tests;
 pub use render_state::{
     clear_transient_scroll_motion_contexts, current_density, debug_last_fling_velocity,
     debug_reset_last_fling_velocity, has_current_app_context, has_pending_draw_repasses,
-    has_pending_layout_repasses, peek_focus_invalidation, peek_layout_invalidation,
-    peek_pointer_invalidation, peek_render_invalidation, pending_layout_repass_nodes_snapshot,
-    request_focus_invalidation, request_layout_invalidation, request_pointer_invalidation,
-    request_render_invalidation, schedule_draw_repass, schedule_layout_repass, set_density,
-    take_draw_repass_nodes, take_focus_invalidation, take_layout_invalidation,
-    take_layout_repass_nodes, take_pointer_invalidation, take_render_invalidation, AppContext,
+    has_pending_layout_repasses, has_pending_measure_repasses, peek_focus_invalidation,
+    peek_layout_invalidation, peek_pointer_invalidation, peek_render_invalidation,
+    pending_layout_repass_nodes_snapshot, request_focus_invalidation, request_layout_invalidation,
+    request_pointer_invalidation, request_render_invalidation, schedule_draw_repass,
+    schedule_layout_repass, schedule_measure_repass, set_density, take_draw_repass_nodes,
+    take_focus_invalidation, take_layout_invalidation, take_layout_repass_nodes,
+    take_measure_repass_nodes, take_pointer_invalidation, take_render_invalidation, AppContext,
     AppContextScope,
 };
 pub use renderer::{HeadlessRenderer, PaintLayer, RecordedRenderScene, RenderOp};
@@ -150,7 +151,7 @@ pub use text_modifier_node::{TextModifierElement, TextModifierNode};
 pub use widgets::clickable_text::ClickableText;
 pub use widgets::lazy_list::{LazyColumn, LazyColumnSpec, LazyRow, LazyRowSpec};
 pub use widgets::linked_text::LinkedText;
-pub use widgets::swipe_to_dismiss::{SwipeToDismiss, SwipeToDismissSpec};
+pub use widgets::swipe_to_dismiss::{SwipeDismissSide, SwipeToDismiss, SwipeToDismissSpec};
 
 // Debug utilities
 pub use debug::{

--- a/crates/cranpose-ui/src/render_state.rs
+++ b/crates/cranpose-ui/src/render_state.rs
@@ -12,6 +12,12 @@ pub(crate) type ModifierChainTraceCallback =
 
 struct RenderState {
     layout_repasses: Mutex<LayoutRepassManager>,
+    /// Scoped re-*measure* requests (see [`schedule_measure_repass`]). Unlike
+    /// `layout_repasses`, processing these bubbles *measure* dirtiness up the
+    /// tree so a subtree is re-measured (not just re-placed) — needed when a
+    /// node's own size changes off a frame callback (e.g. a collapsing row) and
+    /// an ancestor `LazyColumn` would otherwise reuse its cached item slot.
+    measure_repasses: Mutex<LayoutRepassManager>,
     draw_repasses: Mutex<DrawRepassManager>,
     modifier_slice_repasses: Mutex<LayoutRepassManager>,
     render_invalidated: AtomicBool,
@@ -99,6 +105,7 @@ impl RenderState {
     fn new_with_density(density: f32) -> Self {
         Self {
             layout_repasses: Mutex::new(LayoutRepassManager::new()),
+            measure_repasses: Mutex::new(LayoutRepassManager::new()),
             draw_repasses: Mutex::new(DrawRepassManager::new()),
             modifier_slice_repasses: Mutex::new(LayoutRepassManager::new()),
             render_invalidated: AtomicBool::new(false),
@@ -689,6 +696,34 @@ pub fn pending_layout_repass_nodes_snapshot() -> Vec<NodeId> {
 /// The caller should iterate over these and call `bubble_layout_dirty` for each.
 pub fn take_layout_repass_nodes() -> Vec<NodeId> {
     with_render_state(|state| lock_repass_manager(&state.layout_repasses).take_dirty_nodes())
+}
+
+/// Schedules a scoped re-*measure* of `node_id` on the next frame.
+///
+/// Like [`schedule_layout_repass`], but processing bubbles *measure* dirtiness
+/// (not just layout/placement) up the tree, so the node and its ancestors are
+/// re-measured. Use this when a node's own measured size changes off a frame
+/// callback (e.g. a row collapsing after a swipe dismiss): a plain layout
+/// repass would leave the node's `needs_measure` flag unset, and an enclosing
+/// `LazyColumn` would reuse its cached, full-height item slot.
+pub fn schedule_measure_repass(node_id: NodeId) {
+    with_render_state(|state| {
+        lock_repass_manager(&state.measure_repasses).schedule_repass(node_id);
+        state.layout_invalidated.store(true, Ordering::Relaxed);
+    });
+    request_render_invalidation();
+}
+
+/// Returns true if any measure repasses are pending.
+pub fn has_pending_measure_repasses() -> bool {
+    with_render_state(|state| lock_repass_manager(&state.measure_repasses).has_pending_repass())
+}
+
+/// Takes all pending measure repass node IDs.
+///
+/// The caller should iterate over these and call `bubble_measure_dirty` for each.
+pub fn take_measure_repass_nodes() -> Vec<NodeId> {
+    with_render_state(|state| lock_repass_manager(&state.measure_repasses).take_dirty_nodes())
 }
 
 pub(crate) fn take_modifier_slice_repass_nodes() -> Vec<NodeId> {

--- a/crates/cranpose-ui/src/safe_area.rs
+++ b/crates/cranpose-ui/src/safe_area.rs
@@ -26,9 +26,32 @@ pub fn local_safe_area_insets() -> CompositionLocal<EdgeInsets> {
     })
 }
 
+/// CompositionLocal carrying the on-screen soft-keyboard (IME) insets in logical
+/// pixels. The `bottom` field is the height the keyboard currently covers at the
+/// bottom of the window (zero when it is hidden); the other edges are zero.
+///
+/// Mobile backends update this as the keyboard animates in and out so an
+/// application can keep the focused field visible — for example by adding
+/// `bottom` to a scroll container's bottom padding, or scrolling the caret into
+/// view. It defaults to [`EdgeInsets::default`] (zero), so desktop and web
+/// compositions (and mobile frames with no keyboard) are unaffected.
+///
+/// Like [`local_safe_area_insets`], the same `CompositionLocal` instance is
+/// returned on every call (cached per thread).
+pub fn local_ime_insets() -> CompositionLocal<EdgeInsets> {
+    thread_local! {
+        static LOCAL: RefCell<Option<CompositionLocal<EdgeInsets>>> = const { RefCell::new(None) };
+    }
+    LOCAL.with(|cell| {
+        cell.borrow_mut()
+            .get_or_insert_with(|| compositionLocalOf(EdgeInsets::default))
+            .clone()
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::local_safe_area_insets;
+    use super::{local_ime_insets, local_safe_area_insets};
     use cranpose_ui_graphics::EdgeInsets;
 
     #[test]
@@ -40,8 +63,16 @@ mod tests {
     }
 
     #[test]
+    fn ime_insets_default_to_zero() {
+        assert_eq!(local_ime_insets().default_value(), EdgeInsets::default());
+    }
+
+    #[test]
     fn returns_one_shared_local_per_thread() {
         // `CompositionLocal` is not `Debug`, so compare with `==` directly.
         assert!(local_safe_area_insets() == local_safe_area_insets());
+        assert!(local_ime_insets() == local_ime_insets());
+        // The IME local is distinct from the safe-area local.
+        assert!(local_ime_insets() != local_safe_area_insets());
     }
 }

--- a/crates/cranpose-ui/src/subcompose_layout.rs
+++ b/crates/cranpose-ui/src/subcompose_layout.rs
@@ -772,6 +772,12 @@ impl SubcomposeLayoutNode {
         self.invalidate_subcomposition();
     }
 
+    /// Records the composition locals in scope where the `SubcomposeLayout` was
+    /// composed, so they can be replayed during the measure-pass subcomposition.
+    pub fn set_captured_locals(&mut self, locals: cranpose_core::CapturedCompositionLocals) {
+        self.inner.borrow_mut().captured_locals = Some(locals);
+    }
+
     pub fn set_modifier(&mut self, modifier: Modifier) {
         // Capture capabilities BEFORE updating to detect removed modifiers
         let prev_caps = self.modifier_capabilities();
@@ -1286,13 +1292,20 @@ impl SubcomposeLayoutNodeHandle {
             retained_measure_registrar,
             error,
         } = callbacks;
-        let (policy, mut state, slots_host, placement_scratch) = {
+        let (policy, mut state, slots_host, placement_scratch, captured_locals) = {
             let mut inner = self.inner.borrow_mut();
             let policy = Rc::clone(&inner.measure_policy);
             let state = std::mem::take(&mut inner.state);
             let slots_host = Rc::clone(&inner.slots);
             let placement_scratch = std::mem::take(&mut inner.placement_scratch);
-            (policy, state, slots_host, placement_scratch)
+            let captured_locals = inner.captured_locals.clone();
+            (
+                policy,
+                state,
+                slots_host,
+                placement_scratch,
+                captured_locals,
+            )
         };
         state.begin_pass();
 
@@ -1310,8 +1323,11 @@ impl SubcomposeLayoutNodeHandle {
         //
         // Reference: LazyLayoutMeasureScope.subcompose() in JC reuses existing slots by key,
         // and SubcomposeLayoutState holds `slotIdToNode` map across measurements.
-        let ((result, placement_scratch), _) =
-            composer.subcompose_slot(&slots_host, Some(node_id), |inner_composer| {
+        let ((result, placement_scratch), _) = composer.subcompose_slot_with_locals(
+            &slots_host,
+            Some(node_id),
+            captured_locals.as_ref(),
+            |inner_composer| {
                 let mut scope = SubcomposeMeasureScopeImpl::new(SubcomposeMeasureScopeInit {
                     composer: inner_composer.clone(),
                     state: &mut state,
@@ -1327,7 +1343,8 @@ impl SubcomposeLayoutNodeHandle {
                 });
                 let result = (policy)(&mut scope, constraints_copy);
                 (result, scope.into_placement_scratch())
-            })?;
+            },
+        )?;
 
         state.finish_pass();
 
@@ -1393,6 +1410,11 @@ struct SubcomposeLayoutNodeInner {
     last_placements: Vec<NodeId>,
     placement_scratch: Vec<Placement>,
     measured_children_scratch: Rc<RefCell<HashMap<NodeId, Rc<MeasuredNode>>>>,
+    /// Composition locals in scope where this `SubcomposeLayout` was composed,
+    /// replayed while subcomposing off the measure pass so subcomposed content
+    /// observes the same composition locals as the call site (see
+    /// `cranpose_core::Composer::capture_composition_locals`).
+    captured_locals: Option<cranpose_core::CapturedCompositionLocals>,
 }
 
 impl SubcomposeLayoutNodeInner {
@@ -1411,6 +1433,7 @@ impl SubcomposeLayoutNodeInner {
             last_placements: Vec::new(),
             placement_scratch: Vec::new(),
             measured_children_scratch: Rc::new(RefCell::new(HashMap::default())),
+            captured_locals: None,
         }
     }
 

--- a/crates/cranpose-ui/src/tests/popup_tests.rs
+++ b/crates/cranpose-ui/src/tests/popup_tests.rs
@@ -212,3 +212,84 @@ fn popup_is_removed_from_overlay_when_no_longer_composed() {
         "popup removed from overlay after it stops being composed"
     );
 }
+
+#[test]
+fn popup_inside_subcomposition_still_reaches_the_host() {
+    use crate::widgets::BoxWithConstraints;
+
+    // Regression: a `Popup` composed inside a `BoxWithConstraints` (which
+    // subcomposes its content off the measure pass) must still register into
+    // the enclosing `PopupHost`. The registry travels down as a composition
+    // local, and the subcomposition has to inherit the locals in scope where
+    // the `BoxWithConstraints` was composed — otherwise the `Popup` resolves
+    // the detached default registry and never renders. This is exactly the
+    // shape of a real app (screens wrapped in `BoxWithConstraints`/`LazyColumn`
+    // whose text fields show selection handles through `Popup`).
+    let _app_context = crate::render_state::app_context_test_scope();
+    let mut composition = Composition::new(MemoryApplier::new());
+    let key = location_key(file!(), line!(), column!());
+
+    let mut content = || {
+        PopupHost(|| {
+            BoxWithConstraints(
+                Modifier::empty().size(Size {
+                    width: 200.0,
+                    height: 200.0,
+                }),
+                |_scope| {
+                    Popup(
+                        Rect {
+                            x: 120.0,
+                            y: 90.0,
+                            width: 0.0,
+                            height: 0.0,
+                        },
+                        Point { x: 0.0, y: 0.0 },
+                        || {
+                            Column(
+                                Modifier::empty()
+                                    .size(Size {
+                                        width: 15.0,
+                                        height: 15.0,
+                                    })
+                                    .background(MARKER),
+                                ColumnSpec::default(),
+                                || {},
+                            );
+                        },
+                    );
+                },
+            );
+        });
+    };
+
+    composition.render(key, &mut content).expect("render");
+    // The Popup registers during the measure-pass subcomposition, which runs in
+    // `compute_layout`; the enclosing `PopupHost` then needs a follow-up frame
+    // (reconcile + layout) to render the newly registered entry. Alternate the
+    // two a few times, as real frames do, before sampling the scene.
+    let scene = {
+        let mut scene = None;
+        for _ in 0..6 {
+            settle(&mut composition, key, &mut content);
+            let root = composition.root().expect("root");
+            let layout = compute_layout(&mut composition, root);
+            scene = Some(HeadlessRenderer::new().render(&layout));
+        }
+        scene.expect("scene")
+    };
+
+    let rects = marker_rects(&scene);
+    assert_eq!(
+        rects.len(),
+        1,
+        "a Popup composed inside a BoxWithConstraints subcomposition must reach \
+         the enclosing PopupHost, got {rects:?}"
+    );
+    // And it lands at its anchor in window space, not clamped to the origin.
+    assert!(
+        (rects[0].x - 120.0).abs() <= 0.5 && (rects[0].y - 90.0).abs() <= 0.5,
+        "overlay marker should paint at the anchor (120,90), was {:?}",
+        rects[0]
+    );
+}

--- a/crates/cranpose-ui/src/tests/swipe_to_dismiss_render_tests.rs
+++ b/crates/cranpose-ui/src/tests/swipe_to_dismiss_render_tests.rs
@@ -25,7 +25,7 @@ fn compose_row(with_background: bool) -> TestComposition {
     run_test_composition(move || {
         let mut spec = SwipeToDismissSpec::default();
         if with_background {
-            spec = spec.with_background(|| {
+            spec = spec.with_background(|_side| {
                 Box(
                     Modifier::empty().fill_max_size().background(BIN_RED),
                     BoxSpec::new(),
@@ -42,6 +42,48 @@ fn compose_row(with_background: bool) -> TestComposition {
                     "CONTENT".to_string(),
                     Modifier::empty(),
                     TextStyle::default(),
+                );
+            },
+        );
+    })
+}
+
+/// A `SwipeToDismiss` row (with a red bin background) inside a `LazyColumn`
+/// item — the real app shape where the lingering-strip bug appears.
+fn compose_lazy_row_with_background() -> TestComposition {
+    use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope};
+    run_test_composition(move || {
+        let list_state = remember_lazy_list_state();
+        LazyColumn(
+            Modifier::empty().fill_max_size(),
+            list_state,
+            LazyColumnSpec::default(),
+            |scope| {
+                scope.items(
+                    1,
+                    None::<fn(usize) -> u64>,
+                    None::<fn(usize) -> u64>,
+                    |_index| {
+                        let spec = SwipeToDismissSpec::default().with_background(|_side| {
+                            Box(
+                                Modifier::empty().fill_max_size().background(BIN_RED),
+                                BoxSpec::new(),
+                                || {},
+                            );
+                        });
+                        SwipeToDismiss(
+                            Modifier::empty().fill_max_width().height(48.0),
+                            spec,
+                            || {},
+                            || {
+                                Text(
+                                    "CONTENT".to_string(),
+                                    Modifier::empty(),
+                                    TextStyle::default(),
+                                );
+                            },
+                        );
+                    },
                 );
             },
         );
@@ -273,4 +315,117 @@ fn dismissed_row_hides_background_and_collapses_to_zero_height() {
         "the dismissed row must collapse to zero height, got {}",
         settled.root().rect.height
     );
+}
+
+/// The same dismiss, but with the row inside a `LazyColumn` item — the real app
+/// shape. The collapse re-measures via `schedule_measure_repass`, which bubbles
+/// *measure* dirtiness so the list re-measures the shrinking item instead of
+/// reusing its cached, full-height slot. Without that, the red background and
+/// the pre-dismiss height linger until the whole list is rebuilt.
+#[test]
+fn dismissed_row_inside_lazy_column_leaves_no_lingering_strip() {
+    let mut composition = compose_lazy_row_with_background();
+    let root = composition.root().expect("root");
+    measure_row(&mut composition, root);
+
+    let tree = layout_tree(&mut composition, root);
+    // The list's scroll node also carries a pointer handler; the swipe row's is
+    // the deepest one, so dispatch there (the swipe consumes the horizontal
+    // drag before it would reach the parent scroll).
+    let handler = deepest_pointer_handler(&tree);
+
+    // Swipe past the dismiss threshold (0.5 * 320px width = 160px) and release.
+    handler(down(10.0));
+    handler(move_to(30.0)); // capture
+    handler(move_to(210.0)); // dx = 200 >= threshold
+
+    // Sanity: the swipe captured and revealed the background (proves the events
+    // reached the swipe handler, not the parent scroll).
+    composition
+        .process_invalid_scopes()
+        .expect("recompose after capture");
+    measure_row(&mut composition, root);
+    assert!(
+        count_bin_primitives(&layout_tree(&mut composition, root)) > 0,
+        "the swipe must reveal the bin background mid-drag"
+    );
+
+    handler(up(210.0));
+
+    // Settle + collapse. Interleave frame pumps with re-measures/recomposes, as
+    // the shell does each frame: the collapse animation advances and schedules a
+    // measure repass, which the next measure pass consumes to re-measure the row
+    // through the LazyColumn (bubbling measure dirtiness defeats the item cache).
+    let handle = composition.runtime_handle();
+    let mut frame_time = 0u64;
+    for _ in 0..120 {
+        for _ in 0..8 {
+            frame_time += 16_666_667;
+            composition.with_app_context(|| handle.drain_frame_callbacks(frame_time));
+        }
+        composition
+            .process_invalid_scopes()
+            .expect("recompose during collapse");
+        measure_row(&mut composition, root);
+    }
+
+    let settled = layout_tree(&mut composition, root);
+    assert_eq!(
+        count_bin_primitives(&settled),
+        0,
+        "no red background strip may linger after a dismiss inside a LazyColumn"
+    );
+    // The collapsing item node (the outer SubcomposeLayout that scales its height
+    // by the collapse fraction) must have shrunk to zero inside the list.
+    let item_height = outer_item_height(&settled).expect("collapsing item present in tree");
+    assert!(
+        item_height <= 0.5,
+        "the dismissed row inside a LazyColumn must collapse to zero height, got {item_height}"
+    );
+}
+
+/// The deepest pointer handler in the tree — the swipe row's, below the list's
+/// scroll handler.
+fn deepest_pointer_handler(tree: &crate::LayoutTree) -> Rc<dyn Fn(PointerEvent)> {
+    fn walk(
+        node: &crate::LayoutBox,
+        best: &mut Option<(usize, Rc<dyn Fn(PointerEvent)>)>,
+        depth: usize,
+    ) {
+        if let Some(handler) = node.node_data.modifier_slices().pointer_inputs().first() {
+            if best.as_ref().is_none_or(|(d, _)| depth >= *d) {
+                *best = Some((depth, Rc::clone(handler)));
+            }
+        }
+        for child in &node.children {
+            walk(child, best, depth + 1);
+        }
+    }
+    let mut best = None;
+    walk(tree.root(), &mut best, 0);
+    best.expect("swipe pointer handler").1
+}
+
+/// Height of the collapsing item: the parent node of the swipe-handler node
+/// (the outer SubcomposeLayout that scales height by the collapse fraction).
+fn outer_item_height(tree: &crate::LayoutTree) -> Option<f32> {
+    fn walk(node: &crate::LayoutBox) -> Option<f32> {
+        for child in &node.children {
+            if child
+                .node_data
+                .modifier_slices()
+                .pointer_inputs()
+                .first()
+                .is_some()
+                && (node.rect.height - 480.0).abs() > 1.0
+            {
+                return Some(node.rect.height);
+            }
+            if let Some(h) = walk(child) {
+                return Some(h);
+            }
+        }
+        None
+    }
+    walk(tree.root())
 }

--- a/crates/cranpose-ui/src/tests/swipe_to_dismiss_render_tests.rs
+++ b/crates/cranpose-ui/src/tests/swipe_to_dismiss_render_tests.rs
@@ -384,14 +384,13 @@ fn dismissed_row_inside_lazy_column_leaves_no_lingering_strip() {
     );
 }
 
+/// A pointer handler tagged with the tree depth it was found at.
+type DepthTaggedHandler = (usize, Rc<dyn Fn(PointerEvent)>);
+
 /// The deepest pointer handler in the tree — the swipe row's, below the list's
 /// scroll handler.
 fn deepest_pointer_handler(tree: &crate::LayoutTree) -> Rc<dyn Fn(PointerEvent)> {
-    fn walk(
-        node: &crate::LayoutBox,
-        best: &mut Option<(usize, Rc<dyn Fn(PointerEvent)>)>,
-        depth: usize,
-    ) {
+    fn walk(node: &crate::LayoutBox, best: &mut Option<DepthTaggedHandler>, depth: usize) {
         if let Some(handler) = node.node_data.modifier_slices().pointer_inputs().first() {
             if best.as_ref().is_none_or(|(d, _)| depth >= *d) {
                 *best = Some((depth, Rc::clone(handler)));
@@ -411,12 +410,11 @@ fn deepest_pointer_handler(tree: &crate::LayoutTree) -> Rc<dyn Fn(PointerEvent)>
 fn outer_item_height(tree: &crate::LayoutTree) -> Option<f32> {
     fn walk(node: &crate::LayoutBox) -> Option<f32> {
         for child in &node.children {
-            if child
+            if !child
                 .node_data
                 .modifier_slices()
                 .pointer_inputs()
-                .first()
-                .is_some()
+                .is_empty()
                 && (node.rect.height - 480.0).abs() > 1.0
             {
                 return Some(node.rect.height);

--- a/crates/cranpose-ui/src/tests/swipe_to_dismiss_tests.rs
+++ b/crates/cranpose-ui/src/tests/swipe_to_dismiss_tests.rs
@@ -91,6 +91,11 @@ impl Harness {
         self.controller.collapse_fraction()
     }
 
+    /// The edge the background is revealed on for the current displacement.
+    fn side(&self) -> SwipeDismissSide {
+        self.controller.revealed_side()
+    }
+
     /// Advances the frame clock, driving springs and the settle watcher.
     fn pump_frames(&mut self, frames: usize) {
         let handle = self._runtime.handle();
@@ -272,6 +277,25 @@ fn leftward_swipe_dismisses_to_the_left() {
     harness.pump_frames(300);
     assert_eq!(harness.dismiss_count.get(), 1);
     assert!((harness.offset() + 200.0).abs() <= 0.5);
+}
+
+#[test]
+fn revealed_side_follows_the_swipe_direction() {
+    let mut harness = Harness::new(200.0, 0.5);
+
+    // Swipe right: the row moves right, revealing the leading (start) edge.
+    harness.send(&down(20.0, 10.0));
+    harness.send(&move_to(120.0, 10.0)); // offset +100
+    assert!(harness.offset() > 0.0);
+    assert_eq!(harness.side(), SwipeDismissSide::Start);
+    harness.send(&cancel());
+    harness.pump_frames(300);
+
+    // Swipe left: the row moves left, revealing the trailing (end) edge.
+    harness.send(&down(180.0, 10.0));
+    harness.send(&move_to(60.0, 10.0)); // offset -120
+    assert!(harness.offset() < 0.0);
+    assert_eq!(harness.side(), SwipeDismissSide::End);
 }
 
 #[test]

--- a/crates/cranpose-ui/src/widgets/basic_text_field.rs
+++ b/crates/cranpose-ui/src/widgets/basic_text_field.rs
@@ -462,6 +462,85 @@ mod tests {
         HeadlessRenderer::new().render(&layout)
     }
 
+    /// Like [`render_range_menu`], but the metrics + `SelectionHandles` are
+    /// composed inside a `BoxWithConstraints` (which subcomposes its content off
+    /// the measure pass), mirroring a real app where text fields live inside
+    /// `BoxWithConstraints`/`LazyColumn`. The overlay `Popup`s must still reach
+    /// the enclosing `PopupHost` across the subcomposition boundary.
+    fn render_range_menu_subcomposed(touch: bool) -> crate::renderer::RecordedRenderScene {
+        use crate::layout::LayoutEngine;
+        use crate::renderer::HeadlessRenderer;
+        use crate::widgets::{BoxWithConstraints, PopupHost};
+        use cranpose_ui_graphics::Size;
+
+        let mut composition = Composition::new(MemoryApplier::new());
+        let key = location_key(file!(), line!(), column!());
+        let state = TextFieldState::new("hello world");
+
+        let mut content = {
+            let state = state.clone();
+            move || {
+                let state = state.clone();
+                PopupHost(move || {
+                    let state = state.clone();
+                    BoxWithConstraints(
+                        Modifier::empty().size(Size {
+                            width: 300.0,
+                            height: 300.0,
+                        }),
+                        move |_scope| {
+                            let controller = TextFieldHandleController::new();
+                            if state.selection() != TextRange::new(0, 5) {
+                                state.set_selection(TextRange::new(0, 5));
+                            }
+                            controller.publish(TextFieldHandleMetrics {
+                                focused: true,
+                                touch,
+                                node_origin: Point { x: 0.0, y: 40.0 },
+                                padding_left: 0.0,
+                                padding_top: 0.0,
+                                scroll_offset: 0.0,
+                                line_height: 18.0,
+                            });
+                            SelectionHandles(state.clone(), TextStyle::default(), controller);
+                        },
+                    );
+                });
+            }
+        };
+
+        composition.render(key, &mut content).expect("render");
+        let root = composition.root().expect("root");
+        let handle = composition.runtime_handle();
+        let mut scene = None;
+        // The Popups register during the measure-pass subcomposition, so a
+        // follow-up frame (reconcile + layout) is needed for the host to render
+        // them. Alternate the two a few times, as real frames do.
+        for _ in 0..8 {
+            for _ in 0..16 {
+                if !composition.should_render() {
+                    break;
+                }
+                composition.reconcile(key, &mut content).expect("reconcile");
+            }
+            let mut applier = composition.applier_mut();
+            applier.set_runtime_handle(handle.clone());
+            let layout = applier
+                .compute_layout(
+                    root,
+                    Size {
+                        width: 400.0,
+                        height: 400.0,
+                    },
+                )
+                .expect("layout");
+            applier.clear_runtime_handle();
+            drop(applier);
+            scene = Some(HeadlessRenderer::new().render(&layout));
+        }
+        scene.expect("scene")
+    }
+
     fn text_values(scene: &crate::renderer::RecordedRenderScene) -> Vec<String> {
         use crate::renderer::RenderOp;
         scene
@@ -496,6 +575,34 @@ mod tests {
         assert!(
             !mouse.iter().any(|t| t == "Copy"),
             "mouse selection must not show the finger contextual menu, got {mouse:?}"
+        );
+    }
+
+    #[test]
+    fn selection_handles_and_menu_survive_subcomposition() {
+        // Regression: the selection handles and the contextual menu (all drawn
+        // through `Popup`) must reach the enclosing `PopupHost` even when the
+        // text field lives inside a `BoxWithConstraints`/`LazyColumn`, which
+        // subcomposes its content off the measure pass. Both the two teardrop
+        // handles and the menu items are expected.
+        let _app_context = crate::render_state::app_context_test_scope();
+        let scene = render_range_menu_subcomposed(true);
+
+        let texts = text_values(&scene);
+        assert!(
+            texts.iter().any(|t| t == "Copy"),
+            "a touch selection inside a subcomposition should show the Copy menu \
+             item through the host, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t == "Select all"),
+            "expected Select all inside a subcomposition, got {texts:?}"
+        );
+        assert_eq!(
+            image_count(&scene),
+            2,
+            "a touch range selection should show two finger teardrop handles in \
+             the overlay across the subcomposition boundary"
         );
     }
 

--- a/crates/cranpose-ui/src/widgets/layout.rs
+++ b/crates/cranpose-ui/src/widgets/layout.rs
@@ -101,9 +101,17 @@ pub fn SubcomposeLayout(
     let id = cranpose_core::with_current_composer(|composer| {
         composer.emit_node(|| SubcomposeLayoutNode::new(modifier.clone(), Rc::clone(&policy)))
     });
+    // Capture the composition locals in scope here (compose time) so the
+    // measure-pass subcomposition can replay them: content subcomposed off the
+    // measure pass then observes the same composition locals as this call site,
+    // instead of the locals in scope during layout (which no longer carry
+    // ancestor providers once composition has unwound).
+    let captured_locals =
+        cranpose_core::with_current_composer(|composer| composer.capture_composition_locals());
     if let Err(err) = cranpose_core::with_node_mut(id, |node: &mut SubcomposeLayoutNode| {
         node.set_modifier(modifier.clone());
         node.set_measure_policy(Rc::clone(&policy));
+        node.set_captured_locals(captured_locals.clone());
         if policy_captures_changed {
             node.request_measure_recompose();
         }

--- a/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
+++ b/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
@@ -50,6 +50,20 @@ fn swipe_spring() -> AnimationType {
     spring(Spring::DampingRatioNoBouncy, Spring::StiffnessMediumLow)
 }
 
+/// Which edge the dismiss background is revealed on, i.e. the side the row is
+/// being swiped away from. Passed to the [`SwipeToDismissSpec::with_background`]
+/// closure so its label/icon can follow the swipe direction instead of being
+/// pinned to one side.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SwipeDismissSide {
+    /// The row is moving right (offset > 0); the background shows on the leading
+    /// (start / left-in-LTR) edge.
+    Start,
+    /// The row is moving left (offset < 0); the background shows on the trailing
+    /// (end / right-in-LTR) edge.
+    End,
+}
+
 /// Configuration for [`SwipeToDismiss`].
 #[derive(Clone)]
 pub struct SwipeToDismissSpec {
@@ -57,8 +71,9 @@ pub struct SwipeToDismissSpec {
     /// the row to dismiss (default `0.5`). Clamped to `(0, 1]`.
     pub threshold_fraction: f32,
     /// Optional content drawn behind the swiped row (e.g. a delete bin),
-    /// revealed as the row slides away.
-    background: Option<Rc<RefCell<dyn FnMut()>>>,
+    /// revealed as the row slides away. Receives the [`SwipeDismissSide`] the
+    /// row is being swiped toward so the reveal can follow the swipe direction.
+    background: Option<Rc<RefCell<dyn FnMut(SwipeDismissSide)>>>,
 }
 
 impl SwipeToDismissSpec {
@@ -75,8 +90,10 @@ impl SwipeToDismissSpec {
         self
     }
 
-    /// Sets the background content revealed behind the swiped row.
-    pub fn with_background(mut self, background: impl FnMut() + 'static) -> Self {
+    /// Sets the background content revealed behind the swiped row. The closure
+    /// receives the [`SwipeDismissSide`] the row is currently being swiped
+    /// toward, so it can align its label/icon to the revealed edge.
+    pub fn with_background(mut self, background: impl FnMut(SwipeDismissSide) + 'static) -> Self {
         self.background = Some(Rc::new(RefCell::new(background)));
         self
     }
@@ -210,6 +227,16 @@ impl SwipeToDismissController {
 
     fn current_offset(&self) -> f32 {
         self.offset.borrow().state().value()
+    }
+
+    /// The edge the background is revealed on, from the current displacement:
+    /// a rightward offset reveals the start edge, a leftward offset the end.
+    fn revealed_side(&self) -> SwipeDismissSide {
+        if self.current_offset() >= 0.0 {
+            SwipeDismissSide::Start
+        } else {
+            SwipeDismissSide::End
+        }
     }
 
     /// Current row height scale (`1.0` at rest, `0.0` fully collapsed).
@@ -461,7 +488,16 @@ fn watch_collapse(controller: &Rc<SwipeToDismissController>) {
                 };
                 controller.collapse_watcher.borrow_mut().take();
                 if let Some(node_id) = controller.node_id.get() {
-                    crate::schedule_layout_repass(node_id);
+                    // Re-measure the row as it collapses. A plain layout repass
+                    // only bubbles *layout* (placement) dirtiness up the tree,
+                    // which does not set the row node's own `needs_measure` flag —
+                    // and that flag is exactly what an enclosing `LazyColumn`
+                    // consults (`children_need_measure`) before reusing a cached
+                    // item slot. `schedule_measure_repass` bubbles *measure*
+                    // dirtiness so the list actually re-measures the shrinking
+                    // row; otherwise the pre-dismiss height and the still-composed
+                    // red background linger until the whole list is rebuilt.
+                    crate::schedule_measure_repass(node_id);
                 }
                 crate::request_render_invalidation();
                 if controller.collapse_fraction() > COLLAPSE_SETTLE_EPSILON {
@@ -555,8 +591,9 @@ where
                 if controller_for_row.revealed() {
                     if let Some(background) = &background {
                         let background = Rc::clone(background);
+                        let side = controller_for_row.revealed_side();
                         Box(Modifier::empty(), BoxSpec::new(), move || {
-                            (background.borrow_mut())();
+                            (background.borrow_mut())(side);
                         });
                     }
                 }

--- a/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
+++ b/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
@@ -64,6 +64,10 @@ pub enum SwipeDismissSide {
     End,
 }
 
+/// Boxed background closure, invoked each frame with the current
+/// [`SwipeDismissSide`] so the reveal can follow the swipe direction.
+type BackgroundFn = Rc<RefCell<dyn FnMut(SwipeDismissSide)>>;
+
 /// Configuration for [`SwipeToDismiss`].
 #[derive(Clone)]
 pub struct SwipeToDismissSpec {
@@ -73,7 +77,7 @@ pub struct SwipeToDismissSpec {
     /// Optional content drawn behind the swiped row (e.g. a delete bin),
     /// revealed as the row slides away. Receives the [`SwipeDismissSide`] the
     /// row is being swiped toward so the reveal can follow the swipe direction.
-    background: Option<Rc<RefCell<dyn FnMut(SwipeDismissSide)>>>,
+    background: Option<BackgroundFn>,
 }
 
 impl SwipeToDismissSpec {

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeTextInput.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeTextInput.java
@@ -2,6 +2,7 @@ package dev.cranpose.android;
 
 import android.app.Activity;
 import android.content.Context;
+import android.graphics.Rect;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.Selection;
@@ -10,6 +11,7 @@ import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
@@ -85,6 +87,7 @@ public final class CranposeTextInput {
                         return;
                     }
                     content.addView(view, new ViewGroup.LayoutParams(1, 1));
+                    attachKeyboardListener(state, content);
                     current = state;
                 } else {
                     // The session already owns a queue handle; drop the new one.
@@ -128,6 +131,7 @@ public final class CranposeTextInput {
                     return;
                 }
                 current = null;
+                detachKeyboardListener(state);
                 InputMethodManager imm = inputMethodManager(activity);
                 if (imm != null && state.view != null) {
                     imm.hideSoftInputFromWindow(state.view.getWindowToken(), 0);
@@ -231,6 +235,10 @@ public final class CranposeTextInput {
         volatile boolean disposed;
         volatile boolean singleLine;
         Editable editable;
+        /** Content view the keyboard-height listener is attached to. */
+        View insetsView;
+        ViewTreeObserver.OnGlobalLayoutListener keyboardListener;
+        int lastKeyboardHeightPx = -1;
 
         SessionState(long queueHandle) {
             this.queueHandle = queueHandle;
@@ -243,6 +251,52 @@ public final class CranposeTextInput {
                 nativeImeReleaseQueue(queueHandle);
             }
         }
+    }
+
+    /**
+     * Attaches a global-layout listener that reports the on-screen keyboard's
+     * height (physical px, 0 when hidden) via {@link #nativeImeInsetsChanged}.
+     *
+     * <p>Uses the visible-display-frame heuristic (the portion of the window not
+     * covered by the keyboard), which works on every supported API level — the
+     * {@code WindowInsets.Type.ime()} API only exists on API 30+. The reported
+     * height is the distance from the visible frame's bottom to the window
+     * bottom, i.e. how much the keyboard covers; small values (system bars with
+     * no keyboard) are treated as hidden.
+     */
+    private static void attachKeyboardListener(SessionState state, final ViewGroup content) {
+        final View root = content.getRootView();
+        ViewTreeObserver.OnGlobalLayoutListener listener = () -> {
+            if (state.disposed) {
+                return;
+            }
+            Rect frame = new Rect();
+            root.getWindowVisibleDisplayFrame(frame);
+            int windowHeight = root.getHeight();
+            int covered = windowHeight - frame.bottom;
+            // Ignore small margins (navigation bar / rounding) that are not the
+            // keyboard, so a hidden keyboard reports zero.
+            int keyboardHeight = covered > windowHeight / 6 ? covered : 0;
+            if (keyboardHeight != state.lastKeyboardHeightPx) {
+                state.lastKeyboardHeightPx = keyboardHeight;
+                nativeImeInsetsChanged(state.queueHandle, keyboardHeight);
+            }
+        };
+        root.getViewTreeObserver().addOnGlobalLayoutListener(listener);
+        state.insetsView = root;
+        state.keyboardListener = listener;
+    }
+
+    private static void detachKeyboardListener(SessionState state) {
+        if (state.insetsView != null && state.keyboardListener != null) {
+            state.insetsView.getViewTreeObserver()
+                    .removeOnGlobalLayoutListener(state.keyboardListener);
+        }
+        if (state.lastKeyboardHeightPx != 0 && !state.disposed) {
+            nativeImeInsetsChanged(state.queueHandle, 0);
+        }
+        state.insetsView = null;
+        state.keyboardListener = null;
     }
 
     /** Invisible focusable view whose InputConnection feeds the native pipeline. */
@@ -453,6 +507,8 @@ public final class CranposeTextInput {
             long queueHandle, int action, int keyCode, int metaState, int unicodeChar);
 
     private static native void nativeImePerformEditorAction(long queueHandle, int actionCode);
+
+    private static native void nativeImeInsetsChanged(long queueHandle, int bottomPx);
 
     private static native void nativeImeReleaseQueue(long queueHandle);
 }

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -127,6 +127,47 @@ fn push_pending_input_from_android_key_event(
     true
 }
 
+thread_local! {
+    /// Current soft-keyboard (IME) insets in *logical* px, shared between the
+    /// shell content wrapper (which provides them to composition via
+    /// [`cranpose_ui::local_ime_insets`]) and the IME event loop (which updates
+    /// them from Java-forwarded keyboard heights).
+    static ANDROID_IME_INSETS: Rc<Cell<cranpose_ui::EdgeInsets>> =
+        Rc::new(Cell::new(cranpose_ui::EdgeInsets::default()));
+    /// Density used to convert Java's physical keyboard height to logical px.
+    static ANDROID_IME_DENSITY: Cell<f32> = const { Cell::new(1.0) };
+}
+
+/// Shared handle to the current IME insets (logical px), read by the shell
+/// content wrapper on every recomposition.
+fn android_ime_insets_handle() -> Rc<Cell<cranpose_ui::EdgeInsets>> {
+    ANDROID_IME_INSETS.with(Rc::clone)
+}
+
+/// Records the density used to convert the Java keyboard height to logical px.
+fn set_android_ime_density(density: f32) {
+    ANDROID_IME_DENSITY.with(|cell| cell.set(density.max(f32::EPSILON)));
+}
+
+/// Stores the keyboard's covered height (physical px, `0` when hidden) as
+/// bottom IME insets in logical px. Returns whether the value changed.
+fn set_android_ime_bottom_px(bottom_px: i32) -> bool {
+    let density = ANDROID_IME_DENSITY.with(|cell| cell.get());
+    let bottom = (bottom_px.max(0) as f32) / density;
+    let insets = cranpose_ui::EdgeInsets {
+        bottom,
+        ..cranpose_ui::EdgeInsets::default()
+    };
+    ANDROID_IME_INSETS.with(|cell| {
+        if cell.get() == insets {
+            false
+        } else {
+            cell.set(insets);
+            true
+        }
+    })
+}
+
 /// `EditorInfo.IME_ACTION_DONE`: the user tapped the keyboard's Done action.
 const IME_ACTION_DONE: i32 = 6;
 
@@ -202,6 +243,14 @@ fn dispatch_android_ime_event(shell: &mut AppShell<WgpuRenderer>, event: Android
                     );
                     let _ = shell.on_key_event(&key);
                 }
+            }
+        }
+        AndroidImeEvent::ImeInsetsChanged { bottom_px } => {
+            // Publish the keyboard height as IME insets and force a root render
+            // so the content wrapper re-provides `local_ime_insets` (a plain
+            // shared cell is not itself reactive).
+            if set_android_ime_bottom_px(bottom_px) {
+                shell.request_root_render();
             }
         }
     }
@@ -668,10 +717,21 @@ where
 
         let content_clone = content.clone();
         let density = density.max(f32::EPSILON);
+        let ime_insets = android_ime_insets_handle();
         let shell = AppShell::new_with_size_and_density(
             renderer,
             default_root_key(),
-            move || content_clone.borrow_mut()(),
+            move || {
+                // Provide the current soft-keyboard insets to composition so the
+                // app can keep the focused field above the keyboard. Read on
+                // every recomposition; the IME loop forces a root render when the
+                // height changes (see `dispatch_android_ime_event`).
+                let insets = ime_insets.get();
+                cranpose_core::CompositionLocalProvider(
+                    [cranpose_ui::local_ime_insets().provides(insets)],
+                    || content_clone.borrow_mut()(),
+                );
+            },
             (width, height),
             (width as f32 / density, height as f32 / density),
             density,
@@ -701,6 +761,7 @@ where
     if let Some(shell) = app_shell {
         shell.renderer().set_root_scale(density);
         shell.set_density(density);
+        set_android_ime_density(density);
     }
 
     let actual_size = app_shell.as_mut().and_then(|shell| {

--- a/crates/cranpose/src/android_text_input.rs
+++ b/crates/cranpose/src/android_text_input.rs
@@ -87,6 +87,11 @@ pub(crate) enum AndroidImeEvent {
     },
     /// `performEditorAction` with an `EditorInfo.IME_ACTION_*` code.
     EditorAction { action: i32 },
+    /// The on-screen keyboard's height (physical px) at the bottom of the
+    /// window changed. `0` when the keyboard is hidden. Forwarded from a Java
+    /// `View.OnApplyWindowInsetsListener` / visible-frame listener so the shell
+    /// can expose it as IME insets to composition.
+    ImeInsetsChanged { bottom_px: i32 },
 }
 
 /// Cross-thread queue for IME events (pushed on the Android UI thread,
@@ -462,6 +467,20 @@ pub extern "system" fn Java_dev_cranpose_android_CranposeTextInput_nativeImePerf
     action: jint,
 ) {
     push_ime_event_for_handle(queue_handle, AndroidImeEvent::EditorAction { action });
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeTextInput_nativeImeInsetsChanged(
+    _env: EnvUnowned<'_>,
+    _class: JClass<'_>,
+    queue_handle: jlong,
+    bottom_px: jint,
+) {
+    push_ime_event_for_handle(
+        queue_handle,
+        AndroidImeEvent::ImeInsetsChanged { bottom_px },
+    );
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
Round 9 of the CranScan input fixes. All three bugs were reproduced, root-caused, verified headlessly (regression tests that fail without the fix) **and on a real arm64 device**.

## Device note (up front)

The intended target — Samsung Galaxy Tab S7+ **R52R40K1F2A** — was **physically disconnected for this whole session**: it enumerated at the start, was then unplugged, and a **Huawei EVR-AL00 (`LKN5T19419001735`, arm64, Android 10)** took its place on the same USB port and never came back (watched repeatedly). All device verification below was done on the **Huawei arm64 device** with the local cranpose worktree patched into a throwaway CranScan build. It is a genuine arm64 handset exercising the real Android pointer/IME/render path, just not the exact hardware requested. (Huawei EMUI also suppresses third-party logcat after a while, so the decisive Bug A finding was captured early before logs went quiet.)

---

## Bug A — selection handles + caret + context menu invisible (CHRONIC, 3rd attempt)

**Previous attempts fixed the wrong layer.** On-device logging of the pointer path showed classification was already correct: a finger tap reports `tool=Unknown event_source=Touchscreen resolved=Touch`, the field receives `source=Touch is_touch_like=true`, and `SelectionHandles` emits the caret/selection `Popup`s. Yet the overlay reported `popup-host render entries=0` — the popups registered into the **detached default `PopupRegistry`**, not the shell's `PopupHost` registry. A fixed marker rendered by `PopupHost` itself *did* draw, proving the overlay works; only the registrations weren't arriving.

**True root cause:** CompositionLocals are dropped at the subcompose boundary. `SubcomposeLayout` (backing `BoxWithConstraints`, `LazyColumn`, …) subcomposes its content during the **measure** pass, and `Composer::subcompose_slot` captured the composition-local stack **at measure time** — after composition has unwound, so ancestor providers are gone. CranScan wraps its whole UI in a `BoxWithConstraints`, so every text field lives inside a subcomposition and its `Popup` resolved the detached registry → nothing rendered. Headless popup tests passed only because they compose the field *directly* under `PopupHost` with no subcompose boundary between.

**Fix:** capture the composition locals when the `SubcomposeLayout` is composed (`Composer::capture_composition_locals` → `CapturedCompositionLocals`) and replay them during the measure-pass subcomposition (`subcompose_slot_with_locals`). A general framework fix that also makes the Bug B IME local reach nested fields, and matches Jetpack Compose semantics.

**Device proof:** `entries` went `0 → 1`; screenshots on the Huawei show the blue caret teardrop after a tap and, after a drag-select, both selection teardrop handles **and** the floating `Copy · Cut · Select all` menu. (Earlier "range doesn't render" shots were an adb artifact — the caret handle intercepts the second tap of a double-tap; a drag-select produces a stable range and everything renders.)

Regression tests (fail without the fix): `popup_inside_subcomposition_still_reaches_the_host`, `selection_handles_and_menu_survive_subcomposition`.

## Bug B — soft keyboard overlaps the focused field

New `local_ime_insets()` CompositionLocal (zero by default, cross-platform-friendly). `CranposeTextInput.java` attaches a global-layout keyboard-height listener (visible-display-frame heuristic — works on API 26+, unlike `WindowInsets.Type.ime()` which is API 30+) that forwards the covered height via a new `nativeImeInsetsChanged` JNI callback → new `AndroidImeEvent::ImeInsetsChanged`. The Android shell provides it through `local_ime_insets` (mirroring the iOS safe-area provider) and forces a root render on change so a plain shared cell becomes reactive. Thanks to the Bug A fix, apps read the local from inside their `BoxWithConstraints`.

**Device proof:** with the IME up, the CranScan document screen's scrollable content is bounded above the keyboard (not behind it); screenshot shows "groceries" typed into a field sitting directly above the keyboard instead of under it.

## Bug C — SwipeToDismiss

**C1 (background follows swipe direction):** new `SwipeDismissSide` passed to the `with_background` closure (`Start` when the row moves right, `End` when it moves left) so the label aligns to the revealed edge. **Breaking API** — see CranScan adoption below. Device proof: swiping a library row left now shows the red "Move to bin" reveal on the **right** edge, following the finger.

**C2 (red strip / height lingered until list refresh):** the post-dismiss collapse scheduled only a *layout* repass. `process_pending_layout_repasses` bubbles `bubble_layout_dirty` (placement), which never sets the row node's own `needs_measure` flag — exactly what a `LazyColumn`'s item cache (`children_need_measure` → `nodes_need_measure`) checks before reusing a slot. So the list kept the pre-dismiss height and the still-composed red background. Fix: new `schedule_measure_repass` (drained in the same layout pass, bubbling `bubble_measure_dirty`) so the list re-measures the shrinking row. Device proof: dismissing a row leaves a clean empty state — no red strip lingers.

Regression tests (fail without the fix): `revealed_side_follows_the_swipe_direction`, `dismissed_row_inside_lazy_column_leaves_no_lingering_strip`.

---

## CranScan adoption required (breaking API in C1)

`with_background` now hands the closure a `SwipeDismissSide`. When CranScan bumps cranpose:

```rust
.with_background(|side| SwipeBinBackground(side))
fn SwipeBinBackground(side: cranpose_ui::SwipeDismissSide) {
    let horizontal = match side {
        cranpose_ui::SwipeDismissSide::Start => cranpose_ui::HorizontalAlignment::Start,
        cranpose_ui::SwipeDismissSide::End => cranpose_ui::HorizontalAlignment::End,
    };
    // content_alignment(Alignment::new(horizontal, CenterVertically))
}
// app.rs Root, to consume Bug B insets:
let ime_bottom = cranpose_ui::local_ime_insets().current().bottom;
let inset_bottom = inset_bottom.max(ime_bottom);
```

## Verification

- `cargo fmt --check` clean
- `cargo test -p cranpose-ui -p cranpose-foundation -p cranpose -p cranpose-app-shell` green, incl. the **48 static guards**
- `cargo check --workspace` clean
- Android: cranpose compiles for `aarch64-linux-android` (CranScan arm64 build) + Java compiles (gradle)
- wasm: `apps/desktop-demo` compiles for `wasm32-unknown-unknown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKmJDd6pG9opQHr7btBMke
