### PR TITLE
In-app purchases: a cross-platform API plus a StoreKit 2 backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,7 @@ dependencies = [
  "cranpose-render-pixels",
  "cranpose-render-wgpu",
  "cranpose-services",
+ "cranpose-storekit",
  "cranpose-ui",
  "dispatch2",
  "jni",
@@ -1032,6 +1033,13 @@ dependencies = [
  "web-sys",
  "webbrowser",
  "webpki-root-certs",
+]
+
+[[package]]
+name = "cranpose-storekit"
+version = "0.1.77"
+dependencies = [
+ "cranpose-services",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "apps/desktop-demo",
     "apps/desktop-demo-platform",
     "crates/cranpose-services",
+    "crates/cranpose-storekit",
     "xtask",
 ]
 resolver = "2"
@@ -55,6 +56,7 @@ cranpose-render-pixels = { path = "crates/cranpose-render/pixels", version = "0.
 cranpose-render-wgpu = { path = "crates/cranpose-render/wgpu", version = "0.1.77" }
 cranpose-runtime-std = { path = "crates/cranpose-runtime-std", version = "0.1.77" }
 cranpose-services = { path = "crates/cranpose-services", version = "0.1.77", default-features = false }
+cranpose-storekit = { path = "crates/cranpose-storekit", version = "0.1.77", default-features = false }
 cranpose-ui = { path = "crates/cranpose-ui", version = "0.1.77" }
 cranpose-ui-graphics = { path = "crates/cranpose-ui-graphics", version = "0.1.77" }
 cranpose-ui-layout = { path = "crates/cranpose-ui-layout", version = "0.1.77" }

--- a/crates/cranpose-services/src/lib.rs
+++ b/crates/cranpose-services/src/lib.rs
@@ -17,6 +17,7 @@ pub mod network_status;
 pub mod notifier;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod peer;
+pub mod purchases;
 pub mod share_sheet;
 pub mod theme;
 pub mod uri_handler;
@@ -68,6 +69,10 @@ pub use notifier::{
 pub use peer::{
     content_length, fetch_range, fetch_to_writer, ByteSource, BytesSource, FetchResult, PeerError,
     PeerServer, SourceResolver,
+};
+pub use purchases::{
+    clear_platform_purchases, purchases, set_platform_purchases, store_available, store_state,
+    Product, PurchaseEvent, Purchases, PurchasesRef, StorePhase, StoreState,
 };
 pub use share_sheet::{
     clear_platform_share_sheet, default_share_sheet, local_share_sheet, set_platform_share_sheet,

--- a/crates/cranpose-services/src/purchases.rs
+++ b/crates/cranpose-services/src/purchases.rs
@@ -1,0 +1,284 @@
+//! In-app purchases: products, prices and owned entitlements.
+//!
+//! The shape is the one every mobile store agrees on — ask for a set of
+//! product ids, get back localized prices, start a purchase, and be told what
+//! the account owns — with the store-specific parts (StoreKit, Play Billing)
+//! living in platform backends installed via [`set_platform_purchases`].
+//!
+//! **The default backend reports [`StorePhase::Unavailable`] and owns
+//! nothing.** It deliberately does *not* grant entitlements: a desktop build
+//! with no store must not silently unlock paid features because a backend
+//! failed to register. An app that ships free on storeless platforms decides
+//! that itself, e.g.
+//!
+//! ```no_run
+//! # use cranpose_services::purchases::{store_state, StorePhase};
+//! let unlocked = match store_state().phase {
+//!     // No store on this platform — this app is free there.
+//!     StorePhase::Unavailable => true,
+//!     _ => store_state().owns("com.example.pro"),
+//! };
+//! ```
+//!
+//! # Reading state
+//!
+//! [`store_state`] is a cheap snapshot, safe to call every frame: backends
+//! keep the state and hand out a clone. State changes arrive asynchronously
+//! (the store answers over the network, another device restores a purchase,
+//! a parent approves an Ask-to-Buy request), so read it from the frame loop
+//! rather than expecting a reply to [`purchase`].
+//!
+//! [`take_event`] drains one-shot events — the things a snapshot cannot
+//! express, like "the user cancelled" — for showing a message once.
+
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+use std::rc::Rc;
+
+/// A product as the store describes it, in the user's locale and currency.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Product {
+    /// Store product identifier, as configured in App Store Connect or the
+    /// Play Console.
+    pub id: String,
+    /// Price formatted by the store for the user's storefront — "$34.99",
+    /// "34,99 €", "¥5,000". **Always display this string**; never format a
+    /// price yourself, and never hard-code one. Stores localize currency,
+    /// separators and placement, and they apply regional price tiers.
+    pub display_price: String,
+    /// Display name configured in the store.
+    pub title: String,
+    /// Description configured in the store.
+    pub description: String,
+}
+
+/// How far along the store connection is.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum StorePhase {
+    /// No store on this platform, or no backend installed. Nothing is owned
+    /// and nothing can be bought.
+    #[default]
+    Unavailable,
+    /// A backend is installed and still talking to the store. Prices are not
+    /// known yet; owned entitlements may not be known yet either.
+    Connecting,
+    /// Product and entitlement information has been received at least once.
+    Ready,
+}
+
+/// Snapshot of everything known about the store right now.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct StoreState {
+    /// How far along the connection is.
+    pub phase: StorePhase,
+    /// Products the backend was configured with and the store answered for.
+    /// A configured product missing here is one the store does not know —
+    /// usually a typo in the id, or a product not yet approved.
+    pub products: Vec<Product>,
+    /// Product ids the account currently owns. For non-consumables and
+    /// subscriptions this is the entitlement; consumables never appear.
+    pub owned: BTreeSet<String>,
+    /// Last error reported by the store, for diagnostics. A store being
+    /// briefly unreachable is normal and not worth showing to the user.
+    pub error: Option<String>,
+    /// True while a purchase or restore the user asked for is still running,
+    /// so the UI can disable the buy button and show a spinner.
+    pub busy: bool,
+}
+
+impl StoreState {
+    /// Whether `product_id` is currently owned.
+    pub fn owns(&self, product_id: &str) -> bool {
+        self.owned.contains(product_id)
+    }
+
+    /// The product with `product_id`, if the store answered for it.
+    pub fn product(&self, product_id: &str) -> Option<&Product> {
+        self.products.iter().find(|p| p.id == product_id)
+    }
+
+    /// The localized price of `product_id`, if known.
+    pub fn display_price(&self, product_id: &str) -> Option<&str> {
+        self.product(product_id).map(|p| p.display_price.as_str())
+    }
+}
+
+/// A one-shot thing that happened, which a snapshot cannot express.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PurchaseEvent {
+    /// The purchase completed and the entitlement is in [`StoreState::owned`].
+    Purchased(String),
+    /// The user dismissed the payment sheet. Not an error; say nothing.
+    Cancelled,
+    /// The purchase needs someone else to finish it — Ask to Buy, or a
+    /// bank-side confirmation. It may complete minutes or days later, so tell
+    /// the user it is pending rather than that it failed.
+    Pending,
+    /// The purchase failed. The string is for the user.
+    Failed(String),
+    /// A restore finished. `restored` is how many entitlements it found —
+    /// zero means "nothing to restore on this account", which is worth
+    /// saying, because the user asked.
+    Restored {
+        /// Number of owned entitlements the restore turned up.
+        restored: usize,
+    },
+}
+
+/// A store backend.
+///
+/// Implementations are installed with [`set_platform_purchases`] and must be
+/// non-blocking: every method returns immediately and reports back by
+/// updating the snapshot returned from [`Purchases::state`].
+pub trait Purchases {
+    /// Declare the product ids this app sells and start talking to the store.
+    /// Called again on relaunch; backends should treat it as idempotent.
+    fn configure(&self, product_ids: &[&str]);
+
+    /// The current snapshot. Called every frame — keep it cheap.
+    fn state(&self) -> StoreState;
+
+    /// Begin a purchase. Presents the store's own payment sheet.
+    fn purchase(&self, product_id: &str);
+
+    /// Re-query what the account owns. Stores restore silently at launch, so
+    /// this is for the explicit "Restore purchases" button that Apple
+    /// requires a paid app to provide.
+    fn restore(&self);
+
+    /// Take the next pending one-shot event, if any.
+    fn take_event(&self) -> Option<PurchaseEvent>;
+}
+
+/// Shared handle to the active [`Purchases`] backend.
+pub type PurchasesRef = Rc<dyn Purchases>;
+
+/// The no-store backend: nothing is for sale and nothing is owned.
+struct NoPurchases;
+
+impl Purchases for NoPurchases {
+    fn configure(&self, _product_ids: &[&str]) {}
+
+    fn state(&self) -> StoreState {
+        StoreState::default()
+    }
+
+    fn purchase(&self, _product_id: &str) {}
+
+    fn restore(&self) {}
+
+    fn take_event(&self) -> Option<PurchaseEvent> {
+        None
+    }
+}
+
+thread_local! {
+    static PLATFORM_PURCHASES: RefCell<Option<PurchasesRef>> = const { RefCell::new(None) };
+}
+
+/// Installs a platform purchase backend, replacing any previous one.
+pub fn set_platform_purchases(purchases: PurchasesRef) {
+    PLATFORM_PURCHASES.with(|cell| *cell.borrow_mut() = Some(purchases));
+}
+
+/// Removes any registered purchase backend (tests and teardown).
+pub fn clear_platform_purchases() {
+    PLATFORM_PURCHASES.with(|cell| *cell.borrow_mut() = None);
+}
+
+/// The active backend: the platform one if installed, else the no-store
+/// backend.
+pub fn purchases() -> PurchasesRef {
+    PLATFORM_PURCHASES
+        .with(|cell| cell.borrow().clone())
+        .unwrap_or_else(|| Rc::new(NoPurchases))
+}
+
+/// Whether a real store backend is installed on this platform.
+pub fn store_available() -> bool {
+    PLATFORM_PURCHASES.with(|cell| cell.borrow().is_some())
+}
+
+/// Convenience: declare the products this app sells and connect to the store.
+pub fn configure(product_ids: &[&str]) {
+    purchases().configure(product_ids);
+}
+
+/// Convenience: the current store snapshot.
+pub fn store_state() -> StoreState {
+    purchases().state()
+}
+
+/// Convenience: begin a purchase.
+pub fn purchase(product_id: &str) {
+    purchases().purchase(product_id);
+}
+
+/// Convenience: re-query owned entitlements.
+pub fn restore() {
+    purchases().restore();
+}
+
+/// Convenience: take the next one-shot purchase event.
+pub fn take_event() -> Option<PurchaseEvent> {
+    purchases().take_event()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_backend_sells_nothing_and_owns_nothing() {
+        clear_platform_purchases();
+        let state = store_state();
+        assert_eq!(state.phase, StorePhase::Unavailable);
+        assert!(state.owned.is_empty());
+        assert!(!state.owns("com.example.pro"));
+        assert!(!store_available());
+        // Calling through with no backend must not panic.
+        configure(&["com.example.pro"]);
+        purchase("com.example.pro");
+        restore();
+        assert_eq!(take_event(), None);
+    }
+
+    #[test]
+    fn installed_backend_answers_prices_and_ownership() {
+        struct Fake;
+        impl Purchases for Fake {
+            fn configure(&self, _product_ids: &[&str]) {}
+            fn state(&self) -> StoreState {
+                StoreState {
+                    phase: StorePhase::Ready,
+                    products: vec![Product {
+                        id: "com.example.pro".into(),
+                        display_price: "34,99 €".into(),
+                        title: "Pro".into(),
+                        description: "Everything unlocked".into(),
+                    }],
+                    owned: BTreeSet::from(["com.example.pro".to_string()]),
+                    error: None,
+                    busy: false,
+                }
+            }
+            fn purchase(&self, _product_id: &str) {}
+            fn restore(&self) {}
+            fn take_event(&self) -> Option<PurchaseEvent> {
+                Some(PurchaseEvent::Purchased("com.example.pro".into()))
+            }
+        }
+        set_platform_purchases(Rc::new(Fake));
+        let state = store_state();
+        assert_eq!(state.phase, StorePhase::Ready);
+        assert!(state.owns("com.example.pro"));
+        assert_eq!(state.display_price("com.example.pro"), Some("34,99 €"));
+        assert_eq!(state.display_price("com.example.nope"), None);
+        assert!(store_available());
+        assert_eq!(
+            take_event(),
+            Some(PurchaseEvent::Purchased("com.example.pro".into()))
+        );
+        clear_platform_purchases();
+    }
+}

