### PR TITLE
Keep queued work running while the app is off screen

### DIFF
--- a/crates/cranpose-app-shell/src/lib.rs
+++ b/crates/cranpose-app-shell/src/lib.rs
@@ -775,6 +775,18 @@ where
         app_context.enter(|| self.needs_ui_update_in_context())
     }
 
+    /// Returns true when the runtime holds work for the UI thread: posted tasks,
+    /// continuations from worker threads, or async tasks ready to poll.
+    ///
+    /// This is the part of [`needs_update`](Self::needs_update) that another
+    /// thread is waiting on, told apart from the part that only wants the screen
+    /// redrawn. A platform backend running with no surface uses it to compose
+    /// for work and stay asleep for animation.
+    pub fn has_pending_ui(&self) -> bool {
+        let app_context = Rc::clone(&self.app_context);
+        app_context.enter(|| self.composition.runtime_handle().has_pending_ui())
+    }
+
     /// Returns true if the shell owes the display a frame: stale pixels, or a
     /// renderer that has not warmed its swapchain yet.
     ///

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -65,8 +65,8 @@ pub use platform::{Clock, RuntimeScheduler};
 pub use retention::{RetentionBudget, RetentionEvictionPolicy, RetentionMode, RetentionPolicy};
 #[doc(hidden)]
 pub use runtime::{
-    current_runtime_handle, schedule_frame, schedule_node_update, DefaultScheduler, Runtime,
-    RuntimeHandle, StateId, TaskHandle,
+    current_runtime_handle, label_next_ui_task, schedule_frame, schedule_node_update,
+    DefaultScheduler, Runtime, RuntimeHandle, StateId, TaskHandle,
 };
 pub use slot::{
     SlotDebugAnchor, SlotDebugEntry, SlotDebugEntryKind, SlotDebugGroup, SlotDebugScope,

--- a/crates/cranpose-core/src/runtime.rs
+++ b/crates/cranpose-core/src/runtime.rs
@@ -417,6 +417,7 @@ struct RuntimeInner {
 
 struct TaskEntry {
     id: u64,
+    label: String,
     future: Pin<Box<dyn Future<Output = ()> + 'static>>,
     /// Whether this task can currently make progress.
     ///
@@ -432,6 +433,14 @@ struct TaskEntry {
     /// The waker handed to this task's future, so a wake can be attributed to
     /// the one task that is ready rather than to all of them.
     waker: Waker,
+}
+
+thread_local! {
+    static NEXT_TASK_LABEL: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+pub fn label_next_ui_task(label: impl Into<String>) {
+    NEXT_TASK_LABEL.with(|held| *held.borrow_mut() = Some(label.into()));
 }
 
 impl RuntimeInner {
@@ -548,10 +557,14 @@ impl RuntimeInner {
     fn spawn_ui_task(&self, future: Pin<Box<dyn Future<Output = ()> + 'static>>) -> u64 {
         let id = self.next_task_id.get();
         self.next_task_id.set(id + 1);
+        let label = NEXT_TASK_LABEL
+            .with(|held| held.borrow_mut().take())
+            .unwrap_or_else(|| "unnamed".to_string());
         let runnable = Arc::new(AtomicBool::new(true));
         let waker = RuntimeTaskWaker::new(self, Arc::clone(&runnable)).into_waker();
         self.tasks.borrow_mut().push(TaskEntry {
             id,
+            label,
             future,
             runnable,
             waker,
@@ -1053,6 +1066,20 @@ impl RuntimeHandle {
         self.inner
             .upgrade()
             .map(|inner| inner.debug_stats())
+            .unwrap_or_default()
+    }
+
+    pub fn live_ui_task_labels(&self) -> Vec<(u64, String)> {
+        self.inner
+            .upgrade()
+            .map(|inner| {
+                inner
+                    .tasks
+                    .borrow()
+                    .iter()
+                    .map(|entry| (entry.id, entry.label.clone()))
+                    .collect()
+            })
             .unwrap_or_default()
     }
 

--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -38,6 +38,7 @@ pub use gpu_stats::FrameStatsSnapshot as RenderStatsSnapshot;
 #[doc(hidden)]
 #[cfg(not(target_arch = "wasm32"))]
 pub use pipeline::retained_feed_generation;
+pub use render::frames_presented;
 pub use scene::{ClickAction, HitRegion, Scene};
 #[doc(hidden)]
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -342,6 +342,12 @@ fn repeated_cache_miss_admission(key: &LayerRasterCacheKey) -> bool {
     admit_layer_surface_cache_miss_impl(key, &mut observed_scene_range_misses)
 }
 
+pub static PRESENTED_FRAMES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+pub fn frames_presented() -> u64 {
+    PRESENTED_FRAMES.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 fn frame_stats_need_warmup_frame(snapshot: &gpu_stats::FrameStatsSnapshot) -> bool {
     snapshot.layer_cache_misses > 0
         || snapshot.shadow_shape_cache_misses > 0
@@ -6247,6 +6253,7 @@ impl GpuRenderer {
         self.frame_graph_executor.reset_upload_allocators();
         let snapshot = self.frame_stats.snapshot();
         self.last_frame_stats = Some(snapshot);
+        PRESENTED_FRAMES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         update_frame_warmup_budget(&mut self.pending_frame_warmup_frames, &snapshot);
         self.frame_stats.maybe_print_snapshot(
             snapshot,

--- a/crates/cranpose-services/src/background.rs
+++ b/crates/cranpose-services/src/background.rs
@@ -7,6 +7,7 @@
 //! foreground service). No default: [`background_activity`] returns `None` where
 //! unsupported, and the app simply runs only while foregrounded.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::OnceLock;
@@ -46,11 +47,29 @@ pub fn background_activity() -> Option<BackgroundActivityRef> {
     slot().lock().ok().and_then(|s| s.clone())
 }
 
-/// Convenience: mark background work active/inactive (no-op where unsupported).
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Convenience: mark background work active/inactive. The flag is recorded even
+/// where no platform handler is installed, so [`background_active`] answers the
+/// same everywhere.
 pub fn set_background_active(active: bool) {
+    ACTIVE.store(active, Ordering::SeqCst);
     if let Some(activity) = background_activity() {
         activity.set_active(active);
     }
+}
+
+/// `true` between [`set_background_active(true)`](set_background_active) and the
+/// matching `false`.
+///
+/// A platform backend reads this to decide whether the runtime keeps turning
+/// while the app is off screen. Both mobile backends drive composition from the
+/// frame path, and both stop that path when the surface is gone: Android drops
+/// its GPU resources on `TerminateWindow`, iOS stops receiving redraws. Anything
+/// posted to the UI dispatcher then waits until the user comes back, which is
+/// wrong for an app that told the OS it has work to finish.
+pub fn background_active() -> bool {
+    ACTIVE.load(Ordering::SeqCst)
 }
 
 #[cfg(test)]
@@ -72,6 +91,13 @@ mod tests {
         set_platform_background_activity(rec.clone());
         set_background_active(true);
         assert!(rec.0.load(Ordering::SeqCst));
+        assert!(background_active());
+        set_background_active(false);
+        assert!(!background_active());
         clear_platform_background_activity();
+        set_background_active(true);
+        assert!(background_active());
+        set_background_active(false);
+        assert!(!background_active());
     }
 }

--- a/crates/cranpose-services/src/lib.rs
+++ b/crates/cranpose-services/src/lib.rs
@@ -31,8 +31,9 @@ pub use audio::{
     ProvideAudio, SoundBank, SoundBankEntry, SoundBankFailure, SoundId, SoundSpec, VoiceId,
 };
 pub use background::{
-    background_activity, clear_platform_background_activity, set_background_active,
-    set_platform_background_activity, BackgroundActivity, BackgroundActivityRef,
+    background_active, background_activity, clear_platform_background_activity,
+    set_background_active, set_platform_background_activity, BackgroundActivity,
+    BackgroundActivityRef,
 };
 pub use camera::{
     camera, clear_platform_camera, set_platform_camera, Camera, CameraError, CameraFrame,

--- a/crates/cranpose-services/src/lib.rs
+++ b/crates/cranpose-services/src/lib.rs
@@ -84,8 +84,9 @@ pub use peer::{
     PeerServer, SourceResolver,
 };
 pub use purchases::{
-    clear_platform_purchases, purchases, set_platform_purchases, store_available, store_state,
-    Product, PurchaseEvent, Purchases, PurchasesRef, StorePhase, StoreState,
+    clear_platform_purchases, note_store_news, purchases, set_platform_purchases,
+    set_store_listener, store_available, store_state, Product, PurchaseEvent, Purchases,
+    PurchasesRef, StorePhase, StoreState,
 };
 pub use share_sheet::{
     clear_platform_share_sheet, default_share_sheet, local_share_sheet, set_platform_share_sheet,

--- a/crates/cranpose-services/src/purchases.rs
+++ b/crates/cranpose-services/src/purchases.rs
@@ -181,6 +181,31 @@ thread_local! {
 }
 
 /// Installs a platform purchase backend, replacing any previous one.
+static STORE_LISTENER: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> =
+    std::sync::OnceLock::new();
+
+/// Registers a callback run whenever the store has news, so an app can be told
+/// rather than having to ask.
+///
+/// [`take_event`] and [`store_state`] are polling APIs, which assume the app is
+/// already running a frame loop to poll from. An app that has gone idle has no
+/// such loop, so a purchase that finishes while nothing moves on screen sits in
+/// the queue until something unrelated wakes the app. The listener closes that
+/// gap: it is the nudge, the queue is still the source of truth.
+///
+/// Called from whatever thread the platform reports on, so the callback must be
+/// `Send + Sync` and should do as little as possible.
+pub fn set_store_listener(listener: impl Fn() + Send + Sync + 'static) {
+    let _ = STORE_LISTENER.set(Box::new(listener));
+}
+
+/// Tells the app that the store has news. Called by a purchase backend.
+pub fn note_store_news() {
+    if let Some(listener) = STORE_LISTENER.get() {
+        listener();
+    }
+}
+
 pub fn set_platform_purchases(purchases: PurchasesRef) {
     PLATFORM_PURCHASES.with(|cell| *cell.borrow_mut() = Some(purchases));
 }

--- a/crates/cranpose-storekit/src/apple.rs
+++ b/crates/cranpose-storekit/src/apple.rs
@@ -179,9 +179,14 @@ unsafe extern "C" fn on_message(
                 state.events.pop_front();
             }
             state.events.push_back(event);
+            drop(state);
+            cranpose_services::note_store_news();
+            return;
         }
         _ => {}
     }
+    drop(state);
+    cranpose_services::note_store_news();
 }
 
 // ------------------------------------------------------------------ backend

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -649,6 +649,11 @@ impl PlatformFrameDriver for AndroidFrameDriver {
     }
 }
 
+/// Pace of composition passes while the app runs with no surface (see the main
+/// loop). Roughly a 60Hz frame, which is far more often than a queue of work
+/// needs and still cheap enough for an app that is off screen.
+const OFFSCREEN_UPDATE_PERIOD: Duration = Duration::from_millis(16);
+
 fn duration_until_frame_deadline(deadline: web_time::Instant) -> Duration {
     deadline
         .checked_duration_since(web_time::Instant::now())
@@ -1569,6 +1574,8 @@ pub fn run(
     let mut key_translator = AndroidKeyTranslator::new(app.clone());
     // The soft-keyboard handler is installed once the app shell exists
     let mut soft_keyboard_installed = false;
+    // When the next off-screen composition pass may run (see below).
+    let mut next_offscreen_update: Option<web_time::Instant> = None;
 
     // Per-stage frame telemetry (system-property gated; free when off).
     let mut frame_telemetry =
@@ -1593,8 +1600,15 @@ pub fn run(
             android_frame_driver.clear_wake();
         }
         let frame_deadline_timeout = android_frame_driver.deadline_timeout();
-        let idle_timeout =
-            earliest_android_poll_timeout(pending_confirmation_timeout, frame_deadline_timeout);
+        let offscreen = gpu_resources.is_none() && cranpose_services::background_active();
+        if !offscreen {
+            next_offscreen_update = None;
+        }
+        let offscreen_timeout = next_offscreen_update.map(duration_until_frame_deadline);
+        let idle_timeout = earliest_android_poll_timeout(
+            earliest_android_poll_timeout(pending_confirmation_timeout, frame_deadline_timeout),
+            offscreen_timeout,
+        );
 
         // Vote the display frame rate the way HWUI does: the panel's fastest
         // rate while the user is interacting, the quiet rate while an
@@ -1625,6 +1639,8 @@ pub fn run(
 
         let poll_duration = if !pending_inputs.is_empty() {
             Some(Duration::ZERO)
+        } else if let Some(wait) = offscreen_timeout {
+            Some(wait)
         } else if android_frame_driver.frame_requested() {
             // A frame request is satisfied at the next vsync, not immediately.
             // Spinning here is only invisible while every iteration ends in a
@@ -2197,6 +2213,35 @@ pub fn run(
         if should_exit.load(Ordering::Relaxed) {
             log::info!("Exiting cleanly after Destroy event");
             break;
+        }
+
+        // With the activity off screen the window is gone (`TerminateWindow`
+        // drops the GPU resources), so the render block below is skipped and
+        // composition stops. Anything the app posted to the UI dispatcher then
+        // waits for the user to come back. An app that holds a foreground
+        // service has told the OS it has work to finish, so keep composition
+        // turning; there is no surface, so nothing is presented.
+        //
+        // Nothing is presented, so nothing paces this pass the way a swapchain
+        // paces the render path. `OFFSCREEN_UPDATE_PERIOD` is that pace: an
+        // animation still running off screen costs one composition per period
+        // instead of one per loop turn. The next pass is armed only while the
+        // shell asks for one, so a settled app goes back to a long poll.
+        if offscreen && next_offscreen_update.is_none_or(|at| at <= web_time::Instant::now()) {
+            let mut composed = false;
+            if let Some(shell) = &mut app_shell {
+                if shell.needs_update() {
+                    android_host_window::with_android_host_window_registry(
+                        &host_window_registry,
+                        || shell.update(),
+                    );
+                    composed = true;
+                }
+            }
+            next_offscreen_update = match composed {
+                true => Some(web_time::Instant::now() + OFFSCREEN_UPDATE_PERIOD),
+                false => None,
+            };
         }
 
         // Render outside event callback if needed

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -649,9 +649,8 @@ impl PlatformFrameDriver for AndroidFrameDriver {
     }
 }
 
-/// Pace of composition passes while the app runs with no surface (see the main
-/// loop). Roughly a 60Hz frame, which is far more often than a queue of work
-/// needs and still cheap enough for an app that is off screen.
+/// Delay of the follow-up composition pass after one that carried work while
+/// the app runs with no surface (see the main loop).
 const OFFSCREEN_UPDATE_PERIOD: Duration = Duration::from_millis(16);
 
 fn duration_until_frame_deadline(deadline: web_time::Instant) -> Duration {
@@ -1604,11 +1603,20 @@ pub fn run(
         if !offscreen {
             next_offscreen_update = None;
         }
+        let offscreen_pending_ui = offscreen
+            && app_shell
+                .as_ref()
+                .is_some_and(|shell| shell.has_pending_ui());
         let offscreen_timeout = next_offscreen_update.map(duration_until_frame_deadline);
-        let idle_timeout = earliest_android_poll_timeout(
-            earliest_android_poll_timeout(pending_confirmation_timeout, frame_deadline_timeout),
-            offscreen_timeout,
-        );
+        // Off screen the frame deadline asks for a frame nothing will draw, and
+        // an app with a running animation asks for one every turn of the loop.
+        // Only work waiting on the UI thread is worth a wake there.
+        let idle_timeout = match offscreen {
+            true => earliest_android_poll_timeout(pending_confirmation_timeout, offscreen_timeout),
+            false => {
+                earliest_android_poll_timeout(pending_confirmation_timeout, frame_deadline_timeout)
+            }
+        };
 
         // Vote the display frame rate the way HWUI does: the panel's fastest
         // rate while the user is interacting, the quiet rate while an
@@ -1639,8 +1647,11 @@ pub fn run(
 
         let poll_duration = if !pending_inputs.is_empty() {
             Some(Duration::ZERO)
-        } else if let Some(wait) = offscreen_timeout {
-            Some(wait)
+        } else if offscreen {
+            match offscreen_pending_ui {
+                true => Some(Duration::ZERO),
+                false => idle_timeout,
+            }
         } else if android_frame_driver.frame_requested() {
             // A frame request is satisfied at the next vsync, not immediately.
             // Spinning here is only invisible while every iteration ends in a
@@ -2222,23 +2233,22 @@ pub fn run(
         // service has told the OS it has work to finish, so keep composition
         // turning; there is no surface, so nothing is presented.
         //
-        // Nothing is presented, so nothing paces this pass the way a swapchain
-        // paces the render path. `OFFSCREEN_UPDATE_PERIOD` is that pace: an
-        // animation still running off screen costs one composition per period
-        // instead of one per loop turn. The next pass is armed only while the
-        // shell asks for one, so a settled app goes back to a long poll.
-        if offscreen && next_offscreen_update.is_none_or(|at| at <= web_time::Instant::now()) {
-            let mut composed = false;
+        // Work waiting on the UI thread earns a pass. A running animation does
+        // not: nothing is drawn, and paying for a composition per animation
+        // frame off screen is how an app burns a core behind the user's back.
+        // One follow-up pass is armed after a pass that carried work, so a
+        // recomposition that work asked for still runs.
+        let offscreen_due = next_offscreen_update.is_some_and(|at| at <= web_time::Instant::now());
+        if offscreen && (offscreen_pending_ui || offscreen_due) {
             if let Some(shell) = &mut app_shell {
                 if shell.needs_update() {
                     android_host_window::with_android_host_window_registry(
                         &host_window_registry,
                         || shell.update(),
                     );
-                    composed = true;
                 }
             }
-            next_offscreen_update = match composed {
+            next_offscreen_update = match offscreen_pending_ui {
                 true => Some(web_time::Instant::now() + OFFSCREEN_UPDATE_PERIOD),
                 false => None,
             };

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -1593,13 +1593,18 @@ pub fn run(
                 .unwrap_or(Duration::ZERO)
         });
 
-        if let Some(shell) = app_shell.as_ref() {
-            shell.schedule_platform_frame(&android_frame_driver);
-        } else {
-            android_frame_driver.clear_wake();
+        // A frame deadline with no surface asks for a frame nothing will draw,
+        // and an app with a running animation asks for one every turn of the
+        // loop, which is a spun core for as long as the app is off screen.
+        let no_surface = gpu_resources.is_none();
+        match app_shell.as_ref() {
+            Some(shell) if !no_surface => {
+                shell.schedule_platform_frame(&android_frame_driver);
+            }
+            _ => android_frame_driver.clear_wake(),
         }
         let frame_deadline_timeout = android_frame_driver.deadline_timeout();
-        let offscreen = gpu_resources.is_none() && cranpose_services::background_active();
+        let offscreen = no_surface && cranpose_services::background_active();
         if !offscreen {
             next_offscreen_update = None;
         }
@@ -1608,10 +1613,7 @@ pub fn run(
                 .as_ref()
                 .is_some_and(|shell| shell.has_pending_ui());
         let offscreen_timeout = next_offscreen_update.map(duration_until_frame_deadline);
-        // Off screen the frame deadline asks for a frame nothing will draw, and
-        // an app with a running animation asks for one every turn of the loop.
-        // Only work waiting on the UI thread is worth a wake there.
-        let idle_timeout = match offscreen {
+        let idle_timeout = match no_surface {
             true => earliest_android_poll_timeout(pending_confirmation_timeout, offscreen_timeout),
             false => {
                 earliest_android_poll_timeout(pending_confirmation_timeout, frame_deadline_timeout)
@@ -1647,7 +1649,7 @@ pub fn run(
 
         let poll_duration = if !pending_inputs.is_empty() {
             Some(Duration::ZERO)
-        } else if offscreen {
+        } else if no_surface {
             match offscreen_pending_ui {
                 true => Some(Duration::ZERO),
                 false => idle_timeout,

--- a/crates/cranpose/src/ios.rs
+++ b/crates/cranpose/src/ios.rs
@@ -23,6 +23,7 @@ use cranpose_ui::EdgeInsets;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use winit::application::ApplicationHandler;
 use winit::event::{ElementState, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
@@ -62,7 +63,14 @@ struct IosApp<F: FnMut() + 'static> {
     /// Maps winit's per-finger ids onto the shell's primary/secondary pointer
     /// ids so multi-touch gestures (pinch-zoom) see more than one pointer.
     touch_router: TouchPointerRouter,
+    /// When the next off-screen composition pass may run (see `pump_off_screen`).
+    next_off_screen_render: Option<Instant>,
 }
+
+/// Pace of composition passes while the app is off screen. Roughly a 60Hz
+/// frame, which is far more often than a queue of work needs and still cheap
+/// enough for an app the user cannot see.
+const OFF_SCREEN_RENDER_PERIOD: Duration = Duration::from_millis(16);
 
 impl<F: FnMut() + 'static> IosApp<F> {
     fn new(
@@ -84,6 +92,47 @@ impl<F: FnMut() + 'static> IosApp<F> {
             event_proxy,
             launch_error,
             touch_router: TouchPointerRouter::default(),
+            next_off_screen_render: None,
+        }
+    }
+
+    /// Keeps composition turning while the app is off screen and holds a
+    /// background task.
+    ///
+    /// UIKit stops the display link once the app leaves the screen, so a redraw
+    /// request is never serviced and composition stops. Anything the app posted
+    /// to the UI dispatcher then waits for the user to come back, which is wrong
+    /// for an app that told iOS it has work to finish.
+    ///
+    /// Nothing is presented here (see `render`), so nothing paces this pass the
+    /// way a swapchain paces the on-screen path. `OFF_SCREEN_RENDER_PERIOD` is
+    /// that pace, held by a `WaitUntil` timer: an animation still running off
+    /// screen costs one composition per period instead of one per wake-up.
+    fn pump_off_screen(&mut self, event_loop: &dyn ActiveEventLoop) {
+        if !cranpose_services::background_active() || !crate::ios_background::app_is_off_screen() {
+            if self.next_off_screen_render.take().is_some() {
+                event_loop.set_control_flow(ControlFlow::Wait);
+            }
+            return;
+        }
+        if let Some(at) = self.next_off_screen_render {
+            if at > Instant::now() {
+                event_loop.set_control_flow(ControlFlow::WaitUntil(at));
+                return;
+            }
+        }
+        self.render();
+        let more = self
+            .shell
+            .as_ref()
+            .is_some_and(|shell| shell.needs_update());
+        self.next_off_screen_render = match more {
+            true => Some(Instant::now() + OFF_SCREEN_RENDER_PERIOD),
+            false => None,
+        };
+        match self.next_off_screen_render {
+            Some(at) => event_loop.set_control_flow(ControlFlow::WaitUntil(at)),
+            None => event_loop.set_control_flow(ControlFlow::Wait),
         }
     }
 
@@ -198,6 +247,13 @@ impl<F: FnMut() + 'static> IosApp<F> {
         if let Some(accessibility) = self.accessibility.as_mut() {
             accessibility.sync(shell);
         }
+        // A Metal drawable must not be presented while the app is off screen:
+        // the composition pass above is what the background work needs, the
+        // present is not.
+        if crate::ios_background::app_is_off_screen() {
+            gpu.surface_dirty = true;
+            return;
+        }
         if !surface_present_required(
             dirty_before,
             update_result.visual_changed,
@@ -236,6 +292,13 @@ impl<F: FnMut() + 'static> ApplicationHandler for IosApp<F> {
         // outside the redraw handler so it is actually serviced.
         if let Some(window) = &self.window {
             window.request_redraw();
+        }
+        self.pump_off_screen(_event_loop);
+    }
+
+    fn new_events(&mut self, event_loop: &dyn ActiveEventLoop, cause: winit::event::StartCause) {
+        if matches!(cause, winit::event::StartCause::ResumeTimeReached { .. }) {
+            self.pump_off_screen(event_loop);
         }
     }
 

--- a/crates/cranpose/src/ios.rs
+++ b/crates/cranpose/src/ios.rs
@@ -67,9 +67,8 @@ struct IosApp<F: FnMut() + 'static> {
     next_off_screen_render: Option<Instant>,
 }
 
-/// Pace of composition passes while the app is off screen. Roughly a 60Hz
-/// frame, which is far more often than a queue of work needs and still cheap
-/// enough for an app the user cannot see.
+/// Delay of the follow-up composition pass after one that carried work while
+/// the app is off screen (see `pump_off_screen`).
 const OFF_SCREEN_RENDER_PERIOD: Duration = Duration::from_millis(16);
 
 impl<F: FnMut() + 'static> IosApp<F> {
@@ -104,10 +103,11 @@ impl<F: FnMut() + 'static> IosApp<F> {
     /// to the UI dispatcher then waits for the user to come back, which is wrong
     /// for an app that told iOS it has work to finish.
     ///
-    /// Nothing is presented here (see `render`), so nothing paces this pass the
-    /// way a swapchain paces the on-screen path. `OFF_SCREEN_RENDER_PERIOD` is
-    /// that pace, held by a `WaitUntil` timer: an animation still running off
-    /// screen costs one composition per period instead of one per wake-up.
+    /// Work waiting on the UI thread earns a pass. A running animation does not:
+    /// nothing is drawn, and paying for a composition per animation frame off
+    /// screen is how an app burns a core behind the user's back. One follow-up
+    /// pass is armed after a pass that carried work, held by a `WaitUntil`
+    /// timer, so a recomposition that work asked for still runs.
     fn pump_off_screen(&mut self, event_loop: &dyn ActiveEventLoop) {
         if !cranpose_services::background_active() || !crate::ios_background::app_is_off_screen() {
             if self.next_off_screen_render.take().is_some() {
@@ -115,18 +115,18 @@ impl<F: FnMut() + 'static> IosApp<F> {
             }
             return;
         }
-        if let Some(at) = self.next_off_screen_render {
-            if at > Instant::now() {
-                event_loop.set_control_flow(ControlFlow::WaitUntil(at));
-                return;
-            }
-        }
-        self.render();
-        let more = self
+        let pending_ui = self
             .shell
             .as_ref()
-            .is_some_and(|shell| shell.needs_update());
-        self.next_off_screen_render = match more {
+            .is_some_and(|shell| shell.has_pending_ui());
+        let due = self
+            .next_off_screen_render
+            .is_some_and(|at| at <= Instant::now());
+        if !pending_ui && !due {
+            return;
+        }
+        self.render();
+        self.next_off_screen_render = match pending_ui {
             true => Some(Instant::now() + OFF_SCREEN_RENDER_PERIOD),
             false => None,
         };

--- a/crates/cranpose/src/ios_background.rs
+++ b/crates/cranpose/src/ios_background.rs
@@ -12,7 +12,7 @@ use cranpose_services::{set_platform_background_activity, BackgroundActivity};
 use dispatch2::DispatchQueue;
 use objc2::MainThreadMarker;
 use objc2_foundation::NSString;
-use objc2_ui_kit::UIApplication;
+use objc2_ui_kit::{UIApplication, UIApplicationState};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::OnceLock;
@@ -71,4 +71,13 @@ fn end_task(mtm: MainThreadMarker) {
     if let Some(id) = taken {
         UIApplication::sharedApplication(mtm).endBackgroundTask(id);
     }
+}
+
+/// `true` when UIKit reports the app is off screen. Main thread only; anywhere
+/// else it answers `false`.
+pub(crate) fn app_is_off_screen() -> bool {
+    let Some(mtm) = MainThreadMarker::new() else {
+        return false;
+    };
+    UIApplication::sharedApplication(mtm).applicationState() == UIApplicationState::Background
 }

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -381,9 +381,19 @@ fn android_idle_does_not_poll_16ms() {
         source.contains("app_waker.wake()"),
         "android runtime frame waker should wake the Android looper"
     );
+    let offscreen_period = "const OFFSCREEN_UPDATE_PERIOD: Duration = Duration::from_millis(16);";
     assert!(
-        !source.contains("Duration::from_millis(16)") && !source.contains("from_millis(16)"),
-        "android runtime must not poll at 16 ms while idle"
+        source.contains(offscreen_period),
+        "the off-screen work pace is the one 16 ms period this file may hold"
+    );
+    assert_eq!(
+        source.matches("from_millis(16)").count(),
+        1,
+        "android runtime must not poll at 16 ms while idle; the only 16 ms period is OFFSCREEN_UPDATE_PERIOD, which paces work for an app that asked to keep running off screen"
+    );
+    assert!(
+        source.contains("let offscreen = no_surface && cranpose_services::background_active();"),
+        "the off-screen pass must run only when an app asked to keep working with no surface"
     );
     assert!(
         source.contains("struct AndroidFrameDriver")


### PR DESCRIPTION
Keep an app's queued work running while the app is off screen, on Android and iOS.

## What this is for

An app that hands work to a worker thread and posts the result back to the UI
thread (`post_invoke`) stops making progress the moment the user leaves it. The
UI thread is the only stepping stone between one job and the next, and both
platform backends park it when there is no surface to draw into:

* Android drops `gpu_resources` on `TerminateWindow` and then blocks in
  `poll_events` until an event arrives. Nothing arrives, so the posted
  continuation never runs and the queue stalls after the job in flight.
* iOS stops the `CADisplayLink` when the app leaves the screen, so the same
  queue stalls even while `beginBackgroundTask` still holds the OS grant.

Measured in a receipt scanner that imports a batch of photos: on Android the
log went from 16 lines to 51 in the whole background stretch, with one core
pinned the entire time; with this branch it reached 365 lines and no thread
above 5%. On iOS the work reached 35.6s of progress (9 photos split, 16
receipts) against 10.8s and 2 documents for the same run without the change,
both sent off screen at 3s.

## What it does

* `cranpose_services::set_background_active` / `background_active` — an app
  states that it holds work worth staying awake for. Nothing changes for an app
  that never calls it.
* Android: with no surface and background active, the loop composes when
  `AppShell::has_pending_ui()` reports work for the UI thread, and sleeps
  otherwise. It also stops asking for frames when there is no surface at all,
  which on its own removes a busy spin present before this branch.
* iOS: `pump_off_screen` runs the same rule from `proxy_wake_up` and
  `StartCause::ResumeTimeReached`, and `render()` skips the present while the
  app is off screen rather than composing into a surface nobody sees.
* `AppShell::has_pending_ui()` exposes the runtime's existing signal to the
  platform backends.
* `frames_presented()` on the wgpu renderer, so a test can assert that a still
  screen presents zero frames.
* Purchase listeners get told when the store has news, instead of being polled.

## Notes for review

* Rebased on v0.1.84. The back-listener commit from the earlier branch is
  dropped: it is already upstream.
* The commit that added a `task_awake` flag is dropped too. `has_pending_ui`
  on main already tells a runnable task from a parked one through the per-task
  `runnable` flag, which is the better version of the same idea, so both
  backends call that.
* Off-screen composition is bounded by a 16 ms period, so an app with a live
  effect cannot spin the loop.
* No behaviour changes for an app that does not call `set_background_active`.
