### PR TITLE
fix(text-field): warm-resume keyboard, caret-handle action popup, tap-in-selection granularity, wrap-aware caret (round 15)

### DIFF
--- a/crates/cranpose-app-shell/src/shell_input.rs
+++ b/crates/cranpose-app-shell/src/shell_input.rs
@@ -640,9 +640,11 @@ where
 
     /// Notifies the framework that the host app resumed/foregrounded.
     ///
-    /// Re-requests the soft keyboard only when a text field is actually focused.
-    /// Returns whether the keyboard was re-requested. Platform runtimes call
-    /// this from their resume lifecycle event.
+    /// Never auto-shows the soft keyboard, even for a still-focused field: a
+    /// warm resume keeps the caret but must not resurrect the keyboard (the user
+    /// taps the field to bring it back). Always returns `false` so the platform
+    /// runtime force-hides the OS-restored keyboard. Platform runtimes call this
+    /// from their resume lifecycle event.
     pub fn notify_app_resumed(&mut self) -> bool {
         let app_context = Rc::clone(&self.app_context);
         app_context.enter(cranpose_ui::text_input_session::notify_app_resumed)

--- a/crates/cranpose-ui/src/tests/selection_handle_tests.rs
+++ b/crates/cranpose-ui/src/tests/selection_handle_tests.rs
@@ -86,6 +86,7 @@ fn selection_handle_renders_in_overlay_at_its_tip() {
                 |_pos| {},
                 || {},
                 || {},
+                || {},
             );
         });
     };
@@ -163,6 +164,7 @@ mod long_press {
         drags: Rc<Cell<usize>>,
         drag_ends: Rc<Cell<usize>>,
         long_presses: Rc<Cell<usize>>,
+        taps: Rc<Cell<usize>>,
     }
 
     impl Harness {
@@ -171,6 +173,7 @@ mod long_press {
             let drags = Rc::new(Cell::new(0));
             let drag_ends = Rc::new(Cell::new(0));
             let long_presses = Rc::new(Cell::new(0));
+            let taps = Rc::new(Cell::new(0));
 
             let on_drag: Rc<dyn Fn(Point)> = {
                 let drags = Rc::clone(&drags);
@@ -184,12 +187,17 @@ mod long_press {
                 let long_presses = Rc::clone(&long_presses);
                 Rc::new(move || long_presses.set(long_presses.get() + 1))
             };
+            let on_tap: Rc<dyn Fn()> = {
+                let taps = Rc::clone(&taps);
+                Rc::new(move || taps.set(taps.get() + 1))
+            };
 
             let modifier: Modifier = selection_handle_pointer_input(
                 HandleKind::SelectionStart,
                 on_drag,
                 on_drag_end,
                 on_long_press,
+                on_tap,
             );
             let elements = modifier.elements();
             let mut chain = ModifierNodeChain::new();
@@ -209,6 +217,7 @@ mod long_press {
                 drags,
                 drag_ends,
                 long_presses,
+                taps,
             }
         }
 
@@ -301,6 +310,27 @@ mod long_press {
             0,
             "a quick tap on the handle must not be treated as a long-press"
         );
+        assert_eq!(h.drag_ends.get(), 1);
+        // Bug (b): a quick press→release that did not drag the handle is a tap,
+        // so the handle reports one tap (the cursor handle opens its popup).
+        assert_eq!(
+            h.taps.get(),
+            1,
+            "a quick tap on the handle must report exactly one tap"
+        );
+    }
+
+    #[test]
+    fn dragging_a_handle_is_not_a_tap() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        let h = Harness::new();
+
+        // Press, travel well past the tap slop, then lift: a drag, not a tap.
+        h.send(event(PointerEventKind::Down, 100.0, 100.0, 0));
+        h.send(event(PointerEventKind::Move, 160.0, 130.0, 40));
+        h.send(event(PointerEventKind::Up, 160.0, 130.0, 60));
+
+        assert_eq!(h.taps.get(), 0, "dragging the handle must not report a tap");
         assert_eq!(h.drag_ends.get(), 1);
     }
 
