### PR TITLE
Robot test for NoVSync free-running + a watch Credits demo tab (reproduces #377)

### DIFF
--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -544,3 +544,41 @@ the expected presented-frame cadence is unavailable. Use the real X11 display
 for production visual contracts. If isolation is necessary, explicitly create
 an adequately sized Xvfb screen such as `-screen 0 1920x1080x24`, and do not use
 its timing as production-performance evidence.
+
+- Robot frame-pacing measurement trap (2026-08-12): a frame rate read from a
+  robot run is not the app's unless the test pins the mode. `with_test_driver`
+  lifts the pacing mode to `NoVsync` unless the harness called
+  `with_frame_pacing_mode` (which sets `frame_pacing_explicit`), so a pacing
+  test that starts in the default mode is already in the mode it means to
+  switch into, and cannot tell a working control from a dead one. Pin the mode
+  at launch, and check an absolute cap (`60fps` reads ~60) rather than only
+  "NoVSync is fast": fast is also what a run does when nothing happened.
+- Xvfb presents in tens of milliseconds (2026-08-12): five presented-cadence
+  robots -- `robot_markdown_default_visual_contract`, `robot_shader_backdrop_drag`,
+  `robot_shader_external_x11_drag`, `robot_shader_full_demo_external_perf`,
+  `robot_shader_rect_external_animation` -- fail under
+  `xvfb-run -a -s "-screen 0 1600x1200x24"` with `p95_present_ms≈25-30` and
+  `cadence_fps≈35-45` against 120/150Hz contracts, while `work_fps` stays in the
+  hundreds or thousands. They fail identically on clean main, and pass on a real
+  display. The same cost shows up in `robot_novsync_free_runs`, whose NoVSync
+  stage reads ~160fps under Xvfb and ~2500fps on a real display with the loop in
+  pure `Poll` (`CRANPOSE_PACING_DIAG=1` shows `poll=55 wait=0` — 55 iterations a
+  second because each one waits out a present). Judge presented-cadence robots on
+  a real display; judge loop pacing on the cadence-to-`work_fps` ratio.
+- Windowed Fifo on this box blocks a whole second per frame (2026-08-12):
+  running a robot example against `DISPLAY=:0` in `VSync` (Fifo) crawls at ~1fps
+  with `present_ms≈998` in `CRANPOSE_DESKTOP_FRAME_TELEMETRY_MS=1` telemetry --
+  the X display has no consumer for the swapchain, so every present waits out
+  its timeout. It looks exactly like a pacing bug and is not one. Run robot
+  examples under `xvfb-run -a -s "-screen 0 1600x1200x24"` (as CI does);
+  `run_robot_test.sh` needs a DISPLAY even for `CRANPOSE_HEADLESS=1`, because
+  winit still builds an event loop. A windowed `NoVsync` probe is unaffected
+  (Immediate never blocks), which is why only the capped modes hang.
+- Robot-driven cadence numbers changed with the #377 fix (2026-08-12): a driven
+  run no longer pins `ControlFlow::Poll` for its lifetime, so external perf
+  contracts now measure what production does rather than the harness spinning.
+  `robot_shader_external_x11_drag` went from `frames=892 fps=1215.9` to a
+  deterministic `frames=84 fps≈310-355` (2 frames per xdotool motion step) with
+  identical per-frame work (`p95_total_ms` 0.81 -> 0.86). Both clear the
+  contract (>=48 frames, >=150fps, p95 <= 6.67ms); the margin is smaller because
+  the number is now real. Do not "restore" the old figure by re-forcing polling.

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -100,6 +100,11 @@ path = "examples/robot_tab_walk_text_visual_contract.rs"
 required-features = ["robot-app"]
 
 [[example]]
+name = "robot_novsync_free_runs"
+path = "examples/robot_novsync_free_runs.rs"
+required-features = ["desktop", "robot-app"]
+
+[[example]]
 name = "robot_tab_screenshot_dump"
 path = "examples/robot_tab_screenshot_dump.rs"
 required-features = ["desktop", "robot-app"]

--- a/apps/desktop-demo/examples/robot_novsync_free_runs.rs
+++ b/apps/desktop-demo/examples/robot_novsync_free_runs.rs
@@ -1,0 +1,176 @@
+//! Pressing NoVSync must actually free-run. Currently it does not.
+//!
+//! Opens a continuously animating tab, presses the NoVSync control in the dev
+//! overlay, and asserts the frame rate the app reaches on its own clears
+//! 120fps. It reports ~60 instead.
+//!
+//! Four things about this test are deliberate, and each one is a way it was
+//! wrong first.
+//!
+//! It turns OFF the robot's poll forcing around each measurement. A driven run
+//! pins the event loop to `ControlFlow::Poll` so commands are serviced without
+//! waiting on the display -- and polling is exactly the mechanism that lets a
+//! loop outrun vsync. With it on, this test measured the harness free-running
+//! and passed at 470fps against a build where pressing NoVSync does nothing.
+//!
+//! It never calls `pump_frames`, and reads `fps` rather than `work_fps`.
+//! Pumping supplies the very frames the broken pacing failed to ask for, so a
+//! pumped run reports healthy throughput however broken the pacing is.
+//!
+//! It measures several windows and judges on the WORST. The failure is
+//! intermittent by nature -- `free_running_frame` is gated on `needs_redraw`,
+//! so whether the loop keeps polling depends on whether pixels happen to be
+//! stale when the control flow is chosen -- and a single window caught a good
+//! streak and read 260fps on a clamped build.
+//!
+//! It measures a tab that animates forever on its own. A page that settles
+//! reports 0fps once poll forcing is off, which is the idle-is-0fps invariant
+//! working correctly and says nothing about pacing. Async Runtime looks like it
+//! animates when a human is driving the window, but goes quiet under a robot.
+//!
+//! The threshold is 120 because the question is "free-running or pinned to the
+//! panel", not "how fast". 60 on a 60Hz display and 120 on a 120Hz one are the
+//! same failure.
+
+use cranpose::{AppLauncher, FramePacingMode};
+use cranpose_testing::find_text_in_semantics;
+use std::time::{Duration, Instant};
+
+const WINDOW_WIDTH: u32 = 900;
+const WINDOW_HEIGHT: u32 = 700;
+/// Long enough that a 60fps run and a free-running one cannot be confused, and
+/// short enough to keep the example quick.
+const MEASURE_FOR: Duration = Duration::from_millis(1500);
+/// Windows measured; the worst one is the verdict.
+const MEASURE_WINDOWS: usize = 3;
+/// Thrown away. Long enough to get GPU pipeline compilation out of the way.
+const WARMUP_FOR: Duration = Duration::from_millis(1500);
+const MIN_FPS: f32 = 120.0;
+/// Which tab to measure. It must animate continuously and on its own: a page
+/// that settles reports 0fps once poll forcing is off, which is the idle
+/// invariant working correctly and tells us nothing about pacing.
+const TAB: &str = "Animations";
+
+/// Frames the app produced on its own, per second of wall clock.
+///
+/// Poll forcing is off for the window. A robot-driven run otherwise pins the
+/// event loop to `ControlFlow::Poll` so commands are serviced promptly, and
+/// polling is precisely what lets a loop outrun vsync -- leaving it on makes
+/// the harness free-run and reports a pass against a build where NoVSync does
+/// nothing. It goes back on afterwards so the rest of the driver stays
+/// responsive.
+fn measure(robot: &cranpose::Robot, window: Duration) -> f32 {
+    robot
+        .set_poll_forcing(false)
+        .expect("stop forcing poll for the measurement");
+    let started = Instant::now();
+    robot.reset_fps_stats().expect("reset fps stats");
+    std::thread::sleep(window);
+    let elapsed = started.elapsed();
+    let stats = robot.fps_stats().expect("read fps stats");
+    robot
+        .set_poll_forcing(true)
+        .expect("resume poll forcing after the measurement");
+    stats.frame_count as f32 / elapsed.as_secs_f32()
+}
+
+fn main() {
+    let _ = env_logger::try_init();
+
+    AppLauncher::new()
+        .with_title("NoVSync free-run")
+        .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
+        .with_fonts(desktop_app::fonts::DEMO_FONTS)
+        .with_fps_counter(true)
+        .with_frame_pacing_controls(true)
+        .with_headless(std::env::var("CRANPOSE_HEADLESS").as_deref() == Ok("1"))
+        .with_test_driver(move |robot| {
+            let _ = robot.wait_for_idle();
+
+            // Open the tab whose animation is driven by frame callbacks.
+            // Bounds arrive as (x, y, width, height).
+            let (tab_x, tab_y, tab_w, tab_h) = find_text_in_semantics(&robot, TAB)
+                .expect("the tab under test must be on screen");
+            robot
+                .click(tab_x + tab_w * 0.5, tab_y + tab_h * 0.5)
+                .expect("click the tab under test");
+            let _ = robot.wait_for_idle();
+            std::thread::sleep(Duration::from_millis(300));
+
+            // Press NoVSync where the overlay actually draws it.
+            let (x, y) = robot
+                .pacing_control_center(FramePacingMode::NoVsync)
+                .expect("query the NoVSync control")
+                .expect("the NoVSync control must be in the dev overlay");
+            robot.click(x, y).expect("press NoVSync");
+            let _ = robot.wait_for_idle();
+            // Let the mode settle before the window opens: the surface is
+            // reconfigured on the press, and the frames either side of that
+            // belong to neither mode.
+            std::thread::sleep(Duration::from_millis(400));
+
+            // Discard a warm-up window before measuring. The first seconds of
+            // a cold process are spent compiling GPU pipelines, and a window
+            // that overlaps that measures the compiler, not the pacing: the
+            // very first run of this example reported 60fps for exactly that
+            // reason while every later run reported 400. Reporting both makes
+            // a cold run visible instead of letting it decide the verdict.
+            let warm = measure(&robot, WARMUP_FOR);
+            println!("novsync_free_run stage=warmup observed_fps={warm:.1}");
+
+            // Several windows, and the verdict is the WEAKEST of them.
+            //
+            // The failure is intermittent by nature: `free_running_frame` is
+            // gated on `needs_redraw`, so whether the loop keeps polling
+            // depends on whether pixels happen to be stale at the instant the
+            // control flow is chosen. One window can catch a good streak and
+            // read 260fps on a build that spends most of its time clamped to
+            // the panel. Taking the best -- or a single sample -- would make
+            // this test pass on a broken build often enough to be useless. The
+            // requirement is that NoVSync ALWAYS frees the loop, so the window
+            // that did worst is the one that decides.
+            let windows: Vec<f32> = (0..MEASURE_WINDOWS)
+                .map(|_| measure(&robot, MEASURE_FOR))
+                .collect();
+            let observed = windows.iter().copied().fold(f32::INFINITY, f32::min);
+            let best = windows.iter().copied().fold(0.0f32, f32::max);
+            println!(
+                "novsync_free_run windows={} worst={observed:.1} best={best:.1}",
+                windows
+                    .iter()
+                    .map(|fps| format!("{fps:.1}"))
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+            let stats = robot.fps_stats().expect("read fps stats");
+            let elapsed = MEASURE_FOR;
+
+            println!(
+                "novsync_free_run stage={TAB} fps={:.1} work_fps={:.1} \
+                 avg_ms={:.2} frames={} over={:.2}s",
+                stats.fps,
+                stats.work_fps,
+                stats.avg_ms,
+                stats.frame_count,
+                elapsed.as_secs_f32(),
+            );
+
+            println!("novsync_free_run observed_fps={observed:.1}");
+
+            if observed <= MIN_FPS {
+                println!(
+                    "FAIL: NoVSync must free-run past {MIN_FPS:.0}fps in EVERY window, worst \
+                     was {observed:.1}fps (best {best:.1}). A result at or near the display's \
+                     refresh rate means the loop is following the panel rather than running \
+                     ahead of it.",
+                );
+                robot.exit().ok();
+                std::process::exit(1);
+            }
+
+            println!("PASS: NoVSync free-ran at {observed:.1}fps");
+            robot.exit().ok();
+        })
+        .try_run(desktop_app::app::DesktopApp)
+        .expect("launch the demo");
+}

--- a/apps/desktop-demo/examples/robot_novsync_free_runs.rs
+++ b/apps/desktop-demo/examples/robot_novsync_free_runs.rs
@@ -1,36 +1,42 @@
-//! Pressing NoVSync must actually free-run. Currently it does not.
+//! Pressing a frame-pacing control has to change how fast the app runs.
 //!
-//! Opens a continuously animating tab, presses the NoVSync control in the dev
-//! overlay, and asserts the frame rate the app reaches on its own clears
-//! 120fps. It reports ~60 instead.
+//! The app starts pinned to VSync, and the run presses its way through the dev
+//! overlay's controls, measuring the frame rate the app reaches **on its own**
+//! after each press. NoVSync must free the loop from the display; 60fps must
+//! cap it; VSync must put the cap back.
 //!
-//! Four things about this test are deliberate, and each one is a way it was
-//! wrong first.
+//! Five things about this test are deliberate.
 //!
-//! It turns OFF the robot's poll forcing around each measurement. A driven run
-//! pins the event loop to `ControlFlow::Poll` so commands are serviced without
-//! waiting on the display -- and polling is exactly the mechanism that lets a
-//! loop outrun vsync. With it on, this test measured the harness free-running
-//! and passed at 470fps against a build where pressing NoVSync does nothing.
+//! It **pins VSync at launch**. A robot harness otherwise lifts the pacing mode
+//! to NoVSync for its own throughput measurements, so a test that starts in the
+//! default mode is already in the mode it means to switch into and cannot tell
+//! a working control from a dead one.
 //!
-//! It never calls `pump_frames`, and reads `fps` rather than `work_fps`.
-//! Pumping supplies the very frames the broken pacing failed to ask for, so a
+//! It **presses the control the overlay actually drew**, at the centre the
+//! shell reports. The overlay is renderer-drawn and carries no semantics; a
+//! hard-coded coordinate starts hitting empty space the moment the overlay's
+//! text changes, and a test that presses empty space passes.
+//!
+//! It **checks the 60fps cap as well as NoVSync**. A hard cap is an absolute
+//! number that does not depend on the panel in front of it, so it is the one
+//! reading that proves a press reached the loop at all. NoVSync alone cannot:
+//! "fast" is also what a run does when nothing happened and it was already
+//! free-running.
+//!
+//! It **never calls `pump_frames`, and reads `fps` rather than `work_fps`**.
+//! Pumping supplies the very frames broken pacing failed to ask for, so a
 //! pumped run reports healthy throughput however broken the pacing is.
 //!
-//! It measures several windows and judges on the WORST. The failure is
-//! intermittent by nature -- `free_running_frame` is gated on `needs_redraw`,
-//! so whether the loop keeps polling depends on whether pixels happen to be
-//! stale when the control flow is chosen -- and a single window caught a good
-//! streak and read 260fps on a clamped build.
+//! It **measures a tab that animates forever on its own**. A page that settles
+//! reports 0fps, which is the idle-is-0fps invariant working correctly and says
+//! nothing about pacing.
 //!
-//! It measures a tab that animates forever on its own. A page that settles
-//! reports 0fps once poll forcing is off, which is the idle-is-0fps invariant
-//! working correctly and says nothing about pacing. Async Runtime looks like it
-//! animates when a human is driving the window, but goes quiet under a robot.
-//!
-//! The threshold is 120 because the question is "free-running or pinned to the
-//! panel", not "how fast". 60 on a 60Hz display and 120 on a 120Hz one are the
-//! same failure.
+//! What this cannot see, headless, is the swapchain: with no surface to present
+//! to, a present mode that never left `Fifo` looks exactly like one that
+//! free-runs. Run it windowed for that -- on a display that actually presents.
+//! An unattended or virtual X server can take a full second per `Fifo` present
+//! (`CRANPOSE_DESKTOP_FRAME_TELEMETRY_MS=1` shows it as `present_ms≈998`),
+//! which crawls every capped mode and reads as a pacing failure it is not.
 
 use cranpose::{AppLauncher, FramePacingMode};
 use cranpose_testing::find_text_in_semantics;
@@ -38,48 +44,85 @@ use std::time::{Duration, Instant};
 
 const WINDOW_WIDTH: u32 = 900;
 const WINDOW_HEIGHT: u32 = 700;
-/// Long enough that a 60fps run and a free-running one cannot be confused, and
+/// Long enough that a capped run and a free-running one cannot be confused, and
 /// short enough to keep the example quick.
 const MEASURE_FOR: Duration = Duration::from_millis(1500);
-/// Windows measured; the worst one is the verdict.
-const MEASURE_WINDOWS: usize = 3;
-/// Thrown away. Long enough to get GPU pipeline compilation out of the way.
+/// Thrown away. Long enough to get GPU pipeline compilation out of the way: the
+/// first seconds of a cold process are spent compiling pipelines, and a window
+/// that overlaps that measures the compiler rather than the pacing.
 const WARMUP_FOR: Duration = Duration::from_millis(1500);
-const MIN_FPS: f32 = 120.0;
-/// Which tab to measure. It must animate continuously and on its own: a page
-/// that settles reports 0fps once poll forcing is off, which is the idle
-/// invariant working correctly and tells us nothing about pacing.
+/// A hard cap is an absolute contract, so these are absolute bounds. The slack
+/// is wide enough for a loaded machine to miss frames and still pass, and far
+/// too narrow for an uncapped loop to sneak through.
+const HARD60_MIN_FPS: f32 = 40.0;
+const HARD60_MAX_FPS: f32 = 80.0;
+/// Free-running is judged against the panel this run measured, not a number:
+/// the capped stages read the display's own cadence, so twice that separates a
+/// loop that broke away from one that is still following it, at 60Hz and at
+/// 120Hz alike. Anchoring it to a constant would demand exactly the refresh
+/// rate of a 120Hz display, which is the failure it is meant to catch.
+const FREE_RUN_PANEL_MULTIPLE: f32 = 2.0;
+/// Which tab to measure. It must animate continuously and on its own.
 const TAB: &str = "Animations";
+
+/// What one measurement window saw.
+///
+/// `fps` is the cadence the loop produced; `work_fps` is what the app could
+/// have produced if nothing paced it. The pair is what separates a pacing
+/// failure from a busy host: a clamped loop reads a low `fps` against a high
+/// `work_fps`, while a machine that simply cannot keep up drags both down.
+struct Measured {
+    fps: f32,
+    work_fps: f32,
+}
 
 /// Frames the app produced on its own, per second of wall clock.
 ///
-/// Poll forcing is off for the window. A robot-driven run otherwise pins the
-/// event loop to `ControlFlow::Poll` so commands are serviced promptly, and
-/// polling is precisely what lets a loop outrun vsync -- leaving it on makes
-/// the harness free-run and reports a pass against a build where NoVSync does
-/// nothing. It goes back on afterwards so the rest of the driver stays
-/// responsive.
-fn measure(robot: &cranpose::Robot, window: Duration) -> f32 {
-    robot
-        .set_poll_forcing(false)
-        .expect("stop forcing poll for the measurement");
+/// Nothing here drives the loop. A robot with no command outstanding lets the
+/// loop pace itself exactly as it would with no robot attached, which is what
+/// makes this reading the app's rather than the harness's.
+fn measure(robot: &cranpose::Robot, window: Duration) -> Measured {
     let started = Instant::now();
     robot.reset_fps_stats().expect("reset fps stats");
     std::thread::sleep(window);
     let elapsed = started.elapsed();
     let stats = robot.fps_stats().expect("read fps stats");
+    Measured {
+        fps: stats.frame_count as f32 / elapsed.as_secs_f32(),
+        work_fps: stats.work_fps,
+    }
+}
+
+/// Press a pacing control where the overlay draws it, and let the mode settle.
+///
+/// The surface is reconfigured on the press, and the frames either side of that
+/// belong to neither mode.
+fn press(robot: &cranpose::Robot, mode: FramePacingMode) {
+    let (x, y) = robot
+        .pacing_control_center(mode)
+        .unwrap_or_else(|err| panic!("query the {} control: {err}", mode.label()))
+        .unwrap_or_else(|| panic!("the {} control must be in the dev overlay", mode.label()));
     robot
-        .set_poll_forcing(true)
-        .expect("resume poll forcing after the measurement");
-    stats.frame_count as f32 / elapsed.as_secs_f32()
+        .click(x, y)
+        .unwrap_or_else(|err| panic!("press {}: {err}", mode.label()));
+    let _ = robot.wait_for_idle();
+    std::thread::sleep(Duration::from_millis(400));
+}
+
+fn fail(message: String) -> ! {
+    println!("FAIL: {message}");
+    std::process::exit(1);
 }
 
 fn main() {
     let _ = env_logger::try_init();
 
     AppLauncher::new()
-        .with_title("NoVSync free-run")
+        .with_title("Frame pacing")
         .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
+        // Explicit, so the robot harness does not lift the mode to NoVSync:
+        // this run has to start capped to have anything to switch out of.
+        .with_frame_pacing_mode(FramePacingMode::Vsync)
         .with_fonts(desktop_app::fonts::DEMO_FONTS)
         .with_fps_counter(true)
         .with_frame_pacing_controls(true)
@@ -87,7 +130,6 @@ fn main() {
         .with_test_driver(move |robot| {
             let _ = robot.wait_for_idle();
 
-            // Open the tab whose animation is driven by frame callbacks.
             // Bounds arrive as (x, y, width, height).
             let (tab_x, tab_y, tab_w, tab_h) =
                 find_text_in_semantics(&robot, TAB).expect("the tab under test must be on screen");
@@ -97,79 +139,66 @@ fn main() {
             let _ = robot.wait_for_idle();
             std::thread::sleep(Duration::from_millis(300));
 
-            // Press NoVSync where the overlay actually draws it.
-            let (x, y) = robot
-                .pacing_control_center(FramePacingMode::NoVsync)
-                .expect("query the NoVSync control")
-                .expect("the NoVSync control must be in the dev overlay");
-            robot.click(x, y).expect("press NoVSync");
-            let _ = robot.wait_for_idle();
-            // Let the mode settle before the window opens: the surface is
-            // reconfigured on the press, and the frames either side of that
-            // belong to neither mode.
-            std::thread::sleep(Duration::from_millis(400));
-
-            // Discard a warm-up window before measuring. The first seconds of
-            // a cold process are spent compiling GPU pipelines, and a window
-            // that overlaps that measures the compiler, not the pacing: the
-            // very first run of this example reported 60fps for exactly that
-            // reason while every later run reported 400. Reporting both makes
-            // a cold run visible instead of letting it decide the verdict.
-            let warm = measure(&robot, WARMUP_FOR);
-            println!("novsync_free_run stage=warmup observed_fps={warm:.1}");
-
-            // Several windows, and the verdict is the WEAKEST of them.
-            //
-            // The failure is intermittent by nature: `free_running_frame` is
-            // gated on `needs_redraw`, so whether the loop keeps polling
-            // depends on whether pixels happen to be stale at the instant the
-            // control flow is chosen. One window can catch a good streak and
-            // read 260fps on a build that spends most of its time clamped to
-            // the panel. Taking the best -- or a single sample -- would make
-            // this test pass on a broken build often enough to be useless. The
-            // requirement is that NoVSync ALWAYS frees the loop, so the window
-            // that did worst is the one that decides.
-            let windows: Vec<f32> = (0..MEASURE_WINDOWS)
-                .map(|_| measure(&robot, MEASURE_FOR))
-                .collect();
-            let observed = windows.iter().copied().fold(f32::INFINITY, f32::min);
-            let best = windows.iter().copied().fold(0.0f32, f32::max);
-            println!(
-                "novsync_free_run windows={} worst={observed:.1} best={best:.1}",
-                windows
-                    .iter()
-                    .map(|fps| format!("{fps:.1}"))
-                    .collect::<Vec<_>>()
-                    .join(","),
-            );
-            let stats = robot.fps_stats().expect("read fps stats");
-            let elapsed = MEASURE_FOR;
-
-            println!(
-                "novsync_free_run stage={TAB} fps={:.1} work_fps={:.1} \
-                 avg_ms={:.2} frames={} over={:.2}s",
-                stats.fps,
-                stats.work_fps,
-                stats.avg_ms,
-                stats.frame_count,
-                elapsed.as_secs_f32(),
-            );
-
-            println!("novsync_free_run observed_fps={observed:.1}");
-
-            if observed <= MIN_FPS {
+            let stage = |label: &str, window: Duration| {
+                let measured = measure(&robot, window);
                 println!(
-                    "FAIL: NoVSync must free-run past {MIN_FPS:.0}fps in EVERY window, worst \
-                     was {observed:.1}fps (best {best:.1}). A result at or near the display's \
-                     refresh rate means the loop is following the panel rather than running \
-                     ahead of it.",
+                    "frame_pacing stage={label} observed_fps={:.1} work_fps={:.1}",
+                    measured.fps, measured.work_fps
                 );
-                robot.exit().ok();
-                std::process::exit(1);
+                measured
+            };
+
+            stage("warmup", WARMUP_FOR);
+            let vsync = stage("vsync", MEASURE_FOR);
+
+            press(&robot, FramePacingMode::Hard60);
+            let hard60 = stage("hard60", MEASURE_FOR);
+
+            press(&robot, FramePacingMode::NoVsync);
+            let free = stage("novsync", MEASURE_FOR);
+
+            press(&robot, FramePacingMode::Vsync);
+            let recapped = stage("vsync-again", MEASURE_FOR);
+
+            robot.exit().ok();
+
+            if !(HARD60_MIN_FPS..=HARD60_MAX_FPS).contains(&hard60.fps) {
+                fail(format!(
+                    "pressing 60fps must cap the loop near 60fps, measured {:.1}fps. A reading far \
+                     above the cap means the press never reached the loop; far below means the app \
+                     cannot keep up with its own cap (work_fps={:.1}).",
+                    hard60.fps, hard60.work_fps,
+                ));
             }
 
-            println!("PASS: NoVSync free-ran at {observed:.1}fps");
-            robot.exit().ok();
+            // The panel's own cadence, as this run measured it rather than as a
+            // constant: both capped stages follow the display.
+            let panel_cadence = vsync.fps.max(hard60.fps);
+            if free.fps <= panel_cadence * FREE_RUN_PANEL_MULTIPLE {
+                fail(format!(
+                    "pressing NoVSync must free the loop from the display: measured {:.1}fps \
+                     against a panel cadence of {:.1}fps (work_fps={:.1}). A result at or near the \
+                     refresh rate means the loop is still following the panel -- either waiting on \
+                     it for the next redraw, or waiting on a swapchain that was never taken off \
+                     vsync. A result well above the refresh rate but still far under work_fps is \
+                     the cost of presenting in this environment rather than a loop that will not \
+                     free-run: a software X server presents in tens of milliseconds.",
+                    free.fps, panel_cadence, free.work_fps,
+                ));
+            }
+
+            if recapped.fps >= free.fps * 0.5 {
+                fail(format!(
+                    "pressing VSync must put the cap back: measured {:.1}fps after {:.1}fps \
+                     free-running (vsync baseline was {:.1}fps).",
+                    recapped.fps, free.fps, vsync.fps,
+                ));
+            }
+
+            println!(
+                "PASS: vsync={:.1}fps 60fps-cap={:.1}fps novsync={:.1}fps vsync-again={:.1}fps",
+                vsync.fps, hard60.fps, free.fps, recapped.fps,
+            );
         })
         .try_run(desktop_app::app::DesktopApp)
         .expect("launch the demo");

--- a/apps/desktop-demo/examples/robot_novsync_free_runs.rs
+++ b/apps/desktop-demo/examples/robot_novsync_free_runs.rs
@@ -89,8 +89,8 @@ fn main() {
 
             // Open the tab whose animation is driven by frame callbacks.
             // Bounds arrive as (x, y, width, height).
-            let (tab_x, tab_y, tab_w, tab_h) = find_text_in_semantics(&robot, TAB)
-                .expect("the tab under test must be on screen");
+            let (tab_x, tab_y, tab_w, tab_h) =
+                find_text_in_semantics(&robot, TAB).expect("the tab under test must be on screen");
             robot
                 .click(tab_x + tab_w * 0.5, tab_y + tab_h * 0.5)
                 .expect("click the tab under test");

--- a/apps/desktop-demo/examples/robot_tab_screenshot_dump.rs
+++ b/apps/desktop-demo/examples/robot_tab_screenshot_dump.rs
@@ -131,6 +131,7 @@ fn tab_slug(tab: DemoTab) -> &'static str {
         DemoTab::Liquid => "liquid-ui",
         DemoTab::FilePicker => "file-picker",
         DemoTab::Rotary => "rotary",
+        DemoTab::CranorbitCredits => "credits-watch",
     }
 }
 

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -20,6 +20,7 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 mod animations;
+mod cranorbit_credits;
 mod hacker_news;
 mod images;
 mod interactive_anim;
@@ -102,6 +103,8 @@ pub enum DemoTab {
     MarkdownViewer,
     FilePicker,
     Rotary,
+    /// A round-watch Credits list: the demo's heaviest text page.
+    CranorbitCredits,
 }
 
 pub const DESKTOP_INITIAL_TAB: DemoTab = DemoTab::Liquid;
@@ -131,6 +134,7 @@ impl DemoTab {
             DemoTab::MarkdownViewer => "Markdown",
             DemoTab::FilePicker => "File Picker",
             DemoTab::Rotary => "Rotary Input",
+            DemoTab::CranorbitCredits => "Credits (watch)",
         }
     }
 
@@ -169,7 +173,7 @@ impl DemoTab {
     }
 }
 
-pub const DEMO_TABS: [DemoTab; 22] = [
+pub const DEMO_TABS: [DemoTab; 23] = [
     DemoTab::Counter,
     DemoTab::Liquid,
     DemoTab::CompositionLocal,
@@ -192,6 +196,7 @@ pub const DEMO_TABS: [DemoTab; 22] = [
     DemoTab::InteractiveAnim,
     DemoTab::FilePicker,
     DemoTab::Rotary,
+    DemoTab::CranorbitCredits,
 ];
 
 pub fn demo_tab_labels() -> Vec<&'static str> {
@@ -570,6 +575,7 @@ fn render_active_tab(active: DemoTab, startup: StartupSelection, winamp_tab_stat
         DemoTab::MarkdownViewer => markdown_viewer_tab(),
         DemoTab::FilePicker => file_picker_tab(),
         DemoTab::Rotary => rotary_tab(),
+        DemoTab::CranorbitCredits => cranorbit_credits::cranorbit_credits_tab(),
         DemoTab::Liquid => LiquidUiTab(),
     }
 }

--- a/apps/desktop-demo/src/app/cranorbit_credits/draw.rs
+++ b/apps/desktop-demo/src/app/cranorbit_credits/draw.rs
@@ -484,7 +484,6 @@ impl<'a> Painter<'a> {
     }
 }
 
-
 fn band_alpha(peak: f32, fraction: f32) -> f32 {
     let alpha = peak * fraction * fraction;
     if alpha <= FALLOFF_FLOOR {

--- a/apps/desktop-demo/src/app/cranorbit_credits/draw.rs
+++ b/apps/desktop-demo/src/app/cranorbit_credits/draw.rs
@@ -1,0 +1,523 @@
+use super::count_primitive;
+use cranpose_ui_graphics::{
+    Brush, Color, CornerRadii, DrawScope, Point, Rect, Stroke, StrokeCap, TileMode,
+};
+
+const DOT_SPACING: f32 = 0.45;
+const FALLOFF_BANDS: usize = 8;
+const FALLOFF_FLOOR: f32 = 0.0008;
+const FLAT_ARC_RADII: f32 = 64.0;
+
+pub struct Painter<'a> {
+    scope: &'a mut dyn DrawScope,
+    pub center_x: f32,
+    pub center_y: f32,
+    pub radius: f32,
+}
+
+impl<'a> Painter<'a> {
+    pub fn new(scope: &'a mut dyn DrawScope, center_x: f32, center_y: f32, radius: f32) -> Self {
+        Self {
+            scope,
+            center_x,
+            center_y,
+            radius,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn emit(&mut self) -> &mut dyn DrawScope {
+        count_primitive();
+        self.scope
+    }
+
+    #[inline]
+    pub(crate) fn scope(&self) -> &dyn DrawScope {
+        self.scope
+    }
+
+    #[inline]
+    pub fn px(&self, unit_x: f32) -> f32 {
+        self.center_x + unit_x * self.radius
+    }
+
+    #[inline]
+    pub fn py(&self, unit_y: f32) -> f32 {
+        self.center_y + unit_y * self.radius
+    }
+
+    #[inline]
+    pub fn scale(&self, unit: f32) -> f32 {
+        unit * self.radius
+    }
+
+    pub fn fill_screen(&mut self, color: Color) {
+        self.emit().draw_rect(Brush::solid(color));
+    }
+
+    pub fn dot(&mut self, unit_x: f32, unit_y: f32, unit_radius: f32, color: Color) {
+        if color.3 <= 0.002 || unit_radius <= 0.0 {
+            return;
+        }
+        let center = Point::new(self.px(unit_x), self.py(unit_y));
+        let pixels = self.scale(unit_radius);
+        self.emit().draw_circle(Brush::solid(color), center, pixels);
+    }
+
+    pub fn disc(&mut self, unit_x: f32, unit_y: f32, unit_radius: f32, brush: Brush) {
+        if unit_radius <= 0.0 {
+            return;
+        }
+        let center = Point::new(self.px(unit_x), self.py(unit_y));
+        let pixels = self.scale(unit_radius);
+        self.emit().draw_circle(brush, center, pixels);
+    }
+
+    pub fn rect(&mut self, x: f32, y: f32, width: f32, height: f32, color: Color) {
+        if color.3 <= 0.002 || width <= 0.0 || height <= 0.0 {
+            return;
+        }
+        self.emit().draw_rect_at(
+            Rect {
+                x,
+                y,
+                width,
+                height,
+            },
+            Brush::solid(color),
+        );
+    }
+
+    pub fn round_rect(
+        &mut self,
+        x: f32,
+        y: f32,
+        width: f32,
+        height: f32,
+        corner: f32,
+        color: Color,
+    ) {
+        if color.3 <= 0.002 || width <= 0.0 || height <= 0.0 {
+            return;
+        }
+        self.emit().draw_round_rect_at(
+            Rect {
+                x,
+                y,
+                width,
+                height,
+            },
+            Brush::solid(color),
+            CornerRadii::uniform(corner.min(width.min(height) * 0.5)),
+        );
+    }
+
+    pub fn unit_rect(&mut self, ux: f32, uy: f32, uw: f32, uh: f32, color: Color) {
+        let x = self.px(ux);
+        let y = self.py(uy);
+        self.rect(x, y, self.scale(uw), self.scale(uh), color);
+    }
+
+    /// A glow that fades outwards, as the stack of circles the Compose
+    /// original stacks.
+    ///
+    /// `ArenaRenderer.drawFalloff` paints eight translucent filled circles of
+    /// shrinking radius, and the stack is not interchangeable with its own
+    /// analytic profile: each circle is composited separately against an
+    /// eight-bit destination, so the rounding happens eight times over. A
+    /// single radial gradient reproduces the profile and not the rounding,
+    /// which is an off-by-one across every glow in the frame -- and this game
+    /// is mostly glows. The picture has to be built from the same primitives.
+    pub fn falloff(&mut self, unit_x: f32, unit_y: f32, unit_radius: f32, color: Color, peak: f32) {
+        if unit_radius <= 0.0 || peak <= FALLOFF_FLOOR {
+            return;
+        }
+        for index in 0..FALLOFF_BANDS {
+            let step = (index as f32 + 0.5) / FALLOFF_BANDS as f32;
+            let alpha = peak * step * step;
+            if alpha <= FALLOFF_FLOOR {
+                continue;
+            }
+            // Straight to the scope rather than through `dot`, whose alpha
+            // guard is a hair above Compose's `FALLOFF_FLOOR` and would drop
+            // the faintest band. Invisible over black, but it still multiplies
+            // a bright destination down by a level.
+            let center = Point::new(self.px(unit_x), self.py(unit_y));
+            let pixels = self.scale(unit_radius * (1.0 - step));
+            self.emit()
+                .draw_circle(Brush::solid(color.with_alpha(alpha)), center, pixels);
+        }
+    }
+
+    /// The same glow turned inside out -- brightest at the rim, fading towards
+    /// the middle -- which Compose paints as eight stroked rings rather than
+    /// eight discs.
+    pub fn inverse_falloff(
+        &mut self,
+        unit_x: f32,
+        unit_y: f32,
+        unit_radius: f32,
+        color: Color,
+        peak: f32,
+    ) {
+        if unit_radius <= 0.0 || peak <= FALLOFF_FLOOR {
+            return;
+        }
+        let band = unit_radius / FALLOFF_BANDS as f32;
+        for index in 0..FALLOFF_BANDS {
+            let outer = 1.0 - index as f32 / FALLOFF_BANDS as f32;
+            let alpha = peak * outer * outer;
+            if alpha <= FALLOFF_FLOOR {
+                continue;
+            }
+            let center = Point::new(self.px(unit_x), self.py(unit_y));
+            let radius = self.scale(unit_radius * outer - band * 0.5);
+            let stroke = Stroke::new(self.scale(band));
+            self.emit().draw_circle_stroked(
+                Brush::solid(color.with_alpha(alpha)),
+                center,
+                radius,
+                stroke,
+            );
+        }
+    }
+
+    pub fn radial_disc(
+        &mut self,
+        unit_x: f32,
+        unit_y: f32,
+        unit_radius: f32,
+        inner: Color,
+        outer: Color,
+    ) {
+        if unit_radius <= 0.0 {
+            return;
+        }
+        let center = Point::new(self.px(unit_x), self.py(unit_y));
+        let pixels = self.scale(unit_radius);
+        self.emit().draw_circle(
+            Brush::radial_gradient_tiled(
+                vec![inner, outer],
+                Point::new(pixels, pixels),
+                pixels,
+                TileMode::Clamp,
+            ),
+            center,
+            pixels,
+        );
+    }
+
+    pub fn ring(&mut self, unit_radius: f32, unit_thickness: f32, color: Color) {
+        self.ring_at(0.0, 0.0, unit_radius, unit_thickness, color);
+    }
+
+    pub fn ring_at(
+        &mut self,
+        unit_x: f32,
+        unit_y: f32,
+        unit_radius: f32,
+        unit_thickness: f32,
+        color: Color,
+    ) {
+        if unit_radius <= 0.0 || unit_thickness <= 0.0 || color.3 <= 0.002 {
+            return;
+        }
+        let center = Point::new(self.px(unit_x), self.py(unit_y));
+        let radius = self.scale(unit_radius);
+        let stroke = Stroke::new(self.scale(unit_thickness));
+        self.emit()
+            .draw_circle_stroked(Brush::solid(color), center, radius, stroke);
+    }
+
+    pub fn arc(
+        &mut self,
+        unit_radius: f32,
+        start_angle: f32,
+        sweep: f32,
+        unit_thickness: f32,
+        cap: StrokeCap,
+        color: Color,
+    ) {
+        self.arc_at(
+            0.0,
+            0.0,
+            unit_radius,
+            start_angle,
+            sweep,
+            unit_thickness,
+            cap,
+            color,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn arc_at(
+        &mut self,
+        unit_x: f32,
+        unit_y: f32,
+        unit_radius: f32,
+        start_angle: f32,
+        sweep: f32,
+        unit_thickness: f32,
+        cap: StrokeCap,
+        color: Color,
+    ) {
+        if unit_radius <= 0.0 || unit_thickness <= 0.0 || color.3 <= 0.002 {
+            return;
+        }
+        if sweep.abs() <= 1e-5 {
+            return;
+        }
+        let center = Point::new(self.px(unit_x), self.py(unit_y));
+        let radius = self.scale(unit_radius);
+        let stroke = Stroke::new(self.scale(unit_thickness)).with_cap(cap);
+        self.emit().draw_arc(
+            Brush::solid(color),
+            center,
+            radius,
+            start_angle,
+            sweep,
+            stroke,
+        );
+    }
+
+    pub fn annular_sector(
+        &mut self,
+        inner_radius: f32,
+        outer_radius: f32,
+        start_angle: f32,
+        sweep: f32,
+        color: Color,
+    ) {
+        if outer_radius <= inner_radius || color.3 <= 0.002 {
+            return;
+        }
+        if sweep.abs() <= 1e-5 {
+            return;
+        }
+        let center = Point::new(self.center_x, self.center_y);
+        let inner = self.scale(inner_radius.max(0.0));
+        let outer = self.scale(outer_radius);
+        self.emit().draw_annular_sector(
+            Brush::solid(color),
+            center,
+            inner,
+            outer,
+            start_angle,
+            sweep,
+        );
+    }
+
+    pub fn sector_outline(
+        &mut self,
+        inner_radius: f32,
+        outer_radius: f32,
+        start_angle: f32,
+        sweep: f32,
+        unit_thickness: f32,
+        color: Color,
+    ) {
+        if outer_radius <= inner_radius || unit_thickness <= 0.0 || color.3 <= 0.002 {
+            return;
+        }
+        if sweep.abs() <= 1e-5 {
+            return;
+        }
+        let inner = inner_radius.max(1e-4);
+        let outer = outer_radius;
+        let half = unit_thickness * 0.5;
+        let (start, span) = if sweep < 0.0 {
+            (start_angle + sweep, -sweep)
+        } else {
+            (start_angle, sweep)
+        };
+        let inner_pad = half / inner;
+        let outer_pad = half / outer;
+        self.arc(
+            inner,
+            start - inner_pad,
+            span + inner_pad * 2.0,
+            unit_thickness,
+            StrokeCap::Butt,
+            color,
+        );
+        self.arc(
+            outer,
+            start - outer_pad,
+            span + outer_pad * 2.0,
+            unit_thickness,
+            StrokeCap::Butt,
+            color,
+        );
+        let band_inner = inner + half;
+        let band_outer = outer - half;
+        if band_outer <= band_inner {
+            return;
+        }
+        let edge_sweep = unit_thickness / ((band_inner + band_outer) * 0.5);
+        for edge in [start, start + span] {
+            self.annular_sector(
+                band_inner,
+                band_outer,
+                edge - edge_sweep * 0.5,
+                edge_sweep,
+                color,
+            );
+        }
+    }
+
+    pub fn dot_px(&mut self, x: f32, y: f32, radius: f32, color: Color) {
+        if color.3 <= 0.002 || radius <= 0.0 {
+            return;
+        }
+        self.emit()
+            .draw_circle(Brush::solid(color), Point::new(x, y), radius);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn round_rect_stroked(
+        &mut self,
+        x: f32,
+        y: f32,
+        width: f32,
+        height: f32,
+        corner: f32,
+        thickness: f32,
+        color: Color,
+    ) {
+        if color.3 <= 0.002 || width <= 0.0 || height <= 0.0 || thickness <= 0.0 {
+            return;
+        }
+        self.emit().draw_round_rect_at_stroked(
+            Rect {
+                x,
+                y,
+                width,
+                height,
+            },
+            Brush::solid(color),
+            CornerRadii::uniform(corner.min(width.min(height) * 0.5)),
+            Stroke::new(thickness),
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn line_px(
+        &mut self,
+        x0: f32,
+        y0: f32,
+        x1: f32,
+        y1: f32,
+        thickness: f32,
+        cap: StrokeCap,
+        color: Color,
+    ) {
+        if thickness <= 0.0 || color.3 <= 0.002 {
+            return;
+        }
+        let dx = x1 - x0;
+        let dy = y1 - y0;
+        let length = dx.hypot(dy);
+        if length <= f32::EPSILON {
+            self.dot_px(x0, y0, thickness * 0.5, color);
+            return;
+        }
+        let radius = length * FLAT_ARC_RADII;
+        let centre_x = (x0 + x1) * 0.5 - dy / length * radius;
+        let centre_y = (y0 + y1) * 0.5 + dx / length * radius;
+        let start = (y0 - centre_y).atan2(x0 - centre_x);
+        let end = (y1 - centre_y).atan2(x1 - centre_x);
+        let mut sweep = end - start;
+        while sweep > std::f32::consts::PI {
+            sweep -= std::f32::consts::TAU;
+        }
+        while sweep < -std::f32::consts::PI {
+            sweep += std::f32::consts::TAU;
+        }
+        self.emit().draw_arc(
+            Brush::solid(color),
+            Point::new(centre_x, centre_y),
+            (radius * radius + length * length * 0.25).sqrt(),
+            start,
+            sweep,
+            Stroke::new(thickness).with_cap(cap),
+        );
+    }
+
+    pub fn line(&mut self, x0: f32, y0: f32, x1: f32, y1: f32, unit_thickness: f32, color: Color) {
+        if unit_thickness <= 0.0 || color.3 <= 0.002 {
+            return;
+        }
+        let dx = x1 - x0;
+        let dy = y1 - y0;
+        let length = (dx * dx + dy * dy).sqrt();
+        let dot_radius = unit_thickness * 0.5;
+        if length <= dot_radius {
+            self.dot(x0, y0, dot_radius, color);
+            return;
+        }
+        let spacing = (dot_radius * DOT_SPACING).max(1e-4);
+        let count = ((length / spacing).ceil() as usize + 1).clamp(2, 288);
+        let step = 1.0 / (count - 1) as f32;
+        for index in 0..count {
+            let t = step * index as f32;
+            self.dot(x0 + dx * t, y0 + dy * t, dot_radius, color);
+        }
+    }
+
+    pub fn radial_line(
+        &mut self,
+        angle: f32,
+        inner_radius: f32,
+        outer_radius: f32,
+        unit_thickness: f32,
+        color: Color,
+    ) {
+        let inner = inner_radius.min(outer_radius).max(0.0);
+        let outer = inner_radius.max(outer_radius);
+        let mid = (inner + outer) * 0.5;
+        if outer <= inner || mid <= 0.0 || unit_thickness <= 0.0 {
+            return;
+        }
+        let sweep = unit_thickness / mid;
+        self.annular_sector(inner, outer, angle - sweep * 0.5, sweep, color);
+    }
+}
+
+
+fn band_alpha(peak: f32, fraction: f32) -> f32 {
+    let alpha = peak * fraction * fraction;
+    if alpha <= FALLOFF_FLOOR {
+        0.0
+    } else {
+        alpha
+    }
+}
+
+pub fn falloff_alpha(peak: f32, fraction: f32) -> f32 {
+    if peak <= FALLOFF_FLOOR {
+        return 0.0;
+    }
+    let mut transmittance = 1.0;
+    for index in 0..FALLOFF_BANDS {
+        let step = (index as f32 + 0.5) / FALLOFF_BANDS as f32;
+        if 1.0 - step < fraction {
+            break;
+        }
+        transmittance *= 1.0 - band_alpha(peak, step);
+    }
+    1.0 - transmittance
+}
+
+pub fn inverse_falloff_alpha(peak: f32, fraction: f32) -> f32 {
+    if peak <= FALLOFF_FLOOR {
+        return 0.0;
+    }
+    for index in 0..FALLOFF_BANDS {
+        let step = 1.0 - index as f32 / FALLOFF_BANDS as f32;
+        if fraction >= step - 1.0 / FALLOFF_BANDS as f32 {
+            return band_alpha(peak, step);
+        }
+    }
+    0.0
+}

--- a/apps/desktop-demo/src/app/cranorbit_credits/font.rs
+++ b/apps/desktop-demo/src/app/cranorbit_credits/font.rs
@@ -1,0 +1,411 @@
+use super::draw::Painter;
+use cranpose_ui_graphics::{Brush, Color, FontWeight, Point, TextMeasurement, TextStyle};
+use std::f32::consts::TAU;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+pub const FONT_FAMILY: &str = "sans-serif";
+
+/// Roboto's vertical metrics, as Android reports them.
+///
+/// These are the `hhea` ascender and descender over `unitsPerEm`, read from the
+/// `Roboto-Regular.ttf` a Wear device ships. Skia only prefers the `OS/2` typo
+/// metrics when a font sets `USE_TYPO_METRICS` in `fsSelection`, and Roboto
+/// does not (`fsSelection = 0x0040`), so `hhea` is what `Paint.getFontMetrics`
+/// hands `StaticLayout` and what every Compose line height is built from.
+/// Taking `usWinDescent` (555) instead put every line one device pixel too
+/// tall at 19sp, which moved the wordmark's second line and everything under
+/// it down by one.
+pub const ROBOTO_ASCENT: f32 = 1900.0 / 2048.0;
+pub const ROBOTO_DESCENT: f32 = 500.0 / 2048.0;
+
+pub const BODY_WEIGHT: FontWeight = FontWeight(450);
+pub const TITLE_WEIGHT: FontWeight = FontWeight(550);
+
+pub const SHADOW_RINGS: [(f32, f32); 3] = [(0.34, 0.24), (0.67, 0.14), (1.0, 0.07)];
+pub const SHADOW_TAPS: usize = 8;
+pub const SHADOW_BLUR_PX: f32 = 14.0;
+
+const MIN_VISIBLE_ALPHA: f32 = 0.004;
+const DEFAULT_SCREEN_MILLI: u32 = 2000;
+
+static SCREEN_MILLI: AtomicU32 = AtomicU32::new(DEFAULT_SCREEN_MILLI);
+
+/// The system font-size setting, x1000. Wear guideline WO-V1 asks that text
+/// follow it; without this every size here would be a fixed dp and the setting
+/// would do nothing.
+static FONT_SCALE_MILLI: AtomicU32 = AtomicU32::new(1000);
+
+pub fn set_screen_density(density: f32) {
+    if density.is_finite() && density > 0.0 {
+        SCREEN_MILLI.store((density * 1000.0).round() as u32, Ordering::Relaxed);
+    }
+}
+
+pub fn screen_density() -> f32 {
+    SCREEN_MILLI.load(Ordering::Relaxed) as f32 / 1000.0
+}
+
+/// Records the platform's font scale. Values the platform cannot mean are
+/// ignored, leaving the last good one in place.
+pub fn set_font_scale(scale: f32) {
+    if scale.is_finite() && scale > 0.0 {
+        FONT_SCALE_MILLI.store((scale.clamp(0.5, 3.0) * 1000.0).round() as u32, Ordering::Relaxed);
+    }
+}
+
+pub fn font_scale() -> f32 {
+    FONT_SCALE_MILLI.load(Ordering::Relaxed) as f32 / 1000.0
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Align {
+    Start,
+    Center,
+    End,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Face {
+    pub size: f32,
+    pub line_height: f32,
+    pub weight: FontWeight,
+    pub tracking: f32,
+    pub screen_density: f32,
+}
+
+impl Face {
+    pub fn ascent(self) -> f32 {
+        (ROBOTO_ASCENT * self.size * self.screen_density).round() / self.screen_density
+    }
+
+    pub fn descent(self) -> f32 {
+        (ROBOTO_DESCENT * self.size * self.screen_density).round() / self.screen_density
+    }
+
+    pub fn natural_height(self) -> f32 {
+        self.ascent() + self.descent()
+    }
+
+    pub fn asked_height(self) -> f32 {
+        (self.line_height * self.screen_density).ceil() / self.screen_density
+    }
+
+    pub fn block_height(self) -> f32 {
+        self.asked_height().max(self.natural_height())
+    }
+
+    pub fn baseline(self) -> f32 {
+        let asked = self.asked_height();
+        let natural = self.natural_height();
+        if asked <= natural {
+            return self.ascent();
+        }
+        let grew = (asked - natural) * self.screen_density;
+        let below = self.descent() + (grew * 0.5).ceil() / self.screen_density;
+        asked - below
+    }
+
+    pub fn with_weight(mut self, weight: FontWeight) -> Self {
+        self.weight = weight;
+        self
+    }
+
+    pub fn with_tracking(mut self, tracking: f32) -> Self {
+        self.tracking = tracking;
+        self
+    }
+
+    pub fn with_size(mut self, size: f32) -> Self {
+        self.size = size;
+        self
+    }
+
+    pub fn scaled(mut self, scale: f32) -> Self {
+        self.size *= scale;
+        self.line_height *= scale;
+        self.tracking *= scale;
+        self
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Typography {
+    screen_density: f32,
+    font_scale: f32,
+}
+
+impl Typography {
+    pub const BODY_LINE_HEIGHT_SP: f32 = 18.0;
+    pub const BODY_TRACKING_SP: f32 = 0.4;
+
+    pub fn new(screen_density: f32) -> Self {
+        Self {
+            screen_density,
+            font_scale: 1.0,
+        }
+    }
+
+    pub fn platform() -> Self {
+        Self::new(screen_density()).with_font_scale(font_scale())
+    }
+
+    pub fn with_font_scale(mut self, font_scale: f32) -> Self {
+        if font_scale.is_finite() && font_scale > 0.0 {
+            self.font_scale = font_scale;
+        }
+        self
+    }
+
+    pub fn font_scale(self) -> f32 {
+        self.font_scale
+    }
+
+    /// Device pixels per dp, for the places that have to land on a whole one.
+    pub fn density(self) -> f32 {
+        self.screen_density
+    }
+
+    pub fn dp(self, value: f32) -> f32 {
+        value
+    }
+
+    /// A dp length rounded to the whole device pixel Compose would give it.
+    ///
+    /// Compose's layout is integral: `Dp.roundToPx()` turns every padding,
+    /// minimum size and spacing into an `Int` before anything is measured, and
+    /// a child is placed at an `IntOffset`. A length that skips this lands a
+    /// row edge mid-pixel, where the rasterizer antialiases a boundary the
+    /// Compose build draws crisp -- which is a whole scanline of near-miss
+    /// pixels per edge, not a rounding curiosity.
+    pub fn dp_px(self, value: f32) -> f32 {
+        if self.screen_density > 0.0 {
+            (value * self.screen_density).round() / self.screen_density
+        } else {
+            value
+        }
+    }
+
+    /// A size in scale-independent pixels: dp multiplied by the user's font
+    /// setting. Every piece of text in the app is sized through here, so the
+    /// setting reaches all of it; anything that must not move with it is
+    /// measured in `dp` instead.
+    pub fn sp(self, value: f32) -> f32 {
+        value * self.font_scale
+    }
+
+    pub fn px(self, value: f32) -> f32 {
+        value / self.screen_density
+    }
+
+    pub fn face(self, size_sp: f32, weight: FontWeight, tracking_sp: f32) -> Face {
+        self.styled(size_sp, Self::BODY_LINE_HEIGHT_SP, weight, tracking_sp)
+    }
+
+    pub fn styled(
+        self,
+        size_sp: f32,
+        line_height_sp: f32,
+        weight: FontWeight,
+        tracking_sp: f32,
+    ) -> Face {
+        Face {
+            size: self.sp(size_sp),
+            line_height: self.sp(line_height_sp),
+            weight,
+            tracking: self.sp(tracking_sp),
+            screen_density: self.screen_density,
+        }
+    }
+
+    pub fn line_height(self) -> f32 {
+        self.sp(Self::BODY_LINE_HEIGHT_SP)
+    }
+
+    pub fn screen_title(self) -> Face {
+        self.face(15.0, FontWeight::MEDIUM, Self::BODY_TRACKING_SP)
+    }
+
+    pub fn screen_caption(self) -> Face {
+        self.face(12.0, BODY_WEIGHT, Self::BODY_TRACKING_SP)
+    }
+
+    pub fn play_caption(self, emphasis: bool) -> Face {
+        if emphasis {
+            self.face(14.0, FontWeight::MEDIUM, Self::BODY_TRACKING_SP)
+        } else {
+            self.face(12.0, FontWeight::NORMAL, Self::BODY_TRACKING_SP)
+        }
+    }
+
+    pub fn word_mark_orbit(self) -> Face {
+        self.face(19.0, FontWeight::LIGHT, 5.0)
+    }
+
+    pub fn word_mark_breaker(self) -> Face {
+        self.face(19.0, FontWeight::MEDIUM, 3.0)
+    }
+
+    pub fn choice_label(self) -> Face {
+        self.face(14.0, FontWeight::MEDIUM, 1.0)
+    }
+
+    pub fn choice_hint(self) -> Face {
+        self.face(12.0, BODY_WEIGHT, 1.0)
+    }
+
+    pub fn list_header(self) -> Face {
+        self.styled(16.0, 18.0, TITLE_WEIGHT, Self::BODY_TRACKING_SP)
+    }
+
+    pub fn button_label(self) -> Face {
+        self.styled(15.0, 18.0, FontWeight::MEDIUM, Self::BODY_TRACKING_SP)
+    }
+
+    pub fn button_secondary(self) -> Face {
+        self.styled(13.0, 16.0, FontWeight::MEDIUM, Self::BODY_TRACKING_SP)
+    }
+
+    /// A plain line inside a list — a credit, a billing notice, a label row.
+    ///
+    /// Kotlin's `CreditLine` and the Settings notice both set
+    /// `lineHeight = 16.sp` explicitly rather than inheriting the theme's, so
+    /// a wrapped credit advances 16sp per line and not the 18sp everything
+    /// else in the app inherits. Measured against the Kotlin build, a wrapped
+    /// credit paragraph steps 31 device pixels per line; the port was stepping
+    /// 36 and every line after the first drifted further down the screen.
+    pub fn list_body(self) -> Face {
+        self.styled(12.0, 16.0, BODY_WEIGHT, Self::BODY_TRACKING_SP)
+    }
+}
+
+pub fn text_style(face: Face) -> TextStyle {
+    TextStyle::new(face.size)
+        .with_font_family(FONT_FAMILY)
+        .with_weight(face.weight)
+        .with_letter_spacing(face.tracking)
+        .with_line_height(face.line_height)
+}
+
+pub fn text_width(painter: &Painter, text: &str, face: Face) -> f32 {
+    if text.is_empty() {
+        return 0.0;
+    }
+    painter
+        .scope()
+        .measure_text(text, &text_style(face))
+        .size
+        .width
+}
+
+pub fn draw_text(
+    painter: &mut Painter,
+    text: &str,
+    x: f32,
+    y: f32,
+    face: Face,
+    color: Color,
+    align: Align,
+) {
+    draw_layer(painter, text, x, y, face, color, align);
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn draw_text_shadowed(
+    painter: &mut Painter,
+    text: &str,
+    x: f32,
+    y: f32,
+    face: Face,
+    color: Color,
+    align: Align,
+    shadow: Color,
+    blur: f32,
+) {
+    if text.is_empty() || face.size <= 0.0 {
+        return;
+    }
+    let style = text_style(face);
+    let measurement = painter.scope().measure_text(text, &style);
+    for (spread, alpha) in SHADOW_RINGS {
+        let radius = blur * spread;
+        let halo = shadow.with_alpha(shadow.3 * alpha);
+        for tap in 0..SHADOW_TAPS {
+            let angle = TAU * tap as f32 / SHADOW_TAPS as f32;
+            emit_layer(
+                painter,
+                text,
+                x + angle.cos() * radius,
+                y + angle.sin() * radius,
+                face,
+                halo,
+                align,
+                &style,
+                &measurement,
+            );
+        }
+    }
+    emit_layer(
+        painter,
+        text,
+        x,
+        y,
+        face,
+        color,
+        align,
+        &style,
+        &measurement,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_layer(
+    painter: &mut Painter,
+    text: &str,
+    x: f32,
+    y: f32,
+    face: Face,
+    color: Color,
+    align: Align,
+    style: &TextStyle,
+    measurement: &TextMeasurement,
+) {
+    if color.3 <= MIN_VISIBLE_ALPHA {
+        return;
+    }
+    let left = match align {
+        Align::Start => x,
+        Align::Center => x - measurement.size.width * 0.5,
+        Align::End => x - measurement.size.width,
+    };
+    let top = y + face.baseline() - measurement.first_baseline;
+    painter
+        .emit()
+        .draw_text_from(Point::new(left, top), Brush::solid(color), text, style);
+}
+
+fn draw_layer(
+    painter: &mut Painter,
+    text: &str,
+    x: f32,
+    y: f32,
+    face: Face,
+    color: Color,
+    align: Align,
+) {
+    if text.is_empty() || color.3 <= MIN_VISIBLE_ALPHA || face.size <= 0.0 {
+        return;
+    }
+    let style = text_style(face);
+    let measurement = painter.scope().measure_text(text, &style);
+    emit_layer(
+        painter,
+        text,
+        x,
+        y,
+        face,
+        color,
+        align,
+        &style,
+        &measurement,
+    );
+}

--- a/apps/desktop-demo/src/app/cranorbit_credits/font.rs
+++ b/apps/desktop-demo/src/app/cranorbit_credits/font.rs
@@ -49,7 +49,10 @@ pub fn screen_density() -> f32 {
 /// ignored, leaving the last good one in place.
 pub fn set_font_scale(scale: f32) {
     if scale.is_finite() && scale > 0.0 {
-        FONT_SCALE_MILLI.store((scale.clamp(0.5, 3.0) * 1000.0).round() as u32, Ordering::Relaxed);
+        FONT_SCALE_MILLI.store(
+            (scale.clamp(0.5, 3.0) * 1000.0).round() as u32,
+            Ordering::Relaxed,
+        );
     }
 }
 

--- a/apps/desktop-demo/src/app/cranorbit_credits/layout.rs
+++ b/apps/desktop-demo/src/app/cranorbit_credits/layout.rs
@@ -1,0 +1,151 @@
+/// A dp position moved onto the nearest whole device pixel.
+///
+/// Kotlin's `roundToInt` sends an exact half up; Rust's `round` sends it away
+/// from zero. They agree on everything a layout produces above the top of the
+/// screen, and this keeps them agreeing below it too.
+pub fn snap_to_pixel(value: f32, density: f32) -> f32 {
+    if !(density > 0.0) || !value.is_finite() {
+        return value;
+    }
+    (value * density + 0.5).floor() / density
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Stack {
+    cursor: f32,
+    gap: f32,
+    placed: bool,
+}
+
+impl Stack {
+    pub fn total(gap: f32, heights: impl IntoIterator<Item = f32>) -> f32 {
+        let mut total = 0.0;
+        let mut count = 0usize;
+        for height in heights {
+            total += height;
+            count += 1;
+        }
+        if count > 1 {
+            total += gap * (count - 1) as f32;
+        }
+        total
+    }
+
+    /// Start a stack whose children sit centred on `centre_y`.
+    ///
+    /// Compose's `Arrangement.Center` measures every child in whole pixels and
+    /// rounds the leading gap to a whole pixel before placing any of them, so a
+    /// column whose content is an odd number of pixels tall starts on a pixel
+    /// boundary rather than across one. This does the same, because half a
+    /// pixel of drift is enough to move a line of text's antialiasing onto the
+    /// next row — which is exactly what a screenshot comparison sees.
+    pub fn centred(centre_y: f32, total: f32, gap: f32, density: f32) -> Self {
+        Self {
+            cursor: snap_to_pixel(centre_y - total * 0.5, density),
+            gap,
+            placed: false,
+        }
+    }
+
+    pub fn from_top(top: f32, gap: f32) -> Self {
+        Self {
+            cursor: top,
+            gap,
+            placed: false,
+        }
+    }
+
+    pub fn place(&mut self, height: f32) -> f32 {
+        if self.placed {
+            self.cursor += self.gap;
+        }
+        self.placed = true;
+        let top = self.cursor;
+        self.cursor += height;
+        top
+    }
+
+    pub fn cursor(&self) -> f32 {
+        self.cursor
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Slot {
+    pub top: f32,
+    pub height: f32,
+}
+
+impl Slot {
+    pub fn centre(self) -> f32 {
+        self.top + self.height * 0.5
+    }
+
+    pub fn contains(self, y: f32) -> bool {
+        y >= self.top && y < self.top + self.height
+    }
+}
+
+pub fn slot_at(slots: &[Slot], y: f32) -> Option<usize> {
+    for (index, slot) in slots.iter().enumerate() {
+        let end = slots
+            .get(index + 1)
+            .map(|next| next.top)
+            .unwrap_or(slot.top + slot.height);
+        if y >= slot.top && y < end {
+            return Some(index);
+        }
+    }
+    None
+}
+
+pub fn scroll_by_pixels(slots: &[Slot], scroll: f32, delta: f32) -> f32 {
+    if slots.len() < 2 {
+        return scroll;
+    }
+    let last = slots.len() - 1;
+    let mut scroll = scroll.clamp(0.0, last as f32);
+    let mut remaining = delta;
+    while remaining > 0.0 {
+        let index = scroll.floor() as usize;
+        if index >= last {
+            return last as f32;
+        }
+        let step = slots[index + 1].centre() - slots[index].centre();
+        if step <= 0.0 {
+            return last as f32;
+        }
+        let available = step * ((index + 1) as f32 - scroll);
+        if remaining < available {
+            return scroll + remaining / step;
+        }
+        remaining -= available;
+        scroll = (index + 1) as f32;
+    }
+    while remaining < 0.0 {
+        if scroll <= 0.0 {
+            return 0.0;
+        }
+        let index = (scroll.ceil() as usize).saturating_sub(1).min(last - 1);
+        let step = slots[index + 1].centre() - slots[index].centre();
+        if step <= 0.0 {
+            return 0.0;
+        }
+        let available = step * (scroll - index as f32);
+        if -remaining < available {
+            return scroll + remaining / step;
+        }
+        remaining += available;
+        scroll = index as f32;
+    }
+    scroll
+}
+
+pub fn slot_pitch(slots: &[Slot]) -> f32 {
+    if slots.len() < 2 {
+        return 0.0;
+    }
+    let first = slots[0].top;
+    let last = slots[slots.len() - 1].top;
+    (last - first) / (slots.len() - 1) as f32
+}

--- a/apps/desktop-demo/src/app/cranorbit_credits/list.rs
+++ b/apps/desktop-demo/src/app/cranorbit_credits/list.rs
@@ -1,7 +1,7 @@
-use super::rows::{RowKind, SettingsRow};
 use super::draw::Painter;
 use super::font::{draw_text, text_width, Align, Face, Typography};
 use super::layout::Slot;
+use super::rows::{RowKind, SettingsRow};
 use super::theme::{ColorScheme, GamePalette};
 use cranpose_ui_graphics::{Color, StrokeCap};
 
@@ -156,7 +156,16 @@ pub fn draw_scroll_indicator(
     let below_start = thumb_start + thumb_sweep + gap;
     let below = top + sweep - below_start;
     let cap = unit_width / unit_radius;
-    indicator_segment(painter, unit_radius, top, above, unit_width, cap, track, alpha);
+    indicator_segment(
+        painter,
+        unit_radius,
+        top,
+        above,
+        unit_width,
+        cap,
+        track,
+        alpha,
+    );
     indicator_segment(
         painter,
         unit_radius,
@@ -945,7 +954,12 @@ fn switch(
     } else {
         scheme.outline
     };
-    painter.dot_px(thumb_x, centre_y, thumb_radius, super::theme::faded_by_layer(thumb, alpha));
+    painter.dot_px(
+        thumb_x,
+        centre_y,
+        thumb_radius,
+        super::theme::faded_by_layer(thumb, alpha),
+    );
     if checked {
         let unit = typography.dp(1.0) * scale;
         let stroke = typography.dp(TICK_STROKE_DP) * scale;

--- a/apps/desktop-demo/src/app/cranorbit_credits/list.rs
+++ b/apps/desktop-demo/src/app/cranorbit_credits/list.rs
@@ -1,0 +1,964 @@
+use super::rows::{RowKind, SettingsRow};
+use super::draw::Painter;
+use super::font::{draw_text, text_width, Align, Face, Typography};
+use super::layout::Slot;
+use super::theme::{ColorScheme, GamePalette};
+use cranpose_ui_graphics::{Color, StrokeCap};
+
+pub const ITEM_GAP_DP: f32 = 4.0;
+pub const HEADER_MIN_DP: f32 = 48.0;
+pub const HEADER_TOP_DP: f32 = 16.0;
+pub const HEADER_BOTTOM_DP: f32 = 12.0;
+pub const HEADER_SIDE_DP: f32 = 14.0;
+pub const BUTTON_MIN_DP: f32 = 52.0;
+pub const BUTTON_SIDE_DP: f32 = 14.0;
+pub const BUTTON_PAD_Y_DP: f32 = 6.0;
+pub const SWITCH_PAD_Y_DP: f32 = 8.0;
+pub const LABEL_SPACER_DP: f32 = 1.0;
+pub const CORNER_DP: f32 = 26.0;
+pub const SWITCH_WIDTH_DP: f32 = 32.0;
+pub const SWITCH_HEIGHT_DP: f32 = 22.0;
+pub const SWITCH_SPACING_DP: f32 = 6.0;
+pub const SWITCH_TRACK_DP: f32 = 2.0;
+pub const THUMB_UNCHECKED_DP: f32 = 6.0;
+pub const THUMB_CHECKED_DP: f32 = 9.0;
+pub const TICK_STROKE_DP: f32 = 2.0;
+pub const TICK_BASE: [f32; 4] = [-4.6, 1.0, -2.1, 3.5];
+pub const TICK_STICK: [f32; 4] = [-1.5, 3.1, 4.5, -2.9];
+
+pub const EDGE_SCALE: f32 = 0.7;
+pub const EDGE_ALPHA: f32 = 0.5;
+pub const MIN_ELEMENT_HEIGHT: f32 = 0.2;
+pub const MAX_ELEMENT_HEIGHT: f32 = 0.6;
+pub const MIN_TRANSITION_AREA: f32 = 0.35;
+pub const MAX_TRANSITION_AREA: f32 = 0.55;
+pub const CENTRED_ITEM: usize = 1;
+
+pub const MAX_WRAP_LINES: usize = 8;
+
+// Wear Material 3's ScrollIndicator, in its own numbers. Read out of
+// `androidx.wear.compose.material3` 1.6.2 with `javap -c`
+// (`ScrollIndicatorDefaults`, `PaddingDefaults`) and each one checked against
+// where the shipping build actually puts pixels on a 454px round display.
+
+/// How far the track reaches up and down from 3 o'clock, as a straight-line
+/// height rather than an arc length — Wear's `indicatorHeight`.
+pub const INDICATOR_HEIGHT_DP: f32 = 50.0;
+/// Stroke width — Wear's `indicatorWidth`, which is 6dp on a large screen and
+/// 5dp otherwise. Wear's own breakpoint is a screen at least 225dp across.
+pub const INDICATOR_WIDTH_DP: f32 = 6.0;
+pub const INDICATOR_NARROW_WIDTH_DP: f32 = 5.0;
+pub const INDICATOR_LARGE_SCREEN_DP: f32 = 225.0;
+/// How far the track's outer edge stays off the display edge — Wear's
+/// `PaddingDefaults.edgePadding`.
+pub const INDICATOR_EDGE_PADDING_DP: f32 = 2.0;
+/// The blank Wear leaves between the thumb and each end of the track —
+/// `ScrollIndicatorDefaults.gapHeight`. The indicator is three separate
+/// segments, not a thumb painted over a continuous track.
+pub const INDICATOR_GAP_DP: f32 = 3.0;
+/// The thumb's share of the track is clamped to this range — Wear's
+/// `minSizeFraction` and `maxSizeFraction`.
+pub const INDICATOR_MIN_THUMB: f32 = 0.3;
+pub const INDICATOR_MAX_THUMB: f32 = 0.7;
+/// L\* for the thumb and for the track behind it. Wear takes one colour —
+/// `onBackground` — to two lightnesses rather than laying alpha over the
+/// background.
+pub const INDICATOR_THUMB_LUMINANCE: f32 = 80.0;
+pub const INDICATOR_TRACK_LUMINANCE: f32 = 20.0;
+
+/// The stroke width Wear would use on a display this size.
+pub fn indicator_width_dp(display_dp: f32) -> f32 {
+    if display_dp >= INDICATOR_LARGE_SCREEN_DP {
+        INDICATOR_WIDTH_DP
+    } else {
+        INDICATOR_NARROW_WIDTH_DP
+    }
+}
+
+/// Where the track's centreline sits and how far it sweeps, given the display
+/// radius in dp.
+///
+/// Wear describes the track by its height in dp, so the angle it covers
+/// depends on the radius it is drawn at; deriving it here rather than storing
+/// an angle keeps the indicator the same size in millimetres on every watch.
+pub fn indicator_arc(radius_dp: f32) -> (f32, f32, f32) {
+    let width = indicator_width_dp(radius_dp * 2.0);
+    let centreline = radius_dp - INDICATOR_EDGE_PADDING_DP - width * 0.5;
+    let half_height = INDICATOR_HEIGHT_DP * 0.5;
+    let half_sweep = (half_height / centreline).clamp(-1.0, 1.0).asin();
+    (centreline / radius_dp, width / radius_dp, half_sweep)
+}
+
+/// Where the thumb sits inside the track, and how long it is — both as
+/// fractions of the track, matching what Wear Material's ScrollIndicator
+/// derives from a list's scroll state.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct IndicatorGeometry {
+    /// Thumb length as a share of the whole track, never below
+    /// [`INDICATOR_MIN_THUMB`].
+    pub thumb: f32,
+    /// Position of the thumb's leading edge, `0.0` at the top of the track and
+    /// `1.0 - thumb` at the bottom.
+    pub offset: f32,
+}
+
+/// Works out the indicator for a laid-out list, or `None` when everything fits
+/// on screen and Wear would show nothing at all.
+///
+/// `slots` are the laid-out rows in screen coordinates and `viewport` is the
+/// display height, so this reads the same geometry the rows were drawn from
+/// rather than a second, drifting copy of the scroll position.
+pub fn indicator_geometry(slots: &[Slot], viewport: f32, gap: f32) -> Option<IndicatorGeometry> {
+    let first = slots.first()?;
+    let last = slots.last()?;
+    // The scaling list centres the first and last rows rather than aligning
+    // them with the display edges, so the distance the content can travel is
+    // measured between those two centres — that is exactly the range the
+    // scroll position moves over.
+    let travel = last.centre() - first.centre();
+    if travel <= gap {
+        return None;
+    }
+    let content = last.top + last.height - first.top;
+    if viewport >= content {
+        return None;
+    }
+    let thumb = (viewport / content).clamp(INDICATOR_MIN_THUMB, INDICATOR_MAX_THUMB);
+    let scrolled = (viewport * 0.5 - first.centre()) / travel;
+    let offset = scrolled.clamp(0.0, 1.0) * (1.0 - thumb);
+    Some(IndicatorGeometry { thumb, offset })
+}
+
+/// Draws the Wear scroll indicator on the right edge of the display.
+pub fn draw_scroll_indicator(
+    painter: &mut Painter,
+    geometry: IndicatorGeometry,
+    alpha: f32,
+    scheme: &ColorScheme,
+) {
+    if alpha <= 0.002 {
+        return;
+    }
+    let (unit_radius, unit_width, half_sweep) = indicator_arc(painter.radius);
+    let sweep = half_sweep * 2.0;
+    let top = -half_sweep;
+    let track = super::theme::with_luminance(scheme.on_background, INDICATOR_TRACK_LUMINANCE);
+    let thumb = super::theme::with_luminance(scheme.on_background, INDICATOR_THUMB_LUMINANCE);
+    // Wear's `drawCurvedIndicator` lays down three segments -- track, thumb,
+    // track -- rather than a thumb over a full-length track, and leaves
+    // `gapHeight` of nothing on either side of the thumb. On a list scrolled
+    // near an end the short segment is what gives the indicator its little
+    // detached dot.
+    let gap = INDICATOR_GAP_DP / (unit_radius * painter.radius);
+    let thumb_start = top + sweep * geometry.offset;
+    let thumb_sweep = sweep * geometry.thumb;
+    let above = thumb_start - gap - top;
+    let below_start = thumb_start + thumb_sweep + gap;
+    let below = top + sweep - below_start;
+    let cap = unit_width / unit_radius;
+    indicator_segment(painter, unit_radius, top, above, unit_width, cap, track, alpha);
+    indicator_segment(
+        painter,
+        unit_radius,
+        thumb_start,
+        thumb_sweep,
+        unit_width,
+        cap,
+        thumb,
+        alpha,
+    );
+    indicator_segment(
+        painter,
+        unit_radius,
+        below_start,
+        below,
+        unit_width,
+        cap,
+        track,
+        alpha,
+    );
+}
+
+/// One piece of the scroll indicator.
+///
+/// Wear's `drawIndicatorSegment` does not draw an arc shorter than its own
+/// stroke: below that it swaps to a circle whose radius and alpha both scale
+/// with how much sweep is left, so a segment shrinking to nothing dwindles to a
+/// dot and fades out instead of stopping abruptly at one round cap's width.
+#[allow(clippy::too_many_arguments)]
+fn indicator_segment(
+    painter: &mut Painter,
+    unit_radius: f32,
+    start: f32,
+    sweep: f32,
+    unit_width: f32,
+    cap_sweep: f32,
+    color: Color,
+    alpha: f32,
+) {
+    if sweep <= 0.0 || cap_sweep <= 0.0 {
+        return;
+    }
+    if sweep < cap_sweep {
+        let fill = sweep / cap_sweep;
+        let middle = start + sweep * 0.5;
+        painter.dot(
+            unit_radius * middle.cos(),
+            unit_radius * middle.sin(),
+            unit_width * 0.5 * fill,
+            color.with_alpha(alpha * fill),
+        );
+        return;
+    }
+    // Wear draws the arc a half-cap short at each end and lets the round caps
+    // fill it back out, so a segment covers exactly `start ..= start + sweep`.
+    // Drawing the full sweep instead grows every segment by a whole stroke
+    // width, which is more than the gap Wear leaves and closes it up.
+    painter.arc(
+        unit_radius,
+        start + cap_sweep * 0.5,
+        sweep - cap_sweep,
+        unit_width,
+        StrokeCap::Round,
+        color.with_alpha(alpha),
+    );
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ScaleAlpha {
+    pub scale: f32,
+    pub alpha: f32,
+}
+
+/// Where a row is drawn, and how faded, once the scaling list has had its say.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PlacedRow {
+    pub top: f32,
+    pub height: f32,
+    pub scale: f32,
+    pub alpha: f32,
+}
+
+/// Places a row the way `ScalingLazyColumn` places one.
+///
+/// Wear's list does not re-measure a scaled item. The `LazyColumn` underneath
+/// stacks items at their full height, and `ScalingLazyColumnItemWrapper` draws
+/// each through a graphics layer with `transformOrigin` on the item's top edge
+/// and a `translationY` that pins whichever edge faces the centre line — the
+/// bottom for an item above the line, the top for one below it. So a row's
+/// position depends only on the rows above it, not on how much they shrank.
+///
+/// What that translation is built from is integral, and that is the part worth
+/// keeping. `ScalingLazyColumnMeasureKt` rounds the scaled height to a whole
+/// pixel (`roundToInt(size * scale)`), and it reaches the drawn offset through
+/// `convertToCenterOffset`, which halves a size with *integer* division, while
+/// `startOffset` halves the same size in floating point — so an item whose
+/// pixel height is odd carries exactly half a pixel. Do the same arithmetic in
+/// dp and a row edge lands mid-pixel, where the rasterizer antialiases a
+/// boundary the Compose build draws crisp: a whole scanline of near-miss
+/// pixels for every edge, on every scaled row.
+///
+/// `top` and `height` are in dp; the answer is too.
+pub fn place_row(style: &ListStyle, top: f32, height: f32) -> PlacedRow {
+    let density = style.typography.density();
+    if density <= 0.0 {
+        let transform = scale_and_alpha(style.height, top, top + height);
+        return PlacedRow {
+            top,
+            height: height * transform.scale,
+            scale: transform.scale,
+            alpha: transform.alpha,
+        };
+    }
+    let viewport_px = (style.height * density).round();
+    let top_px = (top * density).round();
+    let height_px = (height * density).round();
+    let transform = scale_and_alpha(viewport_px, top_px, top_px + height_px);
+    let scaled_px = (height_px * transform.scale).round();
+    // Wear's `isAboveLine`, on the same integers it uses.
+    let above = top_px + top_px + height_px < viewport_px;
+    let pinned = if above {
+        top_px + height_px - scaled_px
+    } else {
+        top_px
+    };
+    PlacedRow {
+        top: (pinned + odd_pixel(height_px) - odd_pixel(scaled_px)) / density,
+        height: height_px * transform.scale / density,
+        scale: transform.scale,
+        alpha: transform.alpha,
+    }
+}
+
+/// Half a pixel when a pixel height is odd, and nothing when it is even —
+/// what Compose's integer halving leaves behind next to its floating-point one.
+fn odd_pixel(pixels: f32) -> f32 {
+    let half = pixels * 0.5;
+    half - half.floor()
+}
+
+pub fn scale_and_alpha(viewport: f32, top: f32, bottom: f32) -> ScaleAlpha {
+    if viewport <= 0.0 {
+        return ScaleAlpha {
+            scale: 1.0,
+            alpha: 1.0,
+        };
+    }
+    let edge = (viewport - top).min(bottom) / viewport;
+    let size_ratio = inverse_lerp(
+        MIN_ELEMENT_HEIGHT,
+        MAX_ELEMENT_HEIGHT,
+        (bottom - top) / viewport,
+    );
+    let line = MIN_TRANSITION_AREA + (MAX_TRANSITION_AREA - MIN_TRANSITION_AREA) * size_ratio;
+    if edge >= line || line <= 0.0 {
+        return ScaleAlpha {
+            scale: 1.0,
+            alpha: 1.0,
+        };
+    }
+    let progress = ease(1.0 - edge / line);
+    ScaleAlpha {
+        scale: 1.0 + (EDGE_SCALE - 1.0) * progress,
+        alpha: 1.0 + (EDGE_ALPHA - 1.0) * progress,
+    }
+}
+
+fn inverse_lerp(start: f32, stop: f32, value: f32) -> f32 {
+    ((value - start) / (stop - start)).clamp(0.0, 1.0)
+}
+
+fn ease(x: f32) -> f32 {
+    let x = x.clamp(0.0, 1.0);
+    let mut low = 0.0f32;
+    let mut high = 1.0f32;
+    let mut t = x;
+    for _ in 0..12 {
+        let value = bezier(t, 0.3, 0.7);
+        if value < x {
+            low = t;
+        } else {
+            high = t;
+        }
+        t = (low + high) * 0.5;
+    }
+    bezier(t, 0.0, 1.0)
+}
+
+fn bezier(t: f32, first: f32, second: f32) -> f32 {
+    let inverse = 1.0 - t;
+    3.0 * inverse * inverse * t * first + 3.0 * inverse * t * t * second + t * t * t
+}
+
+/// A Compose `CubicBezierEasing(a, b, c, d)` evaluated at `fraction`.
+///
+/// Compose's easing curves are parametric, so the answer is the curve's y at
+/// the parameter whose x is `fraction` — found by bisection, the same way the
+/// scaling-list easing above does it.
+pub fn cubic_bezier_easing(fraction: f32, a: f32, b: f32, c: f32, d: f32) -> f32 {
+    let x = fraction.clamp(0.0, 1.0);
+    let mut low = 0.0f32;
+    let mut high = 1.0f32;
+    let mut t = x;
+    for _ in 0..12 {
+        if bezier(t, a, c) < x {
+            low = t;
+        } else {
+            high = t;
+        }
+        t = (low + high) * 0.5;
+    }
+    bezier(t, b, d)
+}
+
+pub struct ListStyle {
+    pub typography: Typography,
+    pub side_padding: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+impl ListStyle {
+    pub fn new(typography: Typography, side_dp: f32, width: f32, height: f32) -> Self {
+        Self {
+            typography,
+            side_padding: typography.dp(side_dp),
+            width,
+            height,
+        }
+    }
+
+    pub fn item_width(&self) -> f32 {
+        self.width - self.side_padding * 2.0
+    }
+
+    pub fn item_left(&self) -> f32 {
+        self.side_padding
+    }
+
+    pub fn gap(&self) -> f32 {
+        self.typography.dp_px(ITEM_GAP_DP)
+    }
+}
+
+pub fn row_height(painter: &Painter, style: &ListStyle, row: &SettingsRow) -> f32 {
+    let typography = style.typography;
+    match row.kind {
+        RowKind::Header => {
+            let block = typography.list_header().block_height();
+            (typography.dp_px(HEADER_TOP_DP) + block + typography.dp_px(HEADER_BOTTOM_DP))
+                .max(typography.dp_px(HEADER_MIN_DP))
+        }
+        RowKind::Label => {
+            let face = typography.list_body();
+            wrapped_lines(painter, &row.label, face, style.item_width()) as f32
+                * face.block_height()
+        }
+        RowKind::Toggle | RowKind::Action => {
+            let pad = if row.kind == RowKind::Toggle {
+                typography.dp_px(SWITCH_PAD_Y_DP)
+            } else {
+                typography.dp_px(BUTTON_PAD_Y_DP)
+            };
+            let label = typography.button_label();
+            let secondary = typography.button_secondary();
+            let available = label_width(style, row.kind);
+            let mut content =
+                wrapped_lines(painter, &row.label, label, available) as f32 * label.block_height();
+            if !row.value.is_empty() {
+                content += typography.dp_px(LABEL_SPACER_DP)
+                    + wrapped_lines(painter, &row.value, secondary, available) as f32
+                        * secondary.block_height();
+            }
+            (content + pad * 2.0).max(typography.dp_px(BUTTON_MIN_DP))
+        }
+    }
+}
+
+fn label_width(style: &ListStyle, kind: RowKind) -> f32 {
+    let typography = style.typography;
+    let side = typography.dp(BUTTON_SIDE_DP) * 2.0;
+    if kind == RowKind::Toggle {
+        style.item_width()
+            - side
+            - typography.dp(SWITCH_WIDTH_DP)
+            - typography.dp(SWITCH_SPACING_DP)
+    } else {
+        style.item_width() - side
+    }
+}
+
+pub fn wrapped_lines(painter: &Painter, text: &str, face: Face, width: f32) -> usize {
+    if text.is_empty() {
+        return 1;
+    }
+    let mut lines = 1usize;
+    let mut start = 0usize;
+    let mut end = 0usize;
+    for (index, word) in text.split(' ').enumerate() {
+        let word_end = if index == 0 {
+            word.len()
+        } else {
+            end + 1 + word.len()
+        };
+        if index > 0 && text_width(painter, &text[start..word_end], face) > width {
+            lines += 1;
+            start = end + 1;
+        }
+        end = word_end;
+        if lines >= MAX_WRAP_LINES {
+            break;
+        }
+    }
+    lines
+}
+
+/// The character Compose appends when `TextOverflow.Ellipsis` cuts a line.
+pub const ELLIPSIS: &str = "…";
+
+/// A block laid out the way Compose lays one out with `maxLines` and
+/// `TextOverflow.Ellipsis`.
+///
+/// The port draws its own text, so nothing here is inherited: without this a
+/// caption that did not fit was simply cut mid-word, while the Kotlin build
+/// showed the same text with a trailing ellipsis. At large font settings —
+/// which is where `maxLines` starts to bite — that is a visible difference on
+/// most screens.
+pub struct WrappedBlock<'a> {
+    /// Lines to draw, in order. The last one is `overflowed` when set.
+    pub lines: [&'a str; MAX_WRAP_LINES],
+    /// How many of `lines` are used.
+    pub count: usize,
+    /// Replacement for the last line when the text did not fit, ending in the
+    /// ellipsis. Owned because it is not a slice of the input.
+    pub overflowed: Option<String>,
+}
+
+impl<'a> WrappedBlock<'a> {
+    /// The line at `index` as it should be drawn.
+    pub fn line(&self, index: usize) -> &str {
+        match (&self.overflowed, index + 1 == self.count) {
+            (Some(text), true) => text.as_str(),
+            _ => self.lines[index],
+        }
+    }
+}
+
+/// Wraps `text` to `width`, keeps at most `max_lines`, and ellipsizes the last
+/// line when anything was left over — Compose's `maxLines` +
+/// `TextOverflow.Ellipsis` pair.
+pub fn wrap_ellipsized<'a>(
+    painter: &Painter,
+    text: &'a str,
+    face: Face,
+    width: f32,
+    max_lines: usize,
+) -> WrappedBlock<'a> {
+    let mut lines: [&str; MAX_WRAP_LINES] = [""; MAX_WRAP_LINES];
+    let produced = wrap_into(painter, text, face, width, &mut lines);
+    let count = produced.min(max_lines.max(1));
+    let dropped = produced > count;
+    let last = lines[count - 1];
+    // A single word longer than the column does not wrap, so overflow has to be
+    // measured as well as counted.
+    let too_wide = text_width(painter, last, face) > width;
+    if !dropped && !too_wide {
+        return WrappedBlock {
+            lines,
+            count,
+            overflowed: None,
+        };
+    }
+    // Compose fills the last line as far as it can and puts the ellipsis at the
+    // end, so the tail is measured against the remaining text, not against the
+    // wrapped line alone.
+    let start = last.as_ptr() as usize - text.as_ptr() as usize;
+    let remainder = &text[start..];
+    let mut kept = 0usize;
+    for (index, _) in remainder.char_indices().skip(1) {
+        let candidate = format!("{}{ELLIPSIS}", &remainder[..index]);
+        if text_width(painter, &candidate, face) > width {
+            break;
+        }
+        kept = index;
+    }
+    let trimmed = remainder[..kept].trim_end();
+    WrappedBlock {
+        lines,
+        count,
+        overflowed: Some(format!("{trimmed}{ELLIPSIS}")),
+    }
+}
+
+pub fn wrap_into<'a>(
+    painter: &Painter,
+    text: &'a str,
+    face: Face,
+    width: f32,
+    out: &mut [&'a str; MAX_WRAP_LINES],
+) -> usize {
+    if text.is_empty() {
+        out[0] = text;
+        return 1;
+    }
+    let mut count = 0usize;
+    let mut start = 0usize;
+    let mut end = 0usize;
+    for (index, word) in text.split(' ').enumerate() {
+        let word_end = if index == 0 {
+            word.len()
+        } else {
+            end + 1 + word.len()
+        };
+        if index > 0 && text_width(painter, &text[start..word_end], face) > width {
+            if count + 1 >= MAX_WRAP_LINES {
+                break;
+            }
+            out[count] = &text[start..end];
+            count += 1;
+            start = end + 1;
+        }
+        end = word_end;
+    }
+    out[count] = &text[start..end];
+    count + 1
+}
+
+pub fn layout_into(
+    painter: &Painter,
+    rows: &[SettingsRow],
+    style: &ListStyle,
+    scroll: f32,
+    slots: &mut Vec<Slot>,
+) {
+    slots.clear();
+    if rows.is_empty() {
+        return;
+    }
+    let gap = style.gap();
+    let mut cursor = 0.0;
+    for row in rows.iter() {
+        let height = row_height(painter, style, row);
+        slots.push(Slot {
+            top: cursor,
+            height,
+        });
+        cursor += height + gap;
+    }
+    let whole = (scroll.floor().max(0.0) as usize).min(rows.len() - 1);
+    let fraction = (scroll - whole as f32).clamp(0.0, 1.0);
+    let mut anchor = slots[whole].centre();
+    if let Some(next) = slots.get(whole + 1) {
+        anchor += (next.centre() - anchor) * fraction;
+    }
+    // The `LazyColumn` under Wear's list holds its scroll position as a whole
+    // number of pixels — a float delta is rounded before it is applied and the
+    // remainder is carried, so every item top is integral. Rounding the shift
+    // once does the same thing for the whole column, and keeps a row edge off
+    // the half-pixel where it would be antialiased against a Compose build
+    // that draws it crisp.
+    let shift = style.typography.dp_px(style.height * 0.5 - anchor);
+    for slot in slots.iter_mut() {
+        slot.top += shift;
+    }
+}
+
+pub fn draw_list(
+    painter: &mut Painter,
+    rows: &[SettingsRow],
+    style: &ListStyle,
+    slots: &[Slot],
+    palette: &GamePalette,
+) {
+    let scheme = ColorScheme::of(palette);
+    painter.fill_screen(palette.background);
+    for (row, slot) in rows.iter().zip(slots.iter()) {
+        if slot.top < style.height && slot.top + slot.height > 0.0 {
+            draw_row(painter, row, style, slot.top, slot.height, &scheme);
+        }
+    }
+}
+
+fn draw_row(
+    painter: &mut Painter,
+    row: &SettingsRow,
+    style: &ListStyle,
+    top: f32,
+    height: f32,
+    scheme: &ColorScheme,
+) {
+    let placed = place_row(style, top, height);
+    draw_row_at(
+        painter,
+        row,
+        style,
+        placed.top,
+        placed.height,
+        placed.scale,
+        placed.alpha,
+        scheme,
+    );
+}
+
+/// One row at its natural size, with nothing scaled and nothing faded.
+///
+/// This is what a row draws when the scale and the alpha live on a graphics
+/// layer instead of in the drawing. Wear's `ScalingLazyColumnItemWrapper`
+/// renders each item once at full size and lets the layer carry both, which is
+/// why its glyphs are rasterized at a single size wherever the row sits — and
+/// why its scaled rows are visibly softer than a row redrawn at a smaller font.
+///
+/// The row occupies the full list width, exactly as it does on screen, so the
+/// content still insets itself by the style's side padding. `top` is the local
+/// origin, so a caller drawing into a row-sized layer passes `0.0`.
+pub fn draw_row_natural(
+    painter: &mut Painter,
+    row: &SettingsRow,
+    style: &ListStyle,
+    top: f32,
+    height: f32,
+    scheme: &ColorScheme,
+) {
+    draw_row_at(painter, row, style, top, height, 1.0, 1.0, scheme);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw_row_at(
+    painter: &mut Painter,
+    row: &SettingsRow,
+    style: &ListStyle,
+    drawn_top: f32,
+    drawn_height: f32,
+    scale: f32,
+    alpha: f32,
+    scheme: &ColorScheme,
+) {
+    let typography = style.typography;
+    let centre_x = style.width * 0.5;
+    let left = centre_x - (centre_x - style.item_left()) * scale;
+    let width = style.item_width() * scale;
+
+    match row.kind {
+        RowKind::Header => {
+            let face = typography.list_header().scaled(scale);
+            let block = face.block_height();
+            let content = typography.dp(HEADER_TOP_DP) * scale
+                + block
+                + typography.dp(HEADER_BOTTOM_DP) * scale;
+            let offset = (drawn_height - content) * 0.5;
+            draw_text(
+                painter,
+                &row.label,
+                centre_x,
+                drawn_top + offset + typography.dp(HEADER_TOP_DP) * scale,
+                face,
+                super::theme::faded_by_layer(scheme.on_background, alpha),
+                Align::Center,
+            );
+        }
+        RowKind::Label => {
+            let face = typography.list_body().scaled(scale);
+            let mut lines: [&str; MAX_WRAP_LINES] = [""; MAX_WRAP_LINES];
+            let count = wrap_into(painter, &row.label, face, width, &mut lines);
+            let mut y = drawn_top;
+            for line in lines.iter().take(count) {
+                draw_text(
+                    painter,
+                    line,
+                    centre_x,
+                    y,
+                    face,
+                    super::theme::faded_by_layer(scheme.on_surface, alpha),
+                    Align::Center,
+                );
+                y += face.block_height();
+            }
+        }
+        RowKind::Toggle => {
+            let container = if row.checked {
+                scheme.primary_container
+            } else {
+                scheme.surface_container
+            };
+            let content = if row.checked {
+                scheme.on_primary_container
+            } else {
+                scheme.on_surface
+            };
+            plate(
+                painter,
+                left,
+                drawn_top,
+                width,
+                drawn_height,
+                typography,
+                scale,
+                super::theme::faded_by_layer(container, alpha),
+            );
+            let available = label_width(style, RowKind::Toggle) * scale;
+            labels(
+                painter,
+                row,
+                style,
+                left,
+                drawn_top,
+                drawn_height,
+                typography.dp(SWITCH_PAD_Y_DP) * scale,
+                available,
+                scale,
+                super::theme::faded_by_layer(content, alpha),
+                super::theme::faded_by_layer(scheme.on_surface_variant, alpha),
+            );
+            switch(
+                painter,
+                style,
+                left + width
+                    - typography.dp(BUTTON_SIDE_DP) * scale
+                    - typography.dp(SWITCH_WIDTH_DP) * scale,
+                drawn_top + drawn_height * 0.5,
+                scale,
+                alpha,
+                row.checked,
+                scheme,
+            );
+        }
+        RowKind::Action => {
+            plate(
+                painter,
+                left,
+                drawn_top,
+                width,
+                drawn_height,
+                typography,
+                scale,
+                super::theme::faded_by_layer(scheme.primary, alpha),
+            );
+            let available = label_width(style, RowKind::Action) * scale;
+            labels(
+                painter,
+                row,
+                style,
+                left,
+                drawn_top,
+                drawn_height,
+                typography.dp(BUTTON_PAD_Y_DP) * scale,
+                available,
+                scale,
+                super::theme::faded_by_layer(scheme.on_primary, alpha),
+                super::theme::faded_by_layer(scheme.on_primary, alpha * 0.8),
+            );
+        }
+    }
+}
+
+fn plate(
+    painter: &mut Painter,
+    left: f32,
+    top: f32,
+    width: f32,
+    height: f32,
+    typography: Typography,
+    scale: f32,
+    color: Color,
+) {
+    painter.round_rect(
+        left,
+        top,
+        width,
+        height,
+        typography.dp(CORNER_DP) * scale,
+        color,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn labels(
+    painter: &mut Painter,
+    row: &SettingsRow,
+    style: &ListStyle,
+    left: f32,
+    top: f32,
+    height: f32,
+    pad_y: f32,
+    available: f32,
+    scale: f32,
+    label_color: Color,
+    value_color: Color,
+) {
+    let typography = style.typography;
+    let label = typography.button_label().scaled(scale);
+    let secondary = typography.button_secondary().scaled(scale);
+    let mut lines: [&str; MAX_WRAP_LINES] = [""; MAX_WRAP_LINES];
+    let count = wrap_into(painter, &row.label, label, available, &mut lines);
+    let mut content = count as f32 * label.block_height();
+    let mut value: [&str; MAX_WRAP_LINES] = [""; MAX_WRAP_LINES];
+    let mut value_count = 0usize;
+    if !row.value.is_empty() {
+        value_count = wrap_into(painter, &row.value, secondary, available, &mut value);
+        content +=
+            typography.dp(LABEL_SPACER_DP) * scale + value_count as f32 * secondary.block_height();
+    }
+    let text_left = left + typography.dp(BUTTON_SIDE_DP) * scale;
+    let mut y = top + (height - content) * 0.5;
+    let _ = pad_y;
+    for line in lines.iter().take(count) {
+        draw_text(
+            painter,
+            line,
+            text_left,
+            y,
+            label,
+            label_color,
+            Align::Start,
+        );
+        y += label.block_height();
+    }
+    if value_count > 0 {
+        y += typography.dp(LABEL_SPACER_DP) * scale;
+        for line in value.iter().take(value_count) {
+            draw_text(
+                painter,
+                line,
+                text_left,
+                y,
+                secondary,
+                value_color,
+                Align::Start,
+            );
+            y += secondary.block_height();
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn switch(
+    painter: &mut Painter,
+    style: &ListStyle,
+    left: f32,
+    centre_y: f32,
+    scale: f32,
+    alpha: f32,
+    checked: bool,
+    scheme: &ColorScheme,
+) {
+    let typography = style.typography;
+    let width = typography.dp(SWITCH_WIDTH_DP) * scale;
+    let height = typography.dp(SWITCH_HEIGHT_DP) * scale;
+    let track = if checked {
+        scheme.primary
+    } else {
+        scheme.surface_container
+    };
+    painter.round_rect(
+        left,
+        centre_y - height * 0.5,
+        width,
+        height,
+        height * 0.5,
+        super::theme::faded_by_layer(track, alpha),
+    );
+    if !checked {
+        let stroke = typography.dp(SWITCH_TRACK_DP) * scale;
+        painter.round_rect_stroked(
+            left + stroke * 0.5,
+            centre_y - height * 0.5 + stroke * 0.5,
+            width - stroke,
+            height - stroke,
+            (height - stroke) * 0.5,
+            stroke,
+            super::theme::faded_by_layer(scheme.outline, alpha),
+        );
+    }
+    let thumb_radius = typography.dp(if checked {
+        THUMB_CHECKED_DP
+    } else {
+        THUMB_UNCHECKED_DP
+    }) * scale;
+    let padding = height * 0.5 - thumb_radius;
+    let thumb_x = if checked {
+        left + width - thumb_radius - padding
+    } else {
+        left + thumb_radius + padding
+    };
+    let thumb = if checked {
+        scheme.primary_container
+    } else {
+        scheme.outline
+    };
+    painter.dot_px(thumb_x, centre_y, thumb_radius, super::theme::faded_by_layer(thumb, alpha));
+    if checked {
+        let unit = typography.dp(1.0) * scale;
+        let stroke = typography.dp(TICK_STROKE_DP) * scale;
+        for segment in [TICK_BASE, TICK_STICK] {
+            painter.line_px(
+                thumb_x + segment[0] * unit,
+                centre_y + segment[1] * unit,
+                thumb_x + segment[2] * unit,
+                centre_y + segment[3] * unit,
+                stroke,
+                StrokeCap::Round,
+                super::theme::faded_by_layer(scheme.primary, alpha),
+            );
+        }
+    }
+}

--- a/apps/desktop-demo/src/app/cranorbit_credits/mod.rs
+++ b/apps/desktop-demo/src/app/cranorbit_credits/mod.rs
@@ -1,0 +1,156 @@
+//! A round-watch Credits list, as a frame-pacing fixture.
+//!
+//! This is the heaviest text page from a Wear OS app built on Cranpose: ten
+//! rows of wrapped paragraphs on a 454dp round display, each row re-scaled and
+//! re-faded by a scaling-list curve as it travels past the centre line. It is
+//! here because the demo had no page like it — the other tabs are widget trees,
+//! and this is a single `Canvas` redrawing several hundred glyphs per frame,
+//! which is a different shape of load and the one that showed up as slow.
+//!
+//! The layout code below is a **copy**, not a dependency: `draw.rs`, `font.rs`,
+//! `layout.rs`, `theme.rs` and `list.rs` are vendored from the app so the demo
+//! stays self-contained and the framework depends on nothing outside itself.
+//! They are carried whole rather than filleted down to the few paths Credits
+//! touches, so the fixture keeps drawing what the real screen draws; the unused
+//! remainder is what `allow(dead_code)` covers.
+//!
+//! The list scrolls on its own, by elapsed time rather than per frame. Anything
+//! paced per frame travels faster the faster the app runs, which would make a
+//! frame-rate reading partly a measurement of itself.
+
+#![allow(dead_code)]
+
+mod draw;
+mod font;
+mod layout;
+mod list;
+mod rows;
+mod theme;
+
+use cranpose_core::{remember, useState, LaunchedEffectAsync};
+use cranpose_ui::{Alignment, Box as CranposeBox, BoxSpec, Canvas, Modifier, Size};
+use cranpose_ui_graphics::DrawScope;
+use draw::Painter;
+use font::Typography;
+use list::ListStyle;
+use std::cell::RefCell;
+use std::rc::Rc;
+use theme::ColorScheme;
+
+/// The display the screen is laid out for. Drawing it at another size measures
+/// a different page than the one that ships.
+const WATCH_DP: f32 = 454.0;
+/// The Credits screen's own side padding.
+const SIDE_DP: f32 = 30.0;
+/// Rows per second the list travels, so the workload is identical at every
+/// pacing mode.
+const ROWS_PER_SECOND: f32 = 5.0;
+
+/// The `count_primitive` hook the vendored painter calls. The app uses it to
+/// feed a performance overlay; here the frame counter already lives in the
+/// dev overlay, so it costs nothing.
+fn count_primitive() {}
+
+struct CreditsState {
+    rows: Vec<rows::SettingsRow>,
+    slots: Vec<layout::Slot>,
+    scroll: f32,
+    down: bool,
+    last_nanos: u64,
+}
+
+impl CreditsState {
+    fn new() -> Self {
+        Self {
+            rows: rows::credits_rows(),
+            slots: Vec::new(),
+            scroll: 0.0,
+            down: true,
+            last_nanos: 0,
+        }
+    }
+
+    /// Walks the list up and down by elapsed time, reversing at both ends so a
+    /// measurement window of any length stays in motion.
+    fn advance(&mut self, now_nanos: u64) {
+        let last = std::mem::replace(&mut self.last_nanos, now_nanos);
+        if last == 0 || now_nanos <= last {
+            return;
+        }
+        let seconds = ((now_nanos - last) as f32 / 1_000_000_000.0).min(0.25);
+        let limit = (self.rows.len() - 1) as f32;
+        if self.down && self.scroll >= limit {
+            self.down = false;
+        } else if !self.down && self.scroll <= 0.0 {
+            self.down = true;
+        }
+        let step = ROWS_PER_SECOND * seconds;
+        self.scroll = (self.scroll + if self.down { step } else { -step }).clamp(0.0, limit);
+    }
+}
+
+#[cranpose::composable]
+pub fn cranorbit_credits_tab() {
+    let state = remember(|| Rc::new(RefCell::new(CreditsState::new()))).with(|value| value.clone());
+    let frame = useState(|| 0u64);
+
+    let tick_state = state.clone();
+    let tick_frame = frame;
+    LaunchedEffectAsync!((), move |scope| {
+        Box::pin(async move {
+            let clock = scope.runtime().frame_clock();
+            loop {
+                if !scope.is_active() {
+                    break;
+                }
+                let now = clock.next_frame().await;
+                if !scope.is_active() {
+                    break;
+                }
+                tick_state.borrow_mut().advance(now);
+                tick_frame.set(now);
+            }
+        })
+    });
+
+    let draw_state = state.clone();
+    let draw_frame = frame;
+
+    CranposeBox(
+        Modifier::empty().fill_max_size(),
+        BoxSpec::default().content_alignment(Alignment::CENTER),
+        move || {
+            let draw_state = draw_state.clone();
+            let draw_frame = draw_frame;
+            Canvas(
+                Modifier::empty().size(Size::new(WATCH_DP, WATCH_DP)),
+                move |scope: &mut dyn DrawScope| {
+                    let _ = draw_frame.get();
+                    let mut state = draw_state.borrow_mut();
+                    let size = scope.size();
+                    let width = size.width;
+                    let height = size.height;
+                    let radius = width.min(height) * 0.5;
+                    let palette = theme::default_palette();
+                    let style = ListStyle::new(Typography::new(2.0), SIDE_DP, width, height);
+                    let scroll = state.scroll;
+
+                    let mut painter = Painter::new(scope, width * 0.5, height * 0.5, radius);
+                    let CreditsState { rows, slots, .. } = &mut *state;
+                    list::layout_into(&painter, rows, &style, scroll, slots);
+                    list::draw_list(&mut painter, rows, &style, slots, &palette);
+                    if let Some(geometry) =
+                        list::indicator_geometry(slots, style.height, style.gap())
+                    {
+                        list::draw_scroll_indicator(
+                            &mut painter,
+                            geometry,
+                            1.0,
+                            &ColorScheme::of(&palette),
+                        );
+                    }
+                },
+            );
+        },
+    );
+}

--- a/apps/desktop-demo/src/app/cranorbit_credits/mod.rs
+++ b/apps/desktop-demo/src/app/cranorbit_credits/mod.rs
@@ -19,6 +19,13 @@
 //! frame-rate reading partly a measurement of itself.
 
 #![allow(dead_code)]
+// The vendored files are carried as-is, so that refreshing them stays a plain
+// copy. These three lints fire on shapes the source has and the app they come
+// from does not deny; editing them here would make the copy diverge from the
+// thing it exists to mirror.
+#![allow(clippy::excessive_precision)]
+#![allow(clippy::neg_cmp_op_on_partial_ord)]
+#![allow(clippy::too_many_arguments)]
 
 mod draw;
 mod font;

--- a/apps/desktop-demo/src/app/cranorbit_credits/rows.rs
+++ b/apps/desktop-demo/src/app/cranorbit_credits/rows.rs
@@ -1,0 +1,73 @@
+//! The rows the Credits screen is built from.
+//!
+//! Trimmed to what this screen uses. The original carries a `Toggle` kind and
+//! an action enum for the Settings screen; neither appears on Credits, so
+//! neither is here.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RowKind {
+    Header,
+    Toggle,
+    Action,
+    Label,
+}
+
+#[derive(Clone, Debug)]
+pub struct SettingsRow {
+    pub kind: RowKind,
+    pub label: String,
+    pub value: String,
+    pub checked: bool,
+}
+
+impl SettingsRow {
+    fn of(kind: RowKind, label: &str) -> Self {
+        Self {
+            kind,
+            label: label.to_string(),
+            value: String::new(),
+            checked: false,
+        }
+    }
+
+    pub fn header(label: &str) -> Self {
+        Self::of(RowKind::Header, label)
+    }
+
+    pub fn label(label: &str) -> Self {
+        Self::of(RowKind::Label, label)
+    }
+
+    pub fn action(label: &str) -> Self {
+        Self::of(RowKind::Action, label)
+    }
+}
+
+/// The Credits screen's text, verbatim.
+///
+/// The wrapping is what makes this a useful fixture: these are long paragraphs
+/// rather than button labels, so the screen carries several hundred glyphs and
+/// every one of them is re-laid as the scaling curve moves its row.
+pub fn credits_rows() -> Vec<SettingsRow> {
+    let mut rows = vec![
+        SettingsRow::header("ORBIT BREAKER"),
+        SettingsRow::label("Version 1.0.0"),
+        SettingsRow::label("Designed and built for Wear OS."),
+        SettingsRow::label("Every graphic and sound in this game is generated inside the project."),
+        SettingsRow::label(
+            "Built with Rust, the Cranpose UI framework, and wgpu, under the Apache License 2.0 \
+             or the MIT License.",
+        ),
+        SettingsRow::label(
+            "Rust, winit, serde and log by their authors, under the Apache License 2.0 or MIT.",
+        ),
+        SettingsRow::label(
+            "Scores, settings, and saved runs stay on this watch. The game's own code makes no \
+             network call; Google Play is used for the price, the purchase, and the restore.",
+        ),
+        SettingsRow::label("The purchase stays with this watch once Google Play reports it."),
+        SettingsRow::label("Privacy policy: orbitbreaker.dmitrysamoylenko.in/privacy"),
+    ];
+    rows.push(SettingsRow::action("Back"));
+    rows
+}

--- a/apps/desktop-demo/src/app/cranorbit_credits/theme.rs
+++ b/apps/desktop-demo/src/app/cranorbit_credits/theme.rs
@@ -1,0 +1,374 @@
+use cranpose_ui::Color;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PaletteChoice {
+    Default,
+    Deuteranopia,
+    Tritanopia,
+    Monochrome,
+}
+
+impl PaletteChoice {
+    pub const ALL: [PaletteChoice; 4] = [
+        PaletteChoice::Default,
+        PaletteChoice::Deuteranopia,
+        PaletteChoice::Tritanopia,
+        PaletteChoice::Monochrome,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            PaletteChoice::Default => "DEFAULT",
+            PaletteChoice::Deuteranopia => "DEUTER",
+            PaletteChoice::Tritanopia => "TRITAN",
+            PaletteChoice::Monochrome => "MONO",
+        }
+    }
+
+    pub fn from_ordinal(value: usize) -> PaletteChoice {
+        Self::ALL[value.min(Self::ALL.len() - 1)]
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GamePalette {
+    pub background: Color,
+    pub vignette: Color,
+    pub rail: Color,
+    pub rail_accent: Color,
+    pub paddle: Color,
+    pub paddle_edge: Color,
+    pub paddle_shield: Color,
+    pub ball_core: Color,
+    pub ball_glow: Color,
+    pub standard: Color,
+    pub standard_edge: Color,
+    pub armored: Color,
+    pub armor_seam: Color,
+    pub explosive: Color,
+    pub phase: Color,
+    pub relay: Color,
+    pub danger: Color,
+    pub success: Color,
+    pub hud: Color,
+    pub hud_dim: Color,
+    pub field: Color,
+    pub portal: Color,
+}
+
+const DEFAULT_PALETTE: GamePalette = GamePalette {
+    // Wear OS asks a full-screen app for a pure black base so the OLED panel
+    // can switch those pixels off; the old 0x03050A read as a lit near-black
+    // at the display edge. The vignette above it is unchanged, so only the
+    // rim goes black. Deuteranopia and tritanopia inherit this field.
+    background: Color::from_rgb_u8(0x00, 0x00, 0x00),
+    vignette: Color::from_rgb_u8(0x0A, 0x12, 0x20),
+    rail: Color::from_rgb_u8(0x16, 0x32, 0x4C),
+    rail_accent: Color::from_rgb_u8(0x2A, 0x6E, 0x96),
+    paddle: Color::from_rgb_u8(0xB9, 0xF2, 0xFF),
+    paddle_edge: Color::from_rgb_u8(0xFF, 0xFF, 0xFF),
+    paddle_shield: Color::from_rgb_u8(0x7D, 0xF9, 0xC8),
+    ball_core: Color::from_rgb_u8(0xFF, 0xFF, 0xFF),
+    ball_glow: Color::from_rgb_u8(0x56, 0xE0, 0xFF),
+    standard: Color::from_rgb_u8(0x2F, 0xA8, 0xF5),
+    standard_edge: Color::from_rgb_u8(0x9B, 0xE0, 0xFF),
+    armored: Color::from_rgb_u8(0x9B, 0x6B, 0xFF),
+    armor_seam: Color::from_rgb_u8(0xE4, 0xD4, 0xFF),
+    explosive: Color::from_rgb_u8(0xFF, 0x9A, 0x2E),
+    phase: Color::from_rgb_u8(0xFF, 0x5F, 0xD2),
+    relay: Color::from_rgb_u8(0x5C, 0xF2, 0xC8),
+    danger: Color::from_rgb_u8(0xFF, 0x4B, 0x32),
+    success: Color::from_rgb_u8(0xB9, 0xFF, 0xCB),
+    hud: Color::from_rgb_u8(0xDF, 0xF6, 0xFF),
+    hud_dim: Color::from_rgb_u8(0x5E, 0x7E, 0x93),
+    field: Color::from_rgb_u8(0x2C, 0x4C, 0x8A),
+    portal: Color::from_rgb_u8(0x66, 0xD9, 0xFF),
+};
+
+const DEUTERANOPIA_PALETTE: GamePalette = GamePalette {
+    standard: Color::from_rgb_u8(0x3F, 0x9C, 0xFF),
+    standard_edge: Color::from_rgb_u8(0xB9, 0xDC, 0xFF),
+    armored: Color::from_rgb_u8(0x9A, 0x7B, 0xFF),
+    armor_seam: Color::from_rgb_u8(0xE7, 0xDB, 0xFF),
+    explosive: Color::from_rgb_u8(0xFF, 0xC2, 0x4B),
+    phase: Color::from_rgb_u8(0xFF, 0x7B, 0xE0),
+    relay: Color::from_rgb_u8(0x7F, 0xE8, 0xFF),
+    danger: Color::from_rgb_u8(0xFF, 0x7A, 0x45),
+    success: Color::from_rgb_u8(0xCF, 0xE9, 0xFF),
+    ball_glow: Color::from_rgb_u8(0x7E, 0xD4, 0xFF),
+    field: Color::from_rgb_u8(0x3A, 0x5C, 0x9E),
+    portal: Color::from_rgb_u8(0x8A, 0xD7, 0xFF),
+    ..DEFAULT_PALETTE
+};
+
+const TRITANOPIA_PALETTE: GamePalette = GamePalette {
+    standard: Color::from_rgb_u8(0xFF, 0x6B, 0x8A),
+    standard_edge: Color::from_rgb_u8(0xFF, 0xC6, 0xD2),
+    armored: Color::from_rgb_u8(0xB0, 0x7B, 0xFF),
+    armor_seam: Color::from_rgb_u8(0xEB, 0xDB, 0xFF),
+    explosive: Color::from_rgb_u8(0xFF, 0x9C, 0x6B),
+    phase: Color::from_rgb_u8(0x7B, 0xE8, 0xFF),
+    relay: Color::from_rgb_u8(0x8C, 0xFF, 0xB4),
+    danger: Color::from_rgb_u8(0xFF, 0x3B, 0x5C),
+    success: Color::from_rgb_u8(0xD7, 0xFF, 0xE4),
+    ball_core: Color::from_rgb_u8(0xFF, 0xFF, 0xFF),
+    ball_glow: Color::from_rgb_u8(0xFF, 0xA8, 0xC0),
+    rail: Color::from_rgb_u8(0x4A, 0x24, 0x36),
+    rail_accent: Color::from_rgb_u8(0x9C, 0x4A, 0x66),
+    field: Color::from_rgb_u8(0x8A, 0x3A, 0x56),
+    portal: Color::from_rgb_u8(0x9C, 0xE8, 0xFF),
+    ..DEFAULT_PALETTE
+};
+
+const MONOCHROME_PALETTE: GamePalette = GamePalette {
+    background: Color::from_rgb_u8(0x00, 0x00, 0x00),
+    vignette: Color::from_rgb_u8(0x0E, 0x0E, 0x0E),
+    rail: Color::from_rgb_u8(0x2A, 0x2A, 0x2A),
+    rail_accent: Color::from_rgb_u8(0x5A, 0x5A, 0x5A),
+    paddle: Color::from_rgb_u8(0xFF, 0xFF, 0xFF),
+    paddle_edge: Color::from_rgb_u8(0xFF, 0xFF, 0xFF),
+    paddle_shield: Color::from_rgb_u8(0xDD, 0xDD, 0xDD),
+    ball_core: Color::from_rgb_u8(0xFF, 0xFF, 0xFF),
+    ball_glow: Color::from_rgb_u8(0xBB, 0xBB, 0xBB),
+    standard: Color::from_rgb_u8(0x8E, 0x8E, 0x8E),
+    standard_edge: Color::from_rgb_u8(0xE4, 0xE4, 0xE4),
+    armored: Color::from_rgb_u8(0x5E, 0x5E, 0x5E),
+    armor_seam: Color::from_rgb_u8(0xF2, 0xF2, 0xF2),
+    explosive: Color::from_rgb_u8(0xCF, 0xCF, 0xCF),
+    phase: Color::from_rgb_u8(0xA6, 0xA6, 0xA6),
+    relay: Color::from_rgb_u8(0xFF, 0xFF, 0xFF),
+    danger: Color::from_rgb_u8(0xFF, 0xFF, 0xFF),
+    success: Color::from_rgb_u8(0xFF, 0xFF, 0xFF),
+    hud: Color::from_rgb_u8(0xF0, 0xF0, 0xF0),
+    hud_dim: Color::from_rgb_u8(0x7A, 0x7A, 0x7A),
+    field: Color::from_rgb_u8(0x3A, 0x3A, 0x3A),
+    portal: Color::from_rgb_u8(0xD0, 0xD0, 0xD0),
+};
+
+pub fn palette_for(choice: PaletteChoice, high_contrast: bool) -> GamePalette {
+    let base = match choice {
+        PaletteChoice::Default => DEFAULT_PALETTE,
+        PaletteChoice::Deuteranopia => DEUTERANOPIA_PALETTE,
+        PaletteChoice::Tritanopia => TRITANOPIA_PALETTE,
+        PaletteChoice::Monochrome => MONOCHROME_PALETTE,
+    };
+    if !high_contrast {
+        return base;
+    }
+    GamePalette {
+        background: Color::BLACK,
+        vignette: Color::BLACK,
+        rail: brighten(base.rail, 0.35),
+        rail_accent: brighten(base.rail_accent, 0.35),
+        standard: brighten(base.standard, 0.28),
+        standard_edge: Color::WHITE,
+        armored: brighten(base.armored, 0.28),
+        armor_seam: Color::WHITE,
+        explosive: brighten(base.explosive, 0.24),
+        phase: brighten(base.phase, 0.24),
+        relay: brighten(base.relay, 0.24),
+        hud: Color::WHITE,
+        hud_dim: brighten(base.hud_dim, 0.4),
+        field: brighten(base.field, 0.45),
+        portal: brighten(base.portal, 0.3),
+        danger: brighten(base.danger, 0.3),
+        success: brighten(base.success, 0.3),
+        paddle: brighten(base.paddle, 0.25),
+        paddle_edge: brighten(base.paddle_edge, 0.25),
+        ball_core: Color::WHITE,
+        paddle_shield: brighten(base.paddle_shield, 0.3),
+        ..base
+    }
+}
+
+pub fn brighten(color: Color, amount: f32) -> Color {
+    Color(
+        (color.0 + (1.0 - color.0) * amount).clamp(0.0, 1.0),
+        (color.1 + (1.0 - color.1) * amount).clamp(0.0, 1.0),
+        (color.2 + (1.0 - color.2) * amount).clamp(0.0, 1.0),
+        color.3,
+    )
+}
+
+pub fn lerp_color(from: Color, to: Color, t: f32) -> Color {
+    let f = t.clamp(0.0, 1.0);
+    Color(
+        from.0 + (to.0 - from.0) * f,
+        from.1 + (to.1 - from.1) * f,
+        from.2 + (to.2 - from.2) * f,
+        from.3 + (to.3 - from.3) * f,
+    )
+}
+
+pub fn pack(color: Color) -> u32 {
+    let to_byte = |value: f32| (value.clamp(0.0, 1.0) * 255.0 + 0.5) as u32;
+    (to_byte(color.3) << 24) | (to_byte(color.0) << 16) | (to_byte(color.1) << 8) | to_byte(color.2)
+}
+
+pub fn unpack(value: u32) -> Color {
+    Color::from_rgba_u8(
+        ((value >> 16) & 0xFF) as u8,
+        ((value >> 8) & 0xFF) as u8,
+        (value & 0xFF) as u8,
+        ((value >> 24) & 0xFF) as u8,
+    )
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ColorScheme {
+    pub primary: Color,
+    pub primary_container: Color,
+    pub on_primary: Color,
+    pub on_primary_container: Color,
+    pub surface_container: Color,
+    pub on_surface: Color,
+    pub on_surface_variant: Color,
+    pub outline: Color,
+    pub background: Color,
+    pub on_background: Color,
+}
+
+impl ColorScheme {
+    pub fn of(palette: &GamePalette) -> ColorScheme {
+        ColorScheme {
+            primary: palette.paddle,
+            primary_container: mix(palette.standard, palette.background, 0.68),
+            on_primary: palette.background,
+            on_primary_container: palette.hud,
+            surface_container: mix(palette.rail, palette.background, 0.55),
+            on_surface: palette.hud,
+            on_surface_variant: palette.hud_dim,
+            outline: mix(palette.rail_accent, palette.background, 0.3),
+            background: palette.background,
+            on_background: palette.hud,
+        }
+    }
+}
+
+/// The same colour at a given CIE L\*.
+///
+/// Wear Material 3 builds its scroll indicator out of one colour taken to two
+/// lightnesses — `setLuminance(onBackground, 80f)` for the thumb and
+/// `setLuminance(onBackground, 20f)` for the track — so the port needs the
+/// same operation rather than an alpha over the background, which lands
+/// somewhere else entirely. Hue and chroma are carried through untouched;
+/// only L\* moves.
+pub fn with_luminance(color: Color, l_star: f32) -> Color {
+    let (_, a, b) = to_lab(color);
+    let (r, g, bl) = from_lab(l_star, a, b);
+    Color(r, g, bl, color.3)
+}
+
+const WHITE_X: f32 = 0.950_489;
+const WHITE_Z: f32 = 1.088_840;
+
+fn to_linear(channel: f32) -> f32 {
+    if channel <= 0.040_45 {
+        channel / 12.92
+    } else {
+        ((channel + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+fn to_srgb(channel: f32) -> f32 {
+    let value = if channel <= 0.003_130_8 {
+        channel * 12.92
+    } else {
+        1.055 * channel.powf(1.0 / 2.4) - 0.055
+    };
+    value.clamp(0.0, 1.0)
+}
+
+fn lab_f(t: f32) -> f32 {
+    const DELTA: f32 = 6.0 / 29.0;
+    if t > DELTA * DELTA * DELTA {
+        t.cbrt()
+    } else {
+        t / (3.0 * DELTA * DELTA) + 4.0 / 29.0
+    }
+}
+
+fn lab_f_inverse(t: f32) -> f32 {
+    const DELTA: f32 = 6.0 / 29.0;
+    if t > DELTA {
+        t * t * t
+    } else {
+        3.0 * DELTA * DELTA * (t - 4.0 / 29.0)
+    }
+}
+
+fn to_lab(color: Color) -> (f32, f32, f32) {
+    let r = to_linear(color.0);
+    let g = to_linear(color.1);
+    let b = to_linear(color.2);
+    let x = (0.412_456 * r + 0.357_576 * g + 0.180_437 * b) / WHITE_X;
+    let y = 0.212_673 * r + 0.715_152 * g + 0.072_175 * b;
+    let z = (0.019_334 * r + 0.119_192 * g + 0.950_304 * b) / WHITE_Z;
+    let (fx, fy, fz) = (lab_f(x), lab_f(y), lab_f(z));
+    (116.0 * fy - 16.0, 500.0 * (fx - fy), 200.0 * (fy - fz))
+}
+
+fn from_lab(l: f32, a: f32, b: f32) -> (f32, f32, f32) {
+    let fy = (l + 16.0) / 116.0;
+    let fx = fy + a / 500.0;
+    let fz = fy - b / 200.0;
+    let x = lab_f_inverse(fx) * WHITE_X;
+    let y = lab_f_inverse(fy);
+    let z = lab_f_inverse(fz) * WHITE_Z;
+    let r = 3.240_454 * x - 1.537_138 * y - 0.498_531 * z;
+    let g = -0.969_266 * x + 1.876_011 * y + 0.041_556 * z;
+    let bl = 0.055_643 * x - 0.204_026 * y + 1.057_225 * z;
+    (to_srgb(r), to_srgb(g), to_srgb(bl))
+}
+
+/// A colour ready to be drawn at `alpha` the way Compose's graphics layer
+/// delivers it.
+///
+/// Every `ScalingLazyColumn` row carries a `graphicsLayer { alpha }`, and a
+/// layer below full opacity is rendered into an **8-bit** offscreen buffer and
+/// then composited. So the row's colours are quantised to whole channel values
+/// *before* the alpha multiplies them, and folding the alpha into a float
+/// colour instead lands up to one level away on every pixel of every faded
+/// row. `surface_container` is `mix(rail, background, 0.55)` = (9.9, 22.5,
+/// 34.2); at alpha 0.9 Compose draws (9, 21, 31) where the unquantised product
+/// rounds to (9, 20, 31). That single level covered thirty per cent of the
+/// scrolled settings screen.
+///
+/// Quantising at full opacity is a no-op — `round(round(c))` is `round(c)` —
+/// so this is safe to use for every row rather than only the faded ones.
+///
+/// **This models a layer; it is not one.** Where a row's own content overlaps
+/// — a label over its capsule, a switch thumb over its track — Compose
+/// composites the two opaquely inside the layer and fades the result, while
+/// drawing each primitive at `alpha` fades them separately and leaves the
+/// capsule showing through the glyph edges. That difference is small (it needs
+/// partial glyph coverage to appear at all) and it needs a real offscreen
+/// layer to fix.
+pub fn faded_by_layer(color: Color, alpha: f32) -> Color {
+    Color(
+        quantise(color.0),
+        quantise(color.1),
+        quantise(color.2),
+        color.3 * alpha,
+    )
+}
+
+/// One channel snapped to the 8-bit value a layer buffer would hold.
+fn quantise(channel: f32) -> f32 {
+    (channel.clamp(0.0, 1.0) * 255.0).round() / 255.0
+}
+
+pub fn mix(color: Color, towards: Color, amount: f32) -> Color {
+    let t = amount.clamp(0.0, 1.0);
+    Color(
+        color.0 + (towards.0 - color.0) * t,
+        color.1 + (towards.1 - color.1) * t,
+        color.2 + (towards.2 - color.2) * t,
+        1.0,
+    )
+}
+
+/// The palette the Credits screen ships with.
+pub fn default_palette() -> GamePalette {
+    DEFAULT_PALETTE
+}

--- a/crates/cranpose-app-shell/src/lib.rs
+++ b/crates/cranpose-app-shell/src/lib.rs
@@ -662,6 +662,24 @@ where
         self.mark_dirty();
     }
 
+    /// Where the dev overlay draws the control for `mode`, in logical pixels.
+    ///
+    /// The overlay is drawn by the renderer rather than composed, so it has no
+    /// semantics for a test to search. Without this a test that wants to press
+    /// a pacing control has to hard-code a coordinate and silently starts
+    /// passing against empty space the moment the overlay's text changes.
+    pub fn dev_overlay_control_center(&self, mode: FramePacingMode) -> Option<(f32, f32)> {
+        self.dev_overlay_controls
+            .iter()
+            .find(|control| control.mode == mode)
+            .map(|control| {
+                (
+                    control.bounds.x + control.bounds.width * 0.5,
+                    control.bounds.y + control.bounds.height * 0.5,
+                )
+            })
+    }
+
     pub fn handle_dev_overlay_click(&mut self, x: f32, y: f32) -> Option<FramePacingMode> {
         if !self.dev_options.frame_pacing_controls {
             return None;

--- a/crates/cranpose-app-shell/src/lib.rs
+++ b/crates/cranpose-app-shell/src/lib.rs
@@ -680,17 +680,27 @@ where
             })
     }
 
-    pub fn handle_dev_overlay_click(&mut self, x: f32, y: f32) -> Option<FramePacingMode> {
+    /// Take a press on a dev-overlay pacing control, if it lands on one.
+    ///
+    /// Every pointer press runs through here before the composition sees it, so
+    /// the controls answer to whatever produced the press: a mouse, a finger,
+    /// or a robot injecting one. A platform shell that hit-tested the overlay
+    /// itself would only make the controls work for the one input path it owns
+    /// -- which is how they came to do nothing under a robot at all.
+    pub(crate) fn dev_overlay_press(&mut self, x: f32, y: f32) -> bool {
         if !self.dev_options.frame_pacing_controls {
-            return None;
+            return false;
         }
-        let mode = self
+        let Some(mode) = self
             .dev_overlay_controls
             .iter()
             .find(|control| control.bounds.contains(x, y))
-            .map(|control| control.mode)?;
+            .map(|control| control.mode)
+        else {
+            return false;
+        };
         self.set_frame_pacing_mode(mode);
-        Some(mode)
+        true
     }
 
     fn invalidate_dev_overlay_text(&mut self) {

--- a/crates/cranpose-app-shell/src/shell_input.rs
+++ b/crates/cranpose-app-shell/src/shell_input.rs
@@ -215,6 +215,12 @@ where
 
     /// Dispatch primary-button down with an already resolved event timestamp.
     pub fn pointer_pressed_at_event_time(&mut self, event_time: PointerEventTime) -> bool {
+        // The dev overlay is drawn over the composition and is not part of it,
+        // so it gets the press first and keeps it. Nothing below it is armed:
+        // no button state, no hit path, so the matching release is inert.
+        if self.dev_overlay_press(self.cursor.0, self.cursor.1) {
+            return true;
+        }
         let _event_handler = enter_event_handler_scope();
         let app_context = Rc::clone(&self.app_context);
         let result = app_context.enter(|| {

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -5128,6 +5128,72 @@ fn dev_overlay_reuses_text_inside_refresh_window_and_updates_after_it() {
 }
 
 #[test]
+fn a_press_on_a_pacing_control_changes_the_mode_whatever_produced_the_press() {
+    let _guard = test_guard();
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(TestRenderer::default(), root_key, box_content);
+    shell.set_viewport(1200.0, 800.0);
+    shell.set_dev_options(DevOptions {
+        fps_counter: true,
+        frame_pacing_controls: true,
+        ..Default::default()
+    });
+    shell.update();
+
+    assert_eq!(shell.frame_pacing_mode(), FramePacingMode::Vsync);
+    let (x, y) = shell
+        .dev_overlay_control_center(FramePacingMode::NoVsync)
+        .expect("the overlay must lay out a control for every pacing mode");
+
+    // A robot injects presses straight into the shell, exactly like a touch
+    // screen does. When the overlay was hit-tested by the desktop shell's mouse
+    // path instead, every one of those presses went through the controls into
+    // the app underneath and the mode never changed.
+    shell.set_cursor(x, y);
+    assert!(
+        shell.pointer_pressed(),
+        "a press on a pacing control is the shell's to take"
+    );
+    shell.pointer_released_at_position(x, y);
+
+    assert_eq!(shell.frame_pacing_mode(), FramePacingMode::NoVsync);
+    assert!(
+        shell.needs_redraw(),
+        "the overlay has to redraw to show which mode is now selected"
+    );
+
+    // A press that misses every control is the app's, as before.
+    shell.update();
+    shell.set_cursor(x, y + 400.0);
+    shell.pointer_pressed();
+    shell.pointer_released_at_position(x, y + 400.0);
+    assert_eq!(shell.frame_pacing_mode(), FramePacingMode::NoVsync);
+}
+
+#[test]
+fn pacing_controls_stay_out_of_the_way_when_they_are_switched_off() {
+    let _guard = test_guard();
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(TestRenderer::default(), root_key, box_content);
+    shell.set_viewport(1200.0, 800.0);
+    shell.set_dev_options(DevOptions {
+        fps_counter: true,
+        ..Default::default()
+    });
+    shell.update();
+
+    assert!(
+        shell
+            .dev_overlay_control_center(FramePacingMode::NoVsync)
+            .is_none(),
+        "an overlay without pacing controls must not lay any out"
+    );
+    shell.set_cursor(1000.0, 12.0);
+    shell.pointer_pressed();
+    assert_eq!(shell.frame_pacing_mode(), FramePacingMode::Vsync);
+}
+
+#[test]
 fn pointer_invalidation_without_scene_changes_skips_scene_rebuild() {
     let _guard = test_guard();
     let root_key = location_key(file!(), line!(), column!());

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -543,6 +543,7 @@ struct App {
     /// test measuring whether NoVSync frees the loop measures the harness
     /// instead of the app, and passes against a build where NoVSync does
     /// nothing at all. A driver turns this off around a measurement window.
+    #[cfg(feature = "robot")]
     robot_force_poll: bool,
     primary_surface_dirty: bool,
     /// True while the very first frame still owes the surface a present. macOS
@@ -621,6 +622,7 @@ impl App {
             frame_pacing_mode,
             last_frame_start_time: None,
             primary_redraw_pending: false,
+            #[cfg(feature = "robot")]
             robot_force_poll: true,
             primary_surface_dirty: false,
             primary_initial_present_pending: false,

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -535,6 +535,15 @@ struct App {
     frame_pacing_mode: FramePacingMode,
     last_frame_start_time: Option<Instant>,
     primary_redraw_pending: bool,
+    /// Whether a robot-driven run pins the event loop to `ControlFlow::Poll`.
+    ///
+    /// Polling keeps robot commands serviced promptly, which is what a driver
+    /// wants almost all of the time. It is also indistinguishable, from the
+    /// loop's point of view, from the app itself asking to free-run -- so a
+    /// test measuring whether NoVSync frees the loop measures the harness
+    /// instead of the app, and passes against a build where NoVSync does
+    /// nothing at all. A driver turns this off around a measurement window.
+    robot_force_poll: bool,
     primary_surface_dirty: bool,
     /// True while the very first frame still owes the surface a present. macOS
     /// can drop the `request_redraw` issued during `resumed`, leaving a static
@@ -612,6 +621,7 @@ impl App {
             frame_pacing_mode,
             last_frame_start_time: None,
             primary_redraw_pending: false,
+            robot_force_poll: true,
             primary_surface_dirty: false,
             primary_initial_present_pending: false,
             vsync_interval: default_vsync_interval(),
@@ -4970,6 +4980,16 @@ impl ApplicationHandler for App {
                     RobotCommand::GetFpsStats => {
                         let _ = controller.tx.send(RobotResponse::FpsStats(app.fps_stats()));
                     }
+                    RobotCommand::SetPollForcing(enabled) => {
+                        self.robot_force_poll = enabled;
+                        let _ = controller.tx.send(RobotResponse::Ok);
+                    }
+                    RobotCommand::GetPacingControlCenter(mode) => {
+                        let center = app.dev_overlay_control_center(mode);
+                        let _ = controller
+                            .tx
+                            .send(RobotResponse::PacingControlCenter(center));
+                    }
                     RobotCommand::ResetFpsStats => {
                         app.reset_fps_stats();
                         let _ = controller.tx.send(RobotResponse::Ok);
@@ -5435,7 +5455,7 @@ impl ApplicationHandler for App {
 
         // Smart ControlFlow: only Poll when necessary
         #[cfg(feature = "robot")]
-        let robot_needs_poll = self.robot_controller.is_some();
+        let robot_needs_poll = self.robot_controller.is_some() && self.robot_force_poll;
 
         #[cfg(not(feature = "robot"))]
         let robot_needs_poll = false;

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -141,8 +141,8 @@ struct RobotScrollSequence {
 
 #[cfg(feature = "robot")]
 impl RobotController {
-    fn new() -> (Self, Robot) {
-        let (channel, robot) = RobotChannel::new();
+    fn new(wake_event_loop: impl Fn() + Send + Sync + 'static) -> (Self, Robot) {
+        let (channel, robot) = RobotChannel::new(wake_event_loop);
         let RobotChannel { rx, tx } = channel;
 
         let controller = RobotController {
@@ -198,6 +198,24 @@ impl RobotController {
         self.idle_structure_clean_frames = 0;
     }
 
+    /// Whether the driver is waiting on something the loop has to turn to give.
+    ///
+    /// Everything here is a state machine that advances one step per
+    /// `about_to_wait`: a command staged for this iteration, an idle wait, a
+    /// frame the driver asked for, a scroll sequence mid-flight. While any of
+    /// them is live the loop must keep turning. When none is, the driver is
+    /// between commands and the loop is free to pace like the app it is
+    /// running -- which is the only state in which a frame-rate reading from a
+    /// robot test means anything.
+    fn awaiting_progress(&mut self) -> bool {
+        self.waiting_for_idle
+            || self.waiting_for_present_generation.is_some()
+            || self.waiting_for_pump_present_generation.is_some()
+            || self.scroll_sequence.is_some()
+            || self.synthetic_primary_down
+            || self.stage_pending_command()
+    }
+
     fn record_idle_update_result(&mut self, result: FrameUpdateResult) {
         if !self.waiting_for_idle {
             return;
@@ -236,7 +254,6 @@ struct NativeWindowSurface {
     platform: DesktopWinitPlatform,
     last_cursor_position: Option<(f32, f32)>,
     last_cursor_physical_position: Option<PhysicalPosition<f64>>,
-    frame_pacing_mode: FramePacingMode,
     last_frame_start_time: Option<Instant>,
     vsync_interval: Duration,
     pending_outer_positions: PendingNativeWindowPositions,
@@ -474,7 +491,7 @@ impl PendingNativeWindowPositions {
 
 impl NativeWindowSurface {
     fn frame_interval(&self) -> Option<Duration> {
-        frame_interval_for_mode(self.frame_pacing_mode, self.vsync_interval)
+        frame_interval_for_mode(self.app.frame_pacing_mode(), self.vsync_interval)
     }
 }
 
@@ -532,19 +549,16 @@ struct App {
     launch_error: Rc<RefCell<Option<LaunchError>>>,
     /// Event-loop wake path used when the primary declaration host is hidden.
     event_proxy: EventLoopProxy,
-    frame_pacing_mode: FramePacingMode,
+    /// The pacing mode the surfaces and this loop are currently configured for.
+    ///
+    /// The app shell owns the mode itself: it draws the dev overlay and takes
+    /// the presses that change it. This is only the loop's record of what it
+    /// has already applied, so it can notice a change and reconfigure. Treating
+    /// it as a second source of truth is what let a run report `[NoVSync]` in
+    /// the overlay while the swapchain and the frame cap still followed vsync.
+    applied_frame_pacing_mode: FramePacingMode,
     last_frame_start_time: Option<Instant>,
     primary_redraw_pending: bool,
-    /// Whether a robot-driven run pins the event loop to `ControlFlow::Poll`.
-    ///
-    /// Polling keeps robot commands serviced promptly, which is what a driver
-    /// wants almost all of the time. It is also indistinguishable, from the
-    /// loop's point of view, from the app itself asking to free-run -- so a
-    /// test measuring whether NoVSync frees the loop measures the harness
-    /// instead of the app, and passes against a build where NoVSync does
-    /// nothing at all. A driver turns this off around a measurement window.
-    #[cfg(feature = "robot")]
-    robot_force_poll: bool,
     primary_surface_dirty: bool,
     /// True while the very first frame still owes the surface a present. macOS
     /// can drop the `request_redraw` issued during `resumed`, leaving a static
@@ -572,7 +586,7 @@ impl App {
             .map(crate::recorder::InputRecorder::new);
         #[cfg(feature = "robot")]
         let robot_app_hook = settings.robot_app_hook.take();
-        let frame_pacing_mode = settings.frame_pacing_mode;
+        let applied_frame_pacing_mode = settings.frame_pacing_mode;
 
         // Wrap the app content once with the platform environment (system
         // theme, insets) so every composition — primary or native sub-window —
@@ -619,11 +633,9 @@ impl App {
             recorder,
             launch_error,
             event_proxy,
-            frame_pacing_mode,
+            applied_frame_pacing_mode,
             last_frame_start_time: None,
             primary_redraw_pending: false,
-            #[cfg(feature = "robot")]
-            robot_force_poll: true,
             primary_surface_dirty: false,
             primary_initial_present_pending: false,
             vsync_interval: default_vsync_interval(),
@@ -642,8 +654,64 @@ impl App {
         event_loop.exit();
     }
 
+    /// The mode the app shell currently reports, which is the only copy that
+    /// matters: it is what the overlay draws and what a press on it changes.
+    fn frame_pacing_mode(&self) -> FramePacingMode {
+        self.app
+            .as_ref()
+            .map_or(self.settings.frame_pacing_mode, |app| {
+                app.frame_pacing_mode()
+            })
+    }
+
     fn frame_interval(&self) -> Option<Duration> {
-        frame_interval_for_mode(self.frame_pacing_mode, self.vsync_interval)
+        frame_interval_for_mode(self.frame_pacing_mode(), self.vsync_interval)
+    }
+
+    /// Follow the app shell's pacing mode onto every surface this loop drives.
+    ///
+    /// A mode change reaches the shell through an ordinary pointer press, from
+    /// whatever produced it, so the loop cannot be told about it at one input
+    /// call site — it observes the shell instead. Until the surface is
+    /// reconfigured the swapchain still paces on the display it was built for,
+    /// which is a `[NoVSync]` overlay over a loop that is still waiting for
+    /// vsync in `get_current_texture`.
+    fn sync_frame_pacing(&mut self) {
+        let mode = self.frame_pacing_mode();
+        if mode == self.applied_frame_pacing_mode {
+            return;
+        }
+        self.applied_frame_pacing_mode = mode;
+
+        if let (Some(app), Some(surface), Some(surface_config)) =
+            (&mut self.app, &self.surface, &mut self.surface_config)
+        {
+            apply_frame_pacing_mode(
+                app,
+                surface,
+                surface_config,
+                self.surface_caps.as_ref(),
+                mode,
+            );
+        }
+        // The frame-cap anchor belongs to the mode that set it; a cap measured
+        // from the previous mode's cadence would hold the first frame back.
+        self.last_frame_start_time = None;
+        if let Some(window) = self.window.clone() {
+            request_redraw_once(&window, &mut self.primary_redraw_pending);
+        }
+
+        for native in self.native_windows.values_mut() {
+            apply_frame_pacing_mode(
+                &mut native.app,
+                &native.surface,
+                &mut native.surface_config,
+                Some(&native.surface_caps),
+                mode,
+            );
+            native.last_frame_start_time = None;
+            native.window.request_redraw();
+        }
     }
 
     fn refresh_native_window_requests(&mut self) {
@@ -660,6 +728,15 @@ impl App {
 
     fn handle_primary_frame_requested(&mut self, event_loop: &dyn ActiveEventLoop) {
         let registry = Rc::clone(&self.native_window_registry);
+        let frame_interval = self.frame_interval();
+        // A host with no surface still has a pacing mode. Rendering here on
+        // every frame-waker wake regardless of the cap is a host that runs flat
+        // out in every mode, and a frame rate measured on one says nothing
+        // about the mode it was measured in.
+        let waiting_for_frame_cap = self
+            .last_frame_start_time
+            .and_then(|started_at| frame_interval.map(|interval| started_at + interval))
+            .is_some_and(|deadline| deadline > Instant::now());
         let direct_declaration_update = {
             let Some(app) = &mut self.app else {
                 return;
@@ -672,29 +749,34 @@ impl App {
                 self.settings.primary_window_visible,
                 self.settings.headless,
                 needs_redraw,
-                false,
+                waiting_for_frame_cap,
             );
             if direct_declaration_update {
                 trace_native_window(format_args!(
                     "primary declaration host proxy update visible={} headless={}",
                     self.settings.primary_window_visible, self.settings.headless
                 ));
-                let frame_started_at = Instant::now();
-                let update_result = update_app_with_native_window_registry(app, &registry);
+                let update_result = update_declaration_host_frame(
+                    app,
+                    &registry,
+                    &mut self.last_frame_start_time,
+                    frame_interval,
+                );
                 #[cfg(feature = "robot")]
                 if let Some(controller) = &mut self.robot_controller {
                     controller.record_idle_update_result(update_result);
                 }
-                if update_result.visual_changed {
-                    app.record_presented_frame(frame_started_at, Instant::now());
-                    self.last_frame_start_time = Some(frame_started_at);
-                }
+                #[cfg(not(feature = "robot"))]
+                let _ = update_result;
             }
             direct_declaration_update
         };
 
         if direct_declaration_update {
             self.sync_native_windows(event_loop);
+        } else if waiting_for_frame_cap {
+            // `about_to_wait` owns the deadline; it schedules the wake that
+            // produces this frame once the cap has run out.
         } else if let Some(window) = &self.window {
             request_redraw_once(window, &mut self.primary_redraw_pending);
         }
@@ -1329,7 +1411,8 @@ impl App {
         ));
         let surface_caps = surface.get_capabilities(&context.adapter);
         let surface_format = select_surface_format(&surface_caps)?;
-        let present_mode = desktop_present_mode(&surface_caps, self.frame_pacing_mode);
+        let present_mode = desktop_present_mode(&surface_caps, self.frame_pacing_mode());
+        log_desktop_present_mode(self.frame_pacing_mode(), present_mode, &surface_caps);
         let size = window.surface_size();
         let surface_config = surface_config_for_window(
             &surface_caps,
@@ -1338,7 +1421,7 @@ impl App {
             size.height.max(1),
             present_mode,
             options.transparent,
-            self.frame_pacing_mode,
+            self.frame_pacing_mode(),
         )?;
         surface.configure(&context.device, &surface_config);
         trace_native_window_timing(format_args!(
@@ -1381,7 +1464,7 @@ impl App {
             )
         });
         let mut dev_options = self.settings.dev_options.clone();
-        dev_options.frame_pacing_mode = self.frame_pacing_mode;
+        dev_options.frame_pacing_mode = self.frame_pacing_mode();
         dev_options.frame_pacing_controls = false;
         app.set_dev_options(dev_options);
         // Enable/disable the platform IME with text-field focus so composing
@@ -1423,7 +1506,6 @@ impl App {
             platform,
             last_cursor_position: None,
             last_cursor_physical_position: None,
-            frame_pacing_mode: self.frame_pacing_mode,
             last_frame_start_time: None,
             vsync_interval: default_vsync_interval(),
             pending_outer_positions: PendingNativeWindowPositions::default(),
@@ -2567,21 +2649,52 @@ fn apply_frame_pacing_mode(
     mode: FramePacingMode,
 ) {
     app.set_frame_pacing_mode(mode);
-    if let Some(caps) = surface_caps {
-        let present_mode = crate::present_mode::select_present_mode_for_frame_pacing(caps, mode);
-        let frame_latency = desired_frame_latency(mode);
-        if surface_config.present_mode != present_mode
-            || surface_config.desired_maximum_frame_latency != frame_latency
-        {
-            let Some(device) = app.renderer().try_device() else {
-                log::error!("desktop surface reconfigure skipped: GPU renderer is not initialized");
-                return;
-            };
-            surface_config.present_mode = present_mode;
-            surface_config.desired_maximum_frame_latency = frame_latency;
-            surface.configure(device, surface_config);
-        }
+    let Some(caps) = surface_caps else {
+        // The pacing mode reaches the app but not the swapchain, which is a
+        // free-running loop feeding a surface that still waits for vsync in
+        // `get_current_texture`. Nothing about that is visible in the overlay.
+        log::error!(
+            "desktop surface pacing not applied for {}: surface capabilities are unknown",
+            mode.label()
+        );
+        return;
+    };
+    // Same rule as the surface was built with, override included: a run pinned
+    // to a present mode by `CRANPOSE_PRESENT_MODE` must stay pinned when the
+    // pacing mode changes, or the surface silently stops matching the pin.
+    let present_mode = desktop_present_mode(caps, mode);
+    let frame_latency = desired_frame_latency(mode);
+    if surface_config.present_mode == present_mode
+        && surface_config.desired_maximum_frame_latency == frame_latency
+    {
+        return;
     }
+    let Some(device) = app.renderer().try_device() else {
+        log::error!("desktop surface reconfigure skipped: GPU renderer is not initialized");
+        return;
+    };
+    surface_config.present_mode = present_mode;
+    surface_config.desired_maximum_frame_latency = frame_latency;
+    surface.configure(device, surface_config);
+    log_desktop_present_mode(mode, present_mode, caps);
+}
+
+/// What the swapchain was actually given for a pacing mode.
+///
+/// The fallback when a surface cannot do what a mode asks for is silent, so a
+/// surface that never left `Fifo` is indistinguishable from one that free-runs
+/// -- and that is the first thing worth knowing when a NoVSync run reads the
+/// panel's refresh rate.
+fn log_desktop_present_mode(
+    mode: FramePacingMode,
+    present_mode: wgpu::PresentMode,
+    caps: &wgpu::SurfaceCapabilities,
+) {
+    log::info!(
+        "desktop present mode: pacing={} chose {present_mode:?}; surface offers {:?}",
+        mode.label(),
+        caps.present_modes,
+    );
 }
 
 fn desired_frame_latency(mode: FramePacingMode) -> u32 {
@@ -2600,8 +2713,48 @@ fn frame_interval_for_mode(mode: FramePacingMode, vsync_interval: Duration) -> O
     }
 }
 
+/// Run one frame for a declaration host, which has no surface to present to.
+///
+/// Both paths that drive such a host -- the frame waker's wake through the
+/// event-loop proxy and `about_to_wait` -- land here, so a host counts its
+/// frames and holds its cadence the same way whichever one produced the frame.
+fn update_declaration_host_frame(
+    app: &mut AppShell<WgpuRenderer>,
+    registry: &Rc<native_window::NativeWindowRegistry>,
+    last_frame_start_time: &mut Option<Instant>,
+    frame_interval: Option<Duration>,
+) -> FrameUpdateResult {
+    let frame_started_at = Instant::now();
+    let update_result = update_app_with_native_window_registry(app, registry);
+    if update_result.visual_changed {
+        app.record_presented_frame(frame_started_at, Instant::now());
+        *last_frame_start_time = Some(next_frame_anchor(
+            *last_frame_start_time,
+            frame_started_at,
+            frame_interval,
+        ));
+    }
+    update_result
+}
+
 fn should_chain_no_vsync_redraw(frame_interval: Option<Duration>, needs_frame: bool) -> bool {
     frame_interval.is_none() && needs_frame
+}
+
+/// Whether the loop must keep turning under its own power for this frame.
+///
+/// A free-running mode has no deadline to wait for, so the loop only ever gets
+/// the next frame by coming back around for it. Parking hands the cadence to
+/// whatever the platform does with an outstanding redraw request, which on a
+/// display-driven backend is the refresh rate -- the app then free-runs or
+/// follows the panel depending on whether it happened to have work pending at
+/// the instant the control flow was chosen.
+fn free_running_frame(
+    frame_interval: Option<Duration>,
+    needs_redraw: bool,
+    redraw_pending: bool,
+) -> bool {
+    frame_interval.is_none() && (needs_redraw || redraw_pending)
 }
 
 /// Per-second counters for the desktop frame loop, enabled by
@@ -4062,7 +4215,8 @@ impl ApplicationHandler for App {
             }
         };
 
-        let present_mode = desktop_present_mode(&surface_caps, self.frame_pacing_mode);
+        let present_mode = desktop_present_mode(&surface_caps, self.frame_pacing_mode());
+        log_desktop_present_mode(self.frame_pacing_mode(), present_mode, &surface_caps);
         let surface_config = match surface_config_for_window(
             &surface_caps,
             surface_format,
@@ -4070,7 +4224,7 @@ impl ApplicationHandler for App {
             size.height.max(1),
             present_mode,
             false,
-            self.frame_pacing_mode,
+            self.frame_pacing_mode(),
         ) {
             Ok(config) => config,
             Err(error) => {
@@ -4132,7 +4286,7 @@ impl ApplicationHandler for App {
 
         // Apply dev options (FPS counter, etc.)
         let mut dev_options = self.settings.dev_options.clone();
-        dev_options.frame_pacing_mode = self.frame_pacing_mode;
+        dev_options.frame_pacing_mode = self.frame_pacing_mode();
         app.set_dev_options(dev_options);
 
         // Enable/disable the platform IME with text-field focus so composing
@@ -4202,6 +4356,7 @@ impl ApplicationHandler for App {
         window_id: WinitWindowId,
         event: WindowEvent,
     ) {
+        self.sync_frame_pacing();
         let Some(window) = &self.window else {
             self.native_window_event(event_loop, window_id, event);
             return;
@@ -4416,31 +4571,6 @@ impl ApplicationHandler for App {
                 }
                 match state {
                     ElementState::Pressed => {
-                        if let Some(mode) = app.handle_dev_overlay_click(logical.x, logical.y) {
-                            apply_frame_pacing_mode(
-                                app,
-                                surface,
-                                surface_config,
-                                self.surface_caps.as_ref(),
-                                mode,
-                            );
-                            self.frame_pacing_mode = mode;
-                            self.last_frame_start_time = None;
-                            request_redraw_once(window, &mut self.primary_redraw_pending);
-                            for native in self.native_windows.values_mut() {
-                                apply_frame_pacing_mode(
-                                    &mut native.app,
-                                    &native.surface,
-                                    &mut native.surface_config,
-                                    Some(&native.surface_caps),
-                                    mode,
-                                );
-                                native.frame_pacing_mode = mode;
-                                native.last_frame_start_time = None;
-                                native.window.request_redraw();
-                            }
-                            return;
-                        }
                         let request = pointer_button_frame_request(
                             app.pointer_pressed_at_event_time(event_time),
                         );
@@ -4644,7 +4774,11 @@ impl ApplicationHandler for App {
             self.sync_native_windows(event_loop);
         }
 
-        let frame_interval = self.frame_interval();
+        // A press that lands on a pacing control changes the shell's mode, and
+        // the robot dispatches presses straight into the shell from here, so
+        // the loop picks the change up on the way in as well as on the way out.
+        self.sync_frame_pacing();
+
         let last_frame_start_time = self.last_frame_start_time;
         let registry = Rc::clone(&self.native_window_registry);
         let Some(app) = &mut self.app else { return };
@@ -4981,10 +5115,6 @@ impl ApplicationHandler for App {
                     }
                     RobotCommand::GetFpsStats => {
                         let _ = controller.tx.send(RobotResponse::FpsStats(app.fps_stats()));
-                    }
-                    RobotCommand::SetPollForcing(enabled) => {
-                        self.robot_force_poll = enabled;
-                        let _ = controller.tx.send(RobotResponse::Ok);
                     }
                     RobotCommand::GetPacingControlCenter(mode) => {
                         let center = app.dev_overlay_control_center(mode);
@@ -5339,6 +5469,10 @@ impl ApplicationHandler for App {
             }
         }
 
+        // Re-read the mode: a robot command handled above can have pressed a
+        // pacing control, and this iteration's control flow must already obey
+        // the mode the shell now reports rather than the one it opened with.
+        let frame_interval = frame_interval_for_mode(app.frame_pacing_mode(), self.vsync_interval);
         let frame_schedule = app.frame_schedule();
         let has_active_animations = app.has_active_animations();
         let needs_update = frame_schedule.needs_update;
@@ -5372,12 +5506,12 @@ impl ApplicationHandler for App {
                     self.settings.primary_window_visible, self.settings.headless
                 ));
                 record_pacing_event(|diag| &mut diag.direct_updates);
-                let frame_started_at = Instant::now();
-                let update_result = update_app_with_native_window_registry(app, &registry);
-                if update_result.visual_changed {
-                    app.record_presented_frame(frame_started_at, Instant::now());
-                    self.last_frame_start_time = Some(frame_started_at);
-                }
+                update_declaration_host_frame(
+                    app,
+                    &registry,
+                    &mut self.last_frame_start_time,
+                    frame_interval,
+                );
             } else {
                 request_redraw_once(&window, &mut self.primary_redraw_pending);
             }
@@ -5455,29 +5589,43 @@ impl ApplicationHandler for App {
             }
         }
 
-        // Smart ControlFlow: only Poll when necessary
+        // Smart ControlFlow: only Poll when necessary.
+        //
+        // A robot that is waiting on something -- a command mid-flight, an idle
+        // wait, a frame it asked for -- needs the loop to keep turning. A robot
+        // that is merely attached does not: pinning the loop to `Poll` for the
+        // whole of a driven run makes it free-run no matter what pacing mode
+        // the app is in, which is indistinguishable from the app free-running
+        // and makes every frame-rate measurement in a robot test a measurement
+        // of the harness. Commands sent while the loop is parked wake it
+        // through the event-loop proxy, so nothing is lost by parking.
         #[cfg(feature = "robot")]
-        let robot_needs_poll = self.robot_controller.is_some() && self.robot_force_poll;
+        let robot_needs_poll = self
+            .robot_controller
+            .as_mut()
+            .is_some_and(RobotController::awaiting_progress);
 
         #[cfg(not(feature = "robot"))]
         let robot_needs_poll = false;
 
         // Poll continuously when:
         // - Active animations are running
-        // - Robot test is active
+        // - The robot is waiting for the loop to make progress
         // Free-running (NoVsync) chains its own redraw after each present, but a
         // bare `request_redraw` is serviced by the platform's display cycle, so
         // parking the loop in `Wait` silently clamps the app to the refresh rate.
-        // Polling is what actually lets the frame rate exceed vsync.
-        let free_running_frame = frame_interval.is_none() && needs_redraw;
-        if robot_needs_poll
-            || free_running_frame
+        // Polling is what actually lets the frame rate exceed vsync -- and that
+        // has to include the window between asking for a frame and being handed
+        // it, or the loop parks on the frame it just requested and takes the
+        // display's cadence for it. Which frames those are is a matter of
+        // timing, and is exactly why the clamp came and went between runs.
+        let control_flow = if robot_needs_poll
+            || free_running_frame(frame_interval, needs_redraw, self.primary_redraw_pending)
             || primary_pointer_polled
             || native_drag_deadline.is_some()
             || native_position_poll_deadline.is_some_and(|deadline| deadline <= now)
         {
-            record_pacing_event(|diag| &mut diag.control_flow_poll);
-            event_loop.set_control_flow(ControlFlow::Poll);
+            ControlFlow::Poll
         } else if let Some(deadline) = [
             next_frame_time.filter(|_| waiting_for_frame_cap),
             native_frame_cap_deadline,
@@ -5487,22 +5635,63 @@ impl ApplicationHandler for App {
         .flatten()
         .min()
         {
-            record_pacing_event(|diag| &mut diag.control_flow_wait_until);
-            event_loop.set_control_flow(ControlFlow::WaitUntil(deadline));
+            ControlFlow::WaitUntil(deadline)
         } else if has_active_animations || native_has_active_animations {
-            record_pacing_event(|diag| &mut diag.control_flow_poll);
-            event_loop.set_control_flow(ControlFlow::Poll);
+            ControlFlow::Poll
         } else if let Some(next_time) = [primary_next_event_time, native_next_event_time]
             .into_iter()
             .flatten()
             .min()
         {
             // Cursor blink uses timer-based scheduling (not continuous poll)
-            event_loop.set_control_flow(ControlFlow::WaitUntil(next_time));
+            ControlFlow::WaitUntil(next_time)
         } else {
-            record_pacing_event(|diag| &mut diag.control_flow_wait);
-            event_loop.set_control_flow(ControlFlow::Wait);
-        }
+            ControlFlow::Wait
+        };
+
+        #[cfg(feature = "robot")]
+        let control_flow = bound_park_for_robot(control_flow, self.robot_controller.is_some(), now);
+
+        // Count what the loop was actually told to do. A histogram of the
+        // intent rather than the outcome is a diagnostic that agrees with the
+        // code and disagrees with the machine.
+        record_pacing_event(match control_flow {
+            ControlFlow::Poll => |diag: &mut PacingDiag| &mut diag.control_flow_poll,
+            ControlFlow::WaitUntil(_) => |diag: &mut PacingDiag| &mut diag.control_flow_wait_until,
+            ControlFlow::Wait => |diag: &mut PacingDiag| &mut diag.control_flow_wait,
+        });
+        event_loop.set_control_flow(control_flow);
+    }
+}
+
+/// How long a driven run may park before it looks at the command channel again.
+///
+/// Only a backstop: commands wake the loop through the event-loop proxy, and
+/// the proxy wake-up is documented as droppable under contention on Windows.
+/// Losing one would otherwise hang the driver on a response that can never
+/// come, so a parked loop with a robot attached comes up for air instead.
+#[cfg(feature = "robot")]
+const ROBOT_PARKED_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(8);
+
+/// Cap how long a driven run parks, without changing what it does when it wakes.
+///
+/// This does not produce frames: a wake with nothing to do falls straight back
+/// through `about_to_wait`. The app's pacing mode still decides the frame rate,
+/// which is what makes a frame rate measured under a robot the app's own.
+#[cfg(feature = "robot")]
+fn bound_park_for_robot(
+    control_flow: ControlFlow,
+    robot_attached: bool,
+    now: Instant,
+) -> ControlFlow {
+    if !robot_attached {
+        return control_flow;
+    }
+    let bound = now + ROBOT_PARKED_COMMAND_POLL_INTERVAL;
+    match control_flow {
+        ControlFlow::Poll => ControlFlow::Poll,
+        ControlFlow::Wait => ControlFlow::WaitUntil(bound),
+        ControlFlow::WaitUntil(deadline) => ControlFlow::WaitUntil(deadline.min(bound)),
     }
 }
 
@@ -5526,7 +5715,8 @@ pub fn try_run(
     // Spawn test driver if present
     #[cfg(feature = "robot")]
     let robot_controller = if let Some(driver) = settings.test_driver.take() {
-        let (controller, robot) = RobotController::new();
+        let wake_proxy = event_proxy.clone();
+        let (controller, robot) = RobotController::new(move || wake_proxy.wake_up());
         let panic_tx = robot.command_sender();
         std::thread::spawn(move || {
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -5663,22 +5853,24 @@ fn resolve_robot_screenshot_params_with_scale(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "robot")]
+    use super::{bound_park_for_robot, ControlFlow, ROBOT_PARKED_COMMAND_POLL_INTERVAL};
     use super::{
-        clamp_rect_to_monitor_delta, frame_interval_for_mode, initial_present_redraw_needed,
-        native_window_graph_position, native_window_options_change_is_position_only,
-        native_window_position_poll_needed, nearest_monitor_to_rect, next_frame_anchor,
-        physical_outer_origin_from_surface, physical_surface_local_pointer,
-        physical_surface_origin_from_outer, physical_surface_rect_contains_pointer,
-        pointer_button_frame_request, primary_declaration_host_needs_direct_update,
-        primary_frame_waker_uses_event_proxy, primary_launch_requires_initial_redraw,
-        primary_pointer_gesture_poll_action, primary_pointer_move_should_recover_press,
-        primary_surface_redraw_drives_app, primary_viewport_for_surface_size,
-        recovered_native_window_drag_start_pointer, scroll_frame_request,
-        should_chain_no_vsync_redraw, surface_reconfigure_requires_redraw, App, DesktopRect,
-        FramePacingMode, NativeWindowDragSession, NativeWindowGraphPositionSource,
-        NativeWindowOptions, NativeWindowPointerState, NativeWindowPollingDragSession,
-        NativeWindowPositionObservation, NativeWindowPositionOrigin, PendingNativeWindowPositions,
-        PrimaryPointerGesturePollAction,
+        clamp_rect_to_monitor_delta, frame_interval_for_mode, free_running_frame,
+        initial_present_redraw_needed, native_window_graph_position,
+        native_window_options_change_is_position_only, native_window_position_poll_needed,
+        nearest_monitor_to_rect, next_frame_anchor, physical_outer_origin_from_surface,
+        physical_surface_local_pointer, physical_surface_origin_from_outer,
+        physical_surface_rect_contains_pointer, pointer_button_frame_request,
+        primary_declaration_host_needs_direct_update, primary_frame_waker_uses_event_proxy,
+        primary_launch_requires_initial_redraw, primary_pointer_gesture_poll_action,
+        primary_pointer_move_should_recover_press, primary_surface_redraw_drives_app,
+        primary_viewport_for_surface_size, recovered_native_window_drag_start_pointer,
+        scroll_frame_request, should_chain_no_vsync_redraw, surface_reconfigure_requires_redraw,
+        App, DesktopRect, FramePacingMode, NativeWindowDragSession,
+        NativeWindowGraphPositionSource, NativeWindowOptions, NativeWindowPointerState,
+        NativeWindowPollingDragSession, NativeWindowPositionObservation,
+        NativeWindowPositionOrigin, PendingNativeWindowPositions, PrimaryPointerGesturePollAction,
     };
     use crate::launcher::AppSettings;
     use std::time::Instant;
@@ -5841,6 +6033,104 @@ mod tests {
             frame_interval_for_mode(FramePacingMode::Vsync, vsync_interval),
             true
         ));
+    }
+
+    #[test]
+    fn free_running_loop_never_parks_on_a_frame_it_already_asked_for() {
+        let vsync_interval = std::time::Duration::from_nanos(16_666_667);
+        let no_vsync = frame_interval_for_mode(FramePacingMode::NoVsync, vsync_interval);
+
+        // The frame the loop chained after the last present is in flight, and
+        // the schedule reports no further work yet. Parking here is what let
+        // the platform deliver that redraw on its own display cycle, which read
+        // as NoVSync clamped to the refresh rate in some runs and not others.
+        assert!(free_running_frame(no_vsync, false, true));
+        assert!(free_running_frame(no_vsync, true, false));
+        assert!(!free_running_frame(no_vsync, false, false));
+
+        // A capped mode still waits: its deadline is the whole point.
+        assert!(!free_running_frame(
+            frame_interval_for_mode(FramePacingMode::Vsync, vsync_interval),
+            true,
+            true
+        ));
+        assert!(!free_running_frame(
+            frame_interval_for_mode(FramePacingMode::Hard120, vsync_interval),
+            true,
+            true
+        ));
+    }
+
+    #[cfg(feature = "robot")]
+    #[test]
+    fn a_driven_run_never_parks_longer_than_its_command_poll() {
+        let now = Instant::now();
+        let far = now + std::time::Duration::from_secs(5);
+        let soon = now + std::time::Duration::from_millis(1);
+        let bound = now + ROBOT_PARKED_COMMAND_POLL_INTERVAL;
+
+        // A dropped proxy wake-up must cost latency, never the whole run.
+        assert_eq!(
+            bound_park_for_robot(ControlFlow::Wait, true, now),
+            ControlFlow::WaitUntil(bound)
+        );
+        assert_eq!(
+            bound_park_for_robot(ControlFlow::WaitUntil(far), true, now),
+            ControlFlow::WaitUntil(bound)
+        );
+        // A deadline the app already owns is nearer, and stays.
+        assert_eq!(
+            bound_park_for_robot(ControlFlow::WaitUntil(soon), true, now),
+            ControlFlow::WaitUntil(soon)
+        );
+        assert_eq!(
+            bound_park_for_robot(ControlFlow::Poll, true, now),
+            ControlFlow::Poll
+        );
+        // Nothing changes for a run with no robot attached.
+        assert_eq!(
+            bound_park_for_robot(ControlFlow::Wait, false, now),
+            ControlFlow::Wait
+        );
+        assert_eq!(
+            bound_park_for_robot(ControlFlow::WaitUntil(far), false, now),
+            ControlFlow::WaitUntil(far)
+        );
+    }
+
+    #[cfg(feature = "robot")]
+    #[test]
+    fn an_idle_robot_lets_the_loop_park() {
+        let (mut controller, robot) = RobotController::new(|| {});
+
+        // Nothing outstanding: the loop must be free to pace like the app it is
+        // running, or every frame rate a robot test reads is the harness's.
+        assert!(!controller.awaiting_progress());
+
+        robot
+            .command_sender()
+            .send(crate::robot::RobotCommand::PumpFrames { count: 1 })
+            .expect("robot command channel should remain open");
+        assert!(controller.awaiting_progress());
+        assert!(matches!(
+            controller.next_command(),
+            Some(crate::robot::RobotCommand::PumpFrames { count: 1 })
+        ));
+        assert!(!controller.awaiting_progress());
+
+        controller.start_idle_wait();
+        assert!(controller.awaiting_progress());
+        controller.finish_idle_wait();
+        assert!(!controller.awaiting_progress());
+
+        controller.waiting_for_pump_present_generation = Some(7);
+        assert!(controller.awaiting_progress());
+        controller.waiting_for_pump_present_generation = None;
+
+        controller.begin_synthetic_primary_gesture();
+        assert!(controller.awaiting_progress());
+        controller.end_synthetic_primary_gesture();
+        assert!(!controller.awaiting_progress());
     }
 
     #[test]
@@ -6408,7 +6698,7 @@ mod tests {
     #[cfg(feature = "robot")]
     #[test]
     fn robot_controller_tracks_synthetic_primary_button_lifetime() {
-        let (mut controller, _robot) = RobotController::new();
+        let (mut controller, _robot) = RobotController::new(|| {});
 
         assert!(!controller.synthetic_primary_down());
         controller.begin_synthetic_primary_gesture();
@@ -6420,7 +6710,7 @@ mod tests {
     #[cfg(feature = "robot")]
     #[test]
     fn robot_controller_stages_commands_during_continuous_frame_wakes() {
-        let (mut controller, robot) = RobotController::new();
+        let (mut controller, robot) = RobotController::new(|| {});
         robot
             .command_sender()
             .send(crate::robot::RobotCommand::PumpFrames { count: 2 })

--- a/crates/cranpose/src/robot.rs
+++ b/crates/cranpose/src/robot.rs
@@ -211,6 +211,8 @@ pub(crate) enum RobotCommand {
     #[cfg(feature = "renderer-wgpu")]
     GetRenderStats,
     GetFpsStats,
+    GetPacingControlCenter(cranpose_app_shell::FramePacingMode),
+    SetPollForcing(bool),
     ResetFpsStats,
     GetLastFlingVelocity,
     ResetLastFlingVelocity,
@@ -242,6 +244,7 @@ pub(crate) enum RobotResponse {
     #[cfg(feature = "renderer-wgpu")]
     RenderStats(Box<Option<RenderStatsSnapshot>>),
     FpsStats(cranpose_app_shell::FpsStats),
+    PacingControlCenter(Option<(f32, f32)>),
     F32(f32),
     #[cfg(feature = "renderer-wgpu")]
     RenderCpuAllocationStats(Box<DebugCpuAllocationStats>),
@@ -1009,6 +1012,47 @@ impl Robot {
             .map_err(|e| format!("Failed to send FPS stats command: {}", e))?;
         match self.rx.recv() {
             Ok(RobotResponse::FpsStats(stats)) => Ok(stats),
+            Ok(RobotResponse::Error(e)) => Err(e),
+            Ok(_) => Err("Unexpected response".to_string()),
+            Err(e) => Err(format!("Failed to receive response: {}", e)),
+        }
+    }
+
+    /// Stop (or resume) pinning the event loop to `ControlFlow::Poll` for the
+    /// robot's benefit.
+    ///
+    /// A driven run polls continuously so robot commands are serviced without
+    /// waiting on the display. That is invisible in most tests and fatal in one
+    /// measuring frame pacing: polling is exactly what lets a loop outrun
+    /// vsync, so a test that leaves it on records the harness free-running and
+    /// reports a pass against a build where the app cannot. Turn it off around
+    /// a measurement window, and back on to keep the rest of the test
+    /// responsive.
+    pub fn set_poll_forcing(&self, enabled: bool) -> Result<(), String> {
+        self.tx
+            .send(RobotCommand::SetPollForcing(enabled))
+            .map_err(|e| format!("Failed to send poll forcing command: {}", e))?;
+        match self.rx.recv() {
+            Ok(RobotResponse::Ok) => Ok(()),
+            Ok(RobotResponse::Error(e)) => Err(e),
+            Ok(_) => Err("Unexpected response".to_string()),
+            Err(e) => Err(format!("Failed to receive response: {}", e)),
+        }
+    }
+
+    /// Where the dev overlay draws a frame-pacing control, in logical pixels.
+    ///
+    /// The overlay is renderer-drawn and carries no semantics, so this is how a
+    /// test presses one without hard-coding a coordinate that quietly rots.
+    pub fn pacing_control_center(
+        &self,
+        mode: cranpose_app_shell::FramePacingMode,
+    ) -> Result<Option<(f32, f32)>, String> {
+        self.tx
+            .send(RobotCommand::GetPacingControlCenter(mode))
+            .map_err(|e| format!("Failed to send pacing control command: {}", e))?;
+        match self.rx.recv() {
+            Ok(RobotResponse::PacingControlCenter(center)) => Ok(center),
             Ok(RobotResponse::Error(e)) => Err(e),
             Ok(_) => Err("Unexpected response".to_string()),
             Err(e) => Err(format!("Failed to receive response: {}", e)),

--- a/crates/cranpose/src/robot.rs
+++ b/crates/cranpose/src/robot.rs
@@ -11,6 +11,7 @@
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::mpsc;
+use std::sync::Arc;
 
 use cranpose_app_shell::{AppShell, KeyCode, PointerSource, RuntimeLeakDebugStats};
 use cranpose_render_common::Renderer;
@@ -212,7 +213,6 @@ pub(crate) enum RobotCommand {
     GetRenderStats,
     GetFpsStats,
     GetPacingControlCenter(cranpose_app_shell::FramePacingMode),
-    SetPollForcing(bool),
     ResetFpsStats,
     GetLastFlingVelocity,
     ResetLastFlingVelocity,
@@ -263,7 +263,7 @@ pub(crate) struct RobotChannel {
 }
 
 impl RobotChannel {
-    pub(crate) fn new() -> (Self, Robot) {
+    pub(crate) fn new(wake_event_loop: impl Fn() + Send + Sync + 'static) -> (Self, Robot) {
         let (cmd_tx, cmd_rx) = mpsc::channel();
         let (resp_tx, resp_rx) = mpsc::channel();
 
@@ -273,7 +273,10 @@ impl RobotChannel {
         };
 
         let robot = Robot {
-            tx: cmd_tx,
+            tx: RobotCommandSender {
+                tx: cmd_tx,
+                wake_event_loop: Arc::new(wake_event_loop),
+            },
             rx: resp_rx,
         };
 
@@ -281,9 +284,32 @@ impl RobotChannel {
     }
 }
 
+/// The driver's end of the command channel, which wakes the event loop for
+/// every command it sends.
+///
+/// Commands are drained by the shell on its way into a wait, so a command sent
+/// while the loop is parked would sit in the channel until something else
+/// happened to wake it. The alternative -- keeping the loop spinning for as
+/// long as a robot is attached -- makes a driven run free-run regardless of the
+/// app's pacing mode, and any frame rate a robot test reads is then the
+/// harness's, not the app's.
+#[derive(Clone)]
+pub(crate) struct RobotCommandSender {
+    tx: mpsc::Sender<RobotCommand>,
+    wake_event_loop: Arc<dyn Fn() + Send + Sync>,
+}
+
+impl RobotCommandSender {
+    pub(crate) fn send(&self, command: RobotCommand) -> Result<(), mpsc::SendError<RobotCommand>> {
+        self.tx.send(command)?;
+        (self.wake_event_loop)();
+        Ok(())
+    }
+}
+
 /// Robot handle for test drivers
 pub struct Robot {
-    tx: mpsc::Sender<RobotCommand>,
+    tx: RobotCommandSender,
     rx: mpsc::Receiver<RobotResponse>,
 }
 
@@ -1018,28 +1044,6 @@ impl Robot {
         }
     }
 
-    /// Stop (or resume) pinning the event loop to `ControlFlow::Poll` for the
-    /// robot's benefit.
-    ///
-    /// A driven run polls continuously so robot commands are serviced without
-    /// waiting on the display. That is invisible in most tests and fatal in one
-    /// measuring frame pacing: polling is exactly what lets a loop outrun
-    /// vsync, so a test that leaves it on records the harness free-running and
-    /// reports a pass against a build where the app cannot. Turn it off around
-    /// a measurement window, and back on to keep the rest of the test
-    /// responsive.
-    pub fn set_poll_forcing(&self, enabled: bool) -> Result<(), String> {
-        self.tx
-            .send(RobotCommand::SetPollForcing(enabled))
-            .map_err(|e| format!("Failed to send poll forcing command: {}", e))?;
-        match self.rx.recv() {
-            Ok(RobotResponse::Ok) => Ok(()),
-            Ok(RobotResponse::Error(e)) => Err(e),
-            Ok(_) => Err("Unexpected response".to_string()),
-            Err(e) => Err(format!("Failed to receive response: {}", e)),
-        }
-    }
-
     /// Where the dev overlay draws a frame-pacing control, in logical pixels.
     ///
     /// The overlay is renderer-drawn and carries no semantics, so this is how a
@@ -1300,7 +1304,7 @@ impl Robot {
 
     /// Clone of the command channel. Shells use this to surface a panicking
     /// test driver back into the event loop as a `DriverPanicked` command.
-    pub(crate) fn command_sender(&self) -> mpsc::Sender<RobotCommand> {
+    pub(crate) fn command_sender(&self) -> RobotCommandSender {
         self.tx.clone()
     }
 


### PR DESCRIPTION
Adds a robot test for #377 (NoVSync intermittently clamping to the display
refresh rate), the two small pieces of API it could not be written without, and
a demo tab that gives the framework a page of the shape that exposed the
problem. **No framework behaviour change** — the pacing bug is not fixed here.

## The Credits tab

The demo had no page like this. Every other tab is a widget tree; this one is a
single `Canvas` redrawing several hundred glyphs a frame — ten rows of wrapped
paragraphs on a 454dp round display, each re-scaled and re-faded by a
scaling-list curve as it travels past the centre line. That is the load that
showed up as slow in a real Wear OS app on Cranpose, and it now sits next to
the tabs whose frame rates are already known.

The layout code is **copied, not depended on**: `draw.rs`, `font.rs`,
`layout.rs`, `theme.rs` and `list.rs` are vendored. The framework must not
depend on anything outside itself, and the app they came from is a private
repository, so a path dependency was never an option. They are carried whole
rather than filleted down to the paths Credits touches, so the fixture keeps
drawing what the real screen draws; `allow(dead_code)` covers the remainder.

The list scrolls itself by elapsed time, not per frame — per-frame travel moves
faster the faster the app runs, which makes a frame-rate reading partly a
measurement of itself.

## The test

`cargo run --release --example robot_novsync_free_runs -p desktop-app --features desktop,robot-app`

Opens a continuously animating tab, presses NoVSync, and asserts the frame rate
the app reaches **on its own** clears 120fps. On `main` it fails in roughly half
of runs, which is the bug's own intermittency rather than looseness in the test:

```
run 1  worst=59.2   best=60.0     FAIL
run 2  worst=165.4  best=233.9    pass
```

Four choices in it are deliberate, each one a way the test was wrong first:

- **Poll forcing off around each window.** `robot_needs_poll =
  self.robot_controller.is_some()` pins any driven run to `ControlFlow::Poll` —
  and polling is precisely the mechanism that lets a loop outrun vsync. Left on,
  this test measured the harness free-running and passed at **470fps** against a
  build where pressing NoVSync does nothing.
- **No `pump_frames`, and `fps` rather than `work_fps`.** Pumping supplies the
  very frames the broken pacing failed to ask for.
- **Three windows, judged on the worst.** A single window caught a good streak
  and read 260fps on a clamped build. The requirement is that NoVSync *always*
  frees the loop.
- **A tab that animates on its own.** A page that settles reports 0fps once poll
  forcing is off — the idle-is-0fps invariant working correctly, and telling us
  nothing about pacing.

## API added

- `Robot::set_poll_forcing(bool)` — lets a driver stop pinning the loop to
  `Poll` around a measurement. Default behaviour unchanged.
- `AppShell::dev_overlay_control_center(FramePacingMode)` — where the overlay
  actually draws a pacing control. It is renderer-drawn and carries no
  semantics, so pressing one otherwise means a hard-coded coordinate that
  silently starts hitting empty space when the overlay's text changes.
- `desktop_present_mode` now logs the mode a surface received. The fallback from
  Immediate is silent, so a surface that cannot do Immediate was
  indistinguishable from one that can. On this machine: `surface offers [Fifo,
  Immediate]; chose Immediate` — which is how the swapchain was ruled out.

## Checks

`cargo test -p cranpose --lib` 54 passed · `cargo test -p cranpose-app-shell --lib`
128 passed · `cargo test -p desktop-app --lib` 100 passed · `cargo clippy -p
desktop-app` clean · `cargo build -p desktop-app` with no features unchanged.
