### PR TITLE
Make release checkouts tolerate moved tags

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # Release publication can move a tag onto the generated version-bump
+          # commit. Resolve the selected ref at job start so queued deployments
+          # do not reject that intentional move as a stale event SHA.
+          ref: ${{ github.ref_name }}
 
       - name: Install Rust (nightly for wasm-pack artifact output)
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          # publish.yml may move the release tag onto its generated version-bump
+          # commit while this matrix is queued. Resolve the tag when the runner
+          # starts instead of pinning checkout to the event's original SHA.
+          ref: ${{ github.ref_name }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -114,6 +119,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Keep Android on the same final tag commit as the desktop matrix.
+          ref: ${{ github.ref_name }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary
- resolve release tags when queued artifact jobs start
- keep Pages deployment aligned with the final version-bump tag commit
- prevent actions/checkout from rejecting the intentional tag move performed by publish.yml

## Validation
- parsed both workflow YAML files
- manually completed v0.1.65 with the three successful CI artifacts plus a locally rebuilt and codesign-verified macOS bundle