### PR TITLE
ci(release): fix macOS runner portability

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -71,6 +71,14 @@ jobs:
           # Prevent Jekyll processing
           touch _site/.nojekyll
 
+      - name: Provision GNU tar for the Pages uploader
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          command -v gtar >/dev/null || brew install gnu-tar
+          echo "$(brew --prefix)/bin" >> "$GITHUB_PATH"
+          "$(brew --prefix)/bin/gtar" --version
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,8 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
 
       - name: Provision Windows cross-build tooling
         run: |
@@ -125,10 +127,10 @@ jobs:
           command -v cargo-xwin >/dev/null \
             || cargo install cargo-xwin --locked --version 0.23.0
 
-      # Cross-compile the Windows MSVC binary on our Linux runner. cargo-xwin
+      # Cross-compile the Windows MSVC binary on our macOS runner. cargo-xwin
       # supplies Microsoft's CRT and SDK import libraries without a hosted
       # Windows VM, so this artifact no longer consumes hosted-runner quota.
-      - name: Build Windows desktop on Linux
+      - name: Build Windows desktop on macOS
         run: >
           cargo xwin build
           --package desktop-app
@@ -167,10 +169,8 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Configure machine-local Android SDK
-        run: |
-          echo "ANDROID_HOME=$HOME/Library/Android/sdk" >> "$GITHUB_ENV"
-          echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> "$GITHUB_ENV"
+      - name: Configure Android SDK
+        uses: android-actions/setup-android@v3
 
       - name: Install Android SDK packages
         run: bash scripts/ci/install_android_ndk.sh 27.0.12077973

--- a/scripts/ci/install_android_ndk.sh
+++ b/scripts/ci/install_android_ndk.sh
@@ -21,16 +21,15 @@ if [[ -z "$sdk_root" ]]; then
   exit 1
 fi
 
-mapfile -t sdkmanager_candidates < <(
-  find "$sdk_root/cmdline-tools" -path "*/bin/sdkmanager" -type f 2>/dev/null | sort -V
-)
+sdkmanager=""
+while IFS= read -r candidate; do
+  sdkmanager="$candidate"
+done < <(find "$sdk_root/cmdline-tools" -path "*/bin/sdkmanager" -type f 2>/dev/null | sort)
 
-if [[ "${#sdkmanager_candidates[@]}" -eq 0 ]]; then
+if [[ -z "$sdkmanager" ]]; then
   echo "sdkmanager was not found under $sdk_root/cmdline-tools" >&2
   exit 1
 fi
-
-sdkmanager="${sdkmanager_candidates[-1]}"
 
 set +o pipefail
 yes | "$sdkmanager" --licenses


### PR DESCRIPTION
## Summary
- make the NDK installer compatible with macOS Bash 3
- provision the Windows Rust target before cargo-xwin
- configure Android SDK through setup-android
- provision GNU tar for the GitHub Pages uploader

## Verified
- actionlint
- bash -n / shellcheck
- the portable NDK installer succeeds under /bin/bash on macOS and finds NDK 27
- failure logs map one-to-one to these fixes