### PR TITLE
Fix nested-layout staleness, iOS multitouch, and zoom rasterization scale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cranpose"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-animation"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-app-shell"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "arboard",
  "cranpose-core",
@@ -881,11 +881,11 @@ dependencies = [
 
 [[package]]
 name = "cranpose-assets"
-version = "0.1.74"
+version = "0.1.75"
 
 [[package]]
 name = "cranpose-core"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "ahash",
  "cranpose-macros",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-foundation"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-liquid"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-macros"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -938,14 +938,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-android"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "cranpose-ui-graphics",
 ]
 
 [[package]]
 name = "cranpose-platform-desktop-winit"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-platform-web"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "cranpose-foundation",
  "cranpose-ui-graphics",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-common"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "ab_glyph",
  "cranpose-core",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-pixels"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "cranpose-core",
  "cranpose-foundation",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-render-wgpu"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "bytemuck",
  "cranpose-app-shell",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-runtime-std"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "cranpose-core",
  "web-time",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-services"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "cranpose-core",
  "cranpose-macros",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-testing"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "cranpose",
  "cranpose-app-shell",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "cranpose-animation",
  "cranpose-core",
@@ -1070,14 +1070,14 @@ dependencies = [
 
 [[package]]
 name = "cranpose-ui-graphics"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cranpose-ui-layout"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "cranpose-core",
  "cranpose-ui-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.74"
+version = "0.1.75"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/samoylenkodmitry/cranpose"

--- a/apps/desktop-demo/tests/counter_tab_roundtrip_regression.rs
+++ b/apps/desktop-demo/tests/counter_tab_roundtrip_regression.rs
@@ -131,21 +131,23 @@ fn max_layer_translation_y(layer: &LayerNode) -> f32 {
 #[composable]
 fn returned_press_lift(press_tick: MutableState<u64>) -> f32 {
     let press_target = cranpose_core::useState(|| 0.0_f32);
+    // The click raises the lift target and nothing lowers it again. An earlier
+    // revision released the lift from a `launch_background` worker that slept
+    // 120ms of WALL time, and that made the probe cancel itself whenever the
+    // frame loop was starved: `animateTo` seeds `start` from the animation's
+    // CURRENT value, so a retarget back to 0.0 that lands before any frame has
+    // moved the value off 0.0 gives start == target == 0.0, and the tween then
+    // interpolates 0.0 -> 0.0 for the rest of the test. That produced exactly
+    // the observed `last translation_y=0`, on a loaded machine, with the
+    // propagation path under test working perfectly.
     cranpose_core::LaunchedEffect!(press_tick.value(), {
         let target_state = press_target;
         let tick_state = press_tick;
-        move |scope| {
+        move |_scope| {
             if tick_state.value() == 0 {
                 return;
             }
             target_state.set(1.0);
-            let reset_target_state = target_state;
-            scope.launch_background(
-                move |_| async move {
-                    std::thread::sleep(Duration::from_millis(120));
-                },
-                move |_| reset_target_state.set(0.0),
-            );
         }
     });
 
@@ -200,8 +202,14 @@ fn animate_float_as_state_returned_value_updates_parent_graphics_layer_after_cli
     let mut saw_intermediate_layer = false;
     let mut last_translation = 0.0;
     for _ in 0..24 {
-        std::thread::sleep(Duration::from_millis(16));
-        shell.update();
+        // Advance the animation on a FRAME clock, not on wall time. `update()`
+        // anchors the tween to `Instant::now()`, so a starved thread that takes
+        // longer than the 240ms duration between two samples jumps the value
+        // straight from 0.0 to the settled 32.0 and never lands inside the band
+        // this test asserts on. `update_after_exact_interval` steps the tween by
+        // exactly one 16ms frame per iteration on any machine, which puts the
+        // first non-zero sample at a fixed 6.67% of the animation.
+        shell.update_after_exact_interval(Duration::from_millis(16));
         let translation = shell
             .scene()
             .graph

--- a/crates/cranpose-core/src/composer.rs
+++ b/crates/cranpose-core/src/composer.rs
@@ -843,6 +843,22 @@ impl Composer {
         })
     }
 
+    /// Whether any of `node_ids` carries a pending *layout* (placement) repass.
+    ///
+    /// Layout-only dirtiness is not a subset of measure dirtiness: a scroll
+    /// offset change keeps every measured size intact and therefore bubbles
+    /// `needs_layout` alone. Callers that gate cache reuse on
+    /// [`Self::nodes_need_measure`] must also consult this, or a node whose
+    /// *position* changed will replay its stale cached placement forever.
+    pub fn nodes_need_layout(&self, node_ids: &[NodeId]) -> bool {
+        let mut applier = self.borrow_applier();
+        node_ids.iter().any(|node_id| {
+            applier
+                .get_mut(*node_id)
+                .is_ok_and(|node| node.needs_layout())
+        })
+    }
+
     /// Records a child node in the current parent frame's expected children list.
     ///
     /// Used by SubcomposeLayout's `perform_subcompose` to register virtual nodes

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -47,7 +47,8 @@ use crate::surface_executor::{clamp_effect_surface_scale, visible_layer_rect};
 use crate::surface_plan::{
     composite_sample_mode_for_effect_layer, composite_sample_mode_for_requirements,
     direct_translation, effect_layer_target_scale, layer_contains_descendant_backdrop,
-    layer_surface_requirements, layer_surface_target_scale, TranslatedContentAxes,
+    layer_surface_requirements, layer_surface_scale, layer_surface_target_scale,
+    TranslatedContentAxes,
 };
 use crate::surface_plan::{
     layer_surface_requirements_cached, layer_uses_external_backdrop_input,
@@ -179,6 +180,10 @@ const INITIAL_UPLOAD_BUFFER_BYTES: u64 = 4 * 1024;
 #[cfg(not(target_arch = "wasm32"))]
 const INITIAL_RETAINED_GLYPH_UNIFORM_SLOTS: usize = 128;
 const MAX_TEXTURE_CACHE_ITEMS: usize = 256;
+/// Byte ceiling for `image_texture_cache` (see `CachedImageTexture::bytes`).
+/// Generous enough for a screenful of full-page images plus thumbnails;
+/// small enough that a camera preview stream can never pin gigabytes.
+const MAX_IMAGE_TEXTURE_CACHE_BYTES: usize = 256 * 1024 * 1024;
 const RETAINED_STAGED_UPLOAD_BYTES: usize = 256 * 1024;
 const RETAINED_STAGED_UPLOAD_COPIES: usize = 128;
 const RETAINED_LAYER_REQUIREMENTS_CAPACITY: usize = 512;
@@ -1399,6 +1404,13 @@ struct CachedImageTexture {
     _view: wgpu::TextureView,
     nearest_bind_group: wgpu::BindGroup,
     linear_bind_group: wgpu::BindGroup,
+    /// GPU bytes this entry pins (w×h×4): the cache is bounded by BYTES as
+    /// well as count. A live camera publishes a new multi-MB bitmap id every
+    /// frame; 256 count-slots of those is ~1.5GB of dead preview textures —
+    /// which on iOS unified memory counts straight against the process's
+    /// jetsam limit (measured: the app died mid-scan under an open camera
+    /// with exactly that ballast).
+    bytes: usize,
 }
 
 impl CachedImageTexture {
@@ -2097,6 +2109,8 @@ pub struct GpuRenderer {
     #[cfg(target_arch = "wasm32")]
     wasm_image_batch_cursor: usize,
     image_texture_cache: BoundedLruCache<u64, CachedImageTexture>,
+    /// Total `CachedImageTexture::bytes` currently in the cache.
+    image_texture_cache_bytes: usize,
     text_image_cache: BoundedLruCache<TextImageCacheKey, CachedTextImage>,
     text_glyph_atlas: TextGlyphAtlas,
     text_glyph_run_cache: BoundedLruCache<TextGlyphRunCacheKey, CachedTextGlyphRun>,
@@ -2484,6 +2498,7 @@ impl GpuRenderer {
             image_texture_cache: BoundedLruCache::with_capacity_at_least_one(
                 MAX_TEXTURE_CACHE_ITEMS,
             ),
+            image_texture_cache_bytes: 0,
             text_image_cache: BoundedLruCache::with_capacity_at_least_one(
                 MAX_TEXT_IMAGE_CACHE_ITEMS,
             ),
@@ -2580,15 +2595,33 @@ impl GpuRenderer {
         let nearest_bind_group = self.image_bind_group(&view, &self.image_nearest_sampler);
         let linear_bind_group = self.image_bind_group(&view, &self.image_linear_sampler);
 
-        self.image_texture_cache.put(
+        let bytes = image.width() as usize * image.height() as usize * 4;
+        if let Some(replaced) = self.image_texture_cache.put(
             image.id(),
             CachedImageTexture {
                 _texture: texture,
                 _view: view,
                 nearest_bind_group,
                 linear_bind_group,
+                bytes,
             },
-        );
+        ) {
+            self.image_texture_cache_bytes = self
+                .image_texture_cache_bytes
+                .saturating_sub(replaced.bytes);
+        }
+        self.image_texture_cache_bytes += bytes;
+        // Byte-bounded eviction on top of the count bound: never evict the
+        // entry just inserted (this frame draws it).
+        while self.image_texture_cache_bytes > MAX_IMAGE_TEXTURE_CACHE_BYTES
+            && self.image_texture_cache.len() > 1
+        {
+            let Some((_, evicted)) = self.image_texture_cache.pop_lru() else {
+                break;
+            };
+            self.image_texture_cache_bytes =
+                self.image_texture_cache_bytes.saturating_sub(evicted.bytes);
+        }
         Ok(())
     }
 
@@ -13166,11 +13199,17 @@ mod tests {
             CompositeSampleMode::Box4
         );
         assert_eq!(
-            layer_surface_target_scale(true, false, requirements, 1.25),
+            layer_surface_target_scale(
+                true,
+                false,
+                requirements,
+                1.25,
+                layer_surface_scale(&layer)
+            ),
             SurfaceRequirementSet::default()
                 .with(SurfaceRequirement::TextMaterialMask)
                 .with(SurfaceRequirement::MotionStableCapture)
-                .target_scale(1.25)
+                .target_scale(1.25, 1.0)
         );
     }
 
@@ -13194,10 +13233,10 @@ mod tests {
             CompositeSampleMode::Linear
         );
         assert_eq!(
-            layer_surface_target_scale(true, true, requirements, 10.0),
+            layer_surface_target_scale(true, true, requirements, 10.0, layer_surface_scale(&layer)),
             SurfaceRequirementSet::default()
                 .with(SurfaceRequirement::TextMaterialMask)
-                .target_scale(10.0)
+                .target_scale(10.0, 1.0)
         );
     }
 

--- a/crates/cranpose-render/wgpu/src/surface_executor.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor.rs
@@ -10,7 +10,9 @@ pub(crate) use geometry::{
     translation_stable_device_pixel_bounds,
 };
 #[cfg(test)]
-pub(crate) use geometry::{clamp_effect_surface_scale, visible_layer_rect};
+pub(crate) use geometry::{
+    clamp_effect_surface_scale, device_pixel_exact_surface_rect, visible_layer_rect,
+};
 pub(crate) use render_paths::{
     apply_backdrop_layer_to_target, backdrop_underlay_is_covered_by_local_content,
     composite_surface_to_view, render_effect_layer_to_target, render_layer_surface,

--- a/crates/cranpose-render/wgpu/src/surface_executor/geometry.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/geometry.rs
@@ -8,11 +8,54 @@ pub(crate) const MAX_EFFECT_LAYER_SURFACE_BYTES: u64 = 8 * 1024 * 1024;
 const QUAD_AXIS_ALIGNMENT_TOLERANCE: f32 = 1e-4;
 const COMPOSITE_DEST_SNAP_TOLERANCE: f32 = 1e-4;
 
+/// Slack absorbed before the ceil, so a rect that already covers a whole
+/// number of device pixels cannot gain one to float error: `51.0 / 1.4 * 1.4`
+/// is `51.000004`, and a bare ceil turns that into 52. Orders of magnitude
+/// below any real sub-pixel coverage.
+const SURFACE_SIZE_CEIL_EPSILON: f32 = 1e-3;
+
 pub(crate) fn surface_target_size(rect: Rect, root_scale: f32, max_dim: u32) -> (u32, u32) {
     (
-        (rect.width * root_scale).ceil().clamp(1.0, max_dim as f32) as u32,
-        (rect.height * root_scale).ceil().clamp(1.0, max_dim as f32) as u32,
+        (rect.width * root_scale - SURFACE_SIZE_CEIL_EPSILON)
+            .ceil()
+            .clamp(1.0, max_dim as f32) as u32,
+        (rect.height * root_scale - SURFACE_SIZE_CEIL_EPSILON)
+            .ceil()
+            .clamp(1.0, max_dim as f32) as u32,
     )
+}
+
+/// The surface rect that `width`x`height` device pixels cover exactly at
+/// `scale`.
+///
+/// `surface_target_size` CEILS each axis, but the composite maps the WHOLE
+/// texture onto the destination quad — `layer_surface_dest_quad` maps the
+/// surface's logical rect through the layer transform, so texture pixel
+/// `(width, height)` lands on the rect's far corner no matter where the
+/// content actually ended. A rect that is not a whole number of device pixels
+/// therefore has its ceil padding stretched across the quad, which compresses
+/// the content toward the quad's origin by up to half a device pixel.
+///
+/// Growing the rect to the pixels that were allocated anyway makes that
+/// mapping exact. The texture is unchanged — this only names the area it
+/// already covers — so nothing here spends memory. Only growth is allowed: a
+/// size clamped by the texture-dimension limit must not shrink the rect and
+/// clip the content off.
+pub(crate) fn device_pixel_exact_surface_rect(
+    rect: Rect,
+    scale: f32,
+    width: u32,
+    height: u32,
+) -> Rect {
+    if !scale.is_finite() || scale <= 0.0 {
+        return rect;
+    }
+    Rect {
+        x: rect.x,
+        y: rect.y,
+        width: (width as f32 / scale).max(rect.width),
+        height: (height as f32 / scale).max(rect.height),
+    }
 }
 
 pub(crate) fn offscreen_byte_size(width: u32, height: u32) -> u64 {
@@ -356,7 +399,7 @@ pub(crate) fn quantize_motion_stable_target_scale(
 #[cfg(test)]
 mod tests {
     use super::{
-        axis_aligned_quad_rect, clamp_effect_surface_scale,
+        axis_aligned_quad_rect, clamp_effect_surface_scale, device_pixel_exact_surface_rect,
         fit_capture_rect_to_scale_budget_for_axes, offscreen_byte_size,
         quantize_motion_stable_target_scale, snap_motion_stable_dest_quad, surface_target_size,
         translation_stable_device_pixel_bounds, MAX_EFFECT_LAYER_SURFACE_BYTES,
@@ -681,6 +724,89 @@ mod tests {
         assert_eq!(
             quantize_motion_stable_target_scale(4.72, CompositeSampleMode::Linear),
             4.72
+        );
+    }
+
+    /// The composite maps the WHOLE texture onto the quad built from the
+    /// surface rect, so a rect that stops short of the ceil'd texture has its
+    /// padding stretched across the quad and its content compressed toward the
+    /// quad's origin. The rect must name the pixels that were allocated.
+    #[test]
+    fn surface_rect_covers_exactly_the_pixels_that_were_allocated() {
+        let rect = Rect {
+            x: 12.0,
+            y: 9.0,
+            width: 36.0,
+            height: 37.0,
+        };
+        let scale = 1.15;
+        let (width, height) = surface_target_size(rect, scale, 8192);
+        assert_eq!((width, height), (42, 43));
+
+        let exact = device_pixel_exact_surface_rect(rect, scale, width, height);
+
+        assert_eq!(
+            exact.x, rect.x,
+            "only the extent is padded, never the origin"
+        );
+        assert_eq!(exact.y, rect.y);
+        assert!((exact.width * scale - width as f32).abs() < 1e-3);
+        assert!((exact.height * scale - height as f32).abs() < 1e-3);
+        assert!(exact.width >= rect.width && exact.height >= rect.height);
+    }
+
+    /// Padding the rect must not cost a byte: the texture it names is the one
+    /// `surface_target_size` already ceil'd to.
+    #[test]
+    fn padding_the_surface_rect_does_not_grow_the_texture() {
+        let rect = Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 36.0,
+            height: 36.0,
+        };
+        for step in 0..32 {
+            let scale = 1.0 + step as f32 * 0.05;
+            let (width, height) = surface_target_size(rect, scale, 8192);
+            let exact = device_pixel_exact_surface_rect(rect, scale, width, height);
+            assert_eq!(
+                surface_target_size(exact, scale, 8192),
+                (width, height),
+                "scale={scale} re-sized the texture"
+            );
+        }
+    }
+
+    /// A size the texture-dimension limit clamped is SMALLER than the rect
+    /// asked for; shrinking the rect to match would clip the content off.
+    #[test]
+    fn a_clamped_surface_size_never_shrinks_the_rect() {
+        let rect = Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 4000.0,
+            height: 4000.0,
+        };
+
+        let exact = device_pixel_exact_surface_rect(rect, 4.0, 8192, 8192);
+
+        assert_eq!(exact.width, 4000.0);
+        assert_eq!(exact.height, 4000.0);
+    }
+
+    #[test]
+    fn a_nonsense_scale_leaves_the_surface_rect_alone() {
+        let rect = Rect {
+            x: 3.0,
+            y: 4.0,
+            width: 10.0,
+            height: 20.0,
+        };
+
+        assert_eq!(device_pixel_exact_surface_rect(rect, 0.0, 10, 20), rect);
+        assert_eq!(
+            device_pixel_exact_surface_rect(rect, f32::NAN, 10, 20),
+            rect
         );
     }
 }

--- a/crates/cranpose-render/wgpu/src/surface_executor/geometry.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/geometry.rs
@@ -356,9 +356,10 @@ pub(crate) fn quantize_motion_stable_target_scale(
 #[cfg(test)]
 mod tests {
     use super::{
-        axis_aligned_quad_rect, fit_capture_rect_to_scale_budget_for_axes,
+        axis_aligned_quad_rect, clamp_effect_surface_scale,
+        fit_capture_rect_to_scale_budget_for_axes, offscreen_byte_size,
         quantize_motion_stable_target_scale, snap_motion_stable_dest_quad, surface_target_size,
-        translation_stable_device_pixel_bounds,
+        translation_stable_device_pixel_bounds, MAX_EFFECT_LAYER_SURFACE_BYTES,
     };
     use crate::effect_renderer::CompositeSampleMode;
     use crate::rect_to_quad;
@@ -624,6 +625,54 @@ mod tests {
         assert!(
             ((fitted.y + fitted.height) - 808.0).abs() < 0.001,
             "trimmed vertical captures must keep the viewport bottom stable instead of preserving phase-shifted trailing content"
+        );
+    }
+
+    /// Raising a zoomed layer's surface density must stay inside the existing
+    /// 8 MB budget: `clamp_effect_surface_scale` only clamps downward, so the
+    /// larger desired scale is bounded, not honoured.
+    #[test]
+    fn zoom_raised_surface_scale_stays_inside_the_byte_budget() {
+        // A full-screen zoomable at 3x device scale pinched to 4x.
+        let rect = Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 390.0,
+            height: 844.0,
+        };
+        let desired_scale = 3.0 * 4.0;
+
+        let clamped = clamp_effect_surface_scale(rect, 1.0, desired_scale, 8192);
+        let (width, height) = surface_target_size(rect, clamped, 8192);
+
+        assert!(
+            clamped < desired_scale,
+            "a full-screen layer is already budget-bound, so the zoom scale must be clamped"
+        );
+        // `surface_target_size` ceils each axis, so allow that one row/column.
+        let ceil_slack = ((width as u64) + (height as u64) + 1) * 4;
+        assert!(
+            offscreen_byte_size(width, height) <= MAX_EFFECT_LAYER_SURFACE_BYTES + ceil_slack,
+            "{width}x{height} = {} bytes exceeds the surface budget",
+            offscreen_byte_size(width, height)
+        );
+    }
+
+    /// The other side of the budget: a widget-sized zoomable does get the full
+    /// effective density, which is the whole point of the fix.
+    #[test]
+    fn zoom_raised_surface_scale_is_honoured_when_it_fits_the_budget() {
+        let rect = Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 120.0,
+            height: 80.0,
+        };
+        let desired_scale = 3.0 * 4.0;
+
+        assert_eq!(
+            clamp_effect_surface_scale(rect, 1.0, desired_scale, 8192),
+            desired_scale
         );
     }
 

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -31,7 +31,7 @@ use crate::scene::{
 use crate::surface_plan::{
     composite_sample_mode_for_effect_layer, composite_sample_mode_for_requirements,
     effect_layer_minimum_scale, effect_layer_target_scale, effective_surface_requirements,
-    layer_contains_descendant_backdrop, layer_surface_target_scale,
+    layer_contains_descendant_backdrop, layer_surface_scale, layer_surface_target_scale,
     layer_uses_external_backdrop_input, translated_content_axes_for_layer,
     LayerSurfaceRenderOptions, LayerSurfaceRequest, LayerSurfaceRequirements,
     TranslatedContentAxes, TranslationRenderContext,
@@ -2028,6 +2028,10 @@ pub(crate) fn render_layer_surface<B: SurfaceExecutionBackend>(
         translation_context.surface_capture_active,
         surface_requirements,
         root_scale,
+        // A scaling layer is composited by mapping this surface through its own
+        // transform, so the texture has to carry that magnification's worth of
+        // detail or the composite just resamples a 1x raster upward.
+        layer_surface_scale(layer),
     );
     let translation_context = layer_surface_translation_context(
         translation_context,

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -3,8 +3,8 @@ use super::backend::{
 };
 use super::geometry::{
     axis_aligned_quad_rect, clamp_effect_surface_scale, content_effect_pixel_rect,
-    fit_capture_rect_to_scale_budget_for_axes, offscreen_byte_size,
-    quantize_motion_stable_target_scale, scaled_quad, snap_delta_for_anchor,
+    device_pixel_exact_surface_rect, fit_capture_rect_to_scale_budget_for_axes,
+    offscreen_byte_size, quantize_motion_stable_target_scale, scaled_quad, snap_delta_for_anchor,
     snap_motion_stable_dest_quad, surface_pixel_rect, surface_target_size, target_quad,
     visible_layer_rect,
 };
@@ -4030,6 +4030,16 @@ fn render_layer_surface_uncached<B: SurfaceExecutionBackend>(
             backend.max_texture_dim(),
         );
         let target_scale = quantize_motion_stable_target_scale(target_scale, composite_sample_mode);
+        let (width, height) =
+            surface_target_size(surface_rect, target_scale, backend.max_texture_dim());
+        // The composite maps the whole texture onto the destination quad, so
+        // the rect the quad is built from has to be the area the texture
+        // actually covers. Without this the ceil padding is stretched across
+        // the quad and the content lands up to half a device pixel toward its
+        // origin — invisible while the scale is constant, per-frame jitter
+        // once the scale animates.
+        let surface_rect =
+            device_pixel_exact_surface_rect(surface_rect, target_scale, width, height);
         let shift = cranpose_ui_graphics::Point {
             x: -surface_rect.x,
             y: -surface_rect.y,
@@ -4050,8 +4060,6 @@ fn render_layer_surface_uncached<B: SurfaceExecutionBackend>(
             }
             child.shadow_draws.translate_by(shift);
         }
-        let (width, height) =
-            surface_target_size(surface_rect, target_scale, backend.max_texture_dim());
         backend.record_isolated_layer_render(
             width,
             height,

--- a/crates/cranpose-render/wgpu/src/surface_plan.rs
+++ b/crates/cranpose-render/wgpu/src/surface_plan.rs
@@ -1024,4 +1024,94 @@ mod tests {
             3.0
         );
     }
+
+    /// The invariant the robot's layout-jitter contract watches, without a GPU:
+    /// a layer whose scale ANIMATES must stay put in layout space and must not
+    /// re-rasterize every frame.
+    ///
+    /// Raising `target_scale` to the live layer scale made both false at once.
+    /// A 36 dp box sweeping 0.85 -> 1.15 got a distinct surface size on nearly
+    /// every frame (measured on the demo's Animations tab: 37, 38, 39, 40, 41,
+    /// 42 px within one sweep), so its rounded-corner antialiasing was
+    /// recomputed at a new sub-pixel phase per frame, and the ceil'd texture
+    /// was stretched across a destination quad built from the unpadded rect,
+    /// compressing the content toward the quad's origin by up to half a device
+    /// pixel. Nothing moved in layout space, but every edge pixel did.
+    #[test]
+    fn an_animated_layer_scale_holds_its_surface_and_its_layout_rect() {
+        use crate::surface_executor::{device_pixel_exact_surface_rect, surface_target_size};
+        use cranpose_render_common::layer_transform::layer_transform_to_parent;
+        use cranpose_ui_graphics::TransformOrigin;
+
+        const MAX_TEXTURE_DIM: u32 = 8192;
+        const ROOT_SCALE: f32 = 1.0;
+        let local_bounds = Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 36.0,
+            height: 36.0,
+        };
+        let placement = Point { x: 54.0, y: 416.0 };
+
+        let mut surface_sizes: Vec<(u32, u32)> = Vec::new();
+        for frame in 0..=40 {
+            // The demo's "Scale + Fade (layer lambda)" animation.
+            let progress = frame as f32 / 40.0;
+            let mut layer = test_layer(local_bounds);
+            layer.graphics_layer.scale = 0.85 + 0.3 * progress;
+            layer.graphics_layer.alpha = 0.4 + 0.6 * progress;
+            layer.graphics_layer.transform_origin = TransformOrigin::CENTER;
+            layer.transform_to_parent =
+                layer_transform_to_parent(local_bounds, placement, &layer.graphics_layer);
+
+            let requirements = layer_surface_requirements(&layer);
+            let target_scale = layer_surface_target_scale(
+                false,
+                false,
+                requirements,
+                ROOT_SCALE,
+                layer_surface_scale(&layer),
+            );
+            let (width, height) = surface_target_size(local_bounds, target_scale, MAX_TEXTURE_DIM);
+            if surface_sizes.last() != Some(&(width, height)) {
+                surface_sizes.push((width, height));
+            }
+
+            // What the composite actually maps: the whole texture onto the quad
+            // the surface rect maps to. The layer's own content stops at
+            // `local_bounds * target_scale` texels, so its layout-space extent
+            // is that fraction of the quad.
+            let surface_rect =
+                device_pixel_exact_surface_rect(local_bounds, target_scale, width, height);
+            let quad = layer.transform_to_parent.bounds_for_rect(surface_rect);
+            let composited = Rect {
+                x: quad.x,
+                y: quad.y,
+                width: quad.width * (local_bounds.width * target_scale) / width as f32,
+                height: quad.height * (local_bounds.height * target_scale) / height as f32,
+            };
+
+            // ... and that has to be exactly where layout put the layer,
+            // whatever resolution the texture happened to get.
+            let laid_out = layer.transform_to_parent.bounds_for_rect(local_bounds);
+            for (label, composited, laid_out) in [
+                ("x", composited.x, laid_out.x),
+                ("y", composited.y, laid_out.y),
+                ("width", composited.width, laid_out.width),
+                ("height", composited.height, laid_out.height),
+            ] {
+                assert!(
+                    (composited - laid_out).abs() < 1e-2,
+                    "frame {frame} (scale {}) composited {label} {composited} away from its laid-out {laid_out}",
+                    layer.graphics_layer.scale
+                );
+            }
+        }
+
+        assert_eq!(
+            surface_sizes,
+            vec![(36, 36), (45, 45)],
+            "a 41-frame scale sweep must reuse two surfaces, not reallocate per frame"
+        );
+    }
 }

--- a/crates/cranpose-render/wgpu/src/surface_plan.rs
+++ b/crates/cranpose-render/wgpu/src/surface_plan.rs
@@ -6,6 +6,7 @@ use cranpose_render_common::graph::{
     LayerNode, PrimitiveEntry, PrimitiveNode, ProjectiveTransform, RenderNode,
 };
 use cranpose_render_common::layer_composition::effective_layer_isolation;
+use cranpose_render_common::layer_transform::layer_uniform_scale;
 use cranpose_ui_graphics::{BlendMode, Brush, CompositingStrategy, Point, Rect};
 
 const SURFACE_PLAN_AFFINE_TOLERANCE: f32 = 1e-4;
@@ -277,11 +278,18 @@ pub(crate) fn composite_sample_mode_for_requirements(
     effective.composite_sample_mode()
 }
 
+/// The density a layer's forced surface must be rasterized at.
+///
+/// `layer_scale` is the uniform scale of the layer's own transform; it raises
+/// the density so a magnifying (pinch-zoomed) layer resolves real detail instead
+/// of being sampled up from a 1x raster. See
+/// [`SurfaceRequirementSet::target_scale`].
 pub(crate) fn layer_surface_target_scale(
     translated_content_context: bool,
     surface_capture_active: bool,
     requirements: LayerSurfaceRequirements,
     root_scale: f32,
+    layer_scale: f32,
 ) -> f32 {
     let effective = effective_surface_requirements(
         translated_content_context,
@@ -294,8 +302,14 @@ pub(crate) fn layer_surface_target_scale(
     if motion_stable_uses_root_scale {
         root_scale
     } else {
-        effective.target_scale(root_scale)
+        effective.target_scale(root_scale, layer_scale)
     }
+}
+
+/// The uniform scale of `layer`'s own transform, for
+/// [`layer_surface_target_scale`].
+pub(crate) fn layer_surface_scale(layer: &LayerNode) -> f32 {
+    layer_uniform_scale(&layer.graphics_layer)
 }
 
 pub(crate) fn composite_sample_mode_for_effect_layer(layer: &EffectLayer) -> CompositeSampleMode {
@@ -312,7 +326,9 @@ pub(crate) fn effect_layer_target_scale(layer: &EffectLayer, root_scale: f32) ->
     {
         root_scale
     } else {
-        layer.requirements.target_scale(root_scale)
+        // Effect layers are already flattened into the scene's device space;
+        // there is no residual layer transform for the composite to magnify.
+        layer.requirements.target_scale(root_scale, 1.0)
     }
 }
 
@@ -484,7 +500,7 @@ mod tests {
     use super::{
         composite_sample_mode_for_effect_layer, composite_sample_mode_for_requirements,
         effect_layer_target_scale, effective_surface_requirements, layer_surface_requirements,
-        layer_surface_target_scale,
+        layer_surface_scale, layer_surface_target_scale,
     };
     use crate::effect_renderer::CompositeSampleMode;
     use crate::scene::EffectLayer;
@@ -567,7 +583,13 @@ mod tests {
             CompositeSampleMode::Box4
         );
         assert_eq!(
-            layer_surface_target_scale(false, false, requirements, 2.0),
+            layer_surface_target_scale(
+                false,
+                false,
+                requirements,
+                2.0,
+                layer_surface_scale(&layer)
+            ),
             2.0
         );
     }
@@ -664,7 +686,7 @@ mod tests {
         let effective = effective_surface_requirements(true, false, requirements);
         assert!(!effective.contains(SurfaceRequirement::MotionStableCapture));
         assert_eq!(
-            layer_surface_target_scale(true, false, requirements, 2.0),
+            layer_surface_target_scale(true, false, requirements, 2.0, layer_surface_scale(&layer)),
             2.0
         );
         assert_eq!(
@@ -736,11 +758,23 @@ mod tests {
         assert!(!effective_surface_requirements(false, true, requirements)
             .contains(SurfaceRequirement::MotionStableCapture));
         assert_eq!(
-            layer_surface_target_scale(false, false, requirements, 2.0),
+            layer_surface_target_scale(
+                false,
+                false,
+                requirements,
+                2.0,
+                layer_surface_scale(&viewport)
+            ),
             2.0
         );
         assert_eq!(
-            layer_surface_target_scale(false, true, requirements, 2.0),
+            layer_surface_target_scale(
+                false,
+                true,
+                requirements,
+                2.0,
+                layer_surface_scale(&viewport)
+            ),
             2.0
         );
     }
@@ -839,7 +873,7 @@ mod tests {
             CompositeSampleMode::Linear
         );
         assert_eq!(
-            layer_surface_target_scale(true, false, requirements, 9.0),
+            layer_surface_target_scale(true, false, requirements, 9.0, layer_surface_scale(&layer)),
             9.0
         );
     }
@@ -866,7 +900,7 @@ mod tests {
             CompositeSampleMode::Linear
         );
         assert_eq!(
-            layer_surface_target_scale(true, false, requirements, 9.0),
+            layer_surface_target_scale(true, false, requirements, 9.0, layer_surface_scale(&layer)),
             9.0
         );
     }
@@ -893,8 +927,101 @@ mod tests {
             CompositeSampleMode::Linear
         );
         assert_eq!(
-            layer_surface_target_scale(true, true, requirements, 9.0),
+            layer_surface_target_scale(true, true, requirements, 9.0, layer_surface_scale(&layer)),
             9.0
+        );
+    }
+
+    /// A pinch-zoomed layer: a scaling `transform_to_parent` forces an
+    /// offscreen surface, and that surface must be allocated at the layer's
+    /// EFFECTIVE device scale. Rasterizing it at plain `root_scale` and letting
+    /// the composite magnify the texture is what made zoom fuzzy.
+    #[test]
+    fn zoomed_layer_surface_resolves_at_root_scale_times_the_layer_scale() {
+        let mut layer = test_layer(Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 120.0,
+            height: 80.0,
+        });
+        layer.transform_to_parent = ProjectiveTransform::uniform_scale(4.0);
+        layer.graphics_layer.scale = 4.0;
+
+        let requirements = layer_surface_requirements(&layer);
+
+        assert!(
+            requirements
+                .surface_requirements
+                .contains(SurfaceRequirement::NonTranslationTransform),
+            "a scaling transform is not a direct translation, so it forces a surface"
+        );
+        assert!(requirements.has_renderer_forced_surface());
+        assert_eq!(
+            composite_sample_mode_for_requirements(false, false, requirements),
+            CompositeSampleMode::Linear,
+            "the composite resamples, so the source density is what decides sharpness"
+        );
+        assert_eq!(
+            layer_surface_target_scale(
+                false,
+                false,
+                requirements,
+                3.0,
+                layer_surface_scale(&layer)
+            ),
+            12.0
+        );
+    }
+
+    /// The scale must come off the layer, not off a constant: halving the zoom
+    /// halves the density the surface is allocated at.
+    #[test]
+    fn zoomed_layer_surface_scale_tracks_the_layer_scale() {
+        let mut layer = test_layer(Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 120.0,
+            height: 80.0,
+        });
+        layer.transform_to_parent = ProjectiveTransform::uniform_scale(2.0);
+        layer.graphics_layer.scale = 2.0;
+
+        let requirements = layer_surface_requirements(&layer);
+
+        assert_eq!(
+            layer_surface_target_scale(
+                false,
+                false,
+                requirements,
+                3.0,
+                layer_surface_scale(&layer)
+            ),
+            6.0
+        );
+    }
+
+    /// An unscaled layer is untouched: same texture density as before the fix.
+    #[test]
+    fn unscaled_layer_surface_keeps_the_root_scale_density() {
+        let layer = test_layer(Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 120.0,
+            height: 80.0,
+        });
+
+        let requirements = layer_surface_requirements(&layer);
+
+        assert_eq!(layer_surface_scale(&layer), 1.0);
+        assert_eq!(
+            layer_surface_target_scale(
+                false,
+                false,
+                requirements,
+                3.0,
+                layer_surface_scale(&layer)
+            ),
+            3.0
         );
     }
 }

--- a/crates/cranpose-render/wgpu/src/surface_requirements.rs
+++ b/crates/cranpose-render/wgpu/src/surface_requirements.rs
@@ -23,6 +23,16 @@ pub(crate) struct SurfaceRequirementSet {
     bits: u16,
 }
 
+/// The share of a layer's uniform scale that may raise its surface density.
+/// Garbage values fall back to `1.0`, and minification never lowers it.
+fn magnifying_layer_scale(layer_scale: f32) -> f32 {
+    if layer_scale.is_finite() {
+        layer_scale.max(1.0)
+    } else {
+        1.0
+    }
+}
+
 impl SurfaceRequirementSet {
     const EXPLICIT_OFFSCREEN: u16 = 1 << 0;
     const RENDER_EFFECT: u16 = 1 << 1;
@@ -135,9 +145,29 @@ impl SurfaceRequirementSet {
         }
     }
 
-    pub(crate) fn target_scale(self, root_scale: f32) -> f32 {
+    /// Device-pixel density the surface texture must be rasterized at.
+    ///
+    /// `layer_scale` is the uniform scale of the layer transform the composite
+    /// will map this surface through (see
+    /// `cranpose_render_common::layer_transform::layer_uniform_scale`). A forced
+    /// surface renders the layer's LOCAL, untransformed rect, so rasterizing a
+    /// magnifying layer at plain `root_scale` and then blowing the texture up
+    /// through the composite's sampler is precisely why zoomed content never
+    /// resolves more detail. A [`SurfaceRequirement::NonTranslationTransform`]
+    /// therefore resolves at the layer's *effective* device scale.
+    ///
+    /// Minification is deliberately not followed downward: `layer_scale` only
+    /// ever raises the density, because shrinking the texture would discard
+    /// detail an interactive scale may zoom straight back into.
+    ///
+    /// This is the *desired* scale. Callers still clamp it against the
+    /// texture-dimension limit and the `MAX_EFFECT_LAYER_SURFACE_BYTES` budget
+    /// via `clamp_effect_surface_scale`, which only clamps downward.
+    pub(crate) fn target_scale(self, root_scale: f32, layer_scale: f32) -> f32 {
         if self.contains(SurfaceRequirement::MotionStableCapture) {
             root_scale * MOTION_STABLE_SURFACE_SCALE_MULTIPLIER
+        } else if self.contains(SurfaceRequirement::NonTranslationTransform) {
+            root_scale * magnifying_layer_scale(layer_scale)
         } else {
             root_scale
         }
@@ -218,7 +248,57 @@ mod tests {
             requirements.composite_sample_mode(),
             CompositeSampleMode::Box4
         );
-        assert_eq!(requirements.target_scale(3.0), 3.0);
+        assert_eq!(requirements.target_scale(3.0, 1.0), 3.0);
+    }
+
+    /// Bug: a magnifying layer's forced surface was rasterized at plain
+    /// `root_scale` and then blown up by the composite's linear sampler, so zoom
+    /// never resolved more detail at any scale.
+    #[test]
+    fn non_translation_transform_resolves_at_the_layer_scale() {
+        let requirements = SurfaceRequirementSet::default()
+            .with(SurfaceRequirement::ExplicitOffscreen)
+            .with(SurfaceRequirement::NonTranslationTransform);
+
+        assert_eq!(
+            requirements.target_scale(3.0, 4.0),
+            12.0,
+            "a 4x layer on a 3x screen needs 12x device density, not 3x"
+        );
+    }
+
+    #[test]
+    fn minified_layer_keeps_the_root_scale_density() {
+        let requirements = SurfaceRequirementSet::default()
+            .with(SurfaceRequirement::ExplicitOffscreen)
+            .with(SurfaceRequirement::NonTranslationTransform);
+
+        assert_eq!(
+            requirements.target_scale(3.0, 0.25),
+            3.0,
+            "shrinking the texture would throw away detail an interactive scale zooms back into"
+        );
+    }
+
+    #[test]
+    fn non_finite_layer_scale_falls_back_to_the_root_scale() {
+        let requirements =
+            SurfaceRequirementSet::default().with(SurfaceRequirement::NonTranslationTransform);
+
+        assert_eq!(requirements.target_scale(2.0, f32::NAN), 2.0);
+        assert_eq!(requirements.target_scale(2.0, f32::INFINITY), 2.0);
+    }
+
+    #[test]
+    fn translation_only_surfaces_ignore_the_layer_scale() {
+        let requirements =
+            SurfaceRequirementSet::default().with(SurfaceRequirement::ExplicitOffscreen);
+
+        assert_eq!(
+            requirements.target_scale(2.0, 4.0),
+            2.0,
+            "without a scaling transform the composite is 1:1 and the extra density is waste"
+        );
     }
 
     #[test]

--- a/crates/cranpose-render/wgpu/src/surface_requirements.rs
+++ b/crates/cranpose-render/wgpu/src/surface_requirements.rs
@@ -23,14 +23,27 @@ pub(crate) struct SurfaceRequirementSet {
     bits: u16,
 }
 
+/// Quantisation ladder for a magnifying layer's surface density: quarter
+/// steps. `ScaleBucket` (~0.004 wide) exists to absorb float noise, not
+/// animation, so an animated or pinched scale walked straight through it and
+/// allocated a fresh texture every frame.
+const LAYER_SCALE_QUANTUM: f32 = 4.0;
+
 /// The share of a layer's uniform scale that may raise its surface density.
 /// Garbage values fall back to `1.0`, and minification never lowers it.
+///
+/// The result is rounded UP to the next [`LAYER_SCALE_QUANTUM`] step, so an
+/// animating or pinched scale holds one surface across a range of frames
+/// instead of reallocating per frame, and the density is never below the
+/// layer's effective scale (rounding down would reintroduce the softness this
+/// whole path exists to remove). The overshoot is at most one quarter step,
+/// and `clamp_effect_surface_scale` still bounds the result against the
+/// texture-dimension limit and the per-surface byte budget.
 fn magnifying_layer_scale(layer_scale: f32) -> f32 {
-    if layer_scale.is_finite() {
-        layer_scale.max(1.0)
-    } else {
-        1.0
+    if !layer_scale.is_finite() || layer_scale <= 1.0 {
+        return 1.0;
     }
+    (layer_scale * LAYER_SCALE_QUANTUM).ceil() / LAYER_SCALE_QUANTUM
 }
 
 impl SurfaceRequirementSet {
@@ -299,6 +312,67 @@ mod tests {
             2.0,
             "without a scaling transform the composite is 1:1 and the extra density is waste"
         );
+    }
+
+    /// Regression: an ANIMATING scale walked straight through `ScaleBucket`'s
+    /// ~0.004 float-noise quantisation and produced a distinct surface size
+    /// every frame, so the layer's antialiasing was recomputed at a new
+    /// sub-pixel phase per frame. Neighbouring frames must land on one scale.
+    #[test]
+    fn neighbouring_animation_frames_share_one_target_scale() {
+        let requirements =
+            SurfaceRequirementSet::default().with(SurfaceRequirement::NonTranslationTransform);
+
+        // The demo's "Scale + Fade" lambda sweeps 0.85 -> 1.15.
+        let scales: Vec<f32> = (0..=40)
+            .map(|frame| 0.85 + 0.3 * (frame as f32 / 40.0))
+            .collect();
+        let mut distinct: Vec<f32> = scales
+            .iter()
+            .map(|scale| requirements.target_scale(1.0, *scale))
+            .collect();
+        distinct.dedup();
+
+        assert_eq!(
+            distinct,
+            vec![1.0, 1.25],
+            "a 41-frame sweep must resolve to two densities, not 41"
+        );
+    }
+
+    /// The quantisation may only ever round UP: rounding down would put the
+    /// texture below the layer's effective device scale and hand back exactly
+    /// the softness this path exists to remove.
+    #[test]
+    fn quantised_target_scale_is_never_below_the_effective_scale() {
+        let requirements =
+            SurfaceRequirementSet::default().with(SurfaceRequirement::NonTranslationTransform);
+
+        for step in 0..=64 {
+            let layer_scale = 1.0 + step as f32 * 0.0625;
+            let target_scale = requirements.target_scale(2.0, layer_scale);
+            assert!(
+                target_scale >= 2.0 * layer_scale - 1e-4,
+                "layer_scale={layer_scale} resolved at {target_scale}, below its own density"
+            );
+            assert!(
+                target_scale <= 2.0 * (layer_scale + 0.25),
+                "layer_scale={layer_scale} overshot a quarter step at {target_scale}"
+            );
+        }
+    }
+
+    /// Whole and quarter scales are already on the ladder, so the density they
+    /// ask for is the density they get.
+    #[test]
+    fn scales_on_the_quantisation_ladder_are_exact() {
+        let requirements =
+            SurfaceRequirementSet::default().with(SurfaceRequirement::NonTranslationTransform);
+
+        assert_eq!(requirements.target_scale(3.0, 4.0), 12.0);
+        assert_eq!(requirements.target_scale(3.0, 2.0), 6.0);
+        assert_eq!(requirements.target_scale(2.0, 1.25), 2.5);
+        assert_eq!(requirements.target_scale(2.0, 1.0), 2.0);
     }
 
     #[test]

--- a/crates/cranpose-services/src/camera.rs
+++ b/crates/cranpose-services/src/camera.rs
@@ -65,6 +65,13 @@ pub trait Camera: Send + Sync {
     fn capture_still(&self) -> Option<CameraStill> {
         None
     }
+    /// Toggle the capture device's torch (flashlight) while the session runs.
+    /// Scanner-style apps light dim scenes instead of trying to analyze
+    /// photon-starved frames. Returns `false` where the device has no torch
+    /// or the backend has none wired; the torch dies with the session.
+    fn set_torch(&self, _on: bool) -> bool {
+        false
+    }
     /// Stop the session and release the device.
     fn stop(&self);
 }

--- a/crates/cranpose-ui/src/subcompose_layout.rs
+++ b/crates/cranpose-ui/src/subcompose_layout.rs
@@ -339,20 +339,31 @@ impl<'a> SubcomposeMeasureScopeImpl<'a> {
             expected_children.push(NodeId::try_from(node_id).ok()?);
         }
 
-        if let Some(virtual_node_ids) = self.activate_current_active_slot_roots(slot_id) {
-            for virtual_node_id in &virtual_node_ids {
-                self.composer.record_subcompose_child(*virtual_node_id);
+        let virtual_node_ids = match self.activate_current_active_slot_roots(slot_id) {
+            Some(virtual_node_ids) => {
+                for virtual_node_id in &virtual_node_ids {
+                    self.composer.record_subcompose_child(*virtual_node_id);
+                }
+                virtual_node_ids
             }
-            return Some((
-                expected_children
-                    .into_iter()
-                    .map(SubcomposeChild::new)
-                    .collect(),
-                true,
-            ));
+            None => self.activate_recycled_exact_retained_slot_roots(slot_id)?,
+        };
+
+        // Always read the LIVE roots out of the applier and compare them against
+        // the caller's cached list. Reporting `children_match = true` from the
+        // cached ids alone is a lie whenever the slot recomposed and emitted a
+        // different set of root children: the caller would reuse the cached
+        // measurement, and any newly composed root would never be measured or
+        // placed.
+        //
+        // Flush queued composer commands first so the read sees the tree the
+        // last recomposition actually produced. Every caller runs this on the
+        // very next statement (`children_need_relayout`), and it is a no-op once
+        // applied, so this only moves the flush one statement earlier.
+        if !self.ensure_pending_commands_applied() {
+            return None;
         }
 
-        let virtual_node_ids = self.activate_recycled_exact_retained_slot_roots(slot_id)?;
         let mut activated_children = Vec::with_capacity(expected_children.len());
         for virtual_node_id in virtual_node_ids {
             activated_children.extend(
@@ -569,14 +580,26 @@ impl<'a> SubcomposeMeasureScopeImpl<'a> {
         (self.retained_measure_registrar)(measurements);
     }
 
-    pub(crate) fn children_need_measure(&mut self, children: &[SubcomposeChild]) -> bool {
+    /// Whether any slot root child still owes layout work — either a re-measure
+    /// (`needs_measure`) or a placement-only repass (`needs_layout`).
+    ///
+    /// Both must be checked. `schedule_layout_repass` (scroll offsets, text
+    /// field panning) bubbles `needs_layout` *without* `needs_measure` on
+    /// purpose, so that reaching the root does not bump the global layout cache
+    /// epoch and wipe every cached measurement in the app. A caller that only
+    /// asked "do you need measuring?" would call such a subtree clean and reuse
+    /// the cached measurement, freezing the scroll on screen.
+    ///
+    /// Stays O(number of slot roots): dirty bubbling already lifted any
+    /// descendant's dirtiness onto these roots, so no subtree walk is needed.
+    pub(crate) fn children_need_relayout(&mut self, children: &[SubcomposeChild]) -> bool {
         if !self.ensure_pending_commands_applied() {
             return true;
         }
 
         let mut root_ids = smallvec::SmallVec::<[NodeId; 8]>::new();
         root_ids.extend(children.iter().map(SubcomposeChild::node_id));
-        self.composer.nodes_need_measure(&root_ids)
+        self.composer.nodes_need_measure(&root_ids) || self.composer.nodes_need_layout(&root_ids)
     }
 
     pub(crate) fn ensure_cached_measurement_node_ids<I>(

--- a/crates/cranpose-ui/src/tests/lazy_list_recompose_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_list_recompose_tests.rs
@@ -14,6 +14,7 @@ use std::rc::Rc;
 thread_local! {
     static LAST_LAZY_STATE: RefCell<Option<LazyListState>> = const { RefCell::new(None) };
     static GROWING_LAZY_LIST_CALL_COUNT: Cell<usize> = const { Cell::new(0) };
+    static LAST_INNER_ROW_SCROLL_STATE: RefCell<Option<ScrollState>> = const { RefCell::new(None) };
 }
 
 struct CountingPreparedTextMeasurer {
@@ -429,6 +430,56 @@ fn TallCachedLazyTextList(body: Rc<String>) {
     );
 }
 
+/// A `LazyColumn` whose single item hosts a horizontally scrollable `Row`.
+///
+/// This mirrors the on-device shape that froze: the inner scroll container is a
+/// direct root child of the lazy item's slot, so a scroll-driven *layout-only*
+/// repass has to survive the item's measurement cache.
+#[composable]
+#[allow(non_snake_case)]
+fn LazyItemWithScrollableRow() {
+    let list_state = remember_lazy_list_state();
+    let row_scroll = cranpose_core::remember(|| ScrollState::new(0.0)).with(ScrollState::clone);
+    LAST_INNER_ROW_SCROLL_STATE.with(|cell| {
+        *cell.borrow_mut() = Some(row_scroll.clone());
+    });
+
+    LazyColumn(
+        Modifier::empty().fill_max_width().height(240.0),
+        list_state,
+        LazyColumnSpec::default(),
+        move |scope| {
+            let row_scroll = row_scroll.clone();
+            scope.item(Some(0), None, move || {
+                Row(
+                    Modifier::empty()
+                        .fill_max_width()
+                        .height(60.0)
+                        .horizontal_scroll(row_scroll.clone(), false),
+                    RowSpec::default(),
+                    || {
+                        Text(
+                            "Chip A".to_string(),
+                            Modifier::empty().width(300.0).height(40.0),
+                            TextStyle::default(),
+                        );
+                        Text(
+                            "Chip B".to_string(),
+                            Modifier::empty().width(300.0).height(40.0),
+                            TextStyle::default(),
+                        );
+                        Text(
+                            "Chip C".to_string(),
+                            Modifier::empty().width(300.0).height(40.0),
+                            TextStyle::default(),
+                        );
+                    },
+                );
+            });
+        },
+    );
+}
+
 fn render_texts(composition: &mut Composition<MemoryApplier>, root: NodeId) -> Vec<String> {
     render_text_records(composition, root)
         .into_iter()
@@ -439,6 +490,7 @@ fn render_texts(composition: &mut Composition<MemoryApplier>, root: NodeId) -> V
 #[derive(Debug)]
 struct RenderedText {
     value: String,
+    x: f32,
     y: f32,
 }
 
@@ -480,6 +532,7 @@ fn render_text_records_with_size(
         .filter_map(|op| match op {
             RenderOp::Text { rect, value, .. } => Some(RenderedText {
                 value: value.clone(),
+                x: rect.x,
                 y: rect.y,
             }),
             _ => None,
@@ -518,6 +571,14 @@ fn text_y(records: &[RenderedText], value: &str) -> f32 {
         .find(|record| record.value == value)
         .unwrap_or_else(|| panic!("expected rendered text {value:?}, got {records:?}"))
         .y
+}
+
+fn text_x(records: &[RenderedText], value: &str) -> f32 {
+    records
+        .iter()
+        .find(|record| record.value == value)
+        .unwrap_or_else(|| panic!("expected rendered text {value:?}, got {records:?}"))
+        .x
 }
 
 fn measure_root(composition: &mut Composition<MemoryApplier>, root: NodeId, size: Size) {
@@ -916,6 +977,57 @@ fn cached_lazy_item_keeps_unbounded_child_measurement_when_placed() {
     assert!(
         cached.height > 900.0,
         "cached lazy item placement must retain the unbounded child measurement instead of viewport-clamping it, got {cached_records:?}"
+    );
+}
+
+#[test]
+fn scrolling_a_row_inside_a_cached_lazy_item_moves_its_rendered_children() {
+    // Regression: a scrollable Row nested in a LazyColumn item updated its
+    // ScrollState but never moved on screen. `dispatch_raw_delta` bubbles
+    // *layout* dirtiness only, and the lazy item's cache-reuse gate consulted
+    // `needs_measure` alone, so the cached measurement (with the stale offset)
+    // was replayed forever. Assert rendered geometry, not state: asserting
+    // `value_non_reactive()` is exactly what let this ship green.
+    let _app_context = crate::render_state::app_context_test_scope();
+    let mut composition = Composition::new(MemoryApplier::new());
+    composition
+        .render(
+            location_key(file!(), line!(), column!()),
+            LazyItemWithScrollableRow,
+        )
+        .expect("initial render");
+    let root = composition.root().expect("lazy list root");
+
+    let viewport = Size {
+        width: 320.0,
+        height: 240.0,
+    };
+    let initial_records = render_text_records_with_size(&mut composition, root, viewport);
+    let initial_x = text_x(&initial_records, "Chip B");
+
+    let row_scroll = LAST_INNER_ROW_SCROLL_STATE
+        .with(|cell| cell.borrow().clone())
+        .expect("inner row scroll state captured");
+    assert!(
+        row_scroll.max_value() > 100.0,
+        "inner row must actually overflow its viewport, max_value={}",
+        row_scroll.max_value()
+    );
+
+    let applied = row_scroll.dispatch_raw_delta(120.0);
+    assert!(
+        (applied - 120.0).abs() < 0.001,
+        "scroll state should accept the full delta, applied={applied}"
+    );
+
+    let scrolled_records = render_text_records_with_size(&mut composition, root, viewport);
+    let scrolled_x = text_x(&scrolled_records, "Chip B");
+
+    assert!(
+        (initial_x - scrolled_x - 120.0).abs() < 0.5,
+        "scrolling the Row inside a lazy item must move its rendered children left by the \
+         scroll delta: initial x={initial_x:.1}, after 120px scroll x={scrolled_x:.1}, \
+         records={scrolled_records:?}"
     );
 }
 
@@ -1354,5 +1466,78 @@ fn scroll_to_item_updates_child_indicator_scope() {
     assert!(
         texts.iter().any(|text| text == "Child first visible 20"),
         "expected child indicator text to track scroll_to_item target; texts={texts:?}"
+    );
+}
+
+/// A lazy item that grows a second *root* child when `show_extra` flips.
+#[composable]
+#[allow(non_snake_case)]
+fn GrowingRootChildLazyItemList(show_extra: MutableState<bool>) {
+    let list_state = remember_lazy_list_state();
+    LazyColumn(
+        Modifier::empty().fill_max_width().height(240.0),
+        list_state,
+        LazyColumnSpec::default(),
+        move |scope| {
+            scope.item(Some(0), None, move || {
+                Text(
+                    "Grown base row".to_string(),
+                    Modifier::empty().height(30.0),
+                    TextStyle::default(),
+                );
+                if show_extra.value() {
+                    Text(
+                        "Grown extra root".to_string(),
+                        Modifier::empty().height(30.0),
+                        TextStyle::default(),
+                    );
+                }
+            });
+        },
+    );
+}
+
+#[test]
+fn recomposed_lazy_item_places_a_newly_emitted_root_child() {
+    // Regression: `activate_exact_retained_slot_with_known_children` reported
+    // `children_match = true` straight from the CACHED id list whenever the slot
+    // was still active, without ever asking the applier what the slot's live
+    // roots were. A root child added by recomposition was therefore invisible to
+    // the lazy item's reuse gate and never got measured or placed.
+    let _app_context = crate::render_state::app_context_test_scope();
+    let mut composition = Composition::new(MemoryApplier::new());
+    let runtime = composition.runtime_handle();
+    let show_extra = MutableState::with_runtime(false, runtime);
+    composition
+        .render(location_key(file!(), line!(), column!()), move || {
+            GrowingRootChildLazyItemList(show_extra);
+        })
+        .expect("initial render");
+    let root = composition.root().expect("lazy list root");
+    let viewport = Size {
+        width: 320.0,
+        height: 240.0,
+    };
+    let initial = render_text_records_with_size(&mut composition, root, viewport);
+    assert!(
+        !initial.iter().any(|r| r.value == "Grown extra root"),
+        "extra root must not render before the state flips, got {initial:?}"
+    );
+
+    show_extra.set(true);
+    while composition
+        .process_invalid_scopes()
+        .expect("grow lazy item root children")
+    {}
+
+    let grown = render_text_records_with_size(&mut composition, root, viewport);
+    assert!(
+        grown.iter().any(|r| r.value == "Grown extra root"),
+        "a root child newly emitted by a cached lazy item must be measured and placed, \
+         got {grown:?}"
+    );
+    assert!(
+        (text_y(&grown, "Grown extra root") - 30.0).abs() < 0.5,
+        "the new root child must be placed below its sibling, got {grown:?}"
     );
 }

--- a/crates/cranpose-ui/src/widgets/lazy_list.rs
+++ b/crates/cranpose-ui/src/widgets/lazy_list.rs
@@ -200,7 +200,7 @@ fn measure_lazy_list_item(
         if let Some((root_children, children_match)) =
             scope.activate_exact_retained_slot_with_known_children(slot_id, &cached.item.node_ids)
         {
-            let children_are_clean = !scope.children_need_measure(&root_children);
+            let children_are_clean = !scope.children_need_relayout(&root_children);
             if children_match && children_are_clean {
                 retained_measurement_batch.extend(cached.retained_children.iter().cloned());
                 inputs.measured_item_cache.borrow_mut().record_exact_reuse();
@@ -257,7 +257,7 @@ fn measure_lazy_list_item(
         content_type,
         &root_node_ids,
     ) {
-        if !scope.children_need_measure(&root_children) {
+        if !scope.children_need_relayout(&root_children) {
             scope.register_retained_measurements(&cached.retained_children);
             return cached.item;
         }

--- a/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
+++ b/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
@@ -530,7 +530,7 @@ fn watch_collapse(controller: &Rc<SwipeToDismissController>) {
                     // only bubbles *layout* (placement) dirtiness up the tree,
                     // which does not set the row node's own `needs_measure` flag —
                     // and that flag is exactly what an enclosing `LazyColumn`
-                    // consults (`children_need_measure`) before reusing a cached
+                    // consults (`children_need_relayout`) before reusing a cached
                     // item slot. `schedule_measure_repass` bubbles *measure*
                     // dirtiness so the list actually re-measures the shrinking
                     // row; otherwise the pre-dismiss height and the still-composed

--- a/crates/cranpose/src/ios.rs
+++ b/crates/cranpose/src/ios.rs
@@ -15,6 +15,7 @@ use crate::wgpu_surface::{current_surface_texture, surface_present_required, Sur
 use crate::winit_pointer::{
     is_primary_pointer_button, pointer_source_from_button, pointer_source_from_winit,
 };
+use crate::winit_touch::{TouchLeave, TouchPointerRouter, TouchRoute};
 use cranpose_app_shell::{default_root_key, AppShell};
 use cranpose_platform_desktop_winit::DesktopWinitPlatform;
 use cranpose_render_wgpu::WgpuRenderer;
@@ -58,6 +59,9 @@ struct IosApp<F: FnMut() + 'static> {
     /// Wakes the event loop for runtime-driven frames (animations, async work).
     event_proxy: EventLoopProxy,
     launch_error: Rc<RefCell<Option<LaunchError>>>,
+    /// Maps winit's per-finger ids onto the shell's primary/secondary pointer
+    /// ids so multi-touch gestures (pinch-zoom) see more than one pointer.
+    touch_router: TouchPointerRouter,
 }
 
 impl<F: FnMut() + 'static> IosApp<F> {
@@ -79,6 +83,7 @@ impl<F: FnMut() + 'static> IosApp<F> {
             last_keyboard_bottom: 0.0,
             event_proxy,
             launch_error,
+            touch_router: TouchPointerRouter::default(),
         }
     }
 
@@ -411,9 +416,19 @@ impl<F: FnMut() + 'static> ApplicationHandler for IosApp<F> {
                 position, source, ..
             } => {
                 let logical = self.platform.pointer_position(position);
+                // Route by finger: a second finger's move belongs to its own
+                // pointer, not to the cursor.
+                let route = self.touch_router.moved(&source);
                 if let Some(shell) = self.shell.as_mut() {
                     shell.set_pointer_source(pointer_source_from_winit(&source));
-                    if shell.set_cursor(logical.x, logical.y) {
+                    let changed = match route {
+                        TouchRoute::Primary => shell.set_cursor(logical.x, logical.y),
+                        TouchRoute::Secondary(id) => {
+                            shell.secondary_pointer_moved(id, logical.x, logical.y, None)
+                        }
+                        TouchRoute::Untracked => false,
+                    };
+                    if changed {
                         window.request_redraw();
                     }
                 }
@@ -425,28 +440,70 @@ impl<F: FnMut() + 'static> ApplicationHandler for IosApp<F> {
                 ..
             } if is_primary_pointer_button(&button) => {
                 let logical = self.platform.pointer_position(position);
-                if let Some(shell) = self.shell.as_mut() {
-                    shell.set_pointer_source(pointer_source_from_button(&button));
-                    let changed = match state {
-                        ElementState::Pressed => {
-                            shell.set_cursor(logical.x, logical.y);
-                            shell.pointer_pressed()
+                match state {
+                    ElementState::Pressed => {
+                        let route = self.touch_router.press(&button);
+                        if let Some(shell) = self.shell.as_mut() {
+                            shell.set_pointer_source(pointer_source_from_button(&button));
+                            let changed = match route {
+                                TouchRoute::Primary => {
+                                    shell.set_cursor(logical.x, logical.y);
+                                    shell.pointer_pressed()
+                                }
+                                TouchRoute::Secondary(id) => {
+                                    shell.secondary_pointer_pressed(id, logical.x, logical.y, None)
+                                }
+                                TouchRoute::Untracked => false,
+                            };
+                            if changed {
+                                window.request_redraw();
+                            }
                         }
-                        // Touch lift-off positions must not become velocity
-                        // samples (see AppShell::pointer_released_at_position).
-                        ElementState::Released => {
-                            shell.pointer_released_at_position(logical.x, logical.y)
+                    }
+                    ElementState::Released => {
+                        let release = self.touch_router.release(&button);
+                        if let Some(shell) = self.shell.as_mut() {
+                            shell.set_pointer_source(pointer_source_from_button(&button));
+                            let mut changed = false;
+                            // Fingers left over from a primary lift close first,
+                            // so the gesture's Ended step lands on the primary.
+                            for id in release.secondaries {
+                                changed |= shell
+                                    .secondary_pointer_released(id, logical.x, logical.y, None);
+                            }
+                            // Touch lift-off positions must not become velocity
+                            // samples (see AppShell::pointer_released_at_position).
+                            if release.releases_primary {
+                                changed |= shell.pointer_released_at_position(logical.x, logical.y);
+                            }
+                            if changed {
+                                window.request_redraw();
+                            }
                         }
-                    };
-                    if changed {
-                        window.request_redraw();
                     }
                 }
             }
-            WindowEvent::PointerLeft { .. } => {
+            WindowEvent::PointerLeft { position, kind, .. } => {
+                // iOS emits one of these per finger, so cancelling the gesture
+                // unconditionally would tear down a pinch the moment either
+                // finger leaves.
+                let leave = self.touch_router.left(&kind);
+                let logical = position.map(|position| self.platform.pointer_position(position));
                 if let Some(shell) = self.shell.as_mut() {
-                    shell.cancel_gesture();
-                    window.request_redraw();
+                    match leave {
+                        TouchLeave::CancelGesture => {
+                            shell.cancel_gesture();
+                            window.request_redraw();
+                        }
+                        TouchLeave::ReleaseSecondary(id) => {
+                            shell.set_pointer_source(cranpose_app_shell::PointerSource::Touch);
+                            let (x, y) = logical.map_or((0.0, 0.0), |point| (point.x, point.y));
+                            if shell.secondary_pointer_released(id, x, y, None) {
+                                window.request_redraw();
+                            }
+                        }
+                        TouchLeave::Ignore => {}
+                    }
                 }
             }
             WindowEvent::RedrawRequested => {

--- a/crates/cranpose/src/ios_camera.rs
+++ b/crates/cranpose/src/ios_camera.rs
@@ -20,7 +20,7 @@ use objc2_av_foundation::{
     AVCapturePhotoCaptureDelegate, AVCapturePhotoOutput, AVCapturePhotoSettings,
     AVCapturePrimaryConstituentDeviceRestrictedSwitchingBehaviorConditions,
     AVCapturePrimaryConstituentDeviceSwitchingBehavior, AVCaptureSession,
-    AVCaptureSessionPresetPhoto, AVCaptureVideoDataOutput,
+    AVCaptureSessionPresetPhoto, AVCaptureTorchMode, AVCaptureVideoDataOutput,
     AVCaptureVideoDataOutputSampleBufferDelegate, AVMediaType, AVMediaTypeVideo, AVVideoCodecKey,
     AVVideoCodecTypeJPEG,
 };
@@ -45,6 +45,18 @@ fn latest() -> &'static Mutex<Option<CameraFrame>> {
     SLOT.get_or_init(|| Mutex::new(None))
 }
 
+/// Recycled RGBA buffers for [`frame_from_sample`]. The delegate replaces
+/// [`latest`] ~25×/s; a fresh multi-MB `Vec` per frame fragments the app
+/// heap against any concurrently running inference's transient buffers
+/// (measured on a phone: each SAM encode grew the process footprint ~500MB
+/// while frames interleaved, straight into a jetsam kill — with frame
+/// delivery paused the identical workload stayed flat). Replaced frames
+/// park their allocation here; steady state allocates nothing.
+fn buffer_pool() -> &'static Mutex<Vec<Vec<u8>>> {
+    static POOL: OnceLock<Mutex<Vec<Vec<u8>>>> = OnceLock::new();
+    POOL.get_or_init(|| Mutex::new(Vec::new()))
+}
+
 /// Holds the running session alive. Its AVFoundation objects are only touched
 /// from `start`/`stop` (the app's single preview-pump thread) and the frame
 /// delegate (its own dispatch queue, which only writes [`latest`]); marking it
@@ -52,6 +64,8 @@ fn latest() -> &'static Mutex<Option<CameraFrame>> {
 struct SessionHolder {
     session: Retained<AVCaptureSession>,
     photo_output: Retained<AVCapturePhotoOutput>,
+    /// The capture device, kept for mid-session reconfiguration (torch).
+    device: Retained<AVCaptureDevice>,
     _delegate: Retained<FrameDelegate>,
     _queue: DispatchRetained<DispatchQueue>,
 }
@@ -85,6 +99,30 @@ impl Camera for IosCamera {
         capture_photo()
     }
 
+    fn set_torch(&self, on: bool) -> bool {
+        let Ok(slot) = session_slot().lock() else {
+            return false;
+        };
+        let Some(holder) = slot.as_ref() else {
+            return false;
+        };
+        let device = &holder.device;
+        let mode = if on {
+            AVCaptureTorchMode::On
+        } else {
+            AVCaptureTorchMode::Off
+        };
+        if !unsafe { device.hasTorch() } || !unsafe { device.isTorchModeSupported(mode) } {
+            return false;
+        }
+        if unsafe { device.lockForConfiguration() }.is_err() {
+            return false;
+        }
+        unsafe { device.setTorchMode(mode) };
+        unsafe { device.unlockForConfiguration() };
+        true
+    }
+
     fn stop(&self) {
         if let Ok(mut slot) = session_slot().lock() {
             if let Some(holder) = slot.take() {
@@ -115,7 +153,13 @@ define_class!(
         ) {
             if let Some(frame) = frame_from_sample(sample_buffer) {
                 if let Ok(mut slot) = latest().lock() {
-                    *slot = Some(frame);
+                    if let Some(old) = slot.replace(frame) {
+                        if let Ok(mut pool) = buffer_pool().lock() {
+                            if pool.len() < 3 {
+                                pool.push(old.rgba);
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -245,7 +289,15 @@ fn frame_from_sample(sample: &CMSampleBuffer) -> Option<CameraFrame> {
     // in-app viewfinder is upright in portrait. Output is `height` x `width`.
     let out_w = height;
     let out_h = width;
-    let mut rgba = vec![0u8; out_w * out_h * 4];
+    // Recycle a parked buffer when one fits (clear keeps capacity, so after
+    // the first few frames this allocates nothing at all).
+    let mut rgba = buffer_pool()
+        .lock()
+        .ok()
+        .and_then(|mut pool| pool.pop())
+        .unwrap_or_default();
+    rgba.clear();
+    rgba.resize(out_w * out_h * 4, 0);
     if !base.is_null() && bytes_per_row >= width * 4 {
         for sy in 0..height {
             let src_row = unsafe { base.add(sy * bytes_per_row) };
@@ -396,6 +448,7 @@ fn start_session() -> Result<String, CameraError> {
         *slot = Some(SessionHolder {
             session,
             photo_output,
+            device,
             _delegate: delegate,
             _queue: queue,
         });

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -157,6 +157,13 @@ mod desktop_input;
 #[cfg(any(feature = "desktop-shell", all(feature = "ios", target_os = "ios")))]
 mod winit_pointer;
 
+/// Multi-touch id routing for the winit ingress. Only the iOS shell consumes it
+/// today (desktop pointers are single-finger), but it is built on every target
+/// that compiles the winit translation so its tests run on the host.
+#[cfg(any(feature = "desktop-shell", all(feature = "ios", target_os = "ios")))]
+#[cfg_attr(not(all(feature = "ios", target_os = "ios")), allow(dead_code))]
+mod winit_touch;
+
 /// Renderer-agnostic robot testing harness shared by the desktop shells.
 #[cfg(all(
     feature = "robot",

--- a/crates/cranpose/src/winit_touch.rs
+++ b/crates/cranpose/src/winit_touch.rs
@@ -1,0 +1,423 @@
+//! Maps winit's per-finger [`FingerId`]s onto the shell's pointer id space.
+//!
+//! winit reports every finger of a multi-touch interaction as its own opaque
+//! [`FingerId`]. The shell has a single *primary* pointer (id `0`, driven by
+//! `set_cursor`/`pointer_pressed`/`pointer_released_at_position`) plus the
+//! `secondary_pointer_*` family for the additional fingers of a gesture. Without
+//! this mapping every finger collapses onto pointer `0`: `TransformGesture`
+//! never sees two pointers (so pinch is unreachable) and the scroll modifier's
+//! `event.id != 0` arbitration cannot tell a second finger from the first.
+//!
+//! The routing mirrors the Android ingress (`android::shell_pointer_id` and
+//! `push_pending_inputs_from_android_event`), which is the contract
+//! `AppShell::secondary_pointer_*` was written against:
+//!
+//! * the finger that starts the gesture drives the primary pointer,
+//! * every other finger gets a stable non-zero id for as long as it is down,
+//! * when the primary finger lifts the whole gesture ends — the remaining
+//!   secondaries are released first, then the primary — and the next finger
+//!   down starts a fresh gesture.
+//!
+//! Android can quote each finger's own coordinates when it closes the
+//! secondaries left over from a primary lift, because its `MotionEvent` carries
+//! the whole pointer set. winit delivers one finger per event, so the leftover
+//! secondaries are released at the lifting finger's position. Nothing consumes
+//! the position of a secondary `Up` (`TransformGesture` only drops the entry,
+//! and the scroll/zoom modifiers ignore non-zero ids there), so this costs
+//! nothing.
+
+use winit::event::{ButtonSource, FingerId, PointerKind, PointerSource as WinitPointerSource};
+
+/// Which shell pointer a winit pointer event drives.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TouchRoute {
+    /// The shell's primary pointer (id `0`).
+    Primary,
+    /// An additional finger of a multi-touch gesture, with a stable non-zero id
+    /// for `AppShell::secondary_pointer_*`.
+    Secondary(u64),
+    /// A finger the router is not tracking: it either arrived while another
+    /// gesture owned the primary pointer and has since been retired, or its
+    /// press was never seen. Dropping it keeps stray fingers from hijacking the
+    /// primary pointer mid-gesture.
+    Untracked,
+}
+
+/// What a finger lifting has to dispatch, in order.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct TouchRelease {
+    /// Secondary pointer ids to release first, in ascending id order.
+    pub(crate) secondaries: Vec<u64>,
+    /// Whether the shell's primary pointer is released afterwards.
+    pub(crate) releases_primary: bool,
+}
+
+/// What a `PointerLeft` has to dispatch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TouchLeave {
+    /// Cancel the whole gesture (`AppShell::cancel_gesture`).
+    CancelGesture,
+    /// Release just this secondary pointer; the primary gesture continues.
+    ReleaseSecondary(u64),
+    /// Nothing to do — this finger's stream already ended.
+    Ignore,
+}
+
+/// Tracks the fingers of the in-flight gesture and hands out shell pointer ids.
+#[derive(Debug, Default)]
+pub(crate) struct TouchPointerRouter {
+    /// The finger that started the gesture; drives the primary pointer.
+    primary: Option<FingerId>,
+    /// Additional fingers currently down, with their assigned shell ids.
+    secondaries: Vec<(FingerId, u64)>,
+    /// Next id to hand out. Reset with the gesture so ids stay small.
+    next_secondary_id: u64,
+}
+
+/// The finger carried by a pointer event, when it is a touch.
+fn button_finger(button: &ButtonSource) -> Option<FingerId> {
+    match button {
+        ButtonSource::Touch { finger_id, .. } => Some(*finger_id),
+        _ => None,
+    }
+}
+
+fn source_finger(source: &WinitPointerSource) -> Option<FingerId> {
+    match source {
+        WinitPointerSource::Touch { finger_id, .. } => Some(*finger_id),
+        _ => None,
+    }
+}
+
+fn kind_finger(kind: &PointerKind) -> Option<FingerId> {
+    match kind {
+        PointerKind::Touch(finger_id) => Some(*finger_id),
+        _ => None,
+    }
+}
+
+impl TouchPointerRouter {
+    /// True while no finger of a gesture is tracked.
+    fn is_idle(&self) -> bool {
+        self.primary.is_none() && self.secondaries.is_empty()
+    }
+
+    fn secondary_id(&self, finger: FingerId) -> Option<u64> {
+        self.secondaries
+            .iter()
+            .find(|(tracked, _)| *tracked == finger)
+            .map(|(_, id)| *id)
+    }
+
+    fn end_gesture(&mut self) {
+        self.primary = None;
+        self.secondaries.clear();
+        self.next_secondary_id = 0;
+    }
+
+    /// Routes a pressed `PointerButton`.
+    ///
+    /// Non-touch buttons (mouse, stylus contact) always drive the primary
+    /// pointer — they are single-pointer devices as far as the shell is
+    /// concerned.
+    pub(crate) fn press(&mut self, button: &ButtonSource) -> TouchRoute {
+        let Some(finger) = button_finger(button) else {
+            return TouchRoute::Primary;
+        };
+
+        match self.primary {
+            None => {
+                self.primary = Some(finger);
+                TouchRoute::Primary
+            }
+            Some(primary) if primary == finger => TouchRoute::Primary,
+            Some(_) => {
+                if let Some(id) = self.secondary_id(finger) {
+                    return TouchRoute::Secondary(id);
+                }
+                self.next_secondary_id += 1;
+                let id = self.next_secondary_id;
+                self.secondaries.push((finger, id));
+                TouchRoute::Secondary(id)
+            }
+        }
+    }
+
+    /// Routes a `PointerMoved`. Fingers that are not tracked are dropped rather
+    /// than moved onto the primary pointer.
+    pub(crate) fn moved(&self, source: &WinitPointerSource) -> TouchRoute {
+        let Some(finger) = source_finger(source) else {
+            return TouchRoute::Primary;
+        };
+        if self.primary == Some(finger) {
+            return TouchRoute::Primary;
+        }
+        match self.secondary_id(finger) {
+            Some(id) => TouchRoute::Secondary(id),
+            None => TouchRoute::Untracked,
+        }
+    }
+
+    /// Routes a released `PointerButton`.
+    pub(crate) fn release(&mut self, button: &ButtonSource) -> TouchRelease {
+        let primary_only = TouchRelease {
+            secondaries: Vec::new(),
+            releases_primary: true,
+        };
+        let Some(finger) = button_finger(button) else {
+            return primary_only;
+        };
+
+        if self.primary == Some(finger) {
+            // The gesture is anchored to the primary pointer, so its lift ends
+            // the whole gesture: close the fingers still down, then the primary.
+            let mut secondaries: Vec<u64> = self.secondaries.iter().map(|(_, id)| *id).collect();
+            secondaries.sort_unstable();
+            self.end_gesture();
+            return TouchRelease {
+                secondaries,
+                releases_primary: true,
+            };
+        }
+
+        if let Some(id) = self.secondary_id(finger) {
+            self.secondaries.retain(|(tracked, _)| *tracked != finger);
+            return TouchRelease {
+                secondaries: vec![id],
+                releases_primary: false,
+            };
+        }
+
+        // An untracked finger. While a gesture is live it must not close it —
+        // that is the fingers-left-over-after-a-primary-lift case. With nothing
+        // tracked this is the ordinary trailing release, which still ends the
+        // shell's pointer stream (matching the Android `ACTION_UP` fallthrough).
+        if self.is_idle() {
+            primary_only
+        } else {
+            TouchRelease::default()
+        }
+    }
+
+    /// Routes a `PointerLeft`.
+    ///
+    /// iOS emits one of these per finger — after the matching release for a
+    /// normal lift, and *instead* of a release when the system cancels the
+    /// touch. Cancelling the whole gesture on every one of them (the previous
+    /// behaviour) tears down the primary gesture the moment a second finger
+    /// leaves, which is exactly what a pinch does.
+    pub(crate) fn left(&mut self, kind: &PointerKind) -> TouchLeave {
+        let Some(finger) = kind_finger(kind) else {
+            self.end_gesture();
+            return TouchLeave::CancelGesture;
+        };
+
+        if self.primary == Some(finger) {
+            self.end_gesture();
+            return TouchLeave::CancelGesture;
+        }
+
+        if let Some(id) = self.secondary_id(finger) {
+            self.secondaries.retain(|(tracked, _)| *tracked != finger);
+            return TouchLeave::ReleaseSecondary(id);
+        }
+
+        // Untracked: the trailing `PointerLeft` of a finger whose release was
+        // already dispatched. Only forward it as a cancel when no gesture is in
+        // flight, preserving the single-finger behaviour this replaced.
+        if self.is_idle() {
+            TouchLeave::CancelGesture
+        } else {
+            TouchLeave::Ignore
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use winit::event::MouseButton;
+
+    fn finger(raw: usize) -> FingerId {
+        FingerId::from_raw(raw)
+    }
+
+    fn touch_button(raw: usize) -> ButtonSource {
+        ButtonSource::Touch {
+            finger_id: finger(raw),
+            force: None,
+        }
+    }
+
+    fn touch_source(raw: usize) -> WinitPointerSource {
+        WinitPointerSource::Touch {
+            finger_id: finger(raw),
+            force: None,
+        }
+    }
+
+    /// The regression: iOS discarded the `FingerId`, so a second finger's Down
+    /// reached the shell as another primary press. Two Downs with DIFFERENT
+    /// finger ids must produce a primary AND a secondary pointer.
+    #[test]
+    fn two_touch_downs_with_different_finger_ids_produce_a_primary_and_a_secondary() {
+        let mut router = TouchPointerRouter::default();
+
+        assert_eq!(router.press(&touch_button(11)), TouchRoute::Primary);
+        assert_eq!(router.press(&touch_button(22)), TouchRoute::Secondary(1));
+    }
+
+    #[test]
+    fn a_third_finger_gets_its_own_stable_non_zero_id() {
+        let mut router = TouchPointerRouter::default();
+
+        router.press(&touch_button(11));
+        assert_eq!(router.press(&touch_button(22)), TouchRoute::Secondary(1));
+        assert_eq!(router.press(&touch_button(33)), TouchRoute::Secondary(2));
+        // Ids stay put for the life of the gesture.
+        assert_eq!(
+            router.moved(&touch_source(22)),
+            TouchRoute::Secondary(1),
+            "a finger must keep its id across moves"
+        );
+        assert_eq!(router.moved(&touch_source(33)), TouchRoute::Secondary(2));
+    }
+
+    #[test]
+    fn moves_route_each_finger_to_its_own_pointer() {
+        let mut router = TouchPointerRouter::default();
+        router.press(&touch_button(11));
+        router.press(&touch_button(22));
+
+        assert_eq!(router.moved(&touch_source(11)), TouchRoute::Primary);
+        assert_eq!(router.moved(&touch_source(22)), TouchRoute::Secondary(1));
+    }
+
+    #[test]
+    fn moves_from_an_untracked_finger_do_not_steal_the_primary_pointer() {
+        let mut router = TouchPointerRouter::default();
+        router.press(&touch_button(11));
+
+        assert_eq!(router.moved(&touch_source(99)), TouchRoute::Untracked);
+    }
+
+    #[test]
+    fn lifting_a_secondary_finger_leaves_the_primary_gesture_running() {
+        let mut router = TouchPointerRouter::default();
+        router.press(&touch_button(11));
+        router.press(&touch_button(22));
+
+        assert_eq!(
+            router.release(&touch_button(22)),
+            TouchRelease {
+                secondaries: vec![1],
+                releases_primary: false,
+            }
+        );
+        assert_eq!(router.moved(&touch_source(11)), TouchRoute::Primary);
+    }
+
+    #[test]
+    fn lifting_the_primary_finger_closes_the_secondaries_first() {
+        let mut router = TouchPointerRouter::default();
+        router.press(&touch_button(11));
+        router.press(&touch_button(22));
+        router.press(&touch_button(33));
+
+        assert_eq!(
+            router.release(&touch_button(11)),
+            TouchRelease {
+                secondaries: vec![1, 2],
+                releases_primary: true,
+            }
+        );
+        // The gesture is over; the fingers still down are retired.
+        assert_eq!(router.moved(&touch_source(22)), TouchRoute::Untracked);
+    }
+
+    #[test]
+    fn a_new_finger_after_the_gesture_ends_becomes_the_next_primary() {
+        let mut router = TouchPointerRouter::default();
+        router.press(&touch_button(11));
+        router.release(&touch_button(11));
+
+        assert_eq!(router.press(&touch_button(44)), TouchRoute::Primary);
+        assert_eq!(
+            router.press(&touch_button(55)),
+            TouchRoute::Secondary(1),
+            "secondary ids restart with each gesture"
+        );
+    }
+
+    #[test]
+    fn pointer_left_for_a_secondary_finger_does_not_cancel_the_gesture() {
+        let mut router = TouchPointerRouter::default();
+        router.press(&touch_button(11));
+        router.press(&touch_button(22));
+
+        assert_eq!(
+            router.left(&PointerKind::Touch(finger(22))),
+            TouchLeave::ReleaseSecondary(1)
+        );
+        assert_eq!(router.moved(&touch_source(11)), TouchRoute::Primary);
+    }
+
+    #[test]
+    fn pointer_left_trailing_a_release_still_cancels_once_the_gesture_is_over() {
+        let mut router = TouchPointerRouter::default();
+        router.press(&touch_button(11));
+        router.release(&touch_button(11));
+
+        assert_eq!(
+            router.left(&PointerKind::Touch(finger(11))),
+            TouchLeave::CancelGesture,
+            "the single-finger sequence must behave as it did before"
+        );
+    }
+
+    #[test]
+    fn pointer_left_trailing_a_secondary_release_is_ignored_mid_gesture() {
+        let mut router = TouchPointerRouter::default();
+        router.press(&touch_button(11));
+        router.press(&touch_button(22));
+        router.release(&touch_button(22));
+
+        assert_eq!(
+            router.left(&PointerKind::Touch(finger(22))),
+            TouchLeave::Ignore
+        );
+    }
+
+    #[test]
+    fn pointer_left_for_the_primary_finger_cancels_the_gesture() {
+        let mut router = TouchPointerRouter::default();
+        router.press(&touch_button(11));
+        router.press(&touch_button(22));
+
+        assert_eq!(
+            router.left(&PointerKind::Touch(finger(11))),
+            TouchLeave::CancelGesture
+        );
+        assert!(router.is_idle());
+    }
+
+    #[test]
+    fn mouse_input_always_drives_the_primary_pointer() {
+        let mut router = TouchPointerRouter::default();
+
+        let button = ButtonSource::Mouse(MouseButton::Left);
+        assert_eq!(router.press(&button), TouchRoute::Primary);
+        assert_eq!(
+            router.moved(&WinitPointerSource::Mouse),
+            TouchRoute::Primary
+        );
+        assert_eq!(
+            router.release(&button),
+            TouchRelease {
+                secondaries: Vec::new(),
+                releases_primary: true,
+            }
+        );
+        assert_eq!(router.left(&PointerKind::Mouse), TouchLeave::CancelGesture);
+    }
+}


### PR DESCRIPTION
Three framework bugs, all surfaced by putting interactive content inside a `LazyColumn` in a downstream app. None were in the app.

## 1. A layout-only change inside a lazy item never reaches layout

Symptom: swipe a horizontally scrolling `Row` inside a `LazyColumn` item — nothing moves. Then any later unrelated touch redraws it as if the swipe had happened.

`dispatch_raw_delta` → `schedule_layout_repass` → `bubble_layout_dirty` marks `needs_layout` only, deliberately not `needs_measure`. But the lazy item's reuse gate consulted `Composer::nodes_need_measure`, which inspects `needs_measure` alone — so the cached measurement was returned verbatim and `ScrollNode::measure` never re-ran. A frame *is* scheduled throughout.

Headless repro, same widget in a plain `Column` vs a `LazyColumn` item:

```
PLAIN  scroll: tile x 240 -> 120   state_value=120   ok
LAZY   scroll: tile x 240 -> 240   state_value=120   frozen
```

Second defect of the same family: `activate_exact_retained_slot_with_known_children` asserted `children_match = true` from the *cached* id list without comparing live children, so a node newly emitted as a direct root child of a lazy item's slot was never measured or placed.

## 2. iOS pinch was unreachable, and two fingers thrashed any scroller

`ios.rs` destructured winit's `FingerId` away, so every finger arrived as pointer id 0. `TransformGesture` keys on that id, so a second finger *updated* the first entry — `pointer_count()` never reached 2. It also defeated the scroll modifier's own `event.id != 0` arbitration, so each finger reset the drag origin and the delta alternated by the full finger separation.

Additionally `winit-uikit` emits `PointerLeft` per finger and we called `cancel_gesture()` on every one — so even with correct routing, a pinch would die the moment either finger lifted.

## 3. Zoom magnified a 1x-rasterized texture

A non-pure-translation transform forces an offscreen surface, but `target_scale()` ignored the layer's own scale and `surface_target_size()` sized from the untransformed rect. Zoom therefore never resolved more detail at any scale.

Two limits are documented in the commit rather than hidden: a moving pinch now re-rasterizes per frame (no hysteresis invented — the existing `ScaleBucket` is float-noise quantisation, and `quantize_motion_stable_target_scale` only applies to `Box4`), and full-screen layers gain nothing because the 8 MB per-surface budget already binds at plain device scale.

## Why all three shipped green

The tests asserted the wrong layer. `scroll_tests.rs` asserts `scroll_state.value_non_reactive()` — the state the swipe *did* correctly update — and never checks rendered geometry. `zoom_tests.rs` drives the gesture handler with synthetic pointer ids, so it never exercises the ingress that fabricates them. The end-to-end pinch test calls `shell.secondary_pointer_*` directly, asserting the **Android** ingress contract while iOS was never wired up at all.

The 21 new tests assert **rendered geometry** and construct the **real winit payload types**.

## Also in this PR

The last commit carries work that was already in the working tree and is not part of the above: iOS camera torch control (`Camera::set_torch` + `AVCaptureTorchMode`), and a byte ceiling on `image_texture_cache` so a live camera republishing a multi-MB bitmap per frame cannot pin ~1.5 GB of dead preview textures against the iOS jetsam limit. Both ship here because the downstream app consumes them from a local checkout and cannot move to a published dependency without them.

## Verification

`cranpose-ui` 672 (670 + the 2 new lazy tests), `cranpose-core` 662, `cranpose-app-shell` 106, `cranpose-render-wgpu` 334 + 9 new surface-scale tests, `cranpose` 12 new touch-router tests. `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)