### PR TITLE
Register the StoreKit FFI as a reviewed unsafe boundary

### DIFF
--- a/crates/cranpose-storekit/src/apple.rs
+++ b/crates/cranpose-storekit/src/apple.rs
@@ -1,5 +1,9 @@
 //! The Apple half: FFI to `swift/storekit.swift` plus the
 //! [`cranpose_services::purchases::Purchases`] implementation.
+//!
+//! The reviewed FFI boundary for this crate — the crate root denies unsafe
+//! code and this is the only module that opts back in.
+#![allow(unsafe_code)]
 
 use cranpose_services::purchases::{
     set_platform_purchases, Product, PurchaseEvent, Purchases, StorePhase, StoreState,

--- a/crates/cranpose-storekit/src/lib.rs
+++ b/crates/cranpose-storekit/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+#![deny(unsafe_code)]
 
 //! StoreKit 2 backend for [`cranpose_services::purchases`].
 //!
@@ -28,6 +29,11 @@
 //! [`std::sync::Mutex`] here, and [`cranpose_services::purchases::Purchases`]
 //! reads a clone of it from the UI thread.
 
+// The crate root denies unsafe code; `apple` is the one boundary module that
+// opts back in, and it is the only place FFI lives. Same shape as cranpose's
+// own platform modules, and
+// `crates/cranpose/tests/platform_scheduling_static.rs` holds the workspace
+// list of modules allowed to do this.
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 mod apple;
 

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -1229,6 +1229,10 @@ fn workspace_ffi_boundaries_are_explicit() {
         "crates/cranpose/src/ios_background.rs",
         "crates/cranpose/src/ios_accessibility.rs",
         "crates/cranpose/src/desktop_accessibility.rs",
+        // The StoreKit 2 bridge: `extern "C"` declarations for the Swift shim
+        // plus the callback it invokes. The crate root denies unsafe code and
+        // opts this one module back in by name.
+        "crates/cranpose-storekit/src/apple.rs",
         "apps/desktop-demo-platform/src/android_entry.rs",
         "apps/isolated-demo/src/native_entry.rs",
     ];


### PR DESCRIPTION
`main` is red after #352. Two architecture contracts caught the new crate, and both were right to:

- `crate_roots_deny_unsafe_code` — `cranpose-storekit`'s root did not carry `#![deny(unsafe_code)]`.
- `workspace_ffi_boundaries_are_explicit` — its `extern "C"` block sat outside the reviewed-boundary list.

Fixed the way every other platform module in this workspace already does it: the crate root denies unsafe code, `src/apple.rs` carries the inner `#![allow(unsafe_code)]`, and the test's allow-list names it. The FFI is now confined to one module by a rule that is checked rather than by convention.

`cargo test -p cranpose --test platform_scheduling_static` → 50 passed, and `check_cranpose_versions.py` is aligned.

**How this reached `main`:** my CI watcher piped `gh pr checks --watch` into `tail` without `pipefail`, so the red exit code was masked by `tail`'s success and the script merged and tagged anyway. The `v0.1.78` tag has been deleted and the Publish run cancelled before it reached crates.io — `cranpose 0.1.78` was never published. Re-tag once this is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)