--- a/crates/cranpose-storekit/Cargo.toml
+++ b/crates/cranpose-storekit/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cranpose-storekit"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+readme = "README.md"
+description = "StoreKit 2 in-app purchases for Cranpose (iOS/macOS)"
+build = "build.rs"
+
+[dependencies]
+cranpose-services = { workspace = true }

--- a/crates/cranpose-storekit/README.md
+++ b/crates/cranpose-storekit/README.md
@@ -1,0 +1,75 @@
+# cranpose-storekit
+
+StoreKit 2 in-app purchases for [Cranpose](https://github.com/samoylenkodmitry/cranpose),
+implementing the cross-platform [`cranpose_services::purchases`] API on iOS and
+macOS.
+
+```rust,no_run
+use cranpose_services::purchases::{self, StorePhase};
+
+cranpose_storekit::register();
+purchases::configure(&["com.example.app.pro"]);
+
+// Read the snapshot from the frame loop — the store answers asynchronously.
+let state = purchases::store_state();
+let unlocked = match state.phase {
+    StorePhase::Unavailable => true, // no store on this platform: free here
+    _ => state.owns("com.example.app.pro"),
+};
+let price = state.display_price("com.example.app.pro").unwrap_or("");
+```
+
+On non-Apple targets `register()` is a no-op, the build script does nothing,
+and the crate compiles away — so it can sit in an Android, desktop or web
+dependency graph unchanged.
+
+## How it works
+
+StoreKit 2 is Swift-only: `Product`, `Transaction`, `Transaction.updates` and
+the on-device JWS verification have no Objective-C surface. The build script
+compiles `swift/storekit.swift` with `swiftc -emit-library -static` and links
+the archive with `+whole-archive` so Swift's autolink records survive.
+
+Two things about that link are worth knowing before changing it:
+
+- **`cargo:rustc-link-arg` does not propagate from a dependency's build
+  script.** An rlib is never linked, so a link-arg emitted here silently
+  vanishes and the build stays green with the symbol missing. Only
+  `rustc-link-lib` and `rustc-link-search` reach the final binary; the build
+  script uses those exclusively.
+- **Swift autolinking needs the toolchain path as well as the SDK path.**
+  `libswiftCompatibility56.a` and `libswiftCompatibilityPacks.a` live in the
+  Xcode toolchain, not the SDK. Without that search path the link fails in a
+  way that reads as "autolinking is broken".
+
+There is no `Frameworks/` copy step and no `@rpath`: the Swift runtime has
+shipped in the OS since iOS 12.2, so the SDK's `.tbd` stubs are all the linker
+needs.
+
+## Requirements
+
+- **`IPHONEOS_DEPLOYMENT_TARGET=15.0` (or `MACOSX_DEPLOYMENT_TARGET=12.0`) must
+  be exported.** The build script refuses to run without it, on purpose.
+  Swift's *concurrency* runtime has been in the OS only since iOS 15 / macOS
+  12; link below that and `libswift_Concurrency` resolves against Xcode's
+  Swift 5.5 back-deployment copy, whose install name is `@rpath/…`. The build
+  stays green and the app dies at launch with "Library not loaded". rustc
+  reads the same variable when it links the final binary, which is why the
+  build script insists rather than defaulting.
+- Xcode installed and selected (`xcode-select -p`), for `swiftc` and `xcrun`.
+
+## Verifying a link
+
+```bash
+export IPHONEOS_DEPLOYMENT_TARGET=15.0
+cargo build -p cranpose-storekit --example link_check --target aarch64-apple-ios
+otool -L target/aarch64-apple-ios/debug/examples/link_check | grep swift
+```
+
+Every line must be an absolute `/usr/lib/swift/…` path. A single `@rpath/…`
+entry means the deployment target slipped and the binary will not launch.
+Measured on device, simulator and macOS host with Xcode 26.5: all absolute.
+
+## License
+
+Apache-2.0

--- a/crates/cranpose-storekit/build.rs
+++ b/crates/cranpose-storekit/build.rs
@@ -1,0 +1,193 @@
+//! Compiles `swift/storekit.swift` into a static archive and tells Cargo to
+//! link it — using **only** directives that propagate from a dependency's
+//! build script all the way to the final binary link.
+//!
+//! The hazard: `cargo:rustc-link-arg` applies only to the crate that emitted
+//! it, and an rlib is never linked, so a link-arg emitted here would silently
+//! vanish — the build stays green and the symbol is simply gone. Measured: a
+//! dependency emitting `cargo:rustc-link-arg=-lNO_SUCH_LIB` produces a binary
+//! that links and runs fine, while the same bogus name via `rustc-link-lib`
+//! fails the link loudly. `rustc-link-lib` and `rustc-link-search` *do*
+//! propagate, so everything below is expressed with those two.
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+const LIB_NAME: &str = "cranpose_storekit_swift";
+
+fn main() {
+    println!("cargo:rerun-if-changed=swift/storekit.swift");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Non-Apple targets: no-op. The crate's Rust side is cfg'd to match, so
+    // Linux/Android/Windows/wasm see an empty crate and an empty build script.
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os != "ios" && target_os != "macos" {
+        return;
+    }
+
+    // Device vs simulator is NOT visible in `CARGO_CFG_TARGET_OS` — both iOS
+    // targets report "ios". Read the full triple: a `-sim` suffix means
+    // simulator, and `x86_64-apple-ios` is simulator-only (there is no Intel
+    // iPhone).
+    let target = env::var("TARGET").expect("TARGET");
+    let arch = match env::var("CARGO_CFG_TARGET_ARCH")
+        .unwrap_or_default()
+        .as_str()
+    {
+        "aarch64" => "arm64",
+        "x86_64" => "x86_64",
+        other => {
+            println!(
+                "cargo:warning=cranpose-storekit: unsupported Apple arch {other}, skipping Swift"
+            );
+            return;
+        }
+    };
+    let simulator = target.ends_with("-sim") || target == "x86_64-apple-ios";
+
+    // (xcrun --sdk name, swiftc -target suffix, toolchain lib subdir)
+    let (sdk_name, swift_triple, platform_dir) = if target_os == "ios" {
+        let deployment = deployment_target("IPHONEOS_DEPLOYMENT_TARGET", (15, 0), "iOS 15");
+        if simulator {
+            (
+                "iphonesimulator",
+                format!("{arch}-apple-ios{deployment}-simulator"),
+                "iphonesimulator",
+            )
+        } else {
+            (
+                "iphoneos",
+                format!("{arch}-apple-ios{deployment}"),
+                "iphoneos",
+            )
+        }
+    } else {
+        let deployment = deployment_target("MACOSX_DEPLOYMENT_TARGET", (12, 0), "macOS 12");
+        (
+            "macosx",
+            format!("{arch}-apple-macosx{deployment}"),
+            "macosx",
+        )
+    };
+
+    let sdk_path = xcrun(&["--sdk", sdk_name, "--show-sdk-path"])
+        .expect("xcrun --show-sdk-path (is Xcode installed and selected?)");
+    let toolchain_lib_swift = xcrun(&["--find", "swiftc"])
+        .map(PathBuf::from)
+        // .../XcodeDefault.xctoolchain/usr/bin/swiftc -> .../usr/lib/swift
+        .and_then(|p| Some(p.parent()?.parent()?.join("lib").join("swift")))
+        .expect("locate the Swift toolchain lib directory");
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"));
+    let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let source = manifest.join("swift").join("storekit.swift");
+    let archive = out_dir.join(format!("lib{LIB_NAME}.a"));
+
+    // `-emit-library -static` => a .a; `-wmo -O` => whole-module optimization,
+    // the shape a release Swift library ships in.
+    let status = Command::new("swiftc")
+        .args(["-emit-library", "-static", "-O", "-wmo"])
+        .args(["-target", &swift_triple])
+        .args(["-sdk", &sdk_path])
+        .args(["-module-name", "CranposeStoreKit"])
+        .arg("-o")
+        .arg(&archive)
+        .arg(&source)
+        .status()
+        .expect("run swiftc");
+    assert!(status.success(), "swiftc failed for {swift_triple}");
+
+    // --- the only directives that reach the final binary --------------------
+    //
+    // 1. Where our archive lives.
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    // 2. Link it whole, so every object — and therefore every
+    //    LC_LINKER_OPTION autolink record swiftc embedded (-lswiftCore,
+    //    -lswift_Concurrency, -framework StoreKit, …) — is seen by the linker.
+    //    Without `+whole-archive` the linker drops objects nothing references
+    //    yet, taking their autolink records with them.
+    println!("cargo:rustc-link-lib=static:+whole-archive={LIB_NAME}");
+    // 3. Where those autolinked Swift runtime stubs resolve. The SDK holds
+    //    libswiftCore.tbd & friends (install name
+    //    /usr/lib/swift/libswiftCore.dylib — in-OS since iOS 12.2, so no
+    //    `Frameworks/` copy and no @rpath are needed).
+    println!("cargo:rustc-link-search=native={sdk_path}/usr/lib/swift");
+    // 4. The toolchain's back-deployment compatibility archives
+    //    (libswiftCompatibility56.a, libswiftCompatibilityPacks.a). These live
+    //    in the *toolchain*, not the SDK, and are in no published recipe —
+    //    without this path the link fails in a way that reads as "autolinking
+    //    is broken".
+    let toolchain_platform = toolchain_lib_swift.join(platform_dir);
+    if toolchain_platform.is_dir() {
+        println!(
+            "cargo:rustc-link-search=native={}",
+            toolchain_platform.display()
+        );
+    }
+
+    // This crate's OWN test and example binaries only. rustc defaults
+    // `aarch64-apple-darwin` to macOS 11 — below the in-OS concurrency floor —
+    // so without an rpath `cargo test -p cranpose-storekit` aborts at start-up
+    // on a machine that is perfectly capable of running it.
+    //
+    // This is deliberately NOT the mechanism apps rely on: `rustc-link-arg`
+    // does not propagate out of a dependency's build script, so it cannot
+    // reach a downstream binary. Apps export the deployment target instead.
+    if target_os == "macos" {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
+    }
+
+    // Note: on Mach-O there is no `swiftrt.o` to fold in — that is an
+    // ELF/COFF artifact. The Swift runtime finds its metadata through Mach-O
+    // section headers, so the archive ships as swiftc emitted it.
+}
+
+/// The deployment target for this platform.
+///
+/// This is load-bearing, and its failure mode is nasty: Swift's **concurrency**
+/// runtime has shipped in the OS only since iOS 15 / macOS 12. Link below that
+/// and `libswift_Concurrency` resolves against Xcode's Swift 5.5
+/// back-deployment copy in `usr/lib/swift-5.5/<platform>/`, whose install name
+/// is `@rpath/libswift_Concurrency.dylib`. Nothing warns — the build is green
+/// and the app dies at launch with "Library not loaded".
+///
+/// The same variable is what *rustc* reads when it links the final binary, so
+/// setting it here only fixes `swiftc`'s half. It is the **app's** build that
+/// must export it, which is why an unset variable is a warning aimed at the
+/// app author rather than a value this crate can fix. An explicitly wrong
+/// value is a different thing and does fail the build.
+///
+/// Verify a real binary with the `link_check` example: every `swift` line from
+/// `otool -L` must be an absolute `/usr/lib/swift/…` path.
+fn deployment_target(var: &str, floor: (u32, u32), floor_label: &str) -> String {
+    let floor_text = format!("{}.{}", floor.0, floor.1);
+    let Ok(value) = env::var(var) else {
+        println!(
+            "cargo:warning=cranpose-storekit: {var} is not set; assuming {floor_text}. \
+             Export {var}={floor_text} in the app's build so rustc links with the same \
+             deployment target, otherwise libswift_Concurrency binds to @rpath and the app \
+             crashes at launch."
+        );
+        return floor_text;
+    };
+    let mut parts = value.split('.').map(|p| p.parse::<u32>().unwrap_or(0));
+    let major = parts.next().unwrap_or(0);
+    let minor = parts.next().unwrap_or(0);
+    assert!(
+        (major, minor) >= floor,
+        "cranpose-storekit: {var}={value} is below {floor_label}, the StoreKit 2 floor. \
+         Swift's concurrency runtime is only in the OS from {floor_label} on; linking below it \
+         produces an @rpath dependency and a launch-time crash."
+    );
+    value
+}
+
+fn xcrun(args: &[&str]) -> Option<String> {
+    let out = Command::new("xcrun").args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8(out.stdout).ok()?.trim().to_string())
+}

