### PR TITLE
feat(liquid): toggle follows the theme accent + unbreak/automate release CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -398,3 +398,77 @@ jobs:
           while IFS= read -r crate; do
             publish_if_needed "$crate"
           done < publish-order.txt
+
+  bump_isolated_demo:
+    name: Point isolated demo at the release
+    runs-on: [self-hosted, macOS, ARM64]
+    needs: publish
+    permissions:
+      contents: write
+    env:
+      TAG_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+      - uses: dtolnay/rust-toolchain@stable
+
+      # apps/isolated-demo is the canary that proves a release is consumable
+      # from crates.io, so `sync_versions` deliberately leaves it alone before
+      # publishing (the version does not exist in the registry yet). Bump it
+      # here instead — otherwise check_cranpose_versions.py fails and main goes
+      # red after every release until someone edits it by hand.
+      - name: Wait for crates.io to serve the release
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          import time
+          import urllib.error
+          import urllib.request
+
+          version = os.environ["TAG_NAME"].lstrip("v")
+          for crate in ("cranpose", "cranpose-core"):
+              for _ in range(30):
+                  url = f"https://crates.io/api/v1/crates/{crate}/{version}"
+                  try:
+                      with urllib.request.urlopen(url) as response:
+                          if response.status == 200:
+                              print(f"{crate} {version} is on crates.io.")
+                              break
+                  except urllib.error.HTTPError as exc:
+                      if exc.code != 404:
+                          raise
+                  except Exception as exc:  # transient registry/network blips
+                      print(f"query for {crate} failed ({exc}); retrying")
+                  time.sleep(10)
+              else:
+                  raise SystemExit(f"{crate} {version} never appeared on crates.io")
+          PY
+
+      - name: Point the isolated demo at the release
+        run: |
+          set -euo pipefail
+          version="${TAG_NAME#v}"
+          python3 scripts/sync_isolated_demo.py "$version"
+          cargo update --manifest-path apps/isolated-demo/Cargo.toml \
+            -p cranpose -p cranpose-core
+
+      - name: Land the bump on the default branch
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- apps/isolated-demo; then
+            echo "Isolated demo already points at ${TAG_NAME}."
+            exit 0
+          fi
+          git diff --stat -- apps/isolated-demo
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add apps/isolated-demo/Cargo.toml apps/isolated-demo/Cargo.lock
+          git commit -m "chore: point isolated demo at ${TAG_NAME}"
+          # Pushes made with GITHUB_TOKEN do not retrigger workflows, so this
+          # cannot recurse into another Publish run.
+          git pull --rebase origin "$DEFAULT_BRANCH"
+          git push origin "HEAD:$DEFAULT_BRANCH"

