### PR TITLE
Fix selection handles + context menu invisible for text fields inside LazyColumn items

### DIFF
--- a/crates/cranpose-ui/src/tests/popup_tests.rs
+++ b/crates/cranpose-ui/src/tests/popup_tests.rs
@@ -9,8 +9,9 @@ use crate::modifier::{Brush, Color, Modifier};
 use crate::primitives::{Column, ColumnSpec};
 use crate::renderer::{HeadlessRenderer, RenderOp};
 use crate::widgets::{Popup, PopupHost};
-use crate::{layout::LayoutTree, Composition};
+use crate::{layout::LayoutTree, Composition, LazyColumn, LazyColumnSpec};
 use cranpose_core::{location_key, MemoryApplier, NodeId};
+use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope};
 use cranpose_ui_graphics::{DrawPrimitive, Point, Rect, Size};
 
 /// A distinctive brush color the overlay content paints, so it can be located
@@ -287,6 +288,94 @@ fn popup_inside_subcomposition_still_reaches_the_host() {
          the enclosing PopupHost, got {rects:?}"
     );
     // And it lands at its anchor in window space, not clamped to the origin.
+    assert!(
+        (rects[0].x - 120.0).abs() <= 0.5 && (rects[0].y - 90.0).abs() <= 0.5,
+        "overlay marker should paint at the anchor (120,90), was {:?}",
+        rects[0]
+    );
+}
+
+#[test]
+fn popup_inside_lazy_column_item_still_reaches_the_host() {
+    // Regression (the reported device bug): a `Popup` composed inside a
+    // `LazyColumn` *item* must still register into the enclosing `PopupHost`.
+    // `LazyColumn` builds its own `SubcomposeLayoutNode` and subcomposes each
+    // item off the measure pass, so — exactly like `BoxWithConstraints` — the
+    // item subcomposition has to inherit the composition locals in scope where
+    // the `LazyColumn` was composed. Otherwise the `Popup` (a text field's
+    // selection handle / context menu in the real app) resolves the detached
+    // default registry and never renders. This failed before the
+    // capture-locals fix in `LazyColumnImpl`/`LazyRowImpl`.
+    let _app_context = crate::render_state::app_context_test_scope();
+    let mut composition = Composition::new(MemoryApplier::new());
+    let key = location_key(file!(), line!(), column!());
+
+    let mut content = || {
+        PopupHost(|| {
+            let state = remember_lazy_list_state();
+            LazyColumn(
+                Modifier::empty().size(Size {
+                    width: 200.0,
+                    height: 200.0,
+                }),
+                state,
+                LazyColumnSpec::default(),
+                |scope| {
+                    scope.items(
+                        1,
+                        None::<fn(usize) -> u64>,
+                        None::<fn(usize) -> u64>,
+                        |_index| {
+                            Popup(
+                                Rect {
+                                    x: 120.0,
+                                    y: 90.0,
+                                    width: 0.0,
+                                    height: 0.0,
+                                },
+                                Point { x: 0.0, y: 0.0 },
+                                || {
+                                    Column(
+                                        Modifier::empty()
+                                            .size(Size {
+                                                width: 15.0,
+                                                height: 15.0,
+                                            })
+                                            .background(MARKER),
+                                        ColumnSpec::default(),
+                                        || {},
+                                    );
+                                },
+                            );
+                        },
+                    );
+                },
+            );
+        });
+    };
+
+    composition.render(key, &mut content).expect("render");
+    // As with the BoxWithConstraints case, the Popup registers during the
+    // measure-pass subcomposition (in `compute_layout`), so alternate
+    // reconcile + layout a few frames before sampling the scene.
+    let scene = {
+        let mut scene = None;
+        for _ in 0..8 {
+            settle(&mut composition, key, &mut content);
+            let root = composition.root().expect("root");
+            let layout = compute_layout(&mut composition, root);
+            scene = Some(HeadlessRenderer::new().render(&layout));
+        }
+        scene.expect("scene")
+    };
+
+    let rects = marker_rects(&scene);
+    assert_eq!(
+        rects.len(),
+        1,
+        "a Popup composed inside a LazyColumn item must reach the enclosing \
+         PopupHost, got {rects:?}"
+    );
     assert!(
         (rects[0].x - 120.0).abs() <= 0.5 && (rects[0].y - 90.0).abs() <= 0.5,
         "overlay marker should paint at the anchor (120,90), was {:?}",

--- a/crates/cranpose-ui/src/tests/selection_handle_tests.rs
+++ b/crates/cranpose-ui/src/tests/selection_handle_tests.rs
@@ -85,6 +85,7 @@ fn selection_handle_renders_in_overlay_at_its_tip() {
                 Color(0.2, 0.5, 0.9, 1.0),
                 |_pos| {},
                 || {},
+                || {},
             );
         });
     };
