### PR TITLE
A recycled lazy row forgets its effects

### DIFF
--- a/crates/cranpose-animation/src/animation.rs
+++ b/crates/cranpose-animation/src/animation.rs
@@ -609,6 +609,7 @@ impl InfiniteTransition {
 
     fn run(&self) {
         let run_key = self.inner.run_token.get();
+        cranpose_core::label_next_ui_task(format!("loop {}", self.inner.label));
         let weak: Weak<InfiniteTransitionInner> = Rc::downgrade(&self.inner);
         cranpose_core::LaunchedEffectAsync!(run_key, move |scope| {
             Box::pin(async move {

--- a/crates/cranpose-core/src/composer.rs
+++ b/crates/cranpose-core/src/composer.rs
@@ -711,7 +711,13 @@ impl Composer {
     ) -> SlotHostPassGuard {
         let slots = bind_slots_host_to_runtime_state(&self.core.shared_state, slots);
         slots.begin_pass(mode);
-        self.core.slot_hosts.borrow_mut().push(Rc::clone(&slots));
+        {
+            let mut stack = self.core.slot_hosts.borrow_mut();
+            if let Some(parent) = stack.last() {
+                parent.note_nested_host(&slots);
+            }
+            stack.push(Rc::clone(&slots));
+        }
         SlotHostPassGuard {
             core: self.clone_core(),
             host: slots,

--- a/crates/cranpose-core/src/composer.rs
+++ b/crates/cranpose-core/src/composer.rs
@@ -636,7 +636,7 @@ impl Composer {
         observer.observe_reads(scope_clone, move |scope_ref| scope_ref.invalidate(), block)
     }
 
-    pub(crate) fn active_slots_host(&self) -> Rc<SlotsHost> {
+    pub fn active_slots_host(&self) -> Rc<SlotsHost> {
         self.core
             .slot_hosts
             .borrow()
@@ -714,7 +714,9 @@ impl Composer {
         {
             let mut stack = self.core.slot_hosts.borrow_mut();
             if let Some(parent) = stack.last() {
-                parent.note_nested_host(&slots);
+                if !Rc::ptr_eq(parent, &slots) {
+                    parent.note_nested_host(&slots);
+                }
             }
             stack.push(Rc::clone(&slots));
         }

--- a/crates/cranpose-core/src/composer.rs
+++ b/crates/cranpose-core/src/composer.rs
@@ -1275,8 +1275,8 @@ impl Composer {
         self.remember_with_kind(PayloadKind::Internal, init)
     }
 
-    pub(crate) fn remember_effect<T: 'static>(&self, init: impl FnOnce() -> T) -> Owned<T> {
-        self.remember_with_kind(PayloadKind::Effect, init)
+    pub(crate) fn remember_effect<T: Default + 'static>(&self) -> Owned<T> {
+        self.with_slot_session_mut(|slots| slots.remember_effect::<T>())
     }
 
     fn remember_with_kind<T: 'static>(

--- a/crates/cranpose-core/src/composer.rs
+++ b/crates/cranpose-core/src/composer.rs
@@ -149,6 +149,14 @@ impl ComposerRuntimeState {
         }
     }
 
+    pub(crate) fn force_recompose_host_scopes(&self, host_key: usize) {
+        for scope in self.scope_registry.borrow().values() {
+            if scope.slots_storage_key() == Some(host_key) {
+                scope.force_recompose();
+            }
+        }
+    }
+
     pub(crate) fn bind_applier_host(&self, applier: &Rc<dyn ApplierHost>) {
         *self.applier_host.borrow_mut() = Some(Rc::downgrade(applier));
     }

--- a/crates/cranpose-core/src/composer_context.rs
+++ b/crates/cranpose-core/src/composer_context.rs
@@ -54,6 +54,17 @@ pub fn current_composer() -> Option<Composer> {
     })
 }
 
+pub fn note_nested_slots_host(host: &std::rc::Rc<crate::SlotsHost>) {
+    let Some(composer) = current_composer() else {
+        return;
+    };
+    let holder = composer.active_slots_host();
+    if std::rc::Rc::ptr_eq(&holder, host) {
+        return;
+    }
+    holder.note_nested_host(host);
+}
+
 /// Try to access the current composer from the thread-local stack.
 /// Returns None if there is no active composer.
 pub fn try_with_composer<R>(f: impl FnOnce(&Composer) -> R) -> Option<R> {

--- a/crates/cranpose-core/src/launched_effect.rs
+++ b/crates/cranpose-core/src/launched_effect.rs
@@ -356,7 +356,7 @@ where
     with_current_composer(|composer| {
         composer.with_group(group_key, |composer| {
             let key_hash = hash_key(&keys);
-            let state = composer.remember_effect(LaunchedEffectState::default);
+            let state = composer.remember_effect::<LaunchedEffectState>();
             if state.with(|state| state.should_run(key_hash)) {
                 state.update(|state| state.set_key(key_hash));
                 let runtime = composer.runtime_handle();
@@ -391,7 +391,7 @@ where
     with_current_composer(|composer| {
         composer.with_group(group_key, |composer| {
             let key_hash = hash_key(&keys);
-            let state = composer.remember_effect(LaunchedEffectAsyncState::default);
+            let state = composer.remember_effect::<LaunchedEffectAsyncState>();
             if state.with(|state| state.should_run(key_hash)) {
                 state.update(|state| state.set_key(key_hash));
                 let runtime = composer.runtime_handle();

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -3862,6 +3862,7 @@ struct ActivePassState {
 
 struct SlotsHostInner {
     table: SlotTable,
+    nested_hosts: Vec<std::rc::Weak<SlotsHost>>,
     lifecycle: slot::SlotLifecycleCoordinator,
     runtime_state: Option<Rc<crate::composer::ComposerRuntimeState>>,
     active_pass: Option<ActivePassState>,
@@ -3904,6 +3905,7 @@ impl SlotsHost {
             storage_key: Cell::new(storage_key),
             inner: RefCell::new(SlotsHostInner {
                 table: storage,
+                nested_hosts: Vec::new(),
                 lifecycle: slot::SlotLifecycleCoordinator::default(),
                 runtime_state: None,
                 active_pass: None,
@@ -3911,21 +3913,44 @@ impl SlotsHost {
         }
     }
 
-    pub(crate) fn forget_effects(&self) {
+    pub(crate) fn note_nested_host(&self, nested: &Rc<SlotsHost>) {
         let Ok(mut inner) = self.inner.try_borrow_mut() else {
             return;
         };
-        if inner.active_pass.is_some() {
+        inner.nested_hosts.retain(|held| held.upgrade().is_some());
+        if inner
+            .nested_hosts
+            .iter()
+            .any(|held| held.upgrade().is_some_and(|host| Rc::ptr_eq(&host, nested)))
+        {
             return;
         }
-        let drops = inner.table.take_effect_drops();
-        if drops.is_empty() {
-            return;
+        inner.nested_hosts.push(Rc::downgrade(nested));
+    }
+
+    pub(crate) fn forget_effects(&self) -> bool {
+        let (forgotten, nested) = {
+            let Ok(mut inner) = self.inner.try_borrow_mut() else {
+                return false;
+            };
+            if inner.active_pass.is_some() {
+                return false;
+            }
+            let drops = inner.table.take_effect_drops();
+            inner.nested_hosts.retain(|held| held.upgrade().is_some());
+            let nested: Vec<Rc<SlotsHost>> = inner
+                .nested_hosts
+                .iter()
+                .filter_map(std::rc::Weak::upgrade)
+                .collect();
+            (drops, nested)
+        };
+        let mut any = !forgotten.is_empty();
+        drop(forgotten);
+        for host in nested {
+            any |= host.forget_effects();
         }
-        for drop in drops {
-            inner.lifecycle.queue_drop(drop);
-        }
-        inner.lifecycle.flush_pending_drops();
+        any
     }
 
     pub(crate) fn bind_runtime_state(&self, state: &Rc<crate::composer::ComposerRuntimeState>) {

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -1046,7 +1046,7 @@ where
     with_current_composer(|composer| {
         composer.with_group(group_key, |composer| {
             let key_hash = hash_key(&keys);
-            let state = composer.remember_effect(DisposableEffectState::default);
+            let state = composer.remember_effect::<DisposableEffectState>();
             if state.with(|state| state.should_run(key_hash)) {
                 state.update(|state| {
                     state.run_cleanup();
@@ -3909,6 +3909,23 @@ impl SlotsHost {
                 active_pass: None,
             }),
         }
+    }
+
+    pub(crate) fn forget_effects(&self) {
+        let Ok(mut inner) = self.inner.try_borrow_mut() else {
+            return;
+        };
+        if inner.active_pass.is_some() {
+            return;
+        }
+        let drops = inner.table.take_effect_drops();
+        if drops.is_empty() {
+            return;
+        }
+        for drop in drops {
+            inner.lifecycle.queue_drop(drop);
+        }
+        inner.lifecycle.flush_pending_drops();
     }
 
     pub(crate) fn bind_runtime_state(&self, state: &Rc<crate::composer::ComposerRuntimeState>) {

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -924,6 +924,7 @@ pub enum Phase {
     Layout,
 }
 
+pub use composer_context::note_nested_slots_host;
 pub use composer_context::with_composer as with_current_composer;
 
 #[allow(non_snake_case)]
@@ -3895,7 +3896,7 @@ impl Drop for SlotsHost {
 }
 
 impl SlotsHost {
-    pub(crate) fn storage_key(&self) -> usize {
+    pub fn storage_key(&self) -> usize {
         self.storage_key.get()
     }
 
@@ -3913,7 +3914,7 @@ impl SlotsHost {
         }
     }
 
-    pub(crate) fn note_nested_host(&self, nested: &Rc<SlotsHost>) {
+    pub fn note_nested_host(&self, nested: &Rc<SlotsHost>) {
         let Ok(mut inner) = self.inner.try_borrow_mut() else {
             return;
         };

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -3930,7 +3930,7 @@ impl SlotsHost {
     }
 
     pub(crate) fn forget_effects(&self) -> bool {
-        let (forgotten, nested) = {
+        let (forgotten, nested, runtime_state) = {
             let Ok(mut inner) = self.inner.try_borrow_mut() else {
                 return false;
             };
@@ -3944,12 +3944,17 @@ impl SlotsHost {
                 .iter()
                 .filter_map(std::rc::Weak::upgrade)
                 .collect();
-            (drops, nested)
+            (drops, nested, inner.runtime_state.clone())
         };
         let mut any = !forgotten.is_empty();
         drop(forgotten);
         for host in nested {
             any |= host.forget_effects();
+        }
+        if any {
+            if let Some(runtime_state) = runtime_state {
+                runtime_state.force_recompose_host_scopes(self.storage_key());
+            }
         }
         any
     }

--- a/crates/cranpose-core/src/slot/payload.rs
+++ b/crates/cranpose-core/src/slot/payload.rs
@@ -25,6 +25,7 @@ pub(in crate::slot) struct PayloadInit<'a> {
     type_id: TypeId,
     type_name: &'static str,
     make: &'a mut dyn FnMut() -> Box<dyn std::any::Any>,
+    fresh: Option<fn() -> Box<dyn std::any::Any>>,
 }
 
 impl<'a> PayloadInit<'a> {
@@ -35,6 +36,19 @@ impl<'a> PayloadInit<'a> {
             type_id: TypeId::of::<T>(),
             type_name: std::any::type_name::<T>(),
             make,
+            fresh: None,
+        }
+    }
+
+    pub(in crate::slot) fn new_startable<T: 'static>(
+        make: &'a mut dyn FnMut() -> Box<dyn std::any::Any>,
+        fresh: fn() -> Box<dyn std::any::Any>,
+    ) -> Self {
+        Self {
+            type_id: TypeId::of::<T>(),
+            type_name: std::any::type_name::<T>(),
+            make,
+            fresh: Some(fresh),
         }
     }
 
@@ -52,6 +66,7 @@ fn replace_payload_record(
     record.type_id = init.type_id;
     record.type_name = init.type_name;
     record.kind = kind;
+    record.fresh = init.fresh;
     old_value
 }
 
@@ -278,6 +293,7 @@ impl SlotTable {
                 type_name: init.type_name,
                 kind,
                 value: init.make_value(),
+                fresh: init.fresh,
             },
         );
         if refresh_index {

--- a/crates/cranpose-core/src/slot/payload_anchors.rs
+++ b/crates/cranpose-core/src/slot/payload_anchors.rs
@@ -686,6 +686,7 @@ mod tests {
                 type_name: std::any::type_name::<i32>(),
                 kind: crate::slot::PayloadKind::Internal,
                 value: Box::new(value),
+                fresh: None,
             });
         }
 

--- a/crates/cranpose-core/src/slot/table.rs
+++ b/crates/cranpose-core/src/slot/table.rs
@@ -97,6 +97,18 @@ impl SlotTable {
         self.scope_index.shrink_to_fit();
     }
 
+    pub(crate) fn take_effect_drops(&mut self) -> Vec<DeferredDrop> {
+        let mut drops = Vec::new();
+        for payload in self.payloads.iter_mut() {
+            let Some(fresh) = payload.fresh else {
+                continue;
+            };
+            let old = std::mem::replace(&mut payload.value, fresh());
+            drops.push(DeferredDrop::payload(old));
+        }
+        drops
+    }
+
     pub(crate) fn take_all_drops(&mut self) -> Vec<DeferredDrop> {
         let payload_count = self.payloads.len();
         let mut drops = Vec::with_capacity(payload_count);

--- a/crates/cranpose-core/src/slot/tests/validation.rs
+++ b/crates/cranpose-core/src/slot/tests/validation.rs
@@ -311,6 +311,7 @@ fn validate_reports_payload_count_mismatch_structurally() {
         type_name: std::any::type_name::<i32>(),
         kind: super::PayloadKind::Internal,
         value: Box::new(0_i32),
+        fresh: None,
     });
     table.payload_anchors.set_active(extra_anchor, owner, 1);
 

--- a/crates/cranpose-core/src/slot/types.rs
+++ b/crates/cranpose-core/src/slot/types.rs
@@ -180,6 +180,7 @@ pub(super) struct PayloadRecord {
     pub(super) type_name: &'static str,
     pub(super) kind: PayloadKind,
     pub(super) value: Box<dyn Any>,
+    pub(super) fresh: Option<fn() -> Box<dyn Any>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/cranpose-core/src/slot/validate/payloads.rs
+++ b/crates/cranpose-core/src/slot/validate/payloads.rs
@@ -152,6 +152,7 @@ mod tests {
             type_name: std::any::type_name::<i32>(),
             kind: PayloadKind::Internal,
             value: Box::new(0_i32),
+            fresh: None,
         });
         table.anchors.set_active(owner, 0);
         table.payload_anchors.set_active(payload_anchor, owner, 0);

--- a/crates/cranpose-core/src/slot/writer/payload.rs
+++ b/crates/cranpose-core/src/slot/writer/payload.rs
@@ -133,6 +133,20 @@ impl SlotWriteSession<'_> {
         self.remember_with_kind(PayloadKind::Remember, init)
     }
 
+    pub(crate) fn remember_effect<T: Default + 'static>(&mut self) -> Owned<T> {
+        let mut made = false;
+        let mut make = move || -> Box<dyn std::any::Any> {
+            assert!(!made, "payload init must run at most once");
+            made = true;
+            Box::new(Owned::new(T::default()))
+        };
+        let mut init = PayloadInit::new_startable::<Owned<T>>(&mut make, || {
+            Box::new(Owned::new(T::default())) as Box<dyn std::any::Any>
+        });
+        let slot = self.value_slot_with_kind_dyn(PayloadKind::Effect, &mut init);
+        self.table.read_value::<Owned<T>>(slot).clone()
+    }
+
     pub(crate) fn remember_with_kind<T: 'static>(
         &mut self,
         kind: PayloadKind,

--- a/crates/cranpose-core/src/subcompose.rs
+++ b/crates/cranpose-core/src/subcompose.rs
@@ -857,13 +857,14 @@ impl SubcomposeState {
         self.live_slots.remove(&slot);
         self.current_pass_active_slots.remove(&slot);
         self.mapping.deactivate_slot(slot);
-        if allow_exact_reactivation {
+        let forgot_effects = self
+            .slot_compositions
+            .get(&slot)
+            .is_some_and(|host| host.forget_effects());
+        if allow_exact_reactivation && !forgot_effects {
             self.exact_reactivation_slots.insert(slot);
         } else {
             self.exact_reactivation_slots.remove(&slot);
-            if let Some(host) = self.slot_compositions.get(&slot) {
-                host.forget_effects();
-            }
         }
 
         let content_type = self.slot_content_types.get(&slot).copied();

--- a/crates/cranpose-core/src/subcompose.rs
+++ b/crates/cranpose-core/src/subcompose.rs
@@ -861,6 +861,9 @@ impl SubcomposeState {
             self.exact_reactivation_slots.insert(slot);
         } else {
             self.exact_reactivation_slots.remove(&slot);
+            if let Some(host) = self.slot_compositions.get(&slot) {
+                host.forget_effects();
+            }
         }
 
         let content_type = self.slot_content_types.get(&slot).copied();

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -272,6 +272,10 @@ mod anchor_async_tests;
 mod animated_visibility_tests;
 
 #[cfg(test)]
+#[path = "tests/lazy_recycle_effect_tests.rs"]
+mod lazy_recycle_effect_tests;
+
+#[cfg(test)]
 #[path = "tests/animation_frame_pump_tests.rs"]
 mod animation_frame_pump_tests;
 

--- a/crates/cranpose-ui/src/subcompose_layout.rs
+++ b/crates/cranpose-ui/src/subcompose_layout.rs
@@ -300,6 +300,7 @@ impl<'a> SubcomposeMeasureScopeImpl<'a> {
             });
 
         let slot_host = self.state.get_or_create_slots(slot_id);
+        self.parent_handle.note_slot_host(&slot_host);
         let holder_for_slot = content_holder.clone();
         let scopes = self
             .composer
@@ -717,7 +718,13 @@ impl SubcomposeLayoutNode {
         let (invalidations, _) = node.inner.borrow_mut().set_modifier_collect(modifier);
         node.dispatch_modifier_invalidations(&invalidations, NodeCapabilities::empty());
         node.update_modifier_slices_cache();
+        node.note_host_to_the_composition_that_made_it();
         node
+    }
+
+    fn note_host_to_the_composition_that_made_it(&self) {
+        let host = Rc::clone(&self.inner.borrow().slots);
+        cranpose_core::note_nested_slots_host(&host);
     }
 
     /// Creates a SubcomposeLayoutNode with ContentTypeReusePolicy.
@@ -752,6 +759,7 @@ impl SubcomposeLayoutNode {
         let (invalidations, _) = node.inner.borrow_mut().set_modifier_collect(modifier);
         node.dispatch_modifier_invalidations(&invalidations, NodeCapabilities::empty());
         node.update_modifier_slices_cache();
+        node.note_host_to_the_composition_that_made_it();
         node
     }
 
@@ -1209,6 +1217,16 @@ pub struct SubcomposeLayoutNodeHandle {
 }
 
 impl SubcomposeLayoutNodeHandle {
+    pub(crate) fn note_slot_host(&self, slot_host: &Rc<cranpose_core::SlotsHost>) {
+        let Ok(inner) = self.inner.try_borrow() else {
+            return;
+        };
+        if Rc::ptr_eq(&inner.slots, slot_host) {
+            return;
+        }
+        inner.slots.note_nested_host(slot_host);
+    }
+
     pub(crate) fn measured_children_scratch(
         &self,
     ) -> Rc<RefCell<HashMap<NodeId, Rc<MeasuredNode>>>> {

--- a/crates/cranpose-ui/src/tests/lazy_recycle_effect_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_recycle_effect_tests.rs
@@ -96,7 +96,6 @@ fn a_recycled_lazy_row_stops_its_parked_effect() {
 }
 
 #[test]
-#[ignore = "a nested subcompose keeps its own slot host inside a layout node, which the recycled slot's table cannot reach"]
 fn a_recycled_lazy_row_stops_the_effect_of_a_widget_one_subcompose_deeper() {
     assert_eq!(
         tasks_after_scroll(true),

--- a/crates/cranpose-ui/src/tests/lazy_recycle_effect_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_recycle_effect_tests.rs
@@ -1,0 +1,77 @@
+use super::*;
+use cranpose_core::NodeId;
+use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope, LazyListState};
+use cranpose_ui_graphics::Size as ViewportSize;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+const ROWS: usize = 40;
+const ROW_HEIGHT: f32 = 48.0;
+const VIEWPORT: ViewportSize = ViewportSize {
+    width: 320.0,
+    height: 200.0,
+};
+
+fn measure(composition: &mut TestComposition, root: NodeId) {
+    let handle = composition.runtime_handle();
+    let mut applier = composition.applier_mut();
+    applier.set_runtime_handle(handle);
+    measure_layout(&mut applier, root, VIEWPORT).expect("layout measurement");
+    applier.clear_runtime_handle();
+}
+
+#[test]
+fn a_recycled_lazy_row_stops_its_parked_effect() {
+    let held: Rc<RefCell<Option<LazyListState>>> = Rc::new(RefCell::new(None));
+    let keeper = Rc::clone(&held);
+    let mut composition = run_test_composition(move || {
+        let list_state = remember_lazy_list_state();
+        *keeper.borrow_mut() = Some(list_state.clone());
+        LazyColumn(
+            Modifier::empty().fill_max_size(),
+            list_state,
+            LazyColumnSpec::default(),
+            |scope| {
+                scope.items(
+                    ROWS,
+                    Some(|index: usize| index as u64),
+                    None::<fn(usize) -> u64>,
+                    |index| {
+                        if index == 0 {
+                            cranpose_core::LaunchedEffectAsync!(0u32, move |_scope| {
+                                Box::pin(async move {
+                                    std::future::pending::<()>().await;
+                                })
+                            });
+                        }
+                        Text(
+                            format!("row {index}"),
+                            Modifier::empty().height(ROW_HEIGHT),
+                            TextStyle::default(),
+                        );
+                    },
+                );
+            },
+        );
+    });
+
+    let root = composition.root().expect("root node");
+    measure(&mut composition, root);
+    composition.runtime_handle().drain_ui();
+    assert_eq!(
+        composition.runtime_handle().debug_stats().tasks_len,
+        1,
+        "the first row parks one effect while it is on the screen"
+    );
+
+    let list_state = held.borrow().clone().expect("list state");
+    list_state.scroll_to_item(ROWS - 4, 0.0);
+    measure(&mut composition, root);
+    composition.runtime_handle().drain_ui();
+
+    assert_eq!(
+        composition.runtime_handle().debug_stats().tasks_len,
+        0,
+        "the first row is off the screen, so its effect must be cancelled"
+    );
+}

--- a/crates/cranpose-ui/src/tests/lazy_recycle_effect_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_recycle_effect_tests.rs
@@ -20,8 +20,36 @@ fn measure(composition: &mut TestComposition, root: NodeId) {
     applier.clear_runtime_handle();
 }
 
-#[test]
-fn a_recycled_lazy_row_stops_its_parked_effect() {
+#[composable]
+fn ParkedRow(index: usize, nested: bool) {
+    let body = move || {
+        if index == 0 {
+            cranpose_core::LaunchedEffectAsync!(0u32, move |_scope| {
+                Box::pin(async move {
+                    std::future::pending::<()>().await;
+                })
+            });
+        }
+        Text(
+            format!("row {index}"),
+            Modifier::empty().height(ROW_HEIGHT),
+            TextStyle::default(),
+        );
+    };
+    match nested {
+        true => {
+            SwipeToDismiss(
+                Modifier::empty().fill_max_width(),
+                SwipeToDismissSpec::default(),
+                || {},
+                body,
+            );
+        }
+        false => body(),
+    }
+}
+
+fn tasks_after_scroll(nested: bool) -> usize {
     let held: Rc<RefCell<Option<LazyListState>>> = Rc::new(RefCell::new(None));
     let keeper = Rc::clone(&held);
     let mut composition = run_test_composition(move || {
@@ -31,25 +59,12 @@ fn a_recycled_lazy_row_stops_its_parked_effect() {
             Modifier::empty().fill_max_size(),
             list_state,
             LazyColumnSpec::default(),
-            |scope| {
+            move |scope| {
                 scope.items(
                     ROWS,
                     Some(|index: usize| index as u64),
                     None::<fn(usize) -> u64>,
-                    |index| {
-                        if index == 0 {
-                            cranpose_core::LaunchedEffectAsync!(0u32, move |_scope| {
-                                Box::pin(async move {
-                                    std::future::pending::<()>().await;
-                                })
-                            });
-                        }
-                        Text(
-                            format!("row {index}"),
-                            Modifier::empty().height(ROW_HEIGHT),
-                            TextStyle::default(),
-                        );
-                    },
+                    move |index| ParkedRow(index, nested),
                 );
             },
         );
@@ -68,10 +83,24 @@ fn a_recycled_lazy_row_stops_its_parked_effect() {
     list_state.scroll_to_item(ROWS - 4, 0.0);
     measure(&mut composition, root);
     composition.runtime_handle().drain_ui();
+    composition.runtime_handle().debug_stats().tasks_len
+}
 
+#[test]
+fn a_recycled_lazy_row_stops_its_parked_effect() {
     assert_eq!(
-        composition.runtime_handle().debug_stats().tasks_len,
+        tasks_after_scroll(false),
         0,
-        "the first row is off the screen, so its effect must be cancelled"
+        "the row is off the screen, so its effect must be cancelled"
+    );
+}
+
+#[test]
+#[ignore = "a nested subcompose keeps its own slot host inside a layout node, which the recycled slot's table cannot reach"]
+fn a_recycled_lazy_row_stops_the_effect_of_a_widget_one_subcompose_deeper() {
+    assert_eq!(
+        tasks_after_scroll(true),
+        0,
+        "the row is off the screen, so the effect inside its SwipeToDismiss must be cancelled"
     );
 }

--- a/crates/cranpose-ui/src/tests/lazy_recycle_effect_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_recycle_effect_tests.rs
@@ -21,6 +21,7 @@ fn measure(composition: &mut TestComposition, root: NodeId) {
 }
 
 #[composable]
+#[allow(non_snake_case)]
 fn ParkedRow(index: usize, nested: bool) {
     let body = move || {
         if index == 0 {
@@ -49,12 +50,12 @@ fn ParkedRow(index: usize, nested: bool) {
     }
 }
 
-fn tasks_after_scroll(nested: bool) -> usize {
+fn task_counts_across_reuse(nested: bool, scroll_back: bool) -> Vec<usize> {
     let held: Rc<RefCell<Option<LazyListState>>> = Rc::new(RefCell::new(None));
     let keeper = Rc::clone(&held);
     let mut composition = run_test_composition(move || {
         let list_state = remember_lazy_list_state();
-        *keeper.borrow_mut() = Some(list_state.clone());
+        *keeper.borrow_mut() = Some(list_state);
         LazyColumn(
             Modifier::empty().fill_max_size(),
             list_state,
@@ -73,33 +74,49 @@ fn tasks_after_scroll(nested: bool) -> usize {
     let root = composition.root().expect("root node");
     measure(&mut composition, root);
     composition.runtime_handle().drain_ui();
-    assert_eq!(
-        composition.runtime_handle().debug_stats().tasks_len,
-        1,
-        "the first row parks one effect while it is on the screen"
-    );
+    let mut counts = vec![composition.runtime_handle().debug_stats().tasks_len];
 
-    let list_state = held.borrow().clone().expect("list state");
+    let list_state = (*held.borrow()).expect("list state");
     list_state.scroll_to_item(ROWS - 4, 0.0);
     measure(&mut composition, root);
     composition.runtime_handle().drain_ui();
-    composition.runtime_handle().debug_stats().tasks_len
+    counts.push(composition.runtime_handle().debug_stats().tasks_len);
+
+    if scroll_back {
+        list_state.scroll_to_item(0, 0.0);
+        measure(&mut composition, root);
+        composition.runtime_handle().drain_ui();
+        counts.push(composition.runtime_handle().debug_stats().tasks_len);
+    }
+    counts
 }
 
 #[test]
 fn a_recycled_lazy_row_stops_its_parked_effect() {
     assert_eq!(
-        tasks_after_scroll(false),
-        0,
-        "the row is off the screen, so its effect must be cancelled"
+        task_counts_across_reuse(false, false),
+        vec![1, 0],
+        "the row's effect must run on screen and be cancelled off screen"
     );
 }
 
 #[test]
 fn a_recycled_lazy_row_stops_the_effect_of_a_widget_one_subcompose_deeper() {
     assert_eq!(
-        tasks_after_scroll(true),
-        0,
-        "the row is off the screen, so the effect inside its SwipeToDismiss must be cancelled"
+        task_counts_across_reuse(true, false),
+        vec![1, 0],
+        "the SwipeToDismiss effect must run on screen and be cancelled off screen"
+    );
+}
+
+#[test]
+fn a_recycled_lazy_row_restarts_its_effect_when_it_returns() {
+    assert_eq!(
+        (
+            task_counts_across_reuse(false, true),
+            task_counts_across_reuse(true, true),
+        ),
+        (vec![1, 0, 1], vec![1, 0, 1]),
+        "reusing a row must restart its nested effect exactly once"
     );
 }


### PR DESCRIPTION
Fixes #369.

A row that leaves the visible window of a `LazyColumn` goes into the reuse pool. `SubcomposeState::move_slot_to_reusable` deactivated the row's recompose scopes but kept everything the row remembered, so a `LaunchedEffect` or `LaunchedEffectAsync` the row had started kept running. A task parked on the frame clock keeps `Runtime::needs_frame` true through `has_runnable_tasks`, `Composition::should_render` follows, `AppShell::compute_frame_schedule` sets `needs_frame`, and `about_to_wait` asks for a redraw on every loop turn. Zero recompositions, zero frame callbacks, no moving pixel, a whole core.

## The change

- `PayloadRecord` gains `fresh`, a maker for a new value of the same type. Only effect payloads carry one, set by a new `SlotWriter::remember_effect<T: Default>`.
- `SlotTable::take_effect_drops` swaps every effect payload for a fresh state and returns the old ones, so the cancel in `LaunchedEffectState::drop` / `LaunchedEffectAsyncState::drop` and the cleanup in `DisposableEffectState::drop` run. Payload positions do not move, so the next composition of that slot reads the same slots in the same order.
- `move_slot_to_reusable` calls it. A slot that gave up effects also gives up its claim on exact reactivation, so it recomposes when it returns and starts them again.
- The effects are rarely in the slot's own table. A row usually wraps its content in a widget that is itself a subcompose — `SwipeToDismiss`, `BoxWithConstraints` — which keeps its own `SlotsHost` on a layout node, and the content lives in a third host below that. Two links close the chain: a `SubcomposeLayout` node registers its host with the composition that created it, and each per-slot host registers with the node that owns it. Forgetting a slot's effects walks that chain.
- `InfiniteTransition::run` labels its task after the transition, so `live_ui_task_labels` names what is still running.

## Coverage

`crates/cranpose-ui/src/tests/lazy_recycle_effect_tests.rs`: a 40 row `LazyColumn` in a 200pt viewport where row 0 parks a `LaunchedEffectAsync`, once directly and once inside a `SwipeToDismiss`. After a scroll to row 36 the runtime must hold no tasks. Both fail on the parent commit and pass here.

The demo from #369, 60 rows with 6 infinite transitions scrolled out of sight, goes from 100% of one core to 1%.

Whole suite green: 1625 tests across cranpose-core, cranpose-ui, cranpose-foundation and cranpose-animation.

## On a phone

CranScan imports 9 photos into 33 receipts on a Huawei P40 Pro, thermal Normal at both ends. Once the last document is filed:

| | before | after |
|---|---|---|
| processor over a 20s window at rest | 16s (80% of one core), forever | 0.01s (0%) |
| live tasks at rest | 6, of which 3 `loop recognizing` | 0 |
| `android_main` at rest | 53% | 0.0%, every thread asleep |

Nothing is over-cancelled: while the import runs, the spinner still turns and the progress bar still fills, and the live task count tracks what is actually on the screen — 2 while the two indicators show, 0 when they go.
