### PR TITLE
Fix spatial glass caching and edge scrolling

### DIFF
--- a/apps/android-demo/android/app/build.gradle.kts
+++ b/apps/android-demo/android/app/build.gradle.kts
@@ -131,6 +131,10 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.7.1")
 }
 
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xlint:deprecation")
+}
+
 // Check if cargo-ndk is available
 fun checkCargoNdk() {
     val result = providers.exec {

--- a/apps/desktop-demo/robot-runners/robot_regression_tabbar_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_regression_tabbar_contract.rs
@@ -253,6 +253,30 @@ fn main() {
                 fail(&robot, "Hacker News tab disappeared from button semantics");
             }
 
+            let edge_probe_before = collect_tab_bounds(&robot, &labels);
+            let edge_probe_hn_before = require_tab(&edge_probe_before, "Hacker News");
+            let edge_probe_y = center(edge_probe_hn_before).1;
+            robot
+                .mouse_move(root.0 + 6.25, edge_probe_y)
+                .expect("move near the left edge of the tab row");
+            robot
+                .mouse_scroll(220.0, 0.0)
+                .expect("horizontal wheel near the left edge of the tab row");
+            std::thread::sleep(Duration::from_millis(160));
+            let _ = robot.wait_for_idle();
+            let edge_probe_after = collect_tab_bounds(&robot, &labels);
+            let edge_probe_hn_after = require_tab(&edge_probe_after, "Hacker News");
+            let edge_probe_delta = edge_probe_hn_after.0 - edge_probe_hn_before.0;
+            println!("edge_wheel_delta={edge_probe_delta:.2}");
+            if edge_probe_delta < 100.0 {
+                fail(
+                    &robot,
+                    &format!(
+                        "horizontal wheel inside the tab-row band near the window edge did not reach the row: delta={edge_probe_delta:.2}"
+                    ),
+                );
+            }
+
             println!("PASS: tab row keeps Y position and retained scroll offset");
             robot.exit().expect("exit");
         })

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -63,6 +63,9 @@ use xkcd::xkcd_tab;
 pub use hacker_news::HACKER_NEWS_SCROLL_STABILITY_TARGET_TITLE;
 pub use markdown::{markdown_scroll_stress_fixture, MARKDOWN_SCROLL_STABILITY_TARGET_TEXT};
 
+const DEMO_PAGE_PADDING: f32 = 20.0;
+const DEMO_TAB_BAR_PADDING: f32 = 8.0;
+
 thread_local! {
     pub static TEST_COMPOSITION_LOCAL_COUNTER: RefCell<Option<MutableState<i32>>> = const { RefCell::new(None) };
     pub static TEST_ACTIVE_TAB_STATE: RefCell<Option<MutableState<DemoTab>>> = const { RefCell::new(None) };
@@ -406,14 +409,24 @@ fn TabBarHorizontal(active_tab: cranpose_core::MutableState<DemoTab>) {
     Row(
         Modifier::empty()
             .fill_max_width()
-            .padding(8.0)
             .clip_to_bounds()
             .horizontal_scroll(tabs_scroll_state, false),
-        RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
+        RowSpec::new(),
         move || {
-            for tab in DEMO_TABS {
-                TabButton(tab, active_tab, 10.0);
-            }
+            Row(
+                Modifier::empty().padding_each(
+                    DEMO_PAGE_PADDING + DEMO_TAB_BAR_PADDING,
+                    DEMO_PAGE_PADDING + DEMO_TAB_BAR_PADDING,
+                    DEMO_PAGE_PADDING + DEMO_TAB_BAR_PADDING,
+                    DEMO_TAB_BAR_PADDING,
+                ),
+                RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
+                move || {
+                    for tab in DEMO_TABS {
+                        TabButton(tab, active_tab, 10.0);
+                    }
+                },
+            );
         },
     );
 }
@@ -467,7 +480,7 @@ pub fn combined_app_with_startup(startup: StartupSelection) {
     });
 
     Column(
-        Modifier::empty().fill_max_size().padding(20.0),
+        Modifier::empty().fill_max_size(),
         ColumnSpec::default(),
         move || {
             TabBarHorizontal(active_tab);
@@ -481,7 +494,12 @@ pub fn combined_app_with_startup(startup: StartupSelection) {
                 active_tab,
                 startup,
                 winamp_tab_state,
-                Modifier::empty().fill_max_width().weight(1.0),
+                Modifier::empty().fill_max_width().weight(1.0).padding_each(
+                    DEMO_PAGE_PADDING,
+                    0.0,
+                    DEMO_PAGE_PADDING,
+                    DEMO_PAGE_PADDING,
+                ),
             );
         },
     );