@@ -115,4 +116,240 @@ fn selection_handle_renders_in_overlay_at_its_tip() {
         rects.iter().any(|rect| rect.y + rect.height >= tip.y),
         "the handle bulb should hang at/below the tip"
     );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Long-press → (re)open the contextual menu
+//
+// A selection handle reports a long-press (finger held on the handle without
+// dragging it) so the field can re-show the Copy/Cut/Paste/Select-all menu even
+// when the selection range has not changed. These drive the real handle gesture
+// modifier synchronously, the same way the zoom gesture tests do.
+// ─────────────────────────────────────────────────────────────────────────────
+
+mod long_press {
+    use crate::widgets::selection_handle::{
+        is_handle_long_press, selection_handle_pointer_input, HANDLE_LONG_PRESS_TIMEOUT_MS,
+    };
+    use crate::{collect_modifier_slices, Modifier};
+    use cranpose_core::{DefaultScheduler, Runtime};
+    use cranpose_foundation::{
+        BasicModifierNodeContext, ModifierNodeChain, PointerButton, PointerButtons, PointerEvent,
+        PointerEventKind,
+    };
+    use cranpose_ui_graphics::Point;
+    use std::cell::Cell;
+    use std::rc::Rc;
+    use std::sync::Arc;
+
+    fn point(x: f32, y: f32) -> Point {
+        Point { x, y }
+    }
+
+    fn event(kind: PointerEventKind, x: f32, y: f32, time_ms: i64) -> PointerEvent {
+        PointerEvent::new(kind, point(x, y), point(x, y))
+            .with_buttons(PointerButtons::new().with(PointerButton::Primary))
+            .with_time_ms(Some(time_ms))
+    }
+
+    /// Builds the real selection-handle gesture modifier and returns a handler
+    /// that synchronously drives its async pointer loop, plus the chain (kept
+    /// alive so the task keeps running). Counters record the fired callbacks.
+    struct Harness {
+        _runtime: Runtime,
+        handler: Rc<dyn Fn(PointerEvent)>,
+        _chain: ModifierNodeChain,
+        drags: Rc<Cell<usize>>,
+        drag_ends: Rc<Cell<usize>>,
+        long_presses: Rc<Cell<usize>>,
+    }
+
+    impl Harness {
+        fn new() -> Self {
+            let runtime = Runtime::new(Arc::new(DefaultScheduler));
+            let drags = Rc::new(Cell::new(0));
+            let drag_ends = Rc::new(Cell::new(0));
+            let long_presses = Rc::new(Cell::new(0));
+
+            let on_drag: Rc<dyn Fn(Point)> = {
+                let drags = Rc::clone(&drags);
+                Rc::new(move |_p| drags.set(drags.get() + 1))
+            };
+            let on_drag_end: Rc<dyn Fn()> = {
+                let drag_ends = Rc::clone(&drag_ends);
+                Rc::new(move || drag_ends.set(drag_ends.get() + 1))
+            };
+            let on_long_press: Rc<dyn Fn()> = {
+                let long_presses = Rc::clone(&long_presses);
+                Rc::new(move || long_presses.set(long_presses.get() + 1))
+            };
+
+            let modifier: Modifier =
+                selection_handle_pointer_input(on_drag, on_drag_end, on_long_press);
+            let elements = modifier.elements();
+            let mut chain = ModifierNodeChain::new();
+            let mut context = BasicModifierNodeContext::new();
+            chain.update_from_slice(&elements, &mut context);
+            let slices = collect_modifier_slices(&chain);
+            let handler = slices
+                .pointer_inputs()
+                .first()
+                .cloned()
+                .expect("selection handle should provide a pointer input handler");
+
+            Self {
+                _runtime: runtime,
+                handler,
+                _chain: chain,
+                drags,
+                drag_ends,
+                long_presses,
+            }
+        }
+
+        fn send(&self, e: PointerEvent) {
+            (self.handler)(e);
+        }
+    }
+
+    #[test]
+    fn holding_a_handle_in_place_reports_a_long_press() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        let h = Harness::new();
+
+        // Finger goes down, rests in place, then a later sample (as a real touch
+        // history emits) crosses the long-press timeout without moving.
+        h.send(event(PointerEventKind::Down, 100.0, 100.0, 0));
+        h.send(event(
+            PointerEventKind::Move,
+            101.0,
+            100.0,
+            HANDLE_LONG_PRESS_TIMEOUT_MS + 20,
+        ));
+
+        assert_eq!(
+            h.long_presses.get(),
+            1,
+            "a finger resting on the handle past the timeout should report one long-press"
+        );
+
+        // It must fire only once per press even as more samples arrive.
+        h.send(event(
+            PointerEventKind::Move,
+            101.0,
+            100.0,
+            HANDLE_LONG_PRESS_TIMEOUT_MS + 200,
+        ));
+        h.send(event(
+            PointerEventKind::Up,
+            101.0,
+            100.0,
+            HANDLE_LONG_PRESS_TIMEOUT_MS + 260,
+        ));
+        assert_eq!(
+            h.long_presses.get(),
+            1,
+            "long-press should fire at most once per press, got {}",
+            h.long_presses.get()
+        );
+        assert_eq!(
+            h.drag_ends.get(),
+            1,
+            "the lift should still settle the drag"
+        );
+    }
+
+    #[test]
+    fn a_held_handle_reports_the_long_press_on_lift() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        let h = Harness::new();
+
+        // A perfectly still finger emits no Move samples; the elapsed hold is
+        // only observable when it lifts. That lift must still report the
+        // long-press (and settle) so the menu can re-open.
+        h.send(event(PointerEventKind::Down, 100.0, 100.0, 0));
+        h.send(event(
+            PointerEventKind::Up,
+            100.0,
+            100.0,
+            HANDLE_LONG_PRESS_TIMEOUT_MS + 5,
+        ));
+
+        assert_eq!(
+            h.long_presses.get(),
+            1,
+            "lifting after a long hold should report a long-press"
+        );
+        assert_eq!(h.drag_ends.get(), 1);
+    }
+
+    #[test]
+    fn a_quick_tap_is_not_a_long_press() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        let h = Harness::new();
+
+        h.send(event(PointerEventKind::Down, 100.0, 100.0, 0));
+        h.send(event(PointerEventKind::Up, 100.0, 100.0, 80));
+
+        assert_eq!(
+            h.long_presses.get(),
+            0,
+            "a quick tap on the handle must not be treated as a long-press"
+        );
+        assert_eq!(h.drag_ends.get(), 1);
+    }
+
+    #[test]
+    fn dragging_a_handle_is_not_a_long_press() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        let h = Harness::new();
+
+        // Held long enough, but the finger travels far — that is a drag to
+        // adjust the selection, not a long-press.
+        h.send(event(PointerEventKind::Down, 100.0, 100.0, 0));
+        h.send(event(
+            PointerEventKind::Move,
+            180.0,
+            140.0,
+            HANDLE_LONG_PRESS_TIMEOUT_MS + 50,
+        ));
+        h.send(event(
+            PointerEventKind::Up,
+            180.0,
+            140.0,
+            HANDLE_LONG_PRESS_TIMEOUT_MS + 90,
+        ));
+
+        assert_eq!(
+            h.long_presses.get(),
+            0,
+            "dragging the handle must not report a long-press"
+        );
+        assert!(h.drags.get() >= 2, "the drag positions should be reported");
+    }
+
+    #[test]
+    fn is_handle_long_press_classifies_hold_vs_tap_vs_drag() {
+        // Held long enough, barely moved → long-press.
+        assert!(is_handle_long_press(
+            0,
+            HANDLE_LONG_PRESS_TIMEOUT_MS,
+            point(10.0, 10.0),
+            point(14.0, 12.0),
+        ));
+        // Not held long enough → not a long-press.
+        assert!(!is_handle_long_press(
+            0,
+            HANDLE_LONG_PRESS_TIMEOUT_MS - 1,
+            point(10.0, 10.0),
+            point(10.0, 10.0),
+        ));
+        // Held long enough but moved far → a drag, not a long-press.
+        assert!(!is_handle_long_press(
+            0,
+            HANDLE_LONG_PRESS_TIMEOUT_MS + 100,
+            point(10.0, 10.0),
+            point(60.0, 10.0),
+        ));
+    }
 }