--- a/crates/cranpose-storekit/examples/link_check.rs
+++ b/crates/cranpose-storekit/examples/link_check.rs
@@ -1,0 +1,28 @@
+//! Links every FFI entry point into an executable so `otool -L` can prove
+//! which Swift runtime libraries the binary ended up depending on.
+//!
+//! The failure this guards against is silent: if the linker resolves
+//! `libswift_Concurrency` against Xcode's Swift 5.5 back-deployment copy
+//! instead of the one in the OS, the dependency is recorded as
+//! `@rpath/libswift_Concurrency.dylib` and the app dies at launch with
+//! "Library not loaded" — on a user's device, not on the build machine.
+//!
+//! ```text
+//! cargo build -p cranpose-storekit --example link_check --target aarch64-apple-ios
+//! otool -L target/aarch64-apple-ios/debug/examples/link_check | grep swift
+//! ```
+//!
+//! Every `swift` line must be an absolute `/usr/lib/swift/...` path.
+
+fn main() {
+    cranpose_storekit::register();
+    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    {
+        use cranpose_services::purchases::{self, Purchases};
+        purchases::configure(&["com.example.link.check"]);
+        let backend = cranpose_storekit::StoreKitPurchases;
+        backend.purchase("com.example.link.check");
+        backend.restore();
+        println!("{:?}", purchases::store_state());
+    }
+}

