### PR TITLE
ci(release): distribute jobs across self-hosted Macs

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [self-hosted, Linux, cranpose-heavy]
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -45,7 +45,7 @@ jobs:
             binaryen_root="$RUNNER_TEMP/binaryen-120"
             mkdir -p "$binaryen_root"
             curl -fL --retry 3 \
-              https://github.com/WebAssembly/binaryen/releases/download/version_120/binaryen-version_120-x86_64-linux.tar.gz \
+              https://github.com/WebAssembly/binaryen/releases/download/version_120/binaryen-version_120-arm64-macos.tar.gz \
               | tar xz -C "$binaryen_root" --strip-components=1
             echo "$binaryen_root/bin" >> "$GITHUB_PATH"
             "$binaryen_root/bin/wasm-opt" --version
@@ -80,7 +80,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: [self-hosted, Linux, cranpose-heavy]
+    runs-on: [self-hosted, macOS, ARM64]
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   sync_versions:
     name: Sync versions with tag
-    runs-on: [self-hosted, Linux, cranpose-heavy]
+    runs-on: [self-hosted, macOS, ARM64]
     permissions:
       contents: write
     outputs:
@@ -50,7 +50,7 @@ jobs:
             exit 1
           fi
 
-          python - <<'PY'
+          python3 - <<'PY'
           import os
           import re
           from pathlib import Path
@@ -163,7 +163,7 @@ jobs:
               path.write_text(text)
           PY
 
-          python - <<'PY'
+          python3 - <<'PY'
           import os
           import re
           from pathlib import Path
@@ -235,7 +235,7 @@ jobs:
 
   publish:
     name: Publish to crates.io
-    runs-on: [self-hosted, Linux, cranpose-heavy]
+    runs-on: [self-hosted, macOS, ARM64]
     needs: sync_versions
     if: needs.sync_versions.outputs.should_publish == 'true'
     env:
@@ -257,7 +257,7 @@ jobs:
             echo "Tag $TAG_NAME does not point to HEAD." >&2
             exit 1
           fi
-          python - <<'PY'
+          python3 - <<'PY'
           import os
           import sys
           import tomllib
@@ -304,7 +304,7 @@ jobs:
           version="${TAG_NAME#v}"
 
           cargo metadata --format-version 1 --no-deps > publish-metadata.json
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           from pathlib import Path
 
@@ -357,7 +357,7 @@ jobs:
           PY
 
           crate_exists() {
-            python - "$1" "$2" <<'PY'
+            python3 - "$1" "$2" <<'PY'
           import sys
           import urllib.error
           import urllib.request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   create-release:
     name: Create GitHub Release
-    runs-on: [self-hosted, Linux, cranpose-heavy]
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - name: Create release
         uses: softprops/action-gh-release@v3
@@ -111,7 +111,7 @@ jobs:
   build-windows:
     name: Build windows-x86_64
     needs: create-release
-    runs-on: [self-hosted, Linux, cranpose-heavy]
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -151,12 +151,7 @@ jobs:
   build-android:
     name: Build Android APK
     needs: create-release
-    runs-on: [self-hosted, Linux, cranpose-heavy]
-    env:
-      # samarch-1-cranpose keeps the SDK outside the paths used by GitHub's
-      # hosted images. Point the installer at the persistent local SDK.
-      ANDROID_HOME: /home/s/develop/sdk
-      ANDROID_SDK_ROOT: /home/s/develop/sdk
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -171,6 +166,11 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+
+      - name: Configure machine-local Android SDK
+        run: |
+          echo "ANDROID_HOME=$HOME/Library/Android/sdk" >> "$GITHUB_ENV"
+          echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> "$GITHUB_ENV"
 
       - name: Install Android SDK packages
         run: bash scripts/ci/install_android_ndk.sh 27.0.12077973


### PR DESCRIPTION
## Summary
- move publish and release-control jobs off the wedged Linux runner
- run Windows cargo-xwin, Android, and Pages on self-hosted ARM Macs
- configure the macOS Android SDK through GITHUB_ENV
- use Python 3 explicitly and a native ARM64 Binaryen fallback
- leave only the native Linux artifact on the Linux runner

## Verified
- actionlint
- no hosted *-latest labels or sudo remain
- source_hygiene_aliases (14 tests)
- platform_scheduling_static (50 tests)
- cargo-xwin already produced a real PE32+ artifact locally on this ARM Mac