### PR TITLE
release: prepare Cranpose v0.1.69

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,8 +40,6 @@ jobs:
             echo "Expected tag starting with 'v', got '$tag'" >&2
             exit 1
           fi
-          version="${tag#v}"
-
           git fetch origin "$DEFAULT_BRANCH"
           git checkout "$DEFAULT_BRANCH"
 
@@ -201,30 +199,11 @@ jobs:
           lock_path.write_text("".join(lines))
           PY
 
-          # Update isolated-demo to point to latest cranpose version
-          python - <<'PY'
-          import os
-          import re
-          from pathlib import Path
-
-          version = os.environ["TAG_NAME"][1:]
-          toml_path = Path("apps/isolated-demo/Cargo.toml")
-          text = toml_path.read_text()
-          text = re.sub(
-              r'(cranpose\s*=\s*\{\s*version\s*=\s*")[^"]+(")',
-              rf"\g<1>{version}\g<2>",
-              text,
-          )
-          text = re.sub(
-              r'(cranpose-core\s*=\s*")[^"]+(")',
-              rf"\g<1>{version}\g<2>",
-              text,
-          )
-          toml_path.write_text(text)
-          PY
-
-          # Update isolated-demo lockfile
-          (cd apps/isolated-demo && cargo update -p cranpose -p cranpose-core 2>/dev/null || true)
+          # Do not update the isolated crates.io consumer before publishing.
+          # At this point the tagged version does not exist in the registry;
+          # suppressing that resolver failure and rewriting lockfile version
+          # strings would leave stale checksums. Update the isolated demo only
+          # after every crate in this release is available on crates.io.
 
           if git diff --quiet; then
             echo "No version changes needed for ${tag}."
@@ -234,10 +213,10 @@ jobs:
             # onto it so the tag tree matches the published crates. Pushes
             # made with GITHUB_TOKEN do not retrigger workflows, so the
             # moved tag cannot recurse into a second Publish run.
-            git diff --stat -- Cargo.toml Cargo.lock apps/isolated-demo/Cargo.toml apps/isolated-demo/Cargo.lock
+            git diff --stat -- Cargo.toml Cargo.lock
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add Cargo.toml Cargo.lock apps/isolated-demo/Cargo.toml apps/isolated-demo/Cargo.lock
+            git add Cargo.toml Cargo.lock
             git commit -m "release: ${tag}"
             if ! git push origin "HEAD:$DEFAULT_BRANCH"; then
               echo "$DEFAULT_BRANCH moved while preparing ${tag}; re-tag from the new HEAD." >&2
@@ -247,7 +226,7 @@ jobs:
             git push origin -f "refs/tags/$tag"
             echo "Landed release metadata for ${tag} on $DEFAULT_BRANCH and moved the tag."
           else
-            git diff -- Cargo.toml Cargo.lock apps/isolated-demo/Cargo.toml apps/isolated-demo/Cargo.lock
+            git diff -- Cargo.toml Cargo.lock
             echo "$DEFAULT_BRANCH must already contain the release metadata for ${tag} for a manual dispatch." >&2
             exit 1
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cranpose"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-animation"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-app-shell"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "arboard",
  "cranpose-core",
@@ -881,11 +881,11 @@ dependencies = [
 
 [[package]]
 name = "cranpose-assets"
-version = "0.1.68"
+version = "0.1.69"
 
 [[package]]
 name = "cranpose-core"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "ahash",
  "cranpose-macros",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-foundation"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-liquid"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-macros"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -938,14 +938,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-android"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "cranpose-ui-graphics",
 ]
 
 [[package]]
 name = "cranpose-platform-desktop-winit"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-web"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-common"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-pixels"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "cranpose-core",
  "cranpose-foundation",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-wgpu"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "bytemuck",
  "cranpose-app-shell",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-runtime-std"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "cranpose-core",
  "web-time",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-services"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-testing"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "cranpose",
  "cranpose-app-shell",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -1070,14 +1070,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui-graphics"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cranpose-ui-layout"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.68"
+version = "0.1.69"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/samoylenkodmitry/cranpose"
@@ -40,24 +40,24 @@ categories = ["gui"]
 [workspace.dependencies]
 # Force android-activity to use native-activity feature across all workspace crates
 android-activity = { version = "0.6", features = ["native-activity"] }
-cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.68" }
-cranpose-liquid = { path = "crates/cranpose-liquid", version = "0.1.68" }
-cranpose = { path = "crates/cranpose", version = "0.1.68", default-features = false }
-cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.68" }
-cranpose-core = { path = "crates/cranpose-core", version = "0.1.68" }
-cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.68" }
-cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.68" }
-cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.68" }
-cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.68", default-features = false }
-cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.68" }
-cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.68", default-features = false }
-cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.68" }
-cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.68" }
-cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.68" }
-cranpose-services = { path = "crates/cranpose-services", version = "0.1.68", default-features = false }
-cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.68" }
-cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.68" }
-cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.68" }
+cranpose-animation = { path = "crates/cranpose-animation", version = "0.1.69" }
+cranpose-liquid = { path = "crates/cranpose-liquid", version = "0.1.69" }
+cranpose = { path = "crates/cranpose", version = "0.1.69", default-features = false }
+cranpose-app-shell = { path = "crates/cranpose-app-shell", version = "0.1.69" }
+cranpose-core = { path = "crates/cranpose-core", version = "0.1.69" }
+cranpose-foundation = { path = "crates/cranpose-foundation", version = "0.1.69" }
+cranpose-macros = { path = "crates/cranpose-macros", version = "0.1.69" }
+cranpose-platform-android = { path = "crates/cranpose-platform/android", version = "0.1.69" }
+cranpose-platform-desktop-winit = { path = "crates/cranpose-platform/desktop-winit", version = "0.1.69", default-features = false }
+cranpose-platform-web = { path = "crates/cranpose-platform/web", version = "0.1.69" }
+cranpose-render-common = { path = "crates/cranpose-render/common", version = "0.1.69", default-features = false }
+cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.1.69" }
+cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.69" }
+cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.69" }
+cranpose-services = { path = "crates/cranpose-services", version = "0.1.69", default-features = false }
+cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.69" }
+cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.69" }
+cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.69" }
 web-time = "1.1"
 
 [patch.crates-io]


### PR DESCRIPTION
## Summary
- bump the workspace and all internal dependency constraints to 0.1.69
- update the root lockfile to the release version
- stop pre-publish isolated-demo lockfile corruption; crates.io consumers update only after the version exists

## Verified
- workspace all-target/all-feature check
- actionlint
- Cranpose liquid menu contract tests (10)
- Cranpose library tests
- release metadata contains no 0.1.68 workspace versions