### PR TITLE
fix(text-field): handle orientation, tap-granularity ladder, consuming context menu, wide-line magnifier, cold-start keyboard

### DIFF
--- a/crates/cranpose-ui/src/text_field_modifier_node.rs
+++ b/crates/cranpose-ui/src/text_field_modifier_node.rs
@@ -398,10 +398,12 @@ impl TextFieldModifierNode {
         line_limits: TextFieldLineLimits,
         style: TextStyle, // Add style
     ) -> Rc<dyn Fn(PointerEvent)> {
-        // Word boundaries for double-tap; selection classification/line
-        // boundaries for the tap-count-driven selection gestures.
+        // Tap-count classification plus word/line/paragraph boundaries drive the
+        // multi-tap selection granularity gestures.
         use crate::text_selection::{
-            classify_tap, find_line_boundaries, TapCount, MULTI_TAP_SLOP_PX, MULTI_TAP_TIMEOUT_MS,
+            classify_tap_count, find_line_boundaries, find_paragraph_boundaries,
+            tap_selection_granularity, SelectionGranularity, MULTI_TAP_SLOP_PX,
+            MULTI_TAP_TIMEOUT_MS,
         };
         use crate::word_boundaries::find_word_boundaries;
 
@@ -445,20 +447,20 @@ impl TextFieldModifierNode {
                         click_y,
                     );
 
-                    // Classify the press into single/double/triple by both the
+                    // Classify the press into a 1-based tap count by both the
                     // time since and the distance from the previous press (a tap
                     // far from the last one starts a fresh single tap, matching
                     // Android's double-tap slop).
-                    let previous = refs.click_count.get().try_into().ok().and_then(|count| {
-                        let (px, py) = refs.last_click_pos.get()?;
-                        Some((count, px, py))
+                    let previous = refs.last_click_pos.get().and_then(|(px, py)| {
+                        let count = refs.click_count.get();
+                        (count > 0).then_some((count, px, py))
                     });
                     let elapsed_ms = refs
                         .last_click_time
                         .get()
                         .map(|last| now.duration_since(last).as_millis())
                         .unwrap_or(u128::MAX);
-                    let tap = classify_tap(
+                    let tap_count = classify_tap_count(
                         previous,
                         elapsed_ms,
                         event.position.x,
@@ -467,25 +469,51 @@ impl TextFieldModifierNode {
                         MULTI_TAP_SLOP_PX,
                     );
 
-                    match tap {
-                        TapCount::Triple => {
-                            // Triple tap/click: select the line/paragraph.
+                    // A lone tap that lands INSIDE an existing (non-collapsed)
+                    // selection selects the word under the finger (Android/iOS
+                    // "tap the selection to re-grab a word"), and seeds the
+                    // progression at "word" so the next in-place tap escalates to
+                    // line then paragraph. A lone tap elsewhere just places the
+                    // caret.
+                    let selection = state.selection();
+                    let effective_count = if tap_count == 1
+                        && !selection.collapsed()
+                        && pos >= selection.min()
+                        && pos <= selection.max()
+                    {
+                        2
+                    } else {
+                        tap_count
+                    };
+
+                    match tap_selection_granularity(effective_count) {
+                        SelectionGranularity::Paragraph => {
+                            // Fourth tap: grow to the whole paragraph.
+                            let (start, end) = find_paragraph_boundaries(&text, pos);
+                            state.edit(|buffer| {
+                                buffer.select(TextRange::new(start, end));
+                            });
+                            refs.drag_anchor.set(Some(start));
+                        }
+                        SelectionGranularity::Line => {
+                            // Triple tap: select the line.
                             let (line_start, line_end) = find_line_boundaries(&text, pos);
                             state.edit(|buffer| {
                                 buffer.select(TextRange::new(line_start, line_end));
                             });
                             refs.drag_anchor.set(Some(line_start));
                         }
-                        TapCount::Double => {
-                            // Double tap/click: select the word.
+                        SelectionGranularity::Word => {
+                            // Double tap (or a tap inside an existing selection):
+                            // select the word.
                             let (word_start, word_end) = find_word_boundaries(&text, pos);
                             state.edit(|buffer| {
                                 buffer.select(TextRange::new(word_start, word_end));
                             });
                             refs.drag_anchor.set(Some(word_start));
                         }
-                        TapCount::Single => {
-                            // Single tap/click: place the cursor.
+                        SelectionGranularity::Caret => {
+                            // Single tap: place the cursor.
                             refs.drag_anchor.set(Some(pos));
                             state.edit(|buffer| {
                                 buffer.place_cursor_before_char(pos);
@@ -493,7 +521,7 @@ impl TextFieldModifierNode {
                         }
                     }
 
-                    refs.click_count.set(tap.as_u8());
+                    refs.click_count.set(effective_count);
                     refs.last_click_time.set(Some(now));
                     refs.last_click_pos
                         .set(Some((event.position.x, event.position.y)));
@@ -1452,6 +1480,119 @@ mod tests {
             assert_eq!(
                 selected, "hello",
                 "double tap should select the whole word under the finger"
+            );
+
+            crate::text_field_focus::clear_focus();
+        });
+    }
+
+    /// The multi-tap selection granularity ladder (bug 8): repeated in-place taps
+    /// escalate word → line → paragraph, then cycle back to word. Mirrors mature
+    /// editors (Android `TextView`, iOS, VS Code).
+    #[test]
+    fn repeated_taps_escalate_word_line_paragraph_then_cycle() {
+        use cranpose_foundation::{PointerEvent, PointerEventKind, PointerSource};
+        use cranpose_ui_graphics::Point;
+
+        let _app_context = crate::render_state::app_context_test_scope();
+        with_test_runtime(|| {
+            // Two lines in the first paragraph, a blank line, then a second
+            // paragraph — so line and paragraph selections differ.
+            let text = "alpha beta\ngamma delta\n\nsecond para";
+            let state = TextFieldState::new(text);
+            let node = TextFieldModifierNode::new(state.clone(), TextStyle::default())
+                .with_line_limits(TextFieldLineLimits::MultiLine {
+                    min_lines: 1,
+                    max_lines: usize::MAX,
+                });
+            node.measured_size.set(Size {
+                width: 400.0,
+                height: 80.0,
+            });
+            let handler = node
+                .pointer_input_handler()
+                .expect("field exposes a pointer handler");
+
+            // Tap in place on the first line ("alpha").
+            let at = Point { x: 2.0, y: 4.0 };
+            let tap = || {
+                handler(
+                    PointerEvent::new(PointerEventKind::Down, at, at)
+                        .with_source(PointerSource::Touch),
+                );
+            };
+            let selected = |state: &TextFieldState| {
+                let s = state.selection();
+                state.text()[s.min()..s.max()].to_string()
+            };
+
+            tap(); // 1 → caret
+            assert!(state.selection().collapsed(), "first tap places the caret");
+            tap(); // 2 → word
+            assert_eq!(selected(&state), "alpha", "double tap selects the word");
+            tap(); // 3 → line
+            assert_eq!(
+                selected(&state),
+                "alpha beta",
+                "triple tap selects the line"
+            );
+            tap(); // 4 → paragraph
+            assert_eq!(
+                selected(&state),
+                "alpha beta\ngamma delta",
+                "fourth tap grows to the paragraph"
+            );
+            tap(); // 5 → cycles back to word
+            assert_eq!(
+                selected(&state),
+                "alpha",
+                "fifth tap cycles back to the word"
+            );
+
+            crate::text_field_focus::clear_focus();
+        });
+    }
+
+    /// A single tap that lands inside an existing selection re-grabs the word
+    /// under the finger (Android/iOS behaviour), rather than collapsing to a
+    /// caret (bug 8).
+    #[test]
+    fn single_tap_inside_selection_selects_the_word() {
+        use cranpose_foundation::{PointerEvent, PointerEventKind, PointerSource};
+        use cranpose_ui_graphics::Point;
+
+        let _app_context = crate::render_state::app_context_test_scope();
+        with_test_runtime(|| {
+            let state = TextFieldState::new("hello world");
+            let node = TextFieldModifierNode::new(state.clone(), TextStyle::default());
+            node.measured_size.set(Size {
+                width: 200.0,
+                height: 20.0,
+            });
+            let handler = node
+                .pointer_input_handler()
+                .expect("field exposes a pointer handler");
+
+            // Pre-existing broad selection over the whole text.
+            state.edit(|buffer| buffer.select(TextRange::new(0, 11)));
+            assert!(!state.selection().collapsed());
+
+            // A lone tap over "hello" (fresh tap count) must select that word,
+            // not drop the selection.
+            let at = Point { x: 2.0, y: 8.0 };
+            handler(
+                PointerEvent::new(PointerEventKind::Down, at, at).with_source(PointerSource::Touch),
+            );
+
+            let selection = state.selection();
+            assert!(
+                !selection.collapsed(),
+                "a tap inside a selection must not collapse it, got {selection:?}"
+            );
+            assert_eq!(
+                &state.text()[selection.min()..selection.max()],
+                "hello",
+                "a tap inside a selection re-selects the word under the finger"
             );
 
             crate::text_field_focus::clear_focus();

--- a/crates/cranpose-ui/src/text_input_session.rs
+++ b/crates/cranpose-ui/src/text_input_session.rs
@@ -303,6 +303,26 @@ mod tests {
     }
 
     #[test]
+    fn cold_start_with_no_focus_does_not_show_the_keyboard() {
+        // Bug 5: on a fresh launch the platform runtime calls `notify_app_resumed`
+        // once and only re-shows the keyboard when a field is actually focused.
+        // With nothing focused (a brand-new app context, e.g. a cold restart) it
+        // must return false and never call `show`, so the runtime knows to force
+        // the OS-restored keyboard hidden instead.
+        let _app_context = crate::render_state::app_context_test_scope();
+        let handler = install_recording_handler();
+
+        assert!(
+            !notify_app_resumed(),
+            "a launch with no focused field must not re-open the keyboard"
+        );
+        assert!(
+            handler.calls.borrow().is_empty(),
+            "no platform show/hide should be requested for an unfocused cold start"
+        );
+    }
+
+    #[test]
     fn pause_is_a_noop_when_the_keyboard_was_not_showing() {
         let _app_context = crate::render_state::app_context_test_scope();
         let handler = install_recording_handler();

--- a/crates/cranpose-ui/src/text_selection.rs
+++ b/crates/cranpose-ui/src/text_selection.rs
@@ -9,40 +9,6 @@
 //! Keeping these as free functions makes the touch behavior testable without a
 //! renderer and keeps `TextFieldModifierNode` focused on wiring.
 
-/// How many consecutive taps a press represents, mirroring the platform text
-/// selection gestures: one tap places the cursor, two select the word, three
-/// select the line/paragraph.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum TapCount {
-    Single,
-    Double,
-    Triple,
-}
-
-impl TapCount {
-    /// The 1-based tap number, capped at three.
-    pub fn as_u8(self) -> u8 {
-        match self {
-            TapCount::Single => 1,
-            TapCount::Double => 2,
-            TapCount::Triple => 3,
-        }
-    }
-}
-
-impl TryFrom<u8> for TapCount {
-    type Error = ();
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            1 => Ok(TapCount::Single),
-            2 => Ok(TapCount::Double),
-            3 => Ok(TapCount::Triple),
-            _ => Err(()),
-        }
-    }
-}
-
 /// Maximum time between taps that still counts as a multi-tap, in milliseconds.
 pub const MULTI_TAP_TIMEOUT_MS: u128 = 500;
 
@@ -52,44 +18,78 @@ pub const MULTI_TAP_TIMEOUT_MS: u128 = 500;
 /// double-tap slop behavior.
 pub const MULTI_TAP_SLOP_PX: f32 = 24.0;
 
-/// Classifies a press into a tap count from the previous tap's count, the time
-/// since it, and the distance from it.
+/// The unit of text a tap gesture selects, growing with the tap count the way
+/// mature text editors do (Android `TextView`, iOS `UITextView`, VS Code):
 ///
-/// `previous` is the last tap's `(count, x, y)` or `None` for the first tap.
-/// A tap escalates the count (single -> double -> triple, then wraps back to
-/// single) only when it lands within both the timeout and the slop radius;
-/// otherwise it restarts at a single tap.
-pub fn classify_tap(
-    previous: Option<(TapCount, f32, f32)>,
+/// * 1 tap → [`Caret`](SelectionGranularity::Caret) (place the cursor);
+/// * 2 taps → [`Word`](SelectionGranularity::Word);
+/// * 3 taps → [`Line`](SelectionGranularity::Line);
+/// * 4 taps → [`Paragraph`](SelectionGranularity::Paragraph);
+/// * 5+ taps → cycle back through word → line → paragraph.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SelectionGranularity {
+    /// Collapsed caret (a single tap places the cursor).
+    Caret,
+    /// The word under the tap.
+    Word,
+    /// The line under the tap (delimited by `\n`).
+    Line,
+    /// The paragraph under the tap (delimited by blank lines).
+    Paragraph,
+}
+
+/// Classifies a press into a 1-based tap count from the previous tap's count,
+/// the time since it, and the distance from it.
+///
+/// `previous` is the last tap's `(count, x, y)` or `None` for the first tap. A
+/// tap increments the count only when it lands within both the timeout and the
+/// slop radius; otherwise it restarts at `1`. The count is **not** wrapped here
+/// — the granularity mapping ([`tap_selection_granularity`]) cycles instead, so
+/// the field can keep escalating (word → line → paragraph → word …) as long as
+/// the finger keeps tapping in place.
+pub fn classify_tap_count(
+    previous: Option<(u8, f32, f32)>,
     elapsed_ms: u128,
     x: f32,
     y: f32,
     timeout_ms: u128,
     slop_px: f32,
-) -> TapCount {
+) -> u8 {
     let Some((prev_count, prev_x, prev_y)) = previous else {
-        return TapCount::Single;
+        return 1;
     };
     let within_time = elapsed_ms <= timeout_ms;
     let dx = x - prev_x;
     let dy = y - prev_y;
     let within_slop = dx * dx + dy * dy <= slop_px * slop_px;
     if !within_time || !within_slop {
-        return TapCount::Single;
+        return 1;
     }
-    match prev_count {
-        TapCount::Single => TapCount::Double,
-        TapCount::Double => TapCount::Triple,
-        // A fourth tap cycles back to a single cursor placement.
-        TapCount::Triple => TapCount::Single,
+    prev_count.saturating_add(1)
+}
+
+/// Maps a 1-based tap count to the granularity it selects.
+///
+/// A single tap places the caret; two taps select the word, three the line,
+/// four the paragraph, and every further tap cycles back through
+/// word → line → paragraph so a resting finger keeps toggling between the three
+/// range granularities (matching desktop editors and iOS).
+pub fn tap_selection_granularity(tap_count: u8) -> SelectionGranularity {
+    match tap_count {
+        0 | 1 => SelectionGranularity::Caret,
+        n => match (n - 2) % 3 {
+            0 => SelectionGranularity::Word,
+            1 => SelectionGranularity::Line,
+            _ => SelectionGranularity::Paragraph,
+        },
     }
 }
 
-/// Returns the byte range `[start, end)` of the line/paragraph containing
-/// `pos`, delimited by `\n` (the newline itself is excluded from the range).
+/// Returns the byte range `[start, end)` of the line containing `pos`, delimited
+/// by `\n` (the newline itself is excluded from the range).
 ///
-/// Used for triple-tap line/paragraph selection. Byte offsets always land on
-/// `char` boundaries because `\n` is a single-byte ASCII character.
+/// Used for triple-tap line selection. Byte offsets always land on `char`
+/// boundaries because `\n` is a single-byte ASCII character.
 pub fn find_line_boundaries(text: &str, pos: usize) -> (usize, usize) {
     let pos = pos.min(text.len());
     let start = text[..pos].rfind('\n').map(|i| i + 1).unwrap_or(0);
@@ -98,6 +98,37 @@ pub fn find_line_boundaries(text: &str, pos: usize) -> (usize, usize) {
         .map(|i| pos + i)
         .unwrap_or(text.len());
     (start, end)
+}
+
+/// Returns the byte range `[start, end)` of the paragraph containing `pos`.
+///
+/// Paragraphs are delimited by blank lines — a run of two or more consecutive
+/// `\n` — so a fourth tap grows the selection from one line to the whole block
+/// of text around it. Text with no blank line is a single paragraph (the whole
+/// string). Byte offsets land on `char` boundaries because `\n` is single-byte
+/// ASCII. Unicode-aware: multi-byte characters inside the paragraph are spanned
+/// whole.
+pub fn find_paragraph_boundaries(text: &str, pos: usize) -> (usize, usize) {
+    let pos = pos.min(text.len());
+    // Start: just after the last blank-line separator at or before `pos`.
+    let start = text[..pos]
+        .rfind("\n\n")
+        .map(|i| {
+            // Skip the whole run of blank lines so the paragraph starts on its
+            // first non-empty line.
+            let mut s = i + 1;
+            while text[s..].starts_with('\n') {
+                s += 1;
+            }
+            s
+        })
+        .unwrap_or(0);
+    // End: the next blank-line separator at or after `pos`.
+    let end = text[pos..]
+        .find("\n\n")
+        .map(|i| pos + i)
+        .unwrap_or(text.len());
+    (start.min(end), end)
 }
 
 /// Which selection handle a teardrop represents.
@@ -136,9 +167,17 @@ pub fn handle_path_data(kind: HandleKind, tip_x: f32, tip_y: f32, radius: f32) -
             // Android start (left) handle: the point sits at the TOP-RIGHT
             // (touching the selection start) with a straight vertical right edge,
             // and the round bulb hangs down and to the LEFT. Traced tip → straight
-            // down the right edge → arc round to the left → back to the tip.
+            // down the right edge → 270° arc round the bulb (whose centre sits at
+            // `(tip_x - r, cy)`, down-left of the tip) → back along the top edge to
+            // the tip.
+            //
+            // The sweep flag is `1` (clockwise, y-down): together with the
+            // large-arc flag this centres the arc on the bulb below-left of the
+            // tip. Sweep `0` would instead centre the arc on the tip itself,
+            // drawing an upward pac-man wedge that overlaps the glyph line — the
+            // reported "inverted teardrop".
             format!(
-                "M {tip_x} {tip_y} L {tip_x} {cy} A {r} {r} 0 1 0 {left} {tip_y} Z",
+                "M {tip_x} {tip_y} L {tip_x} {cy} A {r} {r} 0 1 1 {left} {tip_y} Z",
                 left = tip_x - r,
             )
         }
@@ -147,9 +186,10 @@ pub fn handle_path_data(kind: HandleKind, tip_x: f32, tip_y: f32, radius: f32) -
             // the point sits at the TOP-LEFT (touching the selection end) with a
             // straight vertical left edge, and the round bulb hangs down and to
             // the RIGHT. Same trace as the start handle with the arc swept the
-            // other way so it is a true reflection (not rotated).
+            // other way (sweep `0`) so it is a true reflection (not rotated): the
+            // bulb centre sits at `(tip_x + r, cy)`, down-right of the tip.
             format!(
-                "M {tip_x} {tip_y} L {tip_x} {cy} A {r} {r} 0 1 1 {right} {tip_y} Z",
+                "M {tip_x} {tip_y} L {tip_x} {cy} A {r} {r} 0 1 0 {right} {tip_y} Z",
                 right = tip_x + r,
             )
         }
@@ -201,43 +241,24 @@ mod tests {
 
     #[test]
     fn tap_classification_escalates_within_time_and_slop() {
+        assert_eq!(classify_tap_count(None, 0, 10.0, 10.0, 500, 24.0), 1);
         assert_eq!(
-            classify_tap(None, 0, 10.0, 10.0, 500, 24.0),
-            TapCount::Single
+            classify_tap_count(Some((1, 10.0, 10.0)), 100, 11.0, 12.0, 500, 24.0),
+            2
         );
         assert_eq!(
-            classify_tap(
-                Some((TapCount::Single, 10.0, 10.0)),
-                100,
-                11.0,
-                12.0,
-                500,
-                24.0
-            ),
-            TapCount::Double
+            classify_tap_count(Some((2, 10.0, 10.0)), 100, 11.0, 12.0, 500, 24.0),
+            3
+        );
+        // A fourth in-place tap keeps counting up (the granularity mapping is
+        // what cycles, not the raw count).
+        assert_eq!(
+            classify_tap_count(Some((3, 10.0, 10.0)), 100, 11.0, 12.0, 500, 24.0),
+            4
         );
         assert_eq!(
-            classify_tap(
-                Some((TapCount::Double, 10.0, 10.0)),
-                100,
-                11.0,
-                12.0,
-                500,
-                24.0
-            ),
-            TapCount::Triple
-        );
-        // A fourth quick tap wraps back to a single cursor placement.
-        assert_eq!(
-            classify_tap(
-                Some((TapCount::Triple, 10.0, 10.0)),
-                100,
-                11.0,
-                12.0,
-                500,
-                24.0
-            ),
-            TapCount::Single
+            classify_tap_count(Some((4, 10.0, 10.0)), 100, 11.0, 12.0, 500, 24.0),
+            5
         );
     }
 
@@ -245,28 +266,65 @@ mod tests {
     fn tap_classification_resets_past_timeout_or_slop() {
         // Too slow: restarts.
         assert_eq!(
-            classify_tap(
-                Some((TapCount::Single, 10.0, 10.0)),
-                600,
-                10.0,
-                10.0,
-                500,
-                24.0
-            ),
-            TapCount::Single
+            classify_tap_count(Some((1, 10.0, 10.0)), 600, 10.0, 10.0, 500, 24.0),
+            1
         );
         // Too far: restarts even though it is quick.
         assert_eq!(
-            classify_tap(
-                Some((TapCount::Single, 10.0, 10.0)),
-                50,
-                100.0,
-                10.0,
-                500,
-                24.0
-            ),
-            TapCount::Single
+            classify_tap_count(Some((1, 10.0, 10.0)), 50, 100.0, 10.0, 500, 24.0),
+            1
         );
+        // A reset also applies from a higher count.
+        assert_eq!(
+            classify_tap_count(Some((3, 10.0, 10.0)), 600, 10.0, 10.0, 500, 24.0),
+            1
+        );
+    }
+
+    #[test]
+    fn tap_granularity_grows_then_cycles() {
+        use SelectionGranularity::*;
+        assert_eq!(tap_selection_granularity(0), Caret);
+        assert_eq!(tap_selection_granularity(1), Caret);
+        assert_eq!(tap_selection_granularity(2), Word);
+        assert_eq!(tap_selection_granularity(3), Line);
+        assert_eq!(tap_selection_granularity(4), Paragraph);
+        // Fifth tap cycles back to word, then line, then paragraph again.
+        assert_eq!(tap_selection_granularity(5), Word);
+        assert_eq!(tap_selection_granularity(6), Line);
+        assert_eq!(tap_selection_granularity(7), Paragraph);
+        assert_eq!(tap_selection_granularity(8), Word);
+    }
+
+    #[test]
+    fn paragraph_boundaries_span_blank_line_delimited_blocks() {
+        let text = "line one\nline two\n\nsecond para\nstill second\n\n\nthird";
+        // Inside the first paragraph (two lines).
+        let (s, e) = find_paragraph_boundaries(text, 3);
+        assert_eq!(&text[s..e], "line one\nline two");
+        // Inside the second paragraph.
+        let (s, e) = find_paragraph_boundaries(text, 20);
+        assert_eq!(&text[s..e], "second para\nstill second");
+        // Inside the third paragraph, after a run of THREE newlines.
+        let (s, e) = find_paragraph_boundaries(text, text.len());
+        assert_eq!(&text[s..e], "third");
+    }
+
+    #[test]
+    fn paragraph_boundaries_no_blank_line_is_whole_text() {
+        let text = "just\none\nblock";
+        assert_eq!(find_paragraph_boundaries(text, 5), (0, text.len()));
+    }
+
+    #[test]
+    fn paragraph_boundaries_are_unicode_aware() {
+        // Multi-byte characters must be spanned whole and offsets stay on char
+        // boundaries.
+        let text = "\u{4e2d}\u{6587}\u{6bb5}\u{843d}\n\n\u{6b21}";
+        let first = "\u{4e2d}\u{6587}\u{6bb5}\u{843d}";
+        let (s, e) = find_paragraph_boundaries(text, 3);
+        assert_eq!(&text[s..e], first);
+        assert!(text.is_char_boundary(s) && text.is_char_boundary(e));
     }
 
     #[test]
@@ -309,6 +367,78 @@ mod tests {
             // The bulb hangs below the tip.
             assert!(bounds.y + bounds.height >= 20.0 + HANDLE_RADIUS);
         }
+    }
+
+    /// Regression for the inverted-teardrop bug: the drawn selection handles
+    /// must have the correct Android orientation — the whole teardrop sits AT OR
+    /// BELOW the tip line (never above it, into the glyphs), and each handle's
+    /// bulb hangs to the correct side of its tip:
+    ///
+    /// * start (left) handle — point top-right, bulb down-LEFT (all geometry at
+    ///   or left of the tip's x);
+    /// * end (right) handle — point top-left, bulb down-RIGHT (all geometry at or
+    ///   right of the tip's x);
+    /// * cursor handle — symmetric, centred on the tip.
+    ///
+    /// A sweep-flag mistake used to centre the arc on the tip, producing an
+    /// upward pac-man wedge that extended ABOVE the tip and to the wrong side —
+    /// exactly what this guards against.
+    #[test]
+    fn selection_handles_point_at_the_tip_with_the_bulb_below() {
+        let (tip_x, tip_y, r) = (40.0_f32, 20.0_f32, HANDLE_RADIUS);
+        let eps = 0.5_f32;
+
+        let sample_points = |kind: HandleKind| -> Vec<cranpose_ui_graphics::Point> {
+            let data = handle_path_data(kind, tip_x, tip_y, r);
+            let path = cranpose_ui_graphics::VectorPath::parse(&data).expect("valid handle path");
+            path.subpaths().iter().flatten().copied().collect()
+        };
+
+        // No handle draws any geometry ABOVE the tip line — that region belongs to
+        // the glyphs, and a handle poking up into it is the inverted-teardrop bug.
+        for kind in [
+            HandleKind::Cursor,
+            HandleKind::SelectionStart,
+            HandleKind::SelectionEnd,
+        ] {
+            for p in sample_points(kind) {
+                assert!(
+                    p.y >= tip_y - eps,
+                    "{kind:?}: point {p:?} is above the tip line y={tip_y} (teardrop inverted)"
+                );
+            }
+        }
+
+        // Start bulb hangs down-LEFT: every point is at or left of the tip's x,
+        // and the shape reaches a full bulb-width to the left.
+        let start = sample_points(HandleKind::SelectionStart);
+        assert!(
+            start.iter().all(|p| p.x <= tip_x + eps),
+            "start handle must not extend right of its tip"
+        );
+        assert!(
+            start.iter().any(|p| p.x <= tip_x - 2.0 * r + eps),
+            "start handle bulb must reach a full diameter to the LEFT of the tip"
+        );
+
+        // End bulb hangs down-RIGHT: mirror image of the start handle.
+        let end = sample_points(HandleKind::SelectionEnd);
+        assert!(
+            end.iter().all(|p| p.x >= tip_x - eps),
+            "end handle must not extend left of its tip"
+        );
+        assert!(
+            end.iter().any(|p| p.x >= tip_x + 2.0 * r - eps),
+            "end handle bulb must reach a full diameter to the RIGHT of the tip"
+        );
+
+        // Cursor handle is symmetric about the tip: it reaches ~r to each side.
+        let cursor = sample_points(HandleKind::Cursor);
+        assert!(
+            cursor.iter().any(|p| p.x <= tip_x - r + eps)
+                && cursor.iter().any(|p| p.x >= tip_x + r - eps),
+            "cursor handle must be symmetric about the tip"
+        );
     }
 
     #[test]

--- a/crates/cranpose-ui/src/widgets/magnifier.rs
+++ b/crates/cranpose-ui/src/widgets/magnifier.rs
@@ -25,11 +25,11 @@
 
 use crate::composable;
 use crate::modifier::Modifier;
-use crate::text::{measure_text, AnnotatedString, TextStyle};
+use crate::text::{measure_text, AnnotatedString, TextOptions, TextOverflow, TextStyle};
 use crate::text_field_modifier_node::TextFieldHandleMetrics;
 use crate::widgets::box_widget::{Box, BoxSpec};
 use crate::widgets::popup::Popup;
-use crate::widgets::Text;
+use crate::widgets::TextWithOptions;
 use cranpose_ui_graphics::{Color, GraphicsLayer, Point, Rect, Size, TransformOrigin};
 
 /// Magnification factor for the loupe (Android uses ~1.25–1.5×).
@@ -78,6 +78,13 @@ pub fn CursorMagnifier(
 ) {
     let (line, caret_x) = caret_line(&text, &style, caret_offset);
     let line_height = metrics.line_height.max(1.0);
+    // Full intrinsic width of the caret's line (content px, unscaled). The
+    // magnified text is forced to lay out at exactly this width (see the
+    // `required_size` below), so every glyph up to the caret exists in the layer
+    // before the graphics-layer translation slides the caret slice into view.
+    let line_width = measure_text(&AnnotatedString::from(line.as_str()), &style)
+        .width
+        .max(1.0);
 
     // Float the loupe above the finger, clamped on-screen at the top edge.
     let anchor = Rect {
@@ -139,10 +146,38 @@ pub fn CursorMagnifier(
                     BoxSpec::default(),
                     move || {
                         // Magnified slice of the caret's text line.
-                        Text(
+                        //
+                        // The loupe frame is only ~150px wide, but a wide line's
+                        // caret can sit thousands of px to the right. Two things
+                        // make the far-right glyphs render:
+                        //
+                        // 1. `required_size` forces the text to lay out at the
+                        //    line's FULL intrinsic width, ignoring the loupe box's
+                        //    narrow (~148px) incoming constraint. Without it the
+                        //    text's placeable is clamped to the frame width, so
+                        //    only the leftmost glyphs exist in the layer and the
+                        //    graphics-layer translation slides an empty strip into
+                        //    view — the reported blank loupe on long lines.
+                        // 2. `Visible` overflow (soft-wrap OFF) keeps the text a
+                        //    single unwrapped line and skips the per-node clip.
+                        //
+                        // The graphics layer then translates the caret slice to
+                        // the frame centre and the outer box's `clip_to_bounds`
+                        // trims everything outside the loupe.
+                        TextWithOptions(
                             line.clone(),
-                            Modifier::empty().graphics_layer_value(text_layer.clone()),
+                            Modifier::empty()
+                                .required_size(Size {
+                                    width: line_width,
+                                    height: line_height,
+                                })
+                                .graphics_layer_value(text_layer.clone()),
                             style.clone(),
+                            TextOptions {
+                                overflow: TextOverflow::Visible,
+                                soft_wrap: false,
+                                ..TextOptions::default()
+                            },
                         );
                         // Caret indicator through the loupe center.
                         Box(
@@ -249,6 +284,134 @@ mod tests {
             "the magnified text {} must render above the finger at y={}",
             line.1.y,
             finger.y
+        );
+    }
+
+    #[test]
+    fn magnifier_lays_out_the_full_line_under_the_loupe_width() {
+        // Regression for the "loupe blanks on wide lines" bug. The magnifier
+        // draws the caret's line inside a ~150px frame and slides it with a
+        // graphics-layer translation. If the text is measured against the frame's
+        // narrow max-width (the old behaviour), glyphs past ~150px are never laid
+        // out, so a far-right caret shows only the background. The magnifier now
+        // lays the line out with `TextOverflow::Visible` + no soft-wrap, so it
+        // keeps its FULL intrinsic width no matter how narrow the frame is.
+        use crate::text::{measure_text_with_options, AnnotatedString, TextLayoutOptions};
+
+        let _app_context = crate::render_state::app_context_test_scope();
+        let wide_line = "abcdefghij ".repeat(30); // thousands of px wide
+        let text = AnnotatedString::from(wide_line.as_str());
+        let style = TextStyle::default();
+        let loupe_max = Some(LOUPE_WIDTH);
+
+        // Baseline: clamping to the loupe width (soft-wrap/clip) bounds the line
+        // to the frame — this is exactly the state that blanked far-right glyphs.
+        let clamped = measure_text_with_options(
+            &text,
+            &style,
+            TextLayoutOptions {
+                overflow: TextOverflow::Clip,
+                soft_wrap: true,
+                max_lines: 1,
+                min_lines: 1,
+            },
+            loupe_max,
+        );
+        assert!(
+            clamped.width <= LOUPE_WIDTH + 1.0,
+            "sanity: a clamped line is bounded by the loupe width, got {}",
+            clamped.width
+        );
+
+        // The magnifier's options lay the whole line out regardless of the frame.
+        let full = measure_text_with_options(
+            &text,
+            &style,
+            TextLayoutOptions {
+                overflow: TextOverflow::Visible,
+                soft_wrap: false,
+                max_lines: 1,
+                min_lines: 1,
+            },
+            loupe_max,
+        );
+        assert!(
+            full.width > LOUPE_WIDTH * 3.0,
+            "magnifier text must keep its full intrinsic width under the narrow \
+             loupe max-width so far-right glyphs exist to draw (got {} vs loupe {LOUPE_WIDTH})",
+            full.width
+        );
+    }
+
+    #[test]
+    fn magnifier_text_node_lays_out_at_full_width_in_the_scene() {
+        // The real layout pipeline: the magnified line's Text node must lay out
+        // at its full intrinsic width (via `required_size`), NOT clamped to the
+        // loupe frame — otherwise only the leftmost glyphs exist in the layer and
+        // a far-right caret shows an empty loupe. The recorded Text op's rect
+        // width is the node's laid-out width, so it must exceed the loupe frame.
+        let _app_context = crate::render_state::app_context_test_scope();
+        let wide_line = "abcdefghij ".repeat(30);
+
+        let mut composition = Composition::new(MemoryApplier::new());
+        let key = location_key(file!(), line!(), column!());
+        let metrics = TextFieldHandleMetrics {
+            focused: true,
+            touch: true,
+            node_origin: Point { x: 0.0, y: 40.0 },
+            padding_left: 0.0,
+            padding_top: 0.0,
+            scroll_offset: 0.0,
+            line_height: 18.0,
+        };
+        let line_for_content = wide_line.clone();
+        // Caret far to the right of the wide line — the case that used to blank.
+        let caret_offset = wide_line.len() - 4;
+        let mut content = move || {
+            let line_for_content = line_for_content.clone();
+            PopupHost(move || {
+                CursorMagnifier(
+                    line_for_content.clone(),
+                    TextStyle::default(),
+                    metrics,
+                    caret_offset,
+                    Point { x: 700.0, y: 400.0 },
+                );
+            });
+        };
+        composition.render(key, &mut content).expect("render");
+        for _ in 0..16 {
+            if !composition.should_render() {
+                break;
+            }
+            composition.reconcile(key, &mut content).expect("reconcile");
+        }
+        let root = composition.root().expect("root");
+        let handle = composition.runtime_handle();
+        let mut applier = composition.applier_mut();
+        applier.set_runtime_handle(handle);
+        let layout = applier
+            .compute_layout(
+                root,
+                Size {
+                    width: 1080.0,
+                    height: 800.0,
+                },
+            )
+            .expect("layout");
+        applier.clear_runtime_handle();
+        drop(applier);
+        let scene = HeadlessRenderer::new().render(&layout);
+
+        let line = text_ops(&scene)
+            .into_iter()
+            .find(|(value, _)| value == &wide_line)
+            .expect("magnifier renders the caret's line");
+        assert!(
+            line.1.width > LOUPE_WIDTH,
+            "the magnified line's Text node must lay out at full width (got {} vs \
+             loupe {LOUPE_WIDTH}); a clamped width means far-right glyphs are missing",
+            line.1.width
         );
     }
 

--- a/crates/cranpose-ui/src/widgets/selection_handle.rs
+++ b/crates/cranpose-ui/src/widgets/selection_handle.rs
@@ -391,14 +391,15 @@ mod tests {
     }
 
     /// Reproduces the reported start-vs-end asymmetry as a guard: the start and
-    /// end selection handles point in opposite directions, so a bug that offset
-    /// one hit-box the wrong way would make that handle harder to grab. Their
-    /// grab regions must be mirror images about their (shared-x) tips — i.e.
-    /// each tip sits at the horizontal centre of its own grab box, and the two
-    /// boxes are the same size — so neither handle collapses the selection on a
+    /// end selection handles point in opposite directions (their bulbs hang to
+    /// opposite sides of the shared tip), so a bug that offset one hit-box the
+    /// wrong way would make that handle harder to grab. Their grab regions must
+    /// be mirror images **of each other** about the tip — the start box reaches
+    /// as far LEFT of the tip as the end box reaches RIGHT (over the bulb), and
+    /// both are the same size — so neither handle collapses the selection on a
     /// near-miss while the other drags fine.
     #[test]
-    fn start_and_end_grab_regions_are_symmetric_about_their_tips() {
+    fn start_and_end_grab_regions_are_mirror_images() {
         let tip = Point { x: 100.0, y: 100.0 };
         let start = handle_grab_rect(HandleKind::SelectionStart, tip, HANDLE_RADIUS);
         let end = handle_grab_rect(HandleKind::SelectionEnd, tip, HANDLE_RADIUS);
@@ -408,21 +409,26 @@ mod tests {
             (start.width - end.width).abs() < 0.01 && (start.height - end.height).abs() < 0.01,
             "start {start:?} and end {end:?} grab boxes must be the same size"
         );
-        // Each tip is horizontally centred in its own box, so the box extends
-        // equally toward and away from the bulb — the left extent of one mirrors
-        // the right extent of the other.
-        for (kind, rect) in [
-            (HandleKind::SelectionStart, start),
-            (HandleKind::SelectionEnd, end),
-        ] {
-            let left = tip.x - rect.x;
-            let right = (rect.x + rect.width) - tip.x;
-            assert!(
-                (left - right).abs() < 0.01,
-                "{kind:?}: tip must sit at the horizontal centre of its grab box \
-                 (left extent {left}, right extent {right})"
-            );
-        }
+
+        let start_left = tip.x - start.x;
+        let start_right = (start.x + start.width) - tip.x;
+        let end_left = tip.x - end.x;
+        let end_right = (end.x + end.width) - tip.x;
+
+        // Each box extends toward its bulb (start left, end right) by the same
+        // amount, and away from it by the same smaller amount — the boxes are
+        // reflections of one another.
+        assert!(
+            (start_left - end_right).abs() < 0.01 && (start_right - end_left).abs() < 0.01,
+            "start (l={start_left}, r={start_right}) and end (l={end_left}, r={end_right}) \
+             grab boxes must be horizontal mirror images"
+        );
+        // Sanity: the box genuinely reaches over the bulb (a full diameter to the
+        // handle's own side) so the bulb is grabbable.
+        assert!(
+            start_left >= 2.0 * HANDLE_RADIUS && end_right >= 2.0 * HANDLE_RADIUS,
+            "each grab box must extend a full bulb-diameter toward its bulb"
+        );
     }
 
     /// A touch-DOWN a finger's width to either side of, and below, a handle tip

--- a/crates/cranpose-ui/src/widgets/text_selection_menu.rs
+++ b/crates/cranpose-ui/src/widgets/text_selection_menu.rs
@@ -14,6 +14,8 @@ use crate::text::TextStyle;
 use crate::widgets::box_widget::{Box, BoxSpec};
 use crate::widgets::popup::Popup;
 use crate::widgets::{Row, RowSpec, Text};
+use crate::PointerInputScope;
+use cranpose_foundation::PointerEventKind;
 use cranpose_ui_graphics::{Point, Rect};
 
 /// Background of the menu bar.
@@ -30,15 +32,71 @@ fn menu_text_style() -> TextStyle {
     style
 }
 
-/// A single clickable menu label.
+/// A single tappable menu label.
+///
+/// The button drives its own [`pointer_input`](Modifier::pointer_input) gesture
+/// rather than `clickable`. This is load-bearing: `clickable` only *consumes*
+/// the pointer on the release (and never the press), so a `Down` on the menu
+/// fell through to the text field below — which placed a caret and collapsed the
+/// selection — before the release could run the action (worse after a scroll,
+/// once the finger landed straight on the field). Consuming the whole
+/// press→release gesture here keeps the tap on the menu: the field never sees
+/// it, the selection survives, and the action runs on release.
 fn menu_item(label: &str, action: Rc<dyn Fn()>) {
     Text(
         label.to_string(),
         Modifier::empty()
             .padding(10.0)
-            .clickable(move |_point| action()),
+            .then(menu_item_pointer_input(label, action)),
         menu_text_style(),
     );
+}
+
+/// Builds the consuming tap gesture for a menu button: it swallows the press,
+/// any moves, and the release, and fires `action` when the finger lifts after a
+/// press that started on this button. Every event is consumed so the tap can
+/// never fall through to the text field beneath the overlay. Keyed by the button
+/// label so recomposition reuses the running gesture task.
+pub(crate) fn menu_item_pointer_input(label: &str, action: Rc<dyn Fn()>) -> Modifier {
+    let key = label.to_string();
+    Modifier::empty().pointer_input(key, move |scope: PointerInputScope| {
+        let action = Rc::clone(&action);
+        async move {
+            scope
+                .await_pointer_event_scope(|await_scope| async move {
+                    // Only a release that follows a press *on this button* runs
+                    // the action; a stray release without a press is ignored. The
+                    // Down capture keeps the whole gesture on the button, so the
+                    // field never sees it.
+                    let mut pressed = false;
+                    loop {
+                        let event = await_scope.await_pointer_event().await;
+                        match event.kind {
+                            PointerEventKind::Down => {
+                                pressed = true;
+                                event.consume();
+                            }
+                            PointerEventKind::Move => {
+                                event.consume();
+                            }
+                            PointerEventKind::Up => {
+                                if pressed {
+                                    action();
+                                }
+                                pressed = false;
+                                event.consume();
+                            }
+                            PointerEventKind::Cancel => {
+                                pressed = false;
+                                event.consume();
+                            }
+                            _ => {}
+                        }
+                    }
+                })
+                .await;
+        }
+    })
 }
 
 /// A floating Copy / Cut / Paste / Select-all menu shown just above the text
@@ -92,4 +150,89 @@ pub fn TextSelectionMenu(
             },
         );
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modifier::{collect_slices_from_modifier, ModifierNodeSlices};
+    use cranpose_foundation::PointerEvent;
+    use cranpose_ui_graphics::Point;
+    use std::cell::Cell;
+
+    /// Collects the button's live pointer-input handler. Returns the owning
+    /// [`ModifierNodeSlices`] too: it keeps the attached node (and its running
+    /// coroutine) alive — dropping it would cancel the gesture and swallow the
+    /// events.
+    fn button_handler(modifier: &Modifier) -> (Rc<dyn Fn(PointerEvent)>, ModifierNodeSlices) {
+        let slices = collect_slices_from_modifier(modifier);
+        assert_eq!(
+            slices.pointer_inputs().len(),
+            1,
+            "menu button must install exactly one pointer-input gesture"
+        );
+        let handler = slices.pointer_inputs()[0].clone();
+        (handler, slices)
+    }
+
+    fn down(x: f32, y: f32) -> PointerEvent {
+        PointerEvent::new(PointerEventKind::Down, Point { x, y }, Point { x, y })
+    }
+    fn up(x: f32, y: f32) -> PointerEvent {
+        PointerEvent::new(PointerEventKind::Up, Point { x, y }, Point { x, y })
+    }
+
+    /// Bug 7: a tap (press then release) on a menu button consumes BOTH the
+    /// press and the release — so the tap can never fall through to the text
+    /// field below (which would collapse the selection) — and runs the action on
+    /// release.
+    #[test]
+    fn menu_button_consumes_the_tap_and_runs_the_action() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        let ran = Rc::new(Cell::new(false));
+        let action: Rc<dyn Fn()> = {
+            let ran = Rc::clone(&ran);
+            Rc::new(move || ran.set(true))
+        };
+        let modifier = menu_item_pointer_input("Copy", action);
+        let (handler, _slices) = button_handler(&modifier);
+
+        let press = down(5.0, 5.0);
+        handler(press.clone());
+        assert!(
+            press.is_consumed(),
+            "the press must be consumed so it never reaches the field and collapses the selection"
+        );
+        assert!(!ran.get(), "the action fires on release, not on press");
+
+        let release = up(6.0, 6.0);
+        handler(release.clone());
+        assert!(release.is_consumed(), "the release must be consumed too");
+        assert!(
+            ran.get(),
+            "releasing after a press on the button runs the action"
+        );
+    }
+
+    /// A stray release with no preceding press on this button is still consumed
+    /// (never reaches the field) but does not run the action.
+    #[test]
+    fn menu_button_release_without_press_is_consumed_but_inert() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        let ran = Rc::new(Cell::new(false));
+        let action: Rc<dyn Fn()> = {
+            let ran = Rc::clone(&ran);
+            Rc::new(move || ran.set(true))
+        };
+        let modifier = menu_item_pointer_input("Cut", action);
+        let (handler, _slices) = button_handler(&modifier);
+
+        let release = up(5.0, 5.0);
+        handler(release.clone());
+        assert!(
+            release.is_consumed(),
+            "a release on the menu is consumed so it never hits the field"
+        );
+        assert!(!ran.get(), "a release with no matching press must not act");
+    }
 }

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -1663,6 +1663,17 @@ pub fn run(
                 ))));
                 soft_keyboard_installed = true;
                 log::info!("Android soft keyboard focus hook installed");
+
+                // Cold-start guard (bug 5): on a fresh launch the OS can restore
+                // the soft keyboard left over from the previous process — even on
+                // a screen with no text field. Re-request it only if a field is
+                // genuinely focused this launch; otherwise force it hidden so the
+                // keyboard does not resurrect on relaunch. `notify_app_resumed`
+                // returns whether a focused field re-opened it.
+                if !shell.notify_app_resumed() {
+                    ime_session.ensure_hidden();
+                    log::info!("No focused field at launch; ensured soft keyboard hidden");
+                }
             }
         }
 

--- a/crates/cranpose/src/android_keyboard.rs
+++ b/crates/cranpose/src/android_keyboard.rs
@@ -154,18 +154,24 @@ impl AndroidImeSession {
         self.app.show_soft_input(true);
     }
 
-    /// Closes the IME editor session and hides the keyboard if either is still
-    /// live. Called on app pause (and defensively on resume with no focused
-    /// field) so the invisible editor view is detached and the OS cannot
-    /// restore the soft keyboard when the activity returns to the foreground.
-    /// Idempotent: a no-op once the session is already closed.
+    /// Ensures the soft keyboard is hidden. Called on app pause, on resume with
+    /// no focused field, and once at startup so a relaunch never resurrects the
+    /// keyboard.
+    ///
+    /// When a Java editor session is open it is closed (detaching the invisible
+    /// editor view so the OS cannot restore the IME for it). When none is open
+    /// the keyboard is still force-hidden via `hide_soft_input`: on a COLD start
+    /// the OS may restore the soft keyboard from the previous process even though
+    /// no editor session or focused field exists yet, and only an explicit hide
+    /// dismisses it. Idempotent.
     pub(crate) fn ensure_hidden(&self) {
-        if self.bridge_failed.get() {
-            self.app.hide_soft_input(false);
-            return;
-        }
-        if self.active.get() {
+        if !self.bridge_failed.get() && self.active.get() {
             self.hide();
+        } else {
+            // No live Java editor session (cold start, or the `show_soft_input`
+            // fallback path). Force the IME hidden directly. `false` = do not
+            // restrict to implicitly-shown keyboards; always hide.
+            self.app.hide_soft_input(false);
         }
     }
 }


### PR DESCRIPTION
Round-14 selection fixes from on-device 0.9.4 (0.1.41) testing. Each fix is device-verified on a real **Huawei EVR-AL00 (arm64, 1080x2244)** by building CranScan against this worktree, seeding a library, and driving taps/scrolls/handle-drags with screenshots read back.

## Bug 2 — selection handle teardrops were inverted
**Root cause:** `text_selection::handle_path_data` built the start/end teardrops with the SVG arc **sweep flags swapped**. With the wrong flag the arc centres on the *tip* (per the W3C endpoint→centre conversion, `large_arc == sweep` negates the centre coefficient), drawing an upward pac-man wedge that pokes *above* the glyph line instead of a bulb hanging below it.
**Fix:** start handle uses sweep `1`, end handle sweep `0` — start = point top-right / bulb down-left, end = point top-left / bulb down-right (correct Android convention). Updated the grab-region test to assert the now-asymmetric start/end boxes are horizontal **mirror images of each other** (each extends a full bulb-diameter toward its own bulb).
**Device:** double-tapped a word; the close-up crops show start handle point at the top-right with the bulb down-left, end handle mirror — no longer inverted.

## Bug 5 — soft keyboard resurrected on cold relaunch
**Root cause:** `AndroidImeSession::ensure_hidden` only closed the Java editor session when one was `active`; on a cold start (fresh process) no session exists, so an OS-restored keyboard was never dismissed — it reappeared even on the Library (no text field).
**Fix:** `ensure_hidden` now force-hides via `hide_soft_input(false)` whenever no Java session is active, and the Android entry point (`android.rs`) calls it once right after the shell/hook is installed **unless a field is actually focused** (`notify_app_resumed()` returns whether one re-opened it).
**Device:** focus a field → hide via back → force-stop → relaunch: `dumpsys input_method` reports `mInputShown=false` and the Library shows no keyboard.

## Bug 6 — cursor magnifier clipped text on wide lines
**Root cause:** the loupe magnifies the caret's line inside a ~150px frame. The `Text` was measured against that narrow max-width, so glyphs past ~105 content-px were never laid out; when the caret sat far right the graphics-layer translation slid an empty strip into view (blank loupe).
**Fix:** the magnified `Text` now lays out at its **full intrinsic width** via `required_size` (which ignores the loupe box's incoming constraint) plus `TextOverflow::Visible`; the graphics layer then translates the caret slice into the frame and the outer box's `clip_to_bounds` trims the rest.
**Device:** typed a ~57-char line and dragged the caret far right — the loupe renders the letters at the caret (e.g. `PQRSTU|VWXY`) where the pre-fix build showed only the white background.

## Bug 7 — context-menu taps fell through and deselected
**Root cause:** the menu buttons used `.clickable`, which only *consumes* the pointer on release. The `Down` reached the field beneath the overlay, which placed a caret and collapsed the selection before the action ran (worst right after a scroll).
**Fix:** menu buttons now drive a `pointer_input` gesture that **consumes** the whole press→move→release and runs the action on release, so the tap never reaches the field. The menu Popup already positions at the live composited selection origin for both drawing and hit-testing.
**Device:** selected a word, tapped Copy → menu closes, selection survives; tapped Paste over another word → it inserted the copied text (confirming the clipboard write and that the button ran).

## Bug 8 — native multi-tap selection cycling
**Root cause / feature:** only double-tap→word existed. Implemented the full granularity ladder like mature editors (Android TextView / iOS / VS Code): double→word, triple→line, fourth→paragraph, then cycles back to word; a lone tap **inside an existing selection** re-grabs the word under the finger. Tap-count resets on timeout/position change.
**Fix:** new `SelectionGranularity`, `classify_tap_count`, `tap_selection_granularity` (cycles word→line→paragraph), and `find_paragraph_boundaries` (blank-line delimited, unicode-aware) in `text_selection.rs`; wired into the field's tap handler.
**Device:** on the receipt text, double-tap → word, triple-tap → whole line; a lone tap inside a line selection re-selected the word (the tap-inside-selection rule firing).

## Tests
- `text_selection`: tap-count classification, granularity ladder + cycling, paragraph boundaries (incl. unicode + no-blank-line), handle-orientation geometry (points sampled from the parsed path stay at/below the tip and on the correct side).
- `selection_handle`: start/end grab boxes are mirror images; no slop above the tip.
- `magnifier`: line lays out at full width under a narrow max-width (measure + real scene layout).
- `text_selection_menu`: a tap consumes both press and release and runs the action; a release without a press is consumed but inert.
- `text_field_modifier_node`: double→word, triple→line, fourth→paragraph then cycle; lone tap inside a selection → word.
- `text_input_session`: cold start with no focus does not show the keyboard.

## Verification
`cargo fmt --check`; `cargo test -p cranpose-ui -p cranpose-foundation -p cranpose -p cranpose-app-shell` (incl. the 48 static guards; 627 cranpose-ui tests); `cargo clippy -p cranpose-ui -p cranpose --all-targets -D warnings`; `cargo check --workspace`; aarch64-linux-android check (android,renderer-wgpu); wasm32 web check — all green. Plus the on-device seed+drive verification above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKmJDd6pG9opQHr7btBMke