--- a/crates/cranpose-ui/src/widgets/basic_text_field.rs
+++ b/crates/cranpose-ui/src/widgets/basic_text_field.rs
@@ -210,6 +210,7 @@ fn SelectionHandles(
             HANDLE_COLOR,
             move |pos| on_drag(pos),
             || {},
+            || {},
         );
     } else {
         // Range selection: start (leftmost) and end (rightmost) teardrops.
@@ -231,6 +232,10 @@ fn SelectionHandles(
             HANDLE_COLOR,
             move |pos| on_drag_start(pos),
             || {},
+            // Long-pressing a handle re-opens the contextual menu even when the
+            // selection range has not changed (e.g. after it was dismissed by a
+            // previous action), so the text actions stay reachable.
+            move || menu_open.set(true),
         );
 
         let on_drag_end = drag_edge_closure(
@@ -246,6 +251,7 @@ fn SelectionHandles(
             HANDLE_COLOR,
             move |pos| on_drag_end(pos),
             || {},
+            move || menu_open.set(true),
         );
 
         // Contextual menu (Copy / Cut / Paste / Select all) floating above the
@@ -541,6 +547,100 @@ mod tests {
         scene.expect("scene")
     }
 
+    /// Like [`render_range_menu_subcomposed`], but the field lives inside a
+    /// `LazyColumn` *item* — the exact shape of the reported device bug (a
+    /// multi-line field in a lazy list). The item is subcomposed off the
+    /// measure pass through `LazyColumn`'s own `SubcomposeLayoutNode`, so the
+    /// overlay `Popup`s (handles + menu) only reach the enclosing `PopupHost`
+    /// once the item subcomposition inherits the call-site composition locals.
+    fn render_range_menu_lazy_column(touch: bool) -> crate::renderer::RecordedRenderScene {
+        use crate::layout::LayoutEngine;
+        use crate::renderer::HeadlessRenderer;
+        use crate::widgets::PopupHost;
+        use crate::{LazyColumn, LazyColumnSpec};
+        use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope};
+        use cranpose_ui_graphics::Size;
+
+        let mut composition = Composition::new(MemoryApplier::new());
+        let key = location_key(file!(), line!(), column!());
+        let state = TextFieldState::new("hello world");
+
+        let mut content = {
+            let state = state.clone();
+            move || {
+                let state = state.clone();
+                PopupHost(move || {
+                    let state = state.clone();
+                    let list_state = remember_lazy_list_state();
+                    LazyColumn(
+                        Modifier::empty().size(Size {
+                            width: 300.0,
+                            height: 300.0,
+                        }),
+                        list_state,
+                        LazyColumnSpec::default(),
+                        move |scope| {
+                            let state = state.clone();
+                            scope.items(
+                                1,
+                                None::<fn(usize) -> u64>,
+                                None::<fn(usize) -> u64>,
+                                move |_index| {
+                                    let controller = TextFieldHandleController::new();
+                                    if state.selection() != TextRange::new(0, 5) {
+                                        state.set_selection(TextRange::new(0, 5));
+                                    }
+                                    controller.publish(TextFieldHandleMetrics {
+                                        focused: true,
+                                        touch,
+                                        node_origin: Point { x: 0.0, y: 40.0 },
+                                        padding_left: 0.0,
+                                        padding_top: 0.0,
+                                        scroll_offset: 0.0,
+                                        line_height: 18.0,
+                                    });
+                                    SelectionHandles(
+                                        state.clone(),
+                                        TextStyle::default(),
+                                        controller,
+                                    );
+                                },
+                            );
+                        },
+                    );
+                });
+            }
+        };
+
+        composition.render(key, &mut content).expect("render");
+        let root = composition.root().expect("root");
+        let handle = composition.runtime_handle();
+        let mut scene = None;
+        for _ in 0..8 {
+            for _ in 0..16 {
+                if !composition.should_render() {
+                    break;
+                }
+                composition.reconcile(key, &mut content).expect("reconcile");
+            }
+            let mut applier = composition.applier_mut();
+            applier.set_runtime_handle(handle.clone());
+            let layout = applier
+                .compute_layout(
+                    root,
+                    Size {
+                        width: 400.0,
+                        height: 400.0,
+                    },
+                )
+                .expect("layout");
+            applier.clear_runtime_handle();
+            drop(applier);
+            scene = Some(HeadlessRenderer::new().render(&layout));
+        }
+        scene.expect("scene")
+    }
+
     fn text_values(scene: &crate::renderer::RecordedRenderScene) -> Vec<String> {
         use crate::renderer::RenderOp;
         scene
@@ -603,6 +703,35 @@ mod tests {
             2,
             "a touch range selection should show two finger teardrop handles in \
              the overlay across the subcomposition boundary"
+        );
+    }
+
+    #[test]
+    fn selection_handles_and_menu_survive_lazy_column_item() {
+        // Regression for the reported device bug: a text field inside a
+        // `LazyColumn` item shows neither its selection handles nor its context
+        // menu, because the item is subcomposed off the list's measure pass and
+        // the overlay `Popup`s lose the enclosing `PopupHost` registry across
+        // that boundary. After capturing the call-site locals in `LazyColumn`
+        // the handles + menu reach the host, just like a top-level field.
+        let _app_context = crate::render_state::app_context_test_scope();
+        let scene = render_range_menu_lazy_column(true);
+
+        let texts = text_values(&scene);
+        assert!(
+            texts.iter().any(|t| t == "Copy"),
+            "a touch selection inside a LazyColumn item should show the Copy menu \
+             item through the host, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t == "Select all"),
+            "expected Select all inside a LazyColumn item, got {texts:?}"
+        );
+        assert_eq!(
+            image_count(&scene),
+            2,
+            "a touch range selection should show two finger teardrop handles in \
+             the overlay across the LazyColumn item subcomposition boundary"
         );
     }
 

--- a/crates/cranpose-ui/src/widgets/lazy_list.rs
+++ b/crates/cranpose-ui/src/widgets/lazy_list.rs
@@ -1053,12 +1053,23 @@ fn LazyColumnImpl(
             })
         })
     });
