### PR TITLE
Tell the app when the Play store has news

### DIFF
--- a/crates/cranpose/src/android_purchases.rs
+++ b/crates/cranpose/src/android_purchases.rs
@@ -203,6 +203,11 @@ pub extern "system" fn Java_dev_cranpose_android_CranposeBilling_nativeBillingSn
         Outcome::Err(_) | Outcome::Panic(_) => return,
     };
     *snapshot() = Some(decode_store_snapshot(&payload));
+    // Tell the app, rather than leaving it to ask. Waking the loop alone means
+    // the store is only ever read by an app that re-reads it every frame --
+    // and an app that has gone idle, which is the right thing to be on a
+    // screen showing a price, has no frame to re-read it from.
+    cranpose_services::note_store_news();
     wake_native_loop();
 }
 
@@ -233,5 +238,6 @@ pub extern "system" fn Java_dev_cranpose_android_CranposeBilling_nativeBillingEv
     }
     events.push_back(event);
     drop(events);
+    cranpose_services::note_store_news();
     wake_native_loop();
 }

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -1888,6 +1888,50 @@ fn workspace_crate_roots(workspace_dir: &Path) -> Vec<PathBuf> {
     roots
 }
 
+/// Every store backend has to announce news, not only wake the loop.
+///
+/// `set_store_listener` exists because `take_event`/`store_state` are polling
+/// APIs and an idle app has no frame loop to poll from. A backend that only
+/// calls `wake_native_loop()` leaves the app to notice on some later frame it
+/// may never run: measured on a watch app, zero CPU jiffies over ten seconds on
+/// the screen showing a price, so a purchase approved while sitting there would
+/// never have been seen. iOS announced from the day the listener landed and
+/// Android did not, which is the asymmetry this pins down -- one backend
+/// growing a new decode path and forgetting to tell anyone is the same bug
+/// again.
+#[test]
+fn every_store_backend_tells_the_app_rather_than_leaving_it_to_ask() {
+    let android = crate_source("src/android_purchases.rs");
+    let apple = workspace_source("crates/cranpose-storekit/src/apple.rs");
+
+    for (backend, source) in [("android", &android), ("apple", &apple)] {
+        assert!(
+            source.contains("note_store_news()"),
+            "the {backend} store backend must announce news through note_store_news()"
+        );
+    }
+
+    // Both JNI entry points, not just whichever one was noticed first: a
+    // snapshot and an event are separate ways for the store to have news.
+    for entry_point in [
+        "Java_dev_cranpose_android_CranposeBilling_nativeBillingSnapshot",
+        "Java_dev_cranpose_android_CranposeBilling_nativeBillingEvent",
+    ] {
+        let body = android
+            .split(entry_point)
+            .nth(1)
+            .unwrap_or_else(|| panic!("{entry_point} should exist in android_purchases.rs"));
+        let body = body
+            .split("pub extern \"system\"")
+            .next()
+            .expect("an entry point body should be delimited by the next one");
+        assert!(
+            body.contains("note_store_news()"),
+            "{entry_point} decodes store news and must announce it, not only wake the loop"
+        );
+    }
+}
+
 fn is_crate_root_source(path: &Path) -> bool {
     let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
         return false;


### PR DESCRIPTION
`set_store_listener` worked on iOS and nowhere else.

The Android billing bridge decodes a snapshot or an event and then only calls `wake_native_loop()`. Waking the loop leaves the app to *notice* by re-reading the store on some later frame — so every Android app on this framework has to poll `purchases::store_state()` on a timer, and an app that has gone idle has no frame to re-read from. On a watch app I measured **zero CPU jiffies over ten seconds** on the screen that shows the price: a purchase approved while sitting there would never have been seen.

Both JNI callbacks now call `cranpose_services::note_store_news()` as well. The loop wake stays — an app that wants a redraw out of this still needs one, and `note_store_news` only reaches apps that registered a listener, so nothing changes for an app that polls today.

Two lines. The asymmetry was the bug: `apple.rs` has announced its store changes since it was written.

## Verification

Compiles and links for `aarch64-linux-android` through a consuming app; `cargo fmt --check` and the `cranpose-services` tests are green. The behaviour itself needs a device with a Play account, so it is exercised by the app that prompted this rather than by a unit test here.