--- a/apps/isolated-demo/Cargo.lock
+++ b/apps/isolated-demo/Cargo.lock
@@ -672,9 +672,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cranpose"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21fb89665e08c8f70740c37914e524da2ab84a50e745c2b034e819133648417a"
+checksum = "9908c7ee71b72670d156cdd004248a2ba16af97bcce7818fd8f9083edac1ab7f"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -711,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "cranpose-animation"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55e7e36bf1c56ce768f8b4037700bf8a1ee99e2c6fc1360a243b4944f87ffcf"
+checksum = "d91980999ff3669a21fe479741ffbab314aeeb393af50ef30c72148f15c1cc1a"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "cranpose-app-shell"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ac60fa2c85da14524bff862e000177840c4e49170d622aeb703a77892b80e7"
+checksum = "5729e27fc7b372625e72ff10e036e3b481fe5c03a78aaa079a967bcb7e6320f6"
 dependencies = [
  "arboard",
  "cranpose-core",
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "cranpose-core"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0175165b528c31bddc08e7357bde61564df2d8ec3e4357d19a57d91e87daa22f"
+checksum = "bc5dd30c0d72c4b243f494f828238fef9b98db2bf0f6704fe6157bcc3bb2ea74"
 dependencies = [
  "ahash",
  "futures-task",
@@ -753,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "cranpose-foundation"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5b62becc4bedb081882d8df08d1992ad5fa52eb6cf05a7edc58b7c1b0f0efe"
+checksum = "24377d6a0c7ddfec0a0d3f8b4bd7f7c6b514f8998a847622266d018bb961bd54"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -768,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "cranpose-liquid"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f16aa3ec9a0e19c4934e2b2a371e9c869a935c5cf408c7e6d8fc8f42b2b0d13"
+checksum = "bacae2166a666635d7ea5c7658ff9c21e714e2f19e5a21d565154ce0371a587b"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "cranpose-macros"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f569ea65f75f879ecd6d9bc8f4a570611964470e73ad9a75eca476b439c30a7e"
+checksum = "fe9555b2ef2cc0360aedb9d147e3458646c61a4ee1b2e90ae3a539b0fcd81e84"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -797,18 +797,18 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-android"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f583a8d2c19fb8de45006967dddad4700e6599291841c1fa175d223d331f4c"
+checksum = "ca7c298c210c4e795fc6daa84b46a9c0e3484272c101d4933fc0b6b72cdb48bc"
 dependencies = [
  "cranpose-ui-graphics",
 ]
 
 [[package]]
 name = "cranpose-platform-desktop-winit"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94c67c4d3d92fa5c33b693f8be3f1816b3d0faad36a22d65eafe66861eab21f"
+checksum = "375c710a6a1c7f715530097092da9ad054e79b2e993f1d5008ff7a245423e5fb"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -817,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-web"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a110f3572a556786826b713448bdb6f43e78beb2928bac47fe273839b0790f"
+checksum = "645c6ff24c5e890e8437cac55e62da93184fa8d23d719b8b29d057383df0d577"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -827,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-common"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55f7598d2b031910e0e6348148502af9b64ba4afc08f4698a9a49f0f45e6ca2"
+checksum = "2c380f7770ef8c68ab94337087b04692abc9ab46110cc6eeea1ef5b5f698c98a"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -843,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-pixels"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a56f8cd2351c4729edeefcd57248546fd538e1d238eec4e060d0051fdc2d34a"
+checksum = "bcf13b9d2f114c571caaf67de7cbc15b3e4488eeebb53472fc7bdf03b7d753b0"
 dependencies = [
  "cranpose-core",
  "cranpose-foundation",
@@ -858,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-wgpu"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c913651b61e82fc60b017f87f58dab76a0fcefb8968651f89b2d8d438582aadc"
+checksum = "367a42dd8541b8026f7cbd095aef3026e3f2ee1aedd4b4a7d770414e6258a43c"
 dependencies = [
  "bytemuck",
  "cranpose-core",
@@ -876,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "cranpose-runtime-std"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459d58eaaa824bb5f0f6df4fd99d40287f7088aea31db21bdc2712ab5e39d47e"
+checksum = "544764bc908e55b672f6bae60d743a6a0d8697f1fd66965922a8f7d62963d8af"
 dependencies = [
  "cranpose-core",
  "web-time",
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "cranpose-services"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b56c2294d9a4891e4127e476b8418da9335ea117c4a7bccdad1eeb8cd7b1e176"
+checksum = "3a5de7e5e5dbc4080f1e4915eafa48a8d9b8754ccea309ec641850141dca023b"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -905,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e4a97661179ad7c0acd60e31623460932a930b7f6aa015382d94bca9e70bbc"
+checksum = "f2f34991224be087ad2df94abea944bb500defdeb539049bbf675acc06eb59f2"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -924,18 +924,18 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui-graphics"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc61d0a4fbee1a65083fa01ef4f979491022986a633e1ec9eabf35d07de0a2dc"
+checksum = "fd2eb1aab08accf0f1e060fa764b2ec2854ac81add7e88106fa7e229d8e9cc99"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cranpose-ui-layout"
-version = "0.1.70"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "344024368cf0c98f015f72c02227198f2060fd9fb6998d5eb2ffb469d469d8dd"
+checksum = "9eebeb5400f97d182bb164fed2fe175d5dfb0307af9c368b8368941aa80373bc"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",

--- a/apps/isolated-demo/Cargo.toml
+++ b/apps/isolated-demo/Cargo.toml
@@ -31,11 +31,11 @@ logging = ["dep:env_logger"]
 [dependencies]
 # Default features stay on: the isolated demo ships no fonts of its own and
 # renders text through the framework's embedded fallback font.
-cranpose = { version = "0.1.70" }
+cranpose = { version = "0.1.72" }
 log = "0.4"
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-logger = { version = "0.2", optional = true }
-cranpose-core = "0.1.70"
+cranpose-core = "0.1.72"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = { version = "0.11", optional = true }

--- a/crates/cranpose-liquid/src/theme.rs
+++ b/crates/cranpose-liquid/src/theme.rs
@@ -82,7 +82,9 @@ impl LiquidColors {
             on_accent: Color::WHITE,
             destructive: Color::from_rgb_u8(255, 59, 48),
             success: Color::from_rgb_u8(52, 199, 89),
-            toggle_on: Color::from_rgb_u8(43, 189, 76),
+            // Switch "on" track follows the theme accent (not a fixed iOS green)
+            // so toggles read as part of the app's own color language.
+            toggle_on: accent,
             toggle_off: Color::from_rgb_u8(170, 170, 181),
             warning: Color::from_rgb_u8(255, 149, 0),
             glass_tint: Color::from_rgba_u8(255, 255, 255, 18),
@@ -106,7 +108,8 @@ impl LiquidColors {
             on_accent: Color::WHITE,
             destructive: Color::from_rgb_u8(255, 69, 58),
             success: Color::from_rgb_u8(48, 209, 88),
-            toggle_on: Color::from_rgb_u8(48, 209, 88),
+            // Switch "on" track follows the theme accent (see light()).
+            toggle_on: accent,
             toggle_off: Color::from_rgb_u8(99, 99, 102),
             warning: Color::from_rgb_u8(255, 159, 10),
             glass_tint: Color::from_rgba_u8(20, 20, 24, 40),
@@ -256,7 +259,9 @@ mod tests {
         assert_eq!(light.accent, dark.accent);
         assert_ne!(light.background, dark.background);
         assert_ne!(light.glass_tint, dark.glass_tint);
-        assert_ne!(light.toggle_on, dark.toggle_on);
+        // The "on" track now follows the accent in both schemes.
+        assert_eq!(light.toggle_on, accent);
+        assert_eq!(dark.toggle_on, accent);
         assert_ne!(light.toggle_off, dark.toggle_off);
     }
 

--- a/crates/cranpose-liquid/src/widgets/search_field.rs
+++ b/crates/cranpose-liquid/src/widgets/search_field.rs
@@ -81,23 +81,27 @@ pub fn LiquidSearchField(modifier: Modifier, state: TextFieldState, spec: Liquid
                     // (and stays hit-testable) even when empty — otherwise an
                     // empty search field measures to 0px and rejects every tap,
                     // so focus + the soft keyboard never fire.
-                    Box(Modifier::empty().weight(1.0), BoxSpec::default(), move || {
-                        if is_empty {
-                            let placeholder_style = TextStyle {
-                                span_style: SpanStyle {
-                                    color: Some(colors.tertiary_label),
-                                    ..placeholder_typography.body.span_style.clone()
-                                },
-                                ..placeholder_typography.body.clone()
-                            };
-                            Text(placeholder.clone(), Modifier::empty(), placeholder_style);
-                        }
-                        BasicTextField(
-                            state.clone(),
-                            Modifier::empty().fill_max_width(),
-                            field_style.clone(),
-                        );
-                    });
+                    Box(
+                        Modifier::empty().weight(1.0),
+                        BoxSpec::default(),
+                        move || {
+                            if is_empty {
+                                let placeholder_style = TextStyle {
+                                    span_style: SpanStyle {
+                                        color: Some(colors.tertiary_label),
+                                        ..placeholder_typography.body.span_style.clone()
+                                    },
+                                    ..placeholder_typography.body.clone()
+                                };
+                                Text(placeholder.clone(), Modifier::empty(), placeholder_style);
+                            }
+                            BasicTextField(
+                                state.clone(),
+                                Modifier::empty().fill_max_width(),
+                                field_style.clone(),
+                            );
+                        },
+                    );
                 },
             );
         },

--- a/scripts/sync_isolated_demo.py
+++ b/scripts/sync_isolated_demo.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Point `apps/isolated-demo` at a published cranpose version.
+
+The isolated demo deliberately consumes cranpose from crates.io (it is the
+canary that proves a release is usable by a real downstream crate), so it can
+only be moved onto a release *after* that release is on the registry —
+`publish.yml` defers the bump for exactly that reason. Left undone, the next
+`scripts/check_cranpose_versions.py` run fails and main goes red until someone
+bumps it by hand; `publish.yml` now runs this automatically once the crates are
+live.
+
+Usage:
+    scripts/sync_isolated_demo.py            # sync to the workspace version
+    scripts/sync_isolated_demo.py 0.1.73     # sync to an explicit version
+    scripts/sync_isolated_demo.py v0.1.73    # a release tag works too
+
+Only rewrites the manifest; run `cargo update --manifest-path
+apps/isolated-demo/Cargo.toml -p cranpose -p cranpose-core` afterwards to move
+the demo's lockfile (that step needs the version to be resolvable).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "apps/isolated-demo/Cargo.toml"
+
+# `cranpose-foo = { version = "x", ... }` (inline table) and `cranpose-foo = "x"`
+# (bare string), in [dependencies] and any [target.'cfg(..)'.dependencies].
+INLINE_TABLE = re.compile(
+    r'(?P<head>^[ \t]*cranpose[\w-]*[ \t]*=[ \t]*\{[^}\n]*?version[ \t]*=[ \t]*")'
+    r'(?P<version>[^"]+)'
+    r'(?P<tail>")',
+    re.MULTILINE,
+)
+BARE_STRING = re.compile(
+    r'(?P<head>^[ \t]*cranpose[\w-]*[ \t]*=[ \t]*")(?P<version>[^"]+)(?P<tail>")',
+    re.MULTILINE,
+)
+
+
+def workspace_version() -> str:
+    with (ROOT / "Cargo.toml").open("rb") as handle:
+        return tomllib.load(handle)["workspace"]["package"]["version"]
+
+
+def main() -> int:
+    version = sys.argv[1] if len(sys.argv) > 1 else workspace_version()
+    version = version.lstrip("v")
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.\-]+)?", version):
+        print(f"Not a semver version: {version!r}", file=sys.stderr)
+        return 1
+
+    text = MANIFEST.read_text()
+    changed: list[str] = []
+
+    def rewrite(match: re.Match[str]) -> str:
+        name = match.group(0).split("=", 1)[0].strip()
+        if match.group("version") != version:
+            changed.append(f"{name} {match.group('version')} -> {version}")
+        return f"{match.group('head')}{version}{match.group('tail')}"
+
+    updated = BARE_STRING.sub(rewrite, INLINE_TABLE.sub(rewrite, text))
+
+    if not changed:
+        print(f"apps/isolated-demo already depends on cranpose {version}.")
+        return 0
+
+    MANIFEST.write_text(updated)
+    for line in changed:
+        print(f"apps/isolated-demo: {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Three commits: the feature, plus the CI breakage it ran into.

## 1. `feat(liquid)`: LiquidToggle on-track follows the theme accent

`LiquidColors::{light,dark}` hard-coded the switch "on" track to iOS system
green — the only semantic color in the palette that ignored `accent`. A
`LiquidTheme` with a non-green accent got green toggles that clashed with the
rest of its color language, and there was no override (`LiquidThemeSpec` exposes
only `scheme` / `accent` / `typography`).

`toggle_on` now derives from `accent`; the "off" track stays neutral grey, so
on/off contrast is unchanged. Apps wanting classic iOS green pass a green
accent. Found while matching a downstream app (accent = system blue) to its
mockups.

`palettes_differ_and_share_accent` previously asserted the light/dark toggle
colors *differ*; that no longer holds when both follow one accent, so it asserts
they equal the accent in both schemes. `cargo test -p cranpose-liquid` → 81
passed.

## 2. `chore`: unbreak CI

Two pre-existing failures on main, unrelated to the above, that block the
`fmt + tests + clippy` job for **every** PR:

- `cargo fmt --check` fails on `cranpose-liquid/src/widgets/search_field.rs`
  (landed unformatted in 27f88b69) — main has been red since.
- `check_cranpose_versions.py` exits 1: `apps/isolated-demo` still pinned
  cranpose 0.1.70 against a 0.1.72 workspace.

## 3. `ci`: auto-bump `apps/isolated-demo` after publishing

Root cause of the second failure: the demo consumes cranpose from crates.io, so
`sync_versions` deliberately can't bump it before publishing (the version isn't
in the registry yet) — and nothing bumped it afterwards, so main went red after
*every* release until someone fixed it by hand.

New `bump_isolated_demo` job runs after `publish`: waits for crates.io to serve
the released version, points the demo at it via the new
`scripts/sync_isolated_demo.py`, refreshes the demo lockfile, and lands it on
the default branch. Pushes use `GITHUB_TOKEN`, which does not retrigger
workflows, so it can't recurse into another Publish run.

The script also works by hand — no argument syncs to the workspace version, and
it takes `0.1.73` or `v0.1.73`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)