### PR TITLE
Stabilize exact visual interaction contracts

### DIFF
--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -480,3 +480,67 @@ Compounding wasters from the same session, now protocol:
   is in the file before writing.
 - Byte-diff two captures before reasoning about any knob's effect; never
   trust "looks identical" at small scales.
+
+## Remote validation directories must be source-exact (2026-08-01)
+
+Copying only `git ls-files` into a reused remote checkout leaves untracked
+source files behind. `run_robot_test.sh` discovers every Rust runner in
+`apps/desktop-demo/robot-runners`, so three runners from an earlier checkout
+silently expanded a 140-test suite to 143 and produced a failure that could
+not exist in the local tree. Matching hashes for tracked files does not catch
+this condition.
+
+Create a fresh remote source directory or compare its source-file inventory
+against `git ls-files` before validation. Preserve the prior directory under
+an `_old` name when cleanup is needed. Reuse expensive build artifacts through
+an explicit target directory, not by reusing an unaudited source tree.
+Do not combine an excluded `target` directory with `rsync --delete-excluded`:
+that option deletes the build cache it appears to protect. A fresh source tree
+with an explicit shared target directory makes source cleanup and artifact
+retention independent.
+
+When syncing several files from different source directories, never give one
+directory destination to a single `rsync` invocation. Basename placement can
+create a plausible stray `mod.rs` or module source in the wrong directory and
+invalidate the remote build. Sync each file to its exact destination path, then
+compare the remote source inventory before the expensive command.
+
+## Score the exact cheatsheet tile, not a visually similar raw crop (2026-08-02)
+
+The Liquid cheatsheet target sheets contain registered image bands, labels,
+and grid gutters. A manually cropped frame from a nearby raw gesture strip
+looked identical at normal zoom but placed the selected artwork eight pixels
+lower than the tile consumed by `extract_reference_tiles`. Tuning against that
+crop made the correct content placement measurably worse.
+
+For RMSE work, extract the exact tile from the checked-in target sheet with the
+same band/column registration as the robot contract, then normalize the actual
+frame with the same dimensions and filter. Confirm the two candidate target
+images by pixel comparison before interpreting geometry or content offsets.
+
+## Native point-grid mismatches masquerade as material errors (2026-08-02)
+
+The bottom-bar form runner registered two states from `tab_center - 70dp` and
+two from the exact stage bounds. This introduced a repeatable 4–6 physical-px
+shift at 3× and kept the sharp component score near 0.20 despite close-looking
+material. The tab-swipe fixture separately declared a 132dp stage for a
+1320×400 reference, producing a 1320×396 capture that was silently resized.
+Always derive capture bounds from one semantic stage owner and express odd
+native dimensions as physical-pixel ratios (`400.0 / 3.0`), then assert output
+dimensions before tuning optics.
+
+A zero-valued correction is not necessarily a no-op in a modifier-based layout
+engine. Installing `.offset(0, 0)` for every tab changed raster rounding enough
+to move a strict transfer RMSE across its gate. Optional optical corrections
+must omit their modifier node when they are exactly neutral; numeric equality
+inside an installed node does not guarantee structural or pixel equality.
+
+## Visible shader contracts need a production presentation path (2026-08-09)
+
+Bare `xvfb-run` creates a 640×480 display with roughly 30 Hz presentation on
+this host. External shader drag, animation, and performance contracts can fail
+there even when the renderer is correct because the demo window is clipped and
+the expected presented-frame cadence is unavailable. Use the real X11 display
+for production visual contracts. If isolation is necessary, explicitly create
+an adequately sized Xvfb screen such as `-screen 0 1920x1080x24`, and do not use
+its timing as production-performance evidence.

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -812,6 +812,11 @@ path = "robot-runners/robot_liquid_backdrop_feedback.rs"
 required-features = ["desktop", "robot-app"]
 
 [[example]]
+name = "robot_liquid_scroll_exact_external_contract"
+path = "robot-runners/robot_liquid_scroll_exact_external_contract.rs"
+required-features = ["desktop", "robot-app"]
+
+[[example]]
 name = "robot_menu_slide"
 path = "robot-runners/robot_menu_slide.rs"
 required-features = ["desktop", "robot-app"]

--- a/apps/desktop-demo/robot-runners/liquid_cheatsheets/capture.rs
+++ b/apps/desktop-demo/robot-runners/liquid_cheatsheets/capture.rs
@@ -1,7 +1,9 @@
 //! Real-X11 capture support for the static Liquid cheatsheet fixtures.
 
 use anyhow::{bail, Context, Result};
