### PR TITLE
ci: keep self-hosted releases unprivileged

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -36,11 +36,20 @@ jobs:
 
       - name: Install binaryen (wasm-opt) for size optimization
         run: |
-          # Ubuntu apt has outdated binaryen - install version 120 manually
-          # Required for bulk memory operations that Rust 1.83+ emits by default
-          curl -L https://github.com/WebAssembly/binaryen/releases/download/version_120/binaryen-version_120-x86_64-linux.tar.gz | tar xz
-          sudo mv binaryen-version_120/bin/* /usr/local/bin/
-          wasm-opt --version
+          # Keep self-hosted jobs unprivileged. Reuse a provisioned wasm-opt
+          # when available; otherwise install Binaryen 120 under RUNNER_TEMP
+          # and publish that user-writable directory to subsequent steps.
+          if command -v wasm-opt >/dev/null; then
+            wasm-opt --version
+          else
+            binaryen_root="$RUNNER_TEMP/binaryen-120"
+            mkdir -p "$binaryen_root"
+            curl -fL --retry 3 \
+              https://github.com/WebAssembly/binaryen/releases/download/version_120/binaryen-version_120-x86_64-linux.tar.gz \
+              | tar xz -C "$binaryen_root" --strip-components=1
+            echo "$binaryen_root/bin" >> "$GITHUB_PATH"
+            "$binaryen_root/bin/wasm-opt" --version
+          fi
 
       - name: Install wasm-pack
         run: cargo install wasm-pack --version 0.13.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,13 +53,14 @@ jobs:
           targets: ${{ matrix.target }}
           components: rust-src
 
-      - name: Install Linux dependencies
+      - name: Verify provisioned Linux dependencies
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwayland-dev libxkbcommon-dev \
-            libx11-dev libxrandr-dev libxcursor-dev libxi-dev libgl-dev lld
+          # The persistent runner image owns its system packages; release jobs
+          # remain unprivileged and fail clearly if provisioning drifts.
+          command -v pkg-config
+          command -v lld
+          pkg-config --exists wayland-client xkbcommon x11 xrandr xcursor xi gl
 
       # Size-minimized distribution build (nightly build-std + abort panics;
       # see docs/binary_size.md). xtask picks per-OS linker flags.
@@ -118,13 +119,11 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Install Linux and Windows cross-build dependencies
+      - name: Provision Windows cross-build tooling
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwayland-dev libxkbcommon-dev \
-            libx11-dev libxrandr-dev libxcursor-dev libxi-dev libgl-dev lld zip
-          cargo install cargo-xwin --locked --version 0.23.0
+          command -v zip
+          command -v cargo-xwin >/dev/null \
+            || cargo install cargo-xwin --locked --version 0.23.0
 
       # Cross-compile the Windows MSVC binary on our Linux runner. cargo-xwin
       # supplies Microsoft's CRT and SDK import libraries without a hosted


### PR DESCRIPTION
## Summary
- install Binaryen under RUNNER_TEMP instead of sudo /usr/local/bin
- verify pre-provisioned Linux desktop dependencies without apt/sudo
- install cargo-xwin only when absent and verify zip is provisioned
- keep every release and Pages job on our self-hosted runners

## Verified
- actionlint (custom self-hosted label ignored)
- no sudo or hosted *-latest labels remain in workflows
- source_hygiene_aliases (14 tests)
- platform_scheduling_static (50 tests)