### PR TITLE
Isolate release Android Gradle daemon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,10 @@ jobs:
 
       - name: Build APK
         working-directory: apps/android-demo/android
-        run: ./gradlew :app:assembleRelease -PrustFastRelease=false
+        # The self-hosted runner is shared across release jobs. A single-use
+        # daemon inherits this step's toolchain environment instead of attaching
+        # to an unrelated Gradle daemon with stale process state.
+        run: ./gradlew --no-daemon :app:assembleRelease -PrustFastRelease=false
 
       - name: Attach to release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
The tag release workflow invoked Android Gradle through a reusable daemon on the shared macOS runner. Run it with a single-use daemon, matching the verified heavy Android release job, so it receives the current toolchain environment.