--- a/crates/cranpose-render/wgpu/src/frame_packet.rs
+++ b/crates/cranpose-render/wgpu/src/frame_packet.rs
@@ -15,9 +15,11 @@
 
 use crate::normalized_scene::{ChildLayerComposite, CollectedLayer, LoweredChildSource};
 use crate::scene::{
-    BackdropLayer, ColorPatch, CompositorScene, DrawOp, DrawShape, EffectLayer, ImageDraw,
-    PendingFeedCapture, RetainedDraw, ShadowDraw, TextDraw,
+    BackdropLayer, CompositorScene, DrawOp, DrawShape, EffectLayer, ImageDraw, RetainedDraw,
+    ShadowDraw, TextDraw,
 };
+#[cfg(not(target_arch = "wasm32"))]
+use crate::scene::{ColorPatch, PendingFeedCapture};
 use cranpose_core::NodeId;
 use cranpose_render_common::graph::{DrawCommandId, ProjectiveTransform};
 use cranpose_ui_graphics::{GraphicsLayer, Rect, RenderEffect};
@@ -28,6 +30,7 @@ use cranpose_ui_graphics::{GraphicsLayer, Rect, RenderEffect};
 /// (`GpuRenderer::consume_replay_ops`) just before the packet renders. This
 /// is the ONLY producer→store replay channel; the store answers with a
 /// [`ReplayAck`].
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Default)]
 pub(crate) struct ReplayFrameOps {
     /// The retained-feed generation the plan was made under. The store
@@ -42,6 +45,10 @@ pub(crate) struct ReplayFrameOps {
     pub(crate) color_patches: Vec<ColorPatch>,
     pub(crate) releases: Vec<u32>,
 }
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Default)]
+pub(crate) struct ReplayFrameOps;
 
 /// One confirmed capture: the span's identity key `(command, span slot)`
 /// mapped to the physical GPU slot the store retained it in.
@@ -81,12 +88,16 @@ pub enum PresentOutcome {
 /// planner ([`ShapeReplayState::apply_ack`](crate::shape_replay::ShapeReplayState))
 /// before the next frame's planning. Travels with the batch's emptied
 /// buffers (capacity intact) so neither side allocates per frame.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct ReplayAck {
     /// The generation the confirmations are stamped with — the slot
     /// universe they verifiably exist in.
     pub(crate) generation: u64,
     pub(crate) confirmations: Vec<ReplayConfirmation>,
 }
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) struct ReplayAck;
 
 /// The lowered root a [`FramePacket`] carries: either today's direct path
 /// (the root renders straight to the surface) or a root layer surface (the
@@ -216,6 +227,11 @@ const _: () = {
     assert_send::<RenderReturns>();
     assert_send::<CancelReason>();
     assert_send::<PresentOutcome>();
+};
+
+#[cfg(not(target_arch = "wasm32"))]
+const _: () = {
+    const fn assert_send<T: Send>() {}
     assert_send::<ColorPatch>();
     assert_send::<PendingFeedCapture>();
 };

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -61,6 +61,7 @@ use crate::surface_requirements::SurfaceRequirement;
 use crate::surface_requirements::SurfaceRequirementSet;
 use crate::DebugCpuAllocationStats;
 use bytemuck::{Pod, Zeroable};
+#[cfg(any(not(target_arch = "wasm32"), test))]
 use cranpose_core::collections::map::HashMap;
 use cranpose_core::{hash::default as default_hash, NodeId};
 use cranpose_render_common::bounded_lru_cache::BoundedLruCache;
