### PR TITLE
Let an app ask the platform to close it, and say why a drag cannot be read inside its own layer

### DIFF
--- a/apps/desktop-demo/examples/robot_request_exit.rs
+++ b/apps/desktop-demo/examples/robot_request_exit.rs
@@ -1,0 +1,48 @@
+//! `request_exit` must actually close the app.
+//!
+//! An app that owns the affordance meaning "leave" -- a screen-level dismiss
+//! gesture it draws itself, a Quit item in its own menu -- has to be able to
+//! ask the platform to close it. This drives the desktop backend: run the demo,
+//! ask, and let the process end on its own. If the loop keeps turning, the
+//! driver says so and fails rather than hanging a CI run forever.
+//!
+//! Run headless with `CRANPOSE_HEADLESS=1`.
+
+use cranpose::AppLauncher;
+use std::time::Duration;
+
+const WINDOW_WIDTH: u32 = 700;
+const WINDOW_HEIGHT: u32 = 500;
+/// How long the loop gets to notice. Two orders of magnitude more than the
+/// frame it should be noticed on, so a slow machine cannot fail this.
+const GRACE: Duration = Duration::from_secs(3);
+
+fn main() {
+    AppLauncher::new()
+        .with_title("request_exit")
+        .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
+        .with_fonts(desktop_app::fonts::DEMO_FONTS)
+        .with_headless(std::env::var("CRANPOSE_HEADLESS").as_deref() == Ok("1"))
+        .with_test_driver(move |robot| {
+            let _ = robot.wait_for_idle();
+
+            cranpose::request_exit();
+
+            // Nothing else to do: the backend drains the request on its next
+            // turn of the loop and exits. If it is still going after the grace
+            // period, the request was dropped -- kill the process here, since
+            // an unclosed window would otherwise wait for a human.
+            std::thread::sleep(GRACE);
+            println!(
+                "FAIL: still running {}s after request_exit; the desktop backend \
+                 did not drain the request",
+                GRACE.as_secs(),
+            );
+            std::process::exit(1);
+        })
+        .try_run(desktop_app::app::DesktopApp)
+        .expect("launch the demo");
+
+    // `try_run` returning is the loop having exited, which is the whole point.
+    println!("PASS: request_exit closed the app");
+}

--- a/apps/desktop-demo/examples/robot_request_exit.rs
+++ b/apps/desktop-demo/examples/robot_request_exit.rs
@@ -6,6 +6,15 @@
 //! ask, and let the process end on its own. If the loop keeps turning, the
 //! driver says so and fails rather than hanging a CI run forever.
 //!
+//! What this does NOT prove: that a request reaches a loop which has gone to
+//! sleep. The robot harness pins the loop to Poll so a driver's commands are
+//! never waiting on an event that will not come, which means the drain runs
+//! every turn here whatever the app is doing. The idle case is the app's to
+//! handle -- `request_exit` nudges the back-request listener for exactly that
+//! reason, and an app that registers one is woken -- and it is not what is
+//! measured below. Read a pass as "the desktop backend drains and exits",
+//! nothing wider.
+//!
 //! Run headless with `CRANPOSE_HEADLESS=1`.
 
 use cranpose::AppLauncher;

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -8693,3 +8693,127 @@ fn the_shell_stores_the_frame_rate_preference_it_is_given() {
         crate::FrameRatePreference::Exact(60.0)
     );
 }
