### PR TITLE
Use macOS runners for all branch iOS builds

### DIFF
--- a/.github/workflows/heavy-selfhosted.yml
+++ b/.github/workflows/heavy-selfhosted.yml
@@ -67,6 +67,42 @@ jobs:
         if: always()
         run: command -v sccache >/dev/null && sccache --show-stats || true
 
+  ios-build:
+    name: iOS build (self-hosted)
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 45
+    env:
+      RUSTUP_TOOLCHAIN: stable
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Provision iOS Rust targets
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          rustup run stable rustc --version
+          rustup target add --toolchain stable \
+            aarch64-apple-ios-sim \
+            aarch64-apple-ios
+
+      - name: Clippy iOS simulator
+        run: >
+          cargo clippy
+          -p desktop-app --bin cranpose-ios
+          --target aarch64-apple-ios-sim
+          --no-default-features --features ios
+          -- -D warnings -A clippy::question_mark
+
+      - name: Build iOS device binary
+        run: >
+          cargo build
+          -p desktop-app --bin cranpose-ios
+          --target aarch64-apple-ios
+          --no-default-features --features ios
+
+      - name: Assemble simulator app bundle
+        run: apps/ios-demo/ios/build-app.sh aarch64-apple-ios-sim
+
   android-release:
     name: Android release build (self-hosted)
     runs-on: [self-hosted, cranpose-heavy]

--- a/.github/workflows/heavy-selfhosted.yml
+++ b/.github/workflows/heavy-selfhosted.yml
@@ -77,8 +77,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios-sim,aarch64-apple-ios
+
       - name: Provision iOS Rust targets
         run: |
+          export PATH="$HOME/.cargo/bin:$PATH"
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           rustup run stable rustc --version
           rustup target add --toolchain stable \
@@ -115,6 +120,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
       - name: Configure machine-local SDK and cache paths
         env:
           RUNNER_NAME: ${{ runner.name }}
@@ -147,6 +156,7 @@ jobs:
 
       - name: Provision toolchains and start sccache
         run: |
+          export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
           rustup run stable rustc --version
           rustup target add --toolchain stable \
             aarch64-linux-android \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,8 +1,10 @@
 name: Rust
 
 on:
+  # Validate every branch pushed to this repository. Fork pull requests still
+  # run through pull_request below, but remain on GitHub-hosted macOS runners
+  # so untrusted fork code is never executed on a persistent self-hosted Mac.
   push:
-    branches: ["main"]
   pull_request:
     branches: ["main"]
 
@@ -204,7 +206,9 @@ jobs:
 
   ios-build:
     name: iOS build
-    runs-on: macos-latest
+    # Repository branches and same-repository PRs use either registered Mac.
+    # Fork PRs retain an isolated ephemeral runner for self-hosted safety.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","macOS","ARM64"]') || 'macos-latest' }}
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,8 @@
 name: Rust
 
 on:
-  # Validate every branch pushed to this repository. Fork pull requests still
-  # run through pull_request below, but remain on GitHub-hosted macOS runners
-  # so untrusted fork code is never executed on a persistent self-hosted Mac.
   push:
+    branches: ["main"]
   pull_request:
     branches: ["main"]
 


### PR DESCRIPTION
## Summary

- run Rust CI on every repository branch push
- schedule iOS CI from trusted branches and same-repository PRs on either registered ARM64 Mac
- keep fork PR execution on isolated GitHub-hosted macOS runners

## Existing platform coverage

- Android branch builds already use the shared self-hosted pool
- tagged macOS releases already use the self-hosted Mac pool
- Linux and Windows native jobs remain on matching operating systems
- publish and deployment jobs remain isolated from persistent runners

## Validation

- YAML parsed successfully
- git diff --check passed