--- a/crates/cranpose-storekit/src/apple.rs
+++ b/crates/cranpose-storekit/src/apple.rs
@@ -1,0 +1,387 @@
+//! The Apple half: FFI to `swift/storekit.swift` plus the
+//! [`cranpose_services::purchases::Purchases`] implementation.
+
+use cranpose_services::purchases::{
+    set_platform_purchases, Product, PurchaseEvent, Purchases, StorePhase, StoreState,
+};
+use std::collections::{BTreeSet, VecDeque};
+use std::ffi::{c_char, c_void, CStr, CString};
+use std::rc::Rc;
+use std::sync::Mutex;
+
+// ---------------------------------------------------------------- ABI codes
+//
+// These mirror the `Kind`, `PhaseCode` and `EventCode` enums in
+// `swift/storekit.swift`. Both sides are in this crate and change together.
+
+const KIND_BEGIN: i32 = 0;
+const KIND_PRODUCT: i32 = 1;
+const KIND_OWNED: i32 = 2;
+const KIND_PHASE: i32 = 3;
+const KIND_EVENT: i32 = 4;
+const KIND_BUSY: i32 = 5;
+
+const PHASE_UNAVAILABLE: i32 = 0;
+const PHASE_CONNECTING: i32 = 1;
+const PHASE_READY: i32 = 2;
+
+const EVENT_PURCHASED: i32 = 0;
+const EVENT_CANCELLED: i32 = 1;
+const EVENT_PENDING: i32 = 2;
+const EVENT_FAILED: i32 = 3;
+const EVENT_RESTORED: i32 = 4;
+
+/// `(ctx, kind, arg0, arg1, a, b, c, d)` — see `swift/storekit.swift`.
+type StoreCallback = unsafe extern "C" fn(
+    *mut c_void,
+    i32,
+    i32,
+    i32,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+);
+
+extern "C" {
+    fn cranpose_storekit_start(product_ids: *const c_char, ctx: *mut c_void, cb: StoreCallback);
+    fn cranpose_storekit_purchase(product_id: *const c_char);
+    fn cranpose_storekit_restore();
+}
+
+// -------------------------------------------------------------------- state
+
+/// Everything the Swift side has told us.
+///
+/// A snapshot arrives as `begin`, a run of `product`/`owned` rows, then
+/// `phase`, which swaps the staged rows into `live` in one step — so a reader
+/// never observes a half-built product list.
+struct Shared {
+    staging: bool,
+    staged_products: Vec<Product>,
+    staged_owned: BTreeSet<String>,
+    live: StoreState,
+    events: VecDeque<PurchaseEvent>,
+}
+
+impl Shared {
+    const fn new() -> Self {
+        Self {
+            staging: false,
+            staged_products: Vec::new(),
+            staged_owned: BTreeSet::new(),
+            live: StoreState {
+                phase: StorePhase::Unavailable,
+                products: Vec::new(),
+                owned: BTreeSet::new(),
+                error: None,
+                busy: false,
+            },
+            events: VecDeque::new(),
+        }
+    }
+}
+
+static SHARED: Mutex<Shared> = Mutex::new(Shared::new());
+
+/// A poisoned mutex would mean a panic inside the callback; the state is
+/// plain data, so recovering and carrying on is strictly better for the user
+/// than propagating the panic through a StoreKit executor.
+fn shared() -> std::sync::MutexGuard<'static, Shared> {
+    SHARED.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Borrow a C string as an owned `String`. `None` for null.
+///
+/// # Safety
+/// `ptr` is either null or a NUL-terminated string valid for this call, which
+/// is what the Swift side guarantees (its buffers live for the callback's
+/// duration only, so the copy here is required, not an optimization).
+unsafe fn take(ptr: *const c_char) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    Some(CStr::from_ptr(ptr).to_string_lossy().into_owned())
+}
+
+/// The one callback the Swift side pushes everything through.
+unsafe extern "C" fn on_message(
+    _ctx: *mut c_void,
+    kind: i32,
+    arg0: i32,
+    arg1: i32,
+    a: *const c_char,
+    b: *const c_char,
+    c: *const c_char,
+    d: *const c_char,
+) {
+    let mut state = shared();
+    match kind {
+        KIND_BEGIN => {
+            state.staging = true;
+            state.staged_products.clear();
+            state.staged_owned.clear();
+        }
+        KIND_PRODUCT => {
+            let (Some(id), Some(display_price)) = (take(a), take(b)) else {
+                return;
+            };
+            state.staged_products.push(Product {
+                id,
+                display_price,
+                title: take(c).unwrap_or_default(),
+                description: take(d).unwrap_or_default(),
+            });
+        }
+        KIND_OWNED => {
+            if let Some(id) = take(a) {
+                state.staged_owned.insert(id);
+            }
+        }
+        KIND_PHASE => {
+            // Commit, but only if rows were staged: a bare phase update (the
+            // "connecting" ping at start-up) must not blank a price list the
+            // user is already looking at.
+            if state.staging {
+                state.live.products = std::mem::take(&mut state.staged_products);
+                state.live.owned = std::mem::take(&mut state.staged_owned);
+                state.staging = false;
+            }
+            state.live.phase = match arg0 {
+                PHASE_READY => StorePhase::Ready,
+                PHASE_CONNECTING => StorePhase::Connecting,
+                PHASE_UNAVAILABLE => StorePhase::Unavailable,
+                _ => StorePhase::Unavailable,
+            };
+            state.live.error = take(a);
+        }
+        KIND_BUSY => state.live.busy = arg0 != 0,
+        KIND_EVENT => {
+            let event = match arg0 {
+                EVENT_PURCHASED => PurchaseEvent::Purchased(take(a).unwrap_or_default()),
+                EVENT_CANCELLED => PurchaseEvent::Cancelled,
+                EVENT_PENDING => PurchaseEvent::Pending,
+                EVENT_FAILED => PurchaseEvent::Failed(
+                    take(a).unwrap_or_else(|| "The purchase could not be completed".to_string()),
+                ),
+                EVENT_RESTORED => PurchaseEvent::Restored {
+                    restored: arg1.max(0) as usize,
+                },
+                _ => return,
+            };
+            // Bound the queue: a UI that never drains events (a headless run,
+            // a screen the user never opens) must not grow memory forever.
+            if state.events.len() >= 32 {
+                state.events.pop_front();
+            }
+            state.events.push_back(event);
+        }
+        _ => {}
+    }
+}
+
+// ------------------------------------------------------------------ backend
+
+/// The App Store backend. Install it with [`register`].
+pub struct StoreKitPurchases;
+
+impl Purchases for StoreKitPurchases {
+    fn configure(&self, product_ids: &[&str]) {
+        // Newline-separated: product ids are `[A-Za-z0-9._-]` on both stores,
+        // so a newline cannot occur inside one and no escaping is needed.
+        let joined = product_ids.join("\n");
+        let Ok(joined) = CString::new(joined) else {
+            return;
+        };
+        // SAFETY: `joined` outlives the call; the Swift side copies what it
+        // needs before returning. `on_message` has the matching ABI and takes
+        // no context (its state is the `SHARED` static).
+        unsafe {
+            cranpose_storekit_start(joined.as_ptr(), std::ptr::null_mut(), on_message);
+        }
+    }
+
+    fn state(&self) -> StoreState {
+        shared().live.clone()
+    }
+
+    fn purchase(&self, product_id: &str) {
+        let Ok(id) = CString::new(product_id) else {
+            return;
+        };
+        // SAFETY: `id` outlives the call and is NUL-terminated.
+        unsafe { cranpose_storekit_purchase(id.as_ptr()) }
+    }
+
+    fn restore(&self) {
+        // SAFETY: no arguments; the Swift side is a no-op before `configure`.
+        unsafe { cranpose_storekit_restore() }
+    }
+
+    fn take_event(&self) -> Option<PurchaseEvent> {
+        shared().events.pop_front()
+    }
+}
+
+/// Installs StoreKit as the platform purchase backend.
+pub fn register() {
+    set_platform_purchases(Rc::new(StoreKitPurchases));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drive the callback exactly as Swift does and assert the snapshot is
+    /// committed atomically, with prices surviving a bare phase update.
+    #[test]
+    fn snapshot_commits_on_phase_and_survives_a_bare_ping() {
+        let id = CString::new("com.example.pro").unwrap();
+        let price = CString::new("34,99 €").unwrap();
+        let title = CString::new("Pro").unwrap();
+        let body = CString::new("Everything unlocked").unwrap();
+        let null = std::ptr::null();
+
+        unsafe {
+            on_message(
+                std::ptr::null_mut(),
+                KIND_BEGIN,
+                0,
+                0,
+                null,
+                null,
+                null,
+                null,
+            );
+            on_message(
+                std::ptr::null_mut(),
+                KIND_PRODUCT,
+                0,
+                0,
+                id.as_ptr(),
+                price.as_ptr(),
+                title.as_ptr(),
+                body.as_ptr(),
+            );
+            // Still staging: nothing visible yet.
+            assert!(StoreKitPurchases.state().products.is_empty());
+            on_message(
+                std::ptr::null_mut(),
+                KIND_OWNED,
+                0,
+                0,
+                id.as_ptr(),
+                null,
+                null,
+                null,
+            );
+            on_message(
+                std::ptr::null_mut(),
+                KIND_PHASE,
+                PHASE_READY,
+                0,
+                null,
+                null,
+                null,
+                null,
+            );
+        }
+
+        let state = StoreKitPurchases.state();
+        assert_eq!(state.phase, StorePhase::Ready);
+        assert_eq!(state.display_price("com.example.pro"), Some("34,99 €"));
+        assert!(state.owns("com.example.pro"));
+
+        // A "connecting" ping with no rows must not wipe the committed list.
+        unsafe {
+            on_message(
+                std::ptr::null_mut(),
+                KIND_PHASE,
+                PHASE_CONNECTING,
+                0,
+                null,
+                null,
+                null,
+                null,
+            );
+        }
+        let state = StoreKitPurchases.state();
+        assert_eq!(state.phase, StorePhase::Connecting);
+        assert_eq!(state.display_price("com.example.pro"), Some("34,99 €"));
+        assert!(state.owns("com.example.pro"));
+    }
+
+    #[test]
+    fn events_queue_and_drain_in_order_and_are_bounded() {
+        // Start from a known state; the snapshot test shares the static.
+        while StoreKitPurchases.take_event().is_some() {}
+        let msg = CString::new("card declined").unwrap();
+        let null = std::ptr::null();
+        unsafe {
+            on_message(
+                std::ptr::null_mut(),
+                KIND_EVENT,
+                EVENT_CANCELLED,
+                0,
+                null,
+                null,
+                null,
+                null,
+            );
+            on_message(
+                std::ptr::null_mut(),
+                KIND_EVENT,
+                EVENT_FAILED,
+                0,
+                msg.as_ptr(),
+                null,
+                null,
+                null,
+            );
+            on_message(
+                std::ptr::null_mut(),
+                KIND_EVENT,
+                EVENT_RESTORED,
+                3,
+                null,
+                null,
+                null,
+                null,
+            );
+        }
+        assert_eq!(
+            StoreKitPurchases.take_event(),
+            Some(PurchaseEvent::Cancelled)
+        );
+        assert_eq!(
+            StoreKitPurchases.take_event(),
+            Some(PurchaseEvent::Failed("card declined".into()))
+        );
+        assert_eq!(
+            StoreKitPurchases.take_event(),
+            Some(PurchaseEvent::Restored { restored: 3 })
+        );
+        assert_eq!(StoreKitPurchases.take_event(), None);
+
+        // An undrained queue is capped, not unbounded.
+        for _ in 0..100 {
+            unsafe {
+                on_message(
+                    std::ptr::null_mut(),
+                    KIND_EVENT,
+                    EVENT_PENDING,
+                    0,
+                    null,
+                    null,
+                    null,
+                    null,
+                );
+            }
+        }
+        let mut drained = 0;
+        while StoreKitPurchases.take_event().is_some() {
+            drained += 1;
+        }
+        assert_eq!(drained, 32);
+    }
+}