+    // Capture the composition locals in scope at this call site so the
+    // measure-pass subcomposition can replay them for each item. Without this,
+    // item content subcomposed off the measure pass (e.g. a text field's
+    // selection-handle / context-menu `Popup`) resolves the detached default
+    // composition-local values instead of the ancestor providers in scope here
+    // (such as the shell's `PopupHost` registry) and never renders. The
+    // `SubcomposeLayout` widget does the same; `LazyColumn` builds its
+    // `SubcomposeLayoutNode` directly and would otherwise skip it.
+    let captured_locals =
+        cranpose_core::with_current_composer(|composer| composer.capture_composition_locals());
     if let Err(err) = cranpose_core::with_node_mut(node_id, |node: &mut SubcomposeLayoutNode| {
         let modifier_changed = !node.modifier().structural_eq(&scroll_modifier);
         if refresh_content || config_changed || modifier_changed {
             node.set_modifier(scroll_modifier.clone());
         }
         node.set_measure_policy(Rc::clone(&policy));
+        node.set_captured_locals(captured_locals);
         if refresh_content || config_changed || modifier_changed {
             measured_item_cache.borrow_mut().clear();
             node.request_measure_recompose();
@@ -1158,12 +1169,19 @@ fn LazyRowImpl(
             })
         })
     });