@@ -396,7 +426,8 @@ mod kind_restart {
     fn handle_modifier(kind: HandleKind, on_drag: Rc<dyn Fn(Point)>) -> Modifier {
         let noop_end: Rc<dyn Fn()> = Rc::new(|| {});
         let noop_lp: Rc<dyn Fn()> = Rc::new(|| {});
-        selection_handle_pointer_input(kind, on_drag, noop_end, noop_lp)
+        let noop_tap: Rc<dyn Fn()> = Rc::new(|| {});
+        selection_handle_pointer_input(kind, on_drag, noop_end, noop_lp, noop_tap)
     }
 
     fn active_handler(chain: &ModifierNodeChain) -> Rc<dyn Fn(PointerEvent)> {

--- a/crates/cranpose-ui/src/text/measure.rs
+++ b/crates/cranpose-ui/src/text/measure.rs
@@ -711,6 +711,71 @@ pub fn layout_text(text: &crate::text::AnnotatedString, style: &TextStyle) -> Te
     crate::render_state::with_text_service(|service| service.layout(text, style))
 }
 
+/// Returns the source-text byte range covered by each **visual** (wrapped) line
+/// when `text` is laid out at `max_width` with `options`, matching the wrapping
+/// the renderer performs. Each range excludes the trailing `\n`. With
+/// `max_width == None` (or soft-wrap disabled) this is just the logical
+/// `\n`-delimited lines.
+///
+/// The text field uses this to place its caret and selection handles on the
+/// correct visual line for wrapped text: the in-content caret otherwise counts
+/// only logical `\n` lines, so a caret on a wrapped line's second visual line is
+/// drawn on the first (and its x, being the whole logical-line prefix width,
+/// runs off the right edge and is clipped), while typing and the magnifier land
+/// on the correct spot.
+pub fn wrapped_line_ranges(
+    node_id: Option<NodeId>,
+    text: &crate::text::AnnotatedString,
+    style: &TextStyle,
+    options: TextLayoutOptions,
+    max_width: Option<f32>,
+) -> Vec<Range<usize>> {
+    crate::render_state::with_text_measurer(|m| {
+        wrapped_line_ranges_with_measurer(m, node_id, text, style, options, max_width)
+    })
+}
+
+fn wrapped_line_ranges_with_measurer<M: TextMeasurer + ?Sized>(
+    measurer: &M,
+    _node_id: Option<NodeId>,
+    text: &crate::text::AnnotatedString,
+    style: &TextStyle,
+    options: TextLayoutOptions,
+    max_width: Option<f32>,
+) -> Vec<Range<usize>> {
+    let opts = options.normalized();
+    let max_width = normalize_max_width(max_width);
+    // Mirror the wrap decision in `prepare_text_layout_with_measurer_for_node`.
+    let wrap_width = (opts.soft_wrap && opts.overflow != TextOverflow::Visible)
+        .then_some(max_width)
+        .flatten();
+    let line_break_mode = style
+        .paragraph_style
+        .line_break
+        .take_or_else(|| LineBreak::Simple);
+    let hyphens_mode = style.paragraph_style.hyphens.take_or_else(|| Hyphens::None);
+
+    let line_ranges = split_line_ranges(text.text.as_str());
+    let Some(width_limit) = wrap_width else {
+        return line_ranges;
+    };
+    let mut ranges = Vec::with_capacity(line_ranges.len());
+    for line_range in line_ranges {
+        for display_line in wrap_line_to_width(
+            measurer,
+            text,
+            line_range,
+            style,
+            width_limit,
+            line_break_mode,
+            hyphens_mode,
+        ) {
+            ranges.push(display_line.source_range.clone());
+        }
+    }
+    ranges
+}
+
 fn prepare_text_layout_fallback<M: TextMeasurer + ?Sized>(
     measurer: &M,
     text: &crate::text::AnnotatedString,

--- a/crates/cranpose-ui/src/text/mod.rs
+++ b/crates/cranpose-ui/src/text/mod.rs
@@ -19,8 +19,8 @@ pub use layout_options::{TextLayoutOptions, TextOptions, TextOverflow};
 pub use measure::{
     get_cursor_x_for_offset, get_offset_for_position, layout_text, measure_text,
     measure_text_for_node, measure_text_with_options, measure_text_with_options_for_node,
-    prepare_text_layout, prepare_text_layout_for_node, set_text_measurer, PreparedTextLayout,
-    TextLinePrefixWidths, TextMeasurer, TextMetrics,
+    prepare_text_layout, prepare_text_layout_for_node, set_text_measurer, wrapped_line_ranges,
+    PreparedTextLayout, TextLinePrefixWidths, TextMeasurer, TextMetrics,
 };
 pub use paragraph::{
     resolve_text_direction, Hyphens, LineBreak, ResolvedTextDirection, TextAlign, TextDirection,

--- a/crates/cranpose-ui/src/text_field_modifier_node.rs
+++ b/crates/cranpose-ui/src/text_field_modifier_node.rs
@@ -43,6 +43,9 @@ pub struct TextFieldHandleMetrics {
     pub padding_top: f32,
     pub scroll_offset: f32,
     pub line_height: f32,
+    /// Width the field wrapped its text at (`None` for single-line fields).
+    /// Lets the handles resolve the same visual (wrapped) lines the caret does.
+    pub wrap_width: Option<f32>,
 }
 
 /// Shared channel by which a `TextFieldModifierNode` publishes its live handle
@@ -170,6 +173,44 @@ pub(crate) fn intersect_rect(
 /// text field given the current content viewport width in px.
 pub type TextPanResolver = Rc<dyn Fn(f32) -> f32>;
 
+/// Resolves the caret's visual `(line_index, line_start_byte)` for byte
+/// `offset`.
+///
+/// For a wrapping (multi-line) field this lays the text out at the same wrap
+/// width the field measured and returns the VISUAL line the caret sits on, so
+/// the drawn caret lands on the same glyph the renderer draws. For a
+/// non-wrapping field (single line, or when no wrap width is known yet) it falls
+/// back to counting logical `\n` lines. Shared by the in-content caret and the
+/// overlay selection handles so both agree.
+pub(crate) fn caret_visual_line_for_offset(
+    text: &str,
+    style: &TextStyle,
+    node_id: Option<cranpose_core::NodeId>,
+    wrap_width: Option<f32>,
+    offset: usize,
+) -> (usize, usize) {
+    let offset = offset.min(text.len());
+    match wrap_width {
+        Some(width) if width.is_finite() && width > 0.0 => {
+            let annotated = crate::text::AnnotatedString::from(text);
+            let ranges = crate::text::wrapped_line_ranges(
+                node_id,
+                &annotated,
+                style,
+                crate::text::TextLayoutOptions::default(),
+                Some(width),
+            );
+            crate::text_selection::caret_visual_line(&ranges, offset)
+        }
+        _ => {
+            let before = &text[..offset];
+            let line_index = before.matches('\n').count();
+            let line_start = before.rfind('\n').map(|i| i + 1).unwrap_or(0);
+            (line_index, line_start)
+        }
+    }
+}
+
 /// Shared references for text field input handling.
 ///
 /// This struct bundles the shared state references passed to the pointer input handler,
@@ -256,6 +297,12 @@ pub struct TextFieldModifierNode {
     measured_size: Rc<Cell<Size>>,
     /// Cached line height from last measurement (shared with draw closure)
     measured_line_height: Rc<Cell<f32>>,
+    /// Wrap width the last measurement laid the text out at (`None` for
+    /// single-line fields, which pan instead of wrapping). Shared with the draw
+    /// closure so the caret and selection handles resolve the same *visual*
+    /// (wrapped) lines the renderer draws, instead of counting only logical
+    /// `\n` lines.
+    measured_wrap_width: Rc<Cell<Option<f32>>>,
     /// Cached pointer input handler
     cached_handler: Rc<dyn Fn(PointerEvent)>,
     /// Cached horizontal pan resolver (recomputes + stores the scroll offset)
@@ -305,6 +352,7 @@ impl TextFieldModifierNode {
                 height: 0.0,
             })),
             measured_line_height: Rc::new(Cell::new(DEFAULT_LINE_HEIGHT)),
+            measured_wrap_width: Rc::new(Cell::new(None)),
             cached_handler,
             cached_pan_resolver,
             handle_controller: None,
@@ -402,8 +450,8 @@ impl TextFieldModifierNode {
         // multi-tap selection granularity gestures.
         use crate::text_selection::{
             classify_tap_count, find_line_boundaries, find_paragraph_boundaries,
-            tap_selection_granularity, SelectionGranularity, MULTI_TAP_SLOP_PX,
-            MULTI_TAP_TIMEOUT_MS,
+            resolve_selection_tap_count, tap_selection_granularity, SelectionGranularity,
+            MULTI_TAP_SLOP_PX, MULTI_TAP_TIMEOUT_MS,
         };
         use crate::word_boundaries::find_word_boundaries;
 
@@ -471,20 +519,31 @@ impl TextFieldModifierNode {
 
                     // A lone tap that lands INSIDE an existing (non-collapsed)
                     // selection selects the word under the finger (Android/iOS
-                    // "tap the selection to re-grab a word"), and seeds the
-                    // progression at "word" so the next in-place tap escalates to
-                    // line then paragraph. A lone tap elsewhere just places the
-                    // caret.
+                    // "tap the selection to re-grab a word"). Tapping the SAME
+                    // spot again grows the granularity word → line → paragraph →
+                    // word …, keyed on location so it keeps escalating even when
+                    // the taps arrive too slowly to count as a rapid multi-tap.
+                    // A lone tap elsewhere just places the caret.
                     let selection = state.selection();
-                    let effective_count = if tap_count == 1
-                        && !selection.collapsed()
-                        && pos >= selection.min()
-                        && pos <= selection.max()
-                    {
-                        2
-                    } else {
-                        tap_count
-                    };
+                    let tap_in_selection =
+                        !selection.collapsed() && pos >= selection.min() && pos <= selection.max();
+                    // Same-spot repeat, independent of the multi-tap timeout:
+                    // within slop of the previous press.
+                    let repeat_in_place = refs
+                        .last_click_pos
+                        .get()
+                        .map(|(px, py)| {
+                            let dx = event.position.x - px;
+                            let dy = event.position.y - py;
+                            dx * dx + dy * dy <= MULTI_TAP_SLOP_PX * MULTI_TAP_SLOP_PX
+                        })
+                        .unwrap_or(false);
+                    let effective_count = resolve_selection_tap_count(
+                        tap_count,
+                        refs.click_count.get(),
+                        tap_in_selection,
+                        repeat_in_place,
+                    );
 
                     match tap_selection_granularity(effective_count) {
                         SelectionGranularity::Paragraph => {
@@ -817,7 +876,11 @@ impl LayoutModifierNode for TextFieldModifierNode {
         // Measure the text content, wrapping multi-line fields at the available
         // width so the field grows to fit every wrapped line instead of
         // clipping content past the first line.
-        let text_size = self.measure_text_content(self.wrap_width(constraints.max_width));
+        let wrap_width = self.wrap_width(constraints.max_width);
+        // Remember the wrap width so the draw closure can resolve the same
+        // visual (wrapped) lines when placing the caret and selection handles.
+        self.measured_wrap_width.set(wrap_width);
+        let text_size = self.measure_text_content(wrap_width);
 
         // Add minimum height for empty text (cursor needs space)
         let min_height = if text_size.height < 1.0 {
@@ -889,6 +952,8 @@ impl DrawModifierNode for TextFieldModifierNode {
         let style = self.style.clone();
         let cached_line_height = self.measured_line_height.clone();
         let measured_size = self.measured_size.clone();
+        let measured_wrap_width = self.measured_wrap_width.clone();
+        let node_id = self.refs.node_id.clone();
         let pan_resolver = self.cached_pan_resolver.clone();
         let handle_controller = self.handle_controller.clone();
         let node_origin = self.refs.node_origin.clone();
@@ -908,6 +973,7 @@ impl DrawModifierNode for TextFieldModifierNode {
                         padding_top: 0.0,
                         scroll_offset: 0.0,
                         line_height: cached_line_height.get(),
+                        wrap_width: measured_wrap_width.get(),
                     });
                 }
                 return vec![];
@@ -950,6 +1016,7 @@ impl DrawModifierNode for TextFieldModifierNode {
                     padding_top,
                     scroll_offset: pan,
                     line_height,
+                    wrap_width: measured_wrap_width.get(),
                 });
             }
             // Everything the field draws (selection, IME underline, cursor)
@@ -1091,11 +1158,20 @@ impl DrawModifierNode for TextFieldModifierNode {
             // Draw cursor - check visibility at DRAW time for blinking
             if crate::cursor_animation::is_cursor_visible() {
                 let pos = selection.start.min(text.len());
-                let text_before = &text[..pos];
-                let line_index = text_before.matches('\n').count();
-                let line_start = text_before.rfind('\n').map(|i| i + 1).unwrap_or(0);
+                // Resolve the caret's VISUAL (wrapped) line so it lands on the
+                // same glyph the renderer draws — the field wraps long lines, and
+                // counting only logical `\n` lines would draw the caret on the
+                // wrong line (and, with the full logical-line-prefix width, off
+                // the right edge) while typing/the magnifier stay correct.
+                let (line_index, line_start) = caret_visual_line_for_offset(
+                    &text,
+                    &style,
+                    node_id.get(),
+                    measured_wrap_width.get(),
+                    pos,
+                );
                 let cursor_x = crate::text::measure_text(
-                    &crate::text::AnnotatedString::from(&text_before[line_start..]),
+                    &crate::text::AnnotatedString::from(&text[line_start..pos]),
                     &style,
                 )
                 .width
@@ -1593,6 +1669,82 @@ mod tests {
                 &state.text()[selection.min()..selection.max()],
                 "hello",
                 "a tap inside a selection re-selects the word under the finger"
+            );
+
+            crate::text_field_focus::clear_focus();
+        });
+    }
+
+    /// Bug (c) at the handler level: repeated taps at the SAME spot inside an
+    /// existing selection climb the granularity ladder word → line → paragraph →
+    /// word even when each tap arrives after the multi-tap timeout has lapsed
+    /// (the growth is keyed on location, not the double-tap timer). Forcing a
+    /// timeout between taps (clearing `last_click_time`) makes the raw tap count
+    /// reset to 1 each time, so this exercises the location-based path rather
+    /// than the rapid-multi-tap path.
+    #[test]
+    fn slow_taps_inside_selection_cycle_word_line_paragraph_by_location() {
+        use cranpose_foundation::{PointerEvent, PointerEventKind, PointerSource};
+        use cranpose_ui_graphics::Point;
+
+        let _app_context = crate::render_state::app_context_test_scope();
+        with_test_runtime(|| {
+            let text = "alpha beta\ngamma delta\n\nsecond para";
+            let state = TextFieldState::new(text);
+            let node = TextFieldModifierNode::new(state.clone(), TextStyle::default())
+                .with_line_limits(TextFieldLineLimits::MultiLine {
+                    min_lines: 1,
+                    max_lines: usize::MAX,
+                });
+            node.measured_size.set(Size {
+                width: 400.0,
+                height: 80.0,
+            });
+            let handler = node
+                .pointer_input_handler()
+                .expect("field exposes a pointer handler");
+
+            // A broad pre-existing selection over the whole text.
+            state.edit(|buffer| buffer.select(TextRange::new(0, text.len())));
+
+            let at = Point { x: 2.0, y: 4.0 };
+            let selected = |state: &TextFieldState| {
+                let s = state.selection();
+                state.text()[s.min()..s.max()].to_string()
+            };
+            // Each call forces the multi-tap timer to look expired, so the raw
+            // tap count resets to 1 while the tap position stays put.
+            let slow_tap = || {
+                node.refs.last_click_time.set(None);
+                handler(
+                    PointerEvent::new(PointerEventKind::Down, at, at)
+                        .with_source(PointerSource::Touch),
+                );
+            };
+
+            slow_tap(); // inside selection → word
+            assert_eq!(
+                selected(&state),
+                "alpha",
+                "tap inside selection grabs the word"
+            );
+            slow_tap(); // same spot → line
+            assert_eq!(
+                selected(&state),
+                "alpha beta",
+                "same-spot tap grows to the line even after the timeout"
+            );
+            slow_tap(); // same spot → paragraph
+            assert_eq!(
+                selected(&state),
+                "alpha beta\ngamma delta",
+                "same-spot tap grows to the paragraph"
+            );
+            slow_tap(); // same spot → cycles back to word
+            assert_eq!(
+                selected(&state),
+                "alpha",
+                "same-spot tap cycles back to the word"
             );
 
             crate::text_field_focus::clear_focus();

--- a/crates/cranpose-ui/src/text_input_session.rs
+++ b/crates/cranpose-ui/src/text_input_session.rs
@@ -135,17 +135,23 @@ pub fn notify_app_paused() {
 /// Notifies the framework that the host app resumed (foregrounded — e.g.
 /// Android `onResume`).
 ///
-/// Re-requests the soft keyboard **only** when a text field is actually
-/// focused, so an app that comes back with nothing focused does not have the
-/// keyboard pop open. Returns whether the keyboard was re-requested.
+/// The soft keyboard is **never** auto-shown on resume, even when a text field
+/// is still focused. A warm resume (return from HOME / task switch / back-exit
+/// then relaunch) restores the process with the field's focus and caret intact,
+/// but the framework must not resurrect the keyboard for it: the platform's
+/// `InputMethodManager` remembers the last editor and would otherwise pop the
+/// keyboard back open on its own. The user brings it back by tapping the field
+/// (which re-requests it through [`notify_text_input_focus_gained`]).
+///
+/// Always returns `false` so the platform runtime force-hides the OS-restored
+/// keyboard. Pruning stale focus here keeps the keyboard-request bookkeeping
+/// consistent (a focused-but-detached field is dropped and its outstanding
+/// request withdrawn) without ever calling `show`.
 pub fn notify_app_resumed() -> bool {
-    // Read focus first (this also prunes stale focus), then decide — do not
-    // hold the session borrow across the focus query.
-    if !crate::text_field_focus::has_focused_field() {
-        return false;
-    }
-    notify_text_input_focus_gained();
-    true
+    // Prune stale focus (a detached field withdraws its keyboard request), but
+    // never re-request the keyboard: resume must leave it hidden.
+    let _ = crate::text_field_focus::has_focused_field();
+    false
 }
 
 #[cfg(test)]
@@ -283,21 +289,36 @@ mod tests {
     }
 
     #[test]
-    fn pause_hides_and_resume_restores_the_keyboard_for_a_focused_field() {
+    fn resume_never_reshows_the_keyboard_even_for_a_focused_field() {
         let _app_context = crate::render_state::app_context_test_scope();
         let handler = install_recording_handler();
 
         // A focused field shows the keyboard.
-        let _focus = focus_a_field();
+        let focus = focus_a_field();
         assert_eq!(*handler.calls.borrow(), vec!["show"]);
 
         // Pause withdraws it.
         notify_app_paused();
         assert_eq!(*handler.calls.borrow(), vec!["show", "hide"]);
 
-        // Resume with the field still focused brings it back.
-        assert!(notify_app_resumed());
-        assert_eq!(*handler.calls.borrow(), vec!["show", "hide", "show"]);
+        // Resume must NOT bring it back even though the field is still focused
+        // (the reported warm-resume bug): the keyboard stays hidden until the
+        // user taps the field again. Resume reports `false` so the platform
+        // force-hides the OS-restored keyboard.
+        assert!(!notify_app_resumed());
+        assert_eq!(
+            *handler.calls.borrow(),
+            vec!["show", "hide"],
+            "resume must leave the keyboard hidden"
+        );
+
+        // Tapping the still-focused field re-requests the keyboard.
+        crate::text_field_focus::request_focus(Rc::clone(&focus), Rc::new(NoopFocusHandler));
+        assert_eq!(
+            *handler.calls.borrow(),
+            vec!["show", "hide", "show"],
+            "tapping the field after resume re-shows the keyboard"
+        );
 
         crate::text_field_focus::clear_focus();
     }

--- a/crates/cranpose-ui/src/text_selection.rs
+++ b/crates/cranpose-ui/src/text_selection.rs
@@ -68,6 +68,52 @@ pub fn classify_tap_count(
     prev_count.saturating_add(1)
 }
 
+/// Resolves the effective tap count for a press, folding in the "tap inside an
+/// existing selection" gesture so it drives the same word → line → paragraph
+/// granularity ladder ([`tap_selection_granularity`]) as a rapid multi-tap.
+///
+/// Inputs:
+/// * `raw_tap_count` — the time-and-slop-gated multi-tap count from
+///   [`classify_tap_count`] (2+ means a genuine rapid multi-tap in progress);
+/// * `previous_count` — the effective count the *previous* press resolved to
+///   (the field remembers it as its click count);
+/// * `tap_in_selection` — the press landed inside the current, non-collapsed
+///   selection;
+/// * `repeat_in_place` — the press landed within the multi-tap slop of the
+///   previous press, **independent of timing** (the same spot, tapped again).
+///
+/// Behavior:
+/// * a rapid multi-tap (`raw_tap_count >= 2`) uses its own running count, so
+///   double→word, triple→line, … keep working exactly as before;
+/// * a lone tap inside a selection selects the word under the finger, and each
+///   further tap at the *same spot* climbs the ladder (word → line → paragraph →
+///   word …) even when it arrives slowly (the multi-tap timeout has lapsed) —
+///   users tap-then-look-then-tap, so the growth is keyed on location, not time;
+/// * a lone tap at a *new* spot inside the selection re-grabs that word (resets
+///   to word); and
+/// * a lone tap outside any selection is left as-is (a single tap → caret).
+pub fn resolve_selection_tap_count(
+    raw_tap_count: u8,
+    previous_count: u8,
+    tap_in_selection: bool,
+    repeat_in_place: bool,
+) -> u8 {
+    if raw_tap_count >= 2 {
+        raw_tap_count
+    } else if tap_in_selection {
+        if repeat_in_place {
+            // Keep climbing the granularity ladder at the same spot.
+            previous_count.max(1).saturating_add(1)
+        } else {
+            // First tap inside the selection (or a tap on a different word):
+            // grab the word under the finger.
+            2
+        }
+    } else {
+        raw_tap_count
+    }
+}
+
 /// Maps a 1-based tap count to the granularity it selects.
 ///
 /// A single tap places the caret; two taps select the word, three the line,
@@ -129,6 +175,32 @@ pub fn find_paragraph_boundaries(text: &str, pos: usize) -> (usize, usize) {
         .map(|i| pos + i)
         .unwrap_or(text.len());
     (start.min(end), end)
+}
+
+/// Given the source byte ranges of the **visual** (wrapped) lines and a caret
+/// byte `offset`, returns the `(visual_line_index, line_start_byte)` the caret
+/// sits on.
+///
+/// The caret belongs to the last visual line whose start is at or before
+/// `offset`, so:
+/// * a caret in the middle of a visual line resolves to that line;
+/// * a caret at a soft-wrap boundary sits at the start of the lower line;
+/// * a caret at the very end of the text sits on the last visual line.
+///
+/// This is the wrap-aware replacement for counting logical `\n` lines: without
+/// it, a caret on a wrapped line's second visual line is drawn on the first (and
+/// its x runs off the right edge), even though typing and the magnifier place it
+/// correctly. Returns `(0, 0)` when there are no ranges.
+pub fn caret_visual_line(ranges: &[std::ops::Range<usize>], offset: usize) -> (usize, usize) {
+    let mut result = (0usize, 0usize);
+    for (index, range) in ranges.iter().enumerate() {
+        if range.start <= offset {
+            result = (index, range.start);
+        } else {
+            break;
+        }
+    }
+    result
 }
 
 /// Which selection handle a teardrop represents.
@@ -279,6 +351,55 @@ mod tests {
             classify_tap_count(Some((3, 10.0, 10.0)), 600, 10.0, 10.0, 500, 24.0),
             1
         );
+    }
+
+    /// The tap-inside-selection ladder (bug c): a lone tap inside an existing
+    /// selection grabs the word, and every further tap AT THE SAME SPOT grows
+    /// the granularity word → line → paragraph, then cycles back to word — even
+    /// when the taps arrive too slowly to count as a rapid multi-tap (the growth
+    /// is keyed on location, not the double-tap timeout). Tapping a NEW spot
+    /// resets to word.
+    #[test]
+    fn tap_inside_selection_cycles_word_line_paragraph_by_location() {
+        use SelectionGranularity::*;
+
+        // Start: a lone (slow) tap inside a selection. raw_tap_count == 1
+        // (the timeout lapsed), but it still grabs the word.
+        let mut count = resolve_selection_tap_count(1, 0, true, false);
+        assert_eq!(count, 2);
+        assert_eq!(tap_selection_granularity(count), Word);
+
+        // Same spot again, still slow (raw == 1): grow to the line.
+        count = resolve_selection_tap_count(1, count, true, true);
+        assert_eq!(count, 3);
+        assert_eq!(tap_selection_granularity(count), Line);
+
+        // Same spot again: grow to the paragraph.
+        count = resolve_selection_tap_count(1, count, true, true);
+        assert_eq!(count, 4);
+        assert_eq!(tap_selection_granularity(count), Paragraph);
+
+        // Same spot again: cycle back to the word.
+        count = resolve_selection_tap_count(1, count, true, true);
+        assert_eq!(count, 5);
+        assert_eq!(tap_selection_granularity(count), Word);
+
+        // A tap at a NEW spot inside the selection resets to word.
+        let reset = resolve_selection_tap_count(1, count, true, false);
+        assert_eq!(reset, 2);
+        assert_eq!(tap_selection_granularity(reset), Word);
+    }
+
+    /// A genuine rapid multi-tap keeps using its own running count, so
+    /// [`resolve_selection_tap_count`] does not disturb the double→word,
+    /// triple→line ladder, and a lone tap outside a selection stays a caret.
+    #[test]
+    fn resolve_tap_count_preserves_rapid_multitap_and_caret() {
+        // Rapid multi-tap: pass the classify count straight through.
+        assert_eq!(resolve_selection_tap_count(2, 1, false, false), 2);
+        assert_eq!(resolve_selection_tap_count(3, 2, true, true), 3);
+        // Lone tap outside any selection: caret (count 1).
+        assert_eq!(resolve_selection_tap_count(1, 4, false, true), 1);
     }
 
     #[test]
@@ -439,6 +560,37 @@ mod tests {
                 && cursor.iter().any(|p| p.x >= tip_x + r - eps),
             "cursor handle must be symmetric about the tip"
         );
+    }
+
+    /// The wrap-aware caret line lookup (bug d): a caret on a wrapped line's
+    /// later visual line must resolve to that visual line (not the logical
+    /// line's first visual line), with the correct line-start byte so its x is
+    /// measured from the start of the visual line.
+    #[test]
+    fn caret_visual_line_resolves_wrapped_visual_lines() {
+        // "aaaa bbbb" wrapped into ["aaaa " (0..5), "bbbb" (5..9)], then a hard
+        // newline to a short line "cc" (10..12).
+        let ranges = vec![0..5usize, 5..9, 10..12];
+
+        // Start of the first visual line.
+        assert_eq!(caret_visual_line(&ranges, 0), (0, 0));
+        // Middle of the first visual line.
+        assert_eq!(caret_visual_line(&ranges, 3), (0, 0));
+        // Start of the second (wrapped) visual line.
+        assert_eq!(caret_visual_line(&ranges, 5), (1, 5));
+        // Middle of the second visual line — must NOT resolve to line 0.
+        assert_eq!(caret_visual_line(&ranges, 7), (1, 5));
+        // End of the wrapped logical line.
+        assert_eq!(caret_visual_line(&ranges, 9), (1, 5));
+        // The line after the hard newline.
+        assert_eq!(caret_visual_line(&ranges, 11), (2, 10));
+        // End of text.
+        assert_eq!(caret_visual_line(&ranges, 12), (2, 10));
+    }
+
+    #[test]
+    fn caret_visual_line_handles_empty_ranges() {
+        assert_eq!(caret_visual_line(&[], 5), (0, 0));
     }
 
     #[test]

--- a/crates/cranpose-ui/src/widgets/basic_text_field.rs
+++ b/crates/cranpose-ui/src/widgets/basic_text_field.rs
@@ -17,7 +17,9 @@ use crate::text_field_modifier_node::{
     TextFieldElement, TextFieldHandleController, TextFieldHandleMetrics,
 };
 use crate::text_selection::{selection_after_handle_drag, HandleKind, HANDLE_RADIUS};
-use crate::widgets::{CursorMagnifier, Layout, SelectionHandle, TextSelectionMenu};
+use crate::widgets::{
+    CaretActionMenu, CursorMagnifier, Layout, SelectionHandle, TextSelectionMenu,
+};
 use cranpose_core::{mutableStateOf, remember, MutableState, NodeId, SideEffect};
 use cranpose_foundation::modifier_element;
 use cranpose_foundation::text::{TextFieldLineLimits, TextFieldState, TextRange};
@@ -37,10 +39,17 @@ fn handle_tip_window_pos(
     offset: usize,
 ) -> Point {
     let offset = offset.min(text.len());
-    let before = &text[..offset];
-    let line_index = before.matches('\n').count();
-    let line_start = before.rfind('\n').map(|i| i + 1).unwrap_or(0);
-    let caret_x = measure_text(&AnnotatedString::from(&before[line_start..]), style).width;
+    // Resolve the caret's VISUAL (wrapped) line so the handle tip anchors on the
+    // same glyph as the drawn caret (the field wraps long lines; counting only
+    // logical `\n` lines would place the handle on the wrong line, far right).
+    let (line_index, line_start) = crate::text_field_modifier_node::caret_visual_line_for_offset(
+        text,
+        style,
+        None,
+        metrics.wrap_width,
+        offset,
+    );
+    let caret_x = measure_text(&AnnotatedString::from(&text[line_start..offset]), style).width;
     Point {
         x: metrics.node_origin.x + metrics.padding_left + caret_x - metrics.scroll_offset,
         y: metrics.node_origin.y
@@ -266,6 +275,15 @@ fn SelectionHandles(
     // changes (a fresh selection), so tapping an action dismisses it until the
     // next selection.
     let menu_open = remember(|| mutableStateOf(true)).with(|state| *state);
+    // Whether the collapsed-caret action popup (Paste / Select all / Undo /
+    // Redo) is open. Opened by tapping the cursor handle; closed by an action or
+    // when the caret leaves the offset it was opened at (typing / tapping
+    // elsewhere). Kept out of the range branch so hook order stays stable.
+    let caret_menu_open = remember(|| mutableStateOf(false)).with(|state| *state);
+    // The caret offset the popup was opened at, so it auto-dismisses once the
+    // caret moves away.
+    let caret_menu_offset: Rc<Cell<usize>> =
+        remember(|| Rc::new(Cell::new(0usize))).with(Rc::clone);
     let previous_range: Rc<Cell<(usize, usize)>> =
         remember(|| Rc::new(Cell::new(current_range))).with(Rc::clone);
     {
@@ -274,6 +292,19 @@ fn SelectionHandles(
             if previous_range.get() != current_range {
                 previous_range.set(current_range);
                 menu_open.set(true);
+            }
+        });
+    }
+    // Auto-dismiss the caret popup once the caret moves off the offset it was
+    // opened at (the user typed or tapped elsewhere), matching Android.
+    {
+        let caret_menu_offset = Rc::clone(&caret_menu_offset);
+        let caret_start = selection.start;
+        SideEffect(move || {
+            if caret_menu_open.value()
+                && (!selection.collapsed() || caret_start != caret_menu_offset.get())
+            {
+                caret_menu_open.set(false);
             }
         });
     }
@@ -297,6 +328,18 @@ fn SelectionHandles(
         // Collapsed caret: a single symmetric cursor handle.
         let tip = handle_tip_window_pos(&text, &style, &metrics, selection.start);
         let on_drag = drag_caret_closure(state.clone(), style.clone(), controller.clone());
+        // Tapping the cursor handle opens the caret action popup, anchored at
+        // the caret's current offset so it auto-dismisses when the caret moves.
+        let open_caret_menu = {
+            let caret_menu_offset = Rc::clone(&caret_menu_offset);
+            let state = state.clone();
+            move || {
+                caret_menu_offset.set(state.selection().start);
+                caret_menu_open.set(true);
+            }
+        };
+        let on_tap = open_caret_menu.clone();
+        let on_long_press = open_caret_menu;
         SelectionHandle(
             HandleKind::Cursor,
             tip,
@@ -307,8 +350,49 @@ fn SelectionHandles(
                 on_drag(pos);
             },
             move || drag_pos.set(None),
-            || {},
+            on_long_press,
+            on_tap,
         );
+
+        // The caret action popup (Paste / Select all / Undo / Redo), floating
+        // just above the caret.
+        if caret_menu_open.value() {
+            let caret_anchor = Point {
+                x: tip.x,
+                y: tip.y - metrics.line_height,
+            };
+            let can_paste = clipboard_read_text().is_some();
+            let can_undo = state.can_undo();
+            let can_redo = state.can_redo();
+            let undo_state = state.clone();
+            let redo_state = state.clone();
+            CaretActionMenu(
+                caret_anchor,
+                can_paste,
+                can_undo,
+                can_redo,
+                move || {
+                    if let Some(text) = clipboard_read_text() {
+                        dispatch_paste(&text);
+                    }
+                    caret_menu_open.set(false);
+                },
+                move || {
+                    dispatch_select_all();
+                    caret_menu_open.set(false);
+                },
+                move || {
+                    undo_state.undo();
+                    crate::request_render_invalidation();
+                    caret_menu_open.set(false);
+                },
+                move || {
+                    redo_state.redo();
+                    crate::request_render_invalidation();
+                    caret_menu_open.set(false);
+                },
+            );
+        }
     } else {
         // Range selection: start (leftmost) and end (rightmost) teardrops.
         let start = selection.min();
@@ -336,6 +420,8 @@ fn SelectionHandles(
             // selection range has not changed (e.g. after it was dismissed by a
             // previous action), so the text actions stay reachable.
             move || menu_open.set(true),
+            // A tap on a selection-edge handle also re-opens the menu.
+            move || menu_open.set(true),
         );
 
         let on_drag_end = drag_edge_closure(
@@ -354,6 +440,7 @@ fn SelectionHandles(
                 on_drag_end(pos);
             },
             move || drag_pos.set(None),
+            move || menu_open.set(true),
             move || menu_open.set(true),
         );
 
@@ -491,6 +578,7 @@ mod tests {
                         padding_top: 0.0,
                         scroll_offset: 0.0,
                         line_height: 18.0,
+                        wrap_width: None,
                     });
                     SelectionHandles(state.clone(), TextStyle::default(), controller);
                 });
@@ -551,6 +639,7 @@ mod tests {
                         padding_top: 0.0,
                         scroll_offset: 0.0,
                         line_height: 18.0,
+                        wrap_width: None,
                     });
                     SelectionHandles(state.clone(), TextStyle::default(), controller);
                 });
@@ -621,6 +710,7 @@ mod tests {
                                 padding_top: 0.0,
                                 scroll_offset: 0.0,
                                 line_height: 18.0,
+                                wrap_width: None,
                             });
                             SelectionHandles(state.clone(), TextStyle::default(), controller);
                         },
@@ -712,6 +802,7 @@ mod tests {
                                         padding_top: 0.0,
                                         scroll_offset: 0.0,
                                         line_height: 18.0,
+                                        wrap_width: None,
                                     });
                                     SelectionHandles(
                                         state.clone(),
@@ -953,6 +1044,7 @@ mod tests {
                 padding_top: 3.0,
                 scroll_offset: 0.0,
                 line_height: 18.0,
+                wrap_width: None,
             };
             for offset in 0..=text.len() {
                 if !text.is_char_boundary(offset) {
@@ -979,6 +1071,91 @@ mod tests {
                 _ => None,
             })
             .collect()
+    }
+
+    /// Composes the caret action popup directly inside a `PopupHost` (as the
+    /// cursor-handle tap does once `caret_menu_open` is set) and returns the
+    /// rendered scene, so the item labels can be asserted.
+    fn render_caret_action_menu(
+        can_paste: bool,
+        can_undo: bool,
+        can_redo: bool,
+    ) -> crate::renderer::RecordedRenderScene {
+        use crate::layout::LayoutEngine;
+        use crate::renderer::HeadlessRenderer;
+        use crate::widgets::PopupHost;
+        use cranpose_ui_graphics::Size;
+
+        let mut composition = Composition::new(MemoryApplier::new());
+        let key = location_key(file!(), line!(), column!());
+
+        let mut content = move || {
+            PopupHost(move || {
+                CaretActionMenu(
+                    Point { x: 40.0, y: 60.0 },
+                    can_paste,
+                    can_undo,
+                    can_redo,
+                    || {},
+                    || {},
+                    || {},
+                    || {},
+                );
+            });
+        };
+
+        composition.render(key, &mut content).expect("render");
+        for _ in 0..16 {
+            if !composition.should_render() {
+                break;
+            }
+            composition.reconcile(key, &mut content).expect("reconcile");
+        }
+        let root = composition.root().expect("root");
+        let handle = composition.runtime_handle();
+        let mut applier = composition.applier_mut();
+        applier.set_runtime_handle(handle);
+        let layout = applier
+            .compute_layout(
+                root,
+                Size {
+                    width: 400.0,
+                    height: 400.0,
+                },
+            )
+            .expect("layout");
+        applier.clear_runtime_handle();
+        drop(applier);
+        HeadlessRenderer::new().render(&layout)
+    }
+
+    /// Bug (b): the caret action popup offers Paste / Select all / Undo / Redo.
+    /// Paste is hidden when the clipboard is empty, and Undo/Redo when the
+    /// field's history has nothing to undo/redo.
+    #[test]
+    fn caret_action_menu_shows_paste_select_all_undo_redo() {
+        let _app_context = crate::render_state::app_context_test_scope();
+
+        let all = text_values(&render_caret_action_menu(true, true, true));
+        for label in ["Paste", "Select all", "Undo", "Redo"] {
+            assert!(
+                all.iter().any(|t| t == label),
+                "caret menu should show {label:?}, got {all:?}"
+            );
+        }
+
+        // Nothing on the clipboard and an empty history: only Select all.
+        let bare = text_values(&render_caret_action_menu(false, false, false));
+        assert!(
+            bare.iter().any(|t| t == "Select all"),
+            "Select all is always available, got {bare:?}"
+        );
+        assert!(
+            !bare
+                .iter()
+                .any(|t| t == "Paste" || t == "Undo" || t == "Redo"),
+            "Paste/Undo/Redo must be hidden when unavailable, got {bare:?}"
+        );
     }
 
     #[test]

--- a/crates/cranpose-ui/src/widgets/magnifier.rs
+++ b/crates/cranpose-ui/src/widgets/magnifier.rs
@@ -217,6 +217,7 @@ mod tests {
             padding_top: 0.0,
             scroll_offset: 0.0,
             line_height: 18.0,
+            wrap_width: None,
         };
         let mut content = move || {
             PopupHost(move || {
@@ -363,6 +364,7 @@ mod tests {
             padding_top: 0.0,
             scroll_offset: 0.0,
             line_height: 18.0,
+            wrap_width: None,
         };
         let line_for_content = wide_line.clone();
         // Caret far to the right of the wide line — the case that used to blank.

--- a/crates/cranpose-ui/src/widgets/selection_handle.rs
+++ b/crates/cranpose-ui/src/widgets/selection_handle.rs
@@ -29,6 +29,11 @@ pub(crate) const HANDLE_LONG_PRESS_TIMEOUT_MS: i64 = 500;
 /// Movement (px) tolerated during a long-press before it is treated as a drag
 /// instead. Keeps a resting finger a long-press even with minor jitter.
 pub(crate) const HANDLE_LONG_PRESS_SLOP_PX: f32 = 12.0;
+/// Movement (px) tolerated between a handle's press and release for the gesture
+/// to count as a tap (a quick press→release that did not drag the handle). A tap
+/// on the collapsed cursor handle opens its action popup (Paste / Select all /
+/// Undo / Redo).
+pub(crate) const HANDLE_TAP_SLOP_PX: f32 = 12.0;
 
 /// Geometry of a handle's drawable teardrop for a bulb `radius`: the box the
 /// teardrop occupies (which doubles as its finger grab region) and where the tip
@@ -132,6 +137,10 @@ pub(crate) fn handle_grab_rect(kind: HandleKind, tip: Point, radius: f32) -> Rec
 /// * `on_long_press` — invoked once when the finger rests on the handle past the
 ///   long-press timeout without dragging it, so the field can (re)open the
 ///   contextual menu even when the selection range has not changed.
+/// * `on_tap` — invoked when the finger lifts after a quick press that did not
+///   drag the handle beyond [`HANDLE_TAP_SLOP_PX`] (and was not a long-press),
+///   so the collapsed cursor handle can open its action popup.
+#[allow(clippy::too_many_arguments)]
 #[composable]
 pub fn SelectionHandle(
     kind: HandleKind,
@@ -141,6 +150,7 @@ pub fn SelectionHandle(
     on_drag: impl Fn(Point) + 'static,
     on_drag_end: impl Fn() + 'static,
     on_long_press: impl Fn() + 'static,
+    on_tap: impl Fn() + 'static,
 ) {
     let shape = handle_shape(kind, radius);
     let anchor = Rect {
@@ -154,12 +164,14 @@ pub fn SelectionHandle(
     let on_drag: Rc<dyn Fn(Point)> = Rc::new(on_drag);
     let on_drag_end: Rc<dyn Fn()> = Rc::new(on_drag_end);
     let on_long_press: Rc<dyn Fn()> = Rc::new(on_long_press);
+    let on_tap: Rc<dyn Fn()> = Rc::new(on_tap);
 
     Popup(anchor, Point { x: 0.0, y: 0.0 }, move || {
         let path_data = path_data.clone();
         let on_drag = Rc::clone(&on_drag);
         let on_drag_end = Rc::clone(&on_drag_end);
         let on_long_press = Rc::clone(&on_long_press);
+        let on_tap = Rc::clone(&on_tap);
         Box(
             Modifier::empty()
                 .size(box_size)
@@ -173,6 +185,7 @@ pub fn SelectionHandle(
                     Rc::clone(&on_drag),
                     Rc::clone(&on_drag_end),
                     Rc::clone(&on_long_press),
+                    Rc::clone(&on_tap),
                 )),
             BoxSpec::default(),
             || {},
@@ -200,11 +213,13 @@ pub(crate) fn selection_handle_pointer_input(
     on_drag: Rc<dyn Fn(Point)>,
     on_drag_end: Rc<dyn Fn()>,
     on_long_press: Rc<dyn Fn()>,
+    on_tap: Rc<dyn Fn()>,
 ) -> Modifier {
     Modifier::empty().pointer_input(kind, move |scope: PointerInputScope| {
         let on_drag = Rc::clone(&on_drag);
         let on_drag_end = Rc::clone(&on_drag_end);
         let on_long_press = Rc::clone(&on_long_press);
+        let on_tap = Rc::clone(&on_tap);
         async move {
             scope
                 .await_pointer_event_scope(|await_scope| async move {
@@ -215,6 +230,9 @@ pub(crate) fn selection_handle_pointer_input(
                     let mut down_time: Option<i64> = None;
                     let mut down_pos = Point { x: 0.0, y: 0.0 };
                     let mut long_press_fired = false;
+                    // Whether the finger has strayed beyond the tap slop since it
+                    // went down — a stray means a drag, not a tap.
+                    let mut dragged = false;
                     loop {
                         let event = await_scope.await_pointer_event().await;
                         match event.kind {
@@ -222,10 +240,15 @@ pub(crate) fn selection_handle_pointer_input(
                                 down_time = event.time_ms;
                                 down_pos = event.global_position;
                                 long_press_fired = false;
+                                dragged = false;
                                 on_drag(event.global_position);
                                 event.consume();
                             }
                             PointerEventKind::Move => {
+                                if moved_beyond(down_pos, event.global_position, HANDLE_TAP_SLOP_PX)
+                                {
+                                    dragged = true;
+                                }
                                 on_drag(event.global_position);
                                 maybe_fire_long_press(
                                     &event,
@@ -244,7 +267,17 @@ pub(crate) fn selection_handle_pointer_input(
                                     &mut long_press_fired,
                                     &on_long_press,
                                 );
+                                if moved_beyond(down_pos, event.global_position, HANDLE_TAP_SLOP_PX)
+                                {
+                                    dragged = true;
+                                }
                                 on_drag_end();
+                                // A quick press→release that neither dragged the
+                                // handle nor became a long-press is a tap: open
+                                // the handle's action popup.
+                                if !dragged && !long_press_fired {
+                                    on_tap();
+                                }
                                 down_time = None;
                                 event.consume();
                             }
@@ -260,6 +293,14 @@ pub(crate) fn selection_handle_pointer_input(
                 .await;
         }
     })
+}
+
+/// Whether `now` is more than `slop` px from `origin` (used to tell a tap from a
+/// drag on a selection handle).
+fn moved_beyond(origin: Point, now: Point, slop: f32) -> bool {
+    let dx = now.x - origin.x;
+    let dy = now.y - origin.y;
+    dx * dx + dy * dy > slop * slop
 }
 
 /// Fires `on_long_press` at most once per press when the finger has rested on

--- a/crates/cranpose-ui/src/widgets/text_selection_menu.rs
+++ b/crates/cranpose-ui/src/widgets/text_selection_menu.rs
@@ -152,6 +152,69 @@ pub fn TextSelectionMenu(
     });
 }
 
+/// A floating Paste / Select all / Undo / Redo menu shown near the collapsed
+/// caret at `anchor` (window coordinates of the caret's top). Opened by tapping
+/// the cursor handle (there is no selection to Copy/Cut, so this offers the
+/// caret-relevant actions instead).
+///
+/// `can_paste` hides Paste when the clipboard is empty; `can_undo`/`can_redo`
+/// hide those items when the field's history has nothing to undo/redo. Each
+/// action runs against the focused field; the caller dismisses the menu.
+#[allow(clippy::too_many_arguments)]
+#[composable]
+pub fn CaretActionMenu(
+    anchor: Point,
+    can_paste: bool,
+    can_undo: bool,
+    can_redo: bool,
+    on_paste: impl Fn() + 'static,
+    on_select_all: impl Fn() + 'static,
+    on_undo: impl Fn() + 'static,
+    on_redo: impl Fn() + 'static,
+) {
+    // Float the bar above the caret; keep it on-screen at the top edge.
+    let popup_anchor = Rect {
+        x: (anchor.x - 8.0).max(0.0),
+        y: (anchor.y - MENU_HEIGHT).max(0.0),
+        width: 0.0,
+        height: 0.0,
+    };
+
+    let on_paste: Rc<dyn Fn()> = Rc::new(on_paste);
+    let on_select_all: Rc<dyn Fn()> = Rc::new(on_select_all);
+    let on_undo: Rc<dyn Fn()> = Rc::new(on_undo);
+    let on_redo: Rc<dyn Fn()> = Rc::new(on_redo);
+
+    Popup(popup_anchor, Point { x: 0.0, y: 0.0 }, move || {
+        let on_paste = Rc::clone(&on_paste);
+        let on_select_all = Rc::clone(&on_select_all);
+        let on_undo = Rc::clone(&on_undo);
+        let on_redo = Rc::clone(&on_redo);
+        Box(
+            Modifier::empty().background(MENU_BG).rounded_corners(6.0),
+            BoxSpec::default(),
+            move || {
+                let on_paste = Rc::clone(&on_paste);
+                let on_select_all = Rc::clone(&on_select_all);
+                let on_undo = Rc::clone(&on_undo);
+                let on_redo = Rc::clone(&on_redo);
+                Row(Modifier::empty(), RowSpec::default(), move || {
+                    if can_paste {
+                        menu_item("Paste", Rc::clone(&on_paste));
+                    }
+                    menu_item("Select all", Rc::clone(&on_select_all));
+                    if can_undo {
+                        menu_item("Undo", Rc::clone(&on_undo));
+                    }
+                    if can_redo {
+                        menu_item("Redo", Rc::clone(&on_redo));
+                    }
+                });
+            },
+        );
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -1476,8 +1476,12 @@ pub fn run(
                     }
                     MainEvent::Resume { .. } => {
                         log::info!("App resumed");
-                        // Only re-open the keyboard if a field is still focused;
-                        // otherwise make sure it stays hidden.
+                        // Never auto-reopen the soft keyboard on resume, even if a
+                        // field is still focused: a warm resume keeps the field's
+                        // caret/focus but must not resurrect the keyboard (the OS
+                        // InputMethodManager would otherwise pop it back). The user
+                        // taps the field to bring it back. `notify_app_resumed`
+                        // always returns false, so we force the keyboard hidden.
                         let reopened = app_shell
                             .as_mut()
                             .map(|shell| shell.notify_app_resumed())


### PR DESCRIPTION
Round-15 on-device text-field fixes. Every fix was reproduced and verified on a real **Huawei EVR-AL00 (arm64, 1080x2244)** by building CranScan against this branch, installing, and driving the recognized-text field with screenshots/`dumpsys input_method` read back.

---

### (a) Soft keyboard resurrected on warm resume
**Root cause:** `text_input_session::notify_app_resumed` re-requested the IME (`notify_text_input_focus_gained`) whenever a text field was still focused. On a warm resume (HOME → re-foreground, or back-to-leave → reopen) the field is still focused, so the OS-restored keyboard popped straight back open — the round-13 resume path was auto-showing it.
**Fix:** `notify_app_resumed` now **never** auto-shows the keyboard; it prunes stale focus and returns `false` so the Android runtime force-hides the OS-restored IME. The field keeps its caret/focus; the user taps it to bring the keyboard back (`request_focus` still fires `show`). `notify_app_paused` already withdraws the show request.
**Device evidence:** focus field → `mInputShown=true`; press HOME → re-foreground → `mInputShown=false` (keyboard stays hidden, caret retained); tap the field → `mInputShown=true` again. Back-to-hide keyboard also confirmed.

### (b) Tapping the collapsed cursor handle opens an action popup
**Root cause:** the single caret teardrop had no tap action.
**Fix:** `SelectionHandle` gained an `on_tap` callback (a quick press→release that neither drags past `HANDLE_TAP_SLOP_PX` nor becomes a long-press). The collapsed-caret handle opens a new **`CaretActionMenu`** (Paste / Select all / Undo / Redo). Paste → `clipboard_read_text` + `dispatch_paste`; Select all → `dispatch_select_all`; Undo/Redo → `TextFieldState::undo/redo` (already existed). Items hide when unavailable (empty clipboard / empty history); the popup auto-dismisses when the caret moves.
**Device evidence:** tap the cursor handle → popup shows (with Paste when the clipboard has text, Undo when there is edit history) → tapping **Paste** inserts the clipboard text at the caret.

### (c) Tap-inside-selection granularity cycling
**Root cause:** round-14 made a lone tap inside a selection re-grab the word, but a slow re-tap at the same spot always reset to the word (the ladder only climbed on the time-gated double-tap counter).
**Fix:** new `resolve_selection_tap_count` grows the granularity on repeated taps at the **same location** independent of the multi-tap timeout — word → line → paragraph → word …. Genuine rapid multi-taps still use the existing ladder; a tap at a new word restarts at word.
**Device evidence:** double-tap `Cappuccino` → word; tap again → line `Cappuccino 3.80`; again → whole paragraph; again → back to the word (taps were well over the 500 ms timeout — location-based).

### (d) Caret drawn on the wrong line for wrapped text
**Root cause:** the in-content caret (and the selection-handle tips) counted only logical `\n` lines and measured the full logical-line prefix width. For a line that wraps, a caret on a later visual line was drawn on the **first** visual line, and its x — the whole-prefix natural width — ran off the right edge and was clipped, while typing and the magnifier used the wrap-aware layout and stayed correct.
**Fix:** added `wrapped_line_ranges` (reuses the renderer's `split_line_ranges` + `wrap_line_to_width`) and `caret_visual_line`; the field publishes the wrap width it measured at (`TextFieldHandleMetrics.wrap_width`), and the caret + handle tips now resolve the same **visual** (wrapped) line the renderer draws.
**Device evidence:** typed a line that wraps to 3 visual lines. Before: navigating the caret onto a later visual line drew it off-screen (invisible) while a typed marker landed on the correct visual line. After: the caret sits on the same visual line where the typed key lands (`…NOV|cino`, `2026-…09 :15`**`8`**).

---

### Tests
- New unit tests: `resolve_selection_tap_count` cycle, `caret_visual_line`, `resume_never_reshows_the_keyboard_even_for_a_focused_field`, `slow_taps_inside_selection_cycle_word_line_paragraph_by_location`, `caret_action_menu_shows_paste_select_all_undo_redo`, handle `on_tap` gesture tests.
- Green: `cargo fmt --check`; `clippy -D warnings` (touched crates); the **48** `platform_scheduling_static` guards; cranpose-ui (**634**) + app-shell (**105**) + foundation tests; `cargo check --workspace`; aarch64-android (CranScan lib via `cargo ndk`) and wasm (`desktop-app --features web`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKmJDd6pG9opQHr7btBMke