--- a/crates/cranpose-storekit/src/lib.rs
+++ b/crates/cranpose-storekit/src/lib.rs
@@ -1,0 +1,43 @@
+#![deny(missing_docs)]
+
+//! StoreKit 2 backend for [`cranpose_services::purchases`].
+//!
+//! StoreKit 2 has no Objective-C surface — `Product`, `Transaction` and the
+//! on-device JWS verification are Swift-only — so this crate compiles a small
+//! Swift shim (`swift/storekit.swift`) in its build script and links it
+//! statically. Apple recommends StoreKit 2 for anything that can require
+//! iOS 15; StoreKit 1 (`SKPaymentQueue`) is the Objective-C fallback and is
+//! deliberately not used here.
+//!
+//! On non-Apple targets the build script is a no-op and every entry point
+//! compiles away, so this crate can sit in an Android/Linux/web dependency
+//! graph unnoticed.
+//!
+//! ```no_run
+//! # #[cfg(any(target_os = "ios", target_os = "macos"))]
+//! # fn demo() {
+//! cranpose_storekit::register();
+//! cranpose_services::purchases::configure(&["com.example.app.pro"]);
+//! # }
+//! ```
+//!
+//! # Threading
+//!
+//! StoreKit answers on Swift concurrency executors, so the Swift shim calls
+//! back from arbitrary threads. All state therefore lives behind a
+//! [`std::sync::Mutex`] here, and [`cranpose_services::purchases::Purchases`]
+//! reads a clone of it from the UI thread.
+
+#[cfg(any(target_os = "ios", target_os = "macos"))]
+mod apple;
+
+#[cfg(any(target_os = "ios", target_os = "macos"))]
+pub use apple::{register, StoreKitPurchases};
+
+/// Installs the StoreKit backend — a no-op on targets without an App Store.
+///
+/// Call it before
+/// [`configure`](cranpose_services::purchases::configure); apps that also run
+/// on Android or desktop can call it unconditionally.
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+pub fn register() {}

