### PR TITLE
Route release workflows to self-hosted runners

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, cranpose-heavy]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -33,11 +33,6 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           targets: wasm32-unknown-unknown
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
 
       - name: Install binaryen (wasm-opt) for size optimization
         run: |
@@ -69,12 +64,14 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
+        with:
+          retention-days: 1
 
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, cranpose-heavy]
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/heavy-selfhosted.yml
+++ b/.github/workflows/heavy-selfhosted.yml
@@ -6,6 +6,7 @@ name: heavy (self-hosted)
 # is safe for every trigger.
 on:
   push:
+    branches: ["main"]
   pull_request:
     branches: ["main"]
   workflow_dispatch:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   sync_versions:
     name: Sync versions with tag
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, cranpose-heavy]
     permissions:
       contents: write
     outputs:
@@ -26,7 +26,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
 
       - name: Sync Cargo versions with tag
         id: sync
@@ -257,7 +256,7 @@ jobs:
 
   publish:
     name: Publish to crates.io
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, cranpose-heavy]
     needs: sync_versions
     if: needs.sync_versions.outputs.should_publish == 'true'
     env:
@@ -269,7 +268,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.repository.default_branch }}
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
 
       - name: Verify tag and workspace versions
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,25 @@ permissions:
   contents: write
 
 jobs:
+  create-release:
+    name: Create GitHub Release
+    runs-on: [self-hosted, Linux, cranpose-heavy]
+    steps:
+      - name: Create release
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+
   build:
     name: Build ${{ matrix.name }}
+    needs: create-release
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: linux-x86_64
-            runner: ubuntu-latest
+            runner: [self-hosted, Linux, cranpose-heavy]
             target: x86_64-unknown-linux-gnu
             artifact_name: cranpose-demo-linux-x86_64
 
@@ -47,10 +57,6 @@ jobs:
         with:
           targets: ${{ matrix.target }}
           components: rust-src
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: release-${{ matrix.target }}
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
@@ -105,18 +111,24 @@ jobs:
             -Path target\${{ matrix.target }}\release-small\desktop-app.exe `
             -DestinationPath ${{ matrix.artifact_name }}.zip
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
+      # Release assets do not consume the Actions artifact quota. Upload each
+      # platform directly instead of retaining a second copy for 90 days.
+      - name: Attach to release
+        uses: softprops/action-gh-release@v3
         with:
-          name: ${{ matrix.artifact_name }}
-          path: |
+          files: |
             *.tar.gz
             *.zip
-          if-no-files-found: error
 
   build-android:
     name: Build Android APK
-    runs-on: ubuntu-latest
+    needs: create-release
+    runs-on: [self-hosted, Linux, cranpose-heavy]
+    env:
+      # samarch-1-cranpose keeps the SDK outside the paths used by GitHub's
+      # hosted images. Point the installer at the persistent local SDK.
+      ANDROID_HOME: /home/s/develop/sdk
+      ANDROID_SDK_ROOT: /home/s/develop/sdk
     steps:
       - uses: actions/checkout@v6
         with:
@@ -126,10 +138,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: release-android
 
       - uses: actions/setup-java@v4
         with:
@@ -146,25 +154,7 @@ jobs:
         working-directory: apps/android-demo/android
         run: ./gradlew :app:assembleRelease -PrustFastRelease=false
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
+      - name: Attach to release
+        uses: softprops/action-gh-release@v3
         with:
-          name: cranpose-demo-android
-          path: apps/android-demo/android/app/build/outputs/apk/release/app-*-release.apk
-          if-no-files-found: error
-
-  release:
-    name: Create GitHub Release
-    runs-on: ubuntu-latest
-    needs: [build, build-android]
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: artifacts/*
-          generate_release_notes: true
+          files: apps/android-demo/android/app/build/outputs/apk/release/app-*-release.apk


### PR DESCRIPTION
## What changed

- route Pages, crates publishing, Linux release, Android release, and release creation to the existing self-hosted fleet
- upload release binaries directly to GitHub Releases instead of retaining duplicate Actions artifacts
- stop GitHub-backed Rust caches on persistent self-hosted release jobs
- retain the native Windows/MSVC build on the standard hosted runner because the fleet has no Windows host

## Why

Actions artifacts and tag-scoped Rust caches were consuming the storage quota even when compilation ran on self-hosted machines.

## Validation

- `actionlint` on all changed workflows (custom runner labels verified through the GitHub runner API)
- Ruby YAML parse
- `git diff --check`
- online runner labels verified: Linux/X64/cranpose-heavy and macOS/ARM64