### PR TITLE
Let the store say whether being unavailable is worth retrying

### DIFF
--- a/crates/cranpose-services/src/purchases.rs
+++ b/crates/cranpose-services/src/purchases.rs
@@ -71,8 +71,9 @@ pub enum StorePhase {
     /// The difference from [`Unavailable`](Self::Unavailable) is whether
     /// waiting helps. It does not here — no backend retries a store that has
     /// said no — so an app should stop offering the purchase and say why,
-    /// rather than inviting a retry that can only fail the same way. Nothing
-    /// is owned that was not already known, and a restore will find nothing.
+    /// rather than inviting a retry that can only fail the same way.
+    /// Already-known ownership remains authoritative even though the store
+    /// cannot be queried for new purchases.
     Blocked,
     /// A backend is installed and still talking to the store. Prices are not
     /// known yet; owned entitlements may not be known yet either.

--- a/crates/cranpose-services/src/purchases.rs
+++ b/crates/cranpose-services/src/purchases.rs
@@ -12,13 +12,16 @@
 //! that itself, e.g.
 //!
 //! ```no_run
-//! # use cranpose_services::purchases::{store_state, StorePhase};
-//! let unlocked = match store_state().phase {
-//!     // No store on this platform — this app is free there.
-//!     StorePhase::Unavailable => true,
-//!     _ => store_state().owns("com.example.pro"),
-//! };
+//! # use cranpose_services::purchases::store_state;
+//! let state = store_state();
+//! // No store that will sell here — this app is free in that case.
+//! let unlocked = state.phase.cannot_sell() || state.owns("com.example.pro");
 //! ```
+//!
+//! The two phases that cannot sell say different things to a *user*:
+//! [`StorePhase::Unavailable`] is "not reached, try again", and
+//! [`StorePhase::Blocked`] is "this store will not sell to you here". Offering
+//! a retry for the second one only fails the same way again.
 //!
 //! # Reading state
 //!
@@ -55,15 +58,46 @@ pub struct Product {
 /// How far along the store connection is.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum StorePhase {
-    /// No store on this platform, or no backend installed. Nothing is owned
-    /// and nothing can be bought.
+    /// No store on this platform, or no backend installed, or one that has
+    /// not reached the store yet. Nothing is owned and nothing can be bought
+    /// *right now* — a backend that is retrying reports this, so an app may
+    /// reasonably say "not reached" and offer to try again.
     #[default]
     Unavailable,
+    /// The store answered, and it will not sell to this app here: in-app
+    /// billing turned off on the device, an account that cannot pay, a
+    /// country the app is not distributed in.
+    ///
+    /// The difference from [`Unavailable`](Self::Unavailable) is whether
+    /// waiting helps. It does not here — no backend retries a store that has
+    /// said no — so an app should stop offering the purchase and say why,
+    /// rather than inviting a retry that can only fail the same way. Nothing
+    /// is owned that was not already known, and a restore will find nothing.
+    Blocked,
     /// A backend is installed and still talking to the store. Prices are not
     /// known yet; owned entitlements may not be known yet either.
     Connecting,
     /// Product and entitlement information has been received at least once.
     Ready,
+}
+
+impl StorePhase {
+    /// Whether nothing can be bought in this phase.
+    ///
+    /// Saves every paywall from spelling out the same two-variant match, and
+    /// keeps an app that only cares "can I sell?" from having to be updated
+    /// when a phase is added.
+    pub fn cannot_sell(self) -> bool {
+        matches!(self, Self::Unavailable | Self::Blocked)
+    }
+
+    /// Whether the store might still answer differently later.
+    ///
+    /// True while a backend is connecting or has yet to reach the store,
+    /// false once the store has said no or has already answered.
+    pub fn may_yet_change(self) -> bool {
+        matches!(self, Self::Unavailable | Self::Connecting)
+    }
 }
 
 /// Snapshot of everything known about the store right now.
@@ -270,6 +304,29 @@ mod tests {
         purchase("com.example.pro");
         restore();
         assert_eq!(take_event(), None);
+    }
+
+    #[test]
+    fn the_two_phases_that_cannot_sell_differ_on_whether_waiting_helps() {
+        assert!(StorePhase::Unavailable.cannot_sell());
+        assert!(StorePhase::Blocked.cannot_sell());
+        assert!(!StorePhase::Connecting.cannot_sell());
+        assert!(!StorePhase::Ready.cannot_sell());
+
+        assert!(StorePhase::Unavailable.may_yet_change());
+        assert!(StorePhase::Connecting.may_yet_change());
+        assert!(
+            !StorePhase::Blocked.may_yet_change(),
+            "a store that has said no is what the phase exists to say"
+        );
+        assert!(!StorePhase::Ready.may_yet_change());
+    }
+
+    #[test]
+    fn nothing_is_owned_by_default_and_blocked_is_not_the_default() {
+        // The default has to stay the phase that invites a retry: a backend
+        // that has not answered yet must not read as one that refused.
+        assert_eq!(StorePhase::default(), StorePhase::Unavailable);
     }
 
     #[test]

--- a/crates/cranpose-storekit/README.md
+++ b/crates/cranpose-storekit/README.md
@@ -5,17 +5,15 @@ implementing the cross-platform [`cranpose_services::purchases`] API on iOS and
 macOS.
 
 ```rust,no_run
-use cranpose_services::purchases::{self, StorePhase};
+use cranpose_services::purchases;
 
 cranpose_storekit::register();
 purchases::configure(&["com.example.app.pro"]);
 
 // Read the snapshot from the frame loop — the store answers asynchronously.
 let state = purchases::store_state();
-let unlocked = match state.phase {
-    StorePhase::Unavailable => true, // no store on this platform: free here
-    _ => state.owns("com.example.app.pro"),
-};
+// No store that will sell here: free in that case.
+let unlocked = state.phase.cannot_sell() || state.owns("com.example.app.pro");
 let price = state.display_price("com.example.app.pro").unwrap_or("");
 ```
 

--- a/crates/cranpose-storekit/src/apple.rs
+++ b/crates/cranpose-storekit/src/apple.rs
@@ -28,6 +28,7 @@ const KIND_BUSY: i32 = 5;
 const PHASE_UNAVAILABLE: i32 = 0;
 const PHASE_CONNECTING: i32 = 1;
 const PHASE_READY: i32 = 2;
+const PHASE_BLOCKED: i32 = 3;
 
 const EVENT_PURCHASED: i32 = 0;
 const EVENT_CANCELLED: i32 = 1;
@@ -154,7 +155,10 @@ unsafe extern "C" fn on_message(
             state.live.phase = match arg0 {
                 PHASE_READY => StorePhase::Ready,
                 PHASE_CONNECTING => StorePhase::Connecting,
+                PHASE_BLOCKED => StorePhase::Blocked,
                 PHASE_UNAVAILABLE => StorePhase::Unavailable,
+                // An unreadable code is the phase that invites a retry, never
+                // the one that tells the user to give up.
                 _ => StorePhase::Unavailable,
             };
             state.live.error = take(a);

--- a/crates/cranpose-storekit/swift/storekit.swift
+++ b/crates/cranpose-storekit/swift/storekit.swift
@@ -35,6 +35,7 @@ private enum PhaseCode: Int32 {
     case unavailable = 0
     case connecting = 1
     case ready = 2
+    case blocked = 3
 }
 
 /// Mirrors `cranpose_storekit::ffi::EventCode`.
@@ -165,7 +166,9 @@ public func cranpose_storekit_start(
     guard #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) else {
         // Below the StoreKit 2 floor. The app's deployment target should make
         // this unreachable; report it rather than pretending to be connecting.
-        sink.send(.phase, PhaseCode.unavailable.rawValue, 0, "StoreKit 2 requires iOS 15 / macOS 12")
+        // `blocked`, not `unavailable`: the OS version cannot change while the
+        // app runs, so there is nothing here for a retry to reach.
+        sink.send(.phase, PhaseCode.blocked.rawValue, 0, "StoreKit 2 requires iOS 15 / macOS 12")
         return
     }
 

--- a/crates/cranpose/android/java-billing/dev/cranpose/android/CranposeBilling.java
+++ b/crates/cranpose/android/java-billing/dev/cranpose/android/CranposeBilling.java
@@ -309,6 +309,7 @@ public final class CranposeBilling implements PurchasesUpdatedListener {
                                 connected = false;
                                 connecting = true;
                             }
+                            pushSnapshot();
                         }
                     });
         } catch (Throwable failure) {
@@ -317,6 +318,7 @@ public final class CranposeBilling implements PurchasesUpdatedListener {
             synchronized (lock) {
                 connected = false;
                 connecting = false;
+                blocked = false;
                 error = String.valueOf(failure);
             }
             setBusy(false);

--- a/crates/cranpose/android/java-billing/dev/cranpose/android/CranposeBilling.java
+++ b/crates/cranpose/android/java-billing/dev/cranpose/android/CranposeBilling.java
@@ -57,6 +57,7 @@ public final class CranposeBilling implements PurchasesUpdatedListener {
     private static final int PHASE_UNAVAILABLE = 0;
     private static final int PHASE_CONNECTING = 1;
     private static final int PHASE_READY = 2;
+    private static final int PHASE_BLOCKED = 3;
 
     /** Mirrors the event codes in {@code android_purchase_wire.rs}. */
     private static final int EVENT_PURCHASED = 0;
@@ -84,6 +85,15 @@ public final class CranposeBilling implements PurchasesUpdatedListener {
     private boolean ownedKnown;
     private boolean connected;
     private boolean connecting;
+
+    /**
+     * Set when setup failed with a response Play will keep giving. In-app billing turned off
+     * on the device, an account that cannot pay, a country the app is not sold in: the
+     * client reconnects on its own, and every attempt is answered the same way. Reporting
+     * that as a store we have merely not reached yet leaves an app inviting a retry that
+     * cannot work, so it becomes its own phase and the app can say why instead.
+     */
+    private boolean blocked;
     private boolean busy;
     private boolean pendingRestore;
     private String error = "";
@@ -240,6 +250,9 @@ public final class CranposeBilling implements PurchasesUpdatedListener {
             }
             synchronized (lock) {
                 connecting = true;
+                // A fresh attempt has not been refused yet, and the app should see
+                // "connecting" rather than the verdict of the last one.
+                blocked = false;
             }
             pushSnapshot();
             client.startConnection(
@@ -250,6 +263,7 @@ public final class CranposeBilling implements PurchasesUpdatedListener {
                                 synchronized (lock) {
                                     connected = true;
                                     connecting = false;
+                                    blocked = false;
                                     error = "";
                                 }
                                 queryProducts();
@@ -261,6 +275,7 @@ public final class CranposeBilling implements PurchasesUpdatedListener {
                             synchronized (lock) {
                                 connected = false;
                                 connecting = false;
+                                blocked = !isRetryable(result.getResponseCode());
                             }
                             if (takePendingRestore()) {
                                 nativeBillingEvent(EVENT_FAILED, userMessage(result), 0);
@@ -495,6 +510,8 @@ public final class CranposeBilling implements PurchasesUpdatedListener {
                 phase = productsKnown && ownedKnown ? PHASE_READY : PHASE_CONNECTING;
             } else if (connecting) {
                 phase = PHASE_CONNECTING;
+            } else if (blocked) {
+                phase = PHASE_BLOCKED;
             } else {
                 phase = PHASE_UNAVAILABLE;
             }

--- a/crates/cranpose/src/android_purchase_wire.rs
+++ b/crates/cranpose/src/android_purchase_wire.rs
@@ -13,7 +13,8 @@
 //! o\t<id>                               one record per owned entitlement
 //! ```
 //!
-//! `phase` is `0`, `1` or `2` for unavailable, connecting and ready; `busy` is
+//! `phase` is `0`, `1`, `2` or `3` for unavailable, connecting, ready and
+//! blocked — the last being a store that answered and will not sell; `busy` is
 //! `1` while a purchase or restore the user asked for is still running. Names
 //! and values use the same `%09`/`%0A`/`%0D`/`%25` escaping as the
 //! launch-argument payload, because a store-authored title, description or
@@ -45,8 +46,11 @@ pub(crate) fn decode_store_snapshot(payload: &str) -> StoreState {
     let phase = match header.next() {
         Some("1") => StorePhase::Connecting,
         Some("2") => StorePhase::Ready,
+        Some("3") => StorePhase::Blocked,
         // Anything the decoder cannot read is "no store": refusing to guess is
-        // what keeps a garbled payload from granting an entitlement.
+        // what keeps a garbled payload from granting an entitlement. It is
+        // also the safer of the two unsellable phases to guess — it invites a
+        // retry, where `Blocked` tells the user to stop trying.
         _ => StorePhase::Unavailable,
     };
     let busy = matches!(header.next(), Some("1"));
@@ -206,7 +210,7 @@ mod tests {
 
     #[test]
     fn an_unreadable_payload_owns_nothing() {
-        for payload in ["", "\n", "nonsense", "3\t1\t", "o\tcom.example.pro"] {
+        for payload in ["", "\n", "nonsense", "9\t1\t", "o\tcom.example.pro"] {
             let state = decode_store_snapshot(payload);
             assert_eq!(
                 state.phase,
@@ -218,6 +222,35 @@ mod tests {
                 "payload {payload:?} must not grant an entitlement"
             );
         }
+    }
+
+    #[test]
+    fn a_store_that_will_not_sell_here_is_told_apart_from_one_not_reached() {
+        let blocked = decode_store_snapshot("3\t0\tBILLING_UNAVAILABLE");
+        assert_eq!(blocked.phase, StorePhase::Blocked);
+        assert!(blocked.phase.cannot_sell());
+        assert!(
+            !blocked.phase.may_yet_change(),
+            "a store that has said no is not worth waiting on"
+        );
+
+        let unreached = decode_store_snapshot("0\t0\tSERVICE_UNAVAILABLE");
+        assert_eq!(unreached.phase, StorePhase::Unavailable);
+        assert!(unreached.phase.cannot_sell());
+        assert!(
+            unreached.phase.may_yet_change(),
+            "a store that was merely not reached may answer on the next try"
+        );
+    }
+
+    #[test]
+    fn a_blocked_store_still_reports_what_the_account_owns() {
+        // Billing turning off does not un-buy anything: Play still answers the
+        // purchase query for an entitlement bought before, and an app that
+        // dropped it here would lock a paying user out.
+        let state = decode_store_snapshot("3\t0\t\no\tcom.example.pro");
+        assert_eq!(state.phase, StorePhase::Blocked);
+        assert!(state.owns("com.example.pro"));
     }
 
     #[test]


### PR DESCRIPTION
`StorePhase::Unavailable` meant two things that need different words in front of a user.

- A network that is down, a service that is busy, a process that has just started. Worth another try, and every store backend already retries them on its own.
- In-app billing turned off on the device, an account that cannot pay, a country the app is not sold in. Play answers those the same way every time, no backend retries them, and an app that reports them as "store not reached" sends someone round a retry loop that cannot end.

**Both sides of the wire already knew the difference and threw it away.** `CranposeBilling.isRetryable` classifies the setup result — the same four response codes Play's own guidance names — and then `pushSnapshot` flattened every not-connected case into `PHASE_UNAVAILABLE`. The Swift bridge reports the StoreKit 2 version floor, which cannot change while the app runs, as though it might.

## What this adds

`StorePhase::Blocked`, carried as phase `3` on both wires, plus two helpers so a paywall does not have to match on variants:

```rust
let state = purchases::store_state();
let unlocked = state.phase.cannot_sell() || state.owns("com.example.pro");
```

Three decisions worth calling out:

- **`Unavailable` stays the default**, and stays what an unreadable payload decodes to. Of the two phases that cannot sell it is the one that invites a retry rather than the one that tells the user to stop trying — the safer thing to guess.
- **A blocked store still reports what the account owns.** Billing turning off does not un-buy anything; Play still answers the purchase query, and dropping the entitlement here would lock out someone who had already paid. Pinned by a test.
- **A fresh connection attempt clears the flag**, so the app sees "connecting" rather than the verdict of the last attempt.

## Measured

On an emulator whose Play Billing refuses with `BILLING_UNAVAILABLE`, the app this was written for now says "PLAY STORE CANNOT SELL HERE" where it used to say "PLAY STORE NOT REACHED" — matching the Jetpack Compose build it replaces word for word.

| unlock screen vs the Compose build | identical pixels | mean error |
|---|---|---|
| before | 87.6% | 12.9 |
| after | **92.5%** | **3.9** |

The wrong string was also longer: it wrapped to two lines where Kotlin's fit on one, pushing every line below it down the screen.