--- a/crates/cranpose-storekit/swift/storekit.swift
+++ b/crates/cranpose-storekit/swift/storekit.swift
@@ -1,0 +1,334 @@
+// StoreKit 2 bridge for `cranpose-storekit`.
+//
+// StoreKit 2 is Swift-only — `Product`, `Transaction`, `Transaction.updates`
+// and the on-device JWS verification have no Objective-C surface, so this file
+// is the whole reason the crate compiles Swift at all. Everything here is a
+// thin translation layer: no policy, no caching decisions, no UI.
+//
+// The Rust side owns all state. Swift pushes snapshots through one C callback
+// and never answers questions synchronously, because every StoreKit call is
+// async and may block on the network or on a payment sheet.
+//
+// Threading: StoreKit callbacks arrive on Swift concurrency executors, i.e.
+// arbitrary threads. The callback into Rust is therefore made from arbitrary
+// threads and the Rust side guards its state with a mutex. Strings handed to
+// the callback are valid only for the duration of the call — Rust copies them.
+
+import Foundation
+import StoreKit
+
+// MARK: - C ABI
+
+/// Message kinds pushed to Rust. A snapshot is `begin`, then any number of
+/// `product`/`owned` rows, then `phase`, which commits it atomically.
+private enum Kind: Int32 {
+    case begin = 0
+    case product = 1
+    case owned = 2
+    case phase = 3
+    case event = 4
+    case busy = 5
+}
+
+/// Mirrors `cranpose_storekit::ffi::StorePhaseCode`.
+private enum PhaseCode: Int32 {
+    case unavailable = 0
+    case connecting = 1
+    case ready = 2
+}
+
+/// Mirrors `cranpose_storekit::ffi::EventCode`.
+private enum EventCode: Int32 {
+    case purchased = 0
+    case cancelled = 1
+    case pending = 2
+    case failed = 3
+    case restored = 4
+}
+
+/// `(ctx, kind, arg0, arg1, a, b, c, d)`.
+public typealias CranposeStoreCallback = @convention(c) (
+    UnsafeMutableRawPointer?,
+    Int32,
+    Int32,
+    Int32,
+    UnsafePointer<CChar>?,
+    UnsafePointer<CChar>?,
+    UnsafePointer<CChar>?,
+    UnsafePointer<CChar>?
+) -> Void
+
+/// Callback + context, set once by `cranpose_storekit_start`.
+///
+/// `@unchecked Sendable`: the payload is a C function pointer and an opaque
+/// pointer that Rust guarantees outlives the process (it points at a `static`).
+private final class Sink: @unchecked Sendable {
+    let callback: CranposeStoreCallback
+    let ctx: UnsafeMutableRawPointer?
+
+    init(callback: @escaping CranposeStoreCallback, ctx: UnsafeMutableRawPointer?) {
+        self.callback = callback
+        self.ctx = ctx
+    }
+
+    func send(
+        _ kind: Kind,
+        _ arg0: Int32 = 0,
+        _ arg1: Int32 = 0,
+        _ a: String? = nil,
+        _ b: String? = nil,
+        _ c: String? = nil,
+        _ d: String? = nil
+    ) {
+        // Nested `withCString` keeps every buffer alive across the call. Four
+        // levels is the whole product row; nothing needs more.
+        withOptionalCString(a) { pa in
+            withOptionalCString(b) { pb in
+                withOptionalCString(c) { pc in
+                    withOptionalCString(d) { pd in
+                        callback(ctx, kind.rawValue, arg0, arg1, pa, pb, pc, pd)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private func withOptionalCString<R>(
+    _ value: String?,
+    _ body: (UnsafePointer<CChar>?) -> R
+) -> R {
+    guard let value else { return body(nil) }
+    return value.withCString { body($0) }
+}
+
+// MARK: - Bridge state
+
+/// Process-wide bridge state. Guarded by `lock`; every field is touched from
+/// StoreKit's executors as well as from the caller's thread.
+private final class BridgeState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _sink: Sink?
+    private var _productIds: [String] = []
+    private var _started = false
+
+    static let shared = BridgeState()
+
+    var sink: Sink? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _sink
+    }
+
+    var productIds: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _productIds
+    }
+
+    /// Records the sink and ids. Returns true the first time only, so the
+    /// `Transaction.updates` listener is spawned exactly once.
+    func start(sink: Sink, productIds: [String]) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        _sink = sink
+        _productIds = productIds
+        let first = !_started
+        _started = true
+        return first
+    }
+}
+
+// MARK: - Entry points
+
+/// Connect to the App Store and begin watching for transactions.
+///
+/// `productIdsJoined` is a newline-separated list — product ids are
+/// `[A-Za-z0-9._-]`, so a newline cannot occur inside one and no escaping or
+/// JSON parser is needed on either side.
+///
+/// Safe to call again (a relaunch of the app's configure step); the
+/// transaction listener is still spawned only once.
+@_cdecl("cranpose_storekit_start")
+public func cranpose_storekit_start(
+    _ productIdsJoined: UnsafePointer<CChar>,
+    _ ctx: UnsafeMutableRawPointer?,
+    _ callback: @escaping CranposeStoreCallback
+) {
+    let ids = String(cString: productIdsJoined)
+        .split(separator: "\n")
+        .map(String.init)
+        .filter { !$0.isEmpty }
+    let sink = Sink(callback: callback, ctx: ctx)
+    let first = BridgeState.shared.start(sink: sink, productIds: ids)
+
+    guard #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) else {
+        // Below the StoreKit 2 floor. The app's deployment target should make
+        // this unreachable; report it rather than pretending to be connecting.
+        sink.send(.phase, PhaseCode.unavailable.rawValue, 0, "StoreKit 2 requires iOS 15 / macOS 12")
+        return
+    }
+
+    sink.send(.phase, PhaseCode.connecting.rawValue)
+
+    if first {
+        // Long-running: transactions that arrive without a purchase call —
+        // Ask to Buy approvals, purchases made on another device, subscription
+        // renewals, and anything the App Store retried after a crash. Apple
+        // requires this listener to exist for the app's whole lifetime.
+        Task.detached(priority: .background) {
+            for await update in Transaction.updates {
+                if case .verified(let transaction) = update {
+                    await transaction.finish()
+                }
+                await refreshSnapshot()
+            }
+        }
+    }
+
+    Task.detached(priority: .userInitiated) {
+        await refreshSnapshot()
+    }
+}
+
+/// Begin a purchase for `productId`. Presents the App Store payment sheet.
+@_cdecl("cranpose_storekit_purchase")
+public func cranpose_storekit_purchase(_ productId: UnsafePointer<CChar>) {
+    let id = String(cString: productId)
+    guard let sink = BridgeState.shared.sink else { return }
+    guard #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) else {
+        sink.send(.event, EventCode.failed.rawValue, 0, "The App Store is unavailable on this system")
+        return
+    }
+    sink.send(.busy, 1)
+    Task.detached(priority: .userInitiated) {
+        await runPurchase(id: id, sink: sink)
+        sink.send(.busy, 0)
+        await refreshSnapshot()
+    }
+}
+
+/// Re-query what this Apple ID owns, after an explicit "Restore purchases".
+///
+/// `AppStore.sync()` can prompt for the App Store password, so Apple's rule is
+/// that it runs only from a user action — never at launch. Launch restoration
+/// is what `Transaction.currentEntitlements` already does for free.
+@_cdecl("cranpose_storekit_restore")
+public func cranpose_storekit_restore() {
+    guard let sink = BridgeState.shared.sink else { return }
+    guard #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) else {
+        sink.send(.event, EventCode.failed.rawValue, 0, "The App Store is unavailable on this system")
+        return
+    }
+    sink.send(.busy, 1)
+    Task.detached(priority: .userInitiated) {
+        do {
+            try await AppStore.sync()
+        } catch {
+            // A cancelled password prompt lands here too. Report it as a
+            // finished restore that found whatever is already known, rather
+            // than as a failure — the snapshot below is still authoritative.
+            sink.send(.event, EventCode.failed.rawValue, 0, error.localizedDescription)
+        }
+        let owned = await ownedProductIds()
+        await refreshSnapshot()
+        sink.send(.event, EventCode.restored.rawValue, Int32(owned.count))
+        sink.send(.busy, 0)
+    }
+}
+
+// MARK: - StoreKit work
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private func runPurchase(id: String, sink: Sink) async {
+    do {
+        let products = try await Product.products(for: [id])
+        guard let product = products.first else {
+            sink.send(.event, EventCode.failed.rawValue, 0, "That product is not available in your region’s App Store")
+            return
+        }
+        let result = try await product.purchase()
+        switch result {
+        case .success(let verification):
+            switch verification {
+            case .verified(let transaction):
+                // Verified means Apple's signature over the transaction
+                // checked out against the device's copy of the certificate
+                // chain — this is the on-device receipt validation, and it is
+                // done before we grant anything.
+                await transaction.finish()
+                sink.send(.event, EventCode.purchased.rawValue, 0, transaction.productID)
+            case .unverified(_, let error):
+                // A transaction that fails signature verification is never
+                // granted; a jailbreak or a proxy is the usual cause.
+                sink.send(.event, EventCode.failed.rawValue, 0,
+                          "This purchase could not be verified: \(error.localizedDescription)")
+            }
+        case .userCancelled:
+            sink.send(.event, EventCode.cancelled.rawValue)
+        case .pending:
+            // Ask to Buy, or a payment method needing action. It may complete
+            // later; `Transaction.updates` is what will tell us.
+            sink.send(.event, EventCode.pending.rawValue)
+        @unknown default:
+            sink.send(.event, EventCode.failed.rawValue, 0, "The App Store returned an unexpected result")
+        }
+    } catch {
+        sink.send(.event, EventCode.failed.rawValue, 0, error.localizedDescription)
+    }
+}
+
+/// Product ids this Apple ID currently owns, signature-verified.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private func ownedProductIds() async -> [String] {
+    var owned: [String] = []
+    for await entitlement in Transaction.currentEntitlements {
+        guard case .verified(let transaction) = entitlement else { continue }
+        if transaction.revocationDate != nil { continue }
+        if let expires = transaction.expirationDate, expires < Date() { continue }
+        owned.append(transaction.productID)
+    }
+    return owned
+}
+
+/// Fetch products + entitlements and push one committed snapshot.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private func refreshSnapshot() async {
+    guard let sink = BridgeState.shared.sink else { return }
+    let ids = BridgeState.shared.productIds
+
+    var products: [Product] = []
+    var failure: String?
+    if !ids.isEmpty {
+        do {
+            products = try await Product.products(for: Set(ids))
+        } catch {
+            failure = error.localizedDescription
+        }
+    }
+    let owned = await ownedProductIds()
+
+    sink.send(.begin)
+    for product in products {
+        sink.send(
+            .product, 0, 0,
+            product.id,
+            product.displayPrice,
+            product.displayName,
+            product.description
+        )
+    }
+    for id in owned {
+        sink.send(.owned, 0, 0, id)
+    }
+    // Entitlements are authoritative even when the product lookup failed, so
+    // a store outage never revokes an unlock the user already paid for: the
+    // phase still commits as ready, with the error attached for diagnostics.
+    let ready = failure == nil || !owned.isEmpty
+    sink.send(
+        .phase,
+        (ready ? PhaseCode.ready : PhaseCode.connecting).rawValue,
+        0,
+        failure
+    )
+}

