### PR TITLE
SwipeToDismiss: keyed content identity resets leaked slot state

### DIFF
--- a/crates/cranpose-ui/src/tests/swipe_to_dismiss_tests.rs
+++ b/crates/cranpose-ui/src/tests/swipe_to_dismiss_tests.rs
@@ -526,3 +526,46 @@ fn pressing_mid_flight_pins_the_content() {
     assert!(drag.is_consumed());
     assert_eq!(harness.offset(), mid_flight + 20.0);
 }
+
+#[test]
+fn identity_change_resets_a_dismissed_controller() {
+    // The bug this guards: an UNKEYED lazy list reuses composition slots by
+    // index, so after a dismissal the slot's remembered controller — content
+    // translated off-screen, background revealed, height collapsed — is
+    // handed to the NEXT item ("items go shuffled, red boxes stick"). With
+    // `SwipeToDismissSpec::with_key`, the composable resets the controller
+    // whenever the key changes; this drives that reset directly.
+    let mut harness = Harness::new(200.0, 0.5);
+
+    harness.send(&down(10.0, 10.0));
+    harness.send(&move_to(30.0, 12.0)); // capture
+    harness.send(&move_to(180.0, 12.0)); // past the 100 px threshold
+    harness.send(&up(180.0, 12.0));
+    harness.pump_frames(240); // fling + settle + collapse
+    assert_eq!(harness.dismiss_count.get(), 1);
+    assert!(
+        harness.collapse() < 0.05,
+        "dismissed row should have collapsed (got {})",
+        harness.collapse()
+    );
+
+    // The slot is reused for a different item: SwipeToDismiss sees a new
+    // spec key and resets. The new item must start pristine.
+    harness.controller.identity.set(Some(7));
+    harness.controller.reset_to_rest();
+    assert_eq!(harness.offset(), 0.0, "offset must snap back to rest");
+    assert!(
+        (harness.collapse() - 1.0).abs() < 1e-6,
+        "row height must be restored"
+    );
+    assert!(!harness.revealed(), "background must not stay revealed");
+    assert!(!harness.controller.dismissed.get());
+
+    // And the new item swipes like new — including firing its own dismissal.
+    harness.send(&down(10.0, 10.0));
+    harness.send(&move_to(30.0, 12.0));
+    harness.send(&move_to(180.0, 12.0));
+    harness.send(&up(180.0, 12.0));
+    harness.pump_frames(240);
+    assert_eq!(harness.dismiss_count.get(), 2);
+}

--- a/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
+++ b/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
@@ -84,7 +84,7 @@ pub struct SwipeToDismissSpec {
     /// not leak onto the new item: without a key, the next row inherits the
     /// dismissed row's displacement, revealed background and collapsed
     /// height ("items go shuffled, red boxes stick"). `None` keeps the
-    /// legacy per-slot behaviour.
+    /// keyless per-slot behaviour unchanged.
     pub key: Option<u64>,
 }
 

--- a/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
+++ b/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
@@ -78,6 +78,14 @@ pub struct SwipeToDismissSpec {
     /// revealed as the row slides away. Receives the [`SwipeDismissSide`] the
     /// row is being swiped toward so the reveal can follow the swipe direction.
     background: Option<BackgroundFn>,
+    /// Identity of the wrapped content (e.g. the row's database id). When a
+    /// composition slot is reused for a DIFFERENT item — unkeyed lazy-list
+    /// rows all shift up after a removal — the remembered swipe state must
+    /// not leak onto the new item: without a key, the next row inherits the
+    /// dismissed row's displacement, revealed background and collapsed
+    /// height ("items go shuffled, red boxes stick"). `None` keeps the
+    /// legacy per-slot behaviour.
+    pub key: Option<u64>,
 }
 
 impl SwipeToDismissSpec {
@@ -85,7 +93,15 @@ impl SwipeToDismissSpec {
         Self {
             threshold_fraction: 0.5,
             background: None,
+            key: None,
         }
+    }
+
+    /// Declares the identity of the wrapped content. When the key changes,
+    /// the swipe state resets to rest — the new item starts untouched.
+    pub fn with_key(mut self, key: u64) -> Self {
+        self.key = Some(key);
+        self
     }
 
     /// Sets the dismiss threshold as a fraction of the content width.
@@ -208,6 +224,9 @@ struct SwipeToDismissController {
     settle_watcher: RefCell<Option<FrameCallbackRegistration>>,
     /// Frame callback driving the post-dismiss height collapse.
     collapse_watcher: RefCell<Option<FrameCallbackRegistration>>,
+    /// Identity of the content this controller's state belongs to (from
+    /// [`SwipeToDismissSpec::with_key`]); state resets when it changes.
+    identity: Cell<Option<u64>>,
 }
 
 impl SwipeToDismissController {
@@ -226,7 +245,22 @@ impl SwipeToDismissController {
             node_id: Cell::new(None),
             settle_watcher: RefCell::new(None),
             collapse_watcher: RefCell::new(None),
+            identity: Cell::new(None),
         })
+    }
+
+    /// Instantly return to the untouched state. Used when the composition
+    /// slot is reused for a different item (the spec key changed): the new
+    /// item must not inherit the old item's displacement, reveal, collapse
+    /// or a pending dismissal.
+    fn reset_to_rest(&self) {
+        self.settle_watcher.borrow_mut().take();
+        self.collapse_watcher.borrow_mut().take();
+        self.offset.borrow_mut().snapTo(0.0);
+        self.collapse.borrow_mut().snapTo(1.0);
+        self.phase.set(SwipePhase::Idle);
+        self.dismissed.set(false);
+        self.set_revealed(false);
     }
 
     fn current_offset(&self) -> f32 {
@@ -540,6 +574,14 @@ where
             composer.remember(|| SwipeToDismissController::new(runtime));
         owned.with(Rc::clone)
     });
+
+    // Content identity: when this composition slot is reused for a different
+    // item (unkeyed lazy rows shifting up after a removal), the remembered
+    // controller must not leak the old item's swipe state onto the new one.
+    if controller.identity.get() != spec.key {
+        controller.reset_to_rest();
+        controller.identity.set(spec.key);
+    }
 
     // Refresh the per-recomposition inputs so the pointer handler (which
     // lives across recompositions) observes the latest values.


### PR DESCRIPTION
An unkeyed lazy list reuses composition slots by index, so after a dismissal the slot's remembered swipe controller (off-screen offset, revealed background, collapsed height) is handed to the next item — rows shuffle and the red reveal sticks.

`SwipeToDismissSpec::with_key(id)` declares the wrapped content's identity; on key change the controller resets to rest. Keyless specs keep legacy behaviour. Regression test drives a full dismissal, resets via identity change, asserts pristine state, and dismisses again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)