### PR TITLE
Tell an app which purchase granted an entitlement

### DIFF
--- a/crates/cranpose-services/src/purchases.rs
+++ b/crates/cranpose-services/src/purchases.rs
@@ -35,7 +35,7 @@
 //! express, like "the user cancelled" — for showing a message once.
 
 use std::cell::RefCell;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
 /// A product as the store describes it, in the user's locale and currency.
@@ -113,6 +113,20 @@ pub struct StoreState {
     /// Product ids the account currently owns. For non-consumables and
     /// subscriptions this is the entitlement; consumables never appear.
     pub owned: BTreeSet<String>,
+    /// The store's identifier for the purchase that granted each owned
+    /// product — Play's order id, StoreKit's transaction id.
+    ///
+    /// Separate from [`owned`](Self::owned) rather than replacing it, because
+    /// a backend can know that a product is owned without knowing what paid
+    /// for it: Play's `queryPurchases` omits the order id for a test purchase,
+    /// and a restore on a reinstalled app can report ownership before the
+    /// receipt is back. Ownership is the entitlement; this is only the paper
+    /// trail. Never gate access on it.
+    ///
+    /// An app that keeps a local record of the purchase wants it: with only
+    /// the product id there is nothing to quote to the store, or to the user,
+    /// if the entitlement is ever in dispute.
+    pub orders: BTreeMap<String, String>,
     /// Last error reported by the store, for diagnostics. A store being
     /// briefly unreachable is normal and not worth showing to the user.
     pub error: Option<String>,
@@ -125,6 +139,13 @@ impl StoreState {
     /// Whether `product_id` is currently owned.
     pub fn owns(&self, product_id: &str) -> bool {
         self.owned.contains(product_id)
+    }
+
+    /// The store's identifier for the purchase that granted `product_id`, if
+    /// the backend reported one. See [`orders`](Self::orders): absent is
+    /// normal and does not mean unowned.
+    pub fn order_id(&self, product_id: &str) -> Option<&str> {
+        self.orders.get(product_id).map(String::as_str)
     }
 
     /// The product with `product_id`, if the store answered for it.
@@ -345,6 +366,10 @@ mod tests {
                         description: "Everything unlocked".into(),
                     }],
                     owned: BTreeSet::from(["com.example.pro".to_string()]),
+                    orders: BTreeMap::from([(
+                        "com.example.pro".to_string(),
+                        "GPA.1234-5678".to_string(),
+                    )]),
                     error: None,
                     busy: false,
                 }