--- a/crates/cranpose/Cargo.toml
+++ b/crates/cranpose/Cargo.toml
@@ -96,6 +96,11 @@ renderer-wgpu = ["cranpose-render-wgpu", "dep:wgpu", "dep:pollster"]
 # ~0.7 MiB). On by default; drop via `default-features = false` if the app
 # uses only framework effects.
 robot = ["cranpose-app-shell/test-support"] # Enable robot testing support (cranpose-ui now always included)
+# In-app purchases through StoreKit 2 on iOS/macOS, registered into
+# `cranpose_services::purchases`. Off by default: it links the StoreKit
+# framework and compiles a Swift shim, which an app that sells nothing should
+# not pay for. Harmless to enable on non-Apple targets — it compiles away.
+storekit = ["dep:cranpose-storekit"]
 
 [dependencies]
 cranpose-app-shell = { workspace = true }
@@ -153,6 +158,7 @@ js-sys = { version = "0.3", optional = true }
 log = "0.4"
 cranpose-liquid = { workspace = true }
 cranpose-services = { workspace = true, default-features = false }
+cranpose-storekit = { workspace = true, default-features = false, optional = true }
 thiserror = "2.0.18"
 web-time = { workspace = true }
 cranpose-render-common.workspace = true

--- a/crates/cranpose/src/ios.rs
+++ b/crates/cranpose/src/ios.rs
@@ -575,6 +575,9 @@ pub fn try_run(settings: AppSettings, content: impl FnMut() + 'static) -> Result
     crate::ios_background::register();
     crate::ios_writable_folder::register();
     crate::ios_camera::register();
+    // Opt-in: only apps that sell something link StoreKit and the Swift shim.
+    #[cfg(feature = "storekit")]
+    cranpose_storekit::register();
 
     let event_loop = EventLoop::builder()
         .build()


### PR DESCRIPTION
Adds the purchase surface Cranpose was missing, in two pieces.

**`cranpose_services::purchases`** — the app-facing API. Ask for a set of product ids, get back store-localized prices and the set of owned entitlements, start a purchase, restore. Backends register through `set_platform_purchases`, the same shape as camera/picker/haptics.

The default backend reports `StorePhase::Unavailable` and **owns nothing**. It deliberately does not grant entitlements: a desktop build with no store must not unlock paid features just because a backend failed to register. Apps that ship free on storeless platforms say so explicitly by matching on the phase.

**`cranpose-storekit`** — the Apple backend, behind a new `storekit` feature (off by default; an app that sells nothing should not link StoreKit or compile Swift). StoreKit 2 has no Objective-C surface — `Product`, `Transaction.updates` and the on-device JWS verification are Swift-only — so the crate compiles `swift/storekit.swift` in its build script and links it statically. Signature verification happens before anything is granted; `.unverified` is refused.

### Things about this link that are in no published recipe

- **`cargo:rustc-link-arg` does not propagate from a dependency's build script.** An rlib is never linked, so a link-arg emitted there silently vanishes. Measured: a dependency emitting `-lNO_SUCH_LIB` produces a binary that links and runs fine, while the same bogus name via `rustc-link-lib` fails the link loudly. Only `rustc-link-lib` and `rustc-link-search` reach the binary, and the build script uses those exclusively.
- **Swift autolinking needs the toolchain search path as well as the SDK one.** `libswiftCompatibility56.a` and `libswiftCompatibilityPacks.a` are toolchain archives, not SDK ones. Miss that path and the link fails in a way that reads as broken autolinking.
- **`swiftrt.o` does not exist on Apple platforms.** It is an ELF/COFF artifact; Mach-O discovers Swift metadata from section headers, so there is nothing to fold into the archive.

### The sharp edge: deployment target

Swift's *concurrency* runtime has been in the OS only since iOS 15 / macOS 12. Link below that and `libswift_Concurrency` binds to Xcode's Swift 5.5 back-deployment copy as `@rpath/libswift_Concurrency.dylib` — green build, `Library not loaded` crash at launch on the user's device. This reproduced on the macOS host, where rustc defaults `aarch64-apple-darwin` to macOS 11.

rustc reads the same variable when it links the final binary, so the build script warns when it is unset and hard-fails on a value below the floor. The `link_check` example exists to prove a real binary:

```bash
export IPHONEOS_DEPLOYMENT_TARGET=15.0
cargo build -p cranpose-storekit --example link_check --target aarch64-apple-ios
otool -L target/aarch64-apple-ios/debug/examples/link_check | grep swift
```

Every line must be an absolute `/usr/lib/swift/…` path.

### Verified

| | |
|---|---|
| `aarch64-apple-ios` link | all absolute `/usr/lib/swift/…` |
| `aarch64-apple-ios-sim` link | all absolute, `StoreKit.framework` autolinked |
| macOS host `cargo test` | 2 pass (snapshot commit atomicity, event queue bounds) |
| `cranpose --features ios,renderer-wgpu,storekit` | checks clean for `aarch64-apple-ios` |
| non-Apple targets | build script no-ops, crate compiles away |

🤖 Generated with [Claude Code](https://claude.com/claude-code)