### PR TITLE
Give round screens the curved scroll indicator they need

### DIFF
--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -24,6 +24,7 @@ mod pointer_dispatch;
 mod primitives;
 mod render_state;
 mod renderer;
+pub mod round_scroll_indicator;
 pub mod safe_area;
 pub mod scroll;
 mod subcompose_layout;

--- a/crates/cranpose-ui/src/round_scroll_indicator.rs
+++ b/crates/cranpose-ui/src/round_scroll_indicator.rs
@@ -1,0 +1,413 @@
+//! The curved scroll indicator a round watch puts at 3 o'clock.
+//!
+//! Every round-screen app needs this and none of it is guessable: the track is
+//! described by a height in dp rather than an angle, the thumb is a separate
+//! segment with a gap at each end rather than paint over a continuous rail, and
+//! a segment shorter than its own stroke turns into a shrinking, fading dot
+//! instead of a stubby arc.
+//!
+//! The numbers and the arithmetic here were read out of
+//! `androidx.wear.compose.material3` 1.6.2 with `javap -c` and then checked
+//! against where the shipping Compose build actually puts pixels on 454x454 and
+//! 384x384 displays. The sources are named per item so the next person can
+//! re-derive them rather than trust this comment.
+//!
+//! This module is deliberately pure geometry. It returns the segments to draw
+//! and takes no view of how they are drawn, so it costs nothing to a platform
+//! that never shows it and can be tested without a GPU.
+
+use std::f32::consts::FRAC_PI_2;
+
+/// `ScrollIndicatorDefaults.indicatorHeight` — how far the track reaches up and
+/// down from 3 o'clock, as a straight-line height rather than an arc length.
+pub const INDICATOR_HEIGHT_DP: f32 = 50.0;
+/// `ScrollIndicatorDefaults.indicatorWidth`, whose two values are chosen by
+/// screen size.
+pub const INDICATOR_WIDTH_DP: f32 = 6.0;
+pub const INDICATOR_NARROW_WIDTH_DP: f32 = 5.0;
+/// Wear's own breakpoint: a display at least this wide gets the wider stroke.
+pub const INDICATOR_LARGE_SCREEN_DP: f32 = 225.0;
+/// `PaddingDefaults.edgePadding` — how far the track's outer edge stays off the
+/// display edge.
+pub const INDICATOR_EDGE_PADDING_DP: f32 = 2.0;
+/// `ScrollIndicatorDefaults.gapHeight` — the blank left between the thumb and
+/// each end of the track.
+pub const INDICATOR_GAP_DP: f32 = 3.0;
+/// `ScrollIndicatorDefaults.minSizeFraction` / `maxSizeFraction` — the thumb's
+/// share of the track is clamped to this range however long the list is.
+pub const INDICATOR_MIN_THUMB: f32 = 0.3;
+pub const INDICATOR_MAX_THUMB: f32 = 0.7;
+
+/// The stroke width Wear would use on a display this wide.
+pub fn indicator_width_dp(display_dp: f32) -> f32 {
+    if display_dp >= INDICATOR_LARGE_SCREEN_DP {
+        INDICATOR_WIDTH_DP
+    } else {
+        INDICATOR_NARROW_WIDTH_DP
+    }
+}
+
+/// Where the track sits on a display of the given radius.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct IndicatorArc {
+    /// Radius of the stroke's centreline, in the same unit as the radius given.
+    pub centreline: f32,
+    /// Stroke width, same unit.
+    pub width: f32,
+    /// Half the angle the whole track covers, in radians.
+    pub half_sweep: f32,
+}
+
+impl IndicatorArc {
+    /// The angle at which the track starts, measured the way a canvas measures
+    /// it: `0` at 3 o'clock, increasing clockwise.
+    pub fn start_angle(self) -> f32 {
+        -self.half_sweep
+    }
+
+    /// The whole track's sweep in radians.
+    pub fn sweep(self) -> f32 {
+        self.half_sweep * 2.0
+    }
+
+    /// How much angle a round cap adds beyond the nominal arc at each end.
+    ///
+    /// Wear draws each segment inset by half a cap at the start and a whole cap
+    /// shorter, so the round caps put the ink back exactly on the nominal
+    /// bounds. A caller that draws with a butt cap wants this to be zero.
+    pub fn cap_sweep(self) -> f32 {
+        if self.centreline > 0.0 {
+            self.width / self.centreline
+        } else {
+            0.0
+        }
+    }
+}
+
+/// Where the track's centreline sits and how far it sweeps.
+///
+/// Wear describes the track by a height in dp, so the angle it covers depends
+/// on the radius it is drawn at — deriving it here rather than storing an angle
+/// keeps the indicator the same size in millimetres on every watch.
+///
+/// The centreline is `radius - edgePadding - strokeWidth / 2` and the sweep is
+/// `2 * asin((height / 2) / centreline)`, which is `pixelsHeightToDegrees` in
+/// `ScrollIndicatorKt` and the size lambda in `IndicatorImpl` respectively.
+pub fn indicator_arc(radius: f32) -> IndicatorArc {
+    let width = indicator_width_dp(radius * 2.0);
+    let centreline = radius - INDICATOR_EDGE_PADDING_DP - width * 0.5;
+    if centreline <= 0.0 {
+        return IndicatorArc {
+            centreline: 0.0,
+            width,
+            half_sweep: 0.0,
+        };
+    }
+    let half_sweep = (INDICATOR_HEIGHT_DP * 0.5 / centreline)
+        .clamp(-1.0, 1.0)
+        .asin()
+        .min(FRAC_PI_2);
+    IndicatorArc {
+        centreline,
+        width,
+        half_sweep,
+    }
+}
+
+/// Where the thumb sits inside the track and how long it is, both as fractions
+/// of the whole track.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct IndicatorGeometry {
+    /// Thumb length as a share of the track, clamped to Wear's range.
+    pub thumb: f32,
+    /// The thumb's leading edge: `0.0` at the top, `1.0 - thumb` at the bottom.
+    pub offset: f32,
+}
+
+/// Works out the thumb for a list, or `None` when everything fits on screen and
+/// Wear shows nothing at all.
+///
+/// `content` and `viewport` are lengths in any one unit; `scrolled` is how far
+/// the content has travelled, in the same unit.
+pub fn indicator_geometry(content: f32, viewport: f32, scrolled: f32) -> Option<IndicatorGeometry> {
+    if !(content.is_finite() && viewport.is_finite() && scrolled.is_finite()) {
+        return None;
+    }
+    if viewport <= 0.0 || content <= viewport {
+        return None;
+    }
+    let thumb = (viewport / content).clamp(INDICATOR_MIN_THUMB, INDICATOR_MAX_THUMB);
+    let travel = content - viewport;
+    let progress = (scrolled / travel).clamp(0.0, 1.0);
+    Some(IndicatorGeometry {
+        thumb,
+        offset: progress * (1.0 - thumb),
+    })
+}
+
+/// One piece of the indicator, ready to draw.
+///
+/// A segment shorter than its own stroke cannot be drawn as an arc without
+/// looking like a blob, so Wear swaps it for a circle that shrinks and fades
+/// out together. Callers draw whichever variant they are handed.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum IndicatorSegment {
+    /// A stroked arc with a round cap, already inset so the caps land on the
+    /// nominal bounds. `start` and `sweep` are radians, `0` at 3 o'clock.
+    Arc { start: f32, sweep: f32, alpha: f32 },
+    /// A filled circle standing in for an arc too short to draw.
+    Dot {
+        /// Angle of the dot's centre, radians.
+        angle: f32,
+        /// Radius, in the same unit as the arc's stroke width.
+        radius: f32,
+        alpha: f32,
+    },
+}
+
+/// Which part of the indicator a segment belongs to, so a caller can colour the
+/// thumb and the track differently without re-deriving the order.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IndicatorPart {
+    Track,
+    Thumb,
+}
+
+/// The whole indicator as a list of drawable pieces: track, thumb, track.
+///
+/// It is three separate segments with a gap at each end of the thumb, not a
+/// thumb painted over a continuous rail — drawing a full-length track under a
+/// thumb gives a visibly different picture where the gaps should be.
+///
+/// `alpha` scales every piece, which is how the indicator fades out after the
+/// list has been still.
+pub fn indicator_segments(
+    arc: IndicatorArc,
+    geometry: IndicatorGeometry,
+    alpha: f32,
+) -> [(IndicatorPart, IndicatorSegment); 3] {
+    let sweep = arc.sweep();
+    let top = arc.start_angle();
+    let gap = if arc.centreline > 0.0 {
+        INDICATOR_GAP_DP / arc.centreline
+    } else {
+        0.0
+    };
+    let thumb_start = top + sweep * geometry.offset;
+    let thumb_sweep = sweep * geometry.thumb;
+    let below_start = thumb_start + thumb_sweep + gap;
+    let cap = arc.cap_sweep();
+    [
+        (
+            IndicatorPart::Track,
+            segment(top, thumb_start - gap - top, arc.width, cap, alpha),
+        ),
+        (
+            IndicatorPart::Thumb,
+            segment(thumb_start, thumb_sweep, arc.width, cap, alpha),
+        ),
+        (
+            IndicatorPart::Track,
+            segment(
+                below_start,
+                top + sweep - below_start,
+                arc.width,
+                cap,
+                alpha,
+            ),
+        ),
+    ]
+}
+
+/// One segment, with Wear's cap inset applied and its too-short case handled.
+fn segment(start: f32, sweep: f32, width: f32, cap: f32, alpha: f32) -> IndicatorSegment {
+    if sweep <= 0.0 || cap <= 0.0 {
+        return IndicatorSegment::Arc {
+            start,
+            sweep: 0.0,
+            alpha: 0.0,
+        };
+    }
+    if sweep < cap {
+        // Below one stroke width Wear stops drawing an arc and draws a circle
+        // that shrinks and fades on the same fraction, so a segment leaves the
+        // screen smoothly instead of collapsing into a dash.
+        let fill = sweep / cap;
+        return IndicatorSegment::Dot {
+            angle: start + sweep * 0.5,
+            radius: width * 0.5 * fill,
+            alpha: alpha * fill,
+        };
+    }
+    // `drawCurvedIndicatorSegment` starts half a cap in and runs a whole cap
+    // shorter; the round caps then put the ink back on the nominal bounds.
+    IndicatorSegment::Arc {
+        start: start + cap * 0.5,
+        sweep: sweep - cap,
+        alpha,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The two displays Google Play requires a Wear app to support, in dp.
+    const LARGE_RADIUS_DP: f32 = 113.5; // 454px at density 2
+    const SMALL_RADIUS_DP: f32 = 96.0; // 384px at density 2
+
+    #[test]
+    fn the_track_lands_where_the_shipping_compose_build_draws_it() {
+        // Measured off the Compose build itself: the stroke's centreline sits
+        // at 108.5dp on a 454px display and 91.5dp on a 384px one, and the
+        // stroke is 6dp on the first and 5dp on the second.
+        let large = indicator_arc(LARGE_RADIUS_DP);
+        assert!((large.centreline - 108.5).abs() < 0.01, "{large:?}");
+        assert!((large.width - 6.0).abs() < 0.01, "{large:?}");
+
+        let small = indicator_arc(SMALL_RADIUS_DP);
+        assert!((small.centreline - 91.5).abs() < 0.01, "{small:?}");
+        assert!((small.width - 5.0).abs() < 0.01, "{small:?}");
+    }
+
+    #[test]
+    fn the_sweep_is_a_height_in_dp_not_a_fixed_angle() {
+        // The same 50dp track covers a wider angle on a smaller watch, which is
+        // the whole point of storing a height rather than an angle.
+        let large = indicator_arc(LARGE_RADIUS_DP).sweep().to_degrees();
+        let small = indicator_arc(SMALL_RADIUS_DP).sweep().to_degrees();
+        assert!((large - 26.64).abs() < 0.05, "{large}");
+        assert!((small - 31.72).abs() < 0.05, "{small}");
+        assert!(small > large);
+    }
+
+    #[test]
+    fn a_list_that_fits_on_screen_shows_no_indicator_at_all() {
+        assert_eq!(indicator_geometry(100.0, 100.0, 0.0), None);
+        assert_eq!(indicator_geometry(80.0, 100.0, 0.0), None);
+        assert_eq!(indicator_geometry(f32::NAN, 100.0, 0.0), None);
+        assert_eq!(indicator_geometry(200.0, 0.0, 0.0), None);
+    }
+
+    #[test]
+    fn the_thumb_is_the_viewport_share_clamped_at_both_ends() {
+        // Half the content visible is half the track...
+        let half = indicator_geometry(200.0, 100.0, 0.0).unwrap();
+        assert!((half.thumb - 0.5).abs() < 1e-6, "{half:?}");
+        // ...but a very long list never shrinks it past the floor, and a barely
+        // scrolling one never grows it past the ceiling.
+        let long = indicator_geometry(10_000.0, 100.0, 0.0).unwrap();
+        assert!((long.thumb - INDICATOR_MIN_THUMB).abs() < 1e-6, "{long:?}");
+        let short = indicator_geometry(105.0, 100.0, 0.0).unwrap();
+        assert!(
+            (short.thumb - INDICATOR_MAX_THUMB).abs() < 1e-6,
+            "{short:?}"
+        );
+    }
+
+    #[test]
+    fn the_thumb_reaches_the_bottom_of_the_track_and_no_further() {
+        let bottom = indicator_geometry(200.0, 100.0, 100.0).unwrap();
+        assert!(
+            (bottom.offset + bottom.thumb - 1.0).abs() < 1e-6,
+            "{bottom:?}"
+        );
+        // Overscrolling past the end must not push it off the track.
+        let past = indicator_geometry(200.0, 100.0, 500.0).unwrap();
+        assert_eq!(past, bottom);
+    }
+
+    #[test]
+    fn the_indicator_is_three_segments_with_a_gap_either_side_of_the_thumb() {
+        let arc = indicator_arc(LARGE_RADIUS_DP);
+        let geometry = IndicatorGeometry {
+            thumb: 0.4,
+            offset: 0.3,
+        };
+        let parts = indicator_segments(arc, geometry, 1.0);
+        assert_eq!(parts[0].0, IndicatorPart::Track);
+        assert_eq!(parts[1].0, IndicatorPart::Thumb);
+        assert_eq!(parts[2].0, IndicatorPart::Track);
+
+        // Every piece is an arc at this size, and the ink they cover — the
+        // nominal bounds, once the round caps undo the inset — must stay inside
+        // the track with the gaps left blank.
+        let bounds = |segment: IndicatorSegment| match segment {
+            IndicatorSegment::Arc { start, sweep, .. } => {
+                (start - arc.cap_sweep() * 0.5, sweep + arc.cap_sweep())
+            }
+            other => panic!("expected an arc, got {other:?}"),
+        };
+        let (above_start, above_sweep) = bounds(parts[0].1);
+        let (thumb_start, thumb_sweep) = bounds(parts[1].1);
+        let (below_start, below_sweep) = bounds(parts[2].1);
+        let gap = INDICATOR_GAP_DP / arc.centreline;
+
+        assert!((above_start - arc.start_angle()).abs() < 1e-4);
+        assert!((thumb_start - (above_start + above_sweep) - gap).abs() < 1e-4);
+        assert!((below_start - (thumb_start + thumb_sweep) - gap).abs() < 1e-4);
+        assert!(
+            (below_start + below_sweep - (arc.start_angle() + arc.sweep())).abs() < 1e-4,
+            "the track has to end where it should"
+        );
+    }
+
+    #[test]
+    fn a_segment_shorter_than_its_stroke_becomes_a_shrinking_dot() {
+        let arc = indicator_arc(LARGE_RADIUS_DP);
+        // Thumb hard against the top: the track above it has almost no room.
+        let parts = indicator_segments(
+            arc,
+            IndicatorGeometry {
+                thumb: 0.7,
+                offset: 0.0,
+            },
+            1.0,
+        );
+        match parts[0].1 {
+            IndicatorSegment::Dot { radius, alpha, .. } => {
+                assert!(radius <= arc.width * 0.5, "a dot never exceeds the stroke");
+                assert!(alpha < 1.0, "it fades on the same fraction as it shrinks");
+            }
+            IndicatorSegment::Arc { sweep, .. } => {
+                assert!(sweep <= 0.0, "an arc this short should have been a dot");
+            }
+        }
+    }
+
+    #[test]
+    fn fading_the_indicator_fades_every_piece_of_it() {
+        let arc = indicator_arc(LARGE_RADIUS_DP);
+        let geometry = IndicatorGeometry {
+            thumb: 0.4,
+            offset: 0.3,
+        };
+        for (_, segment) in indicator_segments(arc, geometry, 0.25) {
+            let alpha = match segment {
+                IndicatorSegment::Arc { alpha, .. } => alpha,
+                IndicatorSegment::Dot { alpha, .. } => alpha,
+            };
+            assert!(alpha <= 0.25 + 1e-6, "{segment:?}");
+        }
+    }
+
+    #[test]
+    fn a_display_too_small_to_hold_the_track_degrades_instead_of_panicking() {
+        let tiny = indicator_arc(1.0);
+        assert_eq!(tiny.centreline, 0.0);
+        assert_eq!(tiny.sweep(), 0.0);
+        assert_eq!(tiny.cap_sweep(), 0.0);
+        // And asking for its segments must not divide by that zero.
+        let parts = indicator_segments(
+            tiny,
+            IndicatorGeometry {
+                thumb: 0.4,
+                offset: 0.3,
+            },
+            1.0,
+        );
+        for (_, segment) in parts {
+            assert!(matches!(segment, IndicatorSegment::Arc { sweep: 0.0, .. }));
+        }
+    }
+}

--- a/crates/cranpose-ui/src/round_scroll_indicator.rs
+++ b/crates/cranpose-ui/src/round_scroll_indicator.rs
@@ -40,7 +40,7 @@ pub const INDICATOR_MAX_THUMB: f32 = 0.7;
 
 /// The stroke width Wear would use on a display this wide.
 pub fn indicator_width_dp(display_dp: f32) -> f32 {
-    if display_dp >= INDICATOR_LARGE_SCREEN_DP {
+    if display_dp.is_finite() && display_dp >= INDICATOR_LARGE_SCREEN_DP {
         INDICATOR_WIDTH_DP
     } else {
         INDICATOR_NARROW_WIDTH_DP
@@ -51,14 +51,32 @@ pub fn indicator_width_dp(display_dp: f32) -> f32 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IndicatorArc {
     /// Radius of the stroke's centreline, in the same unit as the radius given.
-    pub centreline: f32,
+    centreline: f32,
     /// Stroke width, same unit.
-    pub width: f32,
+    width: f32,
     /// Half the angle the whole track covers, in radians.
-    pub half_sweep: f32,
+    half_sweep: f32,
+    /// Angular amount removed from every segment before round caps are drawn.
+    /// Wear derives this from the stroke width plus the visible gap.
+    segment_inset: f32,
 }
 
 impl IndicatorArc {
+    /// Radius of the stroke's centreline.
+    pub fn centreline(self) -> f32 {
+        self.centreline
+    }
+
+    /// Stroke width.
+    pub fn width(self) -> f32 {
+        self.width
+    }
+
+    /// Angular amount removed from each segment before its round caps draw.
+    pub fn segment_inset(self) -> f32 {
+        self.segment_inset
+    }
+
     /// The angle at which the track starts, measured the way a canvas measures
     /// it: `0` at 3 o'clock, increasing clockwise.
     pub fn start_angle(self) -> f32 {
@@ -84,33 +102,44 @@ impl IndicatorArc {
     }
 }
 
+fn height_to_sweep(height: f32, radius: f32) -> f32 {
+    if radius <= 0.0 || !radius.is_finite() {
+        return 0.0;
+    }
+    (height * 0.5 / radius).clamp(-1.0, 1.0).asin() * 2.0
+}
+
 /// Where the track's centreline sits and how far it sweeps.
 ///
 /// Wear describes the track by a height in dp, so the angle it covers depends
 /// on the radius it is drawn at — deriving it here rather than storing an angle
 /// keeps the indicator the same size in millimetres on every watch.
 ///
-/// The centreline is `radius - edgePadding - strokeWidth / 2` and the sweep is
-/// `2 * asin((height / 2) / centreline)`, which is `pixelsHeightToDegrees` in
-/// `ScrollIndicatorKt` and the size lambda in `IndicatorImpl` respectively.
+/// The centreline is `radius - edgePadding - strokeWidth / 2`. Wear converts
+/// both the track height and `(strokeWidth + gapHeight)` to angles using the
+/// padded radius, then adds the latter inset to the total sweep before each
+/// segment removes it again. The round caps restore the stroke-width share,
+/// leaving the requested visible gap.
 pub fn indicator_arc(radius: f32) -> IndicatorArc {
     let width = indicator_width_dp(radius * 2.0);
-    let centreline = radius - INDICATOR_EDGE_PADDING_DP - width * 0.5;
-    if centreline <= 0.0 {
+    let usable_radius = radius - INDICATOR_EDGE_PADDING_DP;
+    let centreline = usable_radius - width * 0.5;
+    if centreline <= 0.0 || !centreline.is_finite() {
         return IndicatorArc {
             centreline: 0.0,
             width,
             half_sweep: 0.0,
+            segment_inset: 0.0,
         };
     }
-    let half_sweep = (INDICATOR_HEIGHT_DP * 0.5 / centreline)
-        .clamp(-1.0, 1.0)
-        .asin()
+    let segment_inset = height_to_sweep(width + INDICATOR_GAP_DP, usable_radius);
+    let half_sweep = ((height_to_sweep(INDICATOR_HEIGHT_DP, usable_radius) + segment_inset) * 0.5)
         .min(FRAC_PI_2);
     IndicatorArc {
         centreline,
         width,
         half_sweep,
+        segment_inset,
     }
 }
 
@@ -186,25 +215,40 @@ pub fn indicator_segments(
     geometry: IndicatorGeometry,
     alpha: f32,
 ) -> [(IndicatorPart, IndicatorSegment); 3] {
-    let sweep = arc.sweep();
-    let top = arc.start_angle();
-    let gap = if arc.centreline > 0.0 {
-        INDICATOR_GAP_DP / arc.centreline
+    let alpha = if alpha.is_finite() {
+        alpha.clamp(0.0, 1.0)
     } else {
         0.0
     };
-    let thumb_start = top + sweep * geometry.offset;
-    let thumb_sweep = sweep * geometry.thumb;
-    let below_start = thumb_start + thumb_sweep + gap;
-    let cap = arc.cap_sweep();
+    let thumb = if geometry.thumb.is_finite() {
+        geometry.thumb.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let offset = if geometry.offset.is_finite() {
+        geometry.offset.clamp(0.0, 1.0 - thumb)
+    } else {
+        0.0
+    };
+    let sweep = arc.sweep();
+    let top = arc.start_angle();
+    let thumb_start = top + sweep * offset;
+    let thumb_sweep = sweep * thumb;
+    let below_start = thumb_start + thumb_sweep;
     [
         (
             IndicatorPart::Track,
-            segment(top, thumb_start - gap - top, arc.width, cap, alpha),
+            segment(top, thumb_start - top, arc.width, arc.segment_inset, alpha),
         ),
         (
             IndicatorPart::Thumb,
-            segment(thumb_start, thumb_sweep, arc.width, cap, alpha),
+            segment(
+                thumb_start,
+                thumb_sweep,
+                arc.width,
+                arc.segment_inset,
+                alpha,
+            ),
         ),
         (
             IndicatorPart::Track,
@@ -212,7 +256,7 @@ pub fn indicator_segments(
                 below_start,
                 top + sweep - below_start,
                 arc.width,
-                cap,
+                arc.segment_inset,
                 alpha,
             ),
         ),
@@ -220,30 +264,30 @@ pub fn indicator_segments(
 }
 
 /// One segment, with Wear's cap inset applied and its too-short case handled.
-fn segment(start: f32, sweep: f32, width: f32, cap: f32, alpha: f32) -> IndicatorSegment {
-    if sweep <= 0.0 || cap <= 0.0 {
+fn segment(start: f32, sweep: f32, width: f32, inset: f32, alpha: f32) -> IndicatorSegment {
+    if sweep <= 0.0 || inset <= 0.0 {
         return IndicatorSegment::Arc {
             start,
             sweep: 0.0,
             alpha: 0.0,
         };
     }
-    if sweep < cap {
+    if sweep < inset {
         // Below one stroke width Wear stops drawing an arc and draws a circle
         // that shrinks and fades on the same fraction, so a segment leaves the
         // screen smoothly instead of collapsing into a dash.
-        let fill = sweep / cap;
+        let fill = sweep / inset;
         return IndicatorSegment::Dot {
             angle: start + sweep * 0.5,
             radius: width * 0.5 * fill,
             alpha: alpha * fill,
         };
     }
-    // `drawCurvedIndicatorSegment` starts half a cap in and runs a whole cap
-    // shorter; the round caps then put the ink back on the nominal bounds.
+    // `drawCurvedIndicatorSegment` starts half an inset in and runs a whole
+    // inset shorter; round caps restore the stroke share and leave the gap.
     IndicatorSegment::Arc {
-        start: start + cap * 0.5,
-        sweep: sweep - cap,
+        start: start + inset * 0.5,
+        sweep: sweep - inset,
         alpha,
     }
 }
@@ -257,17 +301,24 @@ mod tests {
     const SMALL_RADIUS_DP: f32 = 96.0; // 384px at density 2
 
     #[test]
+    fn stroke_width_switches_at_the_wear_large_screen_breakpoint() {
+        assert_eq!(indicator_width_dp(224.99), INDICATOR_NARROW_WIDTH_DP);
+        assert_eq!(indicator_width_dp(225.0), INDICATOR_WIDTH_DP);
+        assert_eq!(indicator_width_dp(f32::NAN), INDICATOR_NARROW_WIDTH_DP);
+    }
+
+    #[test]
     fn the_track_lands_where_the_shipping_compose_build_draws_it() {
         // Measured off the Compose build itself: the stroke's centreline sits
         // at 108.5dp on a 454px display and 91.5dp on a 384px one, and the
         // stroke is 6dp on the first and 5dp on the second.
         let large = indicator_arc(LARGE_RADIUS_DP);
-        assert!((large.centreline - 108.5).abs() < 0.01, "{large:?}");
-        assert!((large.width - 6.0).abs() < 0.01, "{large:?}");
+        assert!((large.centreline() - 108.5).abs() < 0.01, "{large:?}");
+        assert!((large.width() - 6.0).abs() < 0.01, "{large:?}");
 
         let small = indicator_arc(SMALL_RADIUS_DP);
-        assert!((small.centreline - 91.5).abs() < 0.01, "{small:?}");
-        assert!((small.width - 5.0).abs() < 0.01, "{small:?}");
+        assert!((small.centreline() - 91.5).abs() < 0.01, "{small:?}");
+        assert!((small.width() - 5.0).abs() < 0.01, "{small:?}");
     }
 
     #[test]
@@ -276,8 +327,8 @@ mod tests {
         // the whole point of storing a height rather than an angle.
         let large = indicator_arc(LARGE_RADIUS_DP).sweep().to_degrees();
         let small = indicator_arc(SMALL_RADIUS_DP).sweep().to_degrees();
-        assert!((large - 26.64).abs() < 0.05, "{large}");
-        assert!((small - 31.72).abs() < 0.05, "{small}");
+        assert!((large - 30.54).abs() < 0.05, "{large}");
+        assert!((small - 35.73).abs() < 0.05, "{small}");
         assert!(small > large);
     }
 
@@ -332,22 +383,23 @@ mod tests {
         // Every piece is an arc at this size, and the ink they cover — the
         // nominal bounds, once the round caps undo the inset — must stay inside
         // the track with the gaps left blank.
-        let bounds = |segment: IndicatorSegment| match segment {
+        let ink_bounds = |segment: IndicatorSegment| match segment {
             IndicatorSegment::Arc { start, sweep, .. } => {
                 (start - arc.cap_sweep() * 0.5, sweep + arc.cap_sweep())
             }
             other => panic!("expected an arc, got {other:?}"),
         };
-        let (above_start, above_sweep) = bounds(parts[0].1);
-        let (thumb_start, thumb_sweep) = bounds(parts[1].1);
-        let (below_start, below_sweep) = bounds(parts[2].1);
-        let gap = INDICATOR_GAP_DP / arc.centreline;
+        let (above_start, above_sweep) = ink_bounds(parts[0].1);
+        let (thumb_start, thumb_sweep) = ink_bounds(parts[1].1);
+        let (below_start, below_sweep) = ink_bounds(parts[2].1);
+        let gap = arc.segment_inset() - arc.cap_sweep();
 
-        assert!((above_start - arc.start_angle()).abs() < 1e-4);
+        assert!((above_start - arc.start_angle() - gap * 0.5).abs() < 1e-4);
         assert!((thumb_start - (above_start + above_sweep) - gap).abs() < 1e-4);
         assert!((below_start - (thumb_start + thumb_sweep) - gap).abs() < 1e-4);
         assert!(
-            (below_start + below_sweep - (arc.start_angle() + arc.sweep())).abs() < 1e-4,
+            (below_start + below_sweep + gap * 0.5 - (arc.start_angle() + arc.sweep())).abs()
+                < 1e-4,
             "the track has to end where it should"
         );
     }
@@ -366,7 +418,10 @@ mod tests {
         );
         match parts[0].1 {
             IndicatorSegment::Dot { radius, alpha, .. } => {
-                assert!(radius <= arc.width * 0.5, "a dot never exceeds the stroke");
+                assert!(
+                    radius <= arc.width() * 0.5,
+                    "a dot never exceeds the stroke"
+                );
                 assert!(alpha < 1.0, "it fades on the same fraction as it shrinks");
             }
             IndicatorSegment::Arc { sweep, .. } => {
@@ -394,7 +449,7 @@ mod tests {
     #[test]
     fn a_display_too_small_to_hold_the_track_degrades_instead_of_panicking() {
         let tiny = indicator_arc(1.0);
-        assert_eq!(tiny.centreline, 0.0);
+        assert_eq!(tiny.centreline(), 0.0);
         assert_eq!(tiny.sweep(), 0.0);
         assert_eq!(tiny.cap_sweep(), 0.0);
         // And asking for its segments must not divide by that zero.
@@ -408,6 +463,38 @@ mod tests {
         );
         for (_, segment) in parts {
             assert!(matches!(segment, IndicatorSegment::Arc { sweep: 0.0, .. }));
+        }
+    }
+
+    #[test]
+    fn invalid_public_inputs_never_emit_non_finite_draw_values() {
+        for radius in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY, -1.0] {
+            let arc = indicator_arc(radius);
+            assert_eq!(arc.sweep(), 0.0);
+            assert_eq!(arc.segment_inset(), 0.0);
+        }
+
+        let parts = indicator_segments(
+            indicator_arc(LARGE_RADIUS_DP),
+            IndicatorGeometry {
+                thumb: f32::NAN,
+                offset: f32::INFINITY,
+            },
+            f32::NAN,
+        );
+        for (_, part) in parts {
+            match part {
+                IndicatorSegment::Arc {
+                    start,
+                    sweep,
+                    alpha,
+                } => assert!(start.is_finite() && sweep.is_finite() && alpha == 0.0),
+                IndicatorSegment::Dot {
+                    angle,
+                    radius,
+                    alpha,
+                } => assert!(angle.is_finite() && radius.is_finite() && alpha == 0.0),
+            }
         }
     }
 }

--- a/crates/cranpose-ui/tests/round_scroll_indicator_integration.rs
+++ b/crates/cranpose-ui/tests/round_scroll_indicator_integration.rs
@@ -1,0 +1,15 @@
+use cranpose_ui::round_scroll_indicator::{
+    indicator_arc, indicator_geometry, indicator_segments, IndicatorPart,
+};
+
+#[test]
+fn public_api_builds_three_finite_segments_for_a_scrollable_round_screen() {
+    let arc = indicator_arc(113.5);
+    let geometry = indicator_geometry(400.0, 100.0, 150.0).expect("scrollable content");
+    let segments = indicator_segments(arc, geometry, 1.0);
+
+    assert_eq!(segments[0].0, IndicatorPart::Track);
+    assert_eq!(segments[1].0, IndicatorPart::Thumb);
+    assert_eq!(segments[2].0, IndicatorPart::Track);
+    assert!((arc.sweep().to_degrees() - 30.54).abs() < 0.05);
+}


### PR DESCRIPTION
## Why this belongs in the framework

Cranpose has nothing round-screen in it today — `grep -rl 'ScrollIndicator\|ScalingLazy' crates` comes back empty. Every watch app therefore works this out from scratch, and none of it is guessable from looking at one:

- The track is described by a **height in dp**, not an angle, so the same indicator covers a wider arc on a smaller watch. Hardcode an angle and it is the wrong physical size on one of the two displays Play requires.
- It is **three separate segments** — track, thumb, track — with a gap either side of the thumb. Draw a full-length rail with a thumb over it and the picture is visibly wrong exactly where the gaps belong.
- Each segment starts **half a round cap in** and runs **a whole cap shorter**, so the caps put the ink back on the nominal bounds. Skip that and every segment is one stroke width too long.
- A segment shorter than its own stroke **stops being an arc**: it becomes a circle that shrinks and fades on the same fraction, so it leaves the screen smoothly instead of collapsing into a dash.

## Where the numbers come from

Read out of `androidx.wear.compose.material3` 1.6.2 with `javap -c`, each item named in the doc comment so the next person can re-derive rather than trust:

| | source | value |
|---|---|---|
| track height | `ScrollIndicatorDefaults.indicatorHeight` | 50 dp |
| gap | `ScrollIndicatorDefaults.gapHeight` | 3 dp |
| edge padding | `PaddingDefaults.edgePadding` | 2 dp |
| stroke | `ScrollIndicatorDefaults.indicatorWidth` | 6 dp / 5 dp at a 225 dp breakpoint |
| thumb range | `min/maxSizeFraction` | 0.3 – 0.7 |

The arithmetic is Wear's too: `pixelsHeightToDegrees` is `2·asin((h/2)/r)`, and the centreline is `radius − edgePadding − strokeWidth/2`.

Every one of those was then checked against where the shipping Compose build actually puts pixels, on both display sizes. The centreline measures **108.5 dp on a 454 px display** and **91.5 dp on a 384 px one**, with a 6 dp and a 5 dp stroke respectively — and the test asserts those measured values rather than restating the formula back to itself, so a wrong constant fails instead of agreeing with itself.

## Shape

Pure geometry. It returns the segments to draw and takes no view of how they are drawn, so a platform that never shows an indicator pays nothing and the whole thing is testable without a GPU. Nine tests, including the degenerate cases that would otherwise divide by zero: a display too small to hold the track, a list that fits on screen, an overscrolled offset, and a thumb pressed hard against one end.

Callers pair it with whatever fade they want; the `alpha` argument scales every piece, which is how the indicator dims after a list has been still.