-use cranpose::Robot;
+use cranpose::{Robot, RobotScreenshot};
+use image::imageops::crop_imm;
+use image::RgbaImage;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -23,6 +25,59 @@ pub(crate) struct Crop {
 pub(crate) struct Keyframe {
     pub capture_ms: u64,
     pub label: String,
+}
+
+pub(crate) fn save_exact_robot_keyframe_crops<Label: AsRef<str>>(
+    screenshots: &[RobotScreenshot],
+    case_dir: &Path,
+    crop: Crop,
+    labels: &[Label],
+) -> Result<Vec<PathBuf>> {
+    if screenshots.len() != labels.len() {
+        bail!(
+            "exact-clock capture returned {} screenshots for {} labels",
+            screenshots.len(),
+            labels.len()
+        );
+    }
+    let output_dir = case_dir.join("actual/keyframes");
+    fs::create_dir_all(&output_dir).context("create exact-clock keyframe directory")?;
+    let mut outputs = Vec::with_capacity(screenshots.len());
+    for (index, (screenshot, label)) in screenshots.iter().zip(labels).enumerate() {
+        let scale_x = screenshot.width as f32 / screenshot.logical_width.max(f32::EPSILON);
+        let scale_y = screenshot.height as f32 / screenshot.logical_height.max(f32::EPSILON);
+        if (scale_x - scale_y).abs() > 0.01 {
+            bail!("exact-clock screenshot has non-uniform scale {scale_x}x by {scale_y}x");
+        }
+        let x = (crop.x * scale_x).round() as u32;
+        let y = (crop.y * scale_y).round() as u32;
+        let width = (crop.width * scale_x).round() as u32;
+        let height = (crop.height * scale_y).round() as u32;
+        if width == 0
+            || height == 0
+            || x.saturating_add(width) > screenshot.width
+            || y.saturating_add(height) > screenshot.height
+        {
+            bail!(
+                "exact-clock crop {width}x{height}+{x}+{y} exceeds screenshot {}x{}",
+                screenshot.width,
+                screenshot.height
+            );
+        }
+        let image = RgbaImage::from_raw(
+            screenshot.width,
+            screenshot.height,
+            screenshot.pixels.clone(),
+        )
+        .context("decode exact-clock screenshot buffer")?;
+        let output = output_dir.join(format!("{:02}-{}.png", index + 1, label.as_ref()));
+        crop_imm(&image, x, y, width, height)
+            .to_image()
+            .save(&output)
+            .with_context(|| format!("save exact-clock keyframe {}", output.display()))?;
+        outputs.push(output);
+    }
+    Ok(outputs)
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/apps/desktop-demo/robot-runners/liquid_cheatsheets/mod.rs
+++ b/apps/desktop-demo/robot-runners/liquid_cheatsheets/mod.rs
@@ -13,11 +13,11 @@ mod x11_helpers;
 
 use anyhow::{bail, Context, Result};
 use capture::{
-    capture_x11_keyframes, capture_x11_static_keyframe, compose_comparison, ActualTiming,
-    CaptureRequest, ComparisonGrid, Crop, Keyframe,
+    capture_x11_keyframes, capture_x11_static_keyframe, compose_comparison,
+    save_exact_robot_keyframe_crops, ActualTiming, CaptureRequest, ComparisonGrid, Crop, Keyframe,
 };
 use cranpose::widgets::{BasicTextFieldOptions, BasicTextFieldWithOptions, Box, BoxSpec, Text};
-use cranpose::{AppLauncher, Color, Modifier, Size};
+use cranpose::{AppLauncher, Color, Modifier, RobotTimelineAction, RobotTimelineStep, Size};
 use cranpose_foundation::text::TextFieldState;
 use cranpose_ui::text::{AnnotatedString, TextStyle, TextUnit};
 use desktop_app::app;
@@ -32,6 +32,7 @@ const TEXT_FIELD_Y: f32 = 170.0;
 const TEXT_FIELD_WIDTH: f32 = 420.0;
 const TEXT_CONTENT: &str =
     "Silence. Melody. Then beats. Subtle electronic beats goaantra trance pp ulsy catching melody";
+const IOS_FORM_REFERENCE_SCALE: f32 = 3.0;
 
 type Bounds = (f32, f32, f32, f32);
 
@@ -170,6 +171,7 @@ fn run_liquid_case(case: Case, output: PathBuf) -> Result<()> {
         .with_size(LIQUID_WINDOW_SIZE.0 as u32, LIQUID_WINDOW_SIZE.1 as u32)
         .with_fonts(desktop_app::fonts::DEMO_FONTS)
         .with_headless(false)
+        .with_robot_app_hook(move |name, argument| liquid_fixture_app_hook(case, name, argument))
         .with_test_driver(move |robot| {
             settle(&robot, 900);
             let window_id = x11_helpers::find_window_id(&driver_title);
@@ -194,6 +196,24 @@ fn run_liquid_case(case: Case, output: PathBuf) -> Result<()> {
         .try_run(move || app::LiquidReferenceFixture(fixture_case))
         .context("launch Liquid fixture")?;
     Ok(())
+}
+
+fn liquid_fixture_app_hook(
+    case: Case,
+    name: String,
+    argument: String,
+) -> std::result::Result<Option<String>, String> {
+    if case != Case::TabSwipe || name != "tab-swipe-page" {
+        return Err(format!(
+            "unsupported {} fixture app hook {name}({argument})",
+            case.slug()
+        ));
+    }
+    let page = argument
+        .parse::<usize>()
+        .map_err(|error| format!("parse tab-swipe reference page: {error}"))?;
+    app::set_tab_swipe_reference_page(page)?;
+    Ok(None)
 }
 
 fn liquid_fixture_case(case: Case) -> Result<app::LiquidReferenceFixtureCase> {
@@ -341,54 +361,186 @@ fn capture_menu_open(
 
 fn capture_tab_swipe(
     robot: &cranpose::Robot,
-    window_id: &str,
+    _window_id: &str,
     output: &Path,
 ) -> Result<Vec<PathBuf>> {
     let discover = find_button(robot, "Discover")?;
     let account = find_button(robot, "Account")?;
     let (start_x, y) = center(discover);
     let (end_x, _) = center(account);
-    let keyframes = source_keyframes(14_400, &[0, 267, 533, 800, 1_067, 1_333, 1_600, 1_867]);
-    capture_x11_keyframes(
-        robot,
-        capture_request(
-            window_id,
-            output,
-            LIQUID_WINDOW_SIZE,
-            crop_within(
-                Crop {
-                    x: (LIQUID_WINDOW_SIZE.0 - 440.0) * 0.5,
-                    y: (LIQUID_WINDOW_SIZE.1 - 132.0) * 0.5,
-                    width: 440.0,
-                    height: 132.0,
-                },
-                LIQUID_WINDOW_SIZE,
-            ),
-            Duration::from_millis(2_050),
-            &keyframes,
-        ),
-        move |robot| {
-            robot
-                .click(start_x, y)
-                .context("arm tab backdrop timeline")?;
-            robot.mouse_move(start_x, y).context("hover Discover")?;
-            robot.mouse_down().context("hold tab lens")?;
-            Ok(())
+    let tab_pitch = (end_x - start_x) / 3.0;
+    let mid_swipe_x = start_x + 1.65 * tab_pitch;
+    let wwdc_x = start_x + 2.0 * tab_pitch;
+    let initial_x = start_x + 0.55 * tab_pitch;
+    robot
+        .invoke_app_hook("tab-swipe-page", "0")
+        .context("pin initial tab-swipe backdrop page")?;
+    robot
+        .click(start_x, y)
+        .context("arm tab backdrop timeline")?;
+    let shots = capture_exact_tab_swipe(robot, y, start_x, initial_x, mid_swipe_x, end_x, wwdc_x)?;
+    let labels = TAB_SWIPE_CAPTURE_OFFSETS_MS
+        .iter()
+        .map(|offset| format!("{offset:06}ms-{}ms", 14_400 + offset))
+        .collect::<Vec<_>>();
+    let frames = save_exact_robot_keyframe_crops(
+        &shots,
+        output,
+        Crop {
+            x: (LIQUID_WINDOW_SIZE.0 - app::TAB_SWIPE_REFERENCE_STAGE_WIDTH) * 0.5,
+            y: (LIQUID_WINDOW_SIZE.1 - app::TAB_SWIPE_REFERENCE_STAGE_HEIGHT) * 0.5,
+            width: app::TAB_SWIPE_REFERENCE_STAGE_WIDTH,
+            height: app::TAB_SWIPE_REFERENCE_STAGE_HEIGHT,
         },
-        move |robot, epoch| {
-            for step in 1..=116 {
-                let at = step * 16;
-                epoch.sleep_until(at);
-                let progress = (at as f32 / 1_867.0).min(1.0);
-                robot
-                    .mouse_move(start_x + (end_x - start_x) * progress, y)
-                    .context("drag tab lens")?;
-            }
-            epoch.sleep_until(1_900);
-            robot.mouse_up().context("release tab lens")?;
-            Ok(())
-        },
-    )
+        &labels,
+    )?;
+
+    Ok(frames)
+}
+
+const TAB_SWIPE_CAPTURE_OFFSETS_MS: [u64; 8] = [0, 267, 533, 800, 1_067, 1_333, 1_600, 1_867];
+const TAB_SWIPE_REVERSAL_START_MS: u64 = 1_767;
+const TAB_SWIPE_REVERSAL_END_MS: u64 = 1_867;
+fn tab_swipe_segment_position(at_ms: u64, from_ms: u64, to_ms: u64, from_x: f32, to_x: f32) -> f32 {
+    let progress =
+        (at_ms.saturating_sub(from_ms) as f32 / (to_ms - from_ms).max(1) as f32).clamp(0.0, 1.0);
+    let eased = progress * progress * (3.0 - 2.0 * progress);
+    from_x + (to_x - from_x) * eased
+}
+
+fn exact_pointer_segment_times(duration_ms: u64) -> Vec<u64> {
+    let mut samples = Vec::new();
+    let mut at = 16;
+    while at < duration_ms {
+        samples.push(at);
+        at += 16;
+    }
+    if duration_ms > 0 {
+        samples.push(duration_ms);
+    }
+    samples
+}
+
+fn tab_swipe_linear_position(at_ms: u64, from_ms: u64, to_ms: u64, from_x: f32, to_x: f32) -> f32 {
+    let progress =
+        (at_ms.saturating_sub(from_ms) as f32 / (to_ms - from_ms).max(1) as f32).clamp(0.0, 1.0);
+    from_x + (to_x - from_x) * progress
+}
+
+fn tab_swipe_pointer_position(
+    at_ms: u64,
+    initial_x: f32,
+    mid_x: f32,
+    account_x: f32,
+    wwdc_x: f32,
+) -> Option<f32> {
+    match at_ms {
+        1..=267 => Some(tab_swipe_segment_position(at_ms, 0, 267, initial_x, mid_x)),
+        268..=650 => Some(tab_swipe_segment_position(
+            at_ms, 267, 650, mid_x, account_x,
+        )),
+        TAB_SWIPE_REVERSAL_START_MS..=TAB_SWIPE_REVERSAL_END_MS => Some(tab_swipe_linear_position(
+            at_ms,
+            TAB_SWIPE_REVERSAL_START_MS,
+            TAB_SWIPE_REVERSAL_END_MS,
+            account_x,
+            wwdc_x,
+        )),
+        _ => None,
+    }
+}
+
+fn tab_swipe_exact_timeline() -> Vec<u64> {
+    let mut times = std::collections::BTreeSet::from(TAB_SWIPE_CAPTURE_OFFSETS_MS);
+    for (start, end) in [
+        (0, 267),
+        (267, 650),
+        (TAB_SWIPE_REVERSAL_START_MS, TAB_SWIPE_REVERSAL_END_MS),
+    ] {
+        let mut at = start + 16;
+        while at < end {
+            times.insert(at);
+            at += 16;
+        }
+        times.insert(end);
+    }
+    times.extend([850, 1_660, TAB_SWIPE_REVERSAL_START_MS]);
+    times.into_iter().collect()
+}
+
+fn capture_exact_tab_swipe(
+    robot: &cranpose::Robot,
+    y: f32,
+    start_x: f32,
+    initial_x: f32,
+    mid_x: f32,
+    account_x: f32,
+    wwdc_x: f32,
+) -> Result<Vec<cranpose::RobotScreenshot>> {
+    let mut steps = vec![RobotTimelineStep {
+        advance_ms: 0.0,
+        actions: vec![
+            RobotTimelineAction::MoveTo { x: start_x, y },
+            RobotTimelineAction::MouseDown,
+        ],
+        capture: false,
+    }];
+    let mut previous_ms = 0;
+    for at_ms in exact_pointer_segment_times(160) {
+        steps.push(RobotTimelineStep {
+            advance_ms: (at_ms - previous_ms) as f32,
+            actions: vec![RobotTimelineAction::MoveTo {
+                x: tab_swipe_linear_position(at_ms, 0, 160, start_x, initial_x),
+                y,
+            }],
+            capture: false,
+        });
+        previous_ms = at_ms;
+    }
+    previous_ms = 0;
+    for at_ms in tab_swipe_exact_timeline() {
+        let advance_ms = at_ms - previous_ms;
+        previous_ms = at_ms;
+        let mut actions = Vec::new();
+        if at_ms == 850 {
+            actions.push(RobotTimelineAction::MouseUp);
+            actions.push(RobotTimelineAction::InvokeAppHook {
+                name: "tab-swipe-page".to_string(),
+                argument: "2".to_string(),
+            });
+        } else if at_ms == 1_660 {
+            actions.push(RobotTimelineAction::InvokeAppHook {
+                name: "tab-swipe-page".to_string(),
+                argument: "3".to_string(),
+            });
+            actions.push(RobotTimelineAction::MoveTo { x: account_x, y });
+            actions.push(RobotTimelineAction::MouseDown);
+        }
+        if let Some(x) = tab_swipe_pointer_position(at_ms, initial_x, mid_x, account_x, wwdc_x) {
+            actions.push(RobotTimelineAction::MoveTo { x, y });
+        }
+        steps.push(RobotTimelineStep {
+            advance_ms: advance_ms as f32,
+            actions,
+            capture: TAB_SWIPE_CAPTURE_OFFSETS_MS.contains(&at_ms),
+        });
+    }
+    steps.push(RobotTimelineStep {
+        advance_ms: (1_930 - previous_ms) as f32,
+        actions: vec![RobotTimelineAction::MouseUp],
+        capture: false,
+    });
+    let shots = robot
+        .capture_interaction_keyframes(IOS_FORM_REFERENCE_SCALE, &steps)
+        .context("capture atomic exact-clock tab-swipe interaction")?;
+    if shots.len() != TAB_SWIPE_CAPTURE_OFFSETS_MS.len() {
+        bail!(
+            "exact tab swipe captured {} frames, expected {}",
+            shots.len(),
+            TAB_SWIPE_CAPTURE_OFFSETS_MS.len()
+        );
+    }
+    Ok(shots)
 }
 
 fn capture_segmented(
@@ -1177,4 +1329,56 @@ fn TextSelectionFixture() {
             );
         },
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_tab_swipe_timeline_contains_every_reference_frame_once() {
+        let timeline = tab_swipe_exact_timeline();
+        assert!(timeline.windows(2).all(|pair| pair[0] < pair[1]));
+        for capture in TAB_SWIPE_CAPTURE_OFFSETS_MS {
+            assert_eq!(timeline.iter().filter(|time| **time == capture).count(), 1);
+        }
+        assert!(timeline.contains(&850));
+        assert!(timeline.contains(&1_660));
+        assert!(timeline.contains(&TAB_SWIPE_REVERSAL_END_MS));
+    }
+
+    #[test]
+    fn exact_tab_swipe_trajectory_preserves_speed_and_reversal_phases() {
+        let initial = 0.55;
+        let mid = 1.65;
+        let account = 3.0;
+        let wwdc = 2.0;
+        let launch =
+            tab_swipe_pointer_position(16, initial, mid, account, wwdc).expect("launch position");
+        let cruise =
+            tab_swipe_pointer_position(267, initial, mid, account, wwdc).expect("cruise position");
+        let arrival =
+            tab_swipe_pointer_position(650, initial, mid, account, wwdc).expect("arrival position");
+        let reversal = tab_swipe_pointer_position(1_817, initial, mid, account, wwdc)
+            .expect("reversal position");
+        assert!(initial < launch && launch < cruise && cruise < arrival);
+        assert_eq!(arrival, account);
+        assert!(wwdc < reversal && reversal < account);
+        assert_eq!(
+            tab_swipe_pointer_position(TAB_SWIPE_REVERSAL_END_MS, initial, mid, account, wwdc,),
+            Some(wwdc)
+        );
+    }
+
+    #[test]
+    fn exact_tab_swipe_preroll_has_real_pointer_cadence_before_frame_zero() {
+        let samples = exact_pointer_segment_times(160);
+        assert_eq!(samples.first(), Some(&16));
+        assert_eq!(samples.last(), Some(&160));
+        assert!(samples.windows(2).all(|pair| pair[1] - pair[0] <= 16));
+        assert!(samples.len() >= 10);
+        let previous = tab_swipe_linear_position(144, 0, 160, 0.0, 100.0);
+        let terminal = tab_swipe_linear_position(160, 0, 160, 0.0, 100.0);
+        assert_eq!(terminal - previous, 10.0);
+    }
 }

--- a/apps/desktop-demo/robot-runners/robot_hacker_news_scroll_exact_external_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_hacker_news_scroll_exact_external_contract.rs
@@ -62,6 +62,8 @@ fn main() {
                     step_epsilon: STEP_EPSILON,
                     fallback_trim_top_px: 96,
                     fallback_trim_bottom_px: 96,
+                    fallback_trim_left_px: 0,
+                    fallback_trim_right_px: 0,
                     compare_search_offset_px: COMPARE_SEARCH_OFFSET_PX,
                     compare_max_adjacent_score: COMPARE_MAX_ADJACENT_SCORE,
                     compare_stabilized_guard_px: COMPARE_STABILIZED_GUARD_PX,

--- a/apps/desktop-demo/robot-runners/robot_leetcodedaily_code_scroll_pixel_drift.rs
+++ b/apps/desktop-demo/robot-runners/robot_leetcodedaily_code_scroll_pixel_drift.rs
@@ -548,6 +548,8 @@ fn main() {
                     step_epsilon: STEP_EPSILON,
                     fallback_trim_top_px: 112,
                     fallback_trim_bottom_px: 88,
+                    fallback_trim_left_px: 0,
+                    fallback_trim_right_px: 0,
                     compare_search_offset_px: COMPARE_SEARCH_OFFSET_PX,
                     compare_max_adjacent_score: COMPARE_MAX_ADJACENT_SCORE,
                     compare_stabilized_guard_px: COMPARE_STABILIZED_GUARD_PX,

--- a/apps/desktop-demo/robot-runners/robot_leetcodedaily_full_layout_scroll_stability.rs
+++ b/apps/desktop-demo/robot-runners/robot_leetcodedaily_full_layout_scroll_stability.rs
@@ -9211,6 +9211,8 @@ fn main() {
                     step_epsilon: STEP_EPSILON,
                     fallback_trim_top_px: 450,
                     fallback_trim_bottom_px: 70,
+                    fallback_trim_left_px: 0,
+                    fallback_trim_right_px: 0,
                     compare_search_offset_px: COMPARE_SEARCH_OFFSET_PX,
                     compare_max_adjacent_score: COMPARE_MAX_ADJACENT_SCORE,
                     compare_stabilized_guard_px: COMPARE_STABILIZED_GUARD_PX,

--- a/apps/desktop-demo/robot-runners/robot_liquid_scroll_exact_external_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_liquid_scroll_exact_external_contract.rs
@@ -1,0 +1,349 @@
+//! Real-window pixel-stability contract for the complete Liquid UI tab.
+//!
+//! Six independent scenes are scrolled by exactly one physical pixel per
+//! frame. After compensating for that translation, every adjacent capture in
+//! the shared viewport must remain pixel-stable. This catches coordinate
+//! discontinuities shared by layout, ordinary draw layers, backdrop effects,
+//! and runtime shaders instead of pinning one widget implementation.
+
+mod output_paths;
+mod scroll_stability_external_helpers;
+mod text_showcase_external_helpers;
+
+use cranpose::AppLauncher;
+use desktop_app::app::{
+    self, DemoTab, LIQUID_SCROLL_VIEWPORT_TAG, TEST_ACTIVE_TAB_STATE, TEST_LIQUID_SCROLL_STATE,
+};
+use scroll_stability_external_helpers::{
+    advance_scroll_with_app_hook, run_presented_scroll_probe_with_app_hook,
+    run_scroll_stability_capture_with_app_hook, semantics_bounds_for_exact_text,
+    ExactScrollStepConfig, ScrollStabilityConfig,
+};
+use std::path::Path;
+use std::time::Duration;
+use text_showcase_external_helpers::scroll_text_into_view_between;
+
+const WINDOW_WIDTH: u32 = 800;
+const WINDOW_HEIGHT: u32 = 600;
+const WINDOW_TITLE: &str = "Robot Liquid Scroll Exact External";
+const SCROLL_STEPS: usize = 10;
+const LOGICAL_PHASE_SWEEP_STEPS: usize = 10;
+const STEP_EPSILON: f32 = 0.02;
+const COMPARE_SEARCH_OFFSET_PX: u32 = 32;
+// Total absolute RGBA delta across the full comparison crop. This permits at
+// most 48 one-level 8-bit sampling differences among roughly 900,000 pixels;
+// a moving edge or layer exceeds it by orders of magnitude.
+const COMPARE_MAX_ADJACENT_SCORE: u32 = 48;
+
+#[derive(Clone, Copy)]
+struct LiquidScrollScene {
+    name: &'static str,
+    target_text: &'static str,
+    target_center_range: (f32, f32),
+    trim: (u32, u32, u32, u32),
+}
+
+const SCENES: [LiquidScrollScene; 6] = [
+    LiquidScrollScene {
+        name: "optical_shader_body",
+        target_text: "wcKSRD OPTICS",
+        // Keep the navigation title beyond its intentional 52dp collapse
+        // transition so this scene isolates scrolling shader content.
+        target_center_range: (280.0, 390.0),
+        trim: (180, 180, 0, 0),
+    },
+    LiquidScrollScene {
+        name: "optical_shader_left_edge",
+        target_text: "wcKSRD OPTICS",
+        target_center_range: (280.0, 390.0),
+        // Keep the complete shader-card edge while excluding the
+        // viewport-fixed floating tab bar from the translated comparison.
+        trim: (180, 180, 0, 548),
+    },
+    LiquidScrollScene {
+        name: "optical_shader_right_edge",
+        target_text: "wcKSRD OPTICS",
+        target_center_range: (280.0, 390.0),
+        trim: (180, 180, 548, 0),
+    },
+    LiquidScrollScene {
+        name: "bottom_bar_glass",
+        target_text: "Custom Networking",
+        target_center_range: (300.0, 560.0),
+        trim: (180, 180, 0, 0),
+    },
+    LiquidScrollScene {
+        name: "controls_card",
+        target_text: "Wi-Fi",
+        target_center_range: (300.0, 560.0),
+        trim: (180, 180, 0, 0),
+    },
+    LiquidScrollScene {
+        name: "segmented_control",
+        target_text: "Receiving",
+        target_center_range: (300.0, 560.0),
+        trim: (180, 180, 0, 0),
+    },
+];
+
+fn main() {
+    env_logger::init();
+    println!("=== Robot Liquid Scroll Exact External ===");
+
+    AppLauncher::new()
+        .with_title(WINDOW_TITLE)
+        .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
+        .with_fonts(desktop_app::fonts::DEMO_FONTS)
+        .with_headless(false)
+        .with_robot_app_hook(set_tab_hook)
+        .with_test_driver(move |robot| {
+            std::thread::sleep(Duration::from_millis(900));
+            let _ = robot.wait_for_idle();
+            robot
+                .invoke_app_hook("set-tab", "liquid")
+                .expect("select Liquid UI tab");
+            settle(&robot);
+            let density = robot
+                .invoke_app_hook("liquid-density", "")
+                .expect("read Liquid UI density")
+                .expect("density hook response")
+                .parse::<f32>()
+                .expect("finite density response");
+            assert!(
+                density > 1.0,
+                "fractional-density contract requires scale > 1, got {density}"
+            );
+            let physical_pixel_delta = -1.0 / density;
+            println!(
+                "density={density:.4} logical_delta_for_one_physical_pixel={physical_pixel_delta:.6}"
+            );
+
+            // Put both large shader cards across the viewport boundary. This
+            // makes a one-row clip/surface seam visible without confusing it
+            // with content legitimately entering the viewport.
+            scroll_text_into_view_between(&robot, "wcKSRD OPTICS", 180.0, 230.0, 80);
+            settle(&robot);
+            let viewport = semantics_bounds_for_exact_text(&robot, LIQUID_SCROLL_VIEWPORT_TAG);
+            assert!(
+                run_presented_scroll_probe_with_app_hook(
+                    &robot,
+                    ScrollStabilityConfig {
+                        window_title: WINDOW_TITLE,
+                        output_name: "full_width_viewport_boundary",
+                        file_prefix: "full_width_viewport_boundary",
+                        target_text: "wcKSRD OPTICS",
+                        viewport_tag: None,
+                        window_width: WINDOW_WIDTH,
+                        window_height: WINDOW_HEIGHT,
+                        scroll_steps: LOGICAL_PHASE_SWEEP_STEPS,
+                        scroll_delta_y: -1.0,
+                        step_epsilon: STEP_EPSILON,
+                        fallback_trim_top_px: 0,
+                        fallback_trim_bottom_px: 0,
+                        fallback_trim_left_px: 0,
+                        fallback_trim_right_px: 0,
+                        compare_search_offset_px: 0,
+                        compare_max_adjacent_score: 0,
+                        compare_stabilized_guard_px: 0,
+                        compare_viewport_inset_px: 0,
+                        render_stats_env: None,
+                        active_frame: None,
+                    },
+                    "scroll-liquid-content-by",
+                    |step, path| {
+                        viewport_boundary_has_no_full_width_seam(
+                            step,
+                            path,
+                            viewport,
+                            WINDOW_WIDTH,
+                            WINDOW_HEIGHT,
+                        )
+                    },
+                ),
+                "Liquid viewport exposed a full-width boundary seam while scrolling"
+            );
+
+            let mut failed_scenes = Vec::new();
+            let scene_filter = std::env::var("CRANPOSE_LIQUID_SCROLL_SCENE").ok();
+            if let Some(filter) = scene_filter.as_deref() {
+                assert!(
+                    SCENES.iter().any(|scene| scene.name == filter),
+                    "unknown Liquid scroll scene '{filter}'"
+                );
+            }
+            for scene in SCENES {
+                if scene_filter
+                    .as_deref()
+                    .is_some_and(|filter| filter != scene.name)
+                {
+                    continue;
+                }
+                println!(
+                    "\n--- liquid scroll scene: {} ({}) ---",
+                    scene.name, scene.target_text
+                );
+                scroll_text_into_view_between(
+                    &robot,
+                    scene.target_text,
+                    scene.target_center_range.0,
+                    scene.target_center_range.1,
+                    80,
+                );
+                settle(&robot);
+
+                // Cross multiple fractional-density rounding phases before
+                // comparing complete scene crops. The viewport seam only
+                // appears at particular logical scroll offsets.
+                advance_scroll_with_app_hook(
+                    &robot,
+                    ExactScrollStepConfig {
+                        target_text: scene.target_text,
+                        window_width: WINDOW_WIDTH,
+                        window_height: WINDOW_HEIGHT,
+                        scroll_steps: LOGICAL_PHASE_SWEEP_STEPS,
+                        scroll_delta_y: -1.0,
+                        step_epsilon: STEP_EPSILON,
+                        fallback_trim_top_px: scale_trim(scene.trim.0, density),
+                        fallback_trim_bottom_px: scale_trim(scene.trim.1, density),
+                    },
+                    "scroll-liquid-content-by",
+                );
+
+                if !run_scroll_stability_capture_with_app_hook(
+                    &robot,
+                    ScrollStabilityConfig {
+                        window_title: WINDOW_TITLE,
+                        output_name: scene.name,
+                        file_prefix: scene.name,
+                        target_text: scene.target_text,
+                        viewport_tag: None,
+                        window_width: WINDOW_WIDTH,
+                        window_height: WINDOW_HEIGHT,
+                        scroll_steps: SCROLL_STEPS,
+                        scroll_delta_y: physical_pixel_delta,
+                        step_epsilon: STEP_EPSILON,
+                        fallback_trim_top_px: scale_trim(scene.trim.0, density),
+                        fallback_trim_bottom_px: scale_trim(scene.trim.1, density),
+                        fallback_trim_left_px: scale_trim(scene.trim.2, density),
+                        fallback_trim_right_px: scale_trim(scene.trim.3, density),
+                        compare_search_offset_px: COMPARE_SEARCH_OFFSET_PX,
+                        compare_max_adjacent_score: COMPARE_MAX_ADJACENT_SCORE,
+                        compare_stabilized_guard_px: 0,
+                        compare_viewport_inset_px: 0,
+                        render_stats_env: Some("CRANPOSE_LIQUID_SCROLL_RENDER_STATS"),
+                        active_frame: None,
+                    },
+                    None,
+                    "scroll-liquid-content-by",
+                ) {
+                    failed_scenes.push(scene.name);
+                }
+            }
+
+            assert!(
+                failed_scenes.is_empty(),
+                "Liquid UI layers changed after normalized one-pixel scrolling in: {}",
+                failed_scenes.join(", ")
+            );
+            println!("PASS: every Liquid UI scene stayed stable across exact 1px scrolls");
+            robot.exit().expect("exit");
+        })
+        .run(app::combined_app);
+}
+
+fn settle(robot: &cranpose::Robot) {
+    std::thread::sleep(Duration::from_millis(400));
+    let _ = robot.wait_for_idle();
+}
+
+fn scale_trim(logical: u32, density: f32) -> u32 {
+    (logical as f32 * density).round() as u32
+}
+
+fn viewport_boundary_has_no_full_width_seam(
+    step: usize,
+    path: &Path,
+    viewport: (f32, f32, f32, f32),
+    logical_window_width: u32,
+    logical_window_height: u32,
+) -> bool {
+    let image = image::open(path)
+        .unwrap_or_else(|err| panic!("failed to open {}: {err}", path.display()))
+        .to_rgb8();
+    let scale_x = image.width() as f32 / logical_window_width as f32;
+    let scale_y = image.height() as f32 / logical_window_height as f32;
+    let inset = (24.0 * scale_x).round() as u32;
+    let left = (viewport.0 * scale_x).round().max(0.0) as u32 + inset;
+    let right = ((viewport.0 + viewport.2) * scale_x)
+        .round()
+        .min(image.width() as f32) as u32
+        - inset;
+    assert!(left < right, "Liquid viewport boundary span is empty");
+
+    let boundary = ((viewport.1 + viewport.3) * scale_y)
+        .round()
+        .clamp(2.0, image.height().saturating_sub(5) as f32) as u32;
+    let mut seam = false;
+    // Both shader cards cover every row immediately inside this boundary, so
+    // their orange/purple split prevents any legitimate dominant full-width
+    // color. This catches an exposed row regardless of its actual color.
+    for row in boundary.saturating_sub(3)..boundary {
+        let (color, fraction) = dominant_row_color(&image, left, right, row);
+        println!(
+            "viewport boundary step={step} row={row} dominant={color:?} fraction={fraction:.4}"
+        );
+        seam |= fraction >= 0.85;
+    }
+    !seam
+}
+
+fn dominant_row_color(image: &image::RgbImage, left: u32, right: u32, row: u32) -> ([u8; 3], f32) {
+    let mut colors = (left..right)
+        .map(|x| image.get_pixel(x, row).0)
+        .collect::<Vec<_>>();
+    colors.sort_unstable();
+    let mut dominant = colors[0];
+    let mut dominant_count = 1usize;
+    let mut run_start = 0usize;
+    for index in 1..=colors.len() {
+        if index == colors.len() || colors[index] != colors[run_start] {
+            let count = index - run_start;
+            if count > dominant_count {
+                dominant = colors[run_start];
+                dominant_count = count;
+            }
+            run_start = index;
+        }
+    }
+    (dominant, dominant_count as f32 / colors.len() as f32)
+}
+
+fn set_tab_hook(name: String, argument: String) -> Result<Option<String>, String> {
+    if name == "liquid-density" {
+        return Ok(Some(cranpose_ui::current_density().to_string()));
+    }
+    if name == "scroll-liquid-content-by" {
+        let content_delta = argument
+            .parse::<f32>()
+            .map_err(|err| format!("invalid liquid content delta '{argument}': {err}"))?;
+        let scroll = TEST_LIQUID_SCROLL_STATE
+            .with(|cell| cell.borrow().clone())
+            .ok_or_else(|| "liquid scroll state was not installed".to_string())?;
+        let consumed = scroll.dispatch_raw_delta(-content_delta);
+        return Ok(Some(format!(
+            "content_delta={content_delta:.3} consumed={consumed:.3} offset={:.3}",
+            scroll.value_non_reactive()
+        )));
+    }
+    if name != "set-tab" {
+        return Err(format!("unsupported robot app hook {name}({argument})"));
+    }
+    if argument != "liquid" {
+        return Err(format!("unknown demo tab '{argument}'"));
+    }
+    let state = TEST_ACTIVE_TAB_STATE
+        .with(|cell| cell.borrow().as_ref().copied())
+        .ok_or_else(|| "active tab state was not installed".to_string())?;
+    state.set(DemoTab::Liquid);
+    Ok(None)
+}

--- a/apps/desktop-demo/robot-runners/robot_markdown_scroll_exact_external_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_markdown_scroll_exact_external_contract.rs
@@ -65,6 +65,8 @@ fn main() {
                     step_epsilon: STEP_EPSILON,
                     fallback_trim_top_px: 96,
                     fallback_trim_bottom_px: 96,
+                    fallback_trim_left_px: 0,
+                    fallback_trim_right_px: 0,
                     compare_search_offset_px: COMPARE_SEARCH_OFFSET_PX,
                     compare_max_adjacent_score: COMPARE_MAX_ADJACENT_SCORE,
                     compare_stabilized_guard_px: COMPARE_STABILIZED_GUARD_PX,

--- a/apps/desktop-demo/robot-runners/robot_text_indent_scroll_stability.rs
+++ b/apps/desktop-demo/robot-runners/robot_text_indent_scroll_stability.rs
@@ -85,6 +85,8 @@ fn main() {
                     step_epsilon: STEP_EPSILON,
                     fallback_trim_top_px: 200,
                     fallback_trim_bottom_px: 200,
+                    fallback_trim_left_px: 0,
+                    fallback_trim_right_px: 0,
                     compare_search_offset_px: COMPARE_SEARCH_OFFSET_PX,
                     compare_max_adjacent_score: COMPARE_MAX_ADJACENT_SCORE,
                     compare_stabilized_guard_px: COMPARE_STABILIZED_GUARD_PX,

--- a/apps/desktop-demo/robot-runners/robot_text_scroll_exact_external_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_text_scroll_exact_external_contract.rs
@@ -97,6 +97,8 @@ fn main() {
                     step_epsilon: STEP_EPSILON,
                     fallback_trim_top_px: COMPARE_TRIM_TOP_PX,
                     fallback_trim_bottom_px: COMPARE_TRIM_BOTTOM_PX,
+                    fallback_trim_left_px: 0,
+                    fallback_trim_right_px: 0,
                     compare_search_offset_px: COMPARE_SEARCH_OFFSET_PX,
                     compare_max_adjacent_score: COMPARE_MAX_ADJACENT_SCORE,
                     compare_stabilized_guard_px: COMPARE_STABILIZED_GUARD_PX,

--- a/apps/desktop-demo/robot-runners/scroll_stability_external_helpers.rs
+++ b/apps/desktop-demo/robot-runners/scroll_stability_external_helpers.rs
@@ -29,12 +29,48 @@ pub(crate) struct ScrollStabilityConfig {
     pub step_epsilon: f32,
     pub fallback_trim_top_px: u32,
     pub fallback_trim_bottom_px: u32,
+    pub fallback_trim_left_px: u32,
+    pub fallback_trim_right_px: u32,
     pub compare_search_offset_px: u32,
     pub compare_max_adjacent_score: u32,
     pub compare_stabilized_guard_px: u32,
     pub compare_viewport_inset_px: u32,
     pub render_stats_env: Option<&'static str>,
     pub active_frame: Option<ActiveFrameConfig>,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
+pub(crate) struct ExactScrollStepConfig {
+    pub target_text: &'static str,
+    pub window_width: u32,
+    pub window_height: u32,
+    pub scroll_steps: usize,
+    pub scroll_delta_y: f32,
+    pub step_epsilon: f32,
+    pub fallback_trim_top_px: u32,
+    pub fallback_trim_bottom_px: u32,
+}
+
+impl ScrollStabilityConfig {
+    fn exact_step_config(self) -> ExactScrollStepConfig {
+        ExactScrollStepConfig {
+            target_text: self.target_text,
+            window_width: self.window_width,
+            window_height: self.window_height,
+            scroll_steps: self.scroll_steps,
+            scroll_delta_y: self.scroll_delta_y,
+            step_epsilon: self.step_epsilon,
+            fallback_trim_top_px: self.fallback_trim_top_px,
+            fallback_trim_bottom_px: self.fallback_trim_bottom_px,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ScrollStepDriver<'a> {
+    PointerWheel,
+    AppHook(&'a str),
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -58,6 +94,118 @@ pub(crate) fn run_scroll_stability_capture(
     robot: &cranpose::Robot,
     config: ScrollStabilityConfig,
     internal_diagnostic: Option<&InternalDiagnostic>,
+) -> bool {
+    run_scroll_stability_capture_with_driver(
+        robot,
+        config,
+        internal_diagnostic,
+        ScrollStepDriver::PointerWheel,
+    )
+}
+
+#[allow(dead_code)]
+pub(crate) fn run_scroll_stability_capture_with_app_hook(
+    robot: &cranpose::Robot,
+    config: ScrollStabilityConfig,
+    internal_diagnostic: Option<&InternalDiagnostic>,
+    hook_name: &str,
+) -> bool {
+    assert!(
+        config.active_frame.is_none(),
+        "app-hook scrolling does not support active-frame capture"
+    );
+    run_scroll_stability_capture_with_driver(
+        robot,
+        config,
+        internal_diagnostic,
+        ScrollStepDriver::AppHook(hook_name),
+    )
+}
+
+#[allow(dead_code)]
+pub(crate) fn run_presented_scroll_probe_with_app_hook(
+    robot: &cranpose::Robot,
+    config: ScrollStabilityConfig,
+    hook_name: &str,
+    mut inspect_frame: impl FnMut(usize, &Path) -> bool,
+) -> bool {
+    assert!(
+        config.scroll_steps >= 2,
+        "presented scroll probe needs at least two steps"
+    );
+    let output_dir = prepare_named_output_dir(config.output_name);
+    println!("Output dir: {}", output_dir.display());
+    let window_id = find_window_id(config.window_title);
+    let mut previous_bounds = find_exact_target_in_semantics(robot, config.target_text)
+        .unwrap_or_else(|| fail_with_semantics(robot, "target text must be visible"));
+    let mut capture_paths = Vec::with_capacity(config.scroll_steps);
+    let mut passed = true;
+
+    for step in 0..config.scroll_steps {
+        previous_bounds = scroll_once_and_expect_target_delta(
+            robot,
+            config.exact_step_config(),
+            previous_bounds,
+            step,
+            "probe step",
+            ScrollStepDriver::AppHook(hook_name),
+        );
+        let screenshot_path = output_dir.join(format!("{}_step{step:02}.png", config.file_prefix));
+        take_x11_screenshot(&window_id, screenshot_path.to_str().expect("utf8 path"));
+        passed &= inspect_frame(step, &screenshot_path);
+        capture_paths.push(screenshot_path);
+    }
+
+    if passed {
+        cleanup_capture_paths(&capture_paths);
+    } else {
+        eprintln!(
+            "presented scroll probe failed; captures retained in {}",
+            output_dir.display()
+        );
+    }
+    passed
+}
+
+#[allow(dead_code)]
+pub(crate) fn semantics_bounds_for_exact_text(
+    robot: &cranpose::Robot,
+    text: &str,
+) -> (f32, f32, f32, f32) {
+    wait_for_semantics_text_exact(robot, text, 2_000)
+        .unwrap_or_else(|| fail_with_semantics(robot, "semantic bounds must be visible"))
+}
+
+#[allow(dead_code)]
+pub(crate) fn advance_scroll_with_app_hook(
+    robot: &cranpose::Robot,
+    config: ExactScrollStepConfig,
+    hook_name: &str,
+) {
+    assert!(
+        config.scroll_steps > 0,
+        "exact scroll advance needs at least one step"
+    );
+    let mut previous_bounds = find_exact_target_in_semantics(robot, config.target_text)
+        .unwrap_or_else(|| fail_with_semantics(robot, "target text must be visible"));
+
+    for step in 0..config.scroll_steps {
+        previous_bounds = scroll_once_and_expect_target_delta(
+            robot,
+            config,
+            previous_bounds,
+            step,
+            "phase step",
+            ScrollStepDriver::AppHook(hook_name),
+        );
+    }
+}
+
+fn run_scroll_stability_capture_with_driver(
+    robot: &cranpose::Robot,
+    config: ScrollStabilityConfig,
+    internal_diagnostic: Option<&InternalDiagnostic>,
+    scroll_driver: ScrollStepDriver<'_>,
 ) -> bool {
     assert!(
         config.scroll_steps >= 2,
@@ -113,8 +261,14 @@ pub(crate) fn run_scroll_stability_capture(
             active_capture_paths.extend(active.active_paths);
             previous_presented = Some(active.settled_screenshot);
         } else {
-            previous_bounds =
-                scroll_once_and_expect_target_delta(robot, config, previous_bounds, step, "step");
+            previous_bounds = scroll_once_and_expect_target_delta(
+                robot,
+                config.exact_step_config(),
+                previous_bounds,
+                step,
+                "step",
+                scroll_driver,
+            );
 
             let screenshot_path =
                 output_dir.join(format!("{}_step{step:02}.png", config.file_prefix));
@@ -182,8 +336,14 @@ pub(crate) fn run_internal_scroll_stability_capture(
 
     let mut capture_paths = Vec::with_capacity(config.scroll_steps);
     for step in 0..config.scroll_steps {
-        previous_bounds =
-            scroll_once_and_expect_target_delta(robot, config, previous_bounds, step, "step");
+        previous_bounds = scroll_once_and_expect_target_delta(
+            robot,
+            config.exact_step_config(),
+            previous_bounds,
+            step,
+            "step",
+            ScrollStepDriver::PointerWheel,
+        );
 
         let screenshot = robot
             .screenshot_with_scale(capture_scale)
@@ -206,10 +366,11 @@ pub(crate) fn run_internal_scroll_stability_capture(
 
 fn scroll_once_and_expect_target_delta(
     robot: &cranpose::Robot,
-    config: ScrollStabilityConfig,
+    config: ExactScrollStepConfig,
     previous_bounds: (f32, f32, f32, f32),
     step: usize,
     label: &str,
+    scroll_driver: ScrollStepDriver<'_>,
 ) -> (f32, f32, f32, f32) {
     let anchor_x =
         (previous_bounds.0 + previous_bounds.2 * 0.5).clamp(1.0, config.window_width as f32 - 1.0);
@@ -221,11 +382,22 @@ fn scroll_once_and_expect_target_delta(
     } else {
         anchor_center_y.clamp(1.0, config.window_height as f32 - 1.0)
     };
-    robot.mouse_move(anchor_x, anchor_y).expect("move cursor");
-    std::thread::sleep(Duration::from_millis(30));
-    robot
-        .mouse_scroll(0.0, config.scroll_delta_y)
-        .expect("1px scroll should succeed");
+    match scroll_driver {
+        ScrollStepDriver::PointerWheel => {
+            robot.mouse_move(anchor_x, anchor_y).expect("move cursor");
+            std::thread::sleep(Duration::from_millis(30));
+            robot
+                .mouse_scroll(0.0, config.scroll_delta_y)
+                .expect("1px scroll should succeed");
+        }
+        ScrollStepDriver::AppHook(hook_name) => {
+            let delta = config.scroll_delta_y.to_string();
+            let result = robot
+                .invoke_app_hook(hook_name, &delta)
+                .unwrap_or_else(|err| panic!("exact scroll hook '{hook_name}' failed: {err}"));
+            println!("{label} {step}: exact scroll hook result={result:?}");
+        }
+    }
     std::thread::sleep(Duration::from_millis(150));
     let _ = robot.wait_for_idle();
 
@@ -554,8 +726,8 @@ fn compare_crop(robot: &cranpose::Robot, config: ScrollStabilityConfig) -> Compa
     CompareCrop {
         trim_top_px: config.fallback_trim_top_px,
         trim_bottom_px: config.fallback_trim_bottom_px,
-        trim_left_px: 0,
-        trim_right_px: 0,
+        trim_left_px: config.fallback_trim_left_px,
+        trim_right_px: config.fallback_trim_right_px,
         logical_window_space: false,
     }
 }
@@ -841,6 +1013,8 @@ mod tests {
             step_epsilon: 0.05,
             fallback_trim_top_px: 0,
             fallback_trim_bottom_px: 0,
+            fallback_trim_left_px: 0,
+            fallback_trim_right_px: 0,
             compare_search_offset_px: 4,
             compare_max_adjacent_score: 0,
             compare_stabilized_guard_px: 0,

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -13,8 +13,8 @@ use cranpose_foundation::SemanticsConfiguration;
 use cranpose_ui::{
     composable, BasicTextField, BasicTextFieldOptions, BasicTextFieldWithOptions, BoxSpec, Brush,
     Button, ButtonSpec, Color, Column, ColumnSpec, CornerRadii, GraphicsLayer, IntrinsicSize,
-    LinearArrangement, Modifier, Point, PointerInputScope, RoundedCornerShape, Row, RowSpec, Size,
-    Spacer, Text, TextStyle, VerticalAlignment,
+    LinearArrangement, Modifier, Point, PointerInputScope, RoundedCornerShape, Row, RowSpec,
+    ScrollState, Size, Spacer, Text, TextStyle, VerticalAlignment,
 };
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -41,7 +41,10 @@ use images::images_tab;
 use interactive_anim::InteractiveAnimTab;
 use lazy_list::lazy_list_example;
 use liquid_ui::LiquidUiTab;
-pub use liquid_ui::{LiquidReferenceFixture, LiquidReferenceFixtureCase};
+pub use liquid_ui::{
+    set_tab_swipe_reference_page, LiquidReferenceFixture, LiquidReferenceFixtureCase,
+    LIQUID_SCROLL_VIEWPORT_TAG, TAB_SWIPE_REFERENCE_STAGE_HEIGHT, TAB_SWIPE_REFERENCE_STAGE_WIDTH,
+};
 use markdown::{
     markdown_viewer_tab, MarkdownScrollStabilityFixtureTab, MarkdownScrollStressFixtureTab,
     MarkdownScrollStressFixtureTabWithState,
@@ -67,6 +70,7 @@ thread_local! {
     pub static TEST_RECURSIVE_LAYOUT_DEPTH_STATE: RefCell<Option<MutableState<usize>>> = const { RefCell::new(None) };
     pub static TEST_LAZY_LIST_STATE: RefCell<Option<LazyListState>> = const { RefCell::new(None) };
     pub static TEST_LIQUID_SELECTED_TAB_STATE: RefCell<Option<MutableState<usize>>> = const { RefCell::new(None) };
+    pub static TEST_LIQUID_SCROLL_STATE: RefCell<Option<ScrollState>> = const { RefCell::new(None) };
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/apps/desktop-demo/src/app/liquid_ui.rs
+++ b/apps/desktop-demo/src/app/liquid_ui.rs
@@ -15,7 +15,13 @@ use cranpose::{
     composable, mutableStateOf, remember, Brush, Color, CornerRadii, GraphicsLayer, Modifier,
     Point, PointerEventKind, PointerInputScope, Rect, ScrollState, Size,
 };
+use cranpose_foundation::SemanticsConfiguration;
 use cranpose_ui::{Alignment, HorizontalAlignment, VerticalAlignment};
+use std::cell::RefCell;
+
+thread_local! {
+    static TAB_SWIPE_REFERENCE_PAGE_OVERRIDE: RefCell<Option<cranpose_core::MutableState<Option<usize>>>> = const { RefCell::new(None) };
+}
 
 const PAGE_PADDING: f32 = 18.0;
 const LIQUID_TAB_BAR_BOTTOM_PADDING: f32 = 19.0;
@@ -24,6 +30,9 @@ const ACCOUNT_ICON_SCALE: f32 = 0.95;
 const OPTICAL_PREVIEW_HEIGHT: f32 = 256.0;
 const OPTICAL_PREVIEW_LENS_SIZE: Size = Size::new(150.0, 82.0);
 const OPTICAL_PREVIEW_INITIAL_Y_FRACTION: f32 = 0.28;
+pub const TAB_SWIPE_REFERENCE_STAGE_WIDTH: f32 = 440.0;
+pub const TAB_SWIPE_REFERENCE_STAGE_HEIGHT: f32 = 132.0;
+pub const LIQUID_SCROLL_VIEWPORT_TAG: &str = "LiquidScrollViewport";
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct TabSwipeReferenceLayout {
@@ -98,6 +107,17 @@ fn tab_swipe_reference_page(progress: f32) -> usize {
     } else {
         3
     }
+}
+
+pub fn set_tab_swipe_reference_page(page: usize) -> Result<(), String> {
+    if !matches!(page, 0 | 2 | 3) {
+        return Err(format!("unsupported tab-swipe reference page {page}"));
+    }
+    let state = TAB_SWIPE_REFERENCE_PAGE_OVERRIDE
+        .with(|cell| cell.borrow().as_ref().copied())
+        .ok_or_else(|| "tab-swipe reference page state is not installed".to_string())?;
+    state.set(Some(page));
+    Ok(())
 }
 
 fn heading_style(color: Color) -> TextStyle {
@@ -1770,6 +1790,10 @@ fn MenuOpenReferenceStage() {
 fn TabSwipeReferenceStage() {
     let selected = remember(|| mutableStateOf(0usize)).with(|state| *state);
     let timeline_started = remember(|| mutableStateOf(false)).with(|state| *state);
+    let reference_page_override = remember(|| mutableStateOf(None::<usize>)).with(|state| *state);
+    TAB_SWIPE_REFERENCE_PAGE_OVERRIDE.with(|cell| {
+        *cell.borrow_mut() = Some(reference_page_override);
+    });
     let timeline_progress = cranpose_animation::animateFloatAsState(
         if timeline_started.get() { 1.0 } else { 0.0 },
         cranpose_animation::tween(1_867, cranpose_animation::Easing::LinearEasing),
@@ -1779,7 +1803,11 @@ fn TabSwipeReferenceStage() {
         Modifier::empty().width(440.0).height(132.0),
         BoxSpec::default(),
         move || {
-            TabSwipeFixtureBackdrop(tab_swipe_reference_page(timeline_progress.get()));
+            TabSwipeFixtureBackdrop(
+                reference_page_override
+                    .get()
+                    .unwrap_or_else(|| tab_swipe_reference_page(timeline_progress.get())),
+            );
             let tab_state = selected;
             let start_timeline = timeline_started;
             Box(
@@ -1923,6 +1951,9 @@ pub fn LiquidUiTab() {
             let menu_gesture = menu_gesture.clone();
             let colors = liquid_colors();
             let scroll = remember(|| ScrollState::new(0.0)).with(|s| s.clone());
+            super::TEST_LIQUID_SCROLL_STATE.with(|cell| {
+                *cell.borrow_mut() = Some(scroll.clone());
+            });
             let scroll_for_bar = scroll.clone();
             // The menu anchors to the REAL composited rects of the Featured
             // videos card's trailing circles (window coords via
@@ -1960,9 +1991,14 @@ pub fn LiquidUiTab() {
             let stage_button_spec = absorbed_button_spec.clone();
 
             cranpose::widgets::Box(
-                Modifier::empty().fill_max_size().draw_behind(move |scope| {
-                    scope.draw_rect(Brush::solid(colors.background));
-                }),
+                Modifier::empty()
+                    .semantics(|config: &mut SemanticsConfiguration| {
+                        config.content_description = Some(LIQUID_SCROLL_VIEWPORT_TAG.to_string());
+                    })
+                    .fill_max_size()
+                    .draw_behind(move |scope| {
+                        scope.draw_rect(Brush::solid(colors.background));
+                    }),
                 cranpose::widgets::BoxSpec::default(),
                 move || {
                     // ---- Scrollable content (slides under the bars) ----

--- a/crates/cranpose-animation/src/animation.rs
+++ b/crates/cranpose-animation/src/animation.rs
@@ -348,6 +348,8 @@ pub struct SpringSpec {
     pub velocity_threshold: f32,
     /// Position threshold to stop animation.
     pub position_threshold: f32,
+    /// Delay before the spring begins advancing.
+    pub delay_millis: u64,
 }
 
 impl SpringSpec {
@@ -358,7 +360,14 @@ impl SpringSpec {
             stiffness,
             velocity_threshold: 0.1,
             position_threshold: 0.01,
+            delay_millis: 0,
         }
+    }
+
+    /// Add a delay before the spring starts integrating.
+    pub fn with_delay(mut self, delay_millis: u64) -> Self {
+        self.delay_millis = delay_millis;
+        self
     }
 
     /// Create a spring with default material design values.
@@ -368,6 +377,7 @@ impl SpringSpec {
             stiffness: 1500.0,
             velocity_threshold: 0.1,
             position_threshold: 0.01,
+            delay_millis: 0,
         }
     }
 
@@ -378,6 +388,7 @@ impl SpringSpec {
             stiffness: 1500.0,
             velocity_threshold: 0.1,
             position_threshold: 0.01,
+            delay_millis: 0,
         }
     }
 
@@ -388,6 +399,7 @@ impl SpringSpec {
             stiffness: 3000.0,
             velocity_threshold: 0.1,
             position_threshold: 0.01,
+            delay_millis: 0,
         }
     }
 }
@@ -431,6 +443,16 @@ pub enum AnimationType {
     Tween(AnimationSpec),
     /// Physics-based spring animation.
     Spring(SpringSpec),
+}
+
+impl AnimationType {
+    /// Add the same start delay regardless of the animation model.
+    pub fn with_delay(self, delay_millis: u64) -> Self {
+        match self {
+            Self::Tween(spec) => Self::Tween(spec.with_delay(delay_millis)),
+            Self::Spring(spec) => Self::Spring(spec.with_delay(delay_millis)),
+        }
+    }
 }
 
 impl Default for AnimationType {
@@ -772,8 +794,18 @@ impl<T: SpringScalar + 'static> Animatable<T> {
     /// Retargeting mid-flight keeps the in-flight velocity (springs continue
     /// their physical motion toward the new target).
     pub fn animateTo(&mut self, target: T, animation: AnimationType) {
+        self.start_animation(target, animation, None);
+    }
+
+    fn start_animation(
+        &mut self,
+        target: T,
+        animation: AnimationType,
+        exact_start_time_nanos: Option<u64>,
+    ) {
         {
             let mut inner = self.inner.borrow_mut();
+            let previous_animation = inner.animation_type;
 
             // Cancel existing animation
             if let Some(registration) = inner.registration.take() {
@@ -783,7 +815,22 @@ impl<T: SpringScalar + 'static> Animatable<T> {
             inner.start = inner.current.clone();
             inner.target = target;
             inner.animation_type = animation;
-            inner.start_time_nanos = None;
+            inner.start_time_nanos = exact_start_time_nanos;
+            match animation {
+                AnimationType::Spring(spec) => {
+                    let continues_spring = matches!(previous_animation, AnimationType::Spring(_));
+                    if let Some(start_time_nanos) = exact_start_time_nanos {
+                        let delay_nanos = spec.delay_millis.saturating_mul(1_000_000);
+                        inner.last_frame_nanos = Some(start_time_nanos.saturating_add(delay_nanos));
+                    } else if !continues_spring {
+                        inner.last_frame_nanos = None;
+                    }
+                }
+                AnimationType::Tween(_) => {
+                    inner.last_frame_nanos = None;
+                    inner.velocity = [0.0; SPRING_MAX_DIMENSIONS];
+                }
+            }
             // The spring frame chain (`last_frame_nanos`) survives a
             // retarget: a mid-flight spring keeps integrating real frame
             // deltas toward the new target. Clearing it made the first
@@ -808,6 +855,26 @@ impl<T: SpringScalar + 'static> Animatable<T> {
             }
         }
         self.animateTo(target, animation);
+    }
+
+    /// Animate from an exact point on the shared frame clock. The first
+    /// rendered spring sample integrates every elapsed nanosecond since this
+    /// boundary, so input-to-animation handoff is independent of which vsync
+    /// first services the callback.
+    pub fn animate_to_with_velocity_at(
+        &mut self,
+        target: T,
+        velocity: T,
+        animation: AnimationType,
+        start_time_nanos: u64,
+    ) {
+        {
+            let mut inner = self.inner.borrow_mut();
+            for index in 0..T::DIMENSIONS.min(SPRING_MAX_DIMENSIONS) {
+                inner.velocity[index] = velocity.dimension(index);
+            }
+        }
+        self.start_animation(target, animation, Some(start_time_nanos));
     }
 
     /// The current velocity in value units per second (zero when settled).
@@ -872,7 +939,7 @@ impl<T: SpringScalar + 'static> Animatable<T> {
                 AnimationType::Tween(spec) => {
                     let start_time = inner.start_time_nanos.get_or_insert(frame_time_nanos);
                     let elapsed_nanos = frame_time_nanos.saturating_sub(*start_time);
-                    let delay_nanos = spec.delay_millis * 1_000_000;
+                    let delay_nanos = spec.delay_millis.saturating_mul(1_000_000);
 
                     if elapsed_nanos < delay_nanos {
                         schedule_next = true;
@@ -899,54 +966,64 @@ impl<T: SpringScalar + 'static> Animatable<T> {
                     }
                 }
                 AnimationType::Spring(spec) => {
-                    // Damped harmonic oscillator advanced per dimension in
-                    // VALUE space using the closed-form solution (exact for
-                    // any frame delta — no integration drift at low frame
-                    // rates). Velocity carries across frames and retargets.
-                    let last = inner.last_frame_nanos.replace(frame_time_nanos);
-                    let dt = last
-                        .map(|last| frame_time_nanos.saturating_sub(last) as f32 / 1_000_000_000.0)
-                        .unwrap_or(0.0);
-
-                    if dt <= 0.0 {
+                    let start_time = inner.start_time_nanos.get_or_insert(frame_time_nanos);
+                    let elapsed_nanos = frame_time_nanos.saturating_sub(*start_time);
+                    let delay_nanos = spec.delay_millis.saturating_mul(1_000_000);
+                    if elapsed_nanos < delay_nanos {
+                        inner.last_frame_nanos = Some(start_time.saturating_add(delay_nanos));
                         schedule_next = true;
                     } else {
-                        let dimensions = T::DIMENSIONS.min(SPRING_MAX_DIMENSIONS);
-                        let mut position = [0.0f32; SPRING_MAX_DIMENSIONS];
-                        for (index, slot) in position.iter_mut().enumerate().take(dimensions) {
-                            let value = inner.current.dimension(index);
-                            let target = inner.target.dimension(index);
-                            let (next_value, next_velocity) = advance_spring(
-                                value,
-                                inner.velocity[index],
-                                target,
-                                spec.damping_ratio,
-                                spec.stiffness,
-                                dt,
-                            );
-                            *slot = next_value;
-                            inner.velocity[index] = next_velocity;
-                        }
+                        // Damped harmonic oscillator advanced per dimension in
+                        // VALUE space using the closed-form solution (exact for
+                        // any frame delta — no integration drift at low frame
+                        // rates). Velocity carries across frames and retargets.
+                        let last = inner.last_frame_nanos.replace(frame_time_nanos);
+                        let dt = last
+                            .map(|last| {
+                                frame_time_nanos.saturating_sub(last) as f32 / 1_000_000_000.0
+                            })
+                            .unwrap_or(0.0);
 
-                        inner.current = T::from_dimensions(position);
-                        inner.state.set_value(inner.current.clone());
-
-                        // Settled when every dimension is at rest near the target.
-                        let settled = (0..dimensions).all(|index| {
-                            inner.velocity[index].abs() < spec.velocity_threshold
-                                && (position[index] - inner.target.dimension(index)).abs()
-                                    < spec.position_threshold
-                        });
-
-                        if settled {
-                            inner.current = inner.target.clone();
-                            inner.start = inner.target.clone();
-                            inner.start_time_nanos = None;
-                            inner.last_frame_nanos = None;
-                            inner.velocity = [0.0; SPRING_MAX_DIMENSIONS];
-                            inner.state.set_value(inner.target.clone());
-                        } else {
+                        if dt <= 0.0 {
                             schedule_next = true;
+                        } else {
+                            let dimensions = T::DIMENSIONS.min(SPRING_MAX_DIMENSIONS);
+                            let mut position = [0.0f32; SPRING_MAX_DIMENSIONS];
+                            for (index, slot) in position.iter_mut().enumerate().take(dimensions) {
+                                let value = inner.current.dimension(index);
+                                let target = inner.target.dimension(index);
+                                let (next_value, next_velocity) = advance_spring(
+                                    value,
+                                    inner.velocity[index],
+                                    target,
+                                    spec.damping_ratio,
+                                    spec.stiffness,
+                                    dt,
+                                );
+                                *slot = next_value;
+                                inner.velocity[index] = next_velocity;
+                            }
+
+                            inner.current = T::from_dimensions(position);
+                            inner.state.set_value(inner.current.clone());
+
+                            // Settled when every dimension is at rest near the target.
+                            let settled = (0..dimensions).all(|index| {
+                                inner.velocity[index].abs() < spec.velocity_threshold
+                                    && (position[index] - inner.target.dimension(index)).abs()
+                                        < spec.position_threshold
+                            });
+
+                            if settled {
+                                inner.current = inner.target.clone();
+                                inner.start = inner.target.clone();
+                                inner.start_time_nanos = None;
+                                inner.last_frame_nanos = None;
+                                inner.velocity = [0.0; SPRING_MAX_DIMENSIONS];
+                                inner.state.set_value(inner.target.clone());
+                            } else {
+                                schedule_next = true;
+                            }
                         }
                     }
                 }

--- a/crates/cranpose-animation/src/tests/animation_tests.rs
+++ b/crates/cranpose-animation/src/tests/animation_tests.rs
@@ -367,6 +367,27 @@ fn tween_factory_creates_tween_animation_type() {
     );
 }
 
+#[test]
+fn animation_type_delay_updates_tween_and_spring_specs() {
+    let tween = tween(450, Easing::FastOutSlowInEasing).with_delay(37);
+    let spring = spring(Spring::DampingRatioLowBouncy, Spring::StiffnessMedium).with_delay(83);
+
+    assert!(matches!(
+        tween,
+        AnimationType::Tween(AnimationSpec {
+            delay_millis: 37,
+            ..
+        })
+    ));
+    assert!(matches!(
+        spring,
+        AnimationType::Spring(SpringSpec {
+            delay_millis: 83,
+            ..
+        })
+    ));
+}
+
 /// Drives an [`Animatable`] against a standalone composition's frame clock at
 /// ~60 FPS and samples the value after every frame. Returns (time_ns, value)
 /// pairs including the initial state at t=0.
@@ -525,4 +546,61 @@ fn animate_to_with_velocity_seeds_gesture_handoff() {
         last.abs() < 0.5,
         "spring should return to the anchor, got {last}"
     );
+}
+
+#[test]
+fn exact_spring_start_integrates_from_the_event_clock_after_its_delay() {
+    let composition: Composition<MemoryApplier> = Composition::new(MemoryApplier::new());
+    let runtime = composition.runtime_handle();
+    let mut animatable = Animatable::new(0.0f32, runtime.clone());
+    let start = 100_000_000;
+
+    animatable.animate_to_with_velocity_at(
+        100.0,
+        0.0,
+        AnimationType::Spring(SpringSpec::new(1.0, 200.0).with_delay(20)),
+        start,
+    );
+
+    runtime.drain_frame_callbacks(start + 10_000_000);
+    assert_eq!(animatable.state().get(), 0.0);
+    runtime.drain_frame_callbacks(start + 20_000_000);
+    assert_eq!(animatable.state().get(), 0.0);
+    runtime.drain_frame_callbacks(start + 36_666_667);
+    assert!(
+        animatable.state().get() > 0.0,
+        "the first post-delay frame must integrate elapsed event-clock time"
+    );
+}
+
+#[test]
+fn tween_to_spring_transition_discards_the_stale_spring_clock() {
+    let composition: Composition<MemoryApplier> = Composition::new(MemoryApplier::new());
+    let runtime = composition.runtime_handle();
+    let mut animatable = Animatable::new(0.0f32, runtime.clone());
+
+    animatable.animate_to_with_velocity(
+        100.0,
+        500.0,
+        AnimationType::Spring(SpringSpec::new(1.0, 200.0)),
+    );
+    runtime.drain_frame_callbacks(16_666_667);
+    runtime.drain_frame_callbacks(33_333_334);
+    assert!(animatable.velocity().abs() > 1.0);
+
+    animatable.animateTo(50.0, AnimationType::Tween(AnimationSpec::linear(1)));
+    runtime.drain_frame_callbacks(50_000_001);
+    runtime.drain_frame_callbacks(51_000_001);
+    assert_eq!(animatable.state().get(), 50.0);
+    assert_eq!(animatable.velocity(), 0.0);
+
+    animatable.animateTo(75.0, AnimationType::Spring(SpringSpec::new(1.0, 200.0)));
+    runtime.drain_frame_callbacks(67_666_668);
+    assert_eq!(
+        animatable.state().get(),
+        50.0,
+        "a fresh spring uses its first callback as its clock origin"
+    );
+    runtime.drain_frame_callbacks(84_333_335);
+    assert!(animatable.state().get() > 50.0);
 }

--- a/crates/cranpose-app-shell/src/lib.rs
+++ b/crates/cranpose-app-shell/src/lib.rs
@@ -152,6 +152,15 @@ where
     frame_scheduler: FrameScheduler,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Platform and animation-clock timestamps for one pointer sample.
+pub struct PointerEventTime {
+    /// Timestamp supplied by the platform, in its millisecond clock domain.
+    pub platform_time_ms: Option<i64>,
+    /// Timestamp in the animation frame-clock domain.
+    pub animation_time_nanos: u64,
+}
+
 fn update_stage_telemetry_threshold_ms() -> Option<f64> {
     static THRESHOLD_MS: std::sync::OnceLock<Option<f64>> = std::sync::OnceLock::new();
     *THRESHOLD_MS.get_or_init(|| {
@@ -782,6 +791,24 @@ where
             .unwrap_or_default()
             .as_nanos()
             .min(u128::from(u64::MAX)) as u64
+    }
+
+    /// Timestamp a live input sample against the current animation clock.
+    pub fn realtime_pointer_event_time(&self, platform_time_ms: Option<i64>) -> PointerEventTime {
+        PointerEventTime {
+            platform_time_ms,
+            animation_time_nanos: self
+                .frame_time_nanos_at(Instant::now())
+                .max(self.last_frame_time_nanos),
+        }
+    }
+
+    /// Timestamp deterministic input at the most recently processed frame.
+    pub fn exact_pointer_event_time(&self, platform_time_ms: Option<i64>) -> PointerEventTime {
+        PointerEventTime {
+            platform_time_ms,
+            animation_time_nanos: self.last_frame_time_nanos,
+        }
     }
 
     pub fn update_after_frame_interval(

--- a/crates/cranpose-app-shell/src/shell_input.rs
+++ b/crates/cranpose-app-shell/src/shell_input.rs
@@ -5,6 +5,18 @@ where
     R: Renderer,
     R::Error: Debug,
 {
+    fn pointer_event(
+        &self,
+        kind: PointerEventKind,
+        position: Point,
+        global_position: Point,
+        event_time: PointerEventTime,
+    ) -> PointerEvent {
+        PointerEvent::new(kind, position, global_position)
+            .with_time_ms(event_time.platform_time_ms)
+            .with_animation_time_nanos(event_time.animation_time_nanos)
+    }
+
     fn resolve_gesture_targets(
         &self,
         pointer: PointerId,
@@ -86,22 +98,35 @@ where
     /// this so gesture velocity is computed from real event times instead of
     /// delivery times.
     pub fn set_cursor_at_time(&mut self, x: f32, y: f32, time_ms: Option<i64>) -> bool {
+        let event_time = self.realtime_pointer_event_time(time_ms);
+        self.set_cursor_at_event_time(x, y, event_time)
+    }
+
+    /// Set the cursor using a timestamp already resolved into both clock domains.
+    pub fn set_cursor_at_event_time(
+        &mut self,
+        x: f32,
+        y: f32,
+        event_time: PointerEventTime,
+    ) -> bool {
         let _event_handler = enter_event_handler_scope();
         let app_context = Rc::clone(&self.app_context);
         let result = app_context.enter(|| {
-            run_in_mutable_snapshot(|| self.set_cursor_inner(x, y, time_ms)).unwrap_or(false)
+            run_in_mutable_snapshot(|| self.set_cursor_inner(x, y, event_time)).unwrap_or(false)
         });
         if result {
             self.mark_dirty();
         }
         log::trace!(
             target: "cranpose::input",
-            "set_cursor ({x:.2},{y:.2}) time_ms={time_ms:?} -> {result}"
+            "set_cursor ({x:.2},{y:.2}) time_ms={:?} animation_time_nanos={} -> {result}",
+            event_time.platform_time_ms,
+            event_time.animation_time_nanos,
         );
         result
     }
 
-    fn set_cursor_inner(&mut self, x: f32, y: f32, time_ms: Option<i64>) -> bool {
+    fn set_cursor_inner(&mut self, x: f32, y: f32, event_time: PointerEventTime) -> bool {
         self.cursor = (x, y);
 
         // During a gesture (button pressed), ONLY dispatch to the tracked hit path.
@@ -111,11 +136,15 @@ where
             if self.hit_path_tracker.has_path(PointerId::PRIMARY) {
                 let targets = self.resolve_gesture_targets(PointerId::PRIMARY);
                 if !targets.is_empty() {
-                    let event =
-                        PointerEvent::new(PointerEventKind::Move, Point { x, y }, Point { x, y })
-                            .with_buttons(self.buttons_pressed)
-                            .with_time_ms(time_ms)
-                            .with_source(self.pointer_source);
+                    let event = self
+                        .pointer_event(
+                            PointerEventKind::Move,
+                            Point { x, y },
+                            Point { x, y },
+                            event_time,
+                        )
+                        .with_buttons(self.buttons_pressed)
+                        .with_source(self.pointer_source);
                     self.dispatch_targets(targets, event, false);
                     return true;
                 }
@@ -139,7 +168,8 @@ where
         for old_id in previously_hovered {
             if !new_ids.contains(&old_id) {
                 if let Some(target) = self.renderer.scene().find_target(old_id) {
-                    let exit_event = PointerEvent::new(PointerEventKind::Exit, pos, pos)
+                    let exit_event = self
+                        .pointer_event(PointerEventKind::Exit, pos, pos, event_time)
                         .with_buttons(self.buttons_pressed)
                         .with_source(self.pointer_source);
                     self.dispatch_targets(std::iter::once(target), exit_event, false);
@@ -150,7 +180,8 @@ where
         // Dispatch Enter to newly hovered nodes
         for hit in &hits {
             if !self.hovered_nodes.contains(&hit.node_id()) {
-                let enter_event = PointerEvent::new(PointerEventKind::Enter, pos, pos)
+                let enter_event = self
+                    .pointer_event(PointerEventKind::Enter, pos, pos, event_time)
                     .with_buttons(self.buttons_pressed)
                     .with_source(self.pointer_source);
                 self.dispatch_targets(std::iter::once(hit.clone()), enter_event, false);
@@ -160,9 +191,9 @@ where
         self.hovered_nodes = new_ids;
 
         if !hits.is_empty() {
-            let event = PointerEvent::new(PointerEventKind::Move, pos, pos)
+            let event = self
+                .pointer_event(PointerEventKind::Move, pos, pos, event_time)
                 .with_buttons(self.buttons_pressed)
-                .with_time_ms(time_ms)
                 .with_source(self.pointer_source);
             self.dispatch_targets(hits, event, true);
             true
@@ -178,19 +209,30 @@ where
     /// Like [`pointer_pressed`](Self::pointer_pressed), but carries the
     /// platform input timestamp (milliseconds) of the press sample.
     pub fn pointer_pressed_at_time(&mut self, time_ms: Option<i64>) -> bool {
+        let event_time = self.realtime_pointer_event_time(time_ms);
+        self.pointer_pressed_at_event_time(event_time)
+    }
+
+    /// Dispatch primary-button down with an already resolved event timestamp.
+    pub fn pointer_pressed_at_event_time(&mut self, event_time: PointerEventTime) -> bool {
         let _event_handler = enter_event_handler_scope();
         let app_context = Rc::clone(&self.app_context);
         let result = app_context.enter(|| {
-            run_in_mutable_snapshot(|| self.pointer_pressed_inner(time_ms)).unwrap_or(false)
+            run_in_mutable_snapshot(|| self.pointer_pressed_inner(event_time)).unwrap_or(false)
         });
         if result {
             self.mark_dirty();
         }
-        log::trace!(target: "cranpose::input", "pointer_pressed time_ms={time_ms:?} -> {result}");
+        log::trace!(
+            target: "cranpose::input",
+            "pointer_pressed time_ms={:?} animation_time_nanos={} -> {result}",
+            event_time.platform_time_ms,
+            event_time.animation_time_nanos,
+        );
         result
     }
 
-    fn pointer_pressed_inner(&mut self, time_ms: Option<i64>) -> bool {
+    fn pointer_pressed_inner(&mut self, event_time: PointerEventTime) -> bool {
         // Track button state
         self.buttons_pressed.insert(PointerButton::Primary);
 
@@ -206,20 +248,21 @@ where
             self.hit_path_tracker.remove_path(PointerId::PRIMARY);
             false
         } else {
-            let event = PointerEvent::new(
-                PointerEventKind::Down,
-                Point {
-                    x: self.cursor.0,
-                    y: self.cursor.1,
-                },
-                Point {
-                    x: self.cursor.0,
-                    y: self.cursor.1,
-                },
-            )
-            .with_buttons(self.buttons_pressed)
-            .with_time_ms(time_ms)
-            .with_source(self.pointer_source);
+            let event = self
+                .pointer_event(
+                    PointerEventKind::Down,
+                    Point {
+                        x: self.cursor.0,
+                        y: self.cursor.1,
+                    },
+                    Point {
+                        x: self.cursor.0,
+                        y: self.cursor.1,
+                    },
+                    event_time,
+                )
+                .with_buttons(self.buttons_pressed)
+                .with_source(self.pointer_source);
 
             let mut delivered_capture_paths = Vec::new();
             let mut applier = self.composition.applier_mut();
@@ -280,12 +323,23 @@ where
         y: f32,
         time_ms: Option<i64>,
     ) -> bool {
+        let event_time = self.realtime_pointer_event_time(time_ms);
+        self.pointer_released_at_position_event_time(x, y, event_time)
+    }
+
+    /// Release at a position with an already resolved event timestamp.
+    pub fn pointer_released_at_position_event_time(
+        &mut self,
+        x: f32,
+        y: f32,
+        event_time: PointerEventTime,
+    ) -> bool {
         let _event_handler = enter_event_handler_scope();
         let app_context = Rc::clone(&self.app_context);
         let result = app_context.enter(|| {
             run_in_mutable_snapshot(|| {
                 self.cursor = (x, y);
-                self.pointer_released_inner(time_ms)
+                self.pointer_released_inner(event_time)
             })
             .unwrap_or(false)
         });
@@ -294,7 +348,9 @@ where
         }
         log::trace!(
             target: "cranpose::input",
-            "pointer_released_at_position ({x:.2},{y:.2}) time_ms={time_ms:?} -> {result}"
+            "pointer_released_at_position ({x:.2},{y:.2}) time_ms={:?} animation_time_nanos={} -> {result}",
+            event_time.platform_time_ms,
+            event_time.animation_time_nanos,
         );
         result
     }
@@ -302,19 +358,30 @@ where
     /// Like [`pointer_released`](Self::pointer_released), but carries the
     /// platform input timestamp (milliseconds) of the release sample.
     pub fn pointer_released_at_time(&mut self, time_ms: Option<i64>) -> bool {
+        let event_time = self.realtime_pointer_event_time(time_ms);
+        self.pointer_released_at_event_time(event_time)
+    }
+
+    /// Dispatch primary-button up with an already resolved event timestamp.
+    pub fn pointer_released_at_event_time(&mut self, event_time: PointerEventTime) -> bool {
         let _event_handler = enter_event_handler_scope();
         let app_context = Rc::clone(&self.app_context);
         let result = app_context.enter(|| {
-            run_in_mutable_snapshot(|| self.pointer_released_inner(time_ms)).unwrap_or(false)
+            run_in_mutable_snapshot(|| self.pointer_released_inner(event_time)).unwrap_or(false)
         });
         if result {
             self.mark_dirty();
         }
-        log::trace!(target: "cranpose::input", "pointer_released time_ms={time_ms:?} -> {result}");
+        log::trace!(
+            target: "cranpose::input",
+            "pointer_released time_ms={:?} animation_time_nanos={} -> {result}",
+            event_time.platform_time_ms,
+            event_time.animation_time_nanos,
+        );
         result
     }
 
-    fn pointer_released_inner(&mut self, time_ms: Option<i64>) -> bool {
+    fn pointer_released_inner(&mut self, event_time: PointerEventTime) -> bool {
         // UP events report buttons as "currently pressed" (after release),
         // matching typical platform semantics where primary is already gone.
         self.buttons_pressed.remove(PointerButton::Primary);
@@ -325,20 +392,21 @@ where
         self.hit_path_tracker.remove_path(PointerId::PRIMARY);
 
         if !targets.is_empty() {
-            let event = PointerEvent::new(
-                PointerEventKind::Up,
-                Point {
-                    x: self.cursor.0,
-                    y: self.cursor.1,
-                },
-                Point {
-                    x: self.cursor.0,
-                    y: self.cursor.1,
-                },
-            )
-            .with_buttons(corrected_buttons)
-            .with_time_ms(time_ms)
-            .with_source(self.pointer_source);
+            let event = self
+                .pointer_event(
+                    PointerEventKind::Up,
+                    Point {
+                        x: self.cursor.0,
+                        y: self.cursor.1,
+                    },
+                    Point {
+                        x: self.cursor.0,
+                        y: self.cursor.1,
+                    },
+                    event_time,
+                )
+                .with_buttons(corrected_buttons)
+                .with_source(self.pointer_source);
 
             self.dispatch_targets(targets, event, false);
             true
@@ -362,7 +430,8 @@ where
         y: f32,
         time_ms: Option<i64>,
     ) -> bool {
-        self.dispatch_secondary_pointer(PointerEventKind::Down, pointer_id, x, y, time_ms)
+        let event_time = self.realtime_pointer_event_time(time_ms);
+        self.dispatch_secondary_pointer(PointerEventKind::Down, pointer_id, x, y, event_time)
     }
 
     /// Move counterpart of [`secondary_pointer_pressed`](Self::secondary_pointer_pressed).
@@ -373,7 +442,8 @@ where
         y: f32,
         time_ms: Option<i64>,
     ) -> bool {
-        self.dispatch_secondary_pointer(PointerEventKind::Move, pointer_id, x, y, time_ms)
+        let event_time = self.realtime_pointer_event_time(time_ms);
+        self.dispatch_secondary_pointer(PointerEventKind::Move, pointer_id, x, y, event_time)
     }
 
     /// Release counterpart of [`secondary_pointer_pressed`](Self::secondary_pointer_pressed).
@@ -384,7 +454,8 @@ where
         y: f32,
         time_ms: Option<i64>,
     ) -> bool {
-        self.dispatch_secondary_pointer(PointerEventKind::Up, pointer_id, x, y, time_ms)
+        let event_time = self.realtime_pointer_event_time(time_ms);
+        self.dispatch_secondary_pointer(PointerEventKind::Up, pointer_id, x, y, event_time)
     }
 
     fn dispatch_secondary_pointer(
@@ -393,7 +464,7 @@ where
         pointer_id: u64,
         x: f32,
         y: f32,
-        time_ms: Option<i64>,
+        event_time: PointerEventTime,
     ) -> bool {
         if pointer_id == 0 {
             log::warn!(
@@ -415,9 +486,9 @@ where
                     return false;
                 }
                 let pos = Point { x, y };
-                let event = PointerEvent::new(kind, pos, pos)
+                let event = self
+                    .pointer_event(kind, pos, pos, event_time)
                     .with_buttons(self.buttons_pressed)
-                    .with_time_ms(time_ms)
                     .with_id(pointer_id)
                     .with_source(self.pointer_source);
                 self.dispatch_targets(targets, event, false);
@@ -430,7 +501,9 @@ where
         }
         log::trace!(
             target: "cranpose::input",
-            "secondary_pointer {kind:?} id={pointer_id} ({x:.2},{y:.2}) time_ms={time_ms:?} -> {result}"
+            "secondary_pointer {kind:?} id={pointer_id} ({x:.2},{y:.2}) time_ms={:?} animation_time_nanos={} -> {result}",
+            event_time.platform_time_ms,
+            event_time.animation_time_nanos,
         );
         result
     }
@@ -441,10 +514,12 @@ where
     /// `zoom_factor` is multiplicative: `> 1.0` zooms in, `< 1.0` zooms out.
     /// Returns `true` if a handler consumed the event.
     pub fn pointer_zoomed(&mut self, zoom_factor: f32) -> bool {
+        let event_time = self.realtime_pointer_event_time(None);
         let _event_handler = enter_event_handler_scope();
         let app_context = Rc::clone(&self.app_context);
         let result = app_context.enter(|| {
-            run_in_mutable_snapshot(|| self.pointer_zoomed_inner(zoom_factor)).unwrap_or(false)
+            run_in_mutable_snapshot(|| self.pointer_zoomed_inner(zoom_factor, event_time))
+                .unwrap_or(false)
         });
         if result {
             self.mark_dirty();
@@ -456,7 +531,7 @@ where
         result
     }
 
-    fn pointer_zoomed_inner(&mut self, zoom_factor: f32) -> bool {
+    fn pointer_zoomed_inner(&mut self, zoom_factor: f32, event_time: PointerEventTime) -> bool {
         if !zoom_factor.is_finite() || zoom_factor <= 0.0 || zoom_factor == 1.0 {
             return false;
         }
@@ -470,7 +545,8 @@ where
             x: self.cursor.0,
             y: self.cursor.1,
         };
-        let event = PointerEvent::new(PointerEventKind::Zoom, pos, pos)
+        let event = self
+            .pointer_event(PointerEventKind::Zoom, pos, pos, event_time)
             .with_buttons(self.buttons_pressed)
             .with_zoom_delta(zoom_factor)
             .with_source(self.pointer_source);
@@ -493,10 +569,11 @@ where
     ///
     /// Returns `true` if a handler consumed the event.
     pub fn pointer_scrolled(&mut self, delta_x: f32, delta_y: f32) -> bool {
+        let event_time = self.realtime_pointer_event_time(None);
         let _event_handler = enter_event_handler_scope();
         let app_context = Rc::clone(&self.app_context);
         let result = app_context.enter(|| {
-            run_in_mutable_snapshot(|| self.pointer_scrolled_inner(delta_x, delta_y))
+            run_in_mutable_snapshot(|| self.pointer_scrolled_inner(delta_x, delta_y, event_time))
                 .unwrap_or(false)
         });
         if result {
@@ -509,7 +586,12 @@ where
         result
     }
 
-    fn pointer_scrolled_inner(&mut self, delta_x: f32, delta_y: f32) -> bool {
+    fn pointer_scrolled_inner(
+        &mut self,
+        delta_x: f32,
+        delta_y: f32,
+        event_time: PointerEventTime,
+    ) -> bool {
         if delta_x.abs() <= f32::EPSILON && delta_y.abs() <= f32::EPSILON {
             return false;
         }
@@ -519,23 +601,25 @@ where
             return false;
         }
 
-        let event = PointerEvent::new(
-            PointerEventKind::Scroll,
-            Point {
-                x: self.cursor.0,
-                y: self.cursor.1,
-            },
-            Point {
-                x: self.cursor.0,
-                y: self.cursor.1,
-            },
-        )
-        .with_buttons(self.buttons_pressed)
-        .with_scroll_delta(Point {
-            x: delta_x,
-            y: delta_y,
-        })
-        .with_source(self.pointer_source);
+        let event = self
+            .pointer_event(
+                PointerEventKind::Scroll,
+                Point {
+                    x: self.cursor.0,
+                    y: self.cursor.1,
+                },
+                Point {
+                    x: self.cursor.0,
+                    y: self.cursor.1,
+                },
+                event_time,
+            )
+            .with_buttons(self.buttons_pressed)
+            .with_scroll_delta(Point {
+                x: delta_x,
+                y: delta_y,
+            })
+            .with_source(self.pointer_source);
 
         let capture_paths = hits
             .iter()
@@ -557,16 +641,17 @@ where
     /// - Mouse leaves window while button pressed
     /// - Any other gesture abort scenario
     pub fn cancel_gesture(&mut self) {
+        let event_time = self.realtime_pointer_event_time(None);
         let _event_handler = enter_event_handler_scope();
         let app_context = Rc::clone(&self.app_context);
         let _ = app_context.enter(|| {
             run_in_mutable_snapshot(|| {
-                self.cancel_gesture_inner();
+                self.cancel_gesture_inner(event_time);
             })
         });
     }
 
-    fn cancel_gesture_inner(&mut self) {
+    fn cancel_gesture_inner(&mut self, event_time: PointerEventTime) {
         let targets = self.resolve_gesture_targets(PointerId::PRIMARY);
 
         // Clear tracker and button state
@@ -574,18 +659,20 @@ where
         self.buttons_pressed = PointerButtons::NONE;
 
         if !targets.is_empty() {
-            let event = PointerEvent::new(
-                PointerEventKind::Cancel,
-                Point {
-                    x: self.cursor.0,
-                    y: self.cursor.1,
-                },
-                Point {
-                    x: self.cursor.0,
-                    y: self.cursor.1,
-                },
-            )
-            .with_source(self.pointer_source);
+            let event = self
+                .pointer_event(
+                    PointerEventKind::Cancel,
+                    Point {
+                        x: self.cursor.0,
+                        y: self.cursor.1,
+                    },
+                    Point {
+                        x: self.cursor.0,
+                        y: self.cursor.1,
+                    },
+                    event_time,
+                )
+                .with_source(self.pointer_source);
 
             self.dispatch_targets(targets, event, false);
         }
@@ -598,7 +685,8 @@ where
         let hovered_nodes = self.hovered_nodes.clone();
         for node_id in hovered_nodes {
             if let Some(target) = self.renderer.scene().find_target(node_id) {
-                let exit_event = PointerEvent::new(PointerEventKind::Exit, pos, pos)
+                let exit_event = self
+                    .pointer_event(PointerEventKind::Exit, pos, pos, event_time)
                     .with_source(self.pointer_source);
                 self.dispatch_targets(std::iter::once(target), exit_event, false);
             }

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -1113,6 +1113,35 @@ fn app_shell_idle_updates_do_not_advance_presented_frame_stats() {
 }
 
 #[test]
+fn pointer_event_clock_supports_realtime_and_exact_sampling() {
+    let _guard = test_guard();
+    let mut shell = AppShell::new(
+        TestRenderer::default(),
+        location_key(file!(), line!(), column!()),
+        || {},
+    );
+
+    shell.update_at_frame_time_nanos(120_000_000);
+    assert_eq!(
+        shell.exact_pointer_event_time(Some(17)),
+        PointerEventTime {
+            platform_time_ms: Some(17),
+            animation_time_nanos: 120_000_000,
+        }
+    );
+
+    let realtime = shell.realtime_pointer_event_time(Some(18));
+    assert_eq!(realtime.platform_time_ms, Some(18));
+    assert!(realtime.animation_time_nanos >= 120_000_000);
+
+    shell.update_after_exact_interval(Duration::from_millis(8));
+    assert_eq!(
+        shell.exact_pointer_event_time(None).animation_time_nanos,
+        128_000_000
+    );
+}
+
+#[test]
 fn two_app_shells_do_not_share_text_measurers() {
     let _guard = test_guard();
     reset_public_render_state_for_test();
@@ -7733,6 +7762,13 @@ thread_local! {
         const { RefCell::new(None) };
 }
 
+type PointerTimeSample = (PointerEventKind, Option<i64>, Option<u64>);
+
+thread_local! {
+    static POINTER_TIME_PROBE: RefCell<Option<Rc<RefCell<Vec<PointerTimeSample>>>>> =
+        const { RefCell::new(None) };
+}
+
 /// A probe that records the `PointerSource` of every pointer-down it receives,
 /// exposing it via a thread-local so the test can assert what the shell stamped.
 fn app_shell_pointer_source_probe() {
@@ -7763,6 +7799,81 @@ fn app_shell_pointer_source_probe() {
         BoxSpec::default(),
         || {},
     );
+}
+
+fn app_shell_pointer_time_probe() {
+    let captured = Rc::new(RefCell::new(Vec::new()));
+    POINTER_TIME_PROBE.with(|slot| *slot.borrow_mut() = Some(Rc::clone(&captured)));
+    Box(
+        Modifier::empty()
+            .size(Size {
+                width: 200.0,
+                height: 200.0,
+            })
+            .pointer_input((), move |scope: PointerInputScope| {
+                let captured = Rc::clone(&captured);
+                async move {
+                    scope
+                        .await_pointer_event_scope(|await_scope| async move {
+                            loop {
+                                let event = await_scope.await_pointer_event().await;
+                                captured.borrow_mut().push((
+                                    event.kind,
+                                    event.time_ms,
+                                    event.animation_time_nanos,
+                                ));
+                                event.consume();
+                            }
+                        })
+                        .await;
+                }
+            }),
+        BoxSpec::default(),
+        || {},
+    );
+}
+
+#[test]
+fn shell_preserves_resolved_pointer_timestamps_during_dispatch() {
+    let _guard = test_guard();
+    POINTER_TIME_PROBE.with(|slot| slot.borrow_mut().take());
+
+    let mut shell = AppShell::new(
+        HitGraphRenderer::default(),
+        location_key(file!(), line!(), column!()),
+        app_shell_pointer_time_probe,
+    );
+    shell.set_buffer_size(200, 200);
+    shell.set_viewport(200.0, 200.0);
+    shell.update();
+
+    let captured = POINTER_TIME_PROBE
+        .with(|slot| slot.borrow().as_ref().map(Rc::clone))
+        .expect("probe should expose captured samples");
+    assert!(shell.set_cursor_at_event_time(
+        50.0,
+        50.0,
+        PointerEventTime {
+            platform_time_ms: Some(10),
+            animation_time_nanos: 100,
+        },
+    ));
+    assert!(shell.pointer_pressed_at_event_time(PointerEventTime {
+        platform_time_ms: Some(11),
+        animation_time_nanos: 110,
+    }));
+    assert!(shell.pointer_released_at_position_event_time(
+        51.0,
+        52.0,
+        PointerEventTime {
+            platform_time_ms: Some(12),
+            animation_time_nanos: 120,
+        },
+    ));
+
+    let samples = captured.borrow();
+    assert!(samples.contains(&(PointerEventKind::Down, Some(11), Some(110))));
+    assert!(samples.contains(&(PointerEventKind::Up, Some(12), Some(120))));
 }
 
 #[test]

--- a/crates/cranpose-foundation/src/nodes/input/types.rs
+++ b/crates/cranpose-foundation/src/nodes/input/types.rs
@@ -124,6 +124,10 @@ pub struct PointerEvent {
     /// samples arrive back-to-back and delivery-time stamping makes computed
     /// velocities wildly wrong.
     pub time_ms: Option<i64>,
+    /// Timestamp in the animation frame-clock domain at input dispatch.
+    /// Unlike `time_ms`, this has the same origin as frame callbacks and can
+    /// anchor input-driven animations without a wall/platform clock conversion.
+    pub animation_time_nanos: Option<u64>,
     /// Multiplicative zoom factor for [`PointerEventKind::Zoom`] events
     /// (`> 1.0` zooms in, `< 1.0` zooms out). `1.0` for all other events.
     pub zoom_delta: f32,
@@ -154,6 +158,7 @@ impl PointerEvent {
             scroll_delta: Point { x: 0.0, y: 0.0 },
             buttons: PointerButtons::NONE,
             time_ms: None,
+            animation_time_nanos: None,
             zoom_delta: 1.0,
             source: PointerSource::Unknown,
             consumed: Rc::new(Cell::new(false)),
@@ -181,6 +186,12 @@ impl PointerEvent {
     /// Set the platform timestamp (milliseconds) for this event.
     pub fn with_time_ms(mut self, time_ms: Option<i64>) -> Self {
         self.time_ms = time_ms;
+        self
+    }
+
+    /// Set the timestamp in the animation frame-clock domain.
+    pub fn with_animation_time_nanos(mut self, time_nanos: u64) -> Self {
+        self.animation_time_nanos = Some(time_nanos);
         self
     }
 
@@ -223,6 +234,7 @@ impl PointerEvent {
             scroll_delta: self.scroll_delta,
             buttons: self.buttons,
             time_ms: self.time_ms,
+            animation_time_nanos: self.animation_time_nanos,
             zoom_delta: self.zoom_delta,
             source: self.source,
             consumed: self.consumed.clone(),
@@ -270,11 +282,15 @@ mod tests {
 
     #[test]
     fn pointer_event_copy_with_local_position_preserves_consumption_state() {
-        let event = PointerEvent::new(PointerEventKind::Down, point(4.0, 5.0), point(4.0, 5.0));
+        let event = PointerEvent::new(PointerEventKind::Down, point(4.0, 5.0), point(4.0, 5.0))
+            .with_time_ms(Some(123))
+            .with_animation_time_nanos(456_000_000);
         let local = event.copy_with_local_position(point(1.0, 1.0));
 
         assert_eq!(local.position, point(1.0, 1.0));
         assert_eq!(local.global_position, event.global_position);
+        assert_eq!(local.time_ms, Some(123));
+        assert_eq!(local.animation_time_nanos, Some(456_000_000));
         assert!(!local.is_consumed());
 
         event.consume();

--- a/crates/cranpose-render/pixels/src/draw.rs
+++ b/crates/cranpose-render/pixels/src/draw.rs
@@ -177,9 +177,9 @@ fn draw_shape(
         .map(snap_delta_for_anchor)
         .unwrap_or_default();
     let rect = draw.rect.translate(snap_delta.x, snap_delta.y);
-    let clip = draw
-        .clip
-        .map(|clip| clip.translate(snap_delta.x, snap_delta.y));
+    // Clips are already resolved in scene space and may belong to a fixed
+    // ancestor. Only the draw geometry borrows this item's raster snap.
+    let clip = draw.clip;
     let rect = if draw.snap_to_pixel_grid {
         Rect {
             x: rect.x.round(),
@@ -253,9 +253,7 @@ fn draw_image(
         .map(snap_delta_for_anchor)
         .unwrap_or_default();
     let rect = draw.rect.translate(snap_delta.x, snap_delta.y);
-    let clip = draw
-        .clip
-        .map(|clip| clip.translate(snap_delta.x, snap_delta.y));
+    let clip = draw.clip;
 
     if draw.alpha <= 0.0 || rect.width <= 0.0 || rect.height <= 0.0 {
         return;
@@ -491,9 +489,7 @@ fn draw_text_plain(
         Point::default()
     };
     let rect = draw.rect.translate(snap_delta.x, snap_delta.y);
-    let clip = draw
-        .clip
-        .map(|clip| clip.translate(snap_delta.x, snap_delta.y));
+    let clip = draw.clip;
 
     let raster_rect = if static_text_motion {
         Rect {
@@ -694,6 +690,36 @@ mod tests {
             fallback_cursor_x_for_byte_offset(text, text.len(), 12.0),
             width * 2.0
         );
+    }
+
+    #[test]
+    fn shape_snap_does_not_move_its_fixed_ancestor_clip() {
+        let draw = crate::scene::DrawShape {
+            rect: Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 8.0,
+                height: 8.0,
+            },
+            snap_anchor: Some(Point::new(0.4, 0.4)),
+            snap_to_pixel_grid: false,
+            brush: Brush::solid(Color::WHITE),
+            shape: None,
+            z_index: 0,
+            clip: Some(Rect {
+                x: 2.0,
+                y: 2.0,
+                width: 2.0,
+                height: 2.0,
+            }),
+            blend_mode: BlendMode::SrcOver,
+        };
+        let mut frame = vec![0; 8 * 8 * 4];
+        draw_shape(&mut frame, 8, 8, &draw, &RenderDiagnostics::new());
+
+        let alpha = |x: usize, y: usize| frame[(y * 8 + x) * 4 + 3];
+        assert_eq!(alpha(1, 2), 0, "content snapping moved the clip left");
+        assert_eq!(alpha(2, 2), 255, "the fixed clip must retain its coverage");
     }
 
     fn count_non_background_pixels(frame: &[u8], width: u32, height: u32) -> usize {

--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -371,6 +371,7 @@ pub(crate) struct PreparedShaderDraw<'a> {
 pub(crate) enum CompositeSampleMode {
     Linear,
     Box4,
+    Nearest,
 }
 
 impl EffectRenderer {
@@ -1947,6 +1948,7 @@ fn composite_sampling_mode_value(sample_mode: CompositeSampleMode) -> f32 {
     match sample_mode {
         CompositeSampleMode::Linear => 0.0,
         CompositeSampleMode::Box4 => 1.0,
+        CompositeSampleMode::Nearest => 2.0,
     }
 }
 

--- a/crates/cranpose-render/wgpu/src/normalized_scene.rs
+++ b/crates/cranpose-render/wgpu/src/normalized_scene.rs
@@ -44,6 +44,8 @@ pub(crate) struct ChildLayerComposite<'a> {
     pub(crate) logical_rect: Rect,
     pub(crate) dest_quad: [[f32; 2]; 4],
     pub(crate) snap_anchor: Option<SnapAnchor>,
+    /// Transform pivot in the parent scene's logical coordinate space.
+    pub(crate) composite_snap_origin: Option<Point>,
     pub(crate) backdrop_rect: Rect,
     pub(crate) visual_clip: Option<Rect>,
     pub(crate) surface_clip: Option<Rect>,
@@ -56,6 +58,8 @@ pub(crate) struct ResolvedChildSurfaceComposite {
     pub(crate) logical_rect: Rect,
     pub(crate) dest_quad: [[f32; 2]; 4],
     pub(crate) snap_anchor: Option<SnapAnchor>,
+    /// Transform pivot in the parent scene's logical coordinate space.
+    pub(crate) composite_snap_origin: Option<Point>,
     pub(crate) backdrop_rect: Rect,
     pub(crate) surface_clip: Option<Rect>,
     pub(crate) shadow_draws: Vec<ShadowDraw>,
@@ -532,6 +536,27 @@ fn rigid_snap_anchor(layer_bounds: Rect, layer: &GraphicsLayer) -> Option<SnapAn
     Some(SnapAnchor::rigid(Point::new(mapped.x, mapped.y)))
 }
 
+fn axis_aligned_composite_snap_origin(layer: &LayerNode, layer_offset: Point) -> Option<Point> {
+    let graphics_layer = &layer.graphics_layer;
+    if graphics_layer.rotation_x.abs() > NORMALIZED_SCENE_AFFINE_TOLERANCE
+        || graphics_layer.rotation_y.abs() > NORMALIZED_SCENE_AFFINE_TOLERANCE
+        || graphics_layer.rotation_z.abs() > NORMALIZED_SCENE_AFFINE_TOLERANCE
+    {
+        return None;
+    }
+
+    let local_bounds = layer.local_bounds;
+    let local_origin = Point::new(
+        local_bounds.x + local_bounds.width * graphics_layer.transform_origin.pivot_fraction_x,
+        local_bounds.y + local_bounds.height * graphics_layer.transform_origin.pivot_fraction_y,
+    );
+    let mapped = layer.transform_to_parent.map_point(local_origin);
+    Some(Point::new(
+        mapped.x + layer_offset.x,
+        mapped.y + layer_offset.y,
+    ))
+}
+
 fn surface_composite_needs_rigid_snap(
     requirements: LayerSurfaceRequirements,
     translated_content_context: bool,
@@ -551,6 +576,7 @@ struct SceneCounts {
     texts: usize,
     shadow_draws: usize,
     effect_layers: usize,
+    backdrop_layers: usize,
 }
 
 fn scene_counts(scene: &CompositorScene) -> SceneCounts {
@@ -560,6 +586,7 @@ fn scene_counts(scene: &CompositorScene) -> SceneCounts {
         texts: scene.texts.len(),
         shadow_draws: scene.shadow_draws.len(),
         effect_layers: scene.effect_layers.len(),
+        backdrop_layers: scene.backdrop_layers.len(),
     }
 }
 
@@ -590,6 +617,9 @@ fn assign_snap_anchor_since(
         }
     }
     for layer in &mut scene.effect_layers[counts.effect_layers..] {
+        layer.snap_anchor = Some(snap_anchor);
+    }
+    for layer in &mut scene.backdrop_layers[counts.backdrop_layers..] {
         layer.snap_anchor = Some(snap_anchor);
     }
 }
@@ -684,6 +714,7 @@ pub(crate) fn resolved_child_surface_composite(
         logical_rect: child.logical_rect,
         dest_quad: child.dest_quad,
         snap_anchor: child.snap_anchor,
+        composite_snap_origin: child.composite_snap_origin,
         backdrop_rect: child.backdrop_rect,
         surface_clip: child.surface_clip,
         shadow_draws: child.shadow_draws.clone(),
@@ -979,25 +1010,37 @@ fn collect_layer_contents_into<'a>(
                     child_bounds,
                     child_shadow_clip,
                 );
-                let child_snap_anchor = translated_snap_anchor.or_else(|| {
-                    let child_surface_needs_snap = surface_composite_needs_rigid_snap(
-                        child_requirements,
-                        effective_translated_content_context,
-                        translation_context.surface_capture_active,
-                    );
-                    if effective_translated_content_context || child_surface_needs_snap {
-                        let child_isolation =
-                            effective_layer_isolation(&child_layer.graphics_layer);
-                        let child_content_layer = layer_for_content(
-                            &child_layer.graphics_layer,
-                            child_isolation.as_ref(),
+                let child_composite_snap_origin = if child_requirements
+                    .surface_requirements
+                    .contains(SurfaceRequirement::NonTranslationTransform)
+                {
+                    axis_aligned_composite_snap_origin(child_layer, layer_offset)
+                } else {
+                    None
+                };
+                let child_snap_anchor = if child_composite_snap_origin.is_some() {
+                    None
+                } else {
+                    translated_snap_anchor.or_else(|| {
+                        let child_surface_needs_snap = surface_composite_needs_rigid_snap(
+                            child_requirements,
+                            effective_translated_content_context,
+                            translation_context.surface_capture_active,
                         );
-                        let child_local_layer = local_content_layer(&child_content_layer);
-                        rigid_snap_anchor(child_bounds, &child_local_layer)
-                    } else {
-                        None
-                    }
-                });
+                        if effective_translated_content_context || child_surface_needs_snap {
+                            let child_isolation =
+                                effective_layer_isolation(&child_layer.graphics_layer);
+                            let child_content_layer = layer_for_content(
+                                &child_layer.graphics_layer,
+                                child_isolation.as_ref(),
+                            );
+                            let child_local_layer = local_content_layer(&child_content_layer);
+                            rigid_snap_anchor(child_bounds, &child_local_layer)
+                        } else {
+                            None
+                        }
+                    })
+                };
                 let child_to_parent =
                     child_layer
                         .transform_to_parent
@@ -1031,6 +1074,7 @@ fn collect_layer_contents_into<'a>(
                         layer_offset,
                     ),
                     snap_anchor: child_snap_anchor,
+                    composite_snap_origin: child_composite_snap_origin,
                     backdrop_rect: quad_bounds(translate_quad(
                         child_layer
                             .transform_to_parent
@@ -1255,6 +1299,40 @@ impl TranslateBy for Rect {
     }
 }
 
+impl TranslateBy for SnapAnchor {
+    fn translate_by(&mut self, delta: Point) {
+        self.origin.x += delta.x;
+        self.origin.y += delta.y;
+    }
+}
+
+impl TranslateBy for Point {
+    fn translate_by(&mut self, delta: Point) {
+        self.x += delta.x;
+        self.y += delta.y;
+    }
+}
+
+impl TranslateBy for ChildLayerComposite<'_> {
+    fn translate_by(&mut self, delta: Point) {
+        for point in &mut self.dest_quad {
+            point[0] += delta.x;
+            point[1] += delta.y;
+        }
+        if let Some(anchor) = self.snap_anchor.as_mut() {
+            anchor.translate_by(delta);
+        }
+        if let Some(origin) = self.composite_snap_origin.as_mut() {
+            origin.translate_by(delta);
+        }
+        self.backdrop_rect.translate_by(delta);
+        if let Some(clip) = self.visual_clip.as_mut() {
+            clip.translate_by(delta);
+        }
+        self.shadow_draws.translate_by(delta);
+    }
+}
+
 impl TranslateBy for DrawShape {
     fn translate_by(&mut self, delta: Point) {
         self.rect.translate_by(delta);
@@ -1265,6 +1343,9 @@ impl TranslateBy for DrawShape {
         }
         if let Some(clip) = self.clip.as_mut() {
             clip.translate_by(delta);
+        }
+        if let Some(anchor) = self.snap_anchor.as_mut() {
+            anchor.translate_by(delta);
         }
     }
 }
@@ -1280,6 +1361,9 @@ impl TranslateBy for ImageDraw {
         if let Some(clip) = self.clip.as_mut() {
             clip.translate_by(delta);
         }
+        if let Some(anchor) = self.snap_anchor.as_mut() {
+            anchor.translate_by(delta);
+        }
     }
 }
 
@@ -1288,6 +1372,9 @@ impl TranslateBy for TextDraw {
         self.rect.translate_by(delta);
         if let Some(clip) = self.clip.as_mut() {
             clip.translate_by(delta);
+        }
+        if let Some(anchor) = self.snap_anchor.as_mut() {
+            anchor.translate_by(delta);
         }
     }
 }
@@ -1312,6 +1399,9 @@ impl TranslateBy for EffectLayer {
         if let Some(clip) = self.clip.as_mut() {
             clip.translate_by(delta);
         }
+        if let Some(anchor) = self.snap_anchor.as_mut() {
+            anchor.translate_by(delta);
+        }
     }
 }
 
@@ -1320,6 +1410,9 @@ impl TranslateBy for BackdropLayer {
         self.rect.translate_by(delta);
         if let Some(clip) = self.clip.as_mut() {
             clip.translate_by(delta);
+        }
+        if let Some(anchor) = self.snap_anchor.as_mut() {
+            anchor.translate_by(delta);
         }
     }
 }

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -33,12 +33,13 @@ use crate::shaders;
 use crate::surface_executor::{
     apply_backdrop_layer_to_target as execute_apply_backdrop_layer_to_target,
     axis_aligned_quad_rect, backdrop_underlay_is_covered_by_local_content,
+    canonicalize_device_coordinate, canonicalized_scaled_quad, canonicalized_scaled_rect,
     composite_surface_to_view as execute_composite_surface_to_view, device_pixel_bounds_for_rect,
     offscreen_byte_size, render_effect_layer_to_target as execute_render_effect_layer_to_target,
     render_layer_surface as execute_render_layer_surface,
     render_root_direct as execute_render_root_direct, root_direct_scene_events_are_supported,
     scaled_quad, snap_delta_for_anchor, snap_motion_stable_dest_quad, surface_target_size,
-    translation_stable_device_pixel_bounds, DevicePixelBounds, LayerSurfaceTexture,
+    translation_stable_anchored_device_pixel_bounds, DevicePixelBounds, LayerSurfaceTexture,
     SurfaceExecutionBackend,
 };
 #[cfg(test)]
@@ -384,7 +385,7 @@ impl CachedShadowComposite {
             blend_mode: BlendMode::SrcOver,
             dest_viewport: self.dest_viewport,
             source_viewport: None,
-            sample_mode: CompositeSampleMode::Linear,
+            sample_mode: CompositeSampleMode::Nearest,
         }
     }
 }
@@ -538,7 +539,7 @@ fn direct_shader_composite_viewport(
         return None;
     }
     match sample_mode {
-        CompositeSampleMode::Linear => Some(viewport),
+        CompositeSampleMode::Linear | CompositeSampleMode::Nearest => Some(viewport),
         CompositeSampleMode::Box4
             if shader_composite_preserves_source_pixel_grid(viewport, source_size) =>
         {
@@ -634,15 +635,19 @@ fn text_raster_geometry_for_draw(
         .map(|anchor| snap_delta_for_anchor(anchor, root_scale))
         .unwrap_or_default();
     let logical_rect = text_draw.rect.translate(snap_delta.x, snap_delta.y);
-    let clip = text_draw
-        .clip
-        .map(|clip| clip.translate(snap_delta.x, snap_delta.y));
+    // Clips are resolved in scene space from their own layer ancestry. A draw
+    // item's raster snap must never move a fixed ancestor clip.
+    let clip = text_draw.clip;
     let mut raster_rect = Rect {
         x: logical_rect.x * root_scale,
         y: logical_rect.y * root_scale,
         width: logical_rect.width * root_scale,
         height: logical_rect.height * root_scale,
     };
+    if text_draw.snap_anchor.is_some() {
+        raster_rect.x = canonicalize_device_coordinate(raster_rect.x);
+        raster_rect.y = canonicalize_device_coordinate(raster_rect.y);
+    }
     if static_text_motion {
         raster_rect.x = raster_rect.x.round();
         raster_rect.y = raster_rect.y.round();
@@ -733,9 +738,7 @@ fn shape_draw_is_visible_in_viewport(
         .map(|anchor| snap_delta_for_anchor(anchor, root_scale))
         .unwrap_or_default();
     let rect = quad_bounds(translate_quad(shape.quad, snap_delta));
-    let clip = shape
-        .clip
-        .map(|clip| clip.translate(snap_delta.x, snap_delta.y));
+    let clip = shape.clip;
     draw_rect_is_visible_in_viewport(rect, clip, viewport, root_scale)
 }
 
@@ -913,11 +916,10 @@ fn text_draws_for_ordered_range<'a>(
     }))
 }
 
-/// Shadow geometry is hashed in device pixels quantized to 1/16 px so that
-/// rigid translations (scrolling) reuse the cached blurred raster. Reusing a
-/// raster across device subpixel phases shifts the blurred shadow by less than
-/// one device pixel, which is imperceptible, while re-rendering the blur every
-/// scroll frame on fractional-scale displays is a frame-budget killer.
+/// Shadow geometry is hashed in device pixels quantized to 1/16 px so rigid
+/// translations reuse the cached blurred raster. The cached surface is
+/// composited one-to-one with texel-exact sampling; translation may not change
+/// either the blur or its sampling phase.
 const SHADOW_CACHE_DEVICE_QUANT: f32 = 16.0;
 
 fn hash_shadow_device_offset<H: Hasher>(value: f32, origin: f32, root_scale: f32, state: &mut H) {
@@ -1033,6 +1035,14 @@ fn shape_shadow_bounds(shapes: &[(DrawShape, BlendMode)]) -> Option<Rect> {
         })
 }
 
+fn shared_shape_shadow_snap_anchor(shapes: &[(DrawShape, BlendMode)]) -> Option<SnapAnchor> {
+    let anchor = shapes.first()?.0.snap_anchor?;
+    shapes
+        .iter()
+        .all(|(shape, _)| shape.snap_anchor == Some(anchor))
+        .then_some(anchor)
+}
+
 fn shadow_draw_bounds(shadow: &ShadowDraw) -> Option<Rect> {
     shadow
         .shapes
@@ -1126,9 +1136,13 @@ fn shape_shadow_surface_plan(
     processing_scissor?;
     let visible_device_bounds =
         device_pixel_bounds_for_rect(visible_blur_bounds, width, height, root_scale)?;
-    let source_device_bounds =
-        translation_stable_device_pixel_bounds(source_blur_bounds, root_scale, max_texture_dim)
-            .unwrap_or(visible_device_bounds);
+    let source_device_bounds = translation_stable_anchored_device_pixel_bounds(
+        source_blur_bounds,
+        shared_shape_shadow_snap_anchor(shapes),
+        root_scale,
+        max_texture_dim,
+    )
+    .unwrap_or(visible_device_bounds);
 
     Some(ShapeShadowSurfacePlan {
         source_device_bounds,
@@ -4813,6 +4827,7 @@ impl GpuRenderer {
                             .root
                             .clip_rect()
                             .map(|clip| quad_bounds(graph.root.transform_to_parent.map_rect(clip))),
+                        snap_anchor: None,
                         effect: backdrop.clone(),
                         z_index: 0,
                     },
@@ -6645,7 +6660,7 @@ impl GpuRenderer {
                             rounded_mask,
                             BlendMode::SrcOver,
                             dest_viewport,
-                            CompositeSampleMode::Linear,
+                            CompositeSampleMode::Nearest,
                         );
                 }
                 frame_encoder.record_pass();
@@ -6743,7 +6758,7 @@ impl GpuRenderer {
                     rounded_mask,
                     BlendMode::SrcOver,
                     dest_viewport,
-                    CompositeSampleMode::Linear,
+                    CompositeSampleMode::Nearest,
                 );
         }
         frame_encoder.record_pass();
@@ -6789,17 +6804,48 @@ impl GpuRenderer {
                 .unwrap_or_default();
             let local_rect = shape.local_rect.translate(snap_delta.x, snap_delta.y);
             let quad = translate_quad(shape.quad, snap_delta);
-            let clip = shape
-                .clip
-                .map(|clip| clip.translate(snap_delta.x, snap_delta.y));
+            let clip = shape.clip;
+            let canonicalize = shape.snap_anchor.is_some();
+            let device_local_rect = if canonicalize {
+                canonicalized_scaled_rect(local_rect, root_scale)
+            } else {
+                Rect {
+                    x: local_rect.x * root_scale,
+                    y: local_rect.y * root_scale,
+                    width: local_rect.width * root_scale,
+                    height: local_rect.height * root_scale,
+                }
+            };
+            let device_quad = if canonicalize {
+                canonicalized_scaled_quad(quad, root_scale)
+            } else {
+                scaled_quad(quad, root_scale)
+            };
+            let canonicalize_brush_coordinate = |value| {
+                if canonicalize {
+                    canonicalize_device_coordinate(value)
+                } else {
+                    value
+                }
+            };
 
             // Clip rect (scaled to physical pixels)
             let clip_rect = if let Some(clip) = clip {
+                let device_clip = if canonicalize {
+                    canonicalized_scaled_rect(clip, root_scale)
+                } else {
+                    Rect {
+                        x: clip.x * root_scale,
+                        y: clip.y * root_scale,
+                        width: clip.width * root_scale,
+                        height: clip.height * root_scale,
+                    }
+                };
                 [
-                    clip.x * root_scale,
-                    clip.y * root_scale,
-                    clip.width * root_scale,
-                    clip.height * root_scale,
+                    device_clip.x,
+                    device_clip.y,
+                    device_clip.width,
+                    device_clip.height,
                 ]
             } else {
                 [0.0, 0.0, 0.0, 0.0]
@@ -6842,26 +6888,26 @@ impl GpuRenderer {
                 } => {
                     let (start_idx, count) = push_gradient_entries(colors, stops.as_deref());
                     gradient_params = [
-                        resolve_gradient_point(
-                            local_rect.x * root_scale,
-                            local_rect.width * root_scale,
+                        canonicalize_brush_coordinate(resolve_gradient_point(
+                            device_local_rect.x,
+                            device_local_rect.width,
                             start.x * root_scale,
-                        ),
-                        resolve_gradient_point(
-                            local_rect.y * root_scale,
-                            local_rect.height * root_scale,
+                        )),
+                        canonicalize_brush_coordinate(resolve_gradient_point(
+                            device_local_rect.y,
+                            device_local_rect.height,
                             start.y * root_scale,
-                        ),
-                        resolve_gradient_point(
-                            local_rect.x * root_scale,
-                            local_rect.width * root_scale,
+                        )),
+                        canonicalize_brush_coordinate(resolve_gradient_point(
+                            device_local_rect.x,
+                            device_local_rect.width,
                             end.x * root_scale,
-                        ),
-                        resolve_gradient_point(
-                            local_rect.y * root_scale,
-                            local_rect.height * root_scale,
+                        )),
+                        canonicalize_brush_coordinate(resolve_gradient_point(
+                            device_local_rect.y,
+                            device_local_rect.height,
                             end.y * root_scale,
-                        ),
+                        )),
                     ];
                     (1u32, start_idx, count, gradient_tile_mode_value(*tile_mode))
                 }
@@ -6874,8 +6920,8 @@ impl GpuRenderer {
                 } => {
                     let (start_idx, count) = push_gradient_entries(colors, stops.as_deref());
                     gradient_params = [
-                        local_rect.x * root_scale + center.x * root_scale,
-                        local_rect.y * root_scale + center.y * root_scale,
+                        canonicalize_brush_coordinate(device_local_rect.x + center.x * root_scale),
+                        canonicalize_brush_coordinate(device_local_rect.y + center.y * root_scale),
                         (radius * root_scale).max(f32::EPSILON),
                         0.0,
                     ];
@@ -6888,8 +6934,8 @@ impl GpuRenderer {
                 } => {
                     let (start_idx, count) = push_gradient_entries(colors, stops.as_deref());
                     gradient_params = [
-                        local_rect.x * root_scale + center.x * root_scale,
-                        local_rect.y * root_scale + center.y * root_scale,
+                        canonicalize_brush_coordinate(device_local_rect.x + center.x * root_scale),
+                        canonicalize_brush_coordinate(device_local_rect.y + center.y * root_scale),
                         0.0,
                         0.0,
                     ];
@@ -6915,10 +6961,10 @@ impl GpuRenderer {
             };
 
             let device_rect = [
-                local_rect.x * root_scale,
-                local_rect.y * root_scale,
-                local_rect.width * root_scale,
-                local_rect.height * root_scale,
+                device_local_rect.x,
+                device_local_rect.y,
+                device_local_rect.width,
+                device_local_rect.height,
             ];
 
             self.scratch_shape_data.push(ShapeData {
@@ -6945,12 +6991,7 @@ impl GpuRenderer {
                 }
             };
 
-            let vertices = [
-                [quad[0][0] * root_scale, quad[0][1] * root_scale],
-                [quad[1][0] * root_scale, quad[1][1] * root_scale],
-                [quad[2][0] * root_scale, quad[2][1] * root_scale],
-                [quad[3][0] * root_scale, quad[3][1] * root_scale],
-            ];
+            let vertices = device_quad;
 
             self.scratch_vertices.extend_from_slice(&[
                 Vertex {
@@ -7406,9 +7447,7 @@ impl GpuRenderer {
             color_filter: image_draw.color_filter,
             sampling: image_draw.sampling,
             z_index: image_draw.z_index,
-            clip: image_draw
-                .clip
-                .map(|clip| clip.translate(snap_delta.x, snap_delta.y)),
+            clip: image_draw.clip,
             blend_mode: image_draw.blend_mode,
             src_rect: image_draw.src_rect,
             motion_context_animated: image_draw.motion_context_animated,
@@ -7423,24 +7462,14 @@ impl GpuRenderer {
         let Some(uv_rect) = image_uv_rect(&image_draw.image, image_draw.src_rect) else {
             return Ok(());
         };
-        let device_quad = nearest_image_device_quad(&adjusted_image, root_scale).unwrap_or([
-            [
-                adjusted_image.quad[0][0] * root_scale,
-                adjusted_image.quad[0][1] * root_scale,
-            ],
-            [
-                adjusted_image.quad[1][0] * root_scale,
-                adjusted_image.quad[1][1] * root_scale,
-            ],
-            [
-                adjusted_image.quad[2][0] * root_scale,
-                adjusted_image.quad[2][1] * root_scale,
-            ],
-            [
-                adjusted_image.quad[3][0] * root_scale,
-                adjusted_image.quad[3][1] * root_scale,
-            ],
-        ]);
+        let device_quad =
+            nearest_image_device_quad(&adjusted_image, root_scale).unwrap_or_else(|| {
+                if adjusted_image.snap_anchor.is_some() {
+                    canonicalized_scaled_quad(adjusted_image.quad, root_scale)
+                } else {
+                    scaled_quad(adjusted_image.quad, root_scale)
+                }
+            });
 
         let base_vertex = image_vertices.len() as u32;
         let index_start = image_indices.len() as u32;
@@ -9744,10 +9773,10 @@ pub(crate) fn scissor_rect_for_rect(
     width: u32,
     height: u32,
 ) -> Option<(u32, u32, u32, u32)> {
-    let mut left = rect.x * root_scale;
-    let mut top = rect.y * root_scale;
-    let mut right = (rect.x + rect.width) * root_scale;
-    let mut bottom = (rect.y + rect.height) * root_scale;
+    let mut left = canonicalize_device_coordinate(rect.x * root_scale);
+    let mut top = canonicalize_device_coordinate(rect.y * root_scale);
+    let mut right = canonicalize_device_coordinate((rect.x + rect.width) * root_scale);
+    let mut bottom = canonicalize_device_coordinate((rect.y + rect.height) * root_scale);
 
     left = left.max(0.0).min(width as f32).floor();
     top = top.max(0.0).min(height as f32).floor();
@@ -10654,6 +10683,74 @@ mod tests {
     }
 
     #[test]
+    fn translated_static_text_moves_one_device_pixel_at_half_pixel_phase() {
+        let root_scale = 1.25;
+        let mut base = test_text_draw(
+            Rect {
+                x: 14.0,
+                y: 276.0,
+                width: 220.0,
+                height: 24.0,
+            },
+            TextMotion::Static,
+        );
+        base.snap_anchor = Some(SnapAnchor::rigid(Point::new(0.0, 127.600_006)));
+
+        let mut scrolled = test_text_draw(
+            Rect {
+                x: 14.0,
+                y: 275.2,
+                width: 220.0,
+                height: 24.0,
+            },
+            TextMotion::Static,
+        );
+        scrolled.snap_anchor = Some(SnapAnchor::rigid(Point::new(0.0, 126.799_99)));
+
+        let (_, base_raster, _, _, _) =
+            text_raster_geometry_for_draw(&base, root_scale).expect("base text geometry");
+        let (_, scrolled_raster, _, _, _) =
+            text_raster_geometry_for_draw(&scrolled, root_scale).expect("scrolled text geometry");
+
+        assert_eq!(
+            base_raster.y - scrolled_raster.y,
+            1.0,
+            "one physical pixel of rigid scrolling must move static text by one raster pixel"
+        );
+    }
+
+    #[test]
+    fn translated_text_snap_does_not_move_its_fixed_ancestor_clip() {
+        let root_scale = 1.25;
+        let fixed_clip = Rect {
+            x: 8.0,
+            y: 20.0,
+            width: 300.0,
+            height: 680.0,
+        };
+        let mut draw = test_text_draw(
+            Rect {
+                x: 14.0,
+                y: 276.0,
+                width: 220.0,
+                height: 24.0,
+            },
+            TextMotion::Static,
+        );
+        draw.snap_anchor = Some(SnapAnchor::rigid(Point::new(0.0, 127.4)));
+        draw.clip = Some(fixed_clip);
+
+        let (_, _, clip, _, _) =
+            text_raster_geometry_for_draw(&draw, root_scale).expect("clipped text geometry");
+
+        assert_eq!(
+            clip,
+            Some(fixed_clip),
+            "content pixel snapping must not translate a fixed ancestor clip"
+        );
+    }
+
+    #[test]
     fn clipped_static_multiline_text_raster_source_limits_visible_line_window() {
         let rect = Rect {
             x: 8.0,
@@ -10890,6 +10987,7 @@ mod tests {
                 height: 10.0,
             },
             clip: None,
+            snap_anchor: None,
             effect: RenderEffect::blur(2.0),
             z_index,
         }
@@ -11979,6 +12077,7 @@ mod tests {
             },
             dest_quad: rect_to_quad(rect),
             snap_anchor: None,
+            composite_snap_origin: None,
             backdrop_rect: rect,
             visual_clip: None,
             surface_clip: None,
@@ -12286,6 +12385,7 @@ mod tests {
                 height: 80.0,
             },
             clip: None,
+            snap_anchor: None,
             effect: RenderEffect::blur(6.0),
             z_index: 1,
         });
@@ -13427,6 +13527,42 @@ mod tests {
         assert_eq!(
             collected.child_layers[0].snap_anchor, expected_anchor,
             "active translated leaf surface should keep the content-origin snap phase"
+        );
+    }
+
+    #[test]
+    fn translated_content_assigns_motion_anchor_to_rotated_child_surface() {
+        let mut child = snapped_text_leaf(false, false);
+        child.graphics_layer.rotation_z = 5.0;
+        child.transform_to_parent =
+            cranpose_render_common::layer_transform::layer_transform_to_parent(
+                child.local_bounds,
+                Point::new(108.0, 3.0),
+                &child.graphics_layer,
+            );
+        child.recompute_raster_cache_hashes();
+        let mut root = test_layer(
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 320.0,
+                height: 180.0,
+            },
+            vec![RenderNode::Layer(Box::new(child))],
+        );
+        root.translated_content_context = true;
+        root.translated_content_offset = Point::new(0.0, -80.8);
+        root.recompute_raster_cache_hashes();
+        let mut rect_cache = HashMap::new();
+        let mut requirements_cache = HashMap::new();
+
+        let collected =
+            collect_layer_contents(&root, None, None, &mut rect_cache, &mut requirements_cache);
+
+        assert_eq!(collected.child_layers.len(), 1);
+        assert!(
+            collected.child_layers[0].snap_anchor.is_some(),
+            "a projective child still translates rigidly with its scrolling parent"
         );
     }
 

--- a/crates/cranpose-render/wgpu/src/scene.rs
+++ b/crates/cranpose-render/wgpu/src/scene.rs
@@ -130,6 +130,7 @@ pub(crate) struct BackdropLayer {
     pub node_id: Option<NodeId>,
     pub rect: Rect,
     pub clip: Option<Rect>,
+    pub snap_anchor: Option<SnapAnchor>,
     pub effect: RenderEffect,
     /// Z-index at which this backdrop effect should be applied.
     pub z_index: usize,

--- a/crates/cranpose-render/wgpu/src/surface_executor.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor.rs
@@ -5,9 +5,10 @@ mod render_paths;
 pub(crate) use backend::DevicePixelBounds;
 pub(crate) use backend::{CachedLayerSurface, LayerSurfaceTexture, SurfaceExecutionBackend};
 pub(crate) use geometry::{
-    axis_aligned_quad_rect, device_pixel_bounds_for_rect, offscreen_byte_size, scaled_quad,
+    axis_aligned_quad_rect, canonicalize_device_coordinate, canonicalized_scaled_quad,
+    canonicalized_scaled_rect, device_pixel_bounds_for_rect, offscreen_byte_size, scaled_quad,
     snap_delta_for_anchor, snap_motion_stable_dest_quad, surface_target_size,
-    translation_stable_device_pixel_bounds,
+    translation_stable_anchored_device_pixel_bounds,
 };
 #[cfg(test)]
 pub(crate) use geometry::{

--- a/crates/cranpose-render/wgpu/src/surface_executor/geometry.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/geometry.rs
@@ -7,6 +7,7 @@ use cranpose_ui_graphics::{Point, Rect};
 pub(crate) const MAX_EFFECT_LAYER_SURFACE_BYTES: u64 = 8 * 1024 * 1024;
 const QUAD_AXIS_ALIGNMENT_TOLERANCE: f32 = 1e-4;
 const COMPOSITE_DEST_SNAP_TOLERANCE: f32 = 1e-4;
+const DEVICE_SNAP_SUBPIXEL_STEPS: f64 = 16.0;
 
 /// Slack absorbed before the ceil, so a rect that already covers a whole
 /// number of device pixels cannot gain one to float error: `51.0 / 1.4 * 1.4`
@@ -63,12 +64,7 @@ pub(crate) fn offscreen_byte_size(width: u32, height: u32) -> u64 {
 }
 
 pub(crate) fn surface_pixel_rect(rect: Rect, root_scale: f32) -> Rect {
-    Rect {
-        x: rect.x * root_scale,
-        y: rect.y * root_scale,
-        width: rect.width * root_scale,
-        height: rect.height * root_scale,
-    }
+    canonicalized_scaled_rect(rect, root_scale)
 }
 
 pub(crate) fn local_effect_pixel_rect(width: u32, height: u32) -> [f32; 4] {
@@ -104,10 +100,10 @@ pub(crate) fn content_effect_pixel_rect(
     let scale_x = width as f32 / surface_rect.width;
     let scale_y = height as f32 / surface_rect.height;
     [
-        (content.x - surface_rect.x) * scale_x,
-        (content.y - surface_rect.y) * scale_y,
-        content.width * scale_x,
-        content.height * scale_y,
+        canonicalize_device_coordinate((content.x - surface_rect.x) * scale_x),
+        canonicalize_device_coordinate((content.y - surface_rect.y) * scale_y),
+        canonicalize_device_coordinate(content.width * scale_x),
+        canonicalize_device_coordinate(content.height * scale_y),
     ]
 }
 
@@ -269,8 +265,9 @@ pub(crate) fn device_pixel_bounds_for_rect(
 /// translates across the device-pixel grid, which would change raster cache
 /// keys on every scroll step; the +1 slack column/row covers the worst-case
 /// phase instead so one cached raster size serves every translation.
-pub(crate) fn translation_stable_device_pixel_bounds(
+pub(crate) fn translation_stable_anchored_device_pixel_bounds(
     rect: Rect,
+    snap_anchor: Option<SnapAnchor>,
     root_scale: f32,
     max_texture_dim: u32,
 ) -> Option<DevicePixelBounds> {
@@ -278,10 +275,24 @@ pub(crate) fn translation_stable_device_pixel_bounds(
         return None;
     }
 
-    let min_x = (rect.x * root_scale).floor();
-    let min_y = (rect.y * root_scale).floor();
-    let width = ((rect.width * root_scale).ceil() + 1.0).max(0.0) as u32;
-    let height = ((rect.height * root_scale).ceil() + 1.0).max(0.0) as u32;
+    let device_rect = snap_anchor
+        .and_then(|anchor| {
+            axis_aligned_quad_rect(canonicalized_anchored_scaled_quad(
+                [
+                    [rect.x, rect.y],
+                    [rect.x + rect.width, rect.y],
+                    [rect.x, rect.y + rect.height],
+                    [rect.x + rect.width, rect.y + rect.height],
+                ],
+                anchor,
+                root_scale,
+            ))
+        })
+        .unwrap_or_else(|| canonicalized_scaled_rect(rect, root_scale));
+    let min_x = device_rect.x.floor();
+    let min_y = device_rect.y.floor();
+    let width = (device_rect.width.ceil() + 1.0).max(0.0) as u32;
+    let height = (device_rect.height.ceil() + 1.0).max(0.0) as u32;
     if width == 0 || height == 0 || width > max_texture_dim || height > max_texture_dim {
         return None;
     }
@@ -307,6 +318,65 @@ pub(crate) fn scaled_quad(quad: [[f32; 2]; 4], scale: f32) -> [[f32; 2]; 4] {
     quad.map(|[x, y]| [x * scale, y * scale])
 }
 
+pub(crate) fn canonicalize_device_coordinate(value: f32) -> f32 {
+    if !value.is_finite() {
+        return value;
+    }
+    ((f64::from(value) * DEVICE_SNAP_SUBPIXEL_STEPS).round() / DEVICE_SNAP_SUBPIXEL_STEPS) as f32
+}
+
+pub(crate) fn canonicalized_scaled_rect(rect: Rect, scale: f32) -> Rect {
+    let left = canonicalize_device_coordinate(rect.x * scale);
+    let top = canonicalize_device_coordinate(rect.y * scale);
+    let right = canonicalize_device_coordinate((rect.x + rect.width) * scale);
+    let bottom = canonicalize_device_coordinate((rect.y + rect.height) * scale);
+    Rect {
+        x: left,
+        y: top,
+        width: right - left,
+        height: bottom - top,
+    }
+}
+
+pub(crate) fn canonicalized_scaled_quad(quad: [[f32; 2]; 4], scale: f32) -> [[f32; 2]; 4] {
+    quad.map(|[x, y]| {
+        [
+            canonicalize_device_coordinate(x * scale),
+            canonicalize_device_coordinate(y * scale),
+        ]
+    })
+}
+
+pub(crate) fn canonicalized_anchored_scaled_quad(
+    quad: [[f32; 2]; 4],
+    anchor: SnapAnchor,
+    root_scale: f32,
+) -> [[f32; 2]; 4] {
+    if !root_scale.is_finite() || root_scale <= 0.0 {
+        return canonicalized_scaled_quad(quad, root_scale);
+    }
+    let device_pixel_step =
+        if anchor.device_pixel_step.is_finite() && anchor.device_pixel_step > 0.0 {
+            anchor.device_pixel_step
+        } else {
+            1.0
+        };
+    let snapped_device_origin = |origin: f32| {
+        let snap_units = f64::from(origin) * f64::from(root_scale) / f64::from(device_pixel_step);
+        let canonical_snap_units =
+            (snap_units * DEVICE_SNAP_SUBPIXEL_STEPS).round() / DEVICE_SNAP_SUBPIXEL_STEPS;
+        (canonical_snap_units.round() * f64::from(device_pixel_step)) as f32
+    };
+    let anchor_x = snapped_device_origin(anchor.origin.x);
+    let anchor_y = snapped_device_origin(anchor.origin.y);
+    quad.map(|[x, y]| {
+        [
+            anchor_x + canonicalize_device_coordinate((x - anchor.origin.x) * root_scale),
+            anchor_y + canonicalize_device_coordinate((y - anchor.origin.y) * root_scale),
+        ]
+    })
+}
+
 pub(crate) fn snap_delta_for_anchor(anchor: SnapAnchor, root_scale: f32) -> Point {
     if !root_scale.is_finite() || root_scale <= 0.0 {
         return Point::default();
@@ -317,13 +387,18 @@ pub(crate) fn snap_delta_for_anchor(anchor: SnapAnchor, root_scale: f32) -> Poin
         } else {
             1.0
         };
+    let snapped_axis_delta = |origin: f32| {
+        let root_scale = f64::from(root_scale);
+        let device_pixel_step = f64::from(device_pixel_step);
+        let snap_units = f64::from(origin) * root_scale / device_pixel_step;
+        let canonical_snap_units =
+            (snap_units * DEVICE_SNAP_SUBPIXEL_STEPS).round() / DEVICE_SNAP_SUBPIXEL_STEPS;
+        let snapped_logical = canonical_snap_units.round() * device_pixel_step / root_scale;
+        (snapped_logical - f64::from(origin)) as f32
+    };
     Point::new(
-        ((anchor.origin.x * root_scale) / device_pixel_step).round() * device_pixel_step
-            / root_scale
-            - anchor.origin.x,
-        ((anchor.origin.y * root_scale) / device_pixel_step).round() * device_pixel_step
-            / root_scale
-            - anchor.origin.y,
+        snapped_axis_delta(anchor.origin.x),
+        snapped_axis_delta(anchor.origin.y),
     )
 }
 
@@ -381,6 +456,30 @@ pub(crate) fn snap_motion_stable_dest_quad(
     dest_quad.map(|[x, y]| [x + delta_x, y + delta_y])
 }
 
+/// Translates an axis-aligned composite as one unit so its stable transform
+/// pivot lands exactly on the canonical device pixel selected for that pivot.
+pub(crate) fn snap_dest_quad_to_stable_point(
+    dest_quad: [[f32; 2]; 4],
+    stable_point: [f32; 2],
+) -> [[f32; 2]; 4] {
+    if !quad_is_axis_aligned_rect(dest_quad)
+        || !stable_point[0].is_finite()
+        || !stable_point[1].is_finite()
+    {
+        return dest_quad;
+    }
+
+    let delta_x = canonicalize_device_coordinate(stable_point[0]).round() - stable_point[0];
+    let delta_y = canonicalize_device_coordinate(stable_point[1]).round() - stable_point[1];
+    if delta_x.abs() <= COMPOSITE_DEST_SNAP_TOLERANCE
+        && delta_y.abs() <= COMPOSITE_DEST_SNAP_TOLERANCE
+    {
+        return dest_quad;
+    }
+
+    dest_quad.map(|[x, y]| [x + delta_x, y + delta_y])
+}
+
 pub(crate) fn quantize_motion_stable_target_scale(
     target_scale: f32,
     sample_mode: CompositeSampleMode,
@@ -399,10 +498,12 @@ pub(crate) fn quantize_motion_stable_target_scale(
 #[cfg(test)]
 mod tests {
     use super::{
-        axis_aligned_quad_rect, clamp_effect_surface_scale, device_pixel_exact_surface_rect,
-        fit_capture_rect_to_scale_budget_for_axes, offscreen_byte_size,
-        quantize_motion_stable_target_scale, snap_motion_stable_dest_quad, surface_target_size,
-        translation_stable_device_pixel_bounds, MAX_EFFECT_LAYER_SURFACE_BYTES,
+        axis_aligned_quad_rect, canonicalize_device_coordinate, canonicalized_scaled_quad,
+        canonicalized_scaled_rect, clamp_effect_surface_scale, content_effect_pixel_rect,
+        device_pixel_exact_surface_rect, fit_capture_rect_to_scale_budget_for_axes,
+        offscreen_byte_size, quantize_motion_stable_target_scale, snap_dest_quad_to_stable_point,
+        snap_motion_stable_dest_quad, surface_target_size,
+        translation_stable_anchored_device_pixel_bounds, MAX_EFFECT_LAYER_SURFACE_BYTES,
     };
     use crate::effect_renderer::CompositeSampleMode;
     use crate::rect_to_quad;
@@ -420,6 +521,32 @@ mod tests {
     }
 
     #[test]
+    fn animated_scale_can_snap_around_a_stable_center() {
+        let center = [72.0, 433.6];
+        let snapped_center = [72.0, 434.0];
+
+        for scale in [0.85, 0.93, 1.0, 1.07, 1.15] {
+            let half_extent = 18.0 * scale;
+            let quad = [
+                [center[0] - half_extent, center[1] - half_extent],
+                [center[0] + half_extent, center[1] - half_extent],
+                [center[0] - half_extent, center[1] + half_extent],
+                [center[0] + half_extent, center[1] + half_extent],
+            ];
+            let snapped = snap_dest_quad_to_stable_point(quad, center);
+            let actual_center = [
+                (snapped[0][0] + snapped[3][0]) * 0.5,
+                (snapped[0][1] + snapped[3][1]) * 0.5,
+            ];
+
+            assert_eq!(
+                actual_center, snapped_center,
+                "scale {scale} shifted the layer"
+            );
+        }
+    }
+
+    #[test]
     fn linear_dest_quad_preserves_fractional_translation() {
         let quad = [[12.33, 8.66], [20.33, 8.66], [12.33, 18.66], [20.33, 18.66]];
 
@@ -431,13 +558,14 @@ mod tests {
 
     #[test]
     fn translation_stable_device_bounds_preserve_offscreen_source_origin() {
-        let bounds = translation_stable_device_pixel_bounds(
+        let bounds = translation_stable_anchored_device_pixel_bounds(
             Rect {
                 x: -12.25,
                 y: 8.25,
                 width: 34.5,
                 height: 10.25,
             },
+            None,
             2.0,
             4096,
         )
@@ -458,13 +586,139 @@ mod tests {
             height: 10.25,
         };
         let scale = 130.0 / 96.0;
-        let base = translation_stable_device_pixel_bounds(rect_at(-12.25), scale, 4096)
-            .expect("base bounds");
+        let base =
+            translation_stable_anchored_device_pixel_bounds(rect_at(-12.25), None, scale, 4096)
+                .expect("base bounds");
         for step in 1..=12 {
-            let moved =
-                translation_stable_device_pixel_bounds(rect_at(-12.25 + step as f32), scale, 4096)
-                    .expect("moved bounds");
+            let moved = translation_stable_anchored_device_pixel_bounds(
+                rect_at(-12.25 + step as f32),
+                None,
+                scale,
+                4096,
+            )
+            .expect("moved bounds");
             assert_eq!((base.width, base.height), (moved.width, moved.height));
+        }
+    }
+
+    #[test]
+    fn anchored_translation_stable_bounds_move_one_pixel_at_fractional_densities() {
+        for scale in [1.25, 130.0 / 96.0] {
+            let mut origin_y = 127.600_006_f32;
+            let mut previous_y = None;
+
+            for step in 0..10 {
+                let rect = Rect {
+                    x: 40.0,
+                    y: origin_y - 18.0,
+                    width: 60.0,
+                    height: 60.0,
+                };
+                let anchor = crate::scene::SnapAnchor::rigid(cranpose_ui_graphics::Point::new(
+                    0.0, origin_y,
+                ));
+                let bounds = translation_stable_anchored_device_pixel_bounds(
+                    rect,
+                    Some(anchor),
+                    scale,
+                    4096,
+                )
+                .expect("anchored shadow bounds");
+                if let Some(previous_y) = previous_y {
+                    assert_eq!(
+                        bounds.y,
+                        previous_y - 1.0,
+                        "anchored bounds jumped at step {step} with scale {scale}"
+                    );
+                }
+                previous_y = Some(bounds.y);
+                origin_y -= 1.0 / scale;
+            }
+        }
+    }
+
+    #[test]
+    fn rigid_snap_keeps_half_pixel_phase_across_one_device_pixel_steps() {
+        let scale = 1.25;
+        let logical_device_pixel = 1.0 / scale;
+        let mut origin = 127.600_006;
+        let mut previous_device_origin = None;
+
+        for step in 0..10 {
+            let anchor =
+                crate::scene::SnapAnchor::rigid(cranpose_ui_graphics::Point::new(0.0, origin));
+            let delta = super::snap_delta_for_anchor(anchor, scale);
+            let snapped_device_origin = (origin + delta.y) * scale;
+            assert_eq!(
+                snapped_device_origin.fract(),
+                0.0,
+                "step {step} did not snap to a device pixel: origin={origin:?} delta={:?}",
+                delta.y
+            );
+            if let Some(previous) = previous_device_origin {
+                assert_eq!(
+                    previous - snapped_device_origin,
+                    1.0,
+                    "step {step} changed the half-pixel rounding direction"
+                );
+            }
+            previous_device_origin = Some(snapped_device_origin);
+            origin -= logical_device_pixel;
+        }
+    }
+
+    #[test]
+    fn device_coordinate_canonicalization_absorbs_half_pixel_float_noise() {
+        assert_eq!(canonicalize_device_coordinate(338.499_94), 338.5);
+        assert_eq!(canonicalize_device_coordinate(338.500_06), 338.5);
+        assert_eq!(canonicalize_device_coordinate(f32::INFINITY), f32::INFINITY);
+    }
+
+    #[test]
+    fn scaled_geometry_canonicalization_preserves_edges_and_quad_topology() {
+        let rect = Rect {
+            x: 10.000_02,
+            y: 20.399_96,
+            width: 30.0,
+            height: 40.000_03,
+        };
+        let scaled = canonicalized_scaled_rect(rect, 1.25);
+        assert_eq!(scaled.x, 12.5);
+        assert_eq!(scaled.y, 25.5);
+        assert_eq!(scaled.width, 37.5);
+        assert_eq!(scaled.height, 50.0);
+
+        assert_eq!(
+            canonicalized_scaled_quad(crate::rect_to_quad(rect), 1.25),
+            crate::rect_to_quad(scaled)
+        );
+    }
+
+    #[test]
+    fn effect_pixel_rect_is_stable_under_accumulated_rigid_translation() {
+        let mut translation = 2_352.801;
+        let mut expected = None;
+
+        for step in 0..10 {
+            let surface = Rect {
+                x: 20.0,
+                y: translation,
+                width: 120.0,
+                height: 60.0,
+            };
+            let content = Rect {
+                x: 24.0,
+                y: translation + 7.2,
+                width: 112.0,
+                height: 48.0,
+            };
+            let actual = content_effect_pixel_rect(Some(content), surface, 150, 75);
+            if let Some(expected) = expected {
+                assert_eq!(actual, expected, "effect rect drifted at step {step}");
+            } else {
+                expected = Some(actual);
+            }
+            translation += 0.8;
         }
     }
 

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -2,11 +2,12 @@ use super::backend::{
     LayerSurface, LayerSurfaceRoundedClip, LayerSurfaceTexture, SurfaceExecutionBackend,
 };
 use super::geometry::{
-    axis_aligned_quad_rect, clamp_effect_surface_scale, content_effect_pixel_rect,
-    device_pixel_exact_surface_rect, fit_capture_rect_to_scale_budget_for_axes,
-    offscreen_byte_size, quantize_motion_stable_target_scale, scaled_quad, snap_delta_for_anchor,
-    snap_motion_stable_dest_quad, surface_pixel_rect, surface_target_size, target_quad,
-    visible_layer_rect,
+    axis_aligned_quad_rect, canonicalized_anchored_scaled_quad, clamp_effect_surface_scale,
+    content_effect_pixel_rect, device_pixel_exact_surface_rect,
+    fit_capture_rect_to_scale_budget_for_axes, offscreen_byte_size,
+    quantize_motion_stable_target_scale, scaled_quad, snap_delta_for_anchor,
+    snap_dest_quad_to_stable_point, snap_motion_stable_dest_quad, surface_pixel_rect,
+    surface_target_size, target_quad, visible_layer_rect,
 };
 use crate::effect_renderer::{
     CompositeBatchItem, CompositeSampleMode, ProjectiveSurfaceComposite, RoundedCompositeMask,
@@ -44,7 +45,9 @@ use cranpose_render_common::graph::{CachePolicy, LayerNode, ProjectiveTransform}
 use cranpose_render_common::layer_composition::effective_layer_isolation;
 use cranpose_render_common::raster_cache::{LayerRasterCacheKey, ScaleBucket};
 use cranpose_ui::text::LinkAnnotation;
-use cranpose_ui_graphics::{BlendMode, Brush, Rect, RenderEffect, RenderHash, RuntimeShader};
+use cranpose_ui_graphics::{
+    BlendMode, Brush, Point, Rect, RenderEffect, RenderHash, RuntimeShader,
+};
 use std::cell::RefCell;
 use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::hash::{Hash, Hasher};
@@ -149,17 +152,22 @@ impl AnnotatedStringHashCache {
 fn anchored_composite_dest_quad(
     dest_quad: [[f32; 2]; 4],
     snap_anchor: Option<SnapAnchor>,
+    stable_origin: Option<Point>,
     root_scale: f32,
     sample_mode: CompositeSampleMode,
 ) -> [[f32; 2]; 4] {
     let scaled = if let Some(anchor) = snap_anchor {
-        let snap_delta = snap_delta_for_anchor(anchor, root_scale);
-        scaled_quad(translate_quad(dest_quad, snap_delta), root_scale)
+        canonicalized_anchored_scaled_quad(dest_quad, anchor, root_scale)
     } else {
         scaled_quad(dest_quad, root_scale)
     };
 
-    snap_motion_stable_dest_quad(scaled, sample_mode)
+    if let Some(origin) = stable_origin {
+        let stable_point = [origin.x * root_scale, origin.y * root_scale];
+        snap_dest_quad_to_stable_point(scaled, stable_point)
+    } else {
+        snap_motion_stable_dest_quad(scaled, sample_mode)
+    }
 }
 
 fn composite_dest_viewport(
@@ -423,6 +431,7 @@ fn layer_source_uses_external_backdrop_underlay(
             node_id: child.layer.node_id,
             rect: child.backdrop_rect,
             clip: child.visual_clip,
+            snap_anchor: child.snap_anchor,
             effect: effect.clone(),
             z_index: child.z_index,
         };
@@ -578,6 +587,14 @@ fn axis_aligned_backdrop_snapshot_copy_plan(
 fn backdrop_diag_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| std::env::var_os("CRANPOSE_BACKDROP_DIAG").is_some())
+}
+
+fn snapped_backdrop_geometry(layer: &BackdropLayer, root_scale: f32) -> (Rect, Option<Rect>) {
+    let Some(anchor) = layer.snap_anchor else {
+        return (layer.rect, layer.clip);
+    };
+    let delta = snap_delta_for_anchor(anchor, root_scale);
+    (layer.rect.translate(delta.x, delta.y), layer.clip)
 }
 
 fn backdrop_capture_rect(
@@ -1371,6 +1388,7 @@ fn render_effect_layer_to_view<B: SurfaceExecutionBackend>(
     let dest_quad = anchored_composite_dest_quad(
         crate::rect_to_quad(capture_rect),
         layer.snap_anchor,
+        None,
         root_scale,
         sample_mode,
     );
@@ -1827,6 +1845,7 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
             let dest_quad = anchored_composite_dest_quad(
                 dest_quad,
                 resolved_child.snap_anchor,
+                resolved_child.composite_snap_origin,
                 root_scale,
                 child_surface.sample_mode,
             );
@@ -2772,6 +2791,7 @@ fn hash_backdrop_layer<H: Hasher>(layer: &BackdropLayer, state: &mut H) {
     layer.node_id.hash(state);
     hash_rect(layer.rect, state);
     hash_optional_rect(layer.clip, state);
+    hash_snap_anchor(layer.snap_anchor, state);
     retained_render_effect_hash(&layer.effect).hash(state);
     layer.z_index.hash(state);
 }
@@ -2791,6 +2811,7 @@ fn hash_backdrop_prefix_child<H: Hasher>(child: &BackdropPrefixChildContribution
     match child.sample_mode {
         CompositeSampleMode::Linear => 0u8.hash(state),
         CompositeSampleMode::Box4 => 1u8.hash(state),
+        CompositeSampleMode::Nearest => 2u8.hash(state),
     }
 }
 
@@ -3380,6 +3401,7 @@ fn queue_cached_direct_scene_range<B: SurfaceExecutionBackend>(
     let dest_quad = anchored_composite_dest_quad(
         crate::rect_to_quad(logical_rect),
         None,
+        None,
         root_scale,
         surface.sample_mode,
     );
@@ -3663,6 +3685,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                 node_id: child.layer.node_id,
                 rect: resolved_child.backdrop_rect,
                 clip: child.visual_clip,
+                snap_anchor: resolved_child.snap_anchor,
                 effect: backdrop.clone(),
                 z_index: child.z_index,
             };
@@ -3754,6 +3777,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
         let dest_quad = anchored_composite_dest_quad(
             dest_quad,
             resolved_child.snap_anchor,
+            resolved_child.composite_snap_origin,
             target_scale,
             child_surface.sample_mode,
         );
@@ -4048,17 +4072,7 @@ fn render_layer_surface_uncached<B: SurfaceExecutionBackend>(
 
         let mut child_layers = child_layers;
         for child in &mut child_layers {
-            for point in &mut child.dest_quad {
-                point[0] += shift.x;
-                point[1] += shift.y;
-            }
-            child.backdrop_rect.x += shift.x;
-            child.backdrop_rect.y += shift.y;
-            if let Some(clip) = child.visual_clip.as_mut() {
-                clip.x += shift.x;
-                clip.y += shift.y;
-            }
-            child.shadow_draws.translate_by(shift);
+            child.translate_by(shift);
         }
         backend.record_isolated_layer_render(
             width,
@@ -4393,6 +4407,7 @@ pub(crate) fn render_effect_layer_to_target<B: SurfaceExecutionBackend>(
     let dest_quad = anchored_composite_dest_quad(
         crate::rect_to_quad(capture_rect),
         layer.snap_anchor,
+        None,
         root_scale,
         sample_mode,
     );
@@ -4525,12 +4540,13 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
     input_content_hash: Option<u64>,
 ) -> Result<Option<PreparedBackdropComposite>, String> {
     let diag = backdrop_diag_enabled();
-    let Some(visible_rect) = visible_layer_rect(layer.rect, layer.clip, root_scale, width, height)
+    let (layer_rect, layer_clip) = snapped_backdrop_geometry(layer, root_scale);
+    let Some(visible_rect) = visible_layer_rect(layer_rect, layer_clip, root_scale, width, height)
     else {
         if diag {
             eprintln!(
                 "[backdrop-diag] prepare SKIP: no visible rect for {:?}",
-                layer.rect
+                layer_rect
             );
         }
         return Ok(None);
@@ -4538,7 +4554,7 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
     let Some(scissor) = scissor_rect_for_rect(
         backdrop_output_rect(
             visible_rect,
-            layer.clip,
+            layer_clip,
             &layer.effect,
             root_scale,
             (width, height),
@@ -4554,7 +4570,7 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
     };
     let capture_rect = backdrop_capture_rect(
         visible_rect,
-        layer.clip,
+        layer_clip,
         &layer.effect,
         root_scale,
         (width, height),
@@ -4588,7 +4604,7 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
     let copy_plan = if (backdrop_scale - root_scale).abs() <= 0.01 {
         axis_aligned_backdrop_snapshot_copy_plan(
             capture_rect,
-            layer.rect,
+            layer_rect,
             root_scale,
             (target.width, target.height),
             backend.max_texture_dim(),
@@ -4659,7 +4675,7 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
                 .map(|plan| plan.effect_pixel_rect)
                 .unwrap_or_else(|| {
                     let capture = surface_pixel_rect(capture_rect, backdrop_scale);
-                    let effect = surface_pixel_rect(layer.rect, backdrop_scale);
+                    let effect = surface_pixel_rect(layer_rect, backdrop_scale);
                     [
                         effect.x - capture.x,
                         effect.y - capture.y,
@@ -4705,11 +4721,12 @@ pub(crate) fn apply_backdrop_layer_to_target<B: SurfaceExecutionBackend>(
     root_scale: f32,
     input_content_hash: Option<u64>,
 ) -> Result<(), String> {
+    let (layer_rect, layer_clip) = snapped_backdrop_geometry(layer, root_scale);
     if backdrop_diag_enabled() {
         eprintln!(
             "[backdrop-diag] apply rect={:?} clip={:?} in_pad={} out_pad={} hash={:?}",
-            layer.rect,
-            layer.clip,
+            layer_rect,
+            layer_clip,
             layer.effect.input_padding(),
             layer.effect.output_padding(),
             input_content_hash.is_some()
@@ -4744,7 +4761,7 @@ pub(crate) fn apply_backdrop_layer_to_target<B: SurfaceExecutionBackend>(
         return Ok(());
     }
 
-    let Some(visible_rect) = visible_layer_rect(layer.rect, layer.clip, root_scale, width, height)
+    let Some(visible_rect) = visible_layer_rect(layer_rect, layer_clip, root_scale, width, height)
     else {
         if backdrop_diag_enabled() {
             eprintln!("[backdrop-diag] SKIP: no visible rect");
@@ -4754,7 +4771,7 @@ pub(crate) fn apply_backdrop_layer_to_target<B: SurfaceExecutionBackend>(
     let Some(scissor) = scissor_rect_for_rect(
         backdrop_output_rect(
             visible_rect,
-            layer.clip,
+            layer_clip,
             &layer.effect,
             root_scale,
             (width, height),
@@ -4773,7 +4790,7 @@ pub(crate) fn apply_backdrop_layer_to_target<B: SurfaceExecutionBackend>(
             "[backdrop-diag] uncached visible={visible_rect:?} scissor={scissor:?} capture={:?}",
             backdrop_capture_rect(
                 visible_rect,
-                layer.clip,
+                layer_clip,
                 &layer.effect,
                 root_scale,
                 (width, height),
@@ -4782,7 +4799,7 @@ pub(crate) fn apply_backdrop_layer_to_target<B: SurfaceExecutionBackend>(
     }
     let capture_rect = backdrop_capture_rect(
         visible_rect,
-        layer.clip,
+        layer_clip,
         &layer.effect,
         root_scale,
         (width, height),
@@ -4797,7 +4814,7 @@ pub(crate) fn apply_backdrop_layer_to_target<B: SurfaceExecutionBackend>(
         if backdrop_underlay.is_none() && (backdrop_scale - root_scale).abs() <= 0.01 {
             axis_aligned_backdrop_snapshot_copy_plan(
                 capture_rect,
-                layer.rect,
+                layer_rect,
                 root_scale,
                 (target.width, target.height),
                 backend.max_texture_dim(),
@@ -4813,7 +4830,7 @@ pub(crate) fn apply_backdrop_layer_to_target<B: SurfaceExecutionBackend>(
         .map(|plan| plan.effect_pixel_rect)
         .unwrap_or_else(|| {
             let capture = surface_pixel_rect(capture_rect, backdrop_scale);
-            let effect = surface_pixel_rect(layer.rect, backdrop_scale);
+            let effect = surface_pixel_rect(layer_rect, backdrop_scale);
             [
                 effect.x - capture.x,
                 effect.y - capture.y,
@@ -4936,7 +4953,12 @@ pub(crate) fn composite_surface_to_view<B: SurfaceExecutionBackend>(
     };
     let inverse = ProjectiveTransform::from_rect_to_quad(source_rect, dest_quad)
         .inverse()
-        .ok_or_else(|| "child layer transform is not invertible".to_string())?;
+        .ok_or_else(|| {
+            format!(
+                "child layer transform is not invertible: source={}x{}, destination={dest_quad:?}",
+                source.width, source.height
+            )
+        })?;
     backend.composite_to_view_projective(
         source,
         dest_view,
@@ -5128,12 +5150,13 @@ mod tests {
         layer_source_cache_key, layer_source_uses_external_backdrop_underlay,
         layer_surface_dest_quad, layer_surface_translation_context,
         minimum_surface_scale_for_composite, quad_bounds_rect, rects_intersect,
-        retained_render_effect_hash, surface_target_size, visible_backdrop_capture_rect,
-        BackdropPrefixChildContribution, DEFAULT_DIRECT_SCENE_RANGE_CACHE_BYTES,
-        MAX_DIRECT_SCENE_RANGE_CACHE_DRAW_OPS, MAX_MOTION_SENSITIVE_DIRECT_SCENE_CACHE_DRAW_BYTES,
-        MIN_DIRECT_SCENE_RANGE_CACHE_DRAW_OPS,
+        retained_render_effect_hash, snapped_backdrop_geometry, surface_target_size,
+        visible_backdrop_capture_rect, BackdropPrefixChildContribution,
+        DEFAULT_DIRECT_SCENE_RANGE_CACHE_BYTES, MAX_DIRECT_SCENE_RANGE_CACHE_DRAW_OPS,
+        MAX_MOTION_SENSITIVE_DIRECT_SCENE_CACHE_DRAW_BYTES, MIN_DIRECT_SCENE_RANGE_CACHE_DRAW_OPS,
     };
     use crate::effect_renderer::CompositeSampleMode;
+    use crate::normalized_scene::TranslateBy;
     use crate::scene::{
         BackdropLayer, CompositorScene, DrawOp, DrawOpKind, DrawShape, ImageDraw, SnapAnchor,
     };
@@ -5323,6 +5346,7 @@ mod tests {
             node_id: Some(77),
             rect,
             clip: None,
+            snap_anchor: None,
             effect: RenderEffect::blur(4.0),
             z_index: 1,
         }
@@ -5364,6 +5388,7 @@ mod tests {
             },
             dest_quad: crate::rect_to_quad(rect),
             snap_anchor: None,
+            composite_snap_origin: None,
             backdrop_rect: rect,
             visual_clip: None,
             surface_clip: None,
@@ -6222,6 +6247,7 @@ mod tests {
             anchored_composite_dest_quad(
                 quad,
                 Some(SnapAnchor::rigid(Point::new(0.0, 0.0))),
+                None,
                 1.25,
                 CompositeSampleMode::Box4,
             ),
@@ -6235,14 +6261,107 @@ mod tests {
     }
 
     #[test]
+    fn anchored_projective_composite_is_stable_across_device_pixel_steps() {
+        let mut quad = [
+            [185.134_52, 490.533_26],
+            [236.936_63, 495.065_03],
+            [179.556_53, 554.289_8],
+            [231.358_64, 558.821_6],
+        ];
+        let mut anchor = SnapAnchor::rigid(Point::new(48.0, 127.600_006));
+        let initial =
+            anchored_composite_dest_quad(quad, Some(anchor), None, 1.25, CompositeSampleMode::Box4);
+
+        for step in 1..=10 {
+            for point in &mut quad {
+                point[1] -= 0.8;
+            }
+            anchor.origin.y -= 0.8;
+            let translated = anchored_composite_dest_quad(
+                quad,
+                Some(anchor),
+                None,
+                1.25,
+                CompositeSampleMode::Box4,
+            );
+
+            for (initial_point, translated_point) in initial.iter().zip(translated) {
+                assert_eq!(translated_point[0], initial_point[0]);
+                assert_eq!(
+                    translated_point[1] + step as f32,
+                    initial_point[1],
+                    "projective composite geometry drifted after {step} physical pixels"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn unanchored_box4_composite_snaps_final_dest_quad() {
         let quad = [[0.25, 10.5], [40.75, 10.5], [0.25, 20.25], [40.75, 20.25]];
 
         assert_eq!(
-            anchored_composite_dest_quad(quad, None, 1.0, CompositeSampleMode::Box4),
+            anchored_composite_dest_quad(quad, None, None, 1.0, CompositeSampleMode::Box4),
             [[0.0, 11.0], [40.5, 11.0], [0.0, 20.75], [40.5, 20.75]],
             "unanchored pixel-stable surfaces should keep their composite phase snapped"
         );
+    }
+
+    #[test]
+    fn scaled_linear_composite_snaps_around_its_transform_origin() {
+        let quad = [[54.9, 416.5], [89.1, 416.5], [54.9, 450.7], [89.1, 450.7]];
+        let snapped = anchored_composite_dest_quad(
+            quad,
+            None,
+            Some(Point::new(72.0, 433.6)),
+            1.0,
+            CompositeSampleMode::Linear,
+        );
+        let center = [
+            (snapped[0][0] + snapped[3][0]) * 0.5,
+            (snapped[0][1] + snapped[3][1]) * 0.5,
+        ];
+
+        assert_eq!(center, [72.0, 434.0]);
+        assert!((snapped[1][0] - snapped[0][0] - 34.2).abs() < 1e-4);
+        assert!((snapped[2][1] - snapped[0][1] - 34.2).abs() < 1e-4);
+    }
+
+    #[test]
+    fn parent_surface_translation_keeps_child_composite_coordinates_together() {
+        let layer = crate::test_support::layer_node(
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 36.0,
+                height: 36.0,
+            },
+            ProjectiveTransform::identity(),
+            GraphicsLayer::default(),
+            vec![],
+        );
+        let mut child = child_layer_composite(
+            &layer,
+            0,
+            Rect {
+                x: 54.0,
+                y: 416.0,
+                width: 36.0,
+                height: 36.0,
+            },
+        );
+        child.snap_anchor = Some(SnapAnchor::rigid(Point::new(54.0, 416.0)));
+        child.composite_snap_origin = Some(Point::new(72.0, 434.0));
+        child.translate_by(Point::new(-12.0, 8.0));
+
+        assert_eq!(child.dest_quad[0], [42.0, 424.0]);
+        assert_eq!(
+            child.snap_anchor.expect("snap anchor").origin,
+            Point::new(42.0, 424.0)
+        );
+        assert_eq!(child.composite_snap_origin, Some(Point::new(60.0, 442.0)));
+        assert_eq!(child.backdrop_rect.x, 42.0);
+        assert_eq!(child.backdrop_rect.y, 424.0);
     }
 
     #[test]
@@ -6704,6 +6823,76 @@ mod tests {
         assert_eq!(plan.size, (281, 200));
         assert_eq!(plan.effect_pixel_rect, [0.5, 0.0, 280.0, 200.0]);
         assert_eq!(plan.dest_viewport, (24.0, 41.0, 281.0, 200.0));
+    }
+
+    #[test]
+    fn backdrop_snapshot_effect_geometry_is_stable_across_device_pixel_steps() {
+        let mut layer = test_backdrop_layer(Rect {
+            x: 59.0,
+            y: 416.932_77,
+            width: 398.0,
+            height: 54.0,
+        });
+        let fixed_clip = Rect {
+            x: 40.0,
+            y: 120.0,
+            width: 500.0,
+            height: 600.0,
+        };
+        layer.clip = Some(fixed_clip);
+        layer.snap_anchor = Some(SnapAnchor::rigid(Point::new(0.0, 127.600_006)));
+        let (effect, clip) = snapped_backdrop_geometry(&layer, 1.25);
+        assert_eq!(clip, Some(fixed_clip));
+        let capture = Rect {
+            x: effect.x - 25.9,
+            y: effect.y - 25.9,
+            width: effect.width + 51.8,
+            height: effect.height + 51.8,
+        };
+        let initial =
+            axis_aligned_backdrop_snapshot_copy_plan(capture, effect, 1.25, (900, 1_600), 4_096)
+                .expect("visible backdrop must have a copy plan");
+
+        for step in 1..=10 {
+            layer.rect.y -= 0.8;
+            layer
+                .snap_anchor
+                .as_mut()
+                .expect("test backdrop keeps its snap anchor")
+                .origin
+                .y -= 0.8;
+            let (effect, clip) = snapped_backdrop_geometry(&layer, 1.25);
+            assert_eq!(
+                clip,
+                Some(fixed_clip),
+                "content snapping moved the fixed backdrop clip after {step} physical pixels"
+            );
+            let capture = Rect {
+                x: effect.x - 25.9,
+                y: effect.y - 25.9,
+                width: effect.width + 51.8,
+                height: effect.height + 51.8,
+            };
+            let translated = axis_aligned_backdrop_snapshot_copy_plan(
+                capture,
+                effect,
+                1.25,
+                (900, 1_600),
+                4_096,
+            )
+            .expect("translated backdrop must keep a copy plan");
+
+            assert_eq!(
+                translated.effect_pixel_rect, initial.effect_pixel_rect,
+                "shader-local geometry drifted after {step} physical pixels"
+            );
+            assert_eq!(translated.size, initial.size);
+            assert_eq!(
+                translated.source_origin.1 + step,
+                initial.source_origin.1,
+                "snapshot must translate by exactly one physical pixel per step"
+            );
+        }
     }
 
     #[test]

--- a/crates/cranpose-render/wgpu/tests/effect_semantics.rs
+++ b/crates/cranpose-render/wgpu/tests/effect_semantics.rs
@@ -26,6 +26,7 @@ const FRAME_WIDTH: u32 = 128;
 const FRAME_HEIGHT: u32 = 96;
 const ROOT_SCALE_TEST_SCALE: f32 = 2.0;
 const FRACTIONAL_ROOT_SCALE: f32 = 130.0 / 96.0;
+const DEVICE_SNAP_SUBPIXEL_STEPS: f64 = 16.0;
 const ALPHA_LAYER_SIZE: (u32, u32) = (48, 24);
 const BLUR_LAYER_SIZE: (u32, u32) = (28, 28);
 const BACKDROP_LAYER_SIZE: (u32, u32) = (24, 20);
@@ -2834,8 +2835,12 @@ fn normalize_translated_region_at_scale(
     local_size: (u32, u32),
     root_scale: f32,
 ) -> Vec<u8> {
-    let start_x = (translation.x * root_scale).round() as u32;
-    let start_y = (translation.y * root_scale).round() as u32;
+    let canonical_device_origin = |logical: f32| {
+        let device = f64::from(logical) * f64::from(root_scale);
+        ((device * DEVICE_SNAP_SUBPIXEL_STEPS).round() / DEVICE_SNAP_SUBPIXEL_STEPS).round() as u32
+    };
+    let start_x = canonical_device_origin(translation.x);
+    let start_y = canonical_device_origin(translation.y);
     let width = scaled_dimension(local_size.0, root_scale);
     let height = scaled_dimension(local_size.1, root_scale);
     let mut pixels = Vec::with_capacity((width * height * 4) as usize);

--- a/crates/cranpose-ui-graphics/shaders/composite_sample_fn.wgsl
+++ b/crates/cranpose-ui-graphics/shaders/composite_sample_fn.wgsl
@@ -62,5 +62,10 @@ fn composite_sample(
     if (sampling_mode <= 0.5) {
         return textureSample(input_texture, input_sampler, uv);
     }
-    return composite_sample_box4(source_pos, safe_source_size, span_hint);
+    if (sampling_mode <= 1.5) {
+        return composite_sample_box4(source_pos, safe_source_size, span_hint);
+    }
+    let dims = vec2<i32>(textureDimensions(input_texture));
+    let texel = clamp(vec2<i32>(floor(source_pos)), vec2<i32>(0), dims - vec2<i32>(1));
+    return textureLoad(input_texture, texel, 0);
 }

--- a/crates/cranpose-ui/src/modifier/clickable.rs
+++ b/crates/cranpose-ui/src/modifier/clickable.rs
@@ -19,4 +19,27 @@ impl Modifier {
             );
         self.then(modifier)
     }
+
+    /// Make the component react synchronously to primary-pointer press while
+    /// retaining ordinary click confirmation on release.
+    pub fn clickable_on_press(
+        self,
+        on_press: impl Fn(Point) + 'static,
+        on_click: impl Fn(Point) + 'static,
+    ) -> Self {
+        let modifier = Self::with_element(ClickableElement::with_handlers(
+            Rc::new(on_press),
+            Rc::new(on_click),
+        ))
+        .with_inspector_metadata(inspector_metadata("clickableOnPress", |info| {
+            info.add_property("onPress", "provided");
+            info.add_property("onClick", "provided");
+        }))
+        .then(
+            Modifier::empty().semantics(|config: &mut SemanticsConfiguration| {
+                config.is_clickable = true;
+            }),
+        );
+        self.then(modifier)
+    }
 }

--- a/crates/cranpose-ui/src/modifier_nodes.rs
+++ b/crates/cranpose-ui/src/modifier_nodes.rs
@@ -1136,6 +1136,7 @@ use std::cell::RefCell;
 // The handler closure is cached to ensure the same closure (and press_position state) is returned
 
 pub struct ClickableNode {
+    on_press: Option<Rc<dyn Fn(Point)>>,
     on_click: Rc<dyn Fn(Point)>,
     state: NodeState,
     /// Shared press position for drag detection (per-node state, accessible by handler closure)
@@ -1156,9 +1157,15 @@ impl ClickableNode {
     }
 
     pub fn with_handler(on_click: Rc<dyn Fn(Point)>) -> Self {
+        Self::with_handlers(None, on_click)
+    }
+
+    pub fn with_handlers(on_press: Option<Rc<dyn Fn(Point)>>, on_click: Rc<dyn Fn(Point)>) -> Self {
         let press_position = Rc::new(RefCell::new(None));
-        let cached_handler = Self::create_handler(on_click.clone(), press_position.clone());
+        let cached_handler =
+            Self::create_handler(on_press.clone(), on_click.clone(), press_position.clone());
         Self {
+            on_press,
             on_click,
             state: NodeState::new(),
             press_position,
@@ -1167,7 +1174,8 @@ impl ClickableNode {
     }
 
     fn create_handler(
-        handler: Rc<dyn Fn(Point)>,
+        on_press: Option<Rc<dyn Fn(Point)>>,
+        on_click: Rc<dyn Fn(Point)>,
         press_position: Rc<RefCell<Option<Point>>>,
     ) -> Rc<dyn Fn(PointerEvent)> {
         Rc::new(move |event: PointerEvent| {
@@ -1191,6 +1199,9 @@ impl ClickableNode {
                         x: event.global_position.x,
                         y: event.global_position.y,
                     });
+                    if let Some(on_press) = on_press.as_ref() {
+                        on_press(event.position);
+                    }
                 }
                 PointerEventKind::Move => {
                     // Move events are tracked via press_position for drag detection
@@ -1215,7 +1226,7 @@ impl ClickableNode {
                     *press_position.borrow_mut() = None;
 
                     if should_click {
-                        handler(Point {
+                        on_click(Point {
                             x: event.position.x,
                             y: event.position.y,
                         });
@@ -1288,18 +1299,30 @@ impl PointerInputNode for ClickableNode {
 /// Element that creates and updates clickable nodes.
 #[derive(Clone)]
 pub struct ClickableElement {
+    on_press: Option<Rc<dyn Fn(Point)>>,
     on_click: Rc<dyn Fn(Point)>,
 }
 
 impl ClickableElement {
     pub fn new(on_click: impl Fn(Point) + 'static) -> Self {
         Self {
+            on_press: None,
             on_click: Rc::new(on_click),
         }
     }
 
     pub fn with_handler(on_click: Rc<dyn Fn(Point)>) -> Self {
-        Self { on_click }
+        Self {
+            on_press: None,
+            on_click,
+        }
+    }
+
+    pub fn with_handlers(on_press: Rc<dyn Fn(Point)>, on_click: Rc<dyn Fn(Point)>) -> Self {
+        Self {
+            on_press: Some(on_press),
+            on_click,
+        }
     }
 }
 
@@ -1331,7 +1354,7 @@ impl ModifierNodeElement for ClickableElement {
     type Node = ClickableNode;
 
     fn create(&self) -> Self::Node {
-        ClickableNode::with_handler(self.on_click.clone())
+        ClickableNode::with_handlers(self.on_press.clone(), self.on_click.clone())
     }
 
     // Note: key() is deliberately NOT implemented (returns None by default)
@@ -1342,10 +1365,14 @@ impl ModifierNodeElement for ClickableElement {
     fn update(&self, node: &mut Self::Node) {
         // Update the handler - the cached_handler needs to be recreated
         // with the new on_click while preserving press_position
+        node.on_press = self.on_press.clone();
         node.on_click = self.on_click.clone();
         // Recreate the cached handler with the same press_position but new click handler
-        node.cached_handler =
-            ClickableNode::create_handler(node.on_click.clone(), node.press_position.clone());
+        node.cached_handler = ClickableNode::create_handler(
+            node.on_press.clone(),
+            node.on_click.clone(),
+            node.press_position.clone(),
+        );
     }
 
     fn capabilities(&self) -> NodeCapabilities {

--- a/crates/cranpose-ui/src/tests/modifier_nodes_tests.rs
+++ b/crates/cranpose-ui/src/tests/modifier_nodes_tests.rs
@@ -313,6 +313,35 @@ fn clickable_node_handles_pointer_events() {
 }
 
 #[test]
+fn clickable_on_press_runs_before_release_confirmation() {
+    let _app_context = crate::render_state::app_context_test_scope();
+    let mut chain = ModifierNodeChain::new();
+    let mut context = BasicModifierNodeContext::new();
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let press_events = Rc::clone(&events);
+    let click_events = Rc::clone(&events);
+    let modifier = Modifier::empty().clickable_on_press(
+        move |_| press_events.borrow_mut().push("press"),
+        move |_| click_events.borrow_mut().push("click"),
+    );
+
+    chain.update_from_slice(&modifier.elements(), &mut context);
+    let mut node = chain.node_mut::<ClickableNode>(0).expect("clickable node");
+    let position = Point { x: 10.0, y: 20.0 };
+    node.on_pointer_event(
+        &mut context,
+        &PointerEvent::new(PointerEventKind::Down, position, position),
+    );
+    assert_eq!(&*events.borrow(), &["press"]);
+
+    node.on_pointer_event(
+        &mut context,
+        &PointerEvent::new(PointerEventKind::Up, position, position),
+    );
+    assert_eq!(&*events.borrow(), &["press", "click"]);
+}
+
+#[test]
 fn clickable_node_cancels_click_on_drag() {
     let _app_context = crate::render_state::app_context_test_scope();
     let mut chain = ModifierNodeChain::new();

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -1861,8 +1861,9 @@ pub fn run(
                     match input {
                         PendingInput::PointerDown(x, y, time_ms, source) => {
                             shell.set_pointer_source(source);
-                            shell.set_cursor_at_time(x, y, time_ms);
-                            shell.pointer_pressed_at_time(time_ms);
+                            let event_time = shell.realtime_pointer_event_time(time_ms);
+                            shell.set_cursor_at_event_time(x, y, event_time);
+                            shell.pointer_pressed_at_event_time(event_time);
                         }
                         PendingInput::PointerUp(x, y, time_ms, source) => {
                             // ACTION_UP coordinates carry lift-off roll-back
@@ -1870,11 +1871,13 @@ pub fn run(
                             // (a synthesized Move here can flip the fling
                             // direction), so release without a Move dispatch.
                             shell.set_pointer_source(source);
-                            shell.pointer_released_at_position_time(x, y, time_ms);
+                            let event_time = shell.realtime_pointer_event_time(time_ms);
+                            shell.pointer_released_at_position_event_time(x, y, event_time);
                         }
                         PendingInput::PointerMove(x, y, time_ms, source) => {
                             shell.set_pointer_source(source);
-                            shell.set_cursor_at_time(x, y, time_ms);
+                            let event_time = shell.realtime_pointer_event_time(time_ms);
+                            shell.set_cursor_at_event_time(x, y, event_time);
                         }
                         PendingInput::PointerCancel => {
                             shell.cancel_gesture();

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -13,7 +13,7 @@ use crate::native_window::{
 use crate::robot::{
     char_to_key_code, extract_semantics, find_button_in_app, find_text_in_app,
     panic_payload_message, robot_key_code_and_text, robot_wait_for_idle_animation_loop_only, Robot,
-    RobotChannel, RobotCommand, RobotResponse, RobotScreenshot,
+    RobotChannel, RobotCommand, RobotResponse, RobotScreenshot, RobotTimelineAction,
 };
 use crate::wgpu_surface::surface_present_required;
 use crate::wgpu_surface::{current_surface_texture, SurfaceFrame};
@@ -693,23 +693,19 @@ impl App {
             .app
             .as_ref()
             .is_some_and(AppShell::has_active_pointer_gesture);
-        if !active {
-            return false;
-        }
-
         #[cfg(feature = "robot")]
-        if self
+        let synthetic_primary_down = self
             .robot_controller
             .as_ref()
-            .is_some_and(RobotController::synthetic_primary_down)
-        {
-            return false;
-        }
+            .is_some_and(RobotController::synthetic_primary_down);
+        #[cfg(not(feature = "robot"))]
+        let synthetic_primary_down = false;
 
-        let Some(pointer) = native_window_global_pointer_state(&self.native_window_platform_probe)
-        else {
-            return false;
-        };
+        let action = primary_pointer_gesture_poll_action(
+            active,
+            synthetic_primary_down,
+            native_window_global_pointer_state(&self.native_window_platform_probe),
+        );
 
         let (Some(window), Some(platform), Some(app)) =
             (&self.window, &self.platform, self.app.as_mut())
@@ -717,14 +713,30 @@ impl App {
             return false;
         };
 
-        if !pointer.primary_down {
-            let handled = app.pointer_released();
-            if handled {
-                self.last_frame_start_time = None;
-                request_redraw_once(window, &mut self.primary_redraw_pending);
+        let pointer = match action {
+            PrimaryPointerGesturePollAction::Inactive => return false,
+            PrimaryPointerGesturePollAction::ReleaseAt(position) => {
+                let event_time = app.realtime_pointer_event_time(None);
+                let cursor_dirty = native_window_local_pointer_physical(
+                    &self.native_window_platform_probe,
+                    window,
+                    position,
+                )
+                .is_some_and(|local| {
+                    let logical = platform.pointer_position(local);
+                    self.last_cursor_position = Some((logical.x, logical.y));
+                    app.set_cursor_at_event_time(logical.x, logical.y, event_time)
+                });
+                let released = app.pointer_released_at_event_time(event_time);
+                let handled = cursor_dirty || released;
+                if handled {
+                    self.last_frame_start_time = None;
+                    request_redraw_once(window, &mut self.primary_redraw_pending);
+                }
+                return handled;
             }
-            return handled;
-        }
+            PrimaryPointerGesturePollAction::Pressed(pointer) => pointer,
+        };
 
         if self.last_cursor_position.is_some() {
             return false;
@@ -2795,8 +2807,23 @@ fn current_native_window_physical_position(
     platform_probe: &NativeWindowPlatformProbe,
     window: &Arc<dyn Window>,
 ) -> Option<PhysicalPosition<i32>> {
-    native_window_x11_outer_position_physical(platform_probe, window)
+    native_window_x11_surface_position_physical(platform_probe, window)
+        .map(|surface_origin| {
+            physical_outer_origin_from_surface(surface_origin, window.surface_position())
+        })
         .or_else(|| window.outer_position().ok())
+}
+
+fn current_native_window_surface_physical_position(
+    platform_probe: &NativeWindowPlatformProbe,
+    window: &Arc<dyn Window>,
+) -> Option<PhysicalPosition<i32>> {
+    native_window_x11_surface_position_physical(platform_probe, window).or_else(|| {
+        window
+            .outer_position()
+            .ok()
+            .map(|outer| physical_surface_origin_from_outer(outer, window.surface_position()))
+    })
 }
 
 fn current_native_window_position(
@@ -2844,10 +2871,8 @@ fn native_window_surface_origin(
     platform_probe: &NativeWindowPlatformProbe,
     window: &Arc<dyn Window>,
 ) -> Option<cranpose_ui::Point> {
-    let outer = current_native_window_physical_position(platform_probe, window)?;
-    let surface = window.surface_position();
+    let physical = current_native_window_surface_physical_position(platform_probe, window)?;
     let scale_factor = window.scale_factor();
-    let physical = winit::dpi::PhysicalPosition::new(outer.x + surface.x, outer.y + surface.y);
     let logical = physical.to_logical::<f64>(scale_factor);
     Some(cranpose_ui::Point::new(logical.x as f32, logical.y as f32))
 }
@@ -2857,11 +2882,10 @@ fn native_window_screen_pointer_physical(
     window: &Arc<dyn Window>,
     local: PhysicalPosition<f64>,
 ) -> Option<PhysicalPosition<f64>> {
-    let outer = current_native_window_physical_position(platform_probe, window)?;
-    let surface = window.surface_position();
+    let surface = current_native_window_surface_physical_position(platform_probe, window)?;
     Some(PhysicalPosition::new(
-        outer.x as f64 + surface.x as f64 + local.x,
-        outer.y as f64 + surface.y as f64 + local.y,
+        surface.x as f64 + local.x,
+        surface.y as f64 + local.y,
     ))
 }
 
@@ -2870,12 +2894,8 @@ fn native_window_local_pointer_physical(
     window: &Arc<dyn Window>,
     screen: PhysicalPosition<f64>,
 ) -> Option<PhysicalPosition<f64>> {
-    let outer = current_native_window_physical_position(platform_probe, window)?;
-    let surface = window.surface_position();
-    Some(PhysicalPosition::new(
-        screen.x - outer.x as f64 - surface.x as f64,
-        screen.y - outer.y as f64 - surface.y as f64,
-    ))
+    let surface = current_native_window_surface_physical_position(platform_probe, window)?;
+    Some(physical_surface_local_pointer(surface, screen))
 }
 
 fn native_window_surface_contains_pointer(
@@ -2883,15 +2903,43 @@ fn native_window_surface_contains_pointer(
     native: &NativeWindowSurface,
     pointer: PhysicalPosition<f64>,
 ) -> bool {
-    let Some(outer) = current_native_window_physical_position(platform_probe, &native.window)
+    let Some(surface) =
+        current_native_window_surface_physical_position(platform_probe, &native.window)
     else {
         return false;
     };
     physical_surface_rect_contains_pointer(
-        outer,
-        native.window.surface_position(),
+        surface,
+        PhysicalPosition::new(0, 0),
         native.window.surface_size(),
         pointer,
+    )
+}
+
+fn physical_surface_origin_from_outer(
+    outer: PhysicalPosition<i32>,
+    surface_offset: PhysicalPosition<i32>,
+) -> PhysicalPosition<i32> {
+    PhysicalPosition::new(outer.x + surface_offset.x, outer.y + surface_offset.y)
+}
+
+fn physical_outer_origin_from_surface(
+    surface_origin: PhysicalPosition<i32>,
+    surface_offset: PhysicalPosition<i32>,
+) -> PhysicalPosition<i32> {
+    PhysicalPosition::new(
+        surface_origin.x - surface_offset.x,
+        surface_origin.y - surface_offset.y,
+    )
+}
+
+fn physical_surface_local_pointer(
+    surface_origin: PhysicalPosition<i32>,
+    screen: PhysicalPosition<f64>,
+) -> PhysicalPosition<f64> {
+    PhysicalPosition::new(
+        screen.x - surface_origin.x as f64,
+        screen.y - surface_origin.y as f64,
     )
 }
 
@@ -2942,10 +2990,33 @@ fn physical_surface_rect_contains_pointer(
     pointer.x >= x && pointer.x <= right && pointer.y >= y && pointer.y <= bottom
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 struct NativeWindowPointerState {
     position: PhysicalPosition<f64>,
     primary_down: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum PrimaryPointerGesturePollAction {
+    Inactive,
+    Pressed(NativeWindowPointerState),
+    ReleaseAt(PhysicalPosition<f64>),
+}
+
+fn primary_pointer_gesture_poll_action(
+    active: bool,
+    synthetic_primary_down: bool,
+    pointer: Option<NativeWindowPointerState>,
+) -> PrimaryPointerGesturePollAction {
+    if !active || synthetic_primary_down {
+        return PrimaryPointerGesturePollAction::Inactive;
+    }
+
+    match pointer {
+        Some(pointer) if pointer.primary_down => PrimaryPointerGesturePollAction::Pressed(pointer),
+        Some(pointer) => PrimaryPointerGesturePollAction::ReleaseAt(pointer.position),
+        None => PrimaryPointerGesturePollAction::Inactive,
+    }
 }
 
 #[cfg(all(
@@ -3067,7 +3138,7 @@ impl X11WindowClient {
         Some(())
     }
 
-    fn window_position(&self, window: u32) -> Option<PhysicalPosition<i32>> {
+    fn window_surface_position(&self, window: u32) -> Option<PhysicalPosition<i32>> {
         use x11rb::protocol::xproto::ConnectionExt;
 
         let reply = self
@@ -3127,13 +3198,13 @@ fn native_window_x11_id(window: &Arc<dyn Window>) -> Option<u32> {
     not(target_arch = "wasm32"),
     feature = "desktop-x11"
 ))]
-fn native_window_x11_outer_position_physical(
+fn native_window_x11_surface_position_physical(
     platform_probe: &NativeWindowPlatformProbe,
     window: &Arc<dyn Window>,
 ) -> Option<PhysicalPosition<i32>> {
     let window_id = native_window_x11_id(window)?;
     platform_probe
-        .probe_x11_window_client(|client| client.window_position(window_id))
+        .probe_x11_window_client(|client| client.window_surface_position(window_id))
         .flatten()
 }
 
@@ -3142,7 +3213,7 @@ fn native_window_x11_outer_position_physical(
     not(target_arch = "wasm32"),
     feature = "desktop-x11"
 )))]
-fn native_window_x11_outer_position_physical(
+fn native_window_x11_surface_position_physical(
     _platform_probe: &NativeWindowPlatformProbe,
     _window: &Arc<dyn Window>,
 ) -> Option<PhysicalPosition<i32>> {
@@ -4124,7 +4195,8 @@ impl ApplicationHandler for App {
                     logical.y
                 );
                 app.set_pointer_source(pointer_source_from_winit(&source));
-                if app.set_cursor(logical.x, logical.y) {
+                let event_time = app.realtime_pointer_event_time(None);
+                if app.set_cursor_at_event_time(logical.x, logical.y, event_time) {
                     request_redraw_once(window, &mut self.primary_redraw_pending);
                 }
                 let global_pointer =
@@ -4208,6 +4280,7 @@ impl ApplicationHandler for App {
                 // arrive without a prior hover move.
                 let logical = platform.pointer_position(position);
                 self.last_cursor_position = Some((logical.x, logical.y));
+                let event_time = app.realtime_pointer_event_time(None);
                 log::trace!(
                     target: "cranpose::input",
                     "desktop pointer button {:?} at ({:.2},{:.2})",
@@ -4215,7 +4288,7 @@ impl ApplicationHandler for App {
                     logical.x,
                     logical.y
                 );
-                if app.set_cursor(logical.x, logical.y) {
+                if app.set_cursor_at_event_time(logical.x, logical.y, event_time) {
                     request_redraw_once(window, &mut self.primary_redraw_pending);
                 }
                 match state {
@@ -4245,7 +4318,9 @@ impl ApplicationHandler for App {
                             }
                             return;
                         }
-                        let request = pointer_button_frame_request(app.pointer_pressed());
+                        let request = pointer_button_frame_request(
+                            app.pointer_pressed_at_event_time(event_time),
+                        );
                         apply_primary_pointer_button_frame_request(
                             window,
                             &mut self.last_frame_start_time,
@@ -4260,9 +4335,11 @@ impl ApplicationHandler for App {
                         // Touch lift-off samples must not become velocity
                         // samples (see AppShell::pointer_released_at_position).
                         let released = if source.is_touch_like() {
-                            app.pointer_released_at_position(logical.x, logical.y)
+                            app.pointer_released_at_position_event_time(
+                                logical.x, logical.y, event_time,
+                            )
                         } else {
-                            app.pointer_released()
+                            app.pointer_released_at_event_time(event_time)
                         };
                         let request = pointer_button_frame_request(released);
                         app.sync_selection_to_primary();
@@ -4476,16 +4553,18 @@ impl ApplicationHandler for App {
                 match cmd {
                     RobotCommand::Click { x, y } => {
                         app.set_pointer_source(PointerSource::Mouse);
-                        let cursor_dirty = app.set_cursor(x, y);
+                        let event_time = app.realtime_pointer_event_time(None);
+                        let cursor_dirty = app.set_cursor_at_event_time(x, y, event_time);
                         controller.begin_synthetic_primary_gesture();
-                        let press_dirty = app.pointer_pressed();
-                        let release_dirty = app.pointer_released();
+                        let press_dirty = app.pointer_pressed_at_event_time(event_time);
+                        let release_dirty = app.pointer_released_at_event_time(event_time);
                         controller.end_synthetic_primary_gesture();
                         robot_visual_dirty |= cursor_dirty || press_dirty || release_dirty;
                         let _ = controller.tx.send(RobotResponse::Ok);
                     }
                     RobotCommand::MoveTo { x, y } => {
-                        robot_visual_dirty |= app.set_cursor(x, y);
+                        let event_time = app.realtime_pointer_event_time(None);
+                        robot_visual_dirty |= app.set_cursor_at_event_time(x, y, event_time);
                         // Record for robot test generation
                         if let Some(recorder) = &mut self.recorder {
                             recorder.record_mouse_move(x, y);
@@ -4493,8 +4572,9 @@ impl ApplicationHandler for App {
                         let _ = controller.tx.send(RobotResponse::Ok);
                     }
                     RobotCommand::MouseDown => {
+                        let event_time = app.realtime_pointer_event_time(None);
                         controller.begin_synthetic_primary_gesture();
-                        robot_visual_dirty |= app.pointer_pressed();
+                        robot_visual_dirty |= app.pointer_pressed_at_event_time(event_time);
                         // Record for robot test generation
                         if let Some(recorder) = &mut self.recorder {
                             recorder.record_mouse_down();
@@ -4502,7 +4582,8 @@ impl ApplicationHandler for App {
                         let _ = controller.tx.send(RobotResponse::Ok);
                     }
                     RobotCommand::MouseUp => {
-                        robot_visual_dirty |= app.pointer_released();
+                        let event_time = app.realtime_pointer_event_time(None);
+                        robot_visual_dirty |= app.pointer_released_at_event_time(event_time);
                         controller.end_synthetic_primary_gesture();
                         // Record for robot test generation
                         if let Some(recorder) = &mut self.recorder {
@@ -4582,20 +4663,23 @@ impl ApplicationHandler for App {
 
                     RobotCommand::TouchDown { x, y, source } => {
                         app.set_pointer_source(source);
-                        let cursor_dirty = app.set_cursor(x, y);
+                        let event_time = app.realtime_pointer_event_time(None);
+                        let cursor_dirty = app.set_cursor_at_event_time(x, y, event_time);
                         controller.begin_synthetic_primary_gesture();
-                        let press_dirty = app.pointer_pressed();
+                        let press_dirty = app.pointer_pressed_at_event_time(event_time);
                         robot_visual_dirty |= cursor_dirty || press_dirty;
                         let _ = controller.tx.send(RobotResponse::Ok);
                     }
                     RobotCommand::TouchMove { x, y, source } => {
                         app.set_pointer_source(source);
-                        robot_visual_dirty |= app.set_cursor(x, y);
+                        let event_time = app.realtime_pointer_event_time(None);
+                        robot_visual_dirty |= app.set_cursor_at_event_time(x, y, event_time);
                         let _ = controller.tx.send(RobotResponse::Ok);
                     }
                     RobotCommand::TouchMoveAndWaitForFrame { x, y, source } => {
                         app.set_pointer_source(source);
-                        let visual_dirty = app.set_cursor(x, y);
+                        let event_time = app.realtime_pointer_event_time(None);
+                        let visual_dirty = app.set_cursor_at_event_time(x, y, event_time);
                         if visual_dirty {
                             robot_visual_dirty = true;
                         }
@@ -4623,8 +4707,9 @@ impl ApplicationHandler for App {
                     }
                     RobotCommand::TouchUp { x, y, source } => {
                         app.set_pointer_source(source);
-                        let cursor_dirty = app.set_cursor(x, y);
-                        let release_dirty = app.pointer_released();
+                        let event_time = app.realtime_pointer_event_time(None);
+                        let cursor_dirty = app.set_cursor_at_event_time(x, y, event_time);
+                        let release_dirty = app.pointer_released_at_event_time(event_time);
                         controller.end_synthetic_primary_gesture();
                         robot_visual_dirty |= cursor_dirty || release_dirty;
                         let _ = controller.tx.send(RobotResponse::Ok);
@@ -4694,6 +4779,71 @@ impl ApplicationHandler for App {
                             None => RobotResponse::Screenshots(shots),
                         });
                     }
+                    RobotCommand::CaptureInteractionKeyframes { scale, steps } => {
+                        let mut shots = Vec::new();
+                        let mut capture_err = None;
+                        for step in steps {
+                            native_window::with_native_window_registry(&registry, || {
+                                app.update_after_exact_interval(Duration::from_secs_f64(
+                                    f64::from(step.advance_ms.max(0.0)) / 1000.0,
+                                ))
+                            });
+                            for action in step.actions {
+                                let action_result = match action {
+                                    RobotTimelineAction::MoveTo { x, y } => {
+                                        let event_time = app.exact_pointer_event_time(None);
+                                        app.set_cursor_at_event_time(x, y, event_time);
+                                        Ok(())
+                                    }
+                                    RobotTimelineAction::MouseDown => {
+                                        let event_time = app.exact_pointer_event_time(None);
+                                        controller.begin_synthetic_primary_gesture();
+                                        app.pointer_pressed_at_event_time(event_time);
+                                        Ok(())
+                                    }
+                                    RobotTimelineAction::MouseUp => {
+                                        let event_time = app.exact_pointer_event_time(None);
+                                        app.pointer_released_at_event_time(event_time);
+                                        controller.end_synthetic_primary_gesture();
+                                        Ok(())
+                                    }
+                                    RobotTimelineAction::InvokeAppHook { name, argument } => {
+                                        self.robot_app_hook.as_mut().map_or_else(
+                                            || Err("robot app hook not configured".to_string()),
+                                            |hook| {
+                                                app.debug_enter_app_context(|| hook(name, argument))
+                                                    .map(|_| ())
+                                            },
+                                        )
+                                    }
+                                };
+                                if let Err(err) = action_result {
+                                    capture_err = Some(err);
+                                    break;
+                                }
+                            }
+                            if capture_err.is_some() {
+                                break;
+                            }
+                            native_window::with_native_window_registry(&registry, || {
+                                app.update_after_exact_interval(Duration::ZERO)
+                            });
+                            if step.capture {
+                                match capture_screenshot_with_scale(app, scale) {
+                                    Ok(shot) => shots.push(shot),
+                                    Err(err) => {
+                                        capture_err = Some(err);
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        robot_visual_dirty = true;
+                        let _ = controller.tx.send(match capture_err {
+                            Some(err) => RobotResponse::Error(err),
+                            None => RobotResponse::Screenshots(shots),
+                        });
+                    }
                     RobotCommand::GetRenderStats => {
                         let _ = controller.tx.send(RobotResponse::RenderStats(Box::new(
                             app.renderer().last_frame_stats(),
@@ -4749,7 +4899,9 @@ impl ApplicationHandler for App {
                     }
                     RobotCommand::InvokeAppHook { name, argument } => {
                         let response = match self.robot_app_hook.as_mut() {
-                            Some(hook) => hook(name, argument).map(RobotResponse::AppHookResult),
+                            Some(hook) => app
+                                .debug_enter_app_context(|| hook(name, argument))
+                                .map(RobotResponse::AppHookResult),
                             None => Err("robot app hook not configured".to_string()),
                         };
                         match response {
@@ -5363,15 +5515,18 @@ mod tests {
         clamp_rect_to_monitor_delta, frame_interval_for_mode, initial_present_redraw_needed,
         native_window_graph_position, native_window_options_change_is_position_only,
         native_window_position_poll_needed, nearest_monitor_to_rect,
-        physical_surface_rect_contains_pointer, pointer_button_frame_request,
-        primary_declaration_host_needs_direct_update, primary_frame_waker_uses_event_proxy,
-        primary_launch_requires_initial_redraw, primary_pointer_move_should_recover_press,
+        physical_outer_origin_from_surface, physical_surface_local_pointer,
+        physical_surface_origin_from_outer, physical_surface_rect_contains_pointer,
+        pointer_button_frame_request, primary_declaration_host_needs_direct_update,
+        primary_frame_waker_uses_event_proxy, primary_launch_requires_initial_redraw,
+        primary_pointer_gesture_poll_action, primary_pointer_move_should_recover_press,
         primary_surface_redraw_drives_app, primary_viewport_for_surface_size,
         recovered_native_window_drag_start_pointer, scroll_frame_request,
         should_chain_no_vsync_redraw, surface_reconfigure_requires_redraw, App, DesktopRect,
         FramePacingMode, NativeWindowDragSession, NativeWindowGraphPositionSource,
         NativeWindowOptions, NativeWindowPointerState, NativeWindowPollingDragSession,
         NativeWindowPositionObservation, NativeWindowPositionOrigin, PendingNativeWindowPositions,
+        PrimaryPointerGesturePollAction,
     };
     use crate::launcher::AppSettings;
     use std::time::Instant;
@@ -5388,6 +5543,23 @@ mod tests {
     fn native_window_screen_position_is_declarative() {
         let options = NativeWindowOptions::new("child", 100.0, 50.0).with_position(10.0, 20.0);
         assert!(App::native_window_options_have_screen_position(&options));
+    }
+
+    #[test]
+    fn decorated_window_surface_coordinates_apply_frame_offset_once() {
+        let outer = PhysicalPosition::new(100, 200);
+        let surface_offset = PhysicalPosition::new(2, 32);
+        let surface = physical_surface_origin_from_outer(outer, surface_offset);
+
+        assert_eq!(surface, PhysicalPosition::new(102, 232));
+        assert_eq!(
+            physical_outer_origin_from_surface(surface, surface_offset),
+            outer
+        );
+        assert_eq!(
+            physical_surface_local_pointer(surface, PhysicalPosition::new(250.0, 808.0)),
+            PhysicalPosition::new(148.0, 576.0)
+        );
     }
 
     #[test]
@@ -5939,6 +6111,57 @@ mod tests {
             }),
             true
         ));
+    }
+
+    #[test]
+    fn primary_pointer_poll_synchronizes_global_position_before_releasing() {
+        let position = PhysicalPosition::new(112.0, 57.0);
+
+        assert_eq!(
+            primary_pointer_gesture_poll_action(
+                true,
+                false,
+                Some(NativeWindowPointerState {
+                    position,
+                    primary_down: false,
+                }),
+            ),
+            PrimaryPointerGesturePollAction::ReleaseAt(position)
+        );
+    }
+
+    #[test]
+    fn primary_pointer_poll_preserves_pressed_recovery_state() {
+        let pointer = NativeWindowPointerState {
+            position: PhysicalPosition::new(112.0, 57.0),
+            primary_down: true,
+        };
+
+        assert_eq!(
+            primary_pointer_gesture_poll_action(true, false, Some(pointer)),
+            PrimaryPointerGesturePollAction::Pressed(pointer)
+        );
+    }
+
+    #[test]
+    fn primary_pointer_poll_ignores_inactive_synthetic_and_unavailable_input() {
+        let pointer = Some(NativeWindowPointerState {
+            position: PhysicalPosition::new(112.0, 57.0),
+            primary_down: false,
+        });
+
+        assert_eq!(
+            primary_pointer_gesture_poll_action(false, false, pointer),
+            PrimaryPointerGesturePollAction::Inactive
+        );
+        assert_eq!(
+            primary_pointer_gesture_poll_action(true, true, pointer),
+            PrimaryPointerGesturePollAction::Inactive
+        );
+        assert_eq!(
+            primary_pointer_gesture_poll_action(true, false, None),
+            PrimaryPointerGesturePollAction::Inactive
+        );
     }
 
     #[test]

--- a/crates/cranpose/src/ios.rs
+++ b/crates/cranpose/src/ios.rs
@@ -447,8 +447,10 @@ impl<F: FnMut() + 'static> ApplicationHandler for IosApp<F> {
                             shell.set_pointer_source(pointer_source_from_button(&button));
                             let changed = match route {
                                 TouchRoute::Primary => {
-                                    shell.set_cursor(logical.x, logical.y);
-                                    shell.pointer_pressed()
+                                    let event_time = shell.realtime_pointer_event_time(None);
+                                    shell
+                                        .set_cursor_at_event_time(logical.x, logical.y, event_time);
+                                    shell.pointer_pressed_at_event_time(event_time)
                                 }
                                 TouchRoute::Secondary(id) => {
                                     shell.secondary_pointer_pressed(id, logical.x, logical.y, None)
@@ -474,7 +476,10 @@ impl<F: FnMut() + 'static> ApplicationHandler for IosApp<F> {
                             // Touch lift-off positions must not become velocity
                             // samples (see AppShell::pointer_released_at_position).
                             if release.releases_primary {
-                                changed |= shell.pointer_released_at_position(logical.x, logical.y);
+                                let event_time = shell.realtime_pointer_event_time(None);
+                                changed |= shell.pointer_released_at_position_event_time(
+                                    logical.x, logical.y, event_time,
+                                );
                             }
                             if changed {
                                 window.request_redraw();

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -245,7 +245,9 @@ mod web_services;
     feature = "robot",
     feature = "renderer-wgpu"
 ))]
-pub use robot::{Robot, RobotScreenshot, SemanticElement, SemanticRect};
+pub use robot::{
+    Robot, RobotScreenshot, RobotTimelineAction, RobotTimelineStep, SemanticElement, SemanticRect,
+};
 
 /// Development frame pacing and FPS statistics types.
 #[cfg(all(feature = "desktop-shell", feature = "renderer-wgpu"))]

--- a/crates/cranpose/src/robot.rs
+++ b/crates/cranpose/src/robot.rs
@@ -86,6 +86,40 @@ pub struct RobotScreenshot {
     pub pixels: Vec<u8>,
 }
 
+/// Input or fixture mutation performed at one exact-clock timeline step.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RobotTimelineAction {
+    /// Move the primary mouse pointer in logical pixels.
+    MoveTo {
+        /// Horizontal position in logical pixels.
+        x: f32,
+        /// Vertical position in logical pixels.
+        y: f32,
+    },
+    /// Press the primary mouse button at the current pointer position.
+    MouseDown,
+    /// Release the primary mouse button at the current pointer position.
+    MouseUp,
+    /// Invoke a configured application robot hook.
+    InvokeAppHook {
+        /// Configured hook name.
+        name: String,
+        /// Hook argument payload.
+        argument: String,
+    },
+}
+
+/// One wall-time-independent input step in an atomic robot timeline.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RobotTimelineStep {
+    /// Exact animation-clock advance before applying this step's actions.
+    pub advance_ms: f32,
+    /// Ordered input and fixture actions at the resulting clock instant.
+    pub actions: Vec<RobotTimelineAction>,
+    /// Whether to capture a screenshot after actions and UI work are drained.
+    pub capture: bool,
+}
+
 /// Robot command for controlling the application
 #[derive(Debug)]
 pub(crate) enum RobotCommand {
@@ -168,6 +202,11 @@ pub(crate) enum RobotCommand {
         /// pending input (starting e.g. a release-triggered transition)
         /// without advancing the clock.
         steps: Vec<(f32, bool)>,
+    },
+    /// Atomically advance an exact clock, inject ordered input, and capture.
+    CaptureInteractionKeyframes {
+        scale: f32,
+        steps: Vec<RobotTimelineStep>,
     },
     #[cfg(feature = "renderer-wgpu")]
     GetRenderStats,
@@ -921,6 +960,31 @@ impl Robot {
             Ok(RobotResponse::Error(e)) => Err(e),
             Ok(_) => Err("Unexpected response".to_string()),
             Err(e) => Err(format!("Failed to receive response: {}", e)),
+        }
+    }
+
+    /// Run an input timeline atomically against the exact animation clock.
+    ///
+    /// Unlike separate `mouse_move` and [`Self::capture_keyframes`] calls,
+    /// the free-running desktop loop cannot insert wall-clock frames between
+    /// steps. Pointer event timestamps, physics integration, and captures all
+    /// observe the same deterministic clock.
+    pub fn capture_interaction_keyframes(
+        &self,
+        scale: f32,
+        steps: &[RobotTimelineStep],
+    ) -> Result<Vec<RobotScreenshot>, String> {
+        self.tx
+            .send(RobotCommand::CaptureInteractionKeyframes {
+                scale,
+                steps: steps.to_vec(),
+            })
+            .map_err(|e| format!("Failed to send interaction capture command: {e}"))?;
+        match self.rx.recv() {
+            Ok(RobotResponse::Screenshots(shots)) => Ok(shots),
+            Ok(RobotResponse::Error(e)) => Err(e),
+            Ok(_) => Err("Unexpected response".to_string()),
+            Err(e) => Err(format!("Failed to receive response: {e}")),
         }
     }
 

--- a/crates/cranpose/src/web.rs
+++ b/crates/cranpose/src/web.rs
@@ -452,8 +452,9 @@ pub async fn run(
             let logical = platform.borrow().pointer_position(x, y);
             if let Ok(mut app_mut) = app.try_borrow_mut() {
                 app_mut.set_pointer_source(web_pointer_source(&event));
-                app_mut.set_cursor(logical.x, logical.y);
-                app_mut.pointer_pressed();
+                let event_time = app_mut.realtime_pointer_event_time(None);
+                app_mut.set_cursor_at_event_time(logical.x, logical.y, event_time);
+                app_mut.pointer_pressed_at_event_time(event_time);
                 request_frame();
             }
         }) as Box<dyn FnMut(_)>);
@@ -475,7 +476,8 @@ pub async fn run(
                 app_mut.set_pointer_source(web_pointer_source(&event));
                 // Touch lift-off positions must not become velocity samples
                 // (see AppShell::pointer_released_at_position).
-                app_mut.pointer_released_at_position(logical.x, logical.y);
+                let event_time = app_mut.realtime_pointer_event_time(None);
+                app_mut.pointer_released_at_position_event_time(logical.x, logical.y, event_time);
                 request_frame();
             }
             let _ = pointer_canvas.release_pointer_capture(event.pointer_id());

--- a/docs/liquid_scroll_pixel_stability.md
+++ b/docs/liquid_scroll_pixel_stability.md
@@ -1,0 +1,97 @@
+# Liquid scroll pixel stability
+
+## Contract
+
+At a fractional display density, moving a rigid scroll subtree by exactly one
+physical pixel must only translate its raster by one physical pixel. After
+undoing that translation, adjacent presented frames may differ by at most 48
+summed 8-bit channel levels across the full crop. This bounded allowance covers
+sub-one-pixel linear-sampling quantization; moving even one antialiased edge
+exceeds it by orders of magnitude.
+
+`robot_liquid_scroll_exact_external_contract` exercises this contract at the
+launched application's 1.3541667x density and 800x600 logical window size. It
+first scans the fixed scroll-viewport boundary while both shader cards cover
+it, then compares six independent scrolling regions: the optical shader body,
+both shader-card edges, the bottom glass bar, the controls card, and the
+segmented control. Before each region it crosses ten one-logical-pixel scroll
+phases, then drives the `ScrollState` directly by `1 / density` logical units.
+It checks semantic movement at every step, captures the real X11 window, and
+compares every adjacent normalized frame. The phase sweep ensures that
+boundaries which only fail at particular fractional offsets are part of the
+contract.
+
+## Reproduction evidence
+
+- The production-density semantic target moves by approximately `-0.738462`
+  logical units per exact step, so every requested move is one physical pixel.
+- At 1.25x diagnostic density, all six regions failed before the shared
+  coordinate fixes. The optical body reached a summed adjacent difference of
+  361,377; the right edge reached 304,354; the bottom bar reached 7,108; and
+  the ordinary controls and segmented control reached roughly 960 and 1,200
+  respectively.
+- The strongest discontinuity is not confined to the runtime shader. A static
+  text run flips between two rasterizations at a half-device-pixel boundary.
+  Ordinary shape and glass pixels show the same phase-dependent drift at lower
+  amplitude.
+- Focused renderer regressions reproduce the half-pixel text flip, backdrop
+  shader-local drift, and projective-composite drift without the demo UI.
+- After those faults were corrected, the production-density boundary probe
+  still failed at scroll step 1: one entire sampled viewport row became
+  `[214, 214, 219]`, with a dominant-color fraction of `1.0000`, while the
+  adjacent shader-card rows retained their orange/purple split. Restoring the
+  fixed ancestor clip makes every sampled row retain that split through all
+  ten scroll phases.
+- The remaining 3,785-3,797 score in the broad optical scene was isolated to a
+  slider's cached drop shadow. Disabling only that shadow made the scene exact,
+  proving a second shared renderer fault rather than a Liquid component fault.
+
+## Ranked causes
+
+1. **Draw raster snapping was incorrectly applied to ancestor clips.** Scene
+   normalization resolves each clip from the layer that owns it. Applying a
+   descendant draw's snap delta to that result moved a fixed scroll-viewport
+   edge between adjacent device rows. Shapes, images, text, and backdrop
+   effects all repeated this ownership violation in renderer-specific paths.
+2. **Device snapping is round-tripped through logical `f32` coordinates.**
+   `snap_delta_for_anchor` computes a device-grid decision, divides it by the
+   root scale, adds it to every absolute logical coordinate, and later
+   multiplies those coordinates by the root scale again. Repeated fractional
+   scroll accumulation changes the low bits of otherwise rigid relative
+   geometry. At half-pixel coverage and rounding boundaries those low bits
+   select different raster results. This explains the cross-component failures
+   and is reproduced without the Liquid shader.
+3. **Cached shadow surfaces used unanchored logical bounds.** Shadow pixels
+   used the draw's snap anchor, but the source surface origin and extent were
+   independently floored from accumulated logical `f32` bounds. The allocation
+   could therefore jump while its contents stayed anchored, changing the
+   one-to-one composite sampling phase.
+4. **Backdrop layers discarded the scroll snap anchor.** Shapes, images, text,
+   and ordinary effect layers carried one rigid motion anchor through scene
+   normalization; `BackdropLayer` did not. Its capture rect, shader rect,
+   scissor, and destination therefore made independent rounding decisions.
+5. **Projective child composites scaled absolute coordinates.** Rotated cards
+   moved rigidly with their scroll parent, but their four destination vertices
+   were reconstructed independently from large absolute `f32` values. Their
+   linear sample phase changed even when the intended movement was one device
+   pixel.
+
+## Architecture decision
+
+The renderer must canonicalize rigidly snapped draw geometry in device space
+and preserve the anchor-relative subpixel phase. Direct shapes, images, text,
+isolated surfaces, backdrop/effect composites, and projective child quads
+derive their device coordinates from the same 1/16-device-pixel canonical
+grid. A resolved clip remains in its owning layer's scene space; a descendant
+draw may not borrow that clip and move it with its own raster snap. Backdrops
+retain and translate the same snap anchor as their sibling primitives, and
+projective vertices and cached-surface bounds are calculated relative to that
+anchor instead of round-tripping an absolute logical delta. One-to-one cached
+shadow composites use texel-exact sampling after the anchored device bounds
+have been established.
+
+Patching an individual Liquid component is incorrect: the failure affects
+unrelated primitives and would leave the shared coordinate discontinuity
+intact. The comparison allowance remains smaller than a single visible edge
+change and is documented as a total channel budget rather than a per-pixel
+tolerance.

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -547,6 +547,9 @@ run_test() {
         robot_double_click|robot_multiline_click|robot_multiline_nav)
             timeout_secs=90
             ;;
+        robot_liquid_scroll_exact_external_contract)
+            timeout_secs=480
+            ;;
         robot_memory_leak)
             timeout_secs=900
             ;;
@@ -564,13 +567,16 @@ run_test() {
 
     local headless_env="CRANPOSE_HEADLESS=1"
     case "$example" in
-        robot_hacker_news_scroll_exact_external_contract|robot_leetcodedaily_full_layout_scroll_stability|robot_markdown_default_visual_contract|robot_markdown_scroll_exact_external_contract|robot_presented_window_geometry|robot_presented_window_hidpi_geometry|robot_presented_window_redraw|robot_renderer_micro_contract|robot_regression_shader_visual_contract|robot_shader_external_x11_drag|robot_shader_rect_external_animation|robot_tab_walk_text_visual_contract|robot_text_scroll_exact_external_contract|robot_text_strikeout_presented|robot_underline_screenshot|robot_winamp_native_window_geometry)
+        robot_hacker_news_scroll_exact_external_contract|robot_leetcodedaily_full_layout_scroll_stability|robot_liquid_scroll_exact_external_contract|robot_markdown_default_visual_contract|robot_markdown_scroll_exact_external_contract|robot_presented_window_geometry|robot_presented_window_hidpi_geometry|robot_presented_window_redraw|robot_renderer_micro_contract|robot_regression_shader_visual_contract|robot_shader_external_x11_drag|robot_shader_rect_external_animation|robot_tab_walk_text_visual_contract|robot_text_scroll_exact_external_contract|robot_text_strikeout_presented|robot_underline_screenshot|robot_winamp_native_window_geometry)
             headless_env="CRANPOSE_HEADLESS=0"
             ;;
     esac
 
     local example_env=()
     case "$example" in
+        robot_liquid_scroll_exact_external_contract)
+            example_env+=(WINIT_X11_SCALE_FACTOR=1.3541667)
+            ;;
         robot_presented_window_hidpi_geometry)
             example_env+=(WINIT_X11_SCALE_FACTOR=2)
             ;;


### PR DESCRIPTION
## What changed

- preserve the Liquid reference UI while retaining its exact visual-contract robot harness
- synchronize desktop pointer release with authoritative X11 coordinates and distinguish client-surface from outer-window coordinates
- carry transform pivots through nested offscreen surfaces and snap axis-aligned composites as one physical-pixel unit
- share deterministic frame clocks and external scroll-capture infrastructure across robot contracts
- add focused unit and integration coverage for pointer policy, coordinate conversion, animation timing, and transformed-surface geometry

## Root causes

Queued final pointer movement could be observed after polled button release, decorated X11 client origins were adjusted twice, and scaled offscreen composites lost a stable transform-pivot raster phase during density handoff. These were production defects in input ordering and render-space ownership; the tests remain strict.

## Validation

- cargo fmt
- cargo test (all pass, zero warnings)
- cargo clippy (zero warnings)
- ./run_robot_test.sh --sequential (141/141 pass on real X11)
- Android :app:assembleRelease
- desktop-demo build-web.sh
- release desktop binary built and launched for manual verification
