### PR TITLE
Let a drawn control be a control a screen reader can reach

### DIFF
--- a/apps/desktop-demo/robot-runners/robot_subcompose_invalidation.rs
+++ b/apps/desktop-demo/robot-runners/robot_subcompose_invalidation.rs
@@ -18,6 +18,7 @@ use cranpose_core::useState;
 use cranpose_foundation::lazy::{remember_lazy_list_state, LazyListScope};
 use cranpose_testing::{find_button, find_in_semantics, find_text_in_semantics};
 use cranpose_ui::widgets::*;
+use cranpose_ui::SemanticsWidgetRole;
 use cranpose_ui::{Color, Modifier, TextStyle};
 use std::time::Duration;
 
@@ -67,7 +68,7 @@ fn test_app() {
                     .padding(8.0)
                     .background(Color(0.3, 0.3, 0.5, 1.0))
                     .semantics(|c| {
-                        c.is_button = true;
+                        c.role = Some(SemanticsWidgetRole::Button);
                         c.content_description = Some("Change Colors".into());
                     }),
                 ButtonSpec::default(),

--- a/apps/desktop-demo/src/app/liquid_ui.rs
+++ b/apps/desktop-demo/src/app/liquid_ui.rs
@@ -15,7 +15,7 @@ use cranpose::{
     composable, mutableStateOf, remember, Brush, Color, CornerRadii, GraphicsLayer, Modifier,
     Point, PointerEventKind, PointerInputScope, Rect, ScrollState, Size,
 };
-use cranpose_foundation::SemanticsConfiguration;
+use cranpose_foundation::{SemanticsConfiguration, SemanticsWidgetRole};
 use cranpose_ui::{Alignment, HorizontalAlignment, VerticalAlignment};
 use std::cell::RefCell;
 
@@ -171,7 +171,7 @@ fn TogglePressReferenceStage(checked: bool, on_change: impl Fn(bool) + 'static) 
                 Modifier::empty()
                     .offset(layout.track_origin.x, layout.track_origin.y)
                     .semantics(|config| {
-                        config.is_button = true;
+                        config.role = Some(SemanticsWidgetRole::Button);
                         config.is_clickable = true;
                         config.content_description = Some("Wi-Fi switch".to_string());
                     }),
@@ -1022,7 +1022,7 @@ fn SortFilterStage(suggestion_offset: f32) {
                                         .offset(-16.0, 0.0)
                                         .report_window_rect(std::rc::Rc::clone(&anchor_sink))
                                         .semantics(|config| {
-                                            config.is_button = true;
+                                            config.role = Some(SemanticsWidgetRole::Button);
                                             config.is_clickable = true;
                                             config.content_description =
                                                 Some("Sort filter pill".to_string());
@@ -1316,7 +1316,7 @@ fn StoreHeadersBarExample(selected: usize, on_select: impl Fn(usize) + 'static) 
             .width(440.0)
             .height(112.0)
             .semantics(|config| {
-                config.is_button = true;
+                config.role = Some(SemanticsWidgetRole::Button);
                 config.is_clickable = true;
                 config.content_description = Some("Headers fold stage".to_string());
             }),
@@ -1576,7 +1576,7 @@ fn FeaturedVideosReferenceCard(
         Modifier::empty()
             .required_size(Size::new(330.0, 226.0))
             .semantics(|config| {
-                config.is_button = true;
+                config.role = Some(SemanticsWidgetRole::Button);
                 config.is_clickable = true;
                 config.content_description = Some("Featured videos".to_string());
             })
@@ -2190,7 +2190,8 @@ pub fn LiquidUiTab() {
                                                     let t = toggle_a2;
                                                     LiquidToggle(
                                                         Modifier::empty().semantics(|config| {
-                                                            config.is_button = true;
+                                                            config.role =
+                                                                Some(SemanticsWidgetRole::Button);
                                                             config.is_clickable = true;
                                                             config.content_description = Some(
                                                                 "Wi-Fi settings switch".to_string(),

--- a/crates/cranpose-foundation/src/modifier.rs
+++ b/crates/cranpose-foundation/src/modifier.rs
@@ -663,14 +663,249 @@ pub trait FocusNode: ModifierNode {
     }
 }
 
+/// What kind of control a node is, as screen readers announce it.
+///
+/// This is Compose's `SemanticsProperties.Role` (`Modifier.semantics { role =
+/// Role.RadioButton }`), not a description of where the node sits in the tree.
+/// A screen reader turns it into the trailing noun it speaks after the label —
+/// TalkBack says "CAMPAIGN, radio button, selected" — and into the on/off
+/// wording it uses for a switch. Compose keeps this separate from the node's
+/// structural kind for the same reason Cranpose does: a `Row` that happens to
+/// be clickable is still a row, and a drawn ring segment that is a radio button
+/// has no layout node of its own at all.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SemanticsWidgetRole {
+    Button,
+    Checkbox,
+    Switch,
+    RadioButton,
+    Tab,
+    Image,
+    /// Compose's `heading()`, which is a property rather than a `Role`, but
+    /// reaches the platform through the same field on every backend Cranpose
+    /// targets (`AccessibilityNodeInfo.setHeading`, `Role::Heading`,
+    /// `<h*>`/`UIAccessibilityTraitHeader`).
+    Header,
+}
+
+/// A screen-reader action that is not a click, e.g. Compose's
+/// `customActions = listOf(CustomAccessibilityAction("Pause") { … })`.
+///
+/// TalkBack surfaces these through its actions menu rather than by activating
+/// the node, which is the only way to reach a command that has no on-screen
+/// control — pausing a game whose whole surface is one tap-to-launch target.
+#[derive(Clone)]
+pub struct SemanticsCustomAction {
+    /// What the screen reader reads out in its actions menu.
+    pub label: String,
+    handler: Rc<dyn Fn()>,
+}
+
+impl SemanticsCustomAction {
+    pub fn new(label: impl Into<String>, handler: impl Fn() + 'static) -> Self {
+        Self {
+            label: label.into(),
+            handler: Rc::new(handler),
+        }
+    }
+
+    pub fn invoke(&self) {
+        (self.handler)();
+    }
+}
+
+impl fmt::Debug for SemanticsCustomAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SemanticsCustomAction")
+            .field("label", &self.label)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Two custom actions are the same action when they read the same.
+///
+/// The handler is deliberately excluded. A semantics recorder runs on every
+/// collection, so the closure is a fresh `Rc` each time and comparing handler
+/// identity would report "the tree changed" on every frame — which on Android
+/// means re-serialising and re-publishing the whole virtual-view tree across
+/// JNI 60 times a second. Handlers are looked up in the live semantics tree at
+/// the moment the action fires (see `perform_custom_action`), so a handler that
+/// is newer than the last published snapshot is still the one that runs.
+impl PartialEq for SemanticsCustomAction {
+    fn eq(&self, other: &Self) -> bool {
+        self.label == other.label
+    }
+}
+
+impl Eq for SemanticsCustomAction {}
+
+/// A semantics node for content that is *drawn* rather than laid out.
+///
+/// An immediate-mode surface — one `Canvas` that paints a whole screen — has
+/// exactly one layout node, so the semantics tree built from layout has exactly
+/// one node to offer a screen reader. This is the escape hatch: the drawing
+/// code already knows where it put every control, so it publishes those
+/// rectangles as semantics directly. Android's own answer for a canvas-drawn
+/// `View` is the same shape (`ExploreByTouchHelper` feeding virtual view ids
+/// into an `AccessibilityNodeProvider`), and Cranpose's Android bridge is
+/// already an `AccessibilityNodeProvider`, so these land as first-class
+/// virtual views next to the ones layout produces.
+///
+/// `bounds` is in the publishing node's own coordinates (logical px, origin at
+/// that node's top-left), because that is what a draw scope works in.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CanvasSemanticsNode {
+    /// Identity that must survive a redraw.
+    ///
+    /// A screen reader parks its cursor on a virtual view id; if the id for
+    /// "the Haptics switch" changes when the list scrolls, the cursor jumps.
+    /// Derive this from what the control *is* (a row index, an enum
+    /// discriminant), never from where it currently sits.
+    pub key: u64,
+    /// Where the control was drawn, relative to the publishing node.
+    pub bounds: cranpose_ui_graphics::Rect,
+    pub label: String,
+    pub role: Option<SemanticsWidgetRole>,
+    /// Compose's `stateDescription` — what the control currently reads as
+    /// ("CAMPAIGN", "3 of 18 gold"), spoken after the label and re-spoken on
+    /// its own when only the state changed.
+    pub state_description: Option<String>,
+    /// Compose's `onClick(label = …)`. TalkBack reads it as "double tap to
+    /// <label>", so it is a verb phrase, not a repeat of the label.
+    pub on_click_label: Option<String>,
+    pub clickable: bool,
+    /// Compose's `selected`, for `Role.RadioButton`/`Role.Tab`.
+    pub selected: Option<bool>,
+    /// Compose's `toggleableState`, for `Role.Switch`/`Role.Checkbox`.
+    pub toggled: Option<bool>,
+    pub enabled: bool,
+    pub custom_actions: Vec<SemanticsCustomAction>,
+}
+
+impl Default for CanvasSemanticsNode {
+    fn default() -> Self {
+        Self {
+            key: 0,
+            bounds: cranpose_ui_graphics::Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 0.0,
+                height: 0.0,
+            },
+            label: String::new(),
+            role: None,
+            state_description: None,
+            on_click_label: None,
+            clickable: false,
+            selected: None,
+            toggled: None,
+            // Matches Compose: a node is enabled unless `disabled()` says
+            // otherwise, so an app that never thinks about it gets the right
+            // answer.
+            enabled: true,
+            custom_actions: Vec::new(),
+        }
+    }
+}
+
+impl CanvasSemanticsNode {
+    /// A clickable control drawn at `bounds`.
+    pub fn control(key: u64, bounds: cranpose_ui_graphics::Rect, label: impl Into<String>) -> Self {
+        Self {
+            key,
+            bounds,
+            label: label.into(),
+            clickable: true,
+            ..Self::default()
+        }
+    }
+
+    /// A drawn label that is read but not activated.
+    pub fn text(key: u64, bounds: cranpose_ui_graphics::Rect, label: impl Into<String>) -> Self {
+        Self {
+            key,
+            bounds,
+            label: label.into(),
+            ..Self::default()
+        }
+    }
+
+    pub fn with_role(mut self, role: SemanticsWidgetRole) -> Self {
+        self.role = Some(role);
+        self
+    }
+
+    pub fn with_state_description(mut self, state: impl Into<String>) -> Self {
+        self.state_description = Some(state.into());
+        self
+    }
+
+    pub fn with_click_label(mut self, label: impl Into<String>) -> Self {
+        self.on_click_label = Some(label.into());
+        self.clickable = true;
+        self
+    }
+
+    pub fn with_selected(mut self, selected: bool) -> Self {
+        self.selected = Some(selected);
+        self
+    }
+
+    pub fn with_toggled(mut self, toggled: bool) -> Self {
+        self.toggled = Some(toggled);
+        self
+    }
+
+    pub fn with_enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    pub fn with_custom_action(mut self, action: SemanticsCustomAction) -> Self {
+        self.custom_actions.push(action);
+        self
+    }
+}
+
 /// Semantics configuration for accessibility.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SemanticsConfiguration {
     pub content_description: Option<String>,
-    pub is_button: bool,
+    /// Compose's `stateDescription`.
+    pub state_description: Option<String>,
+    /// Compose's `onClick(label = …)`; implies clickable.
+    pub on_click_label: Option<String>,
+    /// Compose's `Role`.
+    pub role: Option<SemanticsWidgetRole>,
+    pub selected: Option<bool>,
+    pub toggled: Option<bool>,
+    pub enabled: bool,
     pub is_clickable: bool,
     pub is_editable_text: bool,
     pub text_selection: Option<crate::text::TextRange>,
+    pub custom_actions: Vec<SemanticsCustomAction>,
+    /// Controls this node drew itself instead of laying out. See
+    /// [`CanvasSemanticsNode`].
+    pub canvas_children: Vec<CanvasSemanticsNode>,
+}
+
+impl Default for SemanticsConfiguration {
+    fn default() -> Self {
+        Self {
+            content_description: None,
+            state_description: None,
+            on_click_label: None,
+            role: None,
+            selected: None,
+            toggled: None,
+            enabled: true,
+            is_clickable: false,
+            is_editable_text: false,
+            text_selection: None,
+            custom_actions: Vec::new(),
+            canvas_children: Vec::new(),
+        }
+    }
 }
 
 impl SemanticsConfiguration {
@@ -678,12 +913,39 @@ impl SemanticsConfiguration {
         if let Some(description) = &other.content_description {
             self.content_description = Some(description.clone());
         }
-        self.is_button |= other.is_button;
+        if let Some(state) = &other.state_description {
+            self.state_description = Some(state.clone());
+        }
+        if let Some(label) = &other.on_click_label {
+            self.on_click_label = Some(label.clone());
+        }
+        if let Some(role) = other.role {
+            self.role = Some(role);
+        }
+        if let Some(selected) = other.selected {
+            self.selected = Some(selected);
+        }
+        if let Some(toggled) = other.toggled {
+            self.toggled = Some(toggled);
+        }
+        // Disabling wins: a chain that disables the node anywhere disables it,
+        // matching how Compose's `disabled()` is not undone by an inner node.
+        self.enabled &= other.enabled;
         self.is_clickable |= other.is_clickable;
         self.is_editable_text |= other.is_editable_text;
         if let Some(selection) = other.text_selection {
             self.text_selection = Some(selection);
         }
+        self.custom_actions
+            .extend(other.custom_actions.iter().cloned());
+        self.canvas_children
+            .extend(other.canvas_children.iter().cloned());
+    }
+
+    /// Whether a screen reader should offer activation. A named click label is
+    /// how Compose declares `onClick`, so it implies the action the same way.
+    pub fn is_activatable(&self) -> bool {
+        self.is_clickable || self.on_click_label.is_some()
     }
 }
 

--- a/crates/cranpose-liquid/src/widgets/button.rs
+++ b/crates/cranpose-liquid/src/widgets/button.rs
@@ -11,7 +11,7 @@ use cranpose_services::{default_haptics, HapticFeedback};
 use cranpose_ui::rememberMutableInteractionSource;
 use cranpose_ui::text::TextStyle;
 use cranpose_ui::widgets::{Box, BoxSpec, Text};
-use cranpose_ui::{Modifier, PointerEventKind, PointerInputScope, Size};
+use cranpose_ui::{Modifier, PointerEventKind, PointerInputScope, SemanticsWidgetRole, Size};
 use cranpose_ui_graphics::{Color, GraphicsLayer};
 use cranpose_ui_layout::Alignment;
 use std::cell::{Cell, RefCell};
@@ -25,7 +25,7 @@ const TAP_EXIT_SLOP: f32 = 12.0;
 
 fn with_button_semantics(modifier: Modifier) -> Modifier {
     modifier.semantics(|config| {
-        config.is_button = true;
+        config.role = Some(SemanticsWidgetRole::Button);
         config.is_clickable = true;
     })
 }
@@ -893,7 +893,7 @@ pub fn GlassIconButtonGroup(
                     ..Default::default()
                 })
                 .semantics(move |config| {
-                    config.is_button = true;
+                    config.role = Some(SemanticsWidgetRole::Button);
                     config.is_clickable = true;
                     config.content_description = Some(description.clone());
                 });
@@ -995,7 +995,7 @@ mod tests {
         let semantics =
             cranpose_ui::collect_semantics_from_modifier(&with_button_semantics(Modifier::empty()))
                 .expect("glass button semantics");
-        assert!(semantics.is_button);
+        assert_eq!(semantics.role, Some(SemanticsWidgetRole::Button));
         assert!(semantics.is_clickable);
     }
 

--- a/crates/cranpose-liquid/src/widgets/menu.rs
+++ b/crates/cranpose-liquid/src/widgets/menu.rs
@@ -12,6 +12,7 @@ use cranpose_ui::text::{FontWeight, SpanStyle, TextStyle, TextUnit};
 use cranpose_ui::widgets::{
     Box, BoxSpec, Column, ColumnSpec, PopupDismissableWhen, Row, RowSpec, Text,
 };
+use cranpose_ui::SemanticsWidgetRole;
 use cranpose_ui::{
     rememberMutableInteractionSource, Modifier, PointerEventKind, PointerInputScope,
     PressInteractionPress, Size,
@@ -1703,7 +1704,7 @@ fn menu_item_row(
         .fill_max_width()
         .report_window_rect(rect_sink)
         .semantics(move |config| {
-            config.is_button = true;
+            config.role = Some(SemanticsWidgetRole::Button);
             config.is_clickable = true;
             config.content_description = Some(row_label.clone());
         })

--- a/crates/cranpose-liquid/src/widgets/segmented.rs
+++ b/crates/cranpose-liquid/src/widgets/segmented.rs
@@ -16,7 +16,7 @@ use cranpose_ui::text::{FontWeight, SpanStyle, TextStyle};
 use cranpose_ui::widgets::{
     Box, BoxSpec, BoxWithConstraints, BoxWithConstraintsScope, Row, RowSpec, Text,
 };
-use cranpose_ui::{Modifier, PointerInputScope, Size};
+use cranpose_ui::{Modifier, PointerInputScope, SemanticsWidgetRole, Size};
 use cranpose_ui_graphics::{Brush, Color, CornerRadii, GraphicsLayer};
 use cranpose_ui_layout::Alignment;
 use std::rc::Rc;
@@ -225,7 +225,7 @@ pub fn LiquidSegmentedControl(
                     let cell = Modifier::empty()
                         .size(Size::new(segment_width, SEGMENT_HEIGHT))
                         .semantics(move |config| {
-                            config.is_button = true;
+                            config.role = Some(SemanticsWidgetRole::Button);
                             config.is_clickable = true;
                             config.content_description = Some(label_for_semantics.clone());
                         });

--- a/crates/cranpose-liquid/src/widgets/tab_bar.rs
+++ b/crates/cranpose-liquid/src/widgets/tab_bar.rs
@@ -14,7 +14,9 @@ use cranpose_ui::widgets::{
     Box, BoxSpec, BoxWithConstraints, BoxWithConstraintsScope, Column, ColumnSpec, Row, RowSpec,
     Text,
 };
-use cranpose_ui::{Brush, Color, CornerRadii, Modifier, PointerInputScope, Rect, Size};
+use cranpose_ui::{
+    Brush, Color, CornerRadii, Modifier, PointerInputScope, Rect, SemanticsWidgetRole, Size,
+};
 use cranpose_ui_layout::{Alignment, HorizontalAlignment, VerticalAlignment};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -363,7 +365,7 @@ fn TabCells(
             let mut cell = Modifier::empty().size(Size::new(tab_width, BLOB_HEIGHT));
             if spec.interactive {
                 cell = cell.semantics(move |config| {
-                    config.is_button = true;
+                    config.role = Some(SemanticsWidgetRole::Button);
                     config.is_clickable = true;
                     config.content_description = Some(label_for_semantics.to_string());
                 });

--- a/crates/cranpose-testing/src/robot_helpers.rs
+++ b/crates/cranpose-testing/src/robot_helpers.rs
@@ -1477,6 +1477,7 @@ mod tests {
         SemanticElement {
             role: role.to_string(),
             text: text.map(ToString::to_string),
+            state_description: None,
             clickable,
             editable_text: false,
             text_selection: None,

--- a/crates/cranpose-ui/src/layout/mod.rs
+++ b/crates/cranpose-ui/src/layout/mod.rs
@@ -26,8 +26,8 @@ use crate::modifier::{
 use crate::subcompose_layout::{CachedBatchMeasureInputs, SubcomposeLayoutNode};
 use crate::widgets::nodes::{IntrinsicKind, LayoutNode, LayoutNodeCacheHandles, LayoutState};
 use cranpose_foundation::{
-    text::TextRange, InvalidationKind, ModifierNodeContext, NodeCapabilities,
-    SemanticsConfiguration,
+    text::TextRange, CanvasSemanticsNode, InvalidationKind, ModifierNodeContext, NodeCapabilities,
+    SemanticsConfiguration, SemanticsCustomAction, SemanticsWidgetRole,
 };
 use cranpose_ui_layout::{Constraints, MeasurePolicy, Placement};
 use web_time::Instant;
@@ -387,48 +387,67 @@ pub enum SemanticsRole {
     Text { value: String },
     /// Spacer (non-interactive)
     Spacer,
-    /// Button (derived from is_button semantics flag)
+    /// Button (derived from the semantics `role`)
     Button,
     /// Unknown or unspecified role
     Unknown,
 }
 
 /// A single node within the semantics tree.
-#[derive(Clone, Debug, PartialEq, Eq)]
+///
+/// Not `Eq`: a node now carries drawn-control bounds, which are floats. The
+/// tree is compared for "did anything a screen reader can see change", and
+/// that comparison is `PartialEq` everywhere else on the accessibility path
+/// (`AccessibilityRect`, `AccessibilityElement`) for the same reason.
+#[derive(Clone, Debug, PartialEq)]
 pub struct SemanticsNode {
     pub node_id: NodeId,
+    /// Where this node sits in the tree (layout, text, subcomposition …).
     pub role: SemanticsRole,
+    /// What kind of control this node is, as a screen reader announces it —
+    /// Compose's `Role`. Separate from [`SemanticsNode::role`] because a
+    /// clickable `Row` is structurally a layout node and semantically a button.
+    pub widget_role: Option<SemanticsWidgetRole>,
     pub actions: Vec<SemanticsAction>,
     pub children: Vec<SemanticsNode>,
     pub description: Option<String>,
+    pub state_description: Option<String>,
+    pub on_click_label: Option<String>,
+    pub selected: Option<bool>,
+    pub toggled: Option<bool>,
+    pub enabled: bool,
+    pub custom_actions: Vec<SemanticsCustomAction>,
+    /// Controls this node drew rather than laid out; their bounds are relative
+    /// to this node's own top-left. See [`CanvasSemanticsNode`].
+    pub canvas_children: Vec<CanvasSemanticsNode>,
     pub editable_text: bool,
     pub text_selection: Option<TextRange>,
 }
 
-impl SemanticsNode {
-    fn new(
-        node_id: NodeId,
-        role: SemanticsRole,
-        actions: Vec<SemanticsAction>,
-        children: Vec<SemanticsNode>,
-        description: Option<String>,
-        editable_text: bool,
-        text_selection: Option<TextRange>,
-    ) -> Self {
+impl Default for SemanticsNode {
+    fn default() -> Self {
         Self {
-            node_id,
-            role,
-            actions,
-            children,
-            description,
-            editable_text,
-            text_selection,
+            node_id: 0,
+            role: SemanticsRole::Unknown,
+            widget_role: None,
+            actions: Vec::new(),
+            children: Vec::new(),
+            description: None,
+            state_description: None,
+            on_click_label: None,
+            selected: None,
+            toggled: None,
+            enabled: true,
+            custom_actions: Vec::new(),
+            canvas_children: Vec::new(),
+            editable_text: false,
+            text_selection: None,
         }
     }
 }
 
 /// Rooted semantics tree extracted after layout.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SemanticsTree {
     root: SemanticsNode,
 }
@@ -3185,34 +3204,39 @@ fn semantics_node_from_parts(
     config: Option<SemanticsConfiguration>,
     children: Vec<SemanticsNode>,
 ) -> SemanticsNode {
-    let mut actions = Vec::new();
-    let mut description = None;
-    let mut editable_text = false;
-    let mut text_selection = None;
+    let mut node = SemanticsNode {
+        node_id,
+        children,
+        ..SemanticsNode::default()
+    };
 
     if let Some(config) = config {
-        if config.is_button {
+        if config.role == Some(SemanticsWidgetRole::Button) {
             role = SemanticsRole::Button;
         }
-        if config.is_clickable {
-            actions.push(SemanticsAction::Click {
+        // A named click label is how Compose declares `onClick`, so it carries
+        // the action with it; an app should not have to set `is_clickable` as
+        // well to be activatable.
+        if config.is_activatable() {
+            node.actions.push(SemanticsAction::Click {
                 handler: SemanticsCallback::new(node_id),
             });
         }
-        description = config.content_description;
-        editable_text = config.is_editable_text;
-        text_selection = config.text_selection;
+        node.widget_role = config.role;
+        node.description = config.content_description;
+        node.state_description = config.state_description;
+        node.on_click_label = config.on_click_label;
+        node.selected = config.selected;
+        node.toggled = config.toggled;
+        node.enabled = config.enabled;
+        node.custom_actions = config.custom_actions;
+        node.canvas_children = config.canvas_children;
+        node.editable_text = config.is_editable_text;
+        node.text_selection = config.text_selection;
     }
 
-    SemanticsNode::new(
-        node_id,
-        role,
-        actions,
-        children,
-        description,
-        editable_text,
-        text_selection,
-    )
+    node.role = role;
+    node
 }
 
 fn build_semantics_node_from_live_nodes(

--- a/crates/cranpose-ui/src/layout/tests/layout_tests.rs
+++ b/crates/cranpose-ui/src/layout/tests/layout_tests.rs
@@ -1895,7 +1895,7 @@ fn semantics_tree_derives_roles_from_configuration() -> Result<(), NodeError> {
     // Create a button via semantics modifier (not ButtonNode)
     let button_node = LayoutNode::new(
         Modifier::empty().semantics(|config| {
-            config.is_button = true;
+            config.role = Some(cranpose_foundation::SemanticsWidgetRole::Button);
             config.is_clickable = true;
             config.content_description = Some("My Button".into());
         }),
@@ -1910,7 +1910,7 @@ fn semantics_tree_derives_roles_from_configuration() -> Result<(), NodeError> {
         .expect("expected semantics tree");
     let root = semantics_tree.root();
 
-    // Verify the role was derived from is_button flag
+    // Verify the tree role was derived from the semantics role
     assert!(matches!(root.role, SemanticsRole::Button));
 
     // Verify click action was synthesized from is_clickable
@@ -1922,6 +1922,154 @@ fn semantics_tree_derives_roles_from_configuration() -> Result<(), NodeError> {
 
     // Verify description
     assert_eq!(root.description.as_deref(), Some("My Button"));
+
+    Ok(())
+}
+
+/// A canvas app republishes its controls by recording them again, so the
+/// semantics snapshot has to notice a recorder whose captured state moved.
+/// Nothing about the modifier's *shape* changes when a settings row flips from
+/// "On" to "Off" — only the closure does — and a screen reader that keeps
+/// reading the first frame's answer is worse than one that reads nothing.
+#[test]
+fn re_recording_semantics_reopens_the_snapshot() -> Result<(), NodeError> {
+    let _app_context = crate::render_state::app_context_test_scope();
+    use std::cell::Cell;
+    use std::rc::Rc as StdRc;
+
+    fn arena_modifier(state: StdRc<Cell<bool>>) -> Modifier {
+        Modifier::empty().semantics(move |config| {
+            config.state_description = Some(if state.get() { "On" } else { "Off" }.to_string());
+            config.content_description = Some("Haptics".into());
+        })
+    }
+
+    let state = StdRc::new(Cell::new(false));
+    let mut applier = MemoryApplier::new();
+    let node_id = applier.create(Box::new(LayoutNode::new(
+        arena_modifier(StdRc::clone(&state)),
+        Rc::new(MaxSizePolicy),
+    )));
+
+    let measurements = measure_layout(&mut applier, node_id, Size::new(100.0, 100.0))?;
+    assert_eq!(
+        measurements
+            .semantics_tree()
+            .expect("expected semantics tree")
+            .root()
+            .state_description
+            .as_deref(),
+        Some("Off")
+    );
+    assert!(!crate::layout::tree_needs_semantics(&mut applier, node_id)?);
+
+    state.set(true);
+    applier.with_node::<LayoutNode, _>(node_id, |node| {
+        node.set_modifier(arena_modifier(StdRc::clone(&state)));
+    })?;
+
+    assert!(
+        crate::layout::tree_needs_semantics(&mut applier, node_id)?,
+        "re-recording semantics should dirty the snapshot"
+    );
+    let measurements = measure_layout(&mut applier, node_id, Size::new(100.0, 100.0))?;
+    assert_eq!(
+        measurements
+            .semantics_tree()
+            .expect("expected semantics tree")
+            .root()
+            .state_description
+            .as_deref(),
+        Some("On")
+    );
+
+    Ok(())
+}
+
+/// The whole point of canvas semantics: an app that draws its controls has one
+/// layout node, and everything a screen reader needs has to survive the trip
+/// from the recorder closure into the semantics tree on that one node.
+#[test]
+fn semantics_tree_carries_the_controls_a_canvas_published() -> Result<(), NodeError> {
+    let _app_context = crate::render_state::app_context_test_scope();
+    use cranpose_foundation::{CanvasSemanticsNode, SemanticsCustomAction, SemanticsWidgetRole};
+    use cranpose_ui_graphics::Rect;
+    use std::cell::Cell;
+    use std::rc::Rc as StdRc;
+
+    let paused = StdRc::new(Cell::new(false));
+    let toggled = StdRc::new(Cell::new(false));
+
+    let mut applier = MemoryApplier::new();
+    let arena = LayoutNode::new(
+        Modifier::empty().semantics({
+            let paused = StdRc::clone(&paused);
+            let toggled = StdRc::clone(&toggled);
+            move |config| {
+                config.content_description = Some("Level 4. Score 120.".into());
+                config.state_description = Some("Playing".into());
+                config.on_click_label = Some("Launch".into());
+                config.role = Some(SemanticsWidgetRole::RadioButton);
+                config.selected = Some(true);
+                config.custom_actions = vec![SemanticsCustomAction::new("Pause", {
+                    let paused = StdRc::clone(&paused);
+                    move || paused.set(true)
+                })];
+                config.canvas_children = vec![CanvasSemanticsNode::control(
+                    9,
+                    Rect {
+                        x: 4.0,
+                        y: 8.0,
+                        width: 100.0,
+                        height: 52.0,
+                    },
+                    "Haptics",
+                )
+                .with_role(SemanticsWidgetRole::Switch)
+                .with_toggled(false)
+                .with_state_description("Off")
+                .with_custom_action(SemanticsCustomAction::new("Toggle", {
+                    let toggled = StdRc::clone(&toggled);
+                    move || toggled.set(true)
+                }))];
+            }
+        }),
+        Rc::new(MaxSizePolicy),
+    );
+    let arena_id = applier.create(Box::new(arena));
+
+    let measurements = measure_layout(&mut applier, arena_id, Size::new(200.0, 200.0))?;
+    let root = measurements
+        .semantics_tree()
+        .expect("expected semantics tree")
+        .root();
+
+    assert_eq!(root.widget_role, Some(SemanticsWidgetRole::RadioButton));
+    assert_eq!(root.state_description.as_deref(), Some("Playing"));
+    assert_eq!(root.on_click_label.as_deref(), Some("Launch"));
+    assert_eq!(root.selected, Some(true));
+    assert!(root.enabled);
+    // A named click label declares the action on its own, exactly as Compose's
+    // `onClick(label = …)` does — the app should not also have to set
+    // `is_clickable`.
+    assert_eq!(root.actions.len(), 1);
+
+    assert_eq!(root.custom_actions.len(), 1);
+    assert_eq!(root.custom_actions[0].label, "Pause");
+    root.custom_actions[0].invoke();
+    assert!(paused.get(), "the published handler should be the live one");
+
+    assert_eq!(root.canvas_children.len(), 1);
+    let switch = &root.canvas_children[0];
+    assert_eq!(switch.key, 9);
+    assert_eq!(switch.label, "Haptics");
+    assert_eq!(switch.role, Some(SemanticsWidgetRole::Switch));
+    assert_eq!(switch.toggled, Some(false));
+    assert_eq!(switch.state_description.as_deref(), Some("Off"));
+    assert!(switch.clickable);
+    assert_eq!(switch.bounds.y, 8.0);
+    switch.custom_actions[0].invoke();
+    assert!(toggled.get());
 
     Ok(())
 }
@@ -2059,7 +2207,7 @@ fn semantics_tree_matches_with_and_without_layout_tree() -> Result<(), NodeError
         )));
         let button_id = applier.create(Box::new(LayoutNode::new(
             Modifier::empty().semantics(|config| {
-                config.is_button = true;
+                config.role = Some(cranpose_foundation::SemanticsWidgetRole::Button);
                 config.is_clickable = true;
                 config.content_description = Some("action".into());
             }),

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -92,6 +92,13 @@ pub use layout::{
     LayoutNodeKind, LayoutTree, MeasureLayoutOptions, SemanticsAction, SemanticsCallback,
     SemanticsNode, SemanticsRole, SemanticsTree,
 };
+// The accessibility vocabulary an app writes against. It is declared in
+// cranpose-foundation, next to `SemanticsConfiguration`, but an app composes
+// against cranpose-ui and should not have to reach past it to describe a
+// button.
+pub use cranpose_foundation::{
+    CanvasSemanticsNode, SemanticsConfiguration, SemanticsCustomAction, SemanticsWidgetRole,
+};
 pub use modifier::{
     collect_modifier_slices, collect_semantics_from_modifier, collect_slices_from_modifier,
     BlendMode, Brush, Color, CompositingStrategy, CornerRadii, DpOffset, EdgeInsets,

--- a/crates/cranpose-ui/src/modifier/mod.rs
+++ b/crates/cranpose-ui/src/modifier/mod.rs
@@ -451,22 +451,40 @@ impl Modifier {
     where
         F: Fn(&mut SemanticsConfiguration) + 'static,
     {
-        let mut preview = SemanticsConfiguration::default();
-        recorder(&mut preview);
-        let description = preview.content_description.clone();
-        let is_button = preview.is_button;
-        let is_clickable = preview.is_clickable;
-        let metadata = inspector_metadata("semantics", move |info| {
-            if let Some(desc) = &description {
-                info.add_property("contentDescription", desc.clone());
-            }
-            if is_button {
-                info.add_property("isButton", "true");
-            }
-            if is_clickable {
-                info.add_property("isClickable", "true");
-            }
-        });
+        let recorder: std::rc::Rc<dyn Fn(&mut SemanticsConfiguration)> = std::rc::Rc::new(recorder);
+        // Run the recorder for the inspector only when the inspector is on. A
+        // recorder that publishes canvas semantics allocates one node per drawn
+        // control, and this modifier is rebuilt on every recomposition, so the
+        // preview used to double that cost on every frame of a scrolling list
+        // for metadata nothing was reading.
+        let metadata = if inspector_metadata_enabled() {
+            let mut preview = SemanticsConfiguration::default();
+            recorder(&mut preview);
+            let description = preview.content_description.clone();
+            let state_description = preview.state_description.clone();
+            let role = preview.role;
+            let is_clickable = preview.is_activatable();
+            let canvas_children = preview.canvas_children.len();
+            inspector_metadata("semantics", move |info| {
+                if let Some(desc) = &description {
+                    info.add_property("contentDescription", desc.clone());
+                }
+                if let Some(state) = &state_description {
+                    info.add_property("stateDescription", state.clone());
+                }
+                if let Some(role) = role {
+                    info.add_property("role", format!("{role:?}"));
+                }
+                if is_clickable {
+                    info.add_property("isClickable", "true");
+                }
+                if canvas_children > 0 {
+                    info.add_property("canvasSemanticsChildren", canvas_children.to_string());
+                }
+            })
+        } else {
+            inspector_metadata("semantics", |_| {})
+        };
         let element = SemanticsElement::new(recorder);
         let modifier =
             Modifier::from_parts(vec![modifier_element(element)]).with_inspector_metadata(metadata);

--- a/crates/cranpose-ui/src/modifier/semantics.rs
+++ b/crates/cranpose-ui/src/modifier/semantics.rs
@@ -51,13 +51,10 @@ pub struct SemanticsElement {
 }
 
 impl SemanticsElement {
-    pub fn new<F>(recorder: F) -> Self
-    where
-        F: Fn(&mut SemanticsConfiguration) + 'static,
-    {
-        Self {
-            recorder: Rc::new(recorder),
-        }
+    /// Takes an already shared recorder so the caller can run the same closure
+    /// for the inspector preview without asking the app to record twice.
+    pub fn new(recorder: Rc<dyn Fn(&mut SemanticsConfiguration)>) -> Self {
+        Self { recorder }
     }
 }
 

--- a/crates/cranpose-ui/src/modifier/tests/modifier_tests.rs
+++ b/crates/cranpose-ui/src/modifier/tests/modifier_tests.rs
@@ -1627,7 +1627,18 @@ fn semantics_modifier_populates_inspector_metadata() {
     let _app_context = crate::render_state::app_context_test_scope();
     let modifier = Modifier::empty().semantics(|config: &mut SemanticsConfiguration| {
         config.content_description = Some("Submit".into());
-        config.is_button = true;
+        config.state_description = Some("Ready".into());
+        config.role = Some(cranpose_foundation::SemanticsWidgetRole::Button);
+        config.canvas_children = vec![cranpose_foundation::CanvasSemanticsNode::control(
+            1,
+            cranpose_ui_graphics::Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 10.0,
+                height: 10.0,
+            },
+            "Row",
+        )];
     });
 
     let records = modifier.collect_inspector_records();
@@ -1635,14 +1646,17 @@ fn semantics_modifier_populates_inspector_metadata() {
         .first()
         .expect("expected semantics inspector record");
     assert_eq!(semantics.name, "semantics");
-    assert!(semantics
-        .properties
-        .iter()
-        .any(|prop| prop.name == "contentDescription" && prop.value == "Submit"));
-    assert!(semantics
-        .properties
-        .iter()
-        .any(|prop| prop.name == "isButton" && prop.value == "true"));
+    let property = |name: &str| {
+        semantics
+            .properties
+            .iter()
+            .find(|prop| prop.name == name)
+            .map(|prop| prop.value.as_str())
+    };
+    assert_eq!(property("contentDescription"), Some("Submit"));
+    assert_eq!(property("stateDescription"), Some("Ready"));
+    assert_eq!(property("role"), Some("Button"));
+    assert_eq!(property("canvasSemanticsChildren"), Some("1"));
 }
 
 #[test]

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
@@ -85,6 +85,8 @@ public class CranposeActivity extends NativeActivity {
 
     private static native void nativeOnAccessibilityActivate(float x, float y);
 
+    private static native void nativeOnAccessibilityCustomAction(int virtualViewId, int actionIndex);
+
     /** Publishes Cranpose's semantic tree through Android's native virtual-view API. */
     public void cranposeSetAccessibilityElements(String payload) {
         final List<CranposeAccessibilityElement> elements = parseAccessibilityElements(payload);
@@ -105,12 +107,26 @@ public class CranposeActivity extends NativeActivity {
         });
     }
 
+    /** Field count of one accessibility record; see android_accessibility_wire.rs. */
+    private static final int ACCESSIBILITY_FIELDS = 17;
+
+    /** Separator packing a node's custom action labels into one field. */
+    private static final String ACCESSIBILITY_ACTION_SEPARATOR = String.valueOf((char) 0x1f);
+
+    /**
+     * First id handed to a custom action. Custom action ids only have to avoid
+     * the framework's standard actions, which are bit flags well below this;
+     * androidx solves the same problem by using R.id values, which live in the
+     * app's 0x7f resource space, so this starts there too.
+     */
+    private static final int ACCESSIBILITY_CUSTOM_ACTION_BASE = 0x7f000000;
+
     private static List<CranposeAccessibilityElement> parseAccessibilityElements(String payload) {
         if (payload == null || payload.isEmpty()) return Collections.emptyList();
         ArrayList<CranposeAccessibilityElement> result = new ArrayList<>();
         for (String record : payload.split("\\n", -1)) {
             String[] fields = record.split("\\t", -1);
-            if (fields.length != 11) continue;
+            if (fields.length != ACCESSIBILITY_FIELDS) continue;
             try {
                 result.add(new CranposeAccessibilityElement(
                         Integer.parseInt(fields[0]), Integer.parseInt(fields[1]),
@@ -118,7 +134,10 @@ public class CranposeActivity extends NativeActivity {
                                 Integer.parseInt(fields[4]), Integer.parseInt(fields[5])),
                         Float.parseFloat(fields[6]), Float.parseFloat(fields[7]),
                         "1".equals(fields[8]), unescapeAccessibility(fields[9]),
-                        unescapeAccessibility(fields[10])));
+                        unescapeAccessibility(fields[10]), unescapeAccessibility(fields[11]),
+                        unescapeAccessibility(fields[12]), Integer.parseInt(fields[13]),
+                        Integer.parseInt(fields[14]), "1".equals(fields[15]),
+                        parseAccessibilityActions(fields[16])));
             } catch (RuntimeException ignored) {
                 // A malformed record must not make the host Activity inaccessible.
             }
@@ -126,9 +145,22 @@ public class CranposeActivity extends NativeActivity {
         return result;
     }
 
+    private static String[] parseAccessibilityActions(String field) {
+        if (field.isEmpty()) return new String[0];
+        String[] parts = field.split(ACCESSIBILITY_ACTION_SEPARATOR, -1);
+        for (int i = 0; i < parts.length; i++) {
+            parts[i] = unescapeAccessibility(parts[i]);
+        }
+        return parts;
+    }
+
     private static String unescapeAccessibility(String value) {
+        // %25 is undone last: it is the escape for the escape character, so
+        // undoing it first would let an app-authored literal "%09" decode into
+        // a tab.
         return value.replace("%0D", "\r").replace("%0A", "\n")
-                .replace("%09", "\t").replace("%25", "%");
+                .replace("%09", "\t").replace("%1F", ACCESSIBILITY_ACTION_SEPARATOR)
+                .replace("%25", "%");
     }
 
     private static final class CranposeAccessibilityElement {
@@ -140,9 +172,18 @@ public class CranposeActivity extends NativeActivity {
         final boolean clickable;
         final String label;
         final String value;
+        final String stateDescription;
+        final String clickLabel;
+        /** -1 when the app said nothing, otherwise 0 or 1. */
+        final int selected;
+        final int toggled;
+        final boolean enabled;
+        final String[] customActions;
 
         CranposeAccessibilityElement(int id, int role, Rect bounds, float centerX,
-                float centerY, boolean clickable, String label, String value) {
+                float centerY, boolean clickable, String label, String value,
+                String stateDescription, String clickLabel, int selected, int toggled,
+                boolean enabled, String[] customActions) {
             this.id = id;
             this.role = role;
             this.bounds = bounds;
@@ -151,6 +192,35 @@ public class CranposeActivity extends NativeActivity {
             this.clickable = clickable;
             this.label = label;
             this.value = value;
+            this.stateDescription = stateDescription;
+            this.clickLabel = clickLabel;
+            this.selected = selected;
+            this.toggled = toggled;
+            this.enabled = enabled;
+            this.customActions = customActions;
+        }
+
+        /**
+         * The widget class TalkBack reads the trailing noun from ("radio
+         * button", "switch"). Cranpose's role codes are assigned in
+         * android_accessibility_wire.rs.
+         */
+        String className() {
+            switch (role) {
+                case 1: return "android.widget.Button";
+                case 3: return "android.widget.EditText";
+                case 4: return "android.widget.CheckBox";
+                case 5: return "android.widget.Switch";
+                case 6: return "android.widget.RadioButton";
+                case 7: return "android.widget.TabWidget";
+                case 8: return "android.widget.ImageView";
+                default: return "android.widget.TextView";
+            }
+        }
+
+        /** Roles that TalkBack announces an on/off state for. */
+        boolean isCheckable() {
+            return role == 4 || role == 5;
         }
     }
 
@@ -187,17 +257,28 @@ public class CranposeActivity extends NativeActivity {
             info.setSource(host, element.id);
             info.setParent(host);
             info.setPackageName(host.getContext().getPackageName());
-            info.setEnabled(true);
+            info.setEnabled(element.enabled);
             info.setVisibleToUser(true);
             info.setFocusable(true);
             info.setAccessibilityFocused(focusedId == element.id);
             info.setContentDescription(element.label);
-            if (element.role == 1) info.setClassName("android.widget.Button");
-            else if (element.role == 3) {
-                info.setClassName("android.widget.EditText");
+            info.setClassName(element.className());
+            if (element.role == 3) {
                 info.setEditable(true);
                 info.setText(element.value);
-            } else info.setClassName("android.widget.TextView");
+            }
+            if (element.role == 9 && Build.VERSION.SDK_INT >= 28) info.setHeading(true);
+            // Compose's stateDescription. TalkBack speaks it after the label
+            // and, unlike the label, re-speaks it on its own when only the
+            // state changed — which is what makes a settings toggle usable.
+            if (Build.VERSION.SDK_INT >= 30 && !element.stateDescription.isEmpty()) {
+                info.setStateDescription(element.stateDescription);
+            }
+            if (element.isCheckable()) {
+                info.setCheckable(true);
+                info.setChecked(element.toggled == 1);
+            }
+            if (element.selected >= 0) info.setSelected(element.selected == 1);
             info.setBoundsInParent(element.bounds);
             int[] location = new int[2];
             host.getLocationOnScreen(location);
@@ -205,7 +286,21 @@ public class CranposeActivity extends NativeActivity {
             screen.offset(location[0], location[1]);
             info.setBoundsInScreen(screen);
             info.setClickable(element.clickable);
-            if (element.clickable) info.addAction(AccessibilityNodeInfo.ACTION_CLICK);
+            if (element.clickable) {
+                // A labelled click is Compose's onClick(label = …): TalkBack
+                // reads "double tap to <label>" instead of the generic
+                // "double tap to activate".
+                if (element.clickLabel.isEmpty()) {
+                    info.addAction(AccessibilityNodeInfo.ACTION_CLICK);
+                } else {
+                    info.addAction(new AccessibilityNodeInfo.AccessibilityAction(
+                            AccessibilityNodeInfo.ACTION_CLICK, element.clickLabel));
+                }
+            }
+            for (int i = 0; i < element.customActions.length; i++) {
+                info.addAction(new AccessibilityNodeInfo.AccessibilityAction(
+                        ACCESSIBILITY_CUSTOM_ACTION_BASE + i, element.customActions[i]));
+            }
             info.addAction(focusedId == element.id
                     ? AccessibilityNodeInfo.ACTION_CLEAR_ACCESSIBILITY_FOCUS
                     : AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS);
@@ -219,6 +314,14 @@ public class CranposeActivity extends NativeActivity {
             if (action == AccessibilityNodeInfo.ACTION_CLICK && element.clickable) {
                 nativeOnAccessibilityActivate(element.centerX, element.centerY);
                 sendEvent(element.id, AccessibilityEvent.TYPE_VIEW_CLICKED);
+                return true;
+            }
+            int customIndex = action - ACCESSIBILITY_CUSTOM_ACTION_BASE;
+            if (customIndex >= 0 && customIndex < element.customActions.length) {
+                // Only the identity crosses back; the handler is resolved on
+                // the frame loop against the live semantics tree, so a stale
+                // published snapshot cannot run a stale closure.
+                nativeOnAccessibilityCustomAction(element.id, customIndex);
                 return true;
             }
             if (action == AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS) {

--- a/crates/cranpose/src/accessibility.rs
+++ b/crates/cranpose/src/accessibility.rs
@@ -219,10 +219,19 @@ fn element_id(node_id: NodeId, canvas_key: Option<u64>) -> i32 {
         // widgets Cranpose lays out do not move because canvas semantics now
         // exist next to them.
         None => node_id as u64,
-        // Fibonacci hashing of the app's key, folded into the node it belongs
-        // to. Distinct keys on one node land far apart, which keeps the probe
-        // loop above from degenerating on a list of adjacent row indices.
-        Some(key) => (node_id as u64) ^ (key.wrapping_mul(0x9e37_79b9_7f4a_7c15) >> 29),
+        // Two odd multipliers, so both halves are bijections on `u64` and stay
+        // injective in the low 31 bits the id is cut from: two drawn controls
+        // on one node never collide, and neither do the same key on two nodes.
+        // The node half is rotated so that key 0 — the default, and the first
+        // index any app reaches for — does not land exactly on the node's own
+        // id, which would collide with the layout node's element every time and
+        // push some unrelated node off the id its cursor was parked on.
+        Some(key) => {
+            (node_id as u64)
+                .wrapping_mul(0x9e37_79b9_7f4a_7c15)
+                .rotate_left(17)
+                ^ key.wrapping_mul(0xd6e8_feb8_6659_fd93)
+        }
     };
     ((mixed & 0x7fff_ffff) as i32).max(1)
 }
@@ -498,6 +507,8 @@ mod tests {
     /// app publishes a different set: a screen reader's cursor lives on the id.
     #[test]
     fn drawn_controls_get_distinct_ids_that_do_not_move_with_list_position() {
+        // Key 0 is deliberately included: it is `CanvasSemanticsNode`'s default
+        // and the first index an app reaches for.
         let rows: Vec<_> = (0..24).map(|key| element_with(7, Some(key))).collect();
         let ids = element_ids(&rows);
 
@@ -511,9 +522,18 @@ mod tests {
         let scrolled = element_ids(&rows[1..]);
         assert_eq!(scrolled, ids[1..]);
 
-        // And the layout node itself is untouched by the drawn controls
-        // hanging off it.
+        // The layout node itself is untouched by the drawn controls hanging off
+        // it — including by the one keyed 0, which must not land on the node's
+        // own id and probe an unrelated element off its cursor.
         assert_eq!(element_ids(&[element_with(7, None)]), vec![7]);
+        assert!(
+            !ids.contains(&7),
+            "a drawn control took the layout node's id"
+        );
+
+        // The same key on two nodes is two elements, not one.
+        let across = element_ids(&[element_with(7, Some(3)), element_with(8, Some(3))]);
+        assert_ne!(across[0], across[1]);
     }
 
     #[test]

--- a/crates/cranpose/src/accessibility.rs
+++ b/crates/cranpose/src/accessibility.rs
@@ -2,7 +2,7 @@
 
 use cranpose_core::collections::map::HashMap;
 use cranpose_core::NodeId;
-use cranpose_ui::{SemanticsAction, SemanticsNode, SemanticsRole};
+use cranpose_ui::{SemanticsAction, SemanticsNode, SemanticsRole, SemanticsWidgetRole};
 use std::borrow::Cow;
 
 use cranpose_app_shell::AppShell;
@@ -44,22 +44,81 @@ impl AccessibilityRect {
 }
 
 /// Role understood by native accessibility backends.
+///
+/// The first three are structural — what the node *is* in the tree. The rest
+/// are Compose `Role` values an app asked for explicitly, and a backend that
+/// understands them says so out loud ("radio button", "switch, on").
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum AccessibilityRole {
     Button,
     StaticText,
     TextField,
+    Checkbox,
+    Switch,
+    RadioButton,
+    Tab,
+    Image,
+    Header,
+}
+
+impl AccessibilityRole {
+    fn from_widget_role(role: SemanticsWidgetRole) -> Self {
+        match role {
+            SemanticsWidgetRole::Button => Self::Button,
+            SemanticsWidgetRole::Checkbox => Self::Checkbox,
+            SemanticsWidgetRole::Switch => Self::Switch,
+            SemanticsWidgetRole::RadioButton => Self::RadioButton,
+            SemanticsWidgetRole::Tab => Self::Tab,
+            SemanticsWidgetRole::Image => Self::Image,
+            SemanticsWidgetRole::Header => Self::Header,
+        }
+    }
 }
 
 /// A flattened native accessibility element with stable Cranpose identity.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct AccessibilityElement {
     pub(crate) node_id: NodeId,
+    /// Which drawn control inside `node_id` this element is, when it came from
+    /// a [`CanvasSemanticsNode`]. `None` means the element *is* the layout
+    /// node. Kept alongside `node_id` because an accessibility action arriving
+    /// from the platform has to be routed back to the exact publisher.
+    pub(crate) canvas_key: Option<u64>,
     pub(crate) label: String,
+    pub(crate) state_description: Option<String>,
+    pub(crate) click_label: Option<String>,
     pub(crate) value: Option<String>,
     pub(crate) bounds: AccessibilityRect,
     pub(crate) role: AccessibilityRole,
     pub(crate) clickable: bool,
+    pub(crate) selected: Option<bool>,
+    pub(crate) toggled: Option<bool>,
+    pub(crate) enabled: bool,
+    /// Custom action labels in publication order. The index *is* the wire id:
+    /// the platform sends it back and [`perform_custom_action`] resolves it
+    /// against the live semantics tree, so the handler that runs is always the
+    /// current one even if the published snapshot is a frame stale.
+    pub(crate) custom_actions: Vec<String>,
+}
+
+impl Default for AccessibilityElement {
+    fn default() -> Self {
+        Self {
+            node_id: 0,
+            canvas_key: None,
+            label: String::new(),
+            state_description: None,
+            click_label: None,
+            value: None,
+            bounds: AccessibilityRect::default(),
+            role: AccessibilityRole::StaticText,
+            clickable: false,
+            selected: None,
+            toggled: None,
+            enabled: true,
+            custom_actions: Vec::new(),
+        }
+    }
 }
 
 /// Re-projects accessibility elements only when the shell's semantics revision
@@ -129,6 +188,64 @@ fn collect_bounds(root: &LayoutBox, bounds: &mut HashMap<NodeId, AccessibilityRe
     }
 }
 
+/// Assigns the ids every platform backend addresses elements by — Android's
+/// virtual view ids, AccessKit's node ids, the iOS element map's keys.
+///
+/// A screen reader parks its cursor on an id, so the id has to be a function of
+/// *what the element is* rather than where it sits in the list — otherwise
+/// inserting a row above the focused one moves the cursor. That is why the id
+/// is derived from the publishing layout node plus the app's own canvas key,
+/// and why a collision is resolved by probing forward deterministically instead
+/// of by falling back to the index: the same element set always yields the same
+/// ids.
+///
+/// The result is a positive 31-bit value because Android's virtual view ids are
+/// `int` and `View.NO_ID` (-1) already means "the host".
+pub(crate) fn element_ids(elements: &[AccessibilityElement]) -> Vec<i32> {
+    let mut assigned: Vec<i32> = Vec::with_capacity(elements.len());
+    for element in elements {
+        let mut id = element_id(element.node_id, element.canvas_key);
+        while assigned.contains(&id) {
+            id = if id == i32::MAX { 1 } else { id + 1 };
+        }
+        assigned.push(id);
+    }
+    assigned
+}
+
+fn element_id(node_id: NodeId, canvas_key: Option<u64>) -> i32 {
+    let mixed = match canvas_key {
+        // A layout node keeps the identity it always had, so ids for the
+        // widgets Cranpose lays out do not move because canvas semantics now
+        // exist next to them.
+        None => node_id as u64,
+        // Fibonacci hashing of the app's key, folded into the node it belongs
+        // to. Distinct keys on one node land far apart, which keeps the probe
+        // loop above from degenerating on a list of adjacent row indices.
+        Some(key) => (node_id as u64) ^ (key.wrapping_mul(0x9e37_79b9_7f4a_7c15) >> 29),
+    };
+    ((mixed & 0x7fff_ffff) as i32).max(1)
+}
+
+/// Maps an id the platform sent back to the element that owns it.
+///
+/// Recomputed from the published element list rather than remembered, because
+/// the list *is* the assignment: [`element_ids`] is a pure function of it.
+#[cfg(any(
+    test,
+    all(feature = "android", feature = "renderer-wgpu", target_os = "android")
+))]
+pub(crate) fn resolve_element_id(
+    elements: &[AccessibilityElement],
+    id: i32,
+) -> Option<(NodeId, Option<u64>)> {
+    element_ids(elements)
+        .into_iter()
+        .zip(elements)
+        .find(|(assigned, _)| *assigned == id)
+        .map(|(_, element)| (element.node_id, element.canvas_key))
+}
+
 fn project_semantics(
     root: &SemanticsNode,
     bounds: &HashMap<NodeId, AccessibilityRect>,
@@ -159,7 +276,9 @@ fn project_node(
 
     if let Some(label) = label.filter(|label| !label.trim().is_empty()) {
         if rect.is_visible() && (actionable || !suppress_static_text) {
-            let role = if node.editable_text {
+            let role = if let Some(role) = node.widget_role {
+                AccessibilityRole::from_widget_role(role)
+            } else if node.editable_text {
                 AccessibilityRole::TextField
             } else if clickable || matches!(node.role, SemanticsRole::Button) {
                 AccessibilityRole::Button
@@ -169,19 +288,135 @@ fn project_node(
             let label = label.into_owned();
             elements.push(AccessibilityElement {
                 node_id: node.node_id,
+                canvas_key: None,
                 value: node.editable_text.then(|| label.clone()),
                 label,
+                state_description: node.state_description.clone(),
+                click_label: node.on_click_label.clone(),
                 bounds: rect,
                 role,
                 clickable,
+                selected: node.selected,
+                toggled: node.toggled,
+                enabled: node.enabled,
+                custom_actions: node
+                    .custom_actions
+                    .iter()
+                    .map(|action| action.label.clone())
+                    .collect(),
             });
         }
     }
+
+    // Drawn controls come straight after the node that drew them, so a screen
+    // reader walks a canvas screen in the order the app published it. They are
+    // deliberately not subject to `suppress_static_text`: that rule exists so a
+    // button does not read its own inner `Text` twice, and a canvas child is
+    // never a duplicate of anything — it only exists because the app said so.
+    project_canvas_children(node, rect, elements);
 
     let suppress_children = suppress_static_text || actionable;
     for child in &node.children {
         project_node(child, bounds, suppress_children, elements);
     }
+}
+
+fn project_canvas_children(
+    node: &SemanticsNode,
+    owner: AccessibilityRect,
+    elements: &mut Vec<AccessibilityElement>,
+) {
+    for child in &node.canvas_children {
+        // Canvas bounds are in the publishing node's own space, which is what a
+        // draw scope reports; the platform wants window coordinates.
+        let rect = AccessibilityRect::new(
+            owner.x + child.bounds.x,
+            owner.y + child.bounds.y,
+            child.bounds.width,
+            child.bounds.height,
+        );
+        if !rect.is_visible() || child.label.trim().is_empty() {
+            continue;
+        }
+        let role = match child.role {
+            Some(role) => AccessibilityRole::from_widget_role(role),
+            None if child.clickable => AccessibilityRole::Button,
+            None => AccessibilityRole::StaticText,
+        };
+        elements.push(AccessibilityElement {
+            node_id: node.node_id,
+            canvas_key: Some(child.key),
+            label: child.label.clone(),
+            state_description: child.state_description.clone(),
+            click_label: child.on_click_label.clone(),
+            value: None,
+            bounds: rect,
+            role,
+            clickable: child.clickable,
+            selected: child.selected,
+            toggled: child.toggled,
+            enabled: child.enabled,
+            custom_actions: child
+                .custom_actions
+                .iter()
+                .map(|action| action.label.clone())
+                .collect(),
+        });
+    }
+}
+
+/// Runs the custom action a screen reader picked, resolving it against the
+/// *live* semantics tree rather than the published snapshot.
+///
+/// The snapshot exists to answer "has anything changed", and custom-action
+/// handlers are excluded from that comparison on purpose (a recorder closure is
+/// rebuilt every collection, so comparing handler identity would re-publish the
+/// whole tree over JNI every frame). The consequence is that the snapshot's
+/// handlers may be one collection old, so the action is looked up again here,
+/// by the identity the platform sent back: the owning node, which drawn control
+/// inside it, and the action's index in that control's list.
+#[cfg(any(
+    test,
+    all(feature = "desktop-shell", feature = "renderer-wgpu"),
+    all(feature = "android", feature = "renderer-wgpu", target_os = "android")
+))]
+pub(crate) fn perform_custom_action(
+    root: &SemanticsNode,
+    node_id: NodeId,
+    canvas_key: Option<u64>,
+    action_index: usize,
+) -> bool {
+    let Some(node) = find_semantics_node(root, node_id) else {
+        return false;
+    };
+    let actions = match canvas_key {
+        Some(key) => match node.canvas_children.iter().find(|child| child.key == key) {
+            Some(child) => &child.custom_actions,
+            None => return false,
+        },
+        None => &node.custom_actions,
+    };
+    match actions.get(action_index) {
+        Some(action) => {
+            action.invoke();
+            true
+        }
+        None => false,
+    }
+}
+
+#[cfg(any(
+    test,
+    all(feature = "desktop-shell", feature = "renderer-wgpu"),
+    all(feature = "android", feature = "renderer-wgpu", target_os = "android")
+))]
+fn find_semantics_node(node: &SemanticsNode, node_id: NodeId) -> Option<&SemanticsNode> {
+    if node.node_id == node_id {
+        return Some(node);
+    }
+    node.children
+        .iter()
+        .find_map(|child| find_semantics_node(child, node_id))
 }
 
 /// Borrows rather than clones: this runs for every semantics node on every
@@ -216,7 +451,12 @@ fn collect_descendant_labels<'a>(node: &'a SemanticsNode, labels: &mut Vec<&'a s
 mod tests {
     use super::*;
     use cranpose_core::NodeId;
-    use cranpose_ui::{SemanticsAction, SemanticsCallback, SemanticsNode, SemanticsRole};
+    use cranpose_ui::{
+        CanvasSemanticsNode, SemanticsAction, SemanticsCallback, SemanticsCustomAction,
+        SemanticsNode, SemanticsRole, SemanticsWidgetRole,
+    };
+    use std::cell::RefCell;
+    use std::rc::Rc;
 
     fn node(
         node_id: NodeId,
@@ -231,9 +471,71 @@ mod tests {
             actions,
             children,
             description: description.map(str::to_owned),
-            editable_text: false,
-            text_selection: None,
+            ..SemanticsNode::default()
         }
+    }
+
+    fn rect(x: f32, y: f32, width: f32, height: f32) -> cranpose_ui::Rect {
+        cranpose_ui::Rect {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    fn element_with(node_id: NodeId, canvas_key: Option<u64>) -> AccessibilityElement {
+        AccessibilityElement {
+            node_id,
+            canvas_key,
+            label: "Row".into(),
+            bounds: AccessibilityRect::new(0.0, 0.0, 10.0, 10.0),
+            ..AccessibilityElement::default()
+        }
+    }
+
+    /// Drawn controls need ids of their own, and they must not shift when the
+    /// app publishes a different set: a screen reader's cursor lives on the id.
+    #[test]
+    fn drawn_controls_get_distinct_ids_that_do_not_move_with_list_position() {
+        let rows: Vec<_> = (0..24).map(|key| element_with(7, Some(key))).collect();
+        let ids = element_ids(&rows);
+
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), ids.len(), "ids collided: {ids:?}");
+        assert!(ids.iter().all(|id| *id > 0));
+
+        // Drop the first row: every surviving row keeps the id it had.
+        let scrolled = element_ids(&rows[1..]);
+        assert_eq!(scrolled, ids[1..]);
+
+        // And the layout node itself is untouched by the drawn controls
+        // hanging off it.
+        assert_eq!(element_ids(&[element_with(7, None)]), vec![7]);
+    }
+
+    #[test]
+    fn an_element_id_resolves_back_to_the_element_that_published_it() {
+        let elements = vec![
+            element_with(7, None),
+            element_with(7, Some(3)),
+            element_with(9, Some(3)),
+        ];
+        let ids = element_ids(&elements);
+
+        assert_eq!(resolve_element_id(&elements, ids[1]), Some((7, Some(3))));
+        assert_eq!(resolve_element_id(&elements, ids[2]), Some((9, Some(3))));
+        assert_eq!(resolve_element_id(&elements, ids[0]), Some((7, None)));
+        assert_eq!(resolve_element_id(&elements, -12), None);
+    }
+
+    #[test]
+    fn a_layout_node_element_keeps_its_cranpose_node_id() {
+        assert_eq!(element_id(42, None), 42);
+        assert_eq!(element_id(0, None), 1);
+        assert_eq!(element_id(42, None), element_id(42, None));
     }
 
     #[test]
@@ -288,5 +590,222 @@ mod tests {
         assert_eq!(projected[0].bounds.center(), (48.0, 732.0));
         assert_eq!(projected[1].label, "Receipts");
         assert_eq!(projected[1].role, AccessibilityRole::StaticText);
+    }
+
+    /// The case the whole canvas-semantics path exists for: a screen drawn as
+    /// one `Canvas` has exactly one layout node, so without this the screen
+    /// reader is offered one element for a list of controls.
+    #[test]
+    fn drawn_controls_become_elements_positioned_inside_their_canvas() {
+        let canvas_id = 7;
+        let mut root = node(
+            canvas_id,
+            SemanticsRole::Layout,
+            Vec::new(),
+            None,
+            Vec::new(),
+        );
+        root.canvas_children = vec![
+            CanvasSemanticsNode::text(1, rect(0.0, 0.0, 200.0, 30.0), "SETTINGS")
+                .with_role(SemanticsWidgetRole::Header),
+            CanvasSemanticsNode::control(2, rect(0.0, 40.0, 200.0, 52.0), "Haptics")
+                .with_role(SemanticsWidgetRole::Switch)
+                .with_toggled(true)
+                .with_state_description("On"),
+            CanvasSemanticsNode::control(3, rect(0.0, 100.0, 200.0, 52.0), "Reset progress")
+                .with_click_label("Reset")
+                .with_enabled(false),
+        ];
+        // The canvas is inset, so a drawn rect at y=40 is at y=140 on screen.
+        let bounds =
+            HashMap::from_iter([(canvas_id, AccessibilityRect::new(20.0, 100.0, 200.0, 300.0))]);
+
+        let projected = project_semantics(&root, &bounds);
+
+        assert_eq!(projected.len(), 3);
+        assert!(projected.iter().all(|element| element.node_id == canvas_id));
+        assert_eq!(
+            projected
+                .iter()
+                .map(|element| element.canvas_key)
+                .collect::<Vec<_>>(),
+            vec![Some(1), Some(2), Some(3)]
+        );
+
+        assert_eq!(projected[0].role, AccessibilityRole::Header);
+        assert!(!projected[0].clickable);
+
+        assert_eq!(projected[1].label, "Haptics");
+        assert_eq!(projected[1].role, AccessibilityRole::Switch);
+        assert_eq!(projected[1].toggled, Some(true));
+        assert_eq!(projected[1].state_description.as_deref(), Some("On"));
+        assert!(projected[1].clickable);
+        // 20 + 0, 100 + 40 — the drawn rect translated into window space.
+        assert_eq!(projected[1].bounds.center(), (120.0, 166.0));
+
+        assert_eq!(projected[2].click_label.as_deref(), Some("Reset"));
+        assert!(!projected[2].enabled);
+    }
+
+    /// A drawn control with nothing to say is not a stop on the screen
+    /// reader's tour, and neither is one that was drawn to zero size (the
+    /// scrolled-off rows of a scaling list report exactly that).
+    #[test]
+    fn drawn_controls_without_a_label_or_a_size_are_not_published() {
+        let canvas_id = 4;
+        let mut root = node(
+            canvas_id,
+            SemanticsRole::Layout,
+            Vec::new(),
+            None,
+            Vec::new(),
+        );
+        root.canvas_children = vec![
+            CanvasSemanticsNode::control(1, rect(0.0, 0.0, 100.0, 40.0), "   "),
+            CanvasSemanticsNode::control(2, rect(0.0, 40.0, 100.0, 0.0), "Off screen"),
+            CanvasSemanticsNode::control(3, rect(0.0, 60.0, 100.0, 40.0), "Visible"),
+        ];
+        let bounds =
+            HashMap::from_iter([(canvas_id, AccessibilityRect::new(0.0, 0.0, 100.0, 200.0))]);
+
+        let projected = project_semantics(&root, &bounds);
+
+        assert_eq!(projected.len(), 1);
+        assert_eq!(projected[0].label, "Visible");
+    }
+
+    /// The screen-level node keeps its own announcement (Compose's
+    /// `RadialChoiceScreen` reads title + state + hint as one node) and the
+    /// drawn options are published underneath it rather than instead of it.
+    #[test]
+    fn a_labelled_canvas_keeps_its_own_element_ahead_of_its_drawn_controls() {
+        let canvas_id = 9;
+        let mut root = node(
+            canvas_id,
+            SemanticsRole::Layout,
+            vec![SemanticsAction::Click {
+                handler: SemanticsCallback::new(canvas_id),
+            }],
+            Some("Orbit Breaker. CAMPAIGN. Turn the crown to change the choice."),
+            Vec::new(),
+        );
+        root.widget_role = Some(SemanticsWidgetRole::RadioButton);
+        root.state_description = Some("CAMPAIGN".into());
+        root.on_click_label = Some("CAMPAIGN".into());
+        root.selected = Some(true);
+        root.canvas_children = vec![
+            CanvasSemanticsNode::control(1, rect(60.0, 10.0, 80.0, 40.0), "CAMPAIGN")
+                .with_role(SemanticsWidgetRole::RadioButton)
+                .with_selected(true),
+            CanvasSemanticsNode::control(2, rect(60.0, 150.0, 80.0, 40.0), "DAILY")
+                .with_role(SemanticsWidgetRole::RadioButton)
+                .with_selected(false),
+        ];
+        let bounds =
+            HashMap::from_iter([(canvas_id, AccessibilityRect::new(0.0, 0.0, 200.0, 200.0))]);
+
+        let projected = project_semantics(&root, &bounds);
+
+        assert_eq!(projected.len(), 3);
+        assert_eq!(projected[0].canvas_key, None);
+        assert_eq!(projected[0].role, AccessibilityRole::RadioButton);
+        assert_eq!(projected[0].state_description.as_deref(), Some("CAMPAIGN"));
+        assert_eq!(projected[0].click_label.as_deref(), Some("CAMPAIGN"));
+        assert_eq!(projected[1].label, "CAMPAIGN");
+        assert_eq!(projected[1].selected, Some(true));
+        assert_eq!(projected[2].label, "DAILY");
+        assert_eq!(projected[2].selected, Some(false));
+    }
+
+    #[test]
+    fn custom_action_labels_reach_the_platform_in_publication_order() {
+        let arena_id = 3;
+        let mut root = node(
+            arena_id,
+            SemanticsRole::Layout,
+            Vec::new(),
+            Some("Level 4. Score 120."),
+            Vec::new(),
+        );
+        root.custom_actions = vec![
+            SemanticsCustomAction::new("Pause", || {}),
+            SemanticsCustomAction::new("Restart", || {}),
+        ];
+        let bounds =
+            HashMap::from_iter([(arena_id, AccessibilityRect::new(0.0, 0.0, 200.0, 200.0))]);
+
+        let projected = project_semantics(&root, &bounds);
+
+        assert_eq!(projected.len(), 1);
+        assert_eq!(projected[0].custom_actions, vec!["Pause", "Restart"]);
+    }
+
+    #[test]
+    fn a_custom_action_runs_the_handler_the_tree_currently_holds() {
+        let arena_id = 3;
+        let canvas_id = 5;
+        let fired = Rc::new(RefCell::new(Vec::new()));
+
+        let mut root = node(
+            arena_id,
+            SemanticsRole::Layout,
+            Vec::new(),
+            None,
+            Vec::new(),
+        );
+        root.custom_actions = vec![SemanticsCustomAction::new("Pause", {
+            let fired = Rc::clone(&fired);
+            move || fired.borrow_mut().push("pause")
+        })];
+        let mut child = node(
+            canvas_id,
+            SemanticsRole::Layout,
+            Vec::new(),
+            None,
+            Vec::new(),
+        );
+        child.canvas_children =
+            vec![
+                CanvasSemanticsNode::control(42, rect(0.0, 0.0, 40.0, 40.0), "Haptics")
+                    .with_custom_action(SemanticsCustomAction::new("Toggle", {
+                        let fired = Rc::clone(&fired);
+                        move || fired.borrow_mut().push("toggle")
+                    })),
+            ];
+        root.children = vec![child];
+
+        assert!(perform_custom_action(&root, arena_id, None, 0));
+        assert!(perform_custom_action(&root, canvas_id, Some(42), 0));
+
+        // Nothing published these, so nothing may run: an unknown node, a
+        // drawn control that is not on that node, and an index past the end.
+        assert!(!perform_custom_action(&root, 999, None, 0));
+        assert!(!perform_custom_action(&root, canvas_id, Some(43), 0));
+        assert!(!perform_custom_action(&root, arena_id, None, 1));
+
+        assert_eq!(*fired.borrow(), vec!["pause", "toggle"]);
+    }
+
+    /// A recorder closure is rebuilt on every collection, so if a custom action
+    /// compared by handler identity the Android bridge would decide the tree
+    /// changed and re-serialise it across JNI on every frame.
+    #[test]
+    fn rebuilding_a_custom_action_handler_is_not_a_published_change() {
+        let arena_id = 3;
+        let bounds =
+            HashMap::from_iter([(arena_id, AccessibilityRect::new(0.0, 0.0, 200.0, 200.0))]);
+        let project = |handler: fn()| {
+            let mut root = node(
+                arena_id,
+                SemanticsRole::Layout,
+                Vec::new(),
+                Some("Level 4."),
+                Vec::new(),
+            );
+            root.custom_actions = vec![SemanticsCustomAction::new("Pause", handler)];
+            project_semantics(&root, &bounds)
+        };
+
+        assert_eq!(project(|| {}), project(|| panic!("must not run")));
     }
 }

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -2161,6 +2161,26 @@ pub fn run(
                 shell.pointer_pressed();
                 shell.pointer_released_at_position(x, y);
             }
+            // A custom action has no position to synthesise a tap at — it is
+            // the screen reader's way to reach a command with no on-screen
+            // control — so it is dispatched by identity instead, against the
+            // semantics tree as it stands this frame.
+            for (virtual_id, action_index) in crate::android_accessibility::drain_custom_actions() {
+                let Some((node_id, canvas_key)) =
+                    crate::accessibility::resolve_element_id(&accessibility_elements, virtual_id)
+                else {
+                    continue;
+                };
+                let Some(tree) = shell.semantics_tree() else {
+                    continue;
+                };
+                crate::accessibility::perform_custom_action(
+                    tree.root(),
+                    node_id,
+                    canvas_key,
+                    action_index,
+                );
+            }
             for event in ime_event_queue.drain() {
                 dispatch_android_ime_event(shell, event);
             }

--- a/crates/cranpose/src/android_accessibility.rs
+++ b/crates/cranpose/src/android_accessibility.rs
@@ -1,19 +1,21 @@
 //! Android `AccessibilityNodeProvider` bridge for the native canvas surface.
 #![allow(unsafe_code)]
 
-use crate::accessibility::{self, AccessibilityElement, AccessibilityRole};
+use crate::accessibility::{self, AccessibilityElement};
+use crate::android_accessibility_wire::encode_elements;
 use crate::android_jni::{clear_pending_android_jni_exception, with_android_activity_env};
 use cranpose_app_shell::AppShell;
 use cranpose_render_wgpu::WgpuRenderer;
 use jni::{
     jni_sig, jni_str,
     objects::{JClass, JObject, JValue},
-    sys::jfloat,
+    sys::{jfloat, jint},
     EnvUnowned,
 };
 use std::sync::{Mutex, OnceLock};
 
 static ACTIVATIONS: OnceLock<Mutex<Vec<(f32, f32)>>> = OnceLock::new();
+static CUSTOM_ACTIONS: OnceLock<Mutex<Vec<(i32, usize)>>> = OnceLock::new();
 static LOOP_WAKER: OnceLock<android_activity::AndroidAppWaker> = OnceLock::new();
 
 pub(crate) fn set_waker(waker: android_activity::AndroidAppWaker) {
@@ -24,9 +26,23 @@ fn activations() -> &'static Mutex<Vec<(f32, f32)>> {
     ACTIVATIONS.get_or_init(|| Mutex::new(Vec::new()))
 }
 
+fn custom_actions() -> &'static Mutex<Vec<(i32, usize)>> {
+    CUSTOM_ACTIONS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
 pub(crate) fn drain_activations() -> Vec<(f32, f32)> {
     std::mem::take(
         &mut *activations()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()),
+    )
+}
+
+/// `(virtual view id, index into that element's custom action list)` pairs a
+/// screen reader asked for since the last frame.
+pub(crate) fn drain_custom_actions() -> Vec<(i32, usize)> {
+    std::mem::take(
+        &mut *custom_actions()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner()),
     )
@@ -67,48 +83,6 @@ pub(crate) fn sync(
     })
 }
 
-fn encode_elements(elements: &[AccessibilityElement], density: f32) -> String {
-    let density = density.max(f32::EPSILON);
-    elements
-        .iter()
-        .map(|element| {
-            let role = match element.role {
-                AccessibilityRole::Button => 1,
-                AccessibilityRole::StaticText => 2,
-                AccessibilityRole::TextField => 3,
-            };
-            let (center_x, center_y) = element.bounds.center();
-            format!(
-                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
-                virtual_id(element.node_id),
-                role,
-                (element.bounds.x * density).round() as i32,
-                (element.bounds.y * density).round() as i32,
-                ((element.bounds.x + element.bounds.width) * density).round() as i32,
-                ((element.bounds.y + element.bounds.height) * density).round() as i32,
-                center_x,
-                center_y,
-                i32::from(element.clickable),
-                escape(&element.label),
-                escape(element.value.as_deref().unwrap_or("")),
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-fn virtual_id(node_id: cranpose_core::NodeId) -> i32 {
-    ((node_id as u64 & 0x7fff_ffff) as i32).max(1)
-}
-
-fn escape(value: &str) -> String {
-    value
-        .replace('%', "%25")
-        .replace('\t', "%09")
-        .replace('\n', "%0A")
-        .replace('\r', "%0D")
-}
-
 #[doc(hidden)]
 #[no_mangle]
 pub extern "system" fn Java_dev_cranpose_android_CranposeActivity_nativeOnAccessibilityActivate(
@@ -126,19 +100,27 @@ pub extern "system" fn Java_dev_cranpose_android_CranposeActivity_nativeOnAccess
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{escape, virtual_id};
-
-    #[test]
-    fn android_accessibility_wire_values_escape_record_delimiters() {
-        assert_eq!(escape("A%\tB\nC\r"), "A%25%09B%0AC%0D");
+/// A screen reader picked one of the node's custom actions.
+///
+/// Only the identity travels: which virtual view, and which action in the list
+/// that view published. Resolving that to a handler happens on the frame loop
+/// against the live semantics tree, so nothing here holds app state.
+#[doc(hidden)]
+#[no_mangle]
+pub extern "system" fn Java_dev_cranpose_android_CranposeActivity_nativeOnAccessibilityCustomAction(
+    _env: EnvUnowned<'_>,
+    _class: JClass<'_>,
+    virtual_id: jint,
+    action_index: jint,
+) {
+    if action_index < 0 {
+        return;
     }
-
-    #[test]
-    fn android_virtual_ids_are_stable_copies_of_cranpose_node_ids() {
-        assert_eq!(virtual_id(42), 42);
-        assert_eq!(virtual_id(0), 1);
-        assert_eq!(virtual_id(42), virtual_id(42));
+    custom_actions()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .push((virtual_id, action_index as usize));
+    if let Some(waker) = LOOP_WAKER.get() {
+        waker.wake();
     }
 }

--- a/crates/cranpose/src/android_accessibility_wire.rs
+++ b/crates/cranpose/src/android_accessibility_wire.rs
@@ -1,0 +1,171 @@
+//! The wire format that carries Cranpose's semantics into
+//! `CranposeActivity`'s `AccessibilityNodeProvider`.
+//!
+//! The whole visible tree crosses JNI as one `String` on the frames it
+//! changes, rather than one call per node, for the same reason the Play
+//! Billing snapshot does: a screen reader must never observe a half-built
+//! tree. Encoding lives here, in safe Rust, and is unit-tested on the host —
+//! the format is the contract between the two sides, and the Java parser
+//! rejects any record whose field count does not match.
+//!
+//! ```text
+//! <id>\t<role>\t<left>\t<top>\t<right>\t<bottom>\t<centerX>\t<centerY>
+//!      \t<clickable>\t<label>\t<value>\t<stateDescription>\t<clickLabel>
+//!      \t<selected>\t<toggled>\t<enabled>\t<customActions>
+//! ```
+//!
+//! Bounds are physical pixels (Java draws them into `Rect`s); the two centre
+//! coordinates stay logical because they are fed back through the pointer
+//! pipeline as a synthetic tap. `selected` and `toggled` are `-1` when the app
+//! said nothing, so "not a checkable control" is distinguishable from "off".
+//! Text uses the same `%09`/`%0A`/`%0D`/`%25` escaping as the launch-argument
+//! payload, plus `%1F` for the separator that packs custom action labels into
+//! one field, because every one of these strings is app-authored.
+
+use crate::accessibility::{element_ids, AccessibilityElement, AccessibilityRole};
+
+/// Separator between the custom action labels packed into one wire field.
+/// ASCII unit separator, escaped like every other delimiter so a label
+/// containing one cannot split the field.
+const ACTION_SEPARATOR: char = '\u{1f}';
+
+pub(crate) fn encode_elements(elements: &[AccessibilityElement], density: f32) -> String {
+    let density = density.max(f32::EPSILON);
+    let ids = element_ids(elements);
+    elements
+        .iter()
+        .zip(ids)
+        .map(|(element, id)| {
+            let role = match element.role {
+                AccessibilityRole::Button => 1,
+                AccessibilityRole::StaticText => 2,
+                AccessibilityRole::TextField => 3,
+                AccessibilityRole::Checkbox => 4,
+                AccessibilityRole::Switch => 5,
+                AccessibilityRole::RadioButton => 6,
+                AccessibilityRole::Tab => 7,
+                AccessibilityRole::Image => 8,
+                AccessibilityRole::Header => 9,
+            };
+            let (center_x, center_y) = element.bounds.center();
+            let actions = element
+                .custom_actions
+                .iter()
+                .map(|label| escape(label))
+                .collect::<Vec<_>>()
+                .join(&ACTION_SEPARATOR.to_string());
+            format!(
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                id,
+                role,
+                (element.bounds.x * density).round() as i32,
+                (element.bounds.y * density).round() as i32,
+                ((element.bounds.x + element.bounds.width) * density).round() as i32,
+                ((element.bounds.y + element.bounds.height) * density).round() as i32,
+                center_x,
+                center_y,
+                i32::from(element.clickable),
+                escape(&element.label),
+                escape(element.value.as_deref().unwrap_or("")),
+                escape(element.state_description.as_deref().unwrap_or("")),
+                escape(element.click_label.as_deref().unwrap_or("")),
+                tristate(element.selected),
+                tristate(element.toggled),
+                i32::from(element.enabled),
+                actions,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// `-1` when the app said nothing about the state, so Java can tell "this is
+/// not a checkable control" from "this switch is off".
+fn tristate(value: Option<bool>) -> i32 {
+    match value {
+        None => -1,
+        Some(false) => 0,
+        Some(true) => 1,
+    }
+}
+
+fn escape(value: &str) -> String {
+    value
+        .replace('%', "%25")
+        .replace('\t', "%09")
+        .replace('\n', "%0A")
+        .replace('\r', "%0D")
+        .replace(ACTION_SEPARATOR, "%1F")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::accessibility::AccessibilityRect;
+
+    fn element(node_id: usize, canvas_key: Option<u64>) -> AccessibilityElement {
+        AccessibilityElement {
+            node_id,
+            canvas_key,
+            label: "Row".into(),
+            bounds: AccessibilityRect::new(0.0, 0.0, 10.0, 10.0),
+            ..AccessibilityElement::default()
+        }
+    }
+
+    #[test]
+    fn android_accessibility_wire_values_escape_record_delimiters() {
+        assert_eq!(
+            escape(&format!("A%\tB\nC\r{ACTION_SEPARATOR}")),
+            "A%25%09B%0AC%0D%1F"
+        );
+    }
+
+    #[test]
+    fn tristate_distinguishes_unset_from_off() {
+        assert_eq!(tristate(None), -1);
+        assert_eq!(tristate(Some(false)), 0);
+        assert_eq!(tristate(Some(true)), 1);
+    }
+
+    /// The Java parser rejects a record whose field count is wrong, so the
+    /// count is part of the contract and is asserted here rather than left to
+    /// be discovered on a watch.
+    #[test]
+    fn every_encoded_record_carries_the_seventeen_fields_java_parses() {
+        let elements = vec![
+            AccessibilityElement {
+                node_id: 4,
+                label: "Haptics".into(),
+                state_description: Some("On".into()),
+                click_label: Some("Toggle".into()),
+                bounds: AccessibilityRect::new(1.0, 2.0, 30.0, 40.0),
+                role: AccessibilityRole::Switch,
+                clickable: true,
+                toggled: Some(true),
+                custom_actions: vec!["Pause".into(), "Resume".into()],
+                ..AccessibilityElement::default()
+            },
+            element(5, Some(1)),
+        ];
+
+        let payload = encode_elements(&elements, 2.0);
+        let records: Vec<_> = payload.split('\n').collect();
+        assert_eq!(records.len(), 2);
+        for record in &records {
+            assert_eq!(record.split('\t').count(), 17, "record: {record}");
+        }
+
+        let fields: Vec<_> = records[0].split('\t').collect();
+        assert_eq!(fields[1], "5", "Switch should encode as role 5");
+        // Density 2.0 turns logical 1,2 .. 31,42 into physical pixels.
+        assert_eq!(&fields[2..6], ["2", "4", "62", "84"]);
+        assert_eq!(fields[9], "Haptics");
+        assert_eq!(fields[11], "On");
+        assert_eq!(fields[12], "Toggle");
+        assert_eq!(fields[13], "-1", "selected was never set");
+        assert_eq!(fields[14], "1", "toggled on");
+        assert_eq!(fields[15], "1", "enabled by default");
+        assert_eq!(fields[16], format!("Pause{ACTION_SEPARATOR}Resume"));
+    }
+}

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -4384,6 +4384,7 @@ impl ApplicationHandler for App {
                 app.pointer_pressed();
                 app.pointer_released_at_position(x, y);
             }
+            accessibility.run_custom_actions(app);
         }
         let Some(platform) = &mut self.platform else {
             return;
@@ -4801,6 +4802,7 @@ impl ApplicationHandler for App {
                 app.pointer_released_at_position(x, y);
                 activated = true;
             }
+            activated |= accessibility.run_custom_actions(app);
             if activated {
                 request_redraw_once(&window, &mut self.primary_redraw_pending);
             }

--- a/crates/cranpose/src/desktop_accessibility.rs
+++ b/crates/cranpose/src/desktop_accessibility.rs
@@ -3,8 +3,8 @@
 
 use crate::accessibility::{self, AccessibilityElement, AccessibilityRole};
 use accesskit::{
-    Action, ActionHandler, ActionRequest, ActivationHandler, DeactivationHandler, Node, NodeId,
-    Rect, Role, Tree, TreeId, TreeUpdate,
+    Action, ActionData, ActionHandler, ActionRequest, ActivationHandler, CustomAction,
+    DeactivationHandler, Node, NodeId, Rect, Role, Toggled, Tree, TreeId, TreeUpdate,
 };
 use cranpose_app_shell::AppShell;
 use cranpose_render_wgpu::WgpuRenderer;
@@ -55,6 +55,7 @@ pub(crate) struct DesktopAccessibilityBridge {
     initial_tree: Arc<Mutex<Option<TreeUpdate>>>,
     actions: Arc<Mutex<Vec<ActionRequest>>>,
     centers: HashMap<NodeId, (f32, f32)>,
+    pending_custom_actions: Vec<(NodeId, usize)>,
     previous: Vec<AccessibilityElement>,
     seen_revision: Option<u64>,
 }
@@ -77,6 +78,7 @@ impl DesktopAccessibilityBridge {
             initial_tree,
             actions,
             centers: HashMap::new(),
+            pending_custom_actions: Vec::new(),
             previous: Vec::new(),
             seen_revision: None,
         }
@@ -96,10 +98,13 @@ impl DesktopAccessibilityBridge {
         }
         self.previous = elements;
         let update = tree_update(&self.previous);
-        self.centers = self
-            .previous
-            .iter()
-            .map(|element| (NodeId(element.node_id as u64), element.bounds.center()))
+        // Keyed by the shared element id, not the layout node id: several
+        // elements can share one layout node once that node publishes drawn
+        // controls, and a click has to land on the one AccessKit named.
+        self.centers = accessibility::element_ids(&self.previous)
+            .into_iter()
+            .zip(&self.previous)
+            .map(|(id, element)| (NodeId(id as u64), element.bounds.center()))
             .collect();
         *self
             .initial_tree
@@ -109,33 +114,86 @@ impl DesktopAccessibilityBridge {
     }
 
     pub(crate) fn drain_clicks(&mut self) -> Vec<(f32, f32)> {
-        std::mem::take(
+        let requests = std::mem::take(
             &mut *self
                 .actions
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner()),
-        )
-        .into_iter()
-        .filter(|request| request.action == Action::Click)
-        .filter_map(|request| self.centers.get(&request.target_node).copied())
-        .collect()
+        );
+        let mut clicks = Vec::new();
+        for request in requests {
+            match request.action {
+                Action::Click => {
+                    if let Some(center) = self.centers.get(&request.target_node) {
+                        clicks.push(*center);
+                    }
+                }
+                // A custom action has no position to synthesise a click at, so
+                // it is parked by identity and run against the live semantics
+                // tree on the next frame, exactly as the Android bridge does.
+                Action::CustomAction => {
+                    if let Some(ActionData::CustomAction(index)) = request.data {
+                        if index >= 0 {
+                            self.pending_custom_actions
+                                .push((request.target_node, index as usize));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        clicks
+    }
+
+    /// Runs the custom actions a screen reader picked. Returns whether any ran,
+    /// so the caller knows whether a redraw is owed.
+    pub(crate) fn run_custom_actions(&mut self, shell: &mut AppShell<WgpuRenderer>) -> bool {
+        if self.pending_custom_actions.is_empty() {
+            return false;
+        }
+        let pending = std::mem::take(&mut self.pending_custom_actions);
+        let ids = accessibility::element_ids(&self.previous);
+        let Some(tree) = shell.semantics_tree() else {
+            return false;
+        };
+        let mut ran = false;
+        for (target, index) in pending {
+            let Some(element) = ids
+                .iter()
+                .position(|id| NodeId(*id as u64) == target)
+                .and_then(|position| self.previous.get(position))
+            else {
+                continue;
+            };
+            ran |= accessibility::perform_custom_action(
+                tree.root(),
+                element.node_id,
+                element.canvas_key,
+                index,
+            );
+        }
+        ran
     }
 }
 
 fn tree_update(elements: &[AccessibilityElement]) -> TreeUpdate {
-    let children: Vec<NodeId> = elements
-        .iter()
-        .map(|element| NodeId(element.node_id as u64))
-        .collect();
+    let ids = accessibility::element_ids(elements);
+    let children: Vec<NodeId> = ids.iter().map(|id| NodeId(*id as u64)).collect();
     let mut root = Node::new(Role::Window);
     root.set_label("Cranpose application");
     root.set_children(children);
     let mut nodes = vec![(ROOT_ID, root)];
-    nodes.extend(elements.iter().map(|element| {
+    nodes.extend(ids.iter().zip(elements).map(|(id, element)| {
         let role = match element.role {
             AccessibilityRole::Button => Role::Button,
             AccessibilityRole::StaticText => Role::Label,
             AccessibilityRole::TextField => Role::TextInput,
+            AccessibilityRole::Checkbox => Role::CheckBox,
+            AccessibilityRole::Switch => Role::Switch,
+            AccessibilityRole::RadioButton => Role::RadioButton,
+            AccessibilityRole::Tab => Role::Tab,
+            AccessibilityRole::Image => Role::Image,
+            AccessibilityRole::Header => Role::Heading,
         };
         let mut node = Node::new(role);
         if element.role == AccessibilityRole::StaticText {
@@ -146,6 +204,25 @@ fn tree_update(elements: &[AccessibilityElement]) -> TreeUpdate {
         if let Some(value) = &element.value {
             node.set_value(value.as_str());
         }
+        // AccessKit's `description` is the supplementary phrase a screen
+        // reader reads after the label, which is the role Compose's
+        // `stateDescription` plays.
+        if let Some(state) = &element.state_description {
+            node.set_description(state.as_str());
+        }
+        if let Some(selected) = element.selected {
+            node.set_selected(selected);
+        }
+        if let Some(toggled) = element.toggled {
+            node.set_toggled(if toggled {
+                Toggled::True
+            } else {
+                Toggled::False
+            });
+        }
+        if !element.enabled {
+            node.set_disabled();
+        }
         node.set_bounds(Rect {
             x0: element.bounds.x as f64,
             y0: element.bounds.y as f64,
@@ -155,7 +232,21 @@ fn tree_update(elements: &[AccessibilityElement]) -> TreeUpdate {
         if element.clickable {
             node.add_action(Action::Click);
         }
-        (NodeId(element.node_id as u64), node)
+        if !element.custom_actions.is_empty() {
+            node.add_action(Action::CustomAction);
+            node.set_custom_actions(
+                element
+                    .custom_actions
+                    .iter()
+                    .enumerate()
+                    .map(|(index, label)| CustomAction {
+                        id: index as i32,
+                        description: label.as_str().into(),
+                    })
+                    .collect::<Vec<_>>(),
+            );
+        }
+        (NodeId(*id as u64), node)
     }));
     let mut tree = Tree::new(ROOT_ID);
     tree.toolkit_name = Some("Cranpose".into());
@@ -294,18 +385,17 @@ mod tests {
             AccessibilityElement {
                 node_id: 7,
                 label: "Items".into(),
-                value: None,
                 bounds: AccessibilityRect::new(10.0, 20.0, 80.0, 44.0),
                 role: AccessibilityRole::Button,
                 clickable: true,
+                ..AccessibilityElement::default()
             },
             AccessibilityElement {
                 node_id: 8,
                 label: "Receipts".into(),
-                value: None,
                 bounds: AccessibilityRect::new(10.0, 70.0, 120.0, 24.0),
                 role: AccessibilityRole::StaticText,
-                clickable: false,
+                ..AccessibilityElement::default()
             },
         ];
 
@@ -318,5 +408,52 @@ mod tests {
         let label = &update.nodes[2].1;
         assert_eq!(label.role(), Role::Label);
         assert_eq!(label.value(), Some("Receipts"));
+    }
+
+    /// Drawn controls all hang off one layout node, so a bridge that keyed
+    /// AccessKit nodes by layout node id published one node for a whole
+    /// settings list and clicked the wrong row.
+    #[test]
+    fn drawn_controls_sharing_a_layout_node_become_separate_accesskit_nodes() {
+        let elements = vec![
+            AccessibilityElement {
+                node_id: 4,
+                canvas_key: Some(1),
+                label: "Haptics".into(),
+                state_description: Some("On".into()),
+                bounds: AccessibilityRect::new(0.0, 0.0, 100.0, 50.0),
+                role: AccessibilityRole::Switch,
+                clickable: true,
+                toggled: Some(true),
+                ..AccessibilityElement::default()
+            },
+            AccessibilityElement {
+                node_id: 4,
+                canvas_key: Some(2),
+                label: "Sound effects".into(),
+                bounds: AccessibilityRect::new(0.0, 60.0, 100.0, 50.0),
+                role: AccessibilityRole::Switch,
+                clickable: true,
+                toggled: Some(false),
+                enabled: false,
+                ..AccessibilityElement::default()
+            },
+        ];
+
+        let update = tree_update(&elements);
+        let ids: Vec<_> = update.nodes.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids.len(), 3, "root plus one node per drawn control");
+        assert_ne!(ids[1], ids[2]);
+        assert_eq!(update.nodes[0].1.children(), &ids[1..]);
+
+        let haptics = &update.nodes[1].1;
+        assert_eq!(haptics.role(), Role::Switch);
+        assert_eq!(haptics.toggled(), Some(Toggled::True));
+        assert_eq!(haptics.description(), Some("On"));
+        assert!(!haptics.is_disabled());
+
+        let sound = &update.nodes[2].1;
+        assert_eq!(sound.toggled(), Some(Toggled::False));
+        assert!(sound.is_disabled());
     }
 }

--- a/crates/cranpose/src/ios_accessibility.rs
+++ b/crates/cranpose/src/ios_accessibility.rs
@@ -4,7 +4,6 @@
 use crate::accessibility::{self, AccessibilityElement, AccessibilityRole};
 use crate::ios_file_picker::root_view_controller;
 use cranpose_app_shell::{AppShell, PointerSource};
-use cranpose_core::NodeId;
 use cranpose_render_common::Renderer;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, Bool};
@@ -15,7 +14,9 @@ use objc2_ui_kit::{
     NSObjectUIAccessibility, NSObjectUIAccessibilityContainer, UIAccessibilityElement,
     UIAccessibilityIdentification, UIAccessibilityLayoutChangedNotification,
     UIAccessibilityPostNotification, UIAccessibilityScreenChangedNotification,
-    UIAccessibilityTraitButton, UIAccessibilityTraitNone, UIAccessibilityTraitStaticText, UIView,
+    UIAccessibilityTraitButton, UIAccessibilityTraitHeader, UIAccessibilityTraitImage,
+    UIAccessibilityTraitNone, UIAccessibilityTraitNotEnabled, UIAccessibilityTraitSelected,
+    UIAccessibilityTraitStaticText, UIView,
 };
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
@@ -24,9 +25,12 @@ use std::rc::Rc;
 use winit::event_loop::EventLoopProxy;
 
 struct AccessibilityElementIvars {
-    node_id: NodeId,
+    /// The shared accessibility element id, not the layout node id: a node
+    /// that publishes drawn controls owns several elements, and VoiceOver has
+    /// to activate the one it is focused on.
+    element_id: i32,
     actionable: Cell<bool>,
-    pending_activations: Rc<RefCell<Vec<NodeId>>>,
+    pending_activations: Rc<RefCell<Vec<i32>>>,
     wake_proxy: EventLoopProxy,
 }
 
@@ -50,7 +54,7 @@ define_class!(
             self.ivars()
                 .pending_activations
                 .borrow_mut()
-                .push(self.ivars().node_id);
+                .push(self.ivars().element_id);
             self.ivars().wake_proxy.wake_up();
             Bool::YES
         }
@@ -60,13 +64,13 @@ define_class!(
 impl NativeAccessibilityElement {
     fn new(
         container: &AnyObject,
-        node_id: NodeId,
-        pending_activations: Rc<RefCell<Vec<NodeId>>>,
+        element_id: i32,
+        pending_activations: Rc<RefCell<Vec<i32>>>,
         wake_proxy: EventLoopProxy,
         mtm: MainThreadMarker,
     ) -> Retained<Self> {
         let this = Self::alloc(mtm).set_ivars(AccessibilityElementIvars {
-            node_id,
+            element_id,
             actionable: Cell::new(false),
             pending_activations,
             wake_proxy,
@@ -84,9 +88,10 @@ impl NativeAccessibilityElement {
 /// Owns UIKit's retained accessibility elements and dispatches their actions.
 pub(crate) struct IosAccessibilityBridge {
     host_view: Retained<UIView>,
-    native_elements: HashMap<NodeId, Retained<NativeAccessibilityElement>>,
+    native_elements: HashMap<i32, Retained<NativeAccessibilityElement>>,
     snapshot: Vec<AccessibilityElement>,
-    pending_activations: Rc<RefCell<Vec<NodeId>>>,
+    snapshot_ids: Vec<i32>,
+    pending_activations: Rc<RefCell<Vec<i32>>>,
     wake_proxy: EventLoopProxy,
     published_once: bool,
 }
@@ -103,6 +108,7 @@ impl IosAccessibilityBridge {
             host_view,
             native_elements: HashMap::new(),
             snapshot: Vec::new(),
+            snapshot_ids: Vec::new(),
             pending_activations: Rc::new(RefCell::new(Vec::new())),
             wake_proxy: event_proxy,
             published_once: false,
@@ -121,27 +127,29 @@ impl IosAccessibilityBridge {
         }
 
         let structure_changed = !same_structure(&self.snapshot, &next);
-        let current_ids: HashSet<NodeId> = next.iter().map(|element| element.node_id).collect();
+        let next_ids = accessibility::element_ids(&next);
+        let current_ids: HashSet<i32> = next_ids.iter().copied().collect();
         self.native_elements
-            .retain(|node_id, _| current_ids.contains(node_id));
+            .retain(|element_id, _| current_ids.contains(element_id));
 
         let mtm = MainThreadMarker::new().expect("accessibility sync runs on UIKit's main thread");
-        for element in &next {
-            if !self.native_elements.contains_key(&element.node_id) {
-                let native = self.create_element(element, mtm);
-                self.native_elements.insert(element.node_id, native);
+        for (element_id, element) in next_ids.iter().zip(&next) {
+            if !self.native_elements.contains_key(element_id) {
+                let native = self.create_element(*element_id, mtm);
+                self.native_elements.insert(*element_id, native);
             }
             let native = self
                 .native_elements
-                .get(&element.node_id)
+                .get(element_id)
                 .expect("accessibility element inserted above");
             update_native_element(native, element);
         }
 
         if structure_changed {
-            self.publish_container(&next, mtm);
+            self.publish_container(&next_ids, mtm);
         }
         self.snapshot = next;
+        self.snapshot_ids = next_ids;
     }
 
     /// Runs queued VoiceOver/XCTest activations through Cranpose pointer input.
@@ -152,11 +160,12 @@ impl IosAccessibilityBridge {
     {
         let pending = self.pending_activations.take();
         let mut changed = false;
-        for node_id in pending {
+        for element_id in pending {
             let Some(element) = self
-                .snapshot
+                .snapshot_ids
                 .iter()
-                .find(|element| element.node_id == node_id)
+                .position(|id| *id == element_id)
+                .and_then(|index| self.snapshot.get(index))
             else {
                 continue;
             };
@@ -171,29 +180,28 @@ impl IosAccessibilityBridge {
 
     fn create_element(
         &self,
-        element: &AccessibilityElement,
+        element_id: i32,
         mtm: MainThreadMarker,
     ) -> Retained<NativeAccessibilityElement> {
         let container: &AnyObject = self.host_view.as_ref();
         let native = NativeAccessibilityElement::new(
             container,
-            element.node_id,
+            element_id,
             Rc::clone(&self.pending_activations),
             self.wake_proxy.clone(),
             mtm,
         );
         native.setIsAccessibilityElement(true);
         native.setAccessibilityIdentifier(Some(&NSString::from_str(&format!(
-            "cranpose-node-{}",
-            element.node_id
+            "cranpose-node-{element_id}"
         ))));
         native
     }
 
-    fn publish_container(&mut self, next: &[AccessibilityElement], mtm: MainThreadMarker) {
-        let ordered: Vec<Retained<AnyObject>> = next
+    fn publish_container(&mut self, next_ids: &[i32], mtm: MainThreadMarker) {
+        let ordered: Vec<Retained<AnyObject>> = next_ids
             .iter()
-            .filter_map(|element| self.native_elements.get(&element.node_id))
+            .filter_map(|element_id| self.native_elements.get(element_id))
             .map(|element| element.retain().into())
             .collect();
         let array = NSArray::from_retained_slice(&ordered);
@@ -222,20 +230,51 @@ impl IosAccessibilityBridge {
 fn update_native_element(native: &NativeAccessibilityElement, element: &AccessibilityElement) {
     native.set_actionable(element.clickable || element.role == AccessibilityRole::TextField);
     native.setAccessibilityLabel(Some(&NSString::from_str(&element.label)));
-    native.setAccessibilityValue(element.value.as_deref().map(NSString::from_str).as_deref());
+    // VoiceOver reads the value after the label, which is where Compose's
+    // `stateDescription` belongs; a text field's own text still wins, since it
+    // is the value in the literal sense.
+    let value = element
+        .value
+        .as_deref()
+        .or(element.state_description.as_deref());
+    native.setAccessibilityValue(value.map(NSString::from_str).as_deref());
+    // The click label is a verb phrase ("Pause"), which is exactly what a hint
+    // is for: VoiceOver reads it as what activating will do.
+    native.setAccessibilityHint(
+        element
+            .click_label
+            .as_deref()
+            .map(NSString::from_str)
+            .as_deref(),
+    );
     native.setAccessibilityFrameInContainerSpace(CGRect::new(
         CGPoint::new(element.bounds.x as f64, element.bounds.y as f64),
         CGSize::new(element.bounds.width as f64, element.bounds.height as f64),
     ));
     // SAFETY: UIKit accessibility trait constants are immutable process-wide
     // values exported by the linked framework.
-    let traits = unsafe {
+    let mut traits = unsafe {
         match element.role {
-            AccessibilityRole::Button => UIAccessibilityTraitButton,
+            AccessibilityRole::Button
+            | AccessibilityRole::Checkbox
+            | AccessibilityRole::Switch
+            | AccessibilityRole::RadioButton => UIAccessibilityTraitButton,
             AccessibilityRole::StaticText => UIAccessibilityTraitStaticText,
             AccessibilityRole::TextField => UIAccessibilityTraitNone,
+            AccessibilityRole::Tab => UIAccessibilityTraitButton,
+            AccessibilityRole::Image => UIAccessibilityTraitImage,
+            AccessibilityRole::Header => UIAccessibilityTraitHeader,
         }
     };
+    // SAFETY: as above — immutable framework constants.
+    unsafe {
+        if element.selected == Some(true) {
+            traits |= UIAccessibilityTraitSelected;
+        }
+        if !element.enabled {
+            traits |= UIAccessibilityTraitNotEnabled;
+        }
+    }
     native.setAccessibilityTraits(traits);
 }
 
@@ -247,6 +286,7 @@ fn same_structure(current: &[AccessibilityElement], next: &[AccessibilityElement
                 && current.value == next.value
                 && current.role == next.role
                 && current.clickable == next.clickable
+                && current.canvas_key == next.canvas_key
         })
 }
 
@@ -259,10 +299,10 @@ mod tests {
         AccessibilityElement {
             node_id: 7,
             label: "Library".into(),
-            value: None,
             bounds: AccessibilityRect::new(x, 20.0, 80.0, 64.0),
             role: AccessibilityRole::Button,
             clickable: true,
+            ..AccessibilityElement::default()
         }
     }
 

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -17,6 +17,14 @@ pub use android_file_picker::open_content_uri;
 mod accessibility;
 #[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
 mod android_accessibility;
+/// The Android accessibility wire format behind `CranposeActivity`'s
+/// `AccessibilityNodeProvider`. Built on the host as well so its encoding
+/// tests run everywhere.
+#[cfg(any(
+    test,
+    all(feature = "android", feature = "renderer-wgpu", target_os = "android")
+))]
+mod android_accessibility_wire;
 #[cfg(all(feature = "android", target_os = "android"))]
 mod android_app_info;
 #[cfg(all(feature = "android", target_os = "android"))]

--- a/crates/cranpose/src/robot.rs
+++ b/crates/cranpose/src/robot.rs
@@ -1632,20 +1632,56 @@ fn semantic_rect_for_node(
         })
 }
 
+/// Finds a drawn control on `sem_node` by its label.
+///
+/// The result carries the owning layout node's id with the *control's* own
+/// window rect, which is what a robot tap needs: activating a canvas control
+/// is a tap at its centre, exactly as it is for a screen reader.
+fn find_canvas_child(
+    owner: SemanticRect,
+    sem_node: &SemanticsNode,
+    query: &str,
+    match_kind: SemanticTextMatchKind,
+    require_clickable: bool,
+) -> Option<SemanticQueryResult> {
+    sem_node
+        .canvas_children
+        .iter()
+        .find(|child| {
+            (!require_clickable || child.clickable)
+                && semantics_text_matches(&child.label, query, match_kind)
+        })
+        .map(|child| SemanticQueryResult {
+            node_id: sem_node.node_id,
+            bounds: SemanticRect {
+                x: owner.x + child.bounds.x,
+                y: owner.y + child.bounds.y,
+                width: child.bounds.width,
+                height: child.bounds.height,
+            },
+            text: Some(child.label.clone()),
+        })
+}
+
 fn find_text_in_semantics_tree(
     bounds_by_node: &HashMap<cranpose_core::NodeId, SemanticRect>,
     sem_node: &SemanticsNode,
     query: &str,
     match_kind: SemanticTextMatchKind,
 ) -> Option<SemanticQueryResult> {
+    let owner = semantic_rect_for_node(bounds_by_node, sem_node.node_id);
     if let Some(text) = semantics_node_text(sem_node) {
         if semantics_text_matches(text, query, match_kind) {
             return Some(SemanticQueryResult {
                 node_id: sem_node.node_id,
-                bounds: semantic_rect_for_node(bounds_by_node, sem_node.node_id),
+                bounds: owner,
                 text: Some(text.to_string()),
             });
         }
+    }
+
+    if let Some(result) = find_canvas_child(owner, sem_node, query, match_kind, false) {
+        return Some(result);
     }
 
     for child in &sem_node.children {
@@ -1664,12 +1700,20 @@ fn find_button_in_semantics_tree(
     query: &str,
     match_kind: SemanticTextMatchKind,
 ) -> Option<SemanticQueryResult> {
+    let owner = semantic_rect_for_node(bounds_by_node, sem_node.node_id);
+    // A drawn control is checked before the node that drew it: the node itself
+    // is often one full-screen click target, and answering with that would
+    // tap the middle of the screen instead of the row that was asked for.
+    if let Some(result) = find_canvas_child(owner, sem_node, query, match_kind, true) {
+        return Some(result);
+    }
+
     if semantics_node_clickable(sem_node)
         && subtree_contains_matching_text(sem_node, query, match_kind)
     {
         return Some(SemanticQueryResult {
             node_id: sem_node.node_id,
-            bounds: semantic_rect_for_node(bounds_by_node, sem_node.node_id),
+            bounds: owner,
             text: semantics_node_text(sem_node).map(str::to_string),
         });
     }
@@ -1754,10 +1798,11 @@ pub(crate) fn subtree_contains_matching_text(
 #[cfg(test)]
 mod tests {
     use super::{
-        bounds_from_layout_box, panic_payload_message, robot_wait_for_idle_animation_loop_only,
+        bounds_from_layout_box, find_button_in_semantics_tree, find_text_in_semantics_tree,
+        panic_payload_message, robot_wait_for_idle_animation_loop_only,
         semantic_element_from_semantics_node, semantics_node_clickable, semantics_node_text,
-        semantics_text_matches, subtree_contains_matching_text, SemanticQueryResult, SemanticRect,
-        SemanticTextMatchKind,
+        semantics_text_matches, subtree_contains_matching_text, HashMap, SemanticQueryResult,
+        SemanticRect, SemanticTextMatchKind,
     };
     use cranpose_core::NodeId;
     use cranpose_ui::{
@@ -1861,6 +1906,86 @@ mod tests {
             description: description.map(str::to_string),
             ..SemanticsNode::default()
         }
+    }
+
+    /// A canvas screen is one full-screen click target with a list of drawn
+    /// controls inside it. A `find_button` that answered with the canvas node
+    /// would hand back the centre of the screen, so the drawn control has to
+    /// win — and its bounds have to be its own, or the tap lands elsewhere.
+    #[test]
+    fn queries_find_a_drawn_control_ahead_of_the_canvas_that_drew_it() {
+        use cranpose_ui::CanvasSemanticsNode;
+
+        let mut canvas = sample_semantics_node(
+            2,
+            SemanticsRole::Layout,
+            true,
+            Some("Settings screen"),
+            Vec::new(),
+        );
+        canvas.canvas_children = vec![
+            CanvasSemanticsNode::text(
+                1,
+                Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 200.0,
+                    height: 30.0,
+                },
+                "CROWN",
+            ),
+            CanvasSemanticsNode::control(
+                2,
+                Rect {
+                    x: 0.0,
+                    y: 40.0,
+                    width: 200.0,
+                    height: 52.0,
+                },
+                "Haptics",
+            ),
+        ];
+        let bounds_by_node = HashMap::from_iter([(
+            2usize,
+            SemanticRect {
+                x: 10.0,
+                y: 20.0,
+                width: 200.0,
+                height: 400.0,
+            },
+        )]);
+
+        let found = find_text_in_semantics_tree(
+            &bounds_by_node,
+            &canvas,
+            "CROWN",
+            SemanticTextMatchKind::Exact,
+        )
+        .expect("a drawn label should be findable");
+        assert_eq!(found.text.as_deref(), Some("CROWN"));
+        assert_eq!((found.bounds.x, found.bounds.y), (10.0, 20.0));
+        assert_eq!(found.bounds.height, 30.0);
+
+        let button = find_button_in_semantics_tree(
+            &bounds_by_node,
+            &canvas,
+            "Haptics",
+            SemanticTextMatchKind::Exact,
+        )
+        .expect("a drawn control should be findable as a button");
+        assert_eq!(button.text.as_deref(), Some("Haptics"));
+        // The row's own rect, not the canvas's 200x400.
+        assert_eq!((button.bounds.y, button.bounds.height), (60.0, 52.0));
+
+        // The unclickable label is not a button, and the canvas node behind it
+        // must not be offered in its place.
+        assert!(find_button_in_semantics_tree(
+            &bounds_by_node,
+            &canvas,
+            "CROWN",
+            SemanticTextMatchKind::Exact,
+        )
+        .is_none());
     }
 
     /// A robot snapshot of an immediate-mode screen has to show the controls

--- a/crates/cranpose/src/robot.rs
+++ b/crates/cranpose/src/robot.rs
@@ -31,6 +31,8 @@ pub struct SemanticElement {
     pub role: String,
     /// Text content if available
     pub text: Option<String>,
+    /// Compose's `stateDescription` — what the control currently reads as.
+    pub state_description: Option<String>,
     /// Geometric bounds in logical pixels
     pub bounds: SemanticRect,
     /// Whether this element has click actions
@@ -1509,15 +1511,25 @@ where
         .iter()
         .any(|action| matches!(action, SemanticsAction::Click { .. }));
     let bounds = bounds_for(sem_node.node_id);
-    let children = sem_node
-        .children
+    // Controls the node drew rather than laid out come first, in publication
+    // order. Without them a robot snapshot of an immediate-mode screen shows
+    // one node where a screen reader sees a list.
+    let mut children: Vec<SemanticElement> = sem_node
+        .canvas_children
         .iter()
-        .map(|child| semantic_element_from_semantics_node(child, bounds_for))
+        .map(|child| semantic_element_from_canvas_node(child, bounds))
         .collect();
+    children.extend(
+        sem_node
+            .children
+            .iter()
+            .map(|child| semantic_element_from_semantics_node(child, bounds_for)),
+    );
 
     SemanticElement {
         role,
         text,
+        state_description: sem_node.state_description.clone(),
         bounds,
         clickable,
         editable_text: sem_node.editable_text,
@@ -1525,6 +1537,37 @@ where
             .text_selection
             .map(|range| (range.start, range.end)),
         children,
+    }
+}
+
+fn semantic_element_from_canvas_node(
+    node: &cranpose_ui::CanvasSemanticsNode,
+    owner: SemanticRect,
+) -> SemanticElement {
+    SemanticElement {
+        role: node.role.map_or_else(
+            || {
+                if node.clickable {
+                    "Button".to_string()
+                } else {
+                    "Text".to_string()
+                }
+            },
+            |role| format!("{role:?}"),
+        ),
+        text: Some(node.label.clone()),
+        state_description: node.state_description.clone(),
+        // Canvas bounds are relative to the node that drew them.
+        bounds: SemanticRect {
+            x: owner.x + node.bounds.x,
+            y: owner.y + node.bounds.y,
+            width: node.bounds.width,
+            height: node.bounds.height,
+        },
+        clickable: node.clickable,
+        editable_text: false,
+        text_selection: None,
+        children: Vec::new(),
     }
 }
 
@@ -1816,9 +1859,64 @@ mod tests {
             actions,
             children,
             description: description.map(str::to_string),
-            editable_text: false,
-            text_selection: None,
+            ..SemanticsNode::default()
         }
+    }
+
+    /// A robot snapshot of an immediate-mode screen has to show the controls
+    /// the app drew, or a canvas app can only ever be asserted as one node.
+    #[test]
+    fn robot_snapshots_report_the_controls_a_canvas_published() {
+        use cranpose_ui::{CanvasSemanticsNode, SemanticsWidgetRole};
+
+        let mut canvas = sample_semantics_node(2, SemanticsRole::Layout, false, None, Vec::new());
+        canvas.canvas_children = vec![
+            CanvasSemanticsNode::control(
+                1,
+                cranpose_ui::Rect {
+                    x: 4.0,
+                    y: 8.0,
+                    width: 100.0,
+                    height: 52.0,
+                },
+                "Haptics",
+            )
+            .with_role(SemanticsWidgetRole::Switch)
+            .with_state_description("On"),
+            CanvasSemanticsNode::text(
+                2,
+                cranpose_ui::Rect {
+                    x: 4.0,
+                    y: 70.0,
+                    width: 100.0,
+                    height: 20.0,
+                },
+                "CROWN",
+            ),
+        ];
+
+        let mut bounds_for = |node_id: NodeId| {
+            assert_eq!(node_id, 2);
+            SemanticRect {
+                x: 10.0,
+                y: 20.0,
+                width: 200.0,
+                height: 200.0,
+            }
+        };
+        let element = semantic_element_from_semantics_node(&canvas, &mut bounds_for);
+
+        assert_eq!(element.children.len(), 2);
+        let switch = &element.children[0];
+        assert_eq!(switch.role, "Switch");
+        assert_eq!(switch.text.as_deref(), Some("Haptics"));
+        assert_eq!(switch.state_description.as_deref(), Some("On"));
+        assert!(switch.clickable);
+        assert_eq!((switch.bounds.x, switch.bounds.y), (14.0, 28.0));
+
+        let header = &element.children[1];
+        assert_eq!(header.role, "Text");
+        assert!(!header.clickable);
     }
 
     fn sample_semantics_and_layout() -> (SemanticsNode, LayoutBox) {

--- a/crates/cranpose/src/web_accessibility.rs
+++ b/crates/cranpose/src/web_accessibility.rs
@@ -87,12 +87,17 @@ impl WebAccessibilityBridge {
         let scale_x = canvas_rect.width() / viewport.0.max(1.0) as f64;
         let scale_y = canvas_rect.height() / viewport.1.max(1.0) as f64;
 
-        for element in elements {
+        // Identified by the shared accessibility element id rather than the
+        // layout node id: a node that publishes drawn controls owns several
+        // elements, and two DOM nodes claiming the same identity is exactly
+        // the bug a screen reader trips over.
+        let ids = accessibility::element_ids(&elements);
+        for (id, element) in ids.into_iter().zip(elements) {
             let node = document
                 .create_element(if element.clickable { "button" } else { "span" })?
                 .dyn_into::<HtmlElement>()?;
             node.set_attribute("aria-label", &element.label)?;
-            node.set_attribute("data-cranpose-node", &element.node_id.to_string())?;
+            node.set_attribute("data-cranpose-node", &id.to_string())?;
             match element.role {
                 AccessibilityRole::Button => node.set_attribute("role", "button")?,
                 AccessibilityRole::StaticText => {
@@ -105,6 +110,37 @@ impl WebAccessibilityBridge {
                         node.set_attribute("aria-valuetext", value)?;
                     }
                 }
+                AccessibilityRole::Checkbox => node.set_attribute("role", "checkbox")?,
+                AccessibilityRole::Switch => node.set_attribute("role", "switch")?,
+                AccessibilityRole::RadioButton => node.set_attribute("role", "radio")?,
+                AccessibilityRole::Tab => node.set_attribute("role", "tab")?,
+                AccessibilityRole::Image => node.set_attribute("role", "img")?,
+                AccessibilityRole::Header => {
+                    node.set_attribute("role", "heading")?;
+                    node.set_attribute("aria-level", "2")?;
+                    node.set_text_content(Some(&element.label));
+                }
+            }
+            // ARIA has no direct `stateDescription`; the state a control is in
+            // rides on the checked/selected attributes where the role has them,
+            // and `aria-description` carries the app's wording either way.
+            if let Some(state) = &element.state_description {
+                node.set_attribute("aria-description", state)?;
+            }
+            if let Some(toggled) = element.toggled {
+                node.set_attribute("aria-checked", if toggled { "true" } else { "false" })?;
+            }
+            if let Some(selected) = element.selected {
+                let selected = if selected { "true" } else { "false" };
+                match element.role {
+                    AccessibilityRole::RadioButton => {
+                        node.set_attribute("aria-checked", selected)?
+                    }
+                    _ => node.set_attribute("aria-selected", selected)?,
+                }
+            }
+            if !element.enabled {
+                node.set_attribute("aria-disabled", "true")?;
             }
             if element.clickable {
                 let (x, y) = element.bounds.center();

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -564,6 +564,80 @@ fn android_play_billing_reaches_the_purchase_registry() {
     );
 }
 
+/// The accessibility payload is a positional record split on tabs on the Java
+/// side, so the two ends have to agree on how many fields there are. Rust
+/// builds the record and Java rejects any record of the wrong width, which
+/// means a field added on one side alone does not fail loudly — it makes the
+/// app silently unreachable to a screen reader. Hence this check.
+#[test]
+fn android_accessibility_record_width_agrees_across_the_jni_boundary() {
+    let wire_source = crate_source("src/android_accessibility_wire.rs");
+    let java_source =
+        workspace_source("crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java");
+
+    let rust_fields = wire_source
+        .lines()
+        .find(|line| line.trim_start().starts_with("\"{}\\t"))
+        .map(|line| line.matches("{}").count())
+        .expect("the accessibility record format string should be one line");
+    let java_fields = java_source
+        .lines()
+        .find(|line| line.contains("ACCESSIBILITY_FIELDS ="))
+        .and_then(|line| {
+            line.rsplit('=')
+                .next()
+                .map(|value| value.trim().trim_end_matches(';').to_string())
+        })
+        .and_then(|value| value.parse::<usize>().ok())
+        .expect("CranposeActivity should declare the accessibility record width");
+
+    assert_eq!(
+        rust_fields, java_fields,
+        "the encoder writes {rust_fields} fields but CranposeActivity parses {java_fields}"
+    );
+    assert!(
+        java_source.contains("if (fields.length != ACCESSIBILITY_FIELDS) continue;"),
+        "a record of the wrong width should be skipped, not indexed past its end"
+    );
+}
+
+/// A custom action is the only screen-reader command with no position to
+/// synthesise a tap at, so it is the one that needs a dispatch path of its
+/// own — declared in Java, exported from the JNI boundary, and resolved back
+/// to a handler on the frame loop.
+#[test]
+fn android_accessibility_custom_actions_reach_the_frame_loop() {
+    let java_source =
+        workspace_source("crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java");
+    let boundary_source = crate_source("src/android_accessibility.rs");
+    let loop_source = crate_source("src/android.rs");
+    let projection_source = crate_source("src/accessibility.rs");
+
+    assert!(
+        java_source.contains(
+            "private static native void nativeOnAccessibilityCustomAction(int virtualViewId, int actionIndex);"
+        ) && java_source.contains("nativeOnAccessibilityCustomAction(element.id, customIndex);"),
+        "the provider should route a custom action back by identity rather than by synthesising a tap it has no position for"
+    );
+    assert!(
+        boundary_source.contains(
+            "Java_dev_cranpose_android_CranposeActivity_nativeOnAccessibilityCustomAction"
+        ) && boundary_source.contains("pub(crate) fn drain_custom_actions()"),
+        "the JNI boundary should park custom actions for the frame loop instead of running app code on the Java thread"
+    );
+    assert!(
+        loop_source.contains("crate::android_accessibility::drain_custom_actions()")
+            && loop_source.contains("crate::accessibility::resolve_element_id(")
+            && loop_source.contains("crate::accessibility::perform_custom_action("),
+        "the frame loop should resolve the virtual view id and run the action against the live semantics tree"
+    );
+    assert!(
+        projection_source.contains("pub(crate) fn perform_custom_action(")
+            && projection_source.contains("pub(crate) fn element_ids("),
+        "resolving an accessibility id and running its action are platform-neutral and belong outside the JNI boundary"
+    );
+}
+
 #[test]
 fn android_native_input_is_drained_on_input_available_event() {
     let source = crate_source("src/android.rs");

--- a/docs/MODIFIERS.md
+++ b/docs/MODIFIERS.md
@@ -618,6 +618,70 @@ impl PointerInputNode for ClickableNode {
 }
 ```
 
+### Semantics Modifiers
+
+#### SemanticsModifierNode
+
+- **Capability**: `SEMANTICS`
+- **Behavior**: Runs a recorder closure that fills a `SemanticsConfiguration`;
+  the layout pass folds every SEMANTICS node in the chain into one config and
+  turns it into the node's `SemanticsNode`.
+- **Re-recording**: the element declares `always_update`, so a recorder that
+  captured new state re-runs and dirties the semantics snapshot. Nothing about
+  the modifier's *shape* changes when a toggle flips, so without that the
+  screen reader would keep reading the first frame's answer (regression test:
+  `re_recording_semantics_reopens_the_snapshot`).
+
+The vocabulary mirrors Jetpack Compose's `SemanticsProperties`:
+
+| `SemanticsConfiguration` | Compose |
+| --- | --- |
+| `content_description` | `contentDescription` |
+| `state_description` | `stateDescription` |
+| `on_click_label` | `onClick(label = …)` — implies the click action |
+| `role` | `Role` (`Button`, `Checkbox`, `Switch`, `RadioButton`, `Tab`, `Image`, `Header`) |
+| `selected` | `selected` |
+| `toggled` | `toggleableState` |
+| `enabled` | the inverse of `disabled()` |
+| `custom_actions` | `customActions = listOf(CustomAccessibilityAction(…))` |
+| `canvas_children` | *(no Compose equivalent — see below)* |
+
+#### Canvas semantics
+
+An immediate-mode surface — one `Canvas` painting a whole screen — has exactly
+one layout node, so the semantics tree built from layout has exactly one node
+to offer a screen reader. `canvas_children` is the escape hatch: the drawing
+code already knows where it put every control, so it publishes those rectangles
+as semantics directly.
+
+```rust
+Modifier::empty().fill_max_size().semantics(move |config| {
+    config.canvas_children = rows
+        .iter()
+        .map(|row| {
+            CanvasSemanticsNode::control(row.key, row.rect, &row.label)
+                .with_role(SemanticsWidgetRole::Switch)
+                .with_toggled(row.checked)
+                .with_state_description(if row.checked { "On" } else { "Off" })
+        })
+        .collect();
+});
+```
+
+- `bounds` are in the publishing node's own coordinates, because that is what a
+  draw scope works in; the accessibility projection translates them.
+- `key` must survive a redraw. A screen reader parks its cursor on a virtual
+  view id, and the id is derived from `(layout node, key)` — derive the key from
+  what the control *is*, never from where it currently sits.
+- Activation is a synthesised tap at the published rect's centre, so a control
+  the app already hit-tests by geometry needs no extra wiring. A custom action
+  has no position and is instead routed back by identity and run against the
+  live semantics tree.
+- Android's own answer for a canvas-drawn `View` has the same shape
+  (`ExploreByTouchHelper` feeding virtual view ids into an
+  `AccessibilityNodeProvider`), and Cranpose's Android bridge already *is* an
+  `AccessibilityNodeProvider`.
+
 ---
 
 ## Modifier Element System


### PR DESCRIPTION
## Why

An app that paints a whole screen into one `Canvas` has one layout node, so the
semantics tree built from layout has exactly one node to offer a screen reader:
one full-screen element, one label, one click. A Compose app gets past this by
laying out real widgets. An immediate-mode app cannot, and Cranpose had no way
to say "there is a switch here, it is on, and here is where I drew it".

The concrete case is the Wear port of Orbit Breaker (cranorbit), which draws
every screen through one `Canvas` in one `Box`. The shipping Kotlin build it
replaces announces, per screen, a `Role.RadioButton` node with a
`stateDescription`, a named `onClick`, and a `customActions("Pause"/"Resume")`
on the arena — plus real per-widget nodes on Settings and Credits, which are
built from Wear Material `SwitchButton`/`Button`/`ListHeader`. None of that was
expressible here.

## What this adds

**1. Compose's semantics vocabulary.** `SemanticsConfiguration` knew about a
description, a button flag and a click. It now carries:

| new field | Compose |
| --- | --- |
| `state_description` | `stateDescription` |
| `on_click_label` | `onClick(label = …)` — implies the click action |
| `role` | `Role` (`Button`, `Checkbox`, `Switch`, `RadioButton`, `Tab`, `Image`, `Header`) |
| `selected` | `selected` |
| `toggled` | `toggleableState` |
| `enabled` | the inverse of `disabled()` |
| `custom_actions` | `customActions = listOf(CustomAccessibilityAction(…))` |

`is_button` is **removed**, not deprecated: it was `role = Some(Button)` spelled
a second way. All eleven call sites moved over.

**2. Canvas semantics.** `config.canvas_children` publishes the controls a node
drew rather than laid out — key, rect in the node's own coordinates, label,
role, state, click label, custom actions:

```rust
Modifier::empty().fill_max_size().semantics(move |config| {
    config.canvas_children = rows.iter().map(|row| {
        CanvasSemanticsNode::control(row.key, row.rect, &row.label)
            .with_role(SemanticsWidgetRole::Switch)
            .with_toggled(row.checked)
            .with_state_description(if row.checked { "On" } else { "Off" })
    }).collect();
});
```

Android's own answer for a canvas-drawn `View` has this shape
(`ExploreByTouchHelper` feeding an `AccessibilityNodeProvider`), and Cranpose's
Android bridge already *is* an `AccessibilityNodeProvider`, so these land as
first-class virtual views beside the ones layout produces. They also show up in
robot snapshots, so an immediate-mode screen can be asserted control by control.

**3. Element ids, shared by every backend.** Several elements now hang off one
layout node, and Android's virtual view ids, AccessKit's node ids and the iOS
element map were *all* keyed by layout node id — which for a settings list means
one node where there are twenty, and clicks landing on the wrong row. Ids move
into the platform-neutral projection: a function of `(layout node, app key)`
with deterministic forward probing on collision, because a screen reader parks
its cursor on an id and a cursor that jumps when a list scrolls is worse than no
cursor. Test: `drawn_controls_get_distinct_ids_that_do_not_move_with_list_position`.

**4. Action dispatch.** Activation stays a synthesised tap at the published
rect's centre, so a control the app already hit-tests by geometry needs no extra
wiring. A custom action has no position, so it travels back by identity — Android
through a new `nativeOnAccessibilityCustomAction`, desktop through AccessKit's
`ActionData::CustomAction` — and runs on the frame loop against the **live**
semantics tree. Handlers are deliberately excluded from element equality: a
recorder closure is rebuilt on every collection, so comparing handler identity
would decide "the tree changed" and re-serialise it over JNI 60 times a second.
Resolving late is what makes that safe. Test:
`rebuilding_a_custom_action_handler_is_not_a_published_change`.

**5. Backends.** Android (class names, `setStateDescription` behind its API-30
guard, `setHeading` behind API 28, `setCheckable`/`setChecked`/`setSelected`,
`AccessibilityAction(ACTION_CLICK, label)`, custom actions based at `0x7f000000`
like androidx's R.id-based ones); desktop/AccessKit (`Role::Switch` etc.,
`set_description`, `set_toggled`, `set_selected`, `set_disabled`, custom
actions); iOS (traits incl. `Selected`/`NotEnabled`/`Header`, state description
as the accessibility value, click label as the hint); web (`role=switch|radio|
checkbox|heading|tab|img`, `aria-checked`, `aria-selected`, `aria-disabled`,
`aria-description`).

**6. The framework's own query helpers see them.** `find_text_in_semantics`
and `find_button` used to answer a canvas screen with the canvas — one
full-screen click target — so a test asking for a settings row got the middle
of the screen and tapping the result hit whatever was drawn there. Drawn
controls are checked first now, and the result carries the control's own rect,
so a robot tap lands where a screen reader's activation would.

**7. The wire format leaves the JNI boundary.** Encoding now lives in
`android_accessibility_wire.rs`, next to `android_launch_args.rs` and
`android_purchase_wire.rs`, compiled under `any(test, …)` so its tests run on
every host. The unsafe-boundary test enforces that it stays safe.

## Tests that can fail

Verified by mutation, not by inspection:

- `android_accessibility_record_width_agrees_across_the_jni_boundary` — a
  positional record whose two ends disagree does not fail loudly; it silently
  makes the app unreachable to a screen reader. Changing the Java constant to 16
  fails the test with `the encoder writes 17 fields but CranposeActivity parses 16`.
- `re_recording_semantics_reopens_the_snapshot` — nothing about a modifier's
  *shape* changes when a toggle flips, only the closure does. Making
  `SemanticsElement::always_update` return `false` fails it. Without this the
  screen reader would keep reading the first frame's answer forever.

Plus: projection of drawn controls into window coordinates, suppression of
unlabelled/zero-size controls, a labelled canvas keeping its own element ahead
of its children, custom actions resolving through the live tree (including the
three negative cases), AccessKit nodes not collapsing onto one layout node, the
seventeen-field encoding, and the robot snapshot.

## Deliberately not in this PR

- **Nested canvas semantics.** The data model is a flat list. Every backend
  flattens at the boundary today (Android: children of the host; iOS:
  `accessibilityElements` array; AccessKit: children of root; web: sibling
  spans), so nesting would be erased on the way out. A `traversalGroup`-style
  grouping is a separate change to four bridges.
- **Custom actions on iOS and web.** Android and desktop dispatch them; iOS
  would need `UIAccessibilityCustomAction` objects and ARIA has no equivalent at
  all. The helpers are `cfg`-gated to the backends that dispatch them rather
  than left dead.
- **`liveRegion`.** The Compose app it is matched against has none, and the
  arena description changes every frame — announcing that would be unusable.
- **Moving cranorbit's Wear list and swipe-to-dismiss into Cranpose.** See below.

## On the Wear list and swipe-to-dismiss

cranorbit hand-rolls a ~1560-line `ScalingLazyColumn` + scroll indicator
(`app/src/ui/list.rs`) and a Wear edge swipe-to-dismiss. I looked at moving them
here and did not, with reasons:

- Cranpose **already owns the geometry**: `cranpose-ui/src/round_scaling_list.rs`
  is `scale_and_alpha` / row placement derived from
  `androidx.wear.compose.foundation.lazy`, and `round_scroll_indicator.rs` is the
  indicator. cranorbit's copy of that half is duplication to delete, not
  framework surface to add.
- The other half of `list.rs` is *drawing*, and it is typed against cranorbit's
  own `SettingsRow`, `Painter`, `Typography` and `GamePalette`. Lifting it would
  mean lifting cranorbit's hand-rolled text stack and palette into the framework,
  and that code is under a pixel-parity sweep against the shipping Kotlin build —
  the wrong thing to move while parity is the acceptance criterion.
- The swipe is Wear's *full-screen* edge dismiss with a scrim, a 30dp start
  region and a back-interception/exit policy that is app policy;
  `widgets/swipe_to_dismiss.rs` here is Material's per-row swipe. They are
  different widgets, and the app's gesture arbitration happens inside its single
  pointer handler.

So: semantics layer alone, which is the part that is genuinely missing from the
framework.

## What cranorbit does next

1. Delete the geometry half of `app/src/ui/list.rs` in favour of
   `cranpose_ui::round_scaling_list` / `round_scroll_indicator`.
2. Give `RadialSpec` and `SettingsRow` a rect. `layout_into` already produces
   `Slot { top, height }` for list rows; the radial ring has `angle_for_index`
   and a normalised orbit radius, so a node rect is one trig call away.
3. Publish, from the existing `.semantics()` block in `app/src/ui/mod.rs`:
   - screen level — `content_description` as today plus `state_description` =
     selected label, `role = RadioButton`, `on_click_label` = selected label.
     That is `RadialChoiceScreen` exactly.
   - `canvas_children` — one per ring option (`role = RadioButton`, `selected`),
     one per settings row (`Header` / `Switch` + `toggled` + `state_description`
     / `Button`), one per credits line.
   - arena — `custom_actions = vec![SemanticsCustomAction::new(if paused
     { "Resume" } else { "Pause" }, …)]` and `on_click_label` = `"Tap"`/`"Launch"`.
4. `screen_description()` can stop returning `None` for Title, CampaignMap,
   LevelIntro, the result screens, Settings, Credits and Unlock — the test that
   asserts `None` for Settings was written on the premise that per-control
   semantics cover it, and now they can.

Point the local Cranpose checkout at this branch (or bump past the next release)
and the vocabulary is available as `cranpose_ui::{CanvasSemanticsNode,
SemanticsCustomAction, SemanticsWidgetRole}`.

## Gates

`cargo fmt --all --check`, `python3 scripts/check_cranpose_versions.py`,
`cargo clippy --workspace --all-targets -- -D warnings -A clippy::question_mark`,
`cargo test --profile ci --workspace`, and
`cargo check -p cranpose --target aarch64-linux-android --no-default-features --features android,renderer-wgpu`
all pass. Also checked: `aarch64-apple-ios`, `wasm32-unknown-unknown` through the web
demo, `javac` against `android.jar` for the Activity, and a full
`:app:assembleDebug` of `apps/android-demo/android` (Java + Rust + NDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