+    // See `LazyColumnImpl`: capture the call-site composition locals so the
+    // measure-pass subcomposition replays them for each item, keeping overlay
+    // `Popup`s (selection handles / context menu) wired to the enclosing
+    // `PopupHost` across the subcomposition boundary.
+    let captured_locals =
+        cranpose_core::with_current_composer(|composer| composer.capture_composition_locals());
     if let Err(err) = cranpose_core::with_node_mut(node_id, |node: &mut SubcomposeLayoutNode| {
         let modifier_changed = !node.modifier().structural_eq(&scroll_modifier);
         if refresh_content || config_changed || modifier_changed {
             node.set_modifier(scroll_modifier.clone());
         }
         node.set_measure_policy(Rc::clone(&policy));
+        node.set_captured_locals(captured_locals);
         if refresh_content || config_changed || modifier_changed {
             measured_item_cache.borrow_mut().clear();
             node.request_measure_recompose();

--- a/crates/cranpose-ui/src/widgets/selection_handle.rs
+++ b/crates/cranpose-ui/src/widgets/selection_handle.rs
@@ -19,8 +19,16 @@ use crate::text_selection::{handle_path_data, HandleKind, HANDLE_TOUCH_PADDING};
 use crate::widgets::box_widget::{Box, BoxSpec};
 use crate::widgets::popup::Popup;
 use crate::PointerInputScope;
-use cranpose_foundation::PointerEventKind;
+use cranpose_foundation::{PointerEvent, PointerEventKind};
 use cranpose_ui_graphics::{Brush, Color, DrawScope, Point, Rect, Size, VectorPath};
+
+/// How long (ms) the finger must rest on a handle — without moving beyond
+/// [`HANDLE_LONG_PRESS_SLOP_PX`] — before it counts as a long-press. Matches
+/// Android's ~500ms long-press timeout.
+pub(crate) const HANDLE_LONG_PRESS_TIMEOUT_MS: i64 = 500;
+/// Movement (px) tolerated during a long-press before it is treated as a drag
+/// instead. Keeps a resting finger a long-press even with minor jitter.
+pub(crate) const HANDLE_LONG_PRESS_SLOP_PX: f32 = 12.0;
 
 /// Geometry of a handle's drawable teardrop for a bulb `radius`: the box the
 /// teardrop occupies and where the tip sits inside that box, so the caller can
@@ -77,6 +85,9 @@ fn handle_shape(kind: HandleKind, radius: f32) -> HandleShape {
 ///   caret / extend the selection.
 /// * `on_drag_end` — invoked when the finger lifts, so the field can settle
 ///   (e.g. show the contextual menu).
+/// * `on_long_press` — invoked once when the finger rests on the handle past the
+///   long-press timeout without dragging it, so the field can (re)open the
+///   contextual menu even when the selection range has not changed.
 #[composable]
 pub fn SelectionHandle(
     kind: HandleKind,
@@ -85,6 +96,7 @@ pub fn SelectionHandle(
     color: Color,
     on_drag: impl Fn(Point) + 'static,
     on_drag_end: impl Fn() + 'static,
+    on_long_press: impl Fn() + 'static,
 ) {
     let shape = handle_shape(kind, radius);
     let anchor = Rect {
@@ -97,11 +109,13 @@ pub fn SelectionHandle(
     let box_size = shape.box_size;
     let on_drag: Rc<dyn Fn(Point)> = Rc::new(on_drag);
     let on_drag_end: Rc<dyn Fn()> = Rc::new(on_drag_end);
+    let on_long_press: Rc<dyn Fn()> = Rc::new(on_long_press);
 
     Popup(anchor, Point { x: 0.0, y: 0.0 }, move || {
         let path_data = path_data.clone();
         let on_drag = Rc::clone(&on_drag);
         let on_drag_end = Rc::clone(&on_drag_end);
+        let on_long_press = Rc::clone(&on_long_press);
         Box(
             Modifier::empty()
                 .size(box_size)
@@ -110,32 +124,121 @@ pub fn SelectionHandle(
                         scope.draw_vector_path(&path, Brush::solid(color));
                     }
                 })
-                .pointer_input((), move |scope: PointerInputScope| {
-                    let on_drag = Rc::clone(&on_drag);
-                    let on_drag_end = Rc::clone(&on_drag_end);
-                    async move {
-                        scope
-                            .await_pointer_event_scope(|await_scope| async move {
-                                loop {
-                                    let event = await_scope.await_pointer_event().await;
-                                    match event.kind {
-                                        PointerEventKind::Down | PointerEventKind::Move => {
-                                            on_drag(event.global_position);
-                                            event.consume();
-                                        }
-                                        PointerEventKind::Up | PointerEventKind::Cancel => {
-                                            on_drag_end();
-                                            event.consume();
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                            })
-                            .await;
-                    }
-                }),
+                .then(selection_handle_pointer_input(
+                    Rc::clone(&on_drag),
+                    Rc::clone(&on_drag_end),
+                    Rc::clone(&on_long_press),
+                )),
             BoxSpec::default(),
             || {},
         );
     });
+}
+
+/// Builds the pointer-input modifier that drives a selection handle: it reports
+/// every drag position, the drag end (finger lift), and a long-press (finger
+/// held in place past [`HANDLE_LONG_PRESS_TIMEOUT_MS`]). Shared by
+/// [`SelectionHandle`] and exercised directly in tests so the gesture semantics
+/// stay pinned without a full compose/layout/hit-test round-trip.
+pub(crate) fn selection_handle_pointer_input(
+    on_drag: Rc<dyn Fn(Point)>,
+    on_drag_end: Rc<dyn Fn()>,
+    on_long_press: Rc<dyn Fn()>,
+) -> Modifier {
+    Modifier::empty().pointer_input((), move |scope: PointerInputScope| {
+        let on_drag = Rc::clone(&on_drag);
+        let on_drag_end = Rc::clone(&on_drag_end);
+        let on_long_press = Rc::clone(&on_long_press);
+        async move {
+            scope
+                .await_pointer_event_scope(|await_scope| async move {
+                    // Track the initial press so a resting finger can be told
+                    // apart from a drag. `time_ms` is the platform input clock;
+                    // when it is unavailable the long-press simply never fires
+                    // (a drag/lift still settles the selection).
+                    let mut down_time: Option<i64> = None;
+                    let mut down_pos = Point { x: 0.0, y: 0.0 };
+                    let mut long_press_fired = false;
+                    loop {
+                        let event = await_scope.await_pointer_event().await;
+                        match event.kind {
+                            PointerEventKind::Down => {
+                                down_time = event.time_ms;
+                                down_pos = event.global_position;
+                                long_press_fired = false;
+                                on_drag(event.global_position);
+                                event.consume();
+                            }
+                            PointerEventKind::Move => {
+                                on_drag(event.global_position);
+                                maybe_fire_long_press(
+                                    &event,
+                                    down_time,
+                                    down_pos,
+                                    &mut long_press_fired,
+                                    &on_long_press,
+                                );
+                                event.consume();
+                            }
+                            PointerEventKind::Up => {
+                                maybe_fire_long_press(
+                                    &event,
+                                    down_time,
+                                    down_pos,
+                                    &mut long_press_fired,
+                                    &on_long_press,
+                                );
+                                on_drag_end();
+                                down_time = None;
+                                event.consume();
+                            }
+                            PointerEventKind::Cancel => {
+                                on_drag_end();
+                                down_time = None;
+                                event.consume();
+                            }
+                            _ => {}
+                        }
+                    }
+                })
+                .await;
+        }
+    })
+}
+
+/// Fires `on_long_press` at most once per press when the finger has rested on
+/// the handle for at least [`HANDLE_LONG_PRESS_TIMEOUT_MS`] without moving more
+/// than [`HANDLE_LONG_PRESS_SLOP_PX`] from where it went down (i.e. a hold, not
+/// a drag).
+fn maybe_fire_long_press(
+    event: &PointerEvent,
+    down_time: Option<i64>,
+    down_pos: Point,
+    long_press_fired: &mut bool,
+    on_long_press: &Rc<dyn Fn()>,
+) {
+    if *long_press_fired {
+        return;
+    }
+    let (Some(down_ms), Some(now_ms)) = (down_time, event.time_ms) else {
+        return;
+    };
+    if is_handle_long_press(down_ms, now_ms, down_pos, event.global_position) {
+        *long_press_fired = true;
+        on_long_press();
+    }
+}
+
+/// Pure predicate for a handle long-press: held long enough and moved little
+/// enough to be a rest rather than a drag.
+pub(crate) fn is_handle_long_press(
+    down_ms: i64,
+    now_ms: i64,
+    down_pos: Point,
+    now_pos: Point,
+) -> bool {
+    let dx = now_pos.x - down_pos.x;
+    let dy = now_pos.y - down_pos.y;
+    let moved = (dx * dx + dy * dy).sqrt();
+    now_ms - down_ms >= HANDLE_LONG_PRESS_TIMEOUT_MS && moved <= HANDLE_LONG_PRESS_SLOP_PX
 }


### PR DESCRIPTION
## Problem (device-reported)

Text selection handles + the copy/paste context menu **work** in a single-line `BasicTextField` in a screen header (CranScan's library search), but **do not appear** in a multi-line `BasicTextField` inside a `LazyColumn` item (CranScan's document "recognized text" box).

## Root cause — confirmed: the lazy-item subcompose path drops the locals (yes)

PR #313 fixed CompositionLocals being dropped at the `SubcomposeLayout` measure-pass boundary by capturing the call-site locals (`Composer::capture_composition_locals`) and replaying them during subcomposition (`subcompose_slot_with_locals`). That capture is wired **only** in the `SubcomposeLayout` composable — `crates/cranpose-ui/src/widgets/layout.rs:109-114`.

`LazyColumn`/`LazyRow` are a **separate subcompose path**: `LazyColumnImpl` and `LazyRowImpl` build their `SubcomposeLayoutNode` directly (`crates/cranpose-ui/src/widgets/lazy_list.rs:1052` / `:1157`) and configure it via `with_node_mut` **without** calling `set_captured_locals`. So for a field inside a lazy item, `captured_locals` stayed `None`; the item was subcomposed off the measure pass with the detached default locals; the selection-handle / context-menu `Popup` resolved the default `PopupRegistry` instead of the shell's `PopupHost`; nothing rendered. Top-level header fields already worked after PR #313 — exactly matching the report.

The seeded stack does propagate correctly once set: the outer `subcompose_slot_with_locals` seeds the inner composer's `local_stack`, and the per-item inner `subcompose_slot` in `perform_subcompose` reads it back via `current_local_stack()`.

**Multi-line is NOT a separate cause.** `SelectionHandles` is emitted unconditionally regardless of `line_limits`, gated only on `metrics.focused && metrics.touch` + selection state; `handle_tip_window_pos` already positions the handle per visual line (`line_index`). Metrics publishing does not branch on line count either.

## Fix

1. **Locals across the lazy boundary** — `LazyColumnImpl`/`LazyRowImpl` now `capture_composition_locals()` at the call site and `node.set_captured_locals(...)`, mirroring the `SubcomposeLayout` widget. A text field inside a `LazyColumn` item now reaches the same `PopupHost` as a top-level field.

2. **Context menu on long-press of a handle** — the menu already appears when a range is selected (defaults open + reopens on range change). Added: a selection handle reports a **long-press** (finger held ~500ms without dragging) via a new `on_long_press` callback; the range handles wire it to re-open the Copy/Cut/Paste/Select-all menu, so the actions stay reachable after the menu was dismissed and the range hasn't changed. The gesture loop is factored into `selection_handle_pointer_input` (long-press detection via `PointerEvent::time_ms` + movement slop) so it is driven directly in tests.

## Tests (each fails before / passes after the relevant fix)

- `popup_inside_lazy_column_item_still_reaches_the_host` — a `Popup` inside a `LazyColumn` item reaches the enclosing `PopupHost` (empty overlay before the fix).
- `selection_handles_and_menu_survive_lazy_column_item` — a touch range selection in a `LazyColumn` item shows both teardrop handles + the Copy/Select-all menu through the host (nothing before the fix).
- long-press gesture suite in `selection_handle_tests.rs` — hold reports exactly one long-press; a held-then-lifted finger reports it on lift; a quick tap does not; a drag does not; plus the pure `is_handle_long_press` predicate.

## Verification

- `cargo fmt --check` clean
- `cargo test -p cranpose-ui -p cranpose-foundation -p cranpose -p cranpose-app-shell` green, including the 48 static guards
- `cargo check --workspace` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- wasm: `desktop-app` `wasm32-unknown-unknown` (`--features web,renderer-wgpu`) compiles clean
- Android: `desktop-app-platform` `aarch64-linux-android` (`--features android,renderer-wgpu`, NDK toolchain) compiles clean

Device verification was not possible (no usable arm64 device), so this relies on the headless regressions that reproduce the exact `LazyColumn`-item case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKmJDd6pG9opQHr7btBMke