@@ -359,6 +384,10 @@ mod tests {
         let state = store_state();
         assert_eq!(state.phase, StorePhase::Ready);
         assert!(state.owns("com.example.pro"));
+        assert_eq!(state.order_id("com.example.pro"), Some("GPA.1234-5678"));
+        // Absent is normal: a backend can know a product is owned without
+        // knowing what paid for it, so this must never read as "not owned".
+        assert_eq!(state.order_id("com.example.free"), None);
         assert_eq!(state.display_price("com.example.pro"), Some("34,99 €"));
         assert_eq!(state.display_price("com.example.nope"), None);
         assert!(store_available());

--- a/crates/cranpose-storekit/src/apple.rs
+++ b/crates/cranpose-storekit/src/apple.rs
@@ -8,7 +8,7 @@
 use cranpose_services::purchases::{
     set_platform_purchases, Product, PurchaseEvent, Purchases, StorePhase, StoreState,
 };
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ffi::{c_char, c_void, CStr, CString};
 use std::rc::Rc;
 use std::sync::Mutex;
@@ -65,6 +65,7 @@ struct Shared {
     staging: bool,
     staged_products: Vec<Product>,
     staged_owned: BTreeSet<String>,
+    staged_orders: BTreeMap<String, String>,
     live: StoreState,
     events: VecDeque<PurchaseEvent>,
 }
@@ -75,10 +76,12 @@ impl Shared {
             staging: false,
             staged_products: Vec::new(),
             staged_owned: BTreeSet::new(),
+            staged_orders: BTreeMap::new(),
             live: StoreState {
                 phase: StorePhase::Unavailable,
                 products: Vec::new(),
                 owned: BTreeSet::new(),
+                orders: BTreeMap::new(),
                 error: None,
                 busy: false,
             },
@@ -126,6 +129,7 @@ unsafe extern "C" fn on_message(
             state.staging = true;
             state.staged_products.clear();
             state.staged_owned.clear();
+            state.staged_orders.clear();
         }
         KIND_PRODUCT => {
             let (Some(id), Some(display_price)) = (take(a), take(b)) else {
@@ -140,6 +144,13 @@ unsafe extern "C" fn on_message(
         }
         KIND_OWNED => {
             if let Some(id) = take(a) {
+                // The order id is optional on this row and must stay that way:
+                // Android cannot always supply one, so an app reading it has to
+                // handle absence anyway, and a row without it is a normal owned
+                // product rather than a malformed one.
+                if let Some(order) = take(b) {
+                    state.staged_orders.insert(id.clone(), order);
+                }
                 state.staged_owned.insert(id);
             }
         }
@@ -150,6 +161,7 @@ unsafe extern "C" fn on_message(
             if state.staging {
                 state.live.products = std::mem::take(&mut state.staged_products);
                 state.live.owned = std::mem::take(&mut state.staged_owned);
+                state.live.orders = std::mem::take(&mut state.staged_orders);
                 state.staging = false;
             }
             state.live.phase = match arg0 {

--- a/crates/cranpose-storekit/swift/storekit.swift
+++ b/crates/cranpose-storekit/swift/storekit.swift
@@ -333,15 +333,21 @@ private func describe(_ error: Error) -> String {
     return error.localizedDescription
 }
 
-/// Product ids this Apple ID currently owns, signature-verified.
+/// Product ids this Apple ID currently owns, signature-verified, each with the
+/// id of the transaction that granted it.
+///
+/// The transaction id is the paper trail an app needs to quote if an
+/// entitlement is ever in dispute; ownership itself is the product id being
+/// present. StoreKit always has one here, unlike Play, but a caller must still
+/// treat it as optional -- the Android backend cannot always supply it.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private func ownedProductIds() async -> [String] {
-    var owned: [String] = []
+private func ownedProductIds() async -> [(id: String, orderId: String)] {
+    var owned: [(id: String, orderId: String)] = []
     for await entitlement in Transaction.currentEntitlements {
         guard case .verified(let transaction) = entitlement else { continue }
         if transaction.revocationDate != nil { continue }
         if let expires = transaction.expirationDate, expires < Date() { continue }
-        owned.append(transaction.productID)
+        owned.append((transaction.productID, String(transaction.id)))
     }
     return owned
 }
@@ -373,8 +379,8 @@ private func refreshSnapshot() async {
             product.description
         )
     }
-    for id in owned {
-        sink.send(.owned, 0, 0, id)
+    for entitlement in owned {
+        sink.send(.owned, 0, 0, entitlement.id, entitlement.orderId)
     }
     // Entitlements are authoritative even when the product lookup failed, so
     // a store outage never revokes an unlock the user already paid for: the

--- a/crates/cranpose/android/java-billing/dev/cranpose/android/CranposeBilling.java
+++ b/crates/cranpose/android/java-billing/dev/cranpose/android/CranposeBilling.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 
 /**
@@ -83,6 +84,15 @@ public final class CranposeBilling implements PurchasesUpdatedListener {
     private final List<String> productIds = new ArrayList<>();
     private final Map<String, ProductDetails> products = new LinkedHashMap<>();
     private final Set<String> owned = new TreeSet<>();
+    /**
+     * Product id to the order id of the purchase that granted it.
+     *
+     * <p>Kept beside {@link #owned} rather than replacing it: Play does not always have an
+     * order id to give. A test purchase has none, and a restore can report ownership before
+     * the receipt is back. Ownership is the entitlement; this is only the paper trail, and a
+     * caller must never gate access on it.
+     */
+    private final Map<String, String> orders = new TreeMap<>();
     private boolean productsKnown;
     private boolean ownedKnown;
     private boolean connected;
@@ -447,10 +457,17 @@ public final class CranposeBilling implements PurchasesUpdatedListener {
      */
     private int apply(List<Purchase> purchases, boolean announce) {
         Set<String> found = new TreeSet<>();
+        Map<String, String> foundOrders = new TreeMap<>();
         boolean pending = false;
         for (Purchase purchase : purchases) {
             if (purchase.getPurchaseState() == Purchase.PurchaseState.PURCHASED) {
                 found.addAll(purchase.getProducts());
+                String orderId = purchase.getOrderId();
+                if (orderId != null && !orderId.isEmpty()) {
+                    for (String id : purchase.getProducts()) {
+                        foundOrders.put(id, orderId);
+                    }
+                }
                 acknowledge(purchase);
             } else if (purchase.getPurchaseState() == Purchase.PurchaseState.PENDING) {
                 pending = true;
@@ -459,6 +476,8 @@ public final class CranposeBilling implements PurchasesUpdatedListener {
         synchronized (lock) {
             owned.clear();
             owned.addAll(found);
+            orders.clear();
+            orders.putAll(foundOrders);
             ownedKnown = true;
         }
         pushSnapshot();
@@ -631,6 +650,10 @@ public final class CranposeBilling implements PurchasesUpdatedListener {
             }
             for (String id : owned) {
                 payload.append('\n').append("o\t").append(escape(id));
+                String orderId = orders.get(id);
+                if (orderId != null && !orderId.isEmpty()) {
+                    payload.append('\t').append(escape(orderId));
+                }
             }
         }
         nativeBillingSnapshot(payload.toString());

--- a/crates/cranpose/src/android_purchase_wire.rs
+++ b/crates/cranpose/src/android_purchase_wire.rs
@@ -29,7 +29,7 @@
 //! be decoded in lock step.
 
 use cranpose_services::purchases::{Product, PurchaseEvent, StorePhase, StoreState};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// One-shot event codes, mirroring the constants in `CranposeBilling.java`.
 /// Both sides live in this repository and change together.
@@ -58,11 +58,19 @@ pub(crate) fn decode_store_snapshot(payload: &str) -> StoreState {
 
     let mut products = Vec::new();
     let mut owned = BTreeSet::new();
+    let mut orders = BTreeMap::new();
     for record in lines {
         let mut fields = record.split('\t');
         match fields.next() {
             Some("p") => products.extend(decode_product(&mut fields)),
-            Some("o") => owned.extend(decode_owned(&mut fields)),
+            Some("o") => {
+                if let Some((id, order)) = decode_owned(&mut fields) {
+                    if let Some(order) = order {
+                        orders.insert(id.clone(), order);
+                    }
+                    owned.insert(id);
+                }
+            }
             _ => {}
         }
     }
@@ -71,6 +79,7 @@ pub(crate) fn decode_store_snapshot(payload: &str) -> StoreState {
         phase,
         products,
         owned,
+        orders,
         error,
         busy,
     }
@@ -119,9 +128,25 @@ fn decode_product<'a>(fields: &mut impl Iterator<Item = &'a str>) -> Option<Prod
     })
 }
 
-fn decode_owned<'a>(fields: &mut impl Iterator<Item = &'a str>) -> Option<String> {
+/// An owned record: the product id, and the order id if the store had one.
+///
+/// The order id is OPTIONAL and always has been on the wire -- Play does not
+/// always have one to give (a test purchase has none, and a restore can report
+/// ownership before the receipt is back), and a bridge built before this field
+/// existed simply does not append it. A record with no second field is a normal
+/// owned product, not a malformed one.
+fn decode_owned<'a>(
+    fields: &mut impl Iterator<Item = &'a str>,
+) -> Option<(String, Option<String>)> {
     let id = unescape(fields.next()?);
-    (!id.is_empty()).then_some(id)
+    if id.is_empty() {
+        return None;
+    }
+    let order = fields
+        .next()
+        .map(unescape)
+        .filter(|order| !order.is_empty());
+    Some((id, order))
 }
 
 fn unescape(value: &str) -> String {
@@ -138,6 +163,36 @@ fn unescape(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn an_owned_row_carries_the_order_id_when_the_store_had_one() {
+        let state = decode_store_snapshot(concat!(
+            "2\t0\t\n",
+            "o\tcom.example.pro\tGPA.3311-9944-1234-56789\n",
+            // No order id: Play has none for a test purchase, and a restore can
+            // report ownership before the receipt is back. Still owned.
+            "o\tcom.example.hints"
+        ));
+
+        assert!(state.owns("com.example.pro"));
+        assert_eq!(
+            state.order_id("com.example.pro"),
+            Some("GPA.3311-9944-1234-56789")
+        );
+
+        assert!(
+            state.owns("com.example.hints"),
+            "a row without an order id is a normal owned product"
+        );
+        assert_eq!(state.order_id("com.example.hints"), None);
+    }
+
+    #[test]
+    fn an_order_id_containing_a_tab_survives_the_wire() {
+        // Nothing in Play's format forbids it, and the row is tab separated.
+        let state = decode_store_snapshot(concat!("2\t0\t\n", "o\tcom.example.pro\tGPA%09odd"));
+        assert_eq!(state.order_id("com.example.pro"), Some("GPA\todd"));
+    }
 
     #[test]
     fn decoding_recovers_prices_and_owned_entitlements() {

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -564,6 +564,48 @@ fn android_play_billing_reaches_the_purchase_registry() {
     );
 }
 
+/// The writer's half of the owned row's order id.
+///
+/// Nothing in CI compiles or runs `CranposeBilling.java` -- no app in this
+/// workspace enables the `playbilling` feature -- so the decoder's tests are
+/// the only executable coverage the wire has, and they would keep passing with
+/// the Java side of the field deleted: `order_id()` would simply return `None`
+/// on every Android device, forever, which is also what a legitimately absent
+/// order id looks like.
+#[test]
+fn the_play_billing_bridge_sends_the_order_id_that_granted_each_entitlement() {
+    let java_source = workspace_source(
+        "crates/cranpose/android/java-billing/dev/cranpose/android/CranposeBilling.java",
+    );
+
+    assert!(
+        java_source.contains("purchase.getOrderId()"),
+        "the bridge must read Play's order id; the product id is what the app already knew"
+    );
+    assert!(
+        java_source.contains("escape(orderId)"),
+        "the order id must be escaped onto the owned row like every other field: the row is \
+         tab separated and nothing in Play's format forbids a tab"
+    );
+
+    // The two maps are one fact split in half. Refilling `owned` without
+    // refilling `orders` in the same breath leaves an order id outliving the
+    // purchase that produced it -- a paper trail pointing at the wrong sale.
+    let apply = java_source
+        .split("private int apply(")
+        .nth(1)
+        .expect("the snapshot bridge should apply purchase lists in one place");
+    let apply = apply
+        .split("\n    private")
+        .next()
+        .expect("a method body is delimited by the next member");
+    assert!(
+        apply.contains("owned.clear()") && apply.contains("orders.clear()"),
+        "ownership and its order ids must be replaced together, or an order id survives the \
+         purchase it belongs to"
+    );
+}
+
 #[test]
 fn android_native_input_is_drained_on_input_available_event() {
     let source = crate_source("src/android.rs");


### PR DESCRIPTION
`StoreState` said what the account owns and nothing about what paid for it. An app that keeps its own record of a purchase therefore had only the product id — which it already knew — so there is nothing to quote to the store, or to the user, if the entitlement is ever in dispute.

Found from the app side: a Wear game ported onto Cranpose writes an empty string where its Compose predecessor wrote Play's order id, and its published privacy policy still says the order number is kept.

## What this adds

`StoreState::orders: BTreeMap<String, String>` — product id to the store's identifier for the purchase that granted it — plus `StoreState::order_id(product_id) -> Option<&str>`.

Both backends fill it:
- **Android**: `Purchase.getOrderId()`, carried as an optional trailing field on the existing `o` row.
- **Apple**: `transaction.id`, which was already in hand three lines from where the row is sent.

## Why it is separate from `owned`, and optional

A backend can know a product is owned without knowing what paid for it. Play has no order id for a test purchase, and a restore can report ownership before the receipt is back. Ownership is the entitlement; this is only the paper trail — gating access on it would lock out exactly the users whose purchase is hardest to verify. That is documented on the field, on the Java map and on the Swift helper.

The wire row keeps the order id as an optional trailing field for the same reason, so a row without one decodes as a normal owned product rather than a malformed one.

## Tests

- `an_owned_row_carries_the_order_id_when_the_store_had_one` — covers both the present and absent cases, and asserts the absent one is still owned.
- `an_order_id_containing_a_tab_survives_the_wire` — the row is tab separated and nothing in Play's format forbids a tab.
- The services fixture now asserts `order_id` for a known product and `None` for an unknown one.

Gates run locally: `cargo fmt --check`, `check_cranpose_versions.py`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --profile ci --workspace` (114 test binaries), and `cargo check` for `aarch64-linux-android`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)