+
+thread_local! {
+    /// (position, global_position) of every Down the translated node saw.
+    static TRANSLATED_LAYER_POINTER_EVENTS: RefCell<Vec<(Point, Point)>> =
+        const { RefCell::new(Vec::new()) };
+    /// The same, from a handler outside the translated node.
+    static UNTRANSLATED_PARENT_POINTER_EVENTS: RefCell<Vec<(Point, Point)>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+/// How far the inner node is pushed right. Any non-zero value does; 60 is far
+/// enough that a shifted reading cannot be mistaken for rounding.
+const TRANSLATED_LAYER_OFFSET: f32 = 60.0;
+
+/// A pointer handler on a translated node, and another on its untranslated
+/// parent — the two places a drag gesture can be read from.
+#[composable]
+fn translated_layer_pointer_probe() {
+    Box(
+        Modifier::empty().fill_max_size().pointer_input(
+            (),
+            move |scope: PointerInputScope| async move {
+                scope
+                    .await_pointer_event_scope(|await_scope| async move {
+                        loop {
+                            let event = await_scope.await_pointer_event().await;
+                            if event.kind == PointerEventKind::Down {
+                                UNTRANSLATED_PARENT_POINTER_EVENTS.with(|slot| {
+                                    slot.borrow_mut()
+                                        .push((event.position, event.global_position));
+                                });
+                            }
+                        }
+                    })
+                    .await;
+            },
+        ),
+        BoxSpec::default(),
+        || {
+            Box(
+                Modifier::empty()
+                    .fill_max_size()
+                    .graphics_layer(|| GraphicsLayer {
+                        translation_x: TRANSLATED_LAYER_OFFSET,
+                        ..Default::default()
+                    })
+                    .pointer_input((), move |scope: PointerInputScope| async move {
+                        scope
+                            .await_pointer_event_scope(|await_scope| async move {
+                                loop {
+                                    let event = await_scope.await_pointer_event().await;
+                                    if event.kind == PointerEventKind::Down {
+                                        TRANSLATED_LAYER_POINTER_EVENTS.with(|slot| {
+                                            slot.borrow_mut()
+                                                .push((event.position, event.global_position));
+                                        });
+                                    }
+                                }
+                            })
+                            .await;
+                    }),
+                BoxSpec::default(),
+                || {},
+            );
+        },
+    );
+}
+
+/// A pointer position is in its own node's space, so a translated node reports
+/// a finger short by the translation — while `global_position` does not move.
+///
+/// This is the contract a drag gesture is built on, and getting it wrong is
+/// silent: put the handler on the node the drag itself translates and the
+/// offset ends up measuring itself (`offset = (finger - start) / 2`), so it
+/// converges on half the travel and a half-width dismiss threshold can never
+/// be crossed. `SwipeToDismiss` avoids it both ways at once — the gesture is
+/// read on the outer node, and it reads `global_position` — and the
+/// `graphics_layer` docs say so. This is what holds them to it.
+#[test]
+fn a_pointer_inside_a_translated_layer_reports_the_translation() {
+    let _guard = test_guard();
+    TRANSLATED_LAYER_POINTER_EVENTS.with(|slot| slot.borrow_mut().clear());
+    UNTRANSLATED_PARENT_POINTER_EVENTS.with(|slot| slot.borrow_mut().clear());
+
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(
+        HitGraphRenderer::default(),
+        root_key,
+        translated_layer_pointer_probe,
+    );
+    shell.set_viewport(400.0, 400.0);
+    shell.update();
+
+    let tap_x = 200.0;
+    assert!(
+        shell.set_cursor(tap_x, 200.0),
+        "the probe should be hovered"
+    );
+    shell.update();
+    assert!(shell.pointer_pressed(), "pointer down should hit the probe");
+    shell.update();
+
+    let (local, global) = TRANSLATED_LAYER_POINTER_EVENTS
+        .with(|slot| slot.borrow().first().copied())
+        .expect("the translated node should have received the pointer down");
+    assert!(
+        (local.x - (tap_x - TRANSLATED_LAYER_OFFSET)).abs() < 0.5,
+        "a node translated by {TRANSLATED_LAYER_OFFSET} must see the tap {TRANSLATED_LAYER_OFFSET} \
+         to its left, got {local:?}"
+    );
+    assert!(
+        (global.x - tap_x).abs() < 0.5,
+        "global_position must be untouched by the layer, got {global:?}"
+    );
+
+    let (parent_local, parent_global) = UNTRANSLATED_PARENT_POINTER_EVENTS
+        .with(|slot| slot.borrow().first().copied())
+        .expect("the untranslated parent should have received the pointer down too");
+    assert!(
+        (parent_local.x - tap_x).abs() < 0.5 && (parent_global.x - tap_x).abs() < 0.5,
+        "a handler outside the translated node sees the tap where it happened, got \
+         {parent_local:?} / {parent_global:?}"
+    );
+}

--- a/crates/cranpose-services/src/lib.rs
+++ b/crates/cranpose-services/src/lib.rs
@@ -72,8 +72,8 @@ pub use launch_args::{
     LaunchArgs, LaunchArgsRef, ProvideLaunchArgs,
 };
 pub use navigation::{
-    back_interception_enabled, push_back_request, set_back_interception, set_back_request_listener,
-    take_back_requests,
+    back_interception_enabled, push_back_request, request_exit, set_back_interception,
+    set_back_request_listener, take_back_requests, take_exit_request,
 };
 pub use network_status::{
     clear_platform_network_monitor, network_monitor, network_status, set_platform_network_monitor,

--- a/crates/cranpose-services/src/lib.rs
+++ b/crates/cranpose-services/src/lib.rs
@@ -72,8 +72,8 @@ pub use launch_args::{
     LaunchArgs, LaunchArgsRef, ProvideLaunchArgs,
 };
 pub use navigation::{
-    back_interception_enabled, push_back_request, request_exit, set_back_interception,
-    set_back_request_listener, take_back_requests, take_exit_request,
+    back_interception_enabled, exit_requested, push_back_request, request_exit,
+    set_back_interception, set_back_request_listener, take_back_requests, take_exit_request,
 };
 pub use network_status::{
     clear_platform_network_monitor, network_monitor, network_status, set_platform_network_monitor,

--- a/crates/cranpose-services/src/navigation.rs
+++ b/crates/cranpose-services/src/navigation.rs
@@ -16,6 +16,9 @@
 //!   fallback, so it always pushes a request regardless of interception.
 //! - **Desktop/web**: no OS back control; apps may map keys themselves and
 //!   call [`push_back_request`] directly.
+//!
+//! [`request_exit`] is the other direction: the app, rather than the platform,
+//! deciding that it is time to leave.
 
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
@@ -27,6 +30,8 @@ type BackListener = Box<dyn Fn() + Send + Sync + 'static>;
 static BACK_REQUESTS: AtomicUsize = AtomicUsize::new(0);
 static BACK_INTERCEPTION: AtomicBool = AtomicBool::new(false);
 static BACK_LISTENER: OnceLock<BackListener> = OnceLock::new();
+/// A flag rather than a count: closing twice is closing once.
+static EXIT_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 /// Record a system back request (called by the platform backend's gesture /
 /// button handler).
@@ -78,6 +83,55 @@ pub fn back_interception_enabled() -> bool {
     BACK_INTERCEPTION.load(Ordering::SeqCst)
 }
 
+/// Ask the platform to close the app.
+///
+/// The counterpart to [`set_back_interception`]`(false)`: interception says
+/// "let the platform's own back control take me out of here", and this says
+/// the same thing when the app is the one that decided. An app needs it
+/// whenever it owns the affordance that means "leave":
+///
+/// - a screen-level dismiss gesture the app draws itself. On Android a
+///   `NativeActivity` consumes every pointer event on the display, so the
+///   platform's window-level swipe never fires and the app's own gesture is
+///   the only one there is — completing it has to close the app, and there is
+///   no back key on a watch to fall back on.
+/// - a Quit item in the app's own menu.
+///
+/// It is a request, not a teardown: the platform decides when the frame loop
+/// stops, so it is safe to call from the middle of one — including from a
+/// gesture's settle animation, which is where the decision usually lands.
+///
+/// The backend drains it on its next turn of the loop, which is the following
+/// frame for the usual caller. An app that calls this from another thread while
+/// the loop is parked — nothing animating, no input — should wake it the same
+/// way it would for a back request; registering
+/// [`set_back_request_listener`] is enough, because this nudges that listener
+/// too.
+///
+/// Platform behaviour, and where it does nothing:
+///
+/// - **Android**: finishes the activity, the same outcome as Compose's
+///   `backDispatcher.onBackPressed()` on a screen with no `BackHandler`.
+/// - **Desktop**: exits the event loop, closing the window.
+/// - **iOS**: nothing. Apple's guidelines forbid an app terminating itself and
+///   there is no supported API for it; the request is dropped rather than
+///   faked, so an app can call this unconditionally.
+/// - **Web**: nothing. A page cannot close a tab it did not open.
+pub fn request_exit() {
+    EXIT_REQUESTED.store(true, Ordering::SeqCst);
+    if let Some(listener) = BACK_LISTENER.get() {
+        // The same nudge a back request gets, and for the same reason: an app
+        // that has gone idle has no frame loop to notice the flag, and the
+        // platform drains it from that loop.
+        listener();
+    }
+}
+
+/// Take (and clear) a pending exit request. Drained by the platform backend.
+pub fn take_exit_request() -> bool {
+    EXIT_REQUESTED.swap(false, Ordering::SeqCst)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -92,6 +146,10 @@ mod tests {
         assert_eq!(take_back_requests(), 0);
     }
 
+    /// The listener is a `OnceLock`, so exactly one test in this process can
+    /// own it -- a second registration is silently ignored, and a test that
+    /// registered its own would sit there hearing nothing. Everything that has
+    /// to observe the nudge is therefore checked here.
     #[test]
     fn a_registered_listener_hears_every_request() {
         let heard = Arc::new(AtomicUsize::new(0));
@@ -104,6 +162,34 @@ mod tests {
         push_back_request();
         assert_eq!(heard.load(Ordering::SeqCst), before + 2);
         let _ = take_back_requests();
+
+        // An exit request nudges it too. The flag is drained from the frame
+        // loop, and an app with nothing moving has parked that loop; without
+        // the nudge the request would sit there until something unrelated
+        // woke the app.
+        let before = heard.load(Ordering::SeqCst);
+        request_exit();
+        assert_eq!(
+            heard.load(Ordering::SeqCst),
+            before + 1,
+            "an exit request has to wake an idle app the way a back request does"
+        );
+        let _ = take_exit_request();
+    }
+
+    #[test]
+    fn an_exit_request_is_taken_once() {
+        let _ = take_exit_request(); // clear any residue
+        assert!(!take_exit_request());
+        request_exit();
+        // Twice, because closing twice is closing once and a settle animation
+        // can easily ask on two consecutive frames.
+        request_exit();
+        assert!(take_exit_request());
+        assert!(
+            !take_exit_request(),
+            "a drained request came back; the platform would close twice"
+        );
     }
 
     #[test]

--- a/crates/cranpose-services/src/navigation.rs
+++ b/crates/cranpose-services/src/navigation.rs
@@ -127,6 +127,20 @@ pub fn request_exit() {
     }
 }
 
+/// Whether an exit request is outstanding, without consuming it.
+///
+/// For a backend whose way of closing can fail. Consuming the flag and then
+/// discovering the platform call did not land loses the app's only record that
+/// it wanted to close: the app stays open, the gesture the user made did
+/// nothing, and nothing will ever ask again. Such a backend tests with this and
+/// calls [`take_exit_request`] once the request has actually been honoured.
+///
+/// This is also the cheap read for a loop that runs it every turn — see
+/// [`take_exit_request`].
+pub fn exit_requested() -> bool {
+    EXIT_REQUESTED.load(Ordering::SeqCst)
+}
+
 /// Take (and clear) a pending exit request. Drained by the platform backend.
 ///
 /// Read before written: this runs on every turn of the platform's loop, and a
@@ -134,7 +148,7 @@ pub fn request_exit() {
 /// The load is the common case by a very long way — an app asks to close once,
 /// ever.
 pub fn take_exit_request() -> bool {
-    EXIT_REQUESTED.load(Ordering::SeqCst) && EXIT_REQUESTED.swap(false, Ordering::SeqCst)
+    exit_requested() && EXIT_REQUESTED.swap(false, Ordering::SeqCst)
 }
 
 #[cfg(test)]
@@ -142,8 +156,20 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
+    /// Every global in this module is process-wide and the runner is threaded,
+    /// so the tests take turns. They share one lock rather than one each: the
+    /// back-request counter, the exit flag and the listener are entangled --
+    /// `request_exit` nudges the listener, so a test asserting on the listener
+    /// count is moved by a test that only meant to touch the exit flag. One
+    /// failure in twenty, which is the worst rate for anyone to debug.
+    fn navigation_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
     fn requests_accumulate_and_drain() {
+        let _guard = navigation_lock();
         let _ = take_back_requests(); // clear any residue
         push_back_request();
         push_back_request();
@@ -157,6 +183,7 @@ mod tests {
     /// to observe the nudge is therefore checked here.
     #[test]
     fn a_registered_listener_hears_every_request() {
+        let _guard = navigation_lock();
         let heard = Arc::new(AtomicUsize::new(0));
         let counter = Arc::clone(&heard);
         set_back_request_listener(move || {
@@ -184,6 +211,7 @@ mod tests {
 
     #[test]
     fn an_exit_request_is_taken_once() {
+        let _guard = navigation_lock();
         let _ = take_exit_request(); // clear any residue
         assert!(!take_exit_request());
         request_exit();
@@ -198,7 +226,29 @@ mod tests {
     }
 
     #[test]
+    fn a_backend_can_look_at_the_request_without_consuming_it() {
+        let _guard = navigation_lock();
+        // The Android backend's way of closing is a JNI call that can fail.
+        // Consuming the flag first and then discovering the call did not land
+        // loses the app's only record that it asked to close: it stays open,
+        // the gesture the user made did nothing, and nothing asks again.
+        let _ = take_exit_request();
+        assert!(!exit_requested());
+
+        request_exit();
+        assert!(exit_requested());
+        assert!(
+            exit_requested(),
+            "looking at the request consumed it, which is the bug"
+        );
+
+        assert!(take_exit_request());
+        assert!(!exit_requested());
+    }
+
+    #[test]
     fn interception_defaults_off_and_toggles() {
+        let _guard = navigation_lock();
         set_back_interception(false);
         assert!(!back_interception_enabled());
         set_back_interception(true);

--- a/crates/cranpose-services/src/navigation.rs
+++ b/crates/cranpose-services/src/navigation.rs
@@ -128,8 +128,13 @@ pub fn request_exit() {
 }
 
 /// Take (and clear) a pending exit request. Drained by the platform backend.
+///
+/// Read before written: this runs on every turn of the platform's loop, and a
+/// bare `swap` would dirty the cache line each time even with nothing to take.
+/// The load is the common case by a very long way — an app asks to close once,
+/// ever.
 pub fn take_exit_request() -> bool {
-    EXIT_REQUESTED.swap(false, Ordering::SeqCst)
+    EXIT_REQUESTED.load(Ordering::SeqCst) && EXIT_REQUESTED.swap(false, Ordering::SeqCst)
 }
 
 #[cfg(test)]

--- a/crates/cranpose-ui/src/modifier/graphics_layer.rs
+++ b/crates/cranpose-ui/src/modifier/graphics_layer.rs
@@ -45,6 +45,34 @@ impl Modifier {
     ///
     /// Example:
     /// `Modifier::empty().graphics_layer(|| GraphicsLayer { alpha: 0.5, ..Default::default() })`
+    ///
+    /// # A drag that drives the translation must not be read inside it
+    ///
+    /// [`PointerEvent::position`](crate::modifier::PointerEvent::position) is
+    /// in the receiving node's own space, so a node this layer translates
+    /// reports a finger that has moved only as far as it OUTRAN the
+    /// translation. Feed that position back into `translation_x` and the
+    /// gesture measures itself:
+    ///
+    /// ```text
+    /// reported = finger - offset          offset = reported - start
+    ///         => offset = (finger - start) / 2
+    /// ```
+    ///
+    /// The offset converges on half the finger's travel and can never exceed
+    /// it, so a swipe-to-dismiss whose threshold is half the width never
+    /// crosses it however far the finger goes -- silently, with the content
+    /// sliding convincingly the whole time.
+    ///
+    /// Two ways out, and [`SwipeToDismiss`](crate::widgets::SwipeToDismiss)
+    /// uses both:
+    ///
+    /// - put `pointer_input` on a node OUTSIDE the translated one, which is
+    ///   also how Compose's own `SwipeToDismissBox` is built -- the drag is
+    ///   detected on the box, the content carries the layer;
+    /// - or read
+    ///   [`PointerEvent::global_position`](crate::modifier::PointerEvent::global_position),
+    ///   which no layer transform touches.
     pub fn graphics_layer(self, layer: impl Fn() -> GraphicsLayer + 'static) -> Self {
         let modifier = Self::with_element(LazyGraphicsLayerElement::new(Rc::new(layer)))
             .with_inspector_metadata(inspector_metadata("graphicsLayer", |info| {

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -2244,6 +2244,17 @@ pub fn run(
             current_host_window_size,
         );
 
+        // The app asked to be closed -- `cranpose_services::request_exit`. Not
+        // a break: this loop leaving would drop the surface while the activity
+        // is still up. `ANativeActivity_finish` asks the platform to tear the
+        // activity down, which arrives back here as `MainEvent::Destroy` and
+        // takes the ordinary exit below. So the app's request and the system's
+        // own back both end the same way.
+        if cranpose_services::take_exit_request() {
+            log::info!("App requested exit; finishing the activity");
+            crate::android_finish::finish_activity(app.activity_as_ptr());
+        }
+
         // Check if Destroy event requested exit
         if should_exit.load(Ordering::Relaxed) {
             log::info!("Exiting cleanly after Destroy event");

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -1594,6 +1594,12 @@ pub fn run(
         crate::android_frame_telemetry::AndroidFrameTelemetry::from_system_properties();
     crate::android_frame_telemetry::start_vsync_probe_if_enabled();
 
+    /// How many turns of the loop an unhonoured exit request is retried for.
+    /// Enough to ride out a transient JNI thread-attach failure, few enough
+    /// that a permanent one is not a call and a log line every frame.
+    const MAX_EXIT_ATTEMPTS: u32 = 3;
+    let mut exit_attempts = 0u32;
+
     // Main event loop
     loop {
         let mut frame_timings = crate::android_frame_telemetry::FrameTimings {
@@ -2246,13 +2252,30 @@ pub fn run(
 
         // The app asked to be closed -- `cranpose_services::request_exit`. Not
         // a break: this loop leaving would drop the surface while the activity
-        // is still up. `ANativeActivity_finish` asks the platform to tear the
+        // is still up. `Activity.finish()` asks the platform to tear the
         // activity down, which arrives back here as `MainEvent::Destroy` and
         // takes the ordinary exit below. So the app's request and the system's
         // own back both end the same way.
-        if cranpose_services::take_exit_request() {
+        //
+        // The flag is consumed only when the call lands. Taking it first and
+        // ignoring the result means a JNI failure -- a thread that could not
+        // attach, most plausibly -- swallows the app's one record that it
+        // wanted to close: it stays open, the user's gesture did nothing, and
+        // nothing will ever ask again. The retry is bounded so a permanent
+        // failure does not become a JNI call and a log line every frame for
+        // the rest of the process.
+        if cranpose_services::exit_requested() && exit_attempts < MAX_EXIT_ATTEMPTS {
+            exit_attempts += 1;
             log::info!("App requested exit; finishing the activity");
-            crate::android_finish::finish_activity(&app);
+            if crate::android_finish::finish_activity(&app) {
+                let _ = cranpose_services::take_exit_request();
+            } else if exit_attempts == MAX_EXIT_ATTEMPTS {
+                log::error!(
+                    "giving up on the app's exit request after {MAX_EXIT_ATTEMPTS} attempts; \
+                     the activity is still up"
+                );
+                let _ = cranpose_services::take_exit_request();
+            }
         }
 
         // Check if Destroy event requested exit

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -2252,7 +2252,7 @@ pub fn run(
         // own back both end the same way.
         if cranpose_services::take_exit_request() {
             log::info!("App requested exit; finishing the activity");
-            crate::android_finish::finish_activity(app.activity_as_ptr());
+            crate::android_finish::finish_activity(&app);
         }
 
         // Check if Destroy event requested exit

--- a/crates/cranpose/src/android_finish.rs
+++ b/crates/cranpose/src/android_finish.rs
@@ -1,0 +1,36 @@
+//! Closing the activity from inside the app.
+//!
+//! One NDK symbol, `ANativeActivity_finish`, and the safe call through it. It
+//! is the whole of the platform API behind [`crate::request_exit`] on Android:
+//! `android-activity` hands out the `ANativeActivity*` but wraps nothing that
+//! finishes it, and the C function is documented as safe to call from any
+//! thread — it posts a message to the activity's own looper rather than tearing
+//! anything down where it is called.
+//!
+//! `finish()` does not end the process or stop this frame. The activity is
+//! destroyed asynchronously and arrives back at the run loop as
+//! `MainEvent::Destroy`, which is the same path the system's own back takes, so
+//! an app-requested exit and a user-requested one leave through the same door.
+
+#![allow(unsafe_code)]
+
+use std::ffi::c_void;
+
+extern "C" {
+    fn ANativeActivity_finish(activity: *mut c_void);
+}
+
+/// Asks the platform to finish the activity.
+///
+/// `activity` must be the `ANativeActivity*` from the `AndroidApp` the run loop
+/// was handed; a null pointer is ignored rather than passed on.
+pub(crate) fn finish_activity(activity: *mut c_void) {
+    if activity.is_null() {
+        log::warn!("cannot finish the activity: no ANativeActivity pointer");
+        return;
+    }
+    // SAFETY: the pointer comes from `AndroidApp::activity_as_ptr` and the
+    // activity outlives the run loop that owns that handle. The call posts to
+    // the activity's looper and returns; it dereferences nothing here.
+    unsafe { ANativeActivity_finish(activity) };
+}

--- a/crates/cranpose/src/android_finish.rs
+++ b/crates/cranpose/src/android_finish.rs
@@ -1,36 +1,33 @@
-//! Closing the activity from inside the app.
+//! Closing the activity from inside the app: the Android half of
+//! [`crate::request_exit`].
 //!
-//! One NDK symbol, `ANativeActivity_finish`, and the safe call through it. It
-//! is the whole of the platform API behind [`crate::request_exit`] on Android:
-//! `android-activity` hands out the `ANativeActivity*` but wraps nothing that
-//! finishes it, and the C function is documented as safe to call from any
-//! thread — it posts a message to the activity's own looper rather than tearing
-//! anything down where it is called.
+//! It is a JNI call to `Activity.finish()`, and it has to be.
+//! `ANativeActivity_finish` looks like the obvious answer and is a trap:
+//! `AndroidApp::activity_as_ptr` returns a **jobject** global reference to the
+//! Activity, not an `ANativeActivity*` — android-activity's own source says so,
+//! and `android_jni` in this crate has always treated it as a jobject. Passing
+//! it to the NDK function type-confuses the two. Measured on a Pixel Watch 3
+//! before this was understood: `app died, no saved state` and `exited due to
+//! signal 9 (Killed)`, followed by a second of black while the system cleaned
+//! up. That reads exactly like a working-but-slow exit, which is what makes it
+//! worth a module of its own with the reason written down.
 //!
 //! `finish()` does not end the process or stop this frame. The activity is
 //! destroyed asynchronously and arrives back at the run loop as
 //! `MainEvent::Destroy`, which is the same path the system's own back takes, so
 //! an app-requested exit and a user-requested one leave through the same door.
 
-#![allow(unsafe_code)]
-
-use std::ffi::c_void;
-
-extern "C" {
-    fn ANativeActivity_finish(activity: *mut c_void);
-}
+use crate::android_jni::with_android_activity_env;
+use jni::{jni_sig, jni_str};
 
 /// Asks the platform to finish the activity.
-///
-/// `activity` must be the `ANativeActivity*` from the `AndroidApp` the run loop
-/// was handed; a null pointer is ignored rather than passed on.
-pub(crate) fn finish_activity(activity: *mut c_void) {
-    if activity.is_null() {
-        log::warn!("cannot finish the activity: no ANativeActivity pointer");
-        return;
+pub(crate) fn finish_activity(app: &android_activity::AndroidApp) {
+    let finished = with_android_activity_env(app, |env, activity| {
+        env.call_method(&activity, jni_str!("finish"), jni_sig!("()V"), &[])
+            .map(|_| ())
+            .map_err(|error| format!("Activity.finish() failed: {error}"))
+    });
+    if let Err(error) = finished {
+        log::error!("could not finish the activity: {error}");
     }
-    // SAFETY: the pointer comes from `AndroidApp::activity_as_ptr` and the
-    // activity outlives the run loop that owns that handle. The call posts to
-    // the activity's looper and returns; it dereferences nothing here.
-    unsafe { ANativeActivity_finish(activity) };
 }

--- a/crates/cranpose/src/android_finish.rs
+++ b/crates/cranpose/src/android_finish.rs
@@ -1,5 +1,5 @@
 //! Closing the activity from inside the app: the Android half of
-//! [`crate::request_exit`].
+//! [`cranpose_services::request_exit`].
 //!
 //! It is a JNI call to `Activity.finish()`, and it has to be.
 //! `ANativeActivity_finish` looks like the obvious answer and is a trap:
@@ -17,17 +17,35 @@
 //! `MainEvent::Destroy`, which is the same path the system's own back takes, so
 //! an app-requested exit and a user-requested one leave through the same door.
 
-use crate::android_jni::with_android_activity_env;
+use crate::android_jni::{clear_pending_android_jni_exception, with_android_activity_env};
 use jni::{jni_sig, jni_str};
 
-/// Asks the platform to finish the activity.
-pub(crate) fn finish_activity(app: &android_activity::AndroidApp) {
+/// Asks the platform to finish the activity. Returns whether the call landed.
+///
+/// The caller needs the answer: the exit flag is the app's only record that it
+/// asked to close, and consuming it for a call that did not happen loses the
+/// request with nothing left to retry from.
+pub(crate) fn finish_activity(app: &android_activity::AndroidApp) -> bool {
     let finished = with_android_activity_env(app, |env, activity| {
         env.call_method(&activity, jni_str!("finish"), jni_sig!("()V"), &[])
             .map(|_| ())
-            .map_err(|error| format!("Activity.finish() failed: {error}"))
+            .map_err(|error| {
+                // A failed JNI call can leave an exception pending on the
+                // thread, and the NEXT JNI call on that thread is the one that
+                // dies for it -- with this call's exception, in a stack that
+                // has nothing to do with finishing an activity. Every other
+                // caller in this crate clears before returning the error, and
+                // `clear_pending_android_jni_exception` logs it on the way out
+                // so the cause is not simply swallowed.
+                clear_pending_android_jni_exception(env);
+                format!("Activity.finish() failed: {error}")
+            })
     });
-    if let Err(error) = finished {
-        log::error!("could not finish the activity: {error}");
+    match finished {
+        Ok(()) => true,
+        Err(error) => {
+            log::error!("could not finish the activity: {error}");
+            false
+        }
     }
 }

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -4759,6 +4759,14 @@ impl ApplicationHandler for App {
     }
 
     fn about_to_wait(&mut self, event_loop: &dyn ActiveEventLoop) {
+        // The app asked to be closed -- `cranpose_services::request_exit`.
+        // Checked here rather than inside an event handler because the request
+        // usually comes from composition, which runs from this loop, and
+        // `exit()` only takes effect at the next turn of it anyway.
+        if cranpose_services::take_exit_request() {
+            event_loop.exit();
+            return;
+        }
         let now = Instant::now();
         if self.poll_native_window_global_primary_press() {
             self.refresh_native_window_requests();

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -20,6 +20,8 @@ mod android_accessibility;
 #[cfg(all(feature = "android", target_os = "android"))]
 mod android_app_info;
 #[cfg(all(feature = "android", target_os = "android"))]
+mod android_finish;
+#[cfg(all(feature = "android", target_os = "android"))]
 mod android_font_scale;
 #[cfg(all(feature = "android", target_os = "android"))]
 mod android_frame_rate;

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -1141,8 +1141,6 @@ fn unsafe_code_stays_in_reviewed_platform_boundary_modules() {
         "android_services.rs",
         "android_surface.rs",
         "android_file_picker.rs",
-        // One `ANativeActivity_finish`: how `request_exit` closes the app.
-        "android_finish.rs",
         // The Play Billing bridge: the exported symbols
         // `dev.cranpose.android.CranposeBilling` calls back through. Decoding
         // what they carry lives in safe Rust next door, in
@@ -1336,7 +1334,6 @@ fn workspace_ffi_boundaries_are_explicit() {
         "crates/cranpose/src/android_services.rs",
         "crates/cranpose/src/android_surface.rs",
         "crates/cranpose/src/android_file_picker.rs",
-        "crates/cranpose/src/android_finish.rs",
         // The Play Billing bridge: the exported symbols
         // `dev.cranpose.android.CranposeBilling` calls back through, and
         // nothing else. Decoding the payloads they carry lives in safe Rust in

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -1141,6 +1141,8 @@ fn unsafe_code_stays_in_reviewed_platform_boundary_modules() {
         "android_services.rs",
         "android_surface.rs",
         "android_file_picker.rs",
+        // One `ANativeActivity_finish`: how `request_exit` closes the app.
+        "android_finish.rs",
         // The Play Billing bridge: the exported symbols
         // `dev.cranpose.android.CranposeBilling` calls back through. Decoding
         // what they carry lives in safe Rust next door, in
@@ -1334,6 +1336,7 @@ fn workspace_ffi_boundaries_are_explicit() {
         "crates/cranpose/src/android_services.rs",
         "crates/cranpose/src/android_surface.rs",
         "crates/cranpose/src/android_file_picker.rs",
+        "crates/cranpose/src/android_finish.rs",
         // The Play Billing bridge: the exported symbols
         // `dev.cranpose.android.CranposeBilling` calls back through, and
         // nothing else. Decoding the payloads they carry lives in safe Rust in


### PR DESCRIPTION
Two things a Wear app built on Cranpose ran into. Both are small; the second is the one that cost an afternoon.

## `request_exit()`

`set_back_interception(false)` says *"let the platform's own back control take me out of here."* There was no way to say the same thing when the **app** is the one that decided — and an app that owns the affordance meaning "leave" needs exactly that:

- **a screen-level dismiss gesture the app draws itself.** On Android a `NativeActivity` consumes every pointer event on the display, so the window-level swipe never fires and the app's own gesture is the only one there is. Completing it has to close the app, and a watch has no back key to fall back on.
- **a Quit item in the app's own menu.**

`request_exit()` sets a flag beside the back-request counter; the backend drains it.

| platform | behaviour |
|---|---|
| Android | finishes the activity — the same outcome as Compose's `backDispatcher.onBackPressed()` on a screen with no `BackHandler` |
| Desktop | exits the event loop |
| iOS | nothing, documented: Apple forbids an app terminating itself |
| Web | nothing, documented: a page cannot close a tab it did not open |

Doing nothing is deliberate rather than an omission, so an app can call this unconditionally.

It is a *request* and not a call because the decision usually lands inside a gesture's settle animation, where closing the window would tear the frame down mid-draw. On Android it is deliberately **not** a `break` either: the loop leaving would drop the surface with the activity still up. `finish()` is asked for, and the `MainEvent::Destroy` that comes back takes the ordinary exit — so an app request and a user's back leave through the same door.

The one NDK symbol lives in `android_finish.rs` alongside the crate's other FFI boundary modules, and is named in the two guard tests that keep unsafe code where it can be reviewed.

## The `graphics_layer` note

A pointer position is in its own node's space, so a node a graphics layer translates reports a finger that has moved only as far as it *outran* the translation. Feed that back into `translation_x` and the gesture measures itself:

```
reported = finger - offset,   offset = reported - start
  =>  offset = (finger - start) / 2
```

The offset converges on half the finger's travel and can never exceed it — so a swipe-to-dismiss whose threshold is half the width never crosses it, however far the finger goes. It fails silently: the content slides convincingly the whole way and then springs back.

`SwipeToDismiss` already avoids this twice over — the gesture is read on the outer node, the way Compose's own `SwipeToDismissBox` is built, and it reads `global_position` — but nothing said so anywhere, and both escapes read as incidental style until you know why they are there. This adds the rule and both escapes to the `graphics_layer` docs, plus an app-shell test pinning the contract they rest on: a handler inside a translated node sees the tap shifted, `global_position` does not move, and a handler outside sees it where it happened.

## Verification

- `robot_request_exit` drives the desktop backend and the process ends on its own; it fails loudly rather than hanging if the request is dropped.
- The Android side compiles and links through a consuming app (arm64 APK).
- `cargo fmt --check`, `check_cranpose_versions.py`, `cargo test --profile ci --workspace`, `cargo clippy --workspace --all-targets -D warnings`, the iOS-sim clippy target, `--no-default-features` build and `--all-features` check: all green.