### PR TITLE
Add cross-platform accessibility bridges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
+name = "accesskit"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023da0e5097f46df7092d5280b02efb9bbf8d93298daeced42652463e357d636"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "atspi-common",
+ "phf",
+ "serde",
+ "zvariant",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
+dependencies = [
+ "accesskit",
+ "hashbrown",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e156ed3802e35eefe894ef2671bc6c889303d8a7e110b5e1b48f504b91362f"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common",
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite",
+ "futures-util",
+ "serde",
+ "zbus",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106c2b961215864d1c2e703ee63269c25c4e80a577ffb2c1017b9c17dcdf83a1"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown",
+ "static_assertions",
+ "windows",
+ "windows-core",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,9 +261,9 @@ checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
 dependencies = [
  "clipboard-win",
  "log",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
@@ -219,10 +298,178 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atspi"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus",
+]
 
 [[package]]
 name = "autocfg"
@@ -290,11 +537,33 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -542,9 +811,13 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 name = "cranpose"
 version = "0.1.64"
 dependencies = [
+ "accesskit",
+ "accesskit_macos",
+ "accesskit_unix",
+ "accesskit_windows",
  "android-activity",
  "android_logger",
- "block2",
+ "block2 0.6.2",
  "console_error_panic_hook",
  "cranpose-app-shell",
  "cranpose-core",
@@ -562,12 +835,12 @@ dependencies = [
  "js-sys",
  "log",
  "ndk",
- "objc2",
+ "objc2 0.6.4",
  "objc2-av-foundation",
  "objc2-core-foundation",
  "objc2-core-media",
  "objc2-core-video",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
@@ -947,9 +1220,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1006,6 +1279,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1359,27 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -1155,6 +1476,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1334,6 +1668,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexf-parse"
@@ -1896,6 +2236,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,6 +2381,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,16 +2407,32 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2061,11 +2442,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
 dependencies = [
  "bitflags",
- "block2",
+ "block2 0.6.2",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-media",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2075,7 +2456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
 dependencies = [
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-audio-types",
  "objc2-core-foundation",
 ]
@@ -2087,7 +2468,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
 dependencies = [
  "bitflags",
- "objc2",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2097,9 +2490,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags",
- "block2",
+ "block2 0.6.2",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -2111,9 +2504,21 @@ dependencies = [
  "bitflags",
  "dispatch2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -2124,7 +2529,7 @@ checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
 dependencies = [
  "bitflags",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
@@ -2138,7 +2543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
  "bitflags",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-io-surface",
@@ -2152,13 +2557,25 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -2169,8 +2586,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2180,9 +2609,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags",
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -2192,10 +2634,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-metal",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -2205,10 +2647,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-uniform-type-identifiers",
 ]
 
@@ -2218,8 +2660,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7902ac02859fc1f7045f8b598c63f1ae0cc7efeaa06a9bc9f3d9a3c955974fa4"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2229,9 +2671,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
  "bitflags",
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2326,6 +2768,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2343,6 +2795,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2380,6 +2838,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,6 +2905,17 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2697,10 +3209,10 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -2822,15 +3334,15 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
 dependencies = [
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "js-sys",
  "libc",
  "log",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "percent-encoding",
  "pollster",
  "raw-window-handle",
@@ -3085,10 +3597,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3111,6 +3644,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3483,7 +4022,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3512,6 +4063,17 @@ name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicase"
@@ -3566,6 +4128,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"
@@ -3844,8 +4417,8 @@ dependencies = [
  "jni",
  "log",
  "ndk-context",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
  "url",
  "web-sys",
 ]
@@ -3976,7 +4549,7 @@ dependencies = [
  "ash",
  "bit-set",
  "bitflags",
- "block2",
+ "block2 0.6.2",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
@@ -3992,11 +4565,11 @@ dependencies = [
  "log",
  "naga",
  "ndk-sys",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-metal",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "once_cell",
  "ordered-float",
  "parking_lot",
@@ -4399,15 +4972,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21310ca07851a49c348e0c2cc768e36b52ca65afda2c2354d78ed4b90074d8aa"
 dependencies = [
  "bitflags",
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "dpi",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-core-video",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
  "smol_str",
  "tracing",
@@ -4422,7 +4995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45375fbac4cbb77260d83a30b1f9d8105880dbac99a9ae97f56656694680ff69"
 dependencies = [
  "memmap2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "smol_str",
  "tracing",
@@ -4469,12 +5042,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680a356e798837d8eb274d4556e83bceaf81698194e31aafc5cfb8a9f2fab643"
 dependencies = [
  "bitflags",
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "dpi",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "raw-window-handle",
  "smol_str",
@@ -4687,6 +5260,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
+dependencies = [
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus-lockstep",
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_xml"
+version = "5.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
+dependencies = [
+ "serde",
+ "winnow",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4804,4 +5474,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow",
 ]

--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -358,7 +358,6 @@ gesture stopped. Fixed by preserving the spring frame chain across
 retargets; `spring_retargeted_every_frame_tracks_a_moving_target` in
 cranpose-animation pins it. If a widget tracks a moving target, retarget
 per move with `animate_to_with_velocity` — no rate limiting needed.
-
 - Progressive-fps-decay hunts: when EVERY tracked counter is flat (nodes,
   scopes, caches, frame callbacks, heap bytes) but frame work grows
   monotonically across interaction cycles, suspect the snapshot record
@@ -385,3 +384,48 @@ per move with `animate_to_with_velocity` — no rate limiting needed.
   the suspected presented-vs-offscreen divergence was an eyeballing
   error over busy artwork. Numeric scans on flat backgrounds beat zoomed
   eyeballing over gradients.
+
+## macOS robot hangs need a portable timeout and exit must stop scheduling
+
+macOS does not ship GNU `timeout`, so a continuously animating robot scenario
+can otherwise consume a core indefinitely. Use the portable timeout in
+`run_robot_test.sh`, cap focused debugging with
+`CRANPOSE_ROBOT_TEST_TIMEOUT_CAP_SECS`, and reuse a warm build with
+`--skip-build`. Also, after handling `RobotCommand::Exit`, return from the event
+callback immediately: setting `ControlFlow::Poll` later in the same callback
+keeps the animation loop alive even though the robot received `Ok(())`.
+
+## Universal Android verification needs every declared Rust target
+
+The release Gradle task builds arm64, x86_64, and armeabi-v7a in separate
+`cargo ndk` passes. A machine can finish both expensive 64-bit AI builds and
+then fail at the last pass with `can't find crate for core` if
+`armv7-linux-androideabi` is missing. Before starting the release task, run
+`rustup target add aarch64-linux-android x86_64-linux-android
+armv7-linux-androideabi` and ensure `ANDROID_NDK_HOME` points at the installed
+NDK. Also repair broken `~/.cargo/bin/{cargo,rustup}` proxies first; otherwise
+Gradle's nested shell reports misleading `cargo: command not found` failures.
+
+## Prefer in-process GPU telemetry for repeated physical-iOS profiling
+
+Detaching an Instruments `xctrace` recording can leave the phone listed as
+offline to `xctrace` even while CoreDevice and `devicectl` still communicate
+with it. For renderer iteration, launch through `devicectl --console` with
+`CRANPOSE_GPU_STATS=1`; it reports pass, isolated-layer, cache, and retained
+texture counts without repeatedly attaching Instruments. When Instruments is
+needed, use a unique `.trace` output path because `xctrace` will not overwrite
+an existing bundle.
+
+## Keep Android Vulkan-to-GL fallback in separate WGPU instances
+
+An Android API 37 arm64 emulator can expose a Vulkan loader but no usable
+render node. If Vulkan and GL are enabled in the same WGPU instance, adapter
+selection falls through to GL after Vulkan probing and EGL can fail with
+`native_window_api_connect ... already connected to another API`, followed by
+`EGL_BAD_ALLOC`, an invalid surface, and `SIGABRT`. This looks like an app or
+activity lifecycle failure, but it happens during the first
+`Surface::configure`. Probe with a Vulkan-only instance first; on
+`RequestAdapter` failure, drop that instance and create a fresh GL-only
+instance. The GL software path can take about 20 seconds to initialize on this
+emulator, so wait for `Rendering initialized successfully` before treating an
+initial black frame as another failure.

--- a/apps/desktop-demo/robot-runners/robot_copy_paste.rs
+++ b/apps/desktop-demo/robot-runners/robot_copy_paste.rs
@@ -46,6 +46,11 @@ fn main() {
             }
 
             let mut all_passed = true;
+            let (command_ctrl, command_meta) = if cfg!(target_os = "macos") {
+                (false, true)
+            } else {
+                (true, false)
+            };
 
             // =========================================================
             // TEST 1: Switch to Text Input tab
@@ -102,7 +107,8 @@ fn main() {
                 std::thread::sleep(Duration::from_millis(200));
 
                 // Select all text (Ctrl+A) and replace with our test content
-                let _ = robot.send_key_with_modifiers("a", false, true, false, false);
+                let _ =
+                    robot.send_key_with_modifiers("a", false, command_ctrl, false, command_meta);
                 std::thread::sleep(Duration::from_millis(100));
 
                 // Type initial text "abcdef" (replaces selection)
@@ -167,7 +173,7 @@ fn main() {
             // =========================================================
             println!("--- Test 4: Copy Selected Text (Ctrl+C) ---");
 
-            match robot.send_key_with_modifiers("c", false, true, false, false) {
+            match robot.send_key_with_modifiers("c", false, command_ctrl, false, command_meta) {
                 Ok(_) => {
                     let _ = robot.wait_for_idle();
                     std::thread::sleep(Duration::from_millis(200));
@@ -189,7 +195,7 @@ fn main() {
             std::thread::sleep(Duration::from_millis(100));
 
             // Paste first time
-            match robot.send_key_with_modifiers("v", false, true, false, false) {
+            match robot.send_key_with_modifiers("v", false, command_ctrl, false, command_meta) {
                 Ok(_) => {
                     let _ = robot.wait_for_idle();
                     std::thread::sleep(Duration::from_millis(200));
@@ -202,7 +208,7 @@ fn main() {
             }
 
             // Paste second time
-            match robot.send_key_with_modifiers("v", false, true, false, false) {
+            match robot.send_key_with_modifiers("v", false, command_ctrl, false, command_meta) {
                 Ok(_) => {
                     let _ = robot.wait_for_idle();
                     std::thread::sleep(Duration::from_millis(200));

--- a/apps/desktop-demo/robot-runners/robot_regression_fused_viewport_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_regression_fused_viewport_contract.rs
@@ -33,7 +33,12 @@ fn main() {
         .with_robot_app_hook(set_tab_hook)
         .with_test_driver(move |robot| {
             std::thread::sleep(Duration::from_millis(700));
-            let _ = robot.wait_for_idle();
+            // The default Liquid tab owns a perpetual animation, so waiting
+            // for global idleness before switching to the contract's target
+            // tab can never be a valid synchronization point.
+            robot
+                .pump_frames(2)
+                .expect("initial Liquid frames should advance");
 
             // --- Case 1: ShaderRect "SDF Halo Border" visibility across scroll.
             robot
@@ -204,7 +209,9 @@ fn set_tab_hook(name: String, argument: String) -> Result<Option<String>, String
 
 fn settle(robot: &cranpose::Robot, ms: u64) {
     std::thread::sleep(Duration::from_millis(ms));
-    let _ = robot.wait_for_idle();
+    robot
+        .pump_frames(2)
+        .expect("animated contract frames should advance");
 }
 
 fn scroll(robot: &cranpose::Robot, x: f32, y: f32, delta_y: f32) {

--- a/apps/desktop-demo/tests/source_hygiene_aliases.rs
+++ b/apps/desktop-demo/tests/source_hygiene_aliases.rs
@@ -653,6 +653,26 @@ fn heavy_shell_entrypoints_use_local_resource_guards() {
     );
 }
 
+#[test]
+fn robot_runner_enforces_timeouts_without_gnu_coreutils() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("desktop demo should live under workspace/apps");
+    let source = fs::read_to_string(workspace_root.join("run_robot_test.sh"))
+        .expect("failed to read run_robot_test.sh");
+
+    assert!(
+        source.contains("run_with_portable_timeout")
+            && source.contains("timeout_marker")
+            && source.contains("kill -TERM")
+            && source.contains("exit_code=124")
+            && source.contains("robot_regression_fused_viewport_contract"),
+        "robot runners must still time out on macOS hosts without GNU timeout"
+    );
+}
+
 fn manifest_feature_value(source: &str, feature: &str) -> Option<String> {
     let prefix = format!("{feature} = ");
     let mut lines = source.lines();

--- a/crates/cranpose-app-shell/src/lib.rs
+++ b/crates/cranpose-app-shell/src/lib.rs
@@ -140,12 +140,7 @@ where
     /// Used to synthesize Enter/Exit events when the hover set changes.
     hovered_nodes: Vec<NodeId>,
     /// Persistent clipboard for desktop (Linux X11 requires clipboard to stay alive)
-    #[cfg(all(
-        feature = "clipboard-native",
-        not(target_arch = "wasm32"),
-        not(target_os = "android"),
-        not(target_os = "ios")
-    ))]
+    #[cfg(all(feature = "clipboard-native", target_os = "linux"))]
     clipboard: Option<arboard::Clipboard>,
     /// Dev options for debugging and performance monitoring
     dev_options: DevOptions,
@@ -472,12 +467,7 @@ where
             pointer_source: PointerSource::Unknown,
             hit_path_tracker: HitPathTracker::new(),
             hovered_nodes: Vec::new(),
-            #[cfg(all(
-                feature = "clipboard-native",
-                not(target_arch = "wasm32"),
-                not(target_os = "android"),
-                not(target_os = "ios")
-            ))]
+            #[cfg(all(feature = "clipboard-native", target_os = "linux"))]
             clipboard: arboard::Clipboard::new().ok(),
             dev_options: DevOptions::default(),
             dev_overlay_controls: Vec::new(),

--- a/crates/cranpose-app-shell/src/shell_input.rs
+++ b/crates/cranpose-app-shell/src/shell_input.rs
@@ -668,7 +668,6 @@ where
 
         // Only process KeyDown events for clipboard shortcuts
         if event.event_type == KeyDown && event.modifiers.command_or_ctrl() {
-            // Use persistent self.clipboard to keep content alive on Linux X11.
             #[cfg(all(
                 feature = "clipboard-native",
                 not(target_arch = "wasm32"),
@@ -679,19 +678,15 @@ where
                 match event.key_code {
                     // Ctrl+C - Copy
                     KeyCode::C => {
-                        // Get text first, then access clipboard to avoid borrow conflict
-                        let text = self.on_copy_inner();
-                        if let (Some(text), Some(clipboard)) = (text, self.clipboard.as_mut()) {
-                            let _ = clipboard.set_text(&text);
+                        if let Some(text) = self.on_copy_inner() {
+                            cranpose_ui::clipboard_session::clipboard_write_text(&text);
                             return true;
                         }
                     }
                     // Ctrl+X - Cut
                     KeyCode::X => {
-                        // Get text first (this also deletes it), then access clipboard
-                        let text = self.on_cut_inner();
-                        if let (Some(text), Some(clipboard)) = (text, self.clipboard.as_mut()) {
-                            let _ = clipboard.set_text(&text);
+                        if let Some(text) = self.on_cut_inner() {
+                            cranpose_ui::clipboard_session::clipboard_write_text(&text);
                             self.mark_dirty();
                             self.request_layout_pass();
                             return true;
@@ -699,9 +694,7 @@ where
                     }
                     // Ctrl+V - Paste
                     KeyCode::V => {
-                        // Get text from clipboard first, then paste
-                        let text = self.clipboard.as_mut().and_then(|cb| cb.get_text().ok());
-                        if let Some(text) = text {
+                        if let Some(text) = cranpose_ui::clipboard_session::clipboard_read_text() {
                             if self.on_paste_inner(&text) {
                                 return true;
                             }

--- a/crates/cranpose-ui-layout/src/core.rs
+++ b/crates/cranpose-ui-layout/src/core.rs
@@ -1,6 +1,7 @@
 //! Core layout traits and types shared by Compose UI widgets.
 
 use crate::constraints::Constraints;
+use crate::{Alignment, HorizontalAlignment, VerticalAlignment};
 use cranpose_core::NodeId;
 use cranpose_ui_graphics::Size;
 use std::rc::Rc;
@@ -27,6 +28,35 @@ impl FlexParentData {
     }
 }
 
+/// Layout metadata supplied by a child for its direct parent.
+///
+/// Weight/fill apply to Row and Column. Alignment values override the
+/// corresponding parent layout's default alignment for this child only.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct ParentData {
+    pub weight: f32,
+    pub fill: bool,
+    pub box_alignment: Option<Alignment>,
+    pub row_alignment: Option<VerticalAlignment>,
+    pub column_alignment: Option<HorizontalAlignment>,
+}
+
+impl From<FlexParentData> for ParentData {
+    fn from(value: FlexParentData) -> Self {
+        Self {
+            weight: value.weight,
+            fill: value.fill,
+            ..Self::default()
+        }
+    }
+}
+
+impl ParentData {
+    pub fn has_weight(&self) -> bool {
+        self.weight > 0.0
+    }
+}
+
 /// Object capable of measuring a layout child and exposing intrinsic sizes.
 pub trait Measurable {
     /// Measures the child with the provided constraints, returning a [`Placeable`].
@@ -48,6 +78,14 @@ pub trait Measurable {
     /// Default implementation returns None (no weight).
     fn flex_parent_data(&self) -> Option<FlexParentData> {
         None
+    }
+
+    /// Returns all metadata consumed by the direct parent layout.
+    ///
+    /// The default preserves the older `flex_parent_data` customization
+    /// point so existing custom measurables continue to provide weights.
+    fn parent_data(&self) -> ParentData {
+        self.flex_parent_data().map(Into::into).unwrap_or_default()
     }
 }
 

--- a/crates/cranpose-ui/src/clipboard_session.rs
+++ b/crates/cranpose-ui/src/clipboard_session.rs
@@ -44,19 +44,22 @@ impl ClipboardSessionState {
     }
 
     fn write(&self, text: &str) {
+        // Keep a local copy even when a platform bridge is installed: native
+        // clipboards may be temporarily unavailable (notably headless desktop
+        // sessions), and copy/paste must still round-trip within this app.
+        *self.fallback.borrow_mut() = Some(text.to_string());
         if let Some(platform) = self.platform.borrow().clone() {
             platform.write_text(text);
-        } else {
-            *self.fallback.borrow_mut() = Some(text.to_string());
         }
     }
 
     fn read(&self) -> Option<String> {
         if let Some(platform) = self.platform.borrow().clone() {
-            platform.read_text()
-        } else {
-            self.fallback.borrow().clone()
+            if let Some(text) = platform.read_text() {
+                return Some(text);
+            }
         }
+        self.fallback.borrow().clone()
     }
 
     fn has_platform(&self) -> bool {
@@ -152,12 +155,22 @@ mod tests {
         value: RefCell<Option<String>>,
     }
 
+    struct UnavailableClipboard;
+
     impl PlatformClipboard for RecordingClipboard {
         fn write_text(&self, text: &str) {
             *self.value.borrow_mut() = Some(text.to_string());
         }
         fn read_text(&self) -> Option<String> {
             self.value.borrow().clone()
+        }
+    }
+
+    impl PlatformClipboard for UnavailableClipboard {
+        fn write_text(&self, _text: &str) {}
+
+        fn read_text(&self) -> Option<String> {
+            None
         }
     }
 
@@ -189,6 +202,18 @@ mod tests {
 
             clear_platform_clipboard();
             assert!(!clipboard.has_system_clipboard());
+        });
+    }
+
+    #[test]
+    fn manager_falls_back_when_the_installed_platform_is_unavailable() {
+        let context = crate::render_state::AppContext::new();
+        context.enter(|| {
+            set_platform_clipboard(Rc::new(UnavailableClipboard));
+
+            let clipboard = ClipboardManager;
+            clipboard.set_text("headless copy");
+            assert_eq!(clipboard.text().as_deref(), Some("headless copy"));
         });
     }
 }

--- a/crates/cranpose-ui/src/layout/mod.rs
+++ b/crates/cranpose-ui/src/layout/mod.rs
@@ -2797,6 +2797,28 @@ impl LayoutChildMeasurable {
     fn new(state: Rc<LayoutChildMeasureState>) -> Self {
         Self { state }
     }
+
+    fn resolved_parent_data(&self) -> Option<cranpose_ui_layout::ParentData> {
+        let applier = self.state.applier()?;
+        let node_id = self.state.node_id();
+        let Ok(mut applier) = applier.try_borrow_typed() else {
+            return None;
+        };
+
+        applier
+            .with_node::<LayoutNode, _>(node_id, |layout_node| {
+                let props = layout_node.resolved_modifiers().layout_properties();
+                let weight = props.weight().unwrap_or_default();
+                cranpose_ui_layout::ParentData {
+                    weight: weight.weight,
+                    fill: weight.fill,
+                    box_alignment: props.box_alignment(),
+                    row_alignment: props.row_alignment(),
+                    column_alignment: props.column_alignment(),
+                }
+            })
+            .ok()
+    }
 }
 
 impl Measurable for LayoutChildMeasurable {
@@ -3004,21 +3026,18 @@ impl Measurable for LayoutChildMeasurable {
     }
 
     fn flex_parent_data(&self) -> Option<cranpose_ui_layout::FlexParentData> {
-        let applier = self.state.applier()?;
-        let node_id = self.state.node_id();
-        let Ok(mut applier) = applier.try_borrow_typed() else {
+        let parent_data = self.resolved_parent_data()?;
+        if !parent_data.has_weight() {
             return None;
-        };
+        }
+        Some(cranpose_ui_layout::FlexParentData::new(
+            parent_data.weight,
+            parent_data.fill,
+        ))
+    }
 
-        applier
-            .with_node::<LayoutNode, _>(node_id, |layout_node| {
-                let props = layout_node.resolved_modifiers().layout_properties();
-                props.weight().map(|weight_data| {
-                    cranpose_ui_layout::FlexParentData::new(weight_data.weight, weight_data.fill)
-                })
-            })
-            .ok()
-            .flatten()
+    fn parent_data(&self) -> cranpose_ui_layout::ParentData {
+        self.resolved_parent_data().unwrap_or_default()
     }
 }
 

--- a/crates/cranpose-ui/src/layout/policies.rs
+++ b/crates/cranpose-ui/src/layout/policies.rs
@@ -1,9 +1,7 @@
 use crate::layout::core::{
     Alignment, Arrangement, HorizontalAlignment, LinearArrangement, Measurable, VerticalAlignment,
 };
-use cranpose_ui_layout::{
-    Axis, Constraints, FlexParentData, MeasurePolicy, MeasureResult, Placement,
-};
+use cranpose_ui_layout::{Axis, Constraints, MeasurePolicy, MeasureResult, ParentData, Placement};
 use smallvec::SmallVec;
 
 /// MeasurePolicy for Box layout - overlays children according to alignment.
@@ -53,30 +51,35 @@ impl MeasurePolicy for BoxMeasurePolicy {
 
         let mut max_width = 0.0_f32;
         let mut max_height = 0.0_f32;
-        let mut placeables: SmallVec<[cranpose_ui_layout::Placeable; 8]> = SmallVec::new();
+        let mut placeables: SmallVec<[(cranpose_ui_layout::Placeable, Alignment); 8]> =
+            SmallVec::new();
 
         for measurable in measurables {
             let placeable = measurable.measure(child_constraints);
             max_width = max_width.max(placeable.width());
             max_height = max_height.max(placeable.height());
-            placeables.push(placeable);
+            let alignment = measurable
+                .parent_data()
+                .box_alignment
+                .unwrap_or(self.content_alignment);
+            placeables.push((placeable, alignment));
         }
 
         let width = max_width.clamp(constraints.min_width, constraints.max_width);
         let height = max_height.clamp(constraints.min_height, constraints.max_height);
 
         placements.reserve(placeables.len());
-        for placeable in placeables {
+        for (placeable, alignment) in placeables {
             let child_width = placeable.width();
             let child_height = placeable.height();
 
-            let x = match self.content_alignment.horizontal {
+            let x = match alignment.horizontal {
                 HorizontalAlignment::Start => 0.0,
                 HorizontalAlignment::CenterHorizontally => ((width - child_width) / 2.0).max(0.0),
                 HorizontalAlignment::End => (width - child_width).max(0.0),
             };
 
-            let y = match self.content_alignment.vertical {
+            let y = match alignment.vertical {
                 VerticalAlignment::Top => 0.0,
                 VerticalAlignment::CenterVertically => ((height - child_height) / 2.0).max(0.0),
                 VerticalAlignment::Bottom => (height - child_height).max(0.0),
@@ -343,12 +346,15 @@ impl MeasurePolicy for FlexMeasurePolicy {
 
         // Separate children into fixed and weighted
         let mut fixed_children: SmallVec<[usize; 8]> = SmallVec::new();
-        let mut weighted_children: SmallVec<[(usize, FlexParentData); 8]> = SmallVec::new();
+        let parent_data: SmallVec<[ParentData; 8]> = measurables
+            .iter()
+            .map(|child| child.parent_data())
+            .collect();
+        let mut weighted_children: SmallVec<[(usize, ParentData); 8]> = SmallVec::new();
 
-        for (idx, measurable) in measurables.iter().enumerate() {
-            let parent_data = measurable.flex_parent_data().unwrap_or_default();
-            if parent_data.has_weight() {
-                weighted_children.push((idx, parent_data));
+        for (idx, data) in parent_data.iter().copied().enumerate() {
+            if data.has_weight() {
+                weighted_children.push((idx, data));
             } else {
                 fixed_children.push(idx);
             }
@@ -470,11 +476,19 @@ impl MeasurePolicy for FlexMeasurePolicy {
 
         // Place children
         placements.reserve(placeables.len());
-        for (placeable, main_pos) in placeables.into_iter().zip(main_positions) {
+        for (idx, (placeable, main_pos)) in placeables.into_iter().zip(main_positions).enumerate() {
             let child_cross = self.get_cross_axis_size(placeable.width(), placeable.height());
-            let cross_pos = self
-                .cross_axis_alignment
-                .align(container_cross, child_cross);
+            let cross_axis_alignment = match self.axis {
+                Axis::Horizontal => parent_data[idx]
+                    .row_alignment
+                    .map(Into::into)
+                    .unwrap_or(self.cross_axis_alignment),
+                Axis::Vertical => parent_data[idx]
+                    .column_alignment
+                    .map(Into::into)
+                    .unwrap_or(self.cross_axis_alignment),
+            };
+            let cross_pos = cross_axis_alignment.align(container_cross, child_cross);
 
             let (x, y) = match self.axis {
                 Axis::Horizontal => (main_pos, cross_pos),

--- a/crates/cranpose-ui/src/layout/tests/layout_tests.rs
+++ b/crates/cranpose-ui/src/layout/tests/layout_tests.rs
@@ -9,7 +9,7 @@ use std::{
     rc::Rc,
 };
 
-use super::core::Measurable;
+use super::core::{Alignment, Measurable};
 
 fn measure_layout(
     applier: &mut MemoryApplier,
@@ -1814,11 +1814,15 @@ fn property_change_bubbles_without_manual_call() -> Result<(), NodeError> {
 }
 
 #[test]
-fn flex_parent_data_uses_resolved_weight() {
+fn parent_data_uses_resolved_layout_properties() {
     let _app_context = crate::render_state::app_context_test_scope();
     let mut applier = MemoryApplier::new();
     let layout_node = LayoutNode::new(
-        Modifier::empty().columnWeight(1.0, true),
+        Modifier::empty()
+            .columnWeight(1.0, true)
+            .alignInBox(Alignment::BOTTOM_END)
+            .alignInRow(VerticalAlignment::Bottom)
+            .alignInColumn(HorizontalAlignment::End),
         Rc::new(MaxSizePolicy),
     );
     let cache = layout_node.cache_handles();
@@ -1844,6 +1848,11 @@ fn flex_parent_data_uses_resolved_weight() {
         .expect("expected weight to propagate via resolved modifiers");
     assert_eq!(parent_data.weight, 1.0);
     assert!(parent_data.fill);
+
+    let parent_data = measurable.parent_data();
+    assert_eq!(parent_data.box_alignment, Some(Alignment::BOTTOM_END));
+    assert_eq!(parent_data.row_alignment, Some(VerticalAlignment::Bottom));
+    assert_eq!(parent_data.column_alignment, Some(HorizontalAlignment::End));
 }
 
 #[test]

--- a/crates/cranpose-ui/src/layout/tests/policies_tests.rs
+++ b/crates/cranpose-ui/src/layout/tests/policies_tests.rs
@@ -5,6 +5,7 @@ struct MockMeasurable {
     width: f32,
     height: f32,
     node_id: usize,
+    parent_data: cranpose_ui_layout::ParentData,
 }
 
 impl MockMeasurable {
@@ -13,7 +14,13 @@ impl MockMeasurable {
             width,
             height,
             node_id,
+            parent_data: cranpose_ui_layout::ParentData::default(),
         }
+    }
+
+    fn with_parent_data(mut self, parent_data: cranpose_ui_layout::ParentData) -> Self {
+        self.parent_data = parent_data;
+        self
     }
 }
 
@@ -36,6 +43,10 @@ impl Measurable for MockMeasurable {
 
     fn max_intrinsic_height(&self, _width: f32) -> f32 {
         self.height
+    }
+
+    fn parent_data(&self) -> cranpose_ui_layout::ParentData {
+        self.parent_data
     }
 }
 
@@ -60,6 +71,52 @@ fn box_measure_policy_takes_max_size() {
     assert_eq!(result.size.width, 60.0);
     assert_eq!(result.size.height, 30.0);
     assert_eq!(result.placements.len(), 2);
+}
+
+#[test]
+fn box_child_alignment_overrides_content_alignment() {
+    let policy = BoxMeasurePolicy::new(Alignment::TOP_START, false);
+    let measurables: Vec<Box<dyn Measurable>> = vec![Box::new(
+        MockMeasurable::new(20.0, 10.0, 1).with_parent_data(cranpose_ui_layout::ParentData {
+            box_alignment: Some(Alignment::BOTTOM_END),
+            ..Default::default()
+        }),
+    )];
+
+    let result = policy.measure(&measurables, Constraints::tight(100.0, 100.0));
+
+    assert_eq!(result.placements[0].x, 80.0);
+    assert_eq!(result.placements[0].y, 90.0);
+}
+
+#[test]
+fn row_child_alignment_overrides_vertical_alignment() {
+    let policy = FlexMeasurePolicy::row(LinearArrangement::Start, VerticalAlignment::Top);
+    let measurables: Vec<Box<dyn Measurable>> = vec![Box::new(
+        MockMeasurable::new(20.0, 10.0, 1).with_parent_data(cranpose_ui_layout::ParentData {
+            row_alignment: Some(VerticalAlignment::Bottom),
+            ..Default::default()
+        }),
+    )];
+
+    let result = policy.measure(&measurables, Constraints::tight(100.0, 100.0));
+
+    assert_eq!(result.placements[0].y, 90.0);
+}
+
+#[test]
+fn column_child_alignment_overrides_horizontal_alignment() {
+    let policy = FlexMeasurePolicy::column(LinearArrangement::Start, HorizontalAlignment::Start);
+    let measurables: Vec<Box<dyn Measurable>> = vec![Box::new(
+        MockMeasurable::new(20.0, 10.0, 1).with_parent_data(cranpose_ui_layout::ParentData {
+            column_alignment: Some(HorizontalAlignment::End),
+            ..Default::default()
+        }),
+    )];
+
+    let result = policy.measure(&measurables, Constraints::tight(100.0, 100.0));
+
+    assert_eq!(result.placements[0].x, 80.0);
 }
 
 #[test]

--- a/crates/cranpose/Cargo.toml
+++ b/crates/cranpose/Cargo.toml
@@ -55,6 +55,7 @@ desktop-shell = [
     "cranpose-app-shell/clipboard-native",
     "cranpose-platform-desktop-winit",
     "dep:winit",
+    "dep:accesskit",
     "cranpose-services/uri-native",
     "cranpose-services/file-picker-native",
     "cranpose-services/system-theme",
@@ -115,9 +116,11 @@ web-sys = { version = "0.3", optional = true, features = [
     "Element",
     "HtmlElement",
     "HtmlCanvasElement",
+    "DomRect",
     "CanvasRenderingContext2d",
     "Performance",
     "MouseEvent",
+    "EventTarget",
     "Touch",
     "TouchList",
     "TouchEvent",
@@ -154,6 +157,7 @@ thiserror = "2.0.18"
 web-time = { workspace = true }
 cranpose-render-common.workspace = true
 raw-window-handle = "0.6"
+accesskit = { version = "0.24.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1"
@@ -177,6 +181,7 @@ wgpu = { version = "29.0", optional = true, default-features = false, features =
 ] }
 
 [target.'cfg(all(target_os = "linux", not(target_arch = "wasm32")))'.dependencies]
+accesskit_unix = { version = "0.22.1", default-features = false, features = ["async-io"] }
 x11rb = { version = "0.13.2", optional = true }
 wgpu = { version = "29.0", optional = true, default-features = false, features = [
     "std",
@@ -185,6 +190,7 @@ wgpu = { version = "29.0", optional = true, default-features = false, features =
 ] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
+accesskit_windows = "0.34.0"
 wgpu = { version = "29.0", optional = true, default-features = false, features = [
     "std",
     "parking_lot",
@@ -192,6 +198,7 @@ wgpu = { version = "29.0", optional = true, default-features = false, features =
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+accesskit_macos = "0.26.3"
 wgpu = { version = "29.0", optional = true, default-features = false, features = [
     "std",
     "parking_lot",
@@ -232,6 +239,11 @@ objc2-ui-kit = { version = "0.3", default-features = false, optional = true, fea
     "UIScreen",
     "UIActivity",
     "UIActivityViewController",
+    "UIAccessibility",
+    "UIAccessibilityConstants",
+    "UIAccessibilityContainer",
+    "UIAccessibilityElement",
+    "UIAccessibilityIdentification",
     "UIApplication",
     "UIDocumentPickerViewController",
     "UIFeedbackGenerator",

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
@@ -5,6 +5,7 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.graphics.Rect;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
@@ -15,6 +16,9 @@ import android.net.NetworkCapabilities;
 import android.os.Build;
 import android.view.HapticFeedbackConstants;
 import android.view.View;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
+import android.view.accessibility.AccessibilityNodeProvider;
 import android.view.WindowInsets;
 import android.content.UriPermission;
 import android.database.Cursor;
@@ -28,6 +32,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * A {@link NativeActivity} that exposes the Storage Access Framework to
@@ -65,6 +72,174 @@ public class CranposeActivity extends NativeActivity {
     private static final String WRITABLE_PROBE_NAME = ".cranpose-write-probe";
 
     private long pendingToken;
+    private CranposeAccessibilityProvider cranposeAccessibilityProvider;
+
+    private static native void nativeOnAccessibilityActivate(float x, float y);
+
+    /** Publishes Cranpose's semantic tree through Android's native virtual-view API. */
+    public void cranposeSetAccessibilityElements(String payload) {
+        final List<CranposeAccessibilityElement> elements = parseAccessibilityElements(payload);
+        runOnUiThread(() -> {
+            View host = getWindow().getDecorView();
+            if (cranposeAccessibilityProvider == null) {
+                cranposeAccessibilityProvider = new CranposeAccessibilityProvider(host);
+                host.setFocusable(true);
+                host.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES);
+                host.setAccessibilityDelegate(new View.AccessibilityDelegate() {
+                    @Override
+                    public AccessibilityNodeProvider getAccessibilityNodeProvider(View ignored) {
+                        return cranposeAccessibilityProvider;
+                    }
+                });
+            }
+            cranposeAccessibilityProvider.setElements(elements);
+        });
+    }
+
+    private static List<CranposeAccessibilityElement> parseAccessibilityElements(String payload) {
+        if (payload == null || payload.isEmpty()) return Collections.emptyList();
+        ArrayList<CranposeAccessibilityElement> result = new ArrayList<>();
+        for (String record : payload.split("\\n", -1)) {
+            String[] fields = record.split("\\t", -1);
+            if (fields.length != 11) continue;
+            try {
+                result.add(new CranposeAccessibilityElement(
+                        Integer.parseInt(fields[0]), Integer.parseInt(fields[1]),
+                        new Rect(Integer.parseInt(fields[2]), Integer.parseInt(fields[3]),
+                                Integer.parseInt(fields[4]), Integer.parseInt(fields[5])),
+                        Float.parseFloat(fields[6]), Float.parseFloat(fields[7]),
+                        "1".equals(fields[8]), unescapeAccessibility(fields[9]),
+                        unescapeAccessibility(fields[10])));
+            } catch (RuntimeException ignored) {
+                // A malformed record must not make the host Activity inaccessible.
+            }
+        }
+        return result;
+    }
+
+    private static String unescapeAccessibility(String value) {
+        return value.replace("%0D", "\r").replace("%0A", "\n")
+                .replace("%09", "\t").replace("%25", "%");
+    }
+
+    private static final class CranposeAccessibilityElement {
+        final int id;
+        final int role;
+        final Rect bounds;
+        final float centerX;
+        final float centerY;
+        final boolean clickable;
+        final String label;
+        final String value;
+
+        CranposeAccessibilityElement(int id, int role, Rect bounds, float centerX,
+                float centerY, boolean clickable, String label, String value) {
+            this.id = id;
+            this.role = role;
+            this.bounds = bounds;
+            this.centerX = centerX;
+            this.centerY = centerY;
+            this.clickable = clickable;
+            this.label = label;
+            this.value = value;
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static final class CranposeAccessibilityProvider extends AccessibilityNodeProvider {
+        private static final int HOST_ID = View.NO_ID;
+        private final View host;
+        private List<CranposeAccessibilityElement> elements = Collections.emptyList();
+        private int focusedId = HOST_ID;
+
+        CranposeAccessibilityProvider(View host) {
+            this.host = host;
+        }
+
+        void setElements(List<CranposeAccessibilityElement> elements) {
+            this.elements = elements;
+            host.sendAccessibilityEvent(AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED);
+        }
+
+        @Override
+        public AccessibilityNodeInfo createAccessibilityNodeInfo(int virtualViewId) {
+            if (virtualViewId == HOST_ID) {
+                AccessibilityNodeInfo info = AccessibilityNodeInfo.obtain(host);
+                info.setClassName(CranposeActivity.class.getName());
+                info.setPackageName(host.getContext().getPackageName());
+                for (CranposeAccessibilityElement element : elements) {
+                    info.addChild(host, element.id);
+                }
+                return info;
+            }
+            CranposeAccessibilityElement element = find(virtualViewId);
+            if (element == null) return null;
+            AccessibilityNodeInfo info = AccessibilityNodeInfo.obtain();
+            info.setSource(host, element.id);
+            info.setParent(host);
+            info.setPackageName(host.getContext().getPackageName());
+            info.setEnabled(true);
+            info.setVisibleToUser(true);
+            info.setFocusable(true);
+            info.setAccessibilityFocused(focusedId == element.id);
+            info.setContentDescription(element.label);
+            if (element.role == 1) info.setClassName("android.widget.Button");
+            else if (element.role == 3) {
+                info.setClassName("android.widget.EditText");
+                info.setEditable(true);
+                info.setText(element.value);
+            } else info.setClassName("android.widget.TextView");
+            info.setBoundsInParent(element.bounds);
+            int[] location = new int[2];
+            host.getLocationOnScreen(location);
+            Rect screen = new Rect(element.bounds);
+            screen.offset(location[0], location[1]);
+            info.setBoundsInScreen(screen);
+            info.setClickable(element.clickable);
+            if (element.clickable) info.addAction(AccessibilityNodeInfo.ACTION_CLICK);
+            info.addAction(focusedId == element.id
+                    ? AccessibilityNodeInfo.ACTION_CLEAR_ACCESSIBILITY_FOCUS
+                    : AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS);
+            return info;
+        }
+
+        @Override
+        public boolean performAction(int virtualViewId, int action, Bundle arguments) {
+            CranposeAccessibilityElement element = find(virtualViewId);
+            if (element == null) return false;
+            if (action == AccessibilityNodeInfo.ACTION_CLICK && element.clickable) {
+                nativeOnAccessibilityActivate(element.centerX, element.centerY);
+                sendEvent(element.id, AccessibilityEvent.TYPE_VIEW_CLICKED);
+                return true;
+            }
+            if (action == AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS) {
+                focusedId = element.id;
+                sendEvent(element.id, AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
+                return true;
+            }
+            if (action == AccessibilityNodeInfo.ACTION_CLEAR_ACCESSIBILITY_FOCUS) {
+                focusedId = HOST_ID;
+                sendEvent(element.id, AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED);
+                return true;
+            }
+            return false;
+        }
+
+        private CranposeAccessibilityElement find(int id) {
+            for (CranposeAccessibilityElement element : elements) {
+                if (element.id == id) return element;
+            }
+            return null;
+        }
+
+        private void sendEvent(int id, int type) {
+            if (!host.isShown()) return;
+            AccessibilityEvent event = AccessibilityEvent.obtain(type);
+            event.setPackageName(host.getContext().getPackageName());
+            event.setSource(host, id);
+            host.getParent().requestSendAccessibilityEvent(host, event);
+        }
+    }
 
     /** Number of files to accumulate before flushing a streaming batch. */
     private static final int FOLDER_BATCH_SIZE = 32;

--- a/crates/cranpose/src/accessibility.rs
+++ b/crates/cranpose/src/accessibility.rs
@@ -1,0 +1,250 @@
+//! Platform-neutral projection of Cranpose semantics into accessibility elements.
+
+use cranpose_core::NodeId;
+use cranpose_ui::{SemanticsAction, SemanticsNode, SemanticsRole};
+use std::collections::HashMap;
+
+use cranpose_app_shell::AppShell;
+use cranpose_render_common::Renderer;
+use cranpose_ui::LayoutBox;
+use std::fmt::Debug;
+
+/// Logical bounds for a platform accessibility element.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(crate) struct AccessibilityRect {
+    pub(crate) x: f32,
+    pub(crate) y: f32,
+    pub(crate) width: f32,
+    pub(crate) height: f32,
+}
+
+impl AccessibilityRect {
+    pub(crate) const fn new(x: f32, y: f32, width: f32, height: f32) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    pub(crate) fn center(self) -> (f32, f32) {
+        (self.x + self.width * 0.5, self.y + self.height * 0.5)
+    }
+
+    fn is_visible(self) -> bool {
+        self.width > 0.0
+            && self.height > 0.0
+            && self.x.is_finite()
+            && self.y.is_finite()
+            && self.width.is_finite()
+            && self.height.is_finite()
+    }
+}
+
+/// Role understood by native accessibility backends.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AccessibilityRole {
+    Button,
+    StaticText,
+    TextField,
+}
+
+/// A flattened native accessibility element with stable Cranpose identity.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct AccessibilityElement {
+    pub(crate) node_id: NodeId,
+    pub(crate) label: String,
+    pub(crate) value: Option<String>,
+    pub(crate) bounds: AccessibilityRect,
+    pub(crate) role: AccessibilityRole,
+    pub(crate) clickable: bool,
+}
+
+/// Extracts the current semantics and layout snapshots from an app shell.
+#[cfg_attr(test, allow(dead_code))]
+pub(crate) fn snapshot<R>(shell: &mut AppShell<R>) -> Vec<AccessibilityElement>
+where
+    R: Renderer,
+    R::Error: Debug,
+{
+    let Some(layout_tree) = shell.layout_tree().cloned() else {
+        return Vec::new();
+    };
+    let Some(semantics_root) = shell.semantics_tree().map(|tree| tree.root().clone()) else {
+        return Vec::new();
+    };
+    let mut bounds = HashMap::new();
+    collect_bounds(layout_tree.root(), &mut bounds);
+    project_semantics(&semantics_root, &bounds)
+}
+
+#[cfg_attr(test, allow(dead_code))]
+fn collect_bounds(root: &LayoutBox, bounds: &mut HashMap<NodeId, AccessibilityRect>) {
+    bounds.insert(
+        root.node_id,
+        AccessibilityRect::new(root.rect.x, root.rect.y, root.rect.width, root.rect.height),
+    );
+    for child in &root.children {
+        collect_bounds(child, bounds);
+    }
+}
+
+fn project_semantics(
+    root: &SemanticsNode,
+    bounds: &HashMap<NodeId, AccessibilityRect>,
+) -> Vec<AccessibilityElement> {
+    let mut elements = Vec::new();
+    project_node(root, bounds, false, &mut elements);
+    elements
+}
+
+fn project_node(
+    node: &SemanticsNode,
+    bounds: &HashMap<NodeId, AccessibilityRect>,
+    suppress_static_text: bool,
+    elements: &mut Vec<AccessibilityElement>,
+) {
+    let clickable = node
+        .actions
+        .iter()
+        .any(|action| matches!(action, SemanticsAction::Click { .. }));
+    let actionable = clickable || node.editable_text;
+    let own_label = node_label(node);
+    let label = if actionable {
+        own_label.or_else(|| descendant_label(node))
+    } else {
+        own_label
+    };
+    let rect = bounds.get(&node.node_id).copied().unwrap_or_default();
+
+    if let Some(label) = label.filter(|label| !label.trim().is_empty()) {
+        if rect.is_visible() && (actionable || !suppress_static_text) {
+            let role = if node.editable_text {
+                AccessibilityRole::TextField
+            } else if clickable || matches!(node.role, SemanticsRole::Button) {
+                AccessibilityRole::Button
+            } else {
+                AccessibilityRole::StaticText
+            };
+            elements.push(AccessibilityElement {
+                node_id: node.node_id,
+                value: node.editable_text.then(|| label.clone()),
+                label,
+                bounds: rect,
+                role,
+                clickable,
+            });
+        }
+    }
+
+    let suppress_children = suppress_static_text || actionable;
+    for child in &node.children {
+        project_node(child, bounds, suppress_children, elements);
+    }
+}
+
+fn node_label(node: &SemanticsNode) -> Option<String> {
+    node.description.clone().or_else(|| match &node.role {
+        SemanticsRole::Text { value } => Some(value.clone()),
+        _ => None,
+    })
+}
+
+fn descendant_label(node: &SemanticsNode) -> Option<String> {
+    let mut labels = Vec::new();
+    collect_descendant_labels(node, &mut labels);
+    (!labels.is_empty()).then(|| labels.join(", "))
+}
+
+fn collect_descendant_labels(node: &SemanticsNode, labels: &mut Vec<String>) {
+    for child in &node.children {
+        if let Some(label) = node_label(child) {
+            if !label.trim().is_empty() && !labels.iter().any(|existing| existing == &label) {
+                labels.push(label);
+            }
+        } else {
+            collect_descendant_labels(child, labels);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cranpose_core::NodeId;
+    use cranpose_ui::{SemanticsAction, SemanticsCallback, SemanticsNode, SemanticsRole};
+    use std::collections::HashMap;
+
+    fn node(
+        node_id: NodeId,
+        role: SemanticsRole,
+        actions: Vec<SemanticsAction>,
+        description: Option<&str>,
+        children: Vec<SemanticsNode>,
+    ) -> SemanticsNode {
+        SemanticsNode {
+            node_id,
+            role,
+            actions,
+            children,
+            description: description.map(str::to_owned),
+            editable_text: false,
+            text_selection: None,
+        }
+    }
+
+    #[test]
+    fn actionable_parent_uses_descendant_text_without_duplicate_leaf() {
+        let button_id = 2;
+        let root = node(
+            1,
+            SemanticsRole::Layout,
+            Vec::new(),
+            None,
+            vec![
+                node(
+                    button_id,
+                    SemanticsRole::Button,
+                    vec![SemanticsAction::Click {
+                        handler: SemanticsCallback::new(button_id),
+                    }],
+                    None,
+                    vec![node(
+                        3,
+                        SemanticsRole::Text {
+                            value: "Library".into(),
+                        },
+                        Vec::new(),
+                        None,
+                        Vec::new(),
+                    )],
+                ),
+                node(
+                    4,
+                    SemanticsRole::Text {
+                        value: "Receipts".into(),
+                    },
+                    Vec::new(),
+                    None,
+                    Vec::new(),
+                ),
+            ],
+        );
+        let bounds = HashMap::from([
+            (button_id, AccessibilityRect::new(8.0, 700.0, 80.0, 64.0)),
+            (3, AccessibilityRect::new(20.0, 712.0, 50.0, 20.0)),
+            (4, AccessibilityRect::new(16.0, 80.0, 100.0, 28.0)),
+        ]);
+
+        let projected = project_semantics(&root, &bounds);
+
+        assert_eq!(projected.len(), 2);
+        assert_eq!(projected[0].node_id, button_id);
+        assert_eq!(projected[0].label, "Library");
+        assert_eq!(projected[0].role, AccessibilityRole::Button);
+        assert_eq!(projected[0].bounds.center(), (48.0, 732.0));
+        assert_eq!(projected[1].label, "Receipts");
+        assert_eq!(projected[1].role, AccessibilityRole::StaticText);
+    }
+}

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -704,6 +704,39 @@ struct AndroidGpuSetup {
     renderer_needs_init: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AndroidGpuBackend {
+    Vulkan,
+    Gl,
+}
+
+impl AndroidGpuBackend {
+    fn wgpu_backends(self) -> wgpu::Backends {
+        match self {
+            Self::Vulkan => wgpu::Backends::VULKAN,
+            Self::Gl => wgpu::Backends::GL,
+        }
+    }
+}
+
+struct AndroidWgpuContext {
+    instance: wgpu::Instance,
+    backend: AndroidGpuBackend,
+}
+
+impl AndroidWgpuContext {
+    fn new(backend: AndroidGpuBackend) -> Self {
+        let mut descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
+        descriptor.backends = backend.wgpu_backends();
+        // No debug/validation: emulator Vulkan debug utils can crash on null labels.
+        descriptor.flags = wgpu::InstanceFlags::empty();
+        Self {
+            instance: wgpu::Instance::new(descriptor),
+            backend,
+        }
+    }
+}
+
 fn initialize_android_rendering<F>(
     instance: &wgpu::Instance,
     existing_resources: Option<GpuResources>,
@@ -743,7 +776,7 @@ where
         let content_clone = content.clone();
         let density = density.max(f32::EPSILON);
         let platform_env = android_platform_env();
-        let shell = AppShell::new_with_size_and_density(
+        let mut shell = AppShell::new_with_size_and_density(
             renderer,
             default_root_key(),
             move || {
@@ -756,6 +789,7 @@ where
             (width as f32 / density, height as f32 / density),
             density,
         );
+        shell.set_semantics_enabled(true);
 
         *app_shell = Some(shell);
 
@@ -790,6 +824,83 @@ where
     });
 
     Ok((setup.resources, actual_size))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn initialize_android_rendering_with_backend_fallback<F>(
+    wgpu_context: &mut AndroidWgpuContext,
+    existing_resources: Option<GpuResources>,
+    app_shell: &mut Option<AppShell<WgpuRenderer>>,
+    content: &Rc<RefCell<F>>,
+    settings: &AppSettings,
+    frame_driver: &AndroidFrameDriver,
+    host_window_registry: &android_host_window::AndroidHostWindowRegistry,
+    native_window_ptr: NonNull<c_void>,
+    native_window_owner: Option<NativeWindow>,
+    width: u32,
+    height: u32,
+    density: f32,
+) -> Result<(GpuResources, Option<Size>), AndroidSurfaceError>
+where
+    F: FnMut() + 'static,
+{
+    if existing_resources.is_some() || wgpu_context.backend == AndroidGpuBackend::Gl {
+        return initialize_android_rendering(
+            &wgpu_context.instance,
+            existing_resources,
+            app_shell,
+            content,
+            settings,
+            frame_driver,
+            host_window_registry,
+            native_window_ptr,
+            native_window_owner,
+            width,
+            height,
+            density,
+        );
+    }
+
+    match initialize_android_rendering(
+        &wgpu_context.instance,
+        None,
+        app_shell,
+        content,
+        settings,
+        frame_driver,
+        host_window_registry,
+        native_window_ptr,
+        native_window_owner.clone(),
+        width,
+        height,
+        density,
+    ) {
+        Err(AndroidSurfaceError::RequestAdapter(error)) => {
+            // Keep the two backends in separate instances. On Android emulators
+            // where Vulkan probing fails, a combined Vulkan|GL instance can keep
+            // the ANativeWindow connected while WGPU falls through to EGL. EGL
+            // then aborts with BAD_ALLOC because the window belongs to another
+            // graphics API. Dropping the Vulkan-only instance before constructing
+            // the GL surface gives the fallback a clean native window.
+            log::warn!("No compatible Vulkan adapter ({error}); retrying with a fresh GL instance");
+            *wgpu_context = AndroidWgpuContext::new(AndroidGpuBackend::Gl);
+            initialize_android_rendering(
+                &wgpu_context.instance,
+                None,
+                app_shell,
+                content,
+                settings,
+                frame_driver,
+                host_window_registry,
+                native_window_ptr,
+                native_window_owner,
+                width,
+                height,
+                density,
+            )
+        }
+        result => result,
+    }
 }
 
 fn create_android_gpu_resources(
@@ -1176,6 +1287,7 @@ pub fn run(
 
     // App shell (created once, persists across window recreations)
     let mut app_shell: Option<AppShell<WgpuRenderer>> = None;
+    let mut accessibility_elements = Vec::new();
 
     // Initialize logging
     android_logger::init_once(
@@ -1195,6 +1307,7 @@ pub fn run(
     log::info!("Starting Compose Android Application");
 
     let android_frame_driver = AndroidFrameDriver::new(app.create_waker());
+    crate::android_accessibility::set_waker(app.create_waker());
     let host_window_registry = Rc::new(android_host_window::AndroidHostWindowRegistry::default());
     let overlay_event_queue = Arc::new(android_overlay_window::AndroidOverlayEventQueue::default());
 
@@ -1208,16 +1321,11 @@ pub fn run(
     // Exit flag for Destroy event (can't break from inside poll_events closure)
     let should_exit = Arc::new(AtomicBool::new(false));
 
-    // Initialize wgpu instance with GL and Vulkan backends
-    // Use DISCARD_HAL_LABELS to prevent crash in emulator's Vulkan debug utils
-    // (vk_common_SetDebugUtilsObjectNameEXT crashes on null labels)
-    let backends = wgpu::Backends::GL | wgpu::Backends::VULKAN;
-
-    let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
-    instance_descriptor.backends = backends;
-    // No debug/validation: emulator Vulkan debug utils can crash on null labels.
-    instance_descriptor.flags = wgpu::InstanceFlags::empty();
-    let instance = wgpu::Instance::new(instance_descriptor);
+    // Probe Vulkan first, then create a fresh GL-only instance if no compatible
+    // adapter exists. Keeping the backends separate is important on emulators:
+    // a failed Vulkan probe can otherwise leave the ANativeWindow connected and
+    // make EGL surface creation abort with `EGL_BAD_ALLOC`.
+    let mut wgpu_context = AndroidWgpuContext::new(AndroidGpuBackend::Vulkan);
 
     // Platform abstraction for density/pointer conversion
     let mut android_platform = AndroidPlatform::new();
@@ -1325,8 +1433,8 @@ pub fn run(
                                     input_offset_y
                                 );
 
-                                match initialize_android_rendering(
-                                    &instance,
+                                match initialize_android_rendering_with_backend_fallback(
+                                    &mut wgpu_context,
                                     gpu_resources.take(),
                                     &mut app_shell,
                                     &content,
@@ -1572,8 +1680,8 @@ pub fn run(
                         if width > 0 && height > 0 {
                             let density =
                                 update_android_platform_geometry(&app, &mut android_platform);
-                            match initialize_android_rendering(
-                                &instance,
+                            match initialize_android_rendering_with_backend_fallback(
+                                &mut wgpu_context,
                                 gpu_resources.take(),
                                 &mut app_shell,
                                 &content,
@@ -1615,8 +1723,8 @@ pub fn run(
                         }
 
                         let native_window_ptr = native_window.ptr().cast();
-                        match initialize_android_rendering(
-                            &instance,
+                        match initialize_android_rendering_with_backend_fallback(
+                            &mut wgpu_context,
                             gpu_resources.take(),
                             &mut app_shell,
                             &content,
@@ -1729,6 +1837,11 @@ pub fn run(
         // Apply editing operations forwarded by the IME InputConnection
         // (commit/compose/delete/key/editor-action), in arrival order.
         if let Some(shell) = &mut app_shell {
+            for (x, y) in crate::android_accessibility::drain_activations() {
+                shell.set_cursor(x, y);
+                shell.pointer_pressed();
+                shell.pointer_released_at_position(x, y);
+            }
             for event in ime_event_queue.drain() {
                 dispatch_android_ime_event(shell, event);
             }
@@ -1822,6 +1935,14 @@ pub fn run(
                     &host_window_registry,
                     || shell.update(),
                 );
+                if let Err(error) = crate::android_accessibility::sync(
+                    &app,
+                    shell,
+                    android_platform.scale_factor() as f32,
+                    &mut accessibility_elements,
+                ) {
+                    log::warn!("{error}");
+                }
                 dispatch_registered_android_surface_size_request(
                     &app,
                     &host_window_registry,

--- a/crates/cranpose/src/android_accessibility.rs
+++ b/crates/cranpose/src/android_accessibility.rs
@@ -1,0 +1,141 @@
+//! Android `AccessibilityNodeProvider` bridge for the native canvas surface.
+#![allow(unsafe_code)]
+
+use crate::accessibility::{self, AccessibilityElement, AccessibilityRole};
+use crate::android_jni::{clear_pending_android_jni_exception, with_android_activity_env};
+use cranpose_app_shell::AppShell;
+use cranpose_render_wgpu::WgpuRenderer;
+use jni::{
+    jni_sig, jni_str,
+    objects::{JClass, JObject, JValue},
+    sys::jfloat,
+    EnvUnowned,
+};
+use std::sync::{Mutex, OnceLock};
+
+static ACTIVATIONS: OnceLock<Mutex<Vec<(f32, f32)>>> = OnceLock::new();
+static LOOP_WAKER: OnceLock<android_activity::AndroidAppWaker> = OnceLock::new();
+
+pub(crate) fn set_waker(waker: android_activity::AndroidAppWaker) {
+    let _ = LOOP_WAKER.set(waker);
+}
+
+fn activations() -> &'static Mutex<Vec<(f32, f32)>> {
+    ACTIVATIONS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+pub(crate) fn drain_activations() -> Vec<(f32, f32)> {
+    std::mem::take(
+        &mut *activations()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()),
+    )
+}
+
+pub(crate) fn sync(
+    app: &android_activity::AndroidApp,
+    shell: &mut AppShell<WgpuRenderer>,
+    density: f32,
+    previous: &mut Vec<AccessibilityElement>,
+) -> Result<(), String> {
+    let elements = accessibility::snapshot(shell);
+    if elements == *previous {
+        return Ok(());
+    }
+    previous.clone_from(&elements);
+    let payload = encode_elements(&elements, density);
+    with_android_activity_env(app, |env, activity| {
+        let payload = env.new_string(payload).map_err(|error| {
+            clear_pending_android_jni_exception(env);
+            format!("failed to encode Android accessibility tree: {error}")
+        })?;
+        let payload = JObject::from(payload);
+        env.call_method(
+            &activity,
+            jni_str!("cranposeSetAccessibilityElements"),
+            jni_sig!("(Ljava/lang/String;)V"),
+            &[JValue::Object(&payload)],
+        )
+        .map_err(|error| {
+            clear_pending_android_jni_exception(env);
+            format!("failed to publish Android accessibility tree: {error}")
+        })?;
+        Ok(())
+    })
+}
+
+fn encode_elements(elements: &[AccessibilityElement], density: f32) -> String {
+    let density = density.max(f32::EPSILON);
+    elements
+        .iter()
+        .map(|element| {
+            let role = match element.role {
+                AccessibilityRole::Button => 1,
+                AccessibilityRole::StaticText => 2,
+                AccessibilityRole::TextField => 3,
+            };
+            let (center_x, center_y) = element.bounds.center();
+            format!(
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                virtual_id(element.node_id),
+                role,
+                (element.bounds.x * density).round() as i32,
+                (element.bounds.y * density).round() as i32,
+                ((element.bounds.x + element.bounds.width) * density).round() as i32,
+                ((element.bounds.y + element.bounds.height) * density).round() as i32,
+                center_x,
+                center_y,
+                i32::from(element.clickable),
+                escape(&element.label),
+                escape(element.value.as_deref().unwrap_or("")),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn virtual_id(node_id: cranpose_core::NodeId) -> i32 {
+    ((node_id as u64 & 0x7fff_ffff) as i32).max(1)
+}
+
+fn escape(value: &str) -> String {
+    value
+        .replace('%', "%25")
+        .replace('\t', "%09")
+        .replace('\n', "%0A")
+        .replace('\r', "%0D")
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeActivity_nativeOnAccessibilityActivate(
+    _env: EnvUnowned<'_>,
+    _class: JClass<'_>,
+    x: jfloat,
+    y: jfloat,
+) {
+    activations()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .push((x, y));
+    if let Some(waker) = LOOP_WAKER.get() {
+        waker.wake();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{escape, virtual_id};
+
+    #[test]
+    fn android_accessibility_wire_values_escape_record_delimiters() {
+        assert_eq!(escape("A%\tB\nC\r"), "A%25%09B%0AC%0D");
+    }
+
+    #[test]
+    fn android_virtual_ids_are_stable_copies_of_cranpose_node_ids() {
+        assert_eq!(virtual_id(42), 42);
+        assert_eq!(virtual_id(0), 1);
+        assert_eq!(virtual_id(42), virtual_id(42));
+    }
+}

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -121,6 +121,7 @@ fn robot_query_should_drain_frame(app: &AppShell<WgpuRenderer>) -> bool {
 struct RobotController {
     rx: mpsc::Receiver<RobotCommand>,
     tx: mpsc::Sender<RobotResponse>,
+    pending_command: Option<RobotCommand>,
     waiting_for_idle: bool,
     idle_iterations: u32,
     idle_structure_clean_frames: u32,
@@ -147,6 +148,7 @@ impl RobotController {
         let controller = RobotController {
             rx,
             tx,
+            pending_command: None,
             waiting_for_idle: false,
             idle_iterations: 0,
             idle_structure_clean_frames: 0,
@@ -175,6 +177,19 @@ impl RobotController {
         self.waiting_for_idle = true;
         self.idle_iterations = 0;
         self.idle_structure_clean_frames = 0;
+    }
+
+    fn stage_pending_command(&mut self) -> bool {
+        if self.pending_command.is_none() {
+            self.pending_command = self.rx.try_recv().ok();
+        }
+        self.pending_command.is_some()
+    }
+
+    fn next_command(&mut self) -> Option<RobotCommand> {
+        self.pending_command
+            .take()
+            .or_else(|| self.rx.try_recv().ok())
     }
 
     fn finish_idle_wait(&mut self) {
@@ -480,6 +495,8 @@ struct App {
     surface_caps: Option<wgpu::SurfaceCapabilities>,
     /// Compose app shell
     app: Option<AppShell<WgpuRenderer>>,
+    /// Platform-native AccessKit bridge for the primary window.
+    accessibility: Option<crate::desktop_accessibility::DesktopAccessibilityBridge>,
     /// Platform adapter
     platform: Option<DesktopWinitPlatform>,
     /// Shared GPU objects used by all desktop surfaces.
@@ -564,6 +581,7 @@ impl App {
             surface_config: None,
             surface_caps: None,
             app: None,
+            accessibility: None,
             platform: None,
             gpu_context: None,
             native_windows: HashMap::new(),
@@ -3753,6 +3771,15 @@ impl cranpose_app_shell::PlatformTextInputHandler for DesktopTextInput {
 
 impl ApplicationHandler for App {
     fn proxy_wake_up(&mut self, event_loop: &dyn ActiveEventLoop) {
+        #[cfg(feature = "robot")]
+        if self
+            .robot_controller
+            .as_mut()
+            .is_some_and(RobotController::stage_pending_command)
+        {
+            self.about_to_wait(event_loop);
+            return;
+        }
         self.handle_primary_frame_requested(event_loop);
     }
 
@@ -3775,7 +3802,10 @@ impl ApplicationHandler for App {
                     initial_height as f64,
                 ))
                 // Hide window in headless mode for parallel robot testing
-                .with_visible(!headless && primary_window_visible),
+                // AccessKit must subclass/register the native view before its
+                // first show. The window is revealed after the initial
+                // semantic tree has been installed below.
+                .with_visible(false),
         ) {
             Ok(window) => window.into(),
             Err(error) => {
@@ -3895,8 +3925,16 @@ impl ApplicationHandler for App {
                 initial_scale as f32,
             )
         });
-        #[cfg(feature = "robot")]
-        app.set_semantics_enabled(self.robot_controller.is_some());
+        app.set_semantics_enabled(true);
+
+        let mut accessibility = crate::desktop_accessibility::DesktopAccessibilityBridge::new(
+            window.as_ref(),
+            self.event_proxy.clone(),
+        );
+        accessibility.sync(&mut app);
+        if !headless && primary_window_visible {
+            window.set_visible(true);
+        }
 
         // Apply dev options (FPS counter, etc.)
         let mut dev_options = self.settings.dev_options.clone();
@@ -3943,6 +3981,7 @@ impl ApplicationHandler for App {
         self.surface_config = Some(surface_config);
         self.surface_caps = Some(surface_caps);
         self.app = Some(app);
+        self.accessibility = Some(accessibility);
         self.platform = Some(platform);
         self.gpu_context = Some(DesktopGpuContext {
             instance,
@@ -3977,6 +4016,9 @@ impl ApplicationHandler for App {
             self.native_window_event(event_loop, window_id, event);
             return;
         }
+        if let Some(accessibility) = &mut self.accessibility {
+            accessibility.process_event(window.as_ref(), &event);
+        }
 
         let frame_interval = self.frame_interval();
         let last_frame_start_time = self.last_frame_start_time;
@@ -3987,6 +4029,13 @@ impl ApplicationHandler for App {
 
         let registry = Rc::clone(&self.native_window_registry);
         let Some(app) = &mut self.app else { return };
+        if let Some(accessibility) = &mut self.accessibility {
+            for (x, y) in accessibility.drain_clicks() {
+                app.set_cursor(x, y);
+                app.pointer_pressed();
+                app.pointer_released_at_position(x, y);
+            }
+        }
         let Some(platform) = &mut self.platform else {
             return;
         };
@@ -4273,6 +4322,9 @@ impl ApplicationHandler for App {
                 let primary_surface_dirty_before_update = self.primary_surface_dirty;
                 app.set_density(window.scale_factor() as f32);
                 let update_result = update_app_with_native_window_registry(app, &registry);
+                if let Some(accessibility) = &mut self.accessibility {
+                    accessibility.sync(app);
+                }
                 #[cfg(feature = "robot")]
                 if let Some(controller) = &mut self.robot_controller {
                     controller.record_idle_update_result(update_result);
@@ -4392,6 +4444,18 @@ impl ApplicationHandler for App {
         let Some(window) = self.window.clone() else {
             return;
         };
+        if let Some(accessibility) = &mut self.accessibility {
+            let mut activated = false;
+            for (x, y) in accessibility.drain_clicks() {
+                app.set_cursor(x, y);
+                app.pointer_pressed();
+                app.pointer_released_at_position(x, y);
+                activated = true;
+            }
+            if activated {
+                request_redraw_once(&window, &mut self.primary_redraw_pending);
+            }
+        }
 
         // The first frame still owes the surface a present, but the redraw
         // requested during `resumed` can be dropped on macOS, so re-request it
@@ -4408,7 +4472,7 @@ impl ApplicationHandler for App {
         if let Some(controller) = &mut self.robot_controller {
             let mut robot_visual_dirty = false;
             // Process new commands
-            while let Ok(cmd) = controller.rx.try_recv() {
+            while let Some(cmd) = controller.next_command() {
                 match cmd {
                     RobotCommand::Click { x, y } => {
                         app.set_pointer_source(PointerSource::Mouse);
@@ -4830,6 +4894,10 @@ impl ApplicationHandler for App {
                     RobotCommand::Exit => {
                         let _ = controller.tx.send(RobotResponse::Ok);
                         event_loop.exit();
+                        // Nothing after an exit request should reschedule the loop. In
+                        // particular, ControlFlow::Poll below can otherwise keep a
+                        // continuously animating headless robot app alive forever.
+                        return;
                     }
                 }
             }
@@ -5933,6 +6001,23 @@ mod tests {
         assert!(controller.synthetic_primary_down());
         controller.end_synthetic_primary_gesture();
         assert!(!controller.synthetic_primary_down());
+    }
+
+    #[cfg(feature = "robot")]
+    #[test]
+    fn robot_controller_stages_commands_during_continuous_frame_wakes() {
+        let (mut controller, robot) = RobotController::new();
+        robot
+            .command_sender()
+            .send(crate::robot::RobotCommand::PumpFrames { count: 2 })
+            .expect("robot command channel should remain open");
+
+        assert!(controller.stage_pending_command());
+        assert!(matches!(
+            controller.next_command(),
+            Some(crate::robot::RobotCommand::PumpFrames { count: 2 })
+        ));
+        assert!(!controller.stage_pending_command());
     }
 
     #[cfg(feature = "robot")]

--- a/crates/cranpose/src/desktop_accessibility.rs
+++ b/crates/cranpose/src/desktop_accessibility.rs
@@ -1,0 +1,316 @@
+//! Native desktop accessibility through AccessKit platform adapters.
+#![allow(unsafe_code)]
+
+use crate::accessibility::{self, AccessibilityElement, AccessibilityRole};
+use accesskit::{
+    Action, ActionHandler, ActionRequest, ActivationHandler, DeactivationHandler, Node, NodeId,
+    Rect, Role, Tree, TreeId, TreeUpdate,
+};
+use cranpose_app_shell::AppShell;
+use cranpose_render_wgpu::WgpuRenderer;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use winit::event::WindowEvent;
+use winit::event_loop::EventLoopProxy;
+use winit::window::Window;
+
+const ROOT_ID: NodeId = NodeId(u64::MAX);
+
+#[derive(Clone)]
+struct InitialTree(Arc<Mutex<Option<TreeUpdate>>>);
+
+impl ActivationHandler for InitialTree {
+    fn request_initial_tree(&mut self) -> Option<TreeUpdate> {
+        self.0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+}
+
+#[derive(Clone)]
+struct Actions {
+    queue: Arc<Mutex<Vec<ActionRequest>>>,
+    waker: EventLoopProxy,
+}
+
+impl ActionHandler for Actions {
+    fn do_action(&mut self, request: ActionRequest) {
+        self.queue
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(request);
+        self.waker.wake_up();
+    }
+}
+
+struct Deactivation;
+
+impl DeactivationHandler for Deactivation {
+    fn deactivate_accessibility(&mut self) {}
+}
+
+pub(crate) struct DesktopAccessibilityBridge {
+    adapter: PlatformAdapter,
+    initial_tree: Arc<Mutex<Option<TreeUpdate>>>,
+    actions: Arc<Mutex<Vec<ActionRequest>>>,
+    centers: HashMap<NodeId, (f32, f32)>,
+    previous: Vec<AccessibilityElement>,
+}
+
+impl DesktopAccessibilityBridge {
+    pub(crate) fn new(window: &dyn Window, waker: EventLoopProxy) -> Self {
+        let initial_tree = Arc::new(Mutex::new(None));
+        let actions = Arc::new(Mutex::new(Vec::new()));
+        let adapter = PlatformAdapter::new(
+            window,
+            InitialTree(Arc::clone(&initial_tree)),
+            Actions {
+                queue: Arc::clone(&actions),
+                waker,
+            },
+            Deactivation,
+        );
+        Self {
+            adapter,
+            initial_tree,
+            actions,
+            centers: HashMap::new(),
+            previous: Vec::new(),
+        }
+    }
+
+    pub(crate) fn process_event(&mut self, window: &dyn Window, event: &WindowEvent) {
+        self.adapter.process_event(window, event);
+    }
+
+    pub(crate) fn sync(&mut self, shell: &mut AppShell<WgpuRenderer>) {
+        let elements = accessibility::snapshot(shell);
+        if elements == self.previous {
+            return;
+        }
+        self.previous.clone_from(&elements);
+        let update = tree_update(&elements);
+        self.centers = elements
+            .iter()
+            .map(|element| (NodeId(element.node_id as u64), element.bounds.center()))
+            .collect();
+        *self
+            .initial_tree
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(update.clone());
+        self.adapter.update_if_active(|| update);
+    }
+
+    pub(crate) fn drain_clicks(&mut self) -> Vec<(f32, f32)> {
+        std::mem::take(
+            &mut *self
+                .actions
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        )
+        .into_iter()
+        .filter(|request| request.action == Action::Click)
+        .filter_map(|request| self.centers.get(&request.target_node).copied())
+        .collect()
+    }
+}
+
+fn tree_update(elements: &[AccessibilityElement]) -> TreeUpdate {
+    let children: Vec<NodeId> = elements
+        .iter()
+        .map(|element| NodeId(element.node_id as u64))
+        .collect();
+    let mut root = Node::new(Role::Window);
+    root.set_label("Cranpose application");
+    root.set_children(children);
+    let mut nodes = vec![(ROOT_ID, root)];
+    nodes.extend(elements.iter().map(|element| {
+        let role = match element.role {
+            AccessibilityRole::Button => Role::Button,
+            AccessibilityRole::StaticText => Role::Label,
+            AccessibilityRole::TextField => Role::TextInput,
+        };
+        let mut node = Node::new(role);
+        if element.role == AccessibilityRole::StaticText {
+            node.set_value(element.label.as_str());
+        } else {
+            node.set_label(element.label.as_str());
+        }
+        if let Some(value) = &element.value {
+            node.set_value(value.as_str());
+        }
+        node.set_bounds(Rect {
+            x0: element.bounds.x as f64,
+            y0: element.bounds.y as f64,
+            x1: (element.bounds.x + element.bounds.width) as f64,
+            y1: (element.bounds.y + element.bounds.height) as f64,
+        });
+        if element.clickable {
+            node.add_action(Action::Click);
+        }
+        (NodeId(element.node_id as u64), node)
+    }));
+    let mut tree = Tree::new(ROOT_ID);
+    tree.toolkit_name = Some("Cranpose".into());
+    TreeUpdate {
+        nodes,
+        tree: Some(tree),
+        tree_id: TreeId::ROOT,
+        focus: ROOT_ID,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::accessibility::AccessibilityRect;
+
+    #[test]
+    fn desktop_tree_maps_controls_to_native_roles_and_click_actions() {
+        let elements = vec![
+            AccessibilityElement {
+                node_id: 7,
+                label: "Items".into(),
+                value: None,
+                bounds: AccessibilityRect::new(10.0, 20.0, 80.0, 44.0),
+                role: AccessibilityRole::Button,
+                clickable: true,
+            },
+            AccessibilityElement {
+                node_id: 8,
+                label: "Receipts".into(),
+                value: None,
+                bounds: AccessibilityRect::new(10.0, 70.0, 120.0, 24.0),
+                role: AccessibilityRole::StaticText,
+                clickable: false,
+            },
+        ];
+
+        let update = tree_update(&elements);
+        assert_eq!(update.tree.as_ref().map(|tree| tree.root), Some(ROOT_ID));
+        let button = &update.nodes[1].1;
+        assert_eq!(button.role(), Role::Button);
+        assert_eq!(button.label(), Some("Items"));
+        assert!(button.supports_action(Action::Click));
+        let label = &update.nodes[2].1;
+        assert_eq!(label.role(), Role::Label);
+        assert_eq!(label.value(), Some("Receipts"));
+    }
+}
+
+#[cfg(target_os = "macos")]
+struct PlatformAdapter(accesskit_macos::SubclassingAdapter);
+
+#[cfg(target_os = "macos")]
+impl PlatformAdapter {
+    fn new(
+        window: &dyn Window,
+        activation: impl 'static + ActivationHandler,
+        actions: impl 'static + ActionHandler,
+        _deactivation: impl 'static + DeactivationHandler,
+    ) -> Self {
+        use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+        let RawWindowHandle::AppKit(handle) = window.window_handle().unwrap().as_raw() else {
+            unreachable!("macOS desktop window did not expose an AppKit view")
+        };
+        Self(unsafe {
+            accesskit_macos::SubclassingAdapter::new(handle.ns_view.as_ptr(), activation, actions)
+        })
+    }
+
+    fn process_event(&mut self, _window: &dyn Window, event: &WindowEvent) {
+        if let WindowEvent::Focused(focused) = event {
+            if let Some(events) = self.0.update_view_focus_state(*focused) {
+                events.raise();
+            }
+        }
+    }
+
+    fn update_if_active(&mut self, update: impl FnOnce() -> TreeUpdate) {
+        if let Some(events) = self.0.update_if_active(update) {
+            events.raise();
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+struct PlatformAdapter(accesskit_windows::SubclassingAdapter);
+
+#[cfg(target_os = "windows")]
+impl PlatformAdapter {
+    fn new(
+        window: &dyn Window,
+        activation: impl 'static + ActivationHandler,
+        actions: impl 'static + ActionHandler + Send,
+        _deactivation: impl 'static + DeactivationHandler,
+    ) -> Self {
+        use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+        let RawWindowHandle::Win32(handle) = window.window_handle().unwrap().as_raw() else {
+            unreachable!("Windows desktop window did not expose an HWND")
+        };
+        Self(accesskit_windows::SubclassingAdapter::new(
+            accesskit_windows::HWND(handle.hwnd.get() as *mut _),
+            activation,
+            actions,
+        ))
+    }
+
+    fn process_event(&mut self, _window: &dyn Window, _event: &WindowEvent) {}
+
+    fn update_if_active(&mut self, update: impl FnOnce() -> TreeUpdate) {
+        if let Some(events) = self.0.update_if_active(update) {
+            events.raise();
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+struct PlatformAdapter(accesskit_unix::Adapter);
+
+#[cfg(target_os = "linux")]
+impl PlatformAdapter {
+    fn new(
+        _window: &dyn Window,
+        activation: impl 'static + ActivationHandler + Send,
+        actions: impl 'static + ActionHandler + Send,
+        deactivation: impl 'static + DeactivationHandler + Send,
+    ) -> Self {
+        Self(accesskit_unix::Adapter::new(
+            activation,
+            actions,
+            deactivation,
+        ))
+    }
+
+    fn process_event(&mut self, window: &dyn Window, event: &WindowEvent) {
+        match event {
+            WindowEvent::Moved(_) | WindowEvent::SurfaceResized(_) => {
+                // Wayland intentionally does not expose absolute window
+                // positions. AT-SPI only needs this update on X11, where the
+                // outer desktop position is available.
+                let Ok(outer_origin) = window.outer_position() else {
+                    return;
+                };
+                let surface_origin = window.surface_position();
+                let outer_position = (outer_origin.x as f64, outer_origin.y as f64);
+                let outer_size: (_, _) = window.outer_size().cast::<f64>().into();
+                let inner_position = (
+                    (outer_origin.x + surface_origin.x) as f64,
+                    (outer_origin.y + surface_origin.y) as f64,
+                );
+                let inner_size: (_, _) = window.surface_size().cast::<f64>().into();
+                self.0.set_root_window_bounds(
+                    Rect::from_origin_size(outer_position, outer_size),
+                    Rect::from_origin_size(inner_position, inner_size),
+                );
+            }
+            WindowEvent::Focused(focused) => self.0.update_window_focus_state(*focused),
+            _ => {}
+        }
+    }
+
+    fn update_if_active(&mut self, update: impl FnOnce() -> TreeUpdate) {
+        self.0.update_if_active(update);
+    }
+}

--- a/crates/cranpose/src/ios.rs
+++ b/crates/cranpose/src/ios.rs
@@ -44,6 +44,8 @@ struct IosApp<F: FnMut() + 'static> {
     window: Option<Arc<dyn Window>>,
     gpu: Option<GpuResources>,
     shell: Option<AppShell<WgpuRenderer>>,
+    /// Mirrors Cranpose semantics into UIKit and queues native activations.
+    accessibility: Option<crate::ios_accessibility::IosAccessibilityBridge>,
     platform: DesktopWinitPlatform,
     /// Live platform environment (safe-area/IME insets, system theme) provided
     /// to composition by the root wrapper. Shared with the content closure so
@@ -71,6 +73,7 @@ impl<F: FnMut() + 'static> IosApp<F> {
             window: None,
             gpu: None,
             shell: None,
+            accessibility: None,
             platform: DesktopWinitPlatform::default(),
             platform_env: crate::platform_env::PlatformEnvironment::new(),
             last_keyboard_bottom: 0.0,
@@ -148,6 +151,12 @@ impl<F: FnMut() + 'static> IosApp<F> {
             self.event_proxy.wake_up();
         }
 
+        if let (Some(accessibility), Some(shell)) =
+            (self.accessibility.as_mut(), self.shell.as_mut())
+        {
+            accessibility.drain_activations(shell);
+        }
+
         let (Some(gpu), Some(shell)) = (self.gpu.as_mut(), self.shell.as_mut()) else {
             return;
         };
@@ -181,6 +190,9 @@ impl<F: FnMut() + 'static> IosApp<F> {
 
         let dirty_before = gpu.surface_dirty;
         let update_result = shell.update();
+        if let Some(accessibility) = self.accessibility.as_mut() {
+            accessibility.sync(shell);
+        }
         if !surface_present_required(
             dirty_before,
             update_result.visual_changed,
@@ -331,6 +343,13 @@ impl<F: FnMut() + 'static> ApplicationHandler for IosApp<F> {
         shell.app_context().enter(crate::ios_clipboard::register);
         shell.app_context().enter(crate::ios_keyboard::register);
         shell.app_context().enter(crate::ios_back_gesture::register);
+        shell.set_semantics_enabled(true);
+
+        let mut accessibility =
+            crate::ios_accessibility::IosAccessibilityBridge::new(self.event_proxy.clone());
+        if let Some(accessibility) = accessibility.as_mut() {
+            accessibility.sync(&mut shell);
+        }
 
         // Drive runtime-requested frames (animations, async results) through the
         // event-loop proxy. Calling `request_redraw` directly from the waker is
@@ -358,6 +377,7 @@ impl<F: FnMut() + 'static> ApplicationHandler for IosApp<F> {
             surface_dirty: true,
         });
         self.shell = Some(shell);
+        self.accessibility = accessibility;
         self.window = Some(window.clone());
         window.request_redraw();
     }

--- a/crates/cranpose/src/ios_accessibility.rs
+++ b/crates/cranpose/src/ios_accessibility.rs
@@ -1,0 +1,273 @@
+//! UIKit accessibility bridge for the retained Cranpose semantics tree.
+#![allow(unsafe_code)]
+
+use crate::accessibility::{self, AccessibilityElement, AccessibilityRole};
+use crate::ios_file_picker::root_view_controller;
+use cranpose_app_shell::{AppShell, PointerSource};
+use cranpose_core::NodeId;
+use cranpose_render_common::Renderer;
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, Bool};
+use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker, MainThreadOnly, Message};
+use objc2_core_foundation::{CGPoint, CGRect, CGSize};
+use objc2_foundation::{NSArray, NSObject, NSObjectProtocol, NSString};
+use objc2_ui_kit::{
+    NSObjectUIAccessibility, NSObjectUIAccessibilityContainer, UIAccessibilityElement,
+    UIAccessibilityIdentification, UIAccessibilityLayoutChangedNotification,
+    UIAccessibilityPostNotification, UIAccessibilityScreenChangedNotification,
+    UIAccessibilityTraitButton, UIAccessibilityTraitNone, UIAccessibilityTraitStaticText, UIView,
+};
+use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
+use std::rc::Rc;
+use winit::event_loop::EventLoopProxy;
+
+struct AccessibilityElementIvars {
+    node_id: NodeId,
+    actionable: Cell<bool>,
+    pending_activations: Rc<RefCell<Vec<NodeId>>>,
+    wake_proxy: EventLoopProxy,
+}
+
+define_class!(
+    #[unsafe(super(UIAccessibilityElement))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "CranposeAccessibilityElement"]
+    #[ivars = AccessibilityElementIvars]
+    struct NativeAccessibilityElement;
+
+    // SAFETY: The class inherits NSObject protocol conformance from
+    // UIAccessibilityElement and adds only Rust-owned ivars and one override.
+    unsafe impl NSObjectProtocol for NativeAccessibilityElement {}
+
+    impl NativeAccessibilityElement {
+        #[unsafe(method(accessibilityActivate))]
+        fn accessibility_activate(&self) -> Bool {
+            if !self.ivars().actionable.get() {
+                return Bool::NO;
+            }
+            self.ivars()
+                .pending_activations
+                .borrow_mut()
+                .push(self.ivars().node_id);
+            self.ivars().wake_proxy.wake_up();
+            Bool::YES
+        }
+    }
+);
+
+impl NativeAccessibilityElement {
+    fn new(
+        container: &AnyObject,
+        node_id: NodeId,
+        pending_activations: Rc<RefCell<Vec<NodeId>>>,
+        wake_proxy: EventLoopProxy,
+        mtm: MainThreadMarker,
+    ) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(AccessibilityElementIvars {
+            node_id,
+            actionable: Cell::new(false),
+            pending_activations,
+            wake_proxy,
+        });
+        // SAFETY: `container` is the retained winit root UIView and implements
+        // the UIAccessibilityContainer informal protocol.
+        unsafe { msg_send![super(this), initWithAccessibilityContainer: container] }
+    }
+
+    fn set_actionable(&self, actionable: bool) {
+        self.ivars().actionable.set(actionable);
+    }
+}
+
+/// Owns UIKit's retained accessibility elements and dispatches their actions.
+pub(crate) struct IosAccessibilityBridge {
+    host_view: Retained<UIView>,
+    native_elements: HashMap<NodeId, Retained<NativeAccessibilityElement>>,
+    snapshot: Vec<AccessibilityElement>,
+    pending_activations: Rc<RefCell<Vec<NodeId>>>,
+    wake_proxy: EventLoopProxy,
+    published_once: bool,
+}
+
+impl IosAccessibilityBridge {
+    /// Attaches an accessibility container to winit's root UIKit view.
+    pub(crate) fn new(event_proxy: EventLoopProxy) -> Option<Self> {
+        let mtm = MainThreadMarker::new()?;
+        let host_view = root_view_controller(mtm)?.view()?;
+        let host_object: &NSObject = host_view.as_ref();
+        host_object.setIsAccessibilityElement(false, mtm);
+
+        Some(Self {
+            host_view,
+            native_elements: HashMap::new(),
+            snapshot: Vec::new(),
+            pending_activations: Rc::new(RefCell::new(Vec::new())),
+            wake_proxy: event_proxy,
+            published_once: false,
+        })
+    }
+
+    /// Reconciles native elements with the current retained semantics snapshot.
+    pub(crate) fn sync<R>(&mut self, shell: &mut AppShell<R>)
+    where
+        R: Renderer,
+        R::Error: Debug,
+    {
+        let next = accessibility::snapshot(shell);
+        if next == self.snapshot {
+            return;
+        }
+
+        let structure_changed = !same_structure(&self.snapshot, &next);
+        let current_ids: HashSet<NodeId> = next.iter().map(|element| element.node_id).collect();
+        self.native_elements
+            .retain(|node_id, _| current_ids.contains(node_id));
+
+        let mtm = MainThreadMarker::new().expect("accessibility sync runs on UIKit's main thread");
+        for element in &next {
+            if !self.native_elements.contains_key(&element.node_id) {
+                let native = self.create_element(element, mtm);
+                self.native_elements.insert(element.node_id, native);
+            }
+            let native = self
+                .native_elements
+                .get(&element.node_id)
+                .expect("accessibility element inserted above");
+            update_native_element(native, element);
+        }
+
+        if structure_changed {
+            self.publish_container(&next, mtm);
+        }
+        self.snapshot = next;
+    }
+
+    /// Runs queued VoiceOver/XCTest activations through Cranpose pointer input.
+    pub(crate) fn drain_activations<R>(&mut self, shell: &mut AppShell<R>) -> bool
+    where
+        R: Renderer,
+        R::Error: Debug,
+    {
+        let pending = self.pending_activations.take();
+        let mut changed = false;
+        for node_id in pending {
+            let Some(element) = self
+                .snapshot
+                .iter()
+                .find(|element| element.node_id == node_id)
+            else {
+                continue;
+            };
+            let (x, y) = element.bounds.center();
+            shell.set_pointer_source(PointerSource::Touch);
+            changed |= shell.set_cursor(x, y);
+            changed |= shell.pointer_pressed();
+            changed |= shell.pointer_released_at_position(x, y);
+        }
+        changed
+    }
+
+    fn create_element(
+        &self,
+        element: &AccessibilityElement,
+        mtm: MainThreadMarker,
+    ) -> Retained<NativeAccessibilityElement> {
+        let container: &AnyObject = self.host_view.as_ref();
+        let native = NativeAccessibilityElement::new(
+            container,
+            element.node_id,
+            Rc::clone(&self.pending_activations),
+            self.wake_proxy.clone(),
+            mtm,
+        );
+        native.setIsAccessibilityElement(true);
+        native.setAccessibilityIdentifier(Some(&NSString::from_str(&format!(
+            "cranpose-node-{}",
+            element.node_id
+        ))));
+        native
+    }
+
+    fn publish_container(&mut self, next: &[AccessibilityElement], mtm: MainThreadMarker) {
+        let ordered: Vec<Retained<AnyObject>> = next
+            .iter()
+            .filter_map(|element| self.native_elements.get(&element.node_id))
+            .map(|element| element.retain().into())
+            .collect();
+        let array = NSArray::from_retained_slice(&ordered);
+        let host_object: &NSObject = self.host_view.as_ref();
+        // SAFETY: Every array member is a retained UIAccessibilityElement and
+        // both informal-container properties accept NSArray<id>.
+        unsafe {
+            host_object.setAccessibilityElements(Some(&array), mtm);
+            host_object.setAutomationElements(Some(&array), mtm);
+        }
+
+        // SAFETY: UIKit owns both immutable notification constants; a null
+        // argument asks the accessibility service to retain its current focus.
+        unsafe {
+            let notification = if self.published_once {
+                UIAccessibilityLayoutChangedNotification
+            } else {
+                UIAccessibilityScreenChangedNotification
+            };
+            UIAccessibilityPostNotification(notification, None);
+        }
+        self.published_once = true;
+    }
+}
+
+fn update_native_element(native: &NativeAccessibilityElement, element: &AccessibilityElement) {
+    native.set_actionable(element.clickable || element.role == AccessibilityRole::TextField);
+    native.setAccessibilityLabel(Some(&NSString::from_str(&element.label)));
+    native.setAccessibilityValue(element.value.as_deref().map(NSString::from_str).as_deref());
+    native.setAccessibilityFrameInContainerSpace(CGRect::new(
+        CGPoint::new(element.bounds.x as f64, element.bounds.y as f64),
+        CGSize::new(element.bounds.width as f64, element.bounds.height as f64),
+    ));
+    // SAFETY: UIKit accessibility trait constants are immutable process-wide
+    // values exported by the linked framework.
+    let traits = unsafe {
+        match element.role {
+            AccessibilityRole::Button => UIAccessibilityTraitButton,
+            AccessibilityRole::StaticText => UIAccessibilityTraitStaticText,
+            AccessibilityRole::TextField => UIAccessibilityTraitNone,
+        }
+    };
+    native.setAccessibilityTraits(traits);
+}
+
+fn same_structure(current: &[AccessibilityElement], next: &[AccessibilityElement]) -> bool {
+    current.len() == next.len()
+        && current.iter().zip(next).all(|(current, next)| {
+            current.node_id == next.node_id
+                && current.label == next.label
+                && current.value == next.value
+                && current.role == next.role
+                && current.clickable == next.clickable
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::same_structure;
+    use crate::accessibility::{AccessibilityElement, AccessibilityRect, AccessibilityRole};
+
+    fn element(x: f32) -> AccessibilityElement {
+        AccessibilityElement {
+            node_id: 7,
+            label: "Library".into(),
+            value: None,
+            bounds: AccessibilityRect::new(x, 20.0, 80.0, 64.0),
+            role: AccessibilityRole::Button,
+            clickable: true,
+        }
+    }
+
+    #[test]
+    fn moving_an_element_does_not_rebuild_accessibility_focus_order() {
+        assert!(same_structure(&[element(0.0)], &[element(24.0)]));
+    }
+}

--- a/crates/cranpose/src/launcher.rs
+++ b/crates/cranpose/src/launcher.rs
@@ -9,7 +9,7 @@ use cranpose_app_shell::FramePacingMode;
 use std::path::PathBuf;
 #[cfg(all(
     feature = "renderer-wgpu",
-    any(feature = "desktop-shell", feature = "ios")
+    any(feature = "desktop-shell", all(feature = "ios", target_os = "ios"))
 ))]
 use thiserror::Error;
 
@@ -154,7 +154,7 @@ impl AndroidOverlayWindowOptions {
 /// Errors that can occur while launching a windowed (desktop or iOS) application.
 #[cfg(all(
     feature = "renderer-wgpu",
-    any(feature = "desktop-shell", feature = "ios")
+    any(feature = "desktop-shell", all(feature = "ios", target_os = "ios"))
 ))]
 #[derive(Debug, Error)]
 pub enum LaunchError {

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -7,6 +7,16 @@
 mod android_file_picker;
 #[cfg(all(feature = "android", target_os = "android"))]
 pub use android_file_picker::open_content_uri;
+#[cfg(any(
+    test,
+    feature = "desktop-shell",
+    all(feature = "android", target_os = "android"),
+    all(feature = "ios", target_os = "ios"),
+    all(feature = "web", target_arch = "wasm32")
+))]
+mod accessibility;
+#[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
+mod android_accessibility;
 #[cfg_attr(not(all(feature = "android", target_os = "android")), allow(dead_code))]
 mod android_host_window;
 mod android_input;
@@ -140,6 +150,8 @@ pub(crate) mod gpu_limits;
 #[cfg(all(feature = "desktop-shell", feature = "renderer-wgpu"))]
 pub mod desktop;
 #[cfg(all(feature = "desktop-shell", feature = "renderer-wgpu"))]
+mod desktop_accessibility;
+#[cfg(all(feature = "desktop-shell", feature = "renderer-wgpu"))]
 mod desktop_input;
 
 #[cfg(any(feature = "desktop-shell", all(feature = "ios", target_os = "ios")))]
@@ -155,6 +167,9 @@ mod robot;
 
 #[cfg(all(feature = "ios", feature = "renderer-wgpu", target_os = "ios"))]
 pub mod ios;
+
+#[cfg(all(feature = "ios", feature = "renderer-wgpu", target_os = "ios"))]
+mod ios_accessibility;
 
 #[cfg(all(feature = "ios", feature = "renderer-wgpu", target_os = "ios"))]
 mod ios_file_picker;
@@ -200,6 +215,9 @@ pub mod recorder;
 
 #[cfg(all(feature = "web", feature = "renderer-wgpu", target_arch = "wasm32"))]
 pub mod web;
+
+#[cfg(all(feature = "web", feature = "renderer-wgpu", target_arch = "wasm32"))]
+mod web_accessibility;
 
 #[cfg(all(feature = "web", feature = "renderer-wgpu", target_arch = "wasm32"))]
 mod web_services;

--- a/crates/cranpose/src/web.rs
+++ b/crates/cranpose/src/web.rs
@@ -118,21 +118,24 @@ pub async fn run(
     // Get device pixel ratio for proper scaling
     let scale_factor = window.device_pixel_ratio();
 
-    // Set canvas size
-    let width = settings.initial_width;
-    let height = settings.initial_height;
-
-    canvas.set_width((width as f64 * scale_factor) as u32);
-    canvas.set_height((height as f64 * scale_factor) as u32);
-
-    // Set CSS size and disable browser touch gesture handling on the canvas
+    // Keep the requested desktop-sized viewport as an upper bound while
+    // fitting phones and narrow browser windows without horizontal scrolling.
+    let requested_width = settings.initial_width;
+    let requested_height = settings.initial_height;
     if let Some(html_element) = canvas.dyn_ref::<web_sys::HtmlElement>() {
         let style = html_element.style();
-        style.set_property("width", &format!("{}px", width))?;
-        style.set_property("height", &format!("{}px", height))?;
+        style.set_property(
+            "width",
+            &format!("min({requested_width}px, calc(100vw - 36px))"),
+        )?;
+        style.set_property(
+            "height",
+            &format!("min({requested_height}px, calc(100vh - 36px))"),
+        )?;
         style.set_property("touch-action", "none")?;
     }
-
+    let width = canvas.client_width().max(1) as u32;
+    let height = canvas.client_height().max(1) as u32;
     let backend_preference = requested_web_backend(&window);
     let mut instance_desc =
         wgpu::InstanceDescriptor::new_with_display_handle(Box::new(BrowserDisplayHandle));
@@ -160,6 +163,18 @@ pub async fn run(
         .map_err(|e| format!("failed to find suitable adapter: {:?}", e))?;
 
     let adapter_info = adapter.get_info();
+    // Browser WebGPU presents a high-DPI swapchain at the canvas' CSS size.
+    // The WebGL path already maps its drawing buffer to CSS pixels, so applying
+    // devicePixelRatio there a second time makes every scene render zoomed and
+    // clipped. Keep WebGL at CSS resolution while preserving Retina rendering
+    // for Browser WebGPU.
+    let render_scale = if adapter_info.backend == wgpu::Backend::BrowserWebGpu {
+        scale_factor
+    } else {
+        1.0
+    };
+    canvas.set_width((width as f64 * render_scale) as u32);
+    canvas.set_height((height as f64 * render_scale) as u32);
     let adapter_limits = adapter.limits();
     let required_limits =
         required_limits_for_web_backend(adapter_info.backend, adapter_limits.clone());
@@ -196,8 +211,8 @@ pub async fn run(
     let surface_config = wgpu::SurfaceConfiguration {
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         format: surface_format,
-        width: (width as f64 * scale_factor) as u32,
-        height: (height as f64 * scale_factor) as u32,
+        width: (width as f64 * render_scale) as u32,
+        height: (height as f64 * render_scale) as u32,
         present_mode,
         alpha_mode,
         view_formats: vec![],
@@ -209,7 +224,7 @@ pub async fn run(
     let mut surface_config = surface_config;
     let (actual_width, actual_height, effective_scale) =
         if adapter_info.backend == wgpu::Backend::BrowserWebGpu {
-            (surface_config.width, surface_config.height, scale_factor)
+            (surface_config.width, surface_config.height, render_scale)
         } else {
             // WebGL backends can cap the swapchain below the requested size.
             // Probe the actual surface once so layout and root scale match the
@@ -237,10 +252,19 @@ pub async fn run(
                     surface_config.height = actual_height;
                     s
                 } else {
-                    scale_factor
+                    render_scale
                 };
             (actual_width, actual_height, effective_scale)
         };
+    log::info!(
+        "Web canvas css={}x{}, buffer={}x{}, effective_scale={:.2}, device_scale={:.2}",
+        width,
+        height,
+        actual_width,
+        actual_height,
+        effective_scale,
+        scale_factor
+    );
 
     // Create renderer with fonts from settings
     let fonts: &[&[u8]] = settings.fonts.unwrap_or(&[]);
@@ -260,10 +284,18 @@ pub async fn run(
         content,
         (actual_width, actual_height),
         (width as f32, height as f32),
-        effective_scale as f32,
+        scale_factor as f32,
     )));
+    app.borrow_mut().set_semantics_enabled(true);
+    let accessibility = Rc::new(RefCell::new(
+        crate::web_accessibility::WebAccessibilityBridge::install(
+            &document,
+            canvas.clone(),
+            app.clone(),
+        )?,
+    ));
     let platform = Rc::new(RefCell::new(WebPlatform::default()));
-    platform.borrow_mut().set_scale_factor(effective_scale);
+    platform.borrow_mut().set_scale_factor(scale_factor);
 
     let surface = Rc::new(surface);
     let surface_config = Rc::new(RefCell::new(surface_config));
@@ -792,10 +824,20 @@ pub async fn run(
     let render_loop_for_deadline = render_loop.clone();
     let surface_dirty_for_loop = surface_dirty.clone();
     let request_frame_for_loop = request_frame.clone();
+    let document_for_loop = document.clone();
+    let accessibility_for_loop = accessibility.clone();
 
     *render_loop.borrow_mut() = Some(Closure::wrap(Box::new(move || {
         frame_pending_for_loop.set(false);
         let update_result = app.borrow_mut().update();
+        if let Ok(mut app_mut) = app.try_borrow_mut() {
+            if let Err(error) = accessibility_for_loop
+                .borrow_mut()
+                .sync(&document_for_loop, &mut app_mut)
+            {
+                log::error!("web accessibility sync failed: {error:?}");
+            }
+        }
 
         // Present when the surface still owes its first (or post-reconfigure)
         // frame, when `update()` produced visual work, or when the app otherwise

--- a/crates/cranpose/src/web_accessibility.rs
+++ b/crates/cranpose/src/web_accessibility.rs
@@ -1,0 +1,147 @@
+//! Browser accessibility bridge for the canvas renderer.
+
+use crate::accessibility::{self, AccessibilityElement, AccessibilityRole};
+use cranpose_app_shell::AppShell;
+use cranpose_render_wgpu::WgpuRenderer;
+use std::cell::RefCell;
+use std::rc::Rc;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::{JsCast, JsValue};
+use web_sys::{Document, Element, HtmlCanvasElement, HtmlElement, MouseEvent};
+
+/// Transparent DOM nodes mirroring the semantic controls painted on canvas.
+pub(crate) struct WebAccessibilityBridge {
+    root: HtmlElement,
+    canvas: HtmlCanvasElement,
+    previous: Vec<AccessibilityElement>,
+}
+
+impl WebAccessibilityBridge {
+    pub(crate) fn install(
+        document: &Document,
+        canvas: HtmlCanvasElement,
+        app: Rc<RefCell<AppShell<WgpuRenderer>>>,
+    ) -> Result<Self, JsValue> {
+        let root = document.create_element("div")?.dyn_into::<HtmlElement>()?;
+        root.set_attribute("data-cranpose-accessibility", "")?;
+        root.set_attribute("aria-label", "Application controls")?;
+        let style = root.style();
+        style.set_property("position", "fixed")?;
+        style.set_property("inset", "0")?;
+        style.set_property("z-index", "2147483647")?;
+        style.set_property("pointer-events", "none")?;
+
+        let click = Closure::wrap(Box::new(move |event: MouseEvent| {
+            let Some(target) = event
+                .target()
+                .and_then(|target| target.dyn_into::<Element>().ok())
+            else {
+                return;
+            };
+            let Some(x) = target
+                .get_attribute("data-cranpose-x")
+                .and_then(|value| value.parse::<f32>().ok())
+            else {
+                return;
+            };
+            let Some(y) = target
+                .get_attribute("data-cranpose-y")
+                .and_then(|value| value.parse::<f32>().ok())
+            else {
+                return;
+            };
+            if let Ok(mut shell) = app.try_borrow_mut() {
+                shell.set_cursor(x, y);
+                shell.pointer_pressed();
+                shell.pointer_released_at_position(x, y);
+            }
+        }) as Box<dyn FnMut(_)>);
+        root.add_event_listener_with_callback("click", click.as_ref().unchecked_ref())?;
+        click.forget();
+
+        document
+            .body()
+            .ok_or("document has no body")?
+            .append_child(&root)?;
+        Ok(Self {
+            root,
+            canvas,
+            previous: Vec::new(),
+        })
+    }
+
+    pub(crate) fn sync(
+        &mut self,
+        document: &Document,
+        shell: &mut AppShell<WgpuRenderer>,
+    ) -> Result<(), JsValue> {
+        let elements = accessibility::snapshot(shell);
+        if elements == self.previous {
+            return Ok(());
+        }
+        self.previous.clone_from(&elements);
+        self.root.set_inner_html("");
+
+        let canvas_rect = self.canvas.get_bounding_client_rect();
+        let viewport = shell.viewport_size();
+        let scale_x = canvas_rect.width() / viewport.0.max(1.0) as f64;
+        let scale_y = canvas_rect.height() / viewport.1.max(1.0) as f64;
+
+        for element in elements {
+            let node = document
+                .create_element(if element.clickable { "button" } else { "span" })?
+                .dyn_into::<HtmlElement>()?;
+            node.set_attribute("aria-label", &element.label)?;
+            node.set_attribute("data-cranpose-node", &element.node_id.to_string())?;
+            match element.role {
+                AccessibilityRole::Button => node.set_attribute("role", "button")?,
+                AccessibilityRole::StaticText => {
+                    node.set_attribute("role", "text")?;
+                    node.set_text_content(Some(&element.label));
+                }
+                AccessibilityRole::TextField => {
+                    node.set_attribute("role", "textbox")?;
+                    if let Some(value) = &element.value {
+                        node.set_attribute("aria-valuetext", value)?;
+                    }
+                }
+            }
+            if element.clickable {
+                let (x, y) = element.bounds.center();
+                node.set_attribute("data-cranpose-x", &x.to_string())?;
+                node.set_attribute("data-cranpose-y", &y.to_string())?;
+            } else {
+                node.set_attribute("tabindex", "-1")?;
+            }
+            let style = node.style();
+            style.set_property("position", "fixed")?;
+            style.set_property(
+                "left",
+                &format!(
+                    "{}px",
+                    canvas_rect.left() + element.bounds.x as f64 * scale_x
+                ),
+            )?;
+            style.set_property(
+                "top",
+                &format!(
+                    "{}px",
+                    canvas_rect.top() + element.bounds.y as f64 * scale_y
+                ),
+            )?;
+            style.set_property(
+                "width",
+                &format!("{}px", element.bounds.width as f64 * scale_x),
+            )?;
+            style.set_property(
+                "height",
+                &format!("{}px", element.bounds.height as f64 * scale_y),
+            )?;
+            style.set_property("opacity", "0.001")?;
+            style.set_property("pointer-events", "none")?;
+            style.set_property("overflow", "hidden")?;
+            self.root.append_child(&node)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -1023,11 +1023,12 @@ fn tick() {
 }
 
 #[test]
-fn unsafe_code_stays_in_android_boundary_modules() {
+fn unsafe_code_stays_in_reviewed_platform_boundary_modules() {
     let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let source_dir = crate_dir.join("src");
     let allowed = [
         "android_jni.rs",
+        "android_accessibility.rs",
         "android_services.rs",
         "android_surface.rs",
         "android_file_picker.rs",
@@ -1044,6 +1045,8 @@ fn unsafe_code_stays_in_android_boundary_modules() {
         "ios_keyboard.rs",
         "ios_back_gesture.rs",
         "ios_background.rs",
+        "ios_accessibility.rs",
+        "desktop_accessibility.rs",
     ];
     let mut offenders = Vec::new();
 
@@ -1067,7 +1070,7 @@ fn unsafe_code_stays_in_android_boundary_modules() {
 
     assert!(
         offenders.is_empty(),
-        "unsafe code must stay in Android boundary modules; found in {offenders:?}"
+        "unsafe code must stay in reviewed platform boundary modules; found in {offenders:?}"
     );
 }
 
@@ -1204,6 +1207,7 @@ fn workspace_ffi_boundaries_are_explicit() {
     let source_roots = ["crates", "apps", "xtask"];
     let allowed = [
         "crates/cranpose/src/android_jni.rs",
+        "crates/cranpose/src/android_accessibility.rs",
         "crates/cranpose/src/android_services.rs",
         "crates/cranpose/src/android_surface.rs",
         "crates/cranpose/src/android_file_picker.rs",
@@ -1220,6 +1224,8 @@ fn workspace_ffi_boundaries_are_explicit() {
         "crates/cranpose/src/ios_keyboard.rs",
         "crates/cranpose/src/ios_back_gesture.rs",
         "crates/cranpose/src/ios_background.rs",
+        "crates/cranpose/src/ios_accessibility.rs",
+        "crates/cranpose/src/desktop_accessibility.rs",
         "apps/desktop-demo-platform/src/android_entry.rs",
         "apps/isolated-demo/src/native_entry.rs",
     ];
@@ -1262,6 +1268,7 @@ fn unsafe_blocks_have_nearby_safety_invariants() {
     let boundary_modules = [
         "crates/cranpose/src/android_jni.rs",
         "crates/cranpose/src/android_surface.rs",
+        "crates/cranpose/src/ios_accessibility.rs",
         "apps/desktop-demo-platform/src/android_entry.rs",
         "apps/isolated-demo/src/native_entry.rs",
     ];

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -22,12 +22,13 @@ fn workspace_path(path: &str) -> PathBuf {
 #[test]
 fn ci_architecture_budget_runs_required_gates() {
     let workflow = workspace_source(".github/workflows/rust.yml");
+    let heavy_workflow = workspace_source(".github/workflows/heavy-selfhosted.yml");
     let release_workflow = workspace_source(".github/workflows/release.yml");
     let pages_workflow = workspace_source(".github/workflows/deploy-pages.yml");
 
     assert!(
         workflow.contains("architecture-budget:")
-            && workflow.contains("linux / stable / architecture budgets"),
+            && workflow.contains("name: architecture budgets (linux)"),
         "Rust CI should keep a dedicated architecture budget job"
     );
     assert!(
@@ -61,8 +62,8 @@ fn ci_architecture_budget_runs_required_gates() {
     );
     assert!(
         workflow.contains("wasm-build:")
-            && workflow.contains("Install binaryen 120")
-            && workflow.contains("cargo install wasm-pack --version 0.13.1")
+            && workflow.contains("wasm-opt --version")
+            && workflow.contains("cargo install wasm-pack --version 0.13.1 --locked")
             && workflow.contains("run: apps/desktop-demo/build-web.sh --release"),
         "Rust CI should keep the web release build job wired through explicit build-web.sh --release so the wasm-release profile and WASM size budget cannot depend on ambient CI defaults"
     );
@@ -80,9 +81,11 @@ fn ci_architecture_budget_runs_required_gates() {
         "Android CI should install only required SDK packages instead of running the broad setup-android action"
     );
     assert!(
-        workflow.contains("bash scripts/ci/install_android_ndk.sh 27.0.12077973")
+        heavy_workflow.contains("ANDROID_NDK_HOME=$sdk_root/ndk/27.0.12077973")
+            && heavy_workflow.contains("sdkmanager \"ndk;27.0.12077973\"")
+            && heavy_workflow.contains("test -f \"$ANDROID_NDK_HOME/source.properties\"")
             && release_workflow.contains("bash scripts/ci/install_android_ndk.sh 27.0.12077973"),
-        "Android CI and release workflows should share the narrow NDK installer"
+        "self-hosted Android CI and hosted release builds should provision and validate the pinned NDK"
     );
 }
 

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -381,6 +381,40 @@ cleanup_results_dir() {
 }
 trap cleanup_results_dir EXIT
 
+run_with_portable_timeout() {
+    local timeout_secs="$1"
+    local kill_after_secs="$2"
+    local output_file="$3"
+    shift 3
+
+    local timeout_marker="${output_file}.timeout"
+    rm -f -- "$timeout_marker"
+
+    "$@" > "$output_file" 2>&1 &
+    local command_pid=$!
+    (
+        sleep "$timeout_secs"
+        if kill -0 "$command_pid" 2>/dev/null; then
+            : > "$timeout_marker"
+            kill -TERM "$command_pid" 2>/dev/null || true
+            sleep "$kill_after_secs"
+            kill -KILL "$command_pid" 2>/dev/null || true
+        fi
+    ) &
+    local watchdog_pid=$!
+
+    wait "$command_pid"
+    local exit_code=$?
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+
+    if [ -f "$timeout_marker" ]; then
+        rm -f -- "$timeout_marker"
+        exit_code=124
+    fi
+    return "$exit_code"
+}
+
 # Function to run a single test
 run_test() {
     local example="$1"
@@ -443,6 +477,11 @@ run_test() {
             ;;
         robot_fling_edge_cases)
             timeout_secs=240
+            ;;
+        robot_regression_fused_viewport_contract)
+            # Multiple shader screenshots plus two three-position Liquid tab
+            # sweeps exceed the generic one-minute budget on Metal runners.
+            timeout_secs=180
             ;;
         robot_fling_precise)
             timeout_secs=180
@@ -566,7 +605,8 @@ run_test() {
             env -i "${robot_env_args[@]}" timeout --kill-after=15s "${timeout_secs}s" "$example_bin" > "$attempt_output" 2>&1
             local exit_code=$?
         else
-            env -i "${robot_env_args[@]}" "$example_bin" > "$attempt_output" 2>&1
+            run_with_portable_timeout "$timeout_secs" 15 "$attempt_output" \
+                env -i "${robot_env_args[@]}" "$example_bin"
             local exit_code=$?
         fi
 


### PR DESCRIPTION
## What changed

- add one shared semantic accessibility model and platform bridges for iOS, Android, Web, macOS, Windows, and Linux
- expose Android virtual accessibility nodes with activation routing
- preserve exact-position layout semantics required by assistive technology
- isolate Android Vulkan and GL adapter attempts so API 37 emulator fallback cannot reuse an already-connected native window
- harden robot coverage and portable macOS timeouts

## Why

Cranpose-rendered controls previously had no complete native accessibility representation across platforms. Android API 37 emulators also exposed a separate startup failure: failed Vulkan probing in a combined Vulkan/GL instance left the native window connected before EGL fallback.

## Impact

Assistive technologies can discover labels, roles, bounds, values, and actions consistently. Real Android devices retain Vulkan; unsupported Vulkan environments retry through a fresh GL-only instance instead of aborting. Liquid Glass renderer and bar source files are unchanged by this branch.

## Verification

- `cargo test`
- `cargo clippy`
- Android-target Clippy with warnings denied
- `cargo fmt --all -- --check`
- Cranpose WebAssembly build
- Android demo release build
- API 35 Vulkan and API 37 GL-fallback emulator launches
- Android UIAutomator accessibility-tree inspection