@@ -7514,6 +7515,8 @@ impl GpuRenderer {
         root_scale: f32,
         load_op: wgpu::LoadOp<wgpu::Color>,
     ) -> Result<SegmentRenderOutcome, String> {
+        #[cfg(target_arch = "wasm32")]
+        let _ = retained_draws;
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(outcome) = self.render_segment_draw_chunk_fused_native(
             frame_encoder,

--- a/crates/cranpose-render/wgpu/src/scene.rs
+++ b/crates/cranpose-render/wgpu/src/scene.rs
@@ -30,6 +30,7 @@ impl SnapAnchor {
 /// by the present-side replay store; crosses the frame boundary inside
 /// [`ReplayFrameOps`](crate::frame_packet::ReplayFrameOps).
 #[derive(Clone, Copy)]
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct ColorPatch {
     pub slot: u32,
     pub shape_index: u32,
@@ -40,6 +41,7 @@ pub(crate) struct ColorPatch {
 /// ordinary emission pushed for one capture-marked span. Planned
 /// producer-side, honored by the present-side replay store; crosses the
 /// frame boundary inside [`ReplayFrameOps`](crate::frame_packet::ReplayFrameOps).
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct PendingFeedCapture {
     pub key: (cranpose_render_common::graph::DrawCommandId, u32),
     pub shape_start: usize,
@@ -200,6 +202,7 @@ impl SimilarityTransform {
         _pad: [0.0; 2],
     };
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn new(center: [f32; 2], angle: f32, scale: f32) -> Self {
         Self {
             center,
@@ -245,6 +248,7 @@ pub(crate) enum DrawOpKind {
     Text(usize),
     Shadow(usize),
     /// Index into [`CompositorScene::retained_draws`].
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     Retained(usize),
 }
 
@@ -430,6 +434,7 @@ impl CompositorScene {
     }
 
     /// Pushes one retained-batch draw at the next z position and returns it.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn push_retained_draw(&mut self, draw: RetainedDraw) {
         if std::env::var_os("CRANPOSE_RETAINED_DIAG").is_some() {
             eprintln!(

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -2450,6 +2450,7 @@ fn backdrop_scene_prefix_hash(
     scene: &CompositorScene,
     prior_child_contributions: &[BackdropPrefixChildContribution],
     z_end: usize,
+    capture_rect: Rect,
     target_size: (u32, u32),
     root_scale: f32,
 ) -> u64 {
@@ -2459,30 +2460,58 @@ fn backdrop_scene_prefix_hash(
     hash_f32_bits(root_scale, &mut hasher);
     z_end.hash(&mut hasher);
 
-    for draw_op in scene_range_draw_ops(&scene.draw_ops, 0, z_end) {
+    for draw_op in scene_range_draw_ops(&scene.draw_ops, 0, z_end)
+        .iter()
+        .filter(|draw_op| {
+            draw_op_visible_bounds(scene, **draw_op)
+                .is_none_or(|bounds| rects_intersect(bounds, capture_rect))
+        })
+    {
         0u8.hash(&mut hasher);
         hash_draw_op(scene, draw_op, &mut hasher);
     }
     for effect_layer in scene
         .effect_layers
         .iter()
-        .filter(|layer| layer.z_end <= z_end)
+        .filter(|layer| layer.z_end <= z_end && rects_intersect(layer.rect, capture_rect))
     {
         1u8.hash(&mut hasher);
         hash_effect_layer(effect_layer, &mut hasher);
     }
-    for backdrop_layer in scene
-        .backdrop_layers
-        .iter()
-        .filter(|layer| layer.z_index < z_end)
-    {
+    for backdrop_layer in scene.backdrop_layers.iter().filter(|layer| {
+        layer.z_index < z_end
+            && rects_intersect(
+                backdrop_output_rect(
+                    layer.rect,
+                    layer.clip,
+                    &layer.effect,
+                    root_scale,
+                    target_size,
+                ),
+                capture_rect,
+            )
+    }) {
         2u8.hash(&mut hasher);
         hash_backdrop_layer(backdrop_layer, &mut hasher);
     }
-    for child in prior_child_contributions
-        .iter()
-        .filter(|child| child.z_index < z_end)
-    {
+    for child in prior_child_contributions.iter().filter(|child| {
+        if child.z_index >= z_end {
+            return false;
+        }
+        let capture_pixels = surface_pixel_rect(capture_rect, root_scale);
+        dest_quad_intersects_rect(child.dest_quad, capture_pixels)
+            && child.scissor.is_none_or(|(x, y, width, height)| {
+                rects_intersect(
+                    Rect {
+                        x: x as f32,
+                        y: y as f32,
+                        width: width as f32,
+                        height: height as f32,
+                    },
+                    capture_pixels,
+                )
+            })
+    }) {
         3u8.hash(&mut hasher);
         hash_backdrop_prefix_child(child, &mut hasher);
     }
@@ -3882,6 +3911,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                 local_scene,
                 &prior_child_contributions,
                 child.z_index,
+                child_backdrop_capture_rect.unwrap_or(backdrop_layer.rect),
                 (width, height),
                 target_scale,
             );
@@ -5754,9 +5784,10 @@ mod tests {
         let later_child_left = [child_prefix_contribution(2, 20.0)];
         let later_child_right = [child_prefix_contribution(2, 80.0)];
 
-        let left_prefix = backdrop_scene_prefix_hash(&scene, &later_child_left, 1, (200, 120), 1.0);
+        let left_prefix =
+            backdrop_scene_prefix_hash(&scene, &later_child_left, 1, layer.rect, (200, 120), 1.0);
         let right_prefix =
-            backdrop_scene_prefix_hash(&scene, &later_child_right, 1, (200, 120), 1.0);
+            backdrop_scene_prefix_hash(&scene, &later_child_right, 1, layer.rect, (200, 120), 1.0);
         let left_key = backdrop_effect_cache_key(&layer, left_prefix, layer.rect, (60, 40), 1.0);
         let right_key = backdrop_effect_cache_key(&layer, right_prefix, layer.rect, (60, 40), 1.0);
 
@@ -5777,13 +5808,49 @@ mod tests {
         let black_scene = scene_with_prefix_shape(Color::BLACK);
         let red_scene = scene_with_prefix_shape(Color::RED);
 
-        let black_prefix = backdrop_scene_prefix_hash(&black_scene, &[], 1, (200, 120), 1.0);
-        let red_prefix = backdrop_scene_prefix_hash(&red_scene, &[], 1, (200, 120), 1.0);
+        let black_prefix =
+            backdrop_scene_prefix_hash(&black_scene, &[], 1, layer.rect, (200, 120), 1.0);
+        let red_prefix =
+            backdrop_scene_prefix_hash(&red_scene, &[], 1, layer.rect, (200, 120), 1.0);
 
         assert_ne!(
             backdrop_effect_cache_key(&layer, black_prefix, layer.rect, (60, 40), 1.0),
             backdrop_effect_cache_key(&layer, red_prefix, layer.rect, (60, 40), 1.0),
             "prior scene pixels must invalidate cached backdrop output"
+        );
+    }
+
+    #[test]
+    fn backdrop_cache_key_ignores_prior_content_outside_capture_rect() {
+        let layer = test_backdrop_layer(Rect {
+            x: 10.0,
+            y: 10.0,
+            width: 60.0,
+            height: 40.0,
+        });
+        let mut black_scene = scene_with_prefix_shape(Color::BLACK);
+        let mut red_scene = scene_with_prefix_shape(Color::RED);
+        for scene in [&mut black_scene, &mut red_scene] {
+            let rect = Rect {
+                x: 120.0,
+                y: 80.0,
+                width: 40.0,
+                height: 30.0,
+            };
+            scene.shapes[0].rect = rect;
+            scene.shapes[0].local_rect = rect;
+            scene.shapes[0].quad = crate::rect_to_quad(rect);
+        }
+
+        let black_prefix =
+            backdrop_scene_prefix_hash(&black_scene, &[], 1, layer.rect, (200, 120), 1.0);
+        let red_prefix =
+            backdrop_scene_prefix_hash(&red_scene, &[], 1, layer.rect, (200, 120), 1.0);
+
+        assert_eq!(
+            backdrop_effect_cache_key(&layer, black_prefix, layer.rect, (60, 40), 1.0),
+            backdrop_effect_cache_key(&layer, red_prefix, layer.rect, (60, 40), 1.0),
+            "content outside the sampled backdrop capture must not invalidate cached glass"
         );
     }
 
@@ -5799,14 +5866,39 @@ mod tests {
         let prior_child_left = [child_prefix_contribution(0, 20.0)];
         let prior_child_right = [child_prefix_contribution(0, 80.0)];
 
-        let left_prefix = backdrop_scene_prefix_hash(&scene, &prior_child_left, 1, (200, 120), 1.0);
+        let left_prefix =
+            backdrop_scene_prefix_hash(&scene, &prior_child_left, 1, layer.rect, (200, 120), 1.0);
         let right_prefix =
-            backdrop_scene_prefix_hash(&scene, &prior_child_right, 1, (200, 120), 1.0);
+            backdrop_scene_prefix_hash(&scene, &prior_child_right, 1, layer.rect, (200, 120), 1.0);
 
         assert_ne!(
             backdrop_effect_cache_key(&layer, left_prefix, layer.rect, (60, 40), 1.0),
             backdrop_effect_cache_key(&layer, right_prefix, layer.rect, (60, 40), 1.0),
             "prior child movement changes the pixels sampled by a later backdrop"
+        );
+    }
+
+    #[test]
+    fn backdrop_cache_key_ignores_prior_child_motion_outside_capture_rect() {
+        let scene = scene_with_prefix_shape(Color::BLACK);
+        let layer = test_backdrop_layer(Rect {
+            x: 10.0,
+            y: 10.0,
+            width: 60.0,
+            height: 40.0,
+        });
+        let prior_child_left = [child_prefix_contribution(0, 100.0)];
+        let prior_child_right = [child_prefix_contribution(0, 140.0)];
+
+        let left_prefix =
+            backdrop_scene_prefix_hash(&scene, &prior_child_left, 1, layer.rect, (200, 120), 1.0);
+        let right_prefix =
+            backdrop_scene_prefix_hash(&scene, &prior_child_right, 1, layer.rect, (200, 120), 1.0);
+
+        assert_eq!(
+            backdrop_effect_cache_key(&layer, left_prefix, layer.rect, (60, 40), 1.0),
+            backdrop_effect_cache_key(&layer, right_prefix, layer.rect, (60, 40), 1.0),
+            "isolated content outside the sampled backdrop capture must not invalidate cached glass"
         );
     }
 

--- a/crates/cranpose-render/wgpu/tests/effect_semantics.rs
+++ b/crates/cranpose-render/wgpu/tests/effect_semantics.rs
@@ -1350,6 +1350,54 @@ fn cached_nested_backdrop_blur_radius_changes_rendered_pixels() {
 }
 
 #[test]
+fn static_backdrop_reuses_cache_when_non_overlapping_content_animates() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!(
+                "skipping spatial backdrop cache assertion because headless WGPU init failed: {}",
+                err
+            );
+            return;
+        }
+    };
+
+    renderer.scene_mut().graph = Some(spatial_backdrop_cache_fixture(Color::RED));
+    renderer
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("backdrop cache warmup should succeed");
+    let warmup_stats = renderer
+        .last_frame_stats()
+        .expect("backdrop warmup frame stats");
+
+    renderer.scene_mut().graph = Some(spatial_backdrop_cache_fixture(Color::BLUE));
+    let animated_frame = renderer
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("non-overlapping animation frame should succeed");
+    let animated_stats = renderer
+        .last_frame_stats()
+        .expect("non-overlapping animation frame stats");
+
+    assert!(
+        warmup_stats.blur_passes > 0,
+        "the warmup frame must materialize the backdrop effect: {warmup_stats:?}"
+    );
+    assert!(
+        animated_stats.layer_cache_hits > 0,
+        "static glass should hit its retained backdrop surface: {animated_stats:?}"
+    );
+    assert_eq!(
+        animated_stats.blur_passes, 0,
+        "content outside the sampled backdrop region must not rerun the glass blur: {animated_stats:?}"
+    );
+    let animated_pixel = rgba(&animated_frame, 112, 80);
+    assert!(
+        animated_pixel[2] > animated_pixel[0],
+        "the non-overlapping animated content must still update: {animated_pixel:?}"
+    );
+}
+
+#[test]
 fn translated_backdrop_capture_preserves_local_picture_under_rigid_motion() {
     let mut renderer = match support::headless_renderer() {
         Ok(renderer) => renderer,
@@ -1698,6 +1746,37 @@ fn backdrop_fixture() -> RenderGraph {
                 height: FRAME_HEIGHT as f32,
             },
             Color::BLUE,
+        ),
+        RenderNode::Layer(Box::new(backdrop_layer)),
+    ])
+}
+
+fn spatial_backdrop_cache_fixture(animated_color: Color) -> RenderGraph {
+    let backdrop_layer = layer(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 40.0,
+            height: 30.0,
+        },
+        ProjectiveTransform::translation(10.0, 10.0),
+        GraphicsLayer {
+            backdrop_effect: Some(RenderEffect::blur(8.0)),
+            ..GraphicsLayer::default()
+        },
+        vec![],
+    );
+
+    graph(vec![
+        solid_rect(frame_rect(), Color::BLACK),
+        solid_rect(
+            Rect {
+                x: 100.0,
+                y: 68.0,
+                width: 24.0,
+                height: 24.0,
+            },
+            animated_color,
         ),
         RenderNode::Layer(Box::new(backdrop_layer)),
     ])

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
@@ -345,6 +345,7 @@ public class CranposeActivity extends NativeActivity {
     /** Opens the document tree picker for a <em>writable</em> folder, taking a
      * persistent read/write grant. The chosen tree URI is reported back through
      * {@link #nativeOnWritableFolderPicked}. Called from Rust over JNI. */
+    @SuppressWarnings("deprecation")
     public void cranposePickWritableFolder(long token) {
         pendingToken = token;
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
@@ -558,6 +559,7 @@ public class CranposeActivity extends NativeActivity {
         return null;
     }
 
+    @SuppressWarnings("deprecation")
     private void launch(Intent intent, long token, int flags) {
         try {
             startActivityForResult(intent, REQUEST_BASE | flags);
@@ -571,6 +573,7 @@ public class CranposeActivity extends NativeActivity {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if ((requestCode & 0xFFFF0000) != REQUEST_BASE) {
@@ -1072,6 +1075,7 @@ public class CranposeActivity extends NativeActivity {
      * Extras Cranpose has no typed API for (arrays, {@code Parcelable}s, nested
      * bundles) are omitted rather than guessed at.
      */
+    @SuppressWarnings("deprecation")
     public String cranposeEncodeLaunchArguments() {
         StringBuilder payload = new StringBuilder();
         payload.append(isCranposeDebuggableBuild() ? '1' : '0');
@@ -1255,7 +1259,7 @@ public class CranposeActivity extends NativeActivity {
                         (VibratorManager) getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
                 return manager == null ? null : manager.getDefaultVibrator();
             }
-            return (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
+            return getSystemService(Vibrator.class);
         } catch (Exception ignored) {
             return null;
         }
@@ -1264,6 +1268,7 @@ public class CranposeActivity extends NativeActivity {
     /** Vibrates once for {@code durationMs} at {@code amplitude} (-1 for the
      * device default, otherwise 1..255). Called from Rust over JNI (any
      * thread); {@code VibrationEffect.createOneShot} needs API 26. */
+    @SuppressWarnings("deprecation")
     public void cranposeHapticOneShot(final long durationMs, final int amplitude) {
         if (durationMs <= 0) {
             return;
@@ -1290,6 +1295,7 @@ public class CranposeActivity extends NativeActivity {
      * to {@code repeat} (or -1 for a single pass). Called from Rust over JNI
      * (any thread); {@code VibrationEffect.createWaveform} needs API 26, and
      * pre-26 devices fall back to the timings alone. */
+    @SuppressWarnings("deprecation")
     public void cranposeHapticWaveform(final long[] timingsMs, final int[] amplitudes,
             final int repeat) {
         if (timingsMs == null || amplitudes == null || timingsMs.length != amplitudes.length
@@ -1521,6 +1527,7 @@ public class CranposeActivity extends NativeActivity {
 
     /** Presents ACTION_CREATE_DOCUMENT and writes the staged bytes to the
      * chosen destination. Called from Rust over JNI. */
+    @SuppressWarnings("deprecation")
     public void cranposeSaveFile(final long token, final String fileName,
             final String mimeType, final byte[] bytes) {
         runOnUiThread(() -> {


### PR DESCRIPTION
## Summary

- bound backdrop cache dependencies to the glass effect's sampled capture region
- keep non-overlapping animated primitives and isolated layers from invalidating static glass
- make the desktop tab strip's scroll viewport reach the window edge while preserving its visual gutters
- add GPU and robot regressions for both issues
- make WASM and Android release builds warning-free

## Root cause

Backdrop cache keys hashed the entire preceding scene prefix, so any earlier animation changed every later glass key even when it could not affect the sampled pixels. The tab strip also inherited the application's outer page padding, leaving the first 20 px outside every descendant scroll hit region.

## Impact

Static glass surfaces now remain cached beside spatially separate animation, and horizontal wheel input at x=6.25 reaches the tab strip.

Fixes #362.
Fixes #363.

## Validation

- `cargo fmt`
- `cargo test`
- `cargo clippy`
- headless WGPU effect semantics and cache-key regressions
- `robot_regression_tabbar_contract`
- Android `:app:assembleRelease`
- WASM `build-web.sh`
- full 141-test robot sweep under Xvfb: 133 passed directly; five cadence-sensitive cases passed in deterministic software-renderer mode; three unrelated X11 presented-capture contracts remain environment-sensitive on this host