### PR TITLE
Rotary and the clipboard on the web, and the world behind a pressed glass bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,6 +918,7 @@ dependencies = [
  "raw-window-handle",
  "thiserror 2.0.18",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
  "web-time",
  "wgpu",

--- a/README.md
+++ b/README.md
@@ -1,141 +1,167 @@
-[https://codewiki.google/github.com/samoylenkodmitry/cranpose](https://codewiki.google/github.com/samoylenkodmitry/rs-compose)
+# Cranpose
+
+<img width="1536" height="1024" alt="Cranpose" src="https://github.com/user-attachments/assets/2ce48dfe-a048-4b9d-8812-a0e4534691f8" />
+
+Cranpose is a declarative UI framework for Rust, modelled on Jetpack Compose:
+`#[composable]` functions, a slot-table runtime with fine-grained recomposition,
+snapshot state, and a modifier-chain layout system. One Rust codebase targets
+**desktop** (Linux, macOS, Windows), **Android** (including Wear OS),
+**iOS**, and the **web** through WebAssembly, rendering through wgpu on all of
+them.
+
+**[Try the web demo in your browser](https://samoylenkodmitry.github.io/Cranpose/)** ·
+[Releases](https://github.com/samoylenkodmitry/Cranpose/releases) ·
+[crates.io](https://crates.io/crates/cranpose)
 
 [v0.0.40.webm](https://github.com/user-attachments/assets/df50209b-abfd-426a-b79c-a51a9543b385)
 
-## 🌐 Live Demo
+> Pre-alpha. The API changes without deprecation cycles, and versions are not
+> compatible with each other.
 
-**[Try it in your browser!](https://samoylenkodmitry.github.io/Cranpose/)**
+## Quick start
 
-# Cranpose
-
-<img width="1536" height="1024" alt="ChatGPT Image Jan 18, 2026, 10_53_13 AM" src="https://github.com/user-attachments/assets/2ce48dfe-a048-4b9d-8812-a0e4534691f8" />
-
-Cranpose is a declarative UI framework for Rust, inspired by Jetpack Compose. It targets Desktop (Linux, macOS, Windows), Android, and Web (WASM) from a single Rust codebase. iOS is not a supported backend until a real UIKit/CAMetalLayer platform crate exists.
-
-The composition runtime uses Slot Table V2: active groups live in preorder group, payload, and node tables, while inactive retained branches are explicit detached subtrees. Gap-table notes are historical rationale only; the active slot-table specification is [`docs/cranpose_slot_table_v2_design.md`](docs/cranpose_slot_table_v2_design.md).
-
-## Quick Start via Isolated Demo
-
-To get started, use the **Isolated Demo** template found in `apps/isolated-demo`. This project is pre-configured with the dependencies and build scripts for the implemented platforms.
+[`apps/isolated-demo`](apps/isolated-demo) is a complete starter project that
+depends only on published crates — copy it rather than starting from scratch.
 
 ```bash
-# Clone the repository
 git clone https://github.com/samoylenkodmitry/cranpose.git
 cd cranpose/apps/isolated-demo
-
-# Run on Desktop (Linux/macOS/Windows)
 cargo run --features desktop,renderer-wgpu
 ```
 
-## Example: Todo List Application
+Or add the framework to an existing project:
 
-The following example demonstrates managing state, handling user input, and rendering a dynamic list.
+```toml
+[dependencies]
+cranpose = { version = "0.1.88", features = ["desktop", "renderer-wgpu"] }
+```
+
+## Example
+
+State, layout, and input, in the shape the framework actually has: composables
+take a `Modifier`, a spec, and their content; state comes from `useState` and is
+read with `.value()`.
 
 ```rust
+#![allow(non_snake_case)] // #[composable] functions are CamelCase
+
 use cranpose::prelude::*;
 
-#[derive(Clone)]
-struct TodoItem {
-    id: usize,
+#[derive(Clone, PartialEq)]
+struct Todo {
     text: String,
     done: bool,
 }
 
 #[composable]
 fn TodoApp() {
-    // State management using useState
-    let items = useState(|| vec![
-        TodoItem { id: 0, text: "Buy milk".into(), done: false },
-        TodoItem { id: 1, text: "Walk the dog".into(), done: true },
-    ]);
-    let input_text = useState(|| String::new());
-    let next_id = useState(|| 2);
-
-    Column(Modifier.fill_max_size().padding(20.0), || {
-        Text("My Todo List", Modifier.padding(10.0).font_size(24.0));
-
-        // Input Row
-        Row(Modifier.fill_max_width().padding(5.0), || {
-            BasicTextField(
-                value = input_text.value(),
-                on_value_change = move |new_text| input_text.set(new_text),
-                Modifier.weight(1.0).padding(5.0)
-            );
-            
-            Button(
-                onClick = move || {
-                    if !input_text.value().is_empty() {
-                        let mut list = items.value();
-                        list.push(TodoItem {
-                            id: next_id.value(),
-                            text: input_text.value(),
-                            done: false,
-                        });
-                        items.set(list);
-                        next_id.set(next_id.value() + 1);
-                        input_text.set(String::new());
-                    }
-                }, 
-                || Text("Add")
-            );
-        });
-        
-        // Dynamic List Rendering
-        LazyColumn(Modifier.weight(1.0), || {
-            items(items.value().len(), |i| {
-                let item = items.value()[i].clone();
-                
-                Row(
-                    Modifier
-                        .fill_max_width()
-                        .padding(5.0)
-                        .clickable(move || {
-                            // Toggle done status
-                            let mut list = items.value();
-                            if let Some(todo) = list.iter_mut().find(|t| t.id == item.id) {
-                                todo.done = !todo.done;
-                            }
-                            items.set(list);
-                        }),
-                    || {
-                        Text(if item.done { "[x]" } else { "[ ]" });
-                        Spacer(Modifier.width(10.0));
-                        Text(
-                            item.text, 
-                            Modifier.alpha(if item.done { 0.5 } else { 1.0 })
-                        );
-                    }
-                );
-            });
-        });
+    let todos = useState(|| {
+        vec![
+            Todo { text: "Buy milk".into(), done: false },
+            Todo { text: "Walk the dog".into(), done: true },
+        ]
     });
+
+    Column(
+        Modifier::empty().fill_max_size().padding(24.0),
+        ColumnSpec::default().vertical_arrangement(LinearArrangement::spaced_by(12.0)),
+        move || {
+            Text("Todo", Modifier::empty(), TextStyle::default());
+
+            for (index, todo) in todos.value().into_iter().enumerate() {
+                Row(
+                    Modifier::empty().fill_max_width().clickable(move |_| {
+                        let mut next = todos.value();
+                        next[index].done = !next[index].done;
+                        todos.set(next);
+                    }),
+                    RowSpec::default().horizontal_arrangement(LinearArrangement::spaced_by(8.0)),
+                    move || {
+                        Text(
+                            if todo.done { "[x]" } else { "[ ]" },
+                            Modifier::empty(),
+                            TextStyle::default(),
+                        );
+                        Text(todo.text.clone(), Modifier::empty(), TextStyle::default());
+                    },
+                );
+            }
+
+            Button(
+                Modifier::empty().padding(10.0),
+                ButtonSpec::default(),
+                move || {
+                    let mut next = todos.value();
+                    let position = next.len() + 1;
+                    next.push(Todo { text: format!("Item {position}"), done: false });
+                    todos.set(next);
+                },
+                || {
+                    Text("Add", Modifier::empty(), TextStyle::default());
+                },
+            );
+        },
+    );
+}
+
+fn main() {
+    AppLauncher::new()
+        .with_title("Todo")
+        .with_size(420, 560)
+        .try_run(TodoApp)
+        .expect("launch the app");
 }
 ```
 
-## Platform Support
+A list that only composes what is on screen uses `LazyColumn` with
+`remember_lazy_list_state()` from `cranpose_foundation::lazy` instead of the
+`for` loop above.
+
+## What is in the box
+
+| Crate | What it is |
+|---|---|
+| `cranpose` | The facade apps depend on: platform runtimes, `AppLauncher`, prelude |
+| `cranpose-core` | Slot table, recomposition, snapshot state, effects, coroutines |
+| `cranpose-ui` / `cranpose-ui-layout` / `cranpose-ui-graphics` | Widgets, modifiers, measurement, geometry |
+| `cranpose-foundation` | Gestures, pointer/rotary input, lazy lists, text buffers |
+| `cranpose-animation` | Springs, tweens, transitions, `animate*AsState` |
+| `cranpose-liquid` | Glass component library: iOS-26-style materials, spring motion |
+| `cranpose-services` | HTTP, clipboard, share, notifications, file picker, haptics, purchases, camera, theme |
+| `cranpose-audio` | Real-time audio (AAudio on Android/Wear OS, cpal on desktop) |
+| `cranpose-storekit` | StoreKit 2 in-app purchases (iOS/macOS) |
+| `cranpose-testing` | The robot harness that drives real windows in tests |
+
+The composition runtime uses Slot Table V2: active groups live in preorder
+group, payload, and node tables, and inactive retained branches are explicit
+detached subtrees. The specification is
+[`docs/cranpose_slot_table_v2_design.md`](docs/cranpose_slot_table_v2_design.md);
+gap-table notes elsewhere are historical rationale only.
+
+## Platform support
 
 | Platform | Backend | Status |
 |---|---|---|
-| Linux x86_64 | Vulkan via wgpu | Supported and actively tested |
-| macOS aarch64 | Metal via wgpu | Experimental packaging; renderer path implemented |
-| Windows x86_64 | DX12/Vulkan via wgpu | Experimental; not continuously tested |
-| Android | Vulkan/GLES via wgpu | Experimental; release APK build is checked |
-| iOS | UIKit/CAMetalLayer backend | Unavailable |
-| Web (WASM) | WebGPU/WebGL2 via wgpu | Experimental; demo build is checked |
+| Linux x86_64 | Vulkan (GLES fallback opt-in) via wgpu | Supported; the GPU end-to-end suite runs here |
+| macOS aarch64 | Metal via wgpu | Supported; builds, tests and `.app` bundles run in CI |
+| Windows x86_64 | DX12/Vulkan via wgpu | Cross-built and released; not continuously exercised |
+| Android / Wear OS | Vulkan/GLES via wgpu | Release APK build is checked in CI |
+| iOS | UIKit/CAMetalLayer via `winit-uikit` | Simulator and device builds are checked in CI |
+| Web (WASM) | WebGL2 (WebGPU opt-in via `?backend=webgpu`) | Demo build and Pages deploy are checked in CI |
 
-Release artifacts are available on the [Releases](https://github.com/samoylenkodmitry/Cranpose/releases) page for the platforms that have published builds.
+Release binaries for the desktop platforms are attached to each
+[release](https://github.com/samoylenkodmitry/Cranpose/releases).
 
 ## Building
 
-The [`apps/isolated-demo`](apps/isolated-demo) starter project shows the complete cross-platform setup. It depends only on published crates from crates.io.
-
 ### Desktop (Linux/macOS/Windows)
+
 ```bash
 cd apps/isolated-demo
 cargo run --features desktop,renderer-wgpu
 ```
 
-macOS `.app` bundles are built through the workspace task runner:
+macOS `.app` bundles come from the workspace task runner:
 
 ```bash
 cargo xtask bundle-macos \
@@ -145,9 +171,11 @@ cargo xtask bundle-macos \
   --bundle-id io.cranpose.demo
 ```
 
-Pass `--resources <dir>` to copy bundle resources into `Contents/Resources`, and `--sign-identity <id>` to run the explicit codesign step.
+Pass `--resources <dir>` to copy resources into `Contents/Resources`, and
+`--sign-identity <id>` to run the explicit codesign step.
 
 ### Android
+
 ```bash
 # Prerequisites: cargo install cargo-ndk
 cd apps/isolated-demo/android
@@ -155,9 +183,19 @@ cd apps/isolated-demo/android
 ```
 
 ### iOS
-iOS is unavailable. The `ios` cargo feature is reserved for the real platform backend and does not alias desktop.
+
+The app is a pure-Rust binary — winit starts `UIApplicationMain`, so there is no
+Objective-C entry point and no Xcode project. See
+[`apps/ios-demo/README.md`](apps/ios-demo/README.md).
+
+```bash
+rustup target add aarch64-apple-ios-sim aarch64-apple-ios
+cd apps/ios-demo
+./ios/run-sim.sh
+```
 
 ### Web (WASM)
+
 ```bash
 # Prerequisites: cargo install wasm-pack
 cd apps/isolated-demo
@@ -165,15 +203,15 @@ cd apps/isolated-demo
 python3 -m http.server 8080
 ```
 
-## Binary Size
+## Binary size
 
-Cranpose apps stay small when two things are set up right: the cargo profile
-and the feature set.
+Cranpose apps stay small when two things are set up right: the cargo profile and
+the feature set.
 
 **1. Add a tuned release profile to your app's `Cargo.toml`.** Cargo profiles
-are taken from the top-level package, so the framework cannot set them for
-you. Without this, a plain `cargo build --release` produces a binary several
-times larger than necessary (no LTO, no stripping, unwinding kept):
+come from the top-level package, so the framework cannot set them for you.
+Without this, a plain `cargo build --release` produces a binary several times
+larger than necessary (no LTO, no stripping, unwinding kept):
 
 ```toml
 [profile.release]
@@ -184,56 +222,74 @@ strip = true
 panic = "abort"
 ```
 
-**2. Pick features deliberately.** The `cranpose` default feature set favors
-out-of-the-box behavior over size:
+**2. Pick features deliberately.** The `cranpose` default feature set favours
+out-of-the-box behaviour over size:
 
 - `embedded-default-font` (default): embeds the ~1.3 MiB NotoSansMerged
-  fallback font so text renders even when the app provides no fonts. Apps
-  that bundle fonts via `AppLauncher::with_fonts` should build with
+  fallback so text renders even when the app provides no fonts. Apps that
+  bundle fonts through `AppLauncher::with_fonts` should build with
   `default-features = false` to drop it.
-- `renderer-wgpu-gles` (off by default): the GL/GLES fallback backend for
-  desktop machines without a working Vulkan driver. Leaving it off removes
-  the GLES half of wgpu and naga's GLSL writer from the binary. Android
-  always compiles the GLES fallback; web always compiles WebGL.
+- `renderer-wgpu-gles` (off by default): the GL/GLES fallback for desktop
+  machines without a working Vulkan driver. Leaving it off removes the GLES
+  half of wgpu and naga's GLSL writer. Android always compiles the GLES
+  fallback; web always compiles WebGL.
 - `desktop-x11` / `desktop-wayland`: `desktop` compiles both display-server
-  backends; picking one drops the other's window/input stack.
+  backends; picking one drops the other's window and input stack.
 
 ```toml
 [dependencies]
-cranpose = { version = "0.1.28", default-features = false, features = [
+cranpose = { version = "0.1.88", default-features = false, features = [
     "desktop",        # or just "desktop-wayland" / "desktop-x11"
     "renderer-wgpu",
 ] }
 ```
 
-**3. For the smallest binary**, build with the nightly-only pipeline
-(build-std with a size-tuned std and immediate-abort panics):
+**3. For the smallest binary**, build with the nightly-only pipeline (build-std
+with a size-tuned std and immediate-abort panics):
 
 ```bash
 cargo xtask dist-min --package my-app --bin my-app
 ```
 
-Reference ladder for a minimal hello-world app on Linux x86_64 with
-`default-features = false`: ~15 MB with cargo's untuned default release
-profile → 8.7 MB with the profile above → 6.0 MB with the `release-small`
-profile (`opt-level = "z"`, `lto = "fat"`) → **3.4 MB** with a single display
-backend + `dist-min`. The full breakdown and the roadmap toward smaller
-binaries live in [`docs/binary_size.md`](docs/binary_size.md).
+Reference ladder for a minimal hello-world on Linux x86_64 with
+`default-features = false`, measured on 0.1.28: ~15 MB with cargo's untuned
+default release profile → 8.7 MB with the profile above → 6.0 MB with the
+`release-small` profile (`opt-level = "z"`, `lto = "fat"`) → **3.4 MB** with a
+single display backend plus `dist-min`. The full breakdown and the roadmap
+toward smaller binaries live in [`docs/binary_size.md`](docs/binary_size.md).
 
-## Verification Gates
+## Testing
 
-The core workspace gates are:
+Unit and integration tests run with `cargo test`. On top of them the repo drives
+**real windows**: the robot harness in `cranpose-testing` launches an app, finds
+elements through the semantics tree, sends input, and captures presented frames
+— so scrolling, gestures, glass rendering and frame pacing are tested as the
+compositor actually presents them, not as the scene graph describes them.
+
+```bash
+./run_robot_test.sh --sequential     # the end-to-end suite
+./liquid_cheatsheets.sh              # glass component reference sheets
+```
+
+See [`docs/ROBOT_TESTING.md`](docs/ROBOT_TESTING.md).
+
+## Verification gates
 
 ```bash
 cargo fmt --check
 cargo test
-cargo clippy
+cargo clippy --workspace --all-targets -- -D warnings
 cargo build --workspace --no-default-features
-cargo xtask dependency-budget
-cargo xtask binary-size --package isolated-demo --bin isolated-demo --profile release-small --max-bytes 13107200
+cargo xtask dependency-budget --strict --explain
+cargo xtask binary-size --manifest-path apps/isolated-demo/Cargo.toml \
+  --package isolated-demo --bin isolated-demo \
+  --profile release-small --patch-workspace-cranpose --max-bytes 15728640
 ```
 
-See [`apps/isolated-demo/README.md`](apps/isolated-demo/README.md) for full details.
+Zero warnings is the standard, not a target. Contributor conventions live in
+[`AGENTS.md`](AGENTS.md); the starter project's own checks are in
+[`apps/isolated-demo/README.md`](apps/isolated-demo/README.md).
 
 ## License
-This project is available under the terms of the Apache License (Version 2.0). See [`LICENSE-APACHE`](LICENSE-APACHE) for the full license text.
+
+Apache License 2.0. See [`LICENSE-APACHE`](LICENSE-APACHE).

--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -589,3 +589,31 @@ its timing as production-performance evidence.
   identical per-frame work (`p95_total_ms` 0.81 -> 0.86). Both clear the
   contract (>=48 frames, >=150fps, p95 <= 6.67ms); the margin is smaller because
   the number is now real. Do not "restore" the old figure by re-forcing polling.
+- Backdrop-under-a-transform bugs are invisible from the source (2026-08-13):
+  the bottom bar's press lift showed the world behind its glass shrunk ~20% and
+  slid toward the bar's corner. Reading the underlay path end to end argued the
+  code was *correct* — the underlay is copied from the child's post-transform
+  dest quad and squeezed into its logical rect, which the composite unsqueezes,
+  so registration looked like it cancelled out. What actually cracked it, in
+  order: an A/B on the running app (zero the `graphics_layer` lift, rebuild,
+  re-measure: the drift vanished), then `CRANPOSE_BACKDROP_DIAG=1` on the real
+  binary, whose `prepare node=…` lines showed the same backdrop being prepared
+  in *root* space at rest and in *surface-local* space (`y: 31.31`) while
+  pressed, with a scissor implying scale 1.693 against a root scale of 1.354 —
+  the missing 1.25 is `magnifying_layer_scale`, which quantizes a scaling
+  layer's surface UP to the next quarter step. The underlay was built at the
+  parent's scale and addressed at the child's. Measure the displacement before
+  theorizing: two background lines through the glass gave scale 0.688 about a
+  fixed point, which is what identified the culprit as a *rect ratio* rather
+  than the 1.03 lift everyone would suspect.
+- A magnifying layer needs BOTH halves in a renderer test (2026-08-13): the
+  first regression test for the above passed against the bug. `test_support::
+  layer_node` takes `transform_to_parent` and `graphics_layer` independently, and
+  the surface plan reads them from different places — `NonTranslationTransform`
+  (which is what makes the layer take a surface at all) comes from the
+  *transform matrix* via `direct_translation`, while the magnification factor
+  comes from `graphics_layer.scale` via `layer_surface_scale`. A
+  `GraphicsLayer { scale: 1.25 }` beside a plain translation transform is a
+  layer that never isolates, so the whole path under test is skipped. Build the
+  transform with `layer_transform_to_parent(bounds, placement, &layer)` — the
+  same call the scene builder makes — and pass the same `GraphicsLayer`.

--- a/crates/cranpose-app-shell/src/lib.rs
+++ b/crates/cranpose-app-shell/src/lib.rs
@@ -6,6 +6,7 @@ mod hit_path_tracker;
 mod shell_debug;
 mod shell_frame;
 mod shell_input;
+mod wheel;
 #[cfg(test)]
 use shell_frame::build_draw_refresh_scope;
 
@@ -50,6 +51,8 @@ pub use cranpose_foundation::PointerSource;
 pub use cranpose_foundation::{
     rotary_scroll_pixels_from_detents, RotaryScrollEvent, DEFAULT_ROTARY_SCROLL_FACTOR_DP,
 };
+// The wheel sample every host normalizes into, and the convention it carries.
+pub use wheel::WheelScroll;
 
 /// Bridges the in-tree selection menu's clipboard actions to the desktop OS
 /// clipboard (`arboard`). Holds a persistent clipboard handle (Linux X11 loses

--- a/crates/cranpose-app-shell/src/shell_input.rs
+++ b/crates/cranpose-app-shell/src/shell_input.rs
@@ -571,9 +571,64 @@ where
         event.is_consumed()
     }
 
+    /// Dispatches one mouse-wheel / trackpad sample through the whole wheel
+    /// policy, and returns `true` when something consumed it.
+    ///
+    /// This is the single entry point every host with a wheel calls, after
+    /// placing the cursor. A wheel sample is not just a scroll — it is whichever
+    /// of four things the modifiers and the tree make it, in this order:
+    ///
+    /// 1. **Zoom** when ctrl is held. That is the desktop convention and the
+    ///    way browsers deliver a trackpad pinch, so both arrive here as the
+    ///    same gesture.
+    /// 2. **Rotary**, offered to [`rotary_scrolled`](Self::rotary_scrolled)
+    ///    before anything else can take it, so the Wear OS crown stack is
+    ///    developable on a machine with a wheel. Nothing consumes rotary unless
+    ///    the app opts in via `Modifier::on_rotary_scroll_event` or
+    ///    [`set_on_rotary_scroll`](Self::set_on_rotary_scroll), so ordinary
+    ///    scrolling is unaffected.
+    /// 3. **Horizontal scroll** when alt is held on a wheel that only reports a
+    ///    vertical axis.
+    /// 4. **Scroll**, to the hovered scrollable.
+    ///
+    /// Hosts must not re-implement this order. Doing so is how the browser
+    /// ended up scrolling backwards and never delivering rotary at all: the
+    /// policy lived in the desktop event loop, and the second host that grew a
+    /// wheel reimplemented the parts of it that were obvious from the outside.
+    pub fn wheel_scrolled(&mut self, wheel: crate::WheelScroll) -> bool {
+        if wheel.is_zoom() {
+            let zoom_factor = wheel.zoom_factor();
+            log::trace!(
+                target: "cranpose::input",
+                "wheel zoom factor={zoom_factor:.4}"
+            );
+            return self.pointer_zoomed(zoom_factor);
+        }
+
+        let rotary =
+            RotaryScrollEvent::from_wheel_pixels(wheel.delta.y, wheel.delta.x, wheel.uptime_millis);
+        if self.rotary_scrolled(rotary) {
+            return true;
+        }
+
+        let delta = wheel.scroll_delta();
+        log::trace!(
+            target: "cranpose::input",
+            "wheel delta ({:.2},{:.2}) alt={}",
+            delta.x,
+            delta.y,
+            wheel.modifiers.alt
+        );
+        self.pointer_scrolled(delta.x, delta.y)
+    }
+
     /// Dispatches a mouse wheel / trackpad scroll event to hovered pointer handlers.
     ///
     /// Returns `true` if a handler consumed the event.
+    ///
+    /// This is the last step of the wheel policy, not its entry point: hosts
+    /// call [`wheel_scrolled`](Self::wheel_scrolled), which reaches here once
+    /// zoom and rotary have declined the sample.
     pub fn pointer_scrolled(&mut self, delta_x: f32, delta_y: f32) -> bool {
         let event_time = self.realtime_pointer_event_time(None);
         let _event_handler = enter_event_handler_scope();

--- a/crates/cranpose-app-shell/src/wheel.rs
+++ b/crates/cranpose-app-shell/src/wheel.rs
@@ -1,0 +1,141 @@
+//! One mouse-wheel / trackpad sample, in the shell's wheel convention.
+//!
+//! Every host that has a wheel — the winit desktop loop, the browser's `wheel`
+//! listener — has to answer the same four questions in the same order: is this
+//! a zoom gesture, does a rotary handler want it, is it an axis-swapped
+//! horizontal scroll, and otherwise how much does the hovered scrollable move.
+//! [`AppShell::wheel_scrolled`](crate::AppShell::wheel_scrolled) is that answer,
+//! and this type is its input, so a host's whole job is normalizing its native
+//! event into a [`WheelScroll`].
+//!
+//! # Sign convention
+//!
+//! `delta` is **logical pixels, positive when the content being scrolled should
+//! move down and right** — the direction a wheel turned up / away from the user
+//! produces. That is winit's convention and the one the scroll modifiers are
+//! written against (a positive vertical delta walks a `ScrollState` back toward
+//! zero). The DOM's is the opposite: `WheelEvent::delta_y` is positive when the
+//! wheel is turned *down*, so the browser host negates on the way in. Getting
+//! this wrong does not fail loudly — it scrolls backwards.
+
+use cranpose_ui::Modifiers;
+use cranpose_ui_graphics::Point;
+
+/// Logical pixels one wheel notch scrolls, and the notch the ctrl+wheel zoom
+/// step is defined against.
+const NOTCH_LOGICAL_PX: f32 = 40.0;
+/// Zoom applied by one ctrl+wheel notch.
+const ZOOM_PER_NOTCH: f32 = 1.2;
+
+/// A mouse-wheel or trackpad scroll sample ready for
+/// [`AppShell::wheel_scrolled`](crate::AppShell::wheel_scrolled).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct WheelScroll {
+    /// Scroll amount in logical pixels; positive moves content down and right
+    /// (see the module docs — this is winit's sign, not the DOM's).
+    pub delta: Point,
+    /// Keyboard modifiers held during the sample. `ctrl` makes it a zoom
+    /// gesture, `alt` turns a vertical wheel into a horizontal scroll.
+    pub modifiers: Modifiers,
+    /// Monotonic milliseconds, for the rotary event's velocity tracking. Only
+    /// differences between samples are meaningful.
+    pub uptime_millis: u64,
+}
+
+impl WheelScroll {
+    /// A sample with no modifiers held.
+    pub fn new(delta: Point, uptime_millis: u64) -> Self {
+        Self {
+            delta,
+            modifiers: Modifiers::NONE,
+            uptime_millis,
+        }
+    }
+
+    /// This sample with `modifiers` held.
+    pub fn with_modifiers(mut self, modifiers: Modifiers) -> Self {
+        self.modifiers = modifiers;
+        self
+    }
+
+    /// Whether this sample is the zoom gesture (ctrl+wheel, which is also how
+    /// trackpad pinches arrive in a browser) rather than a scroll.
+    pub fn is_zoom(&self) -> bool {
+        self.modifiers.ctrl
+    }
+
+    /// The multiplicative zoom step for a ctrl+wheel sample: one notch up
+    /// (positive delta) zooms in by [`ZOOM_PER_NOTCH`].
+    pub fn zoom_factor(&self) -> f32 {
+        ZOOM_PER_NOTCH.powf(self.delta.y / NOTCH_LOGICAL_PX)
+    }
+
+    /// The delta the hovered scrollable should see: with alt held, a vertical
+    /// wheel drives the horizontal axis instead (the shift-less way to scroll
+    /// a row on a wheel that only has a vertical axis).
+    pub fn scroll_delta(&self) -> Point {
+        if !self.modifiers.alt {
+            return self.delta;
+        }
+        let x = if self.delta.x.abs() <= f32::EPSILON {
+            self.delta.y
+        } else {
+            self.delta.x
+        };
+        Point { x, y: 0.0 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wheel(x: f32, y: f32) -> WheelScroll {
+        WheelScroll::new(Point { x, y }, 0)
+    }
+
+    #[test]
+    fn a_plain_sample_is_neither_a_zoom_nor_axis_swapped() {
+        let sample = wheel(3.0, -40.0);
+
+        assert!(!sample.is_zoom());
+        assert_eq!(sample.scroll_delta(), sample.delta);
+    }
+
+    #[test]
+    fn ctrl_makes_a_sample_a_zoom_that_grows_when_the_wheel_turns_up() {
+        let up = wheel(0.0, NOTCH_LOGICAL_PX).with_modifiers(Modifiers {
+            ctrl: true,
+            ..Modifiers::NONE
+        });
+        let down = wheel(0.0, -NOTCH_LOGICAL_PX).with_modifiers(Modifiers {
+            ctrl: true,
+            ..Modifiers::NONE
+        });
+
+        assert!(up.is_zoom());
+        assert!((up.zoom_factor() - ZOOM_PER_NOTCH).abs() < 1.0e-6);
+        // Zooming out by a notch must undo zooming in by one, or a pinch
+        // in-and-out drifts the scale.
+        assert!((up.zoom_factor() * down.zoom_factor() - 1.0).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn alt_moves_a_vertical_wheel_onto_the_horizontal_axis() {
+        let alt = Modifiers {
+            alt: true,
+            ..Modifiers::NONE
+        };
+
+        assert_eq!(
+            wheel(0.0, 48.0).with_modifiers(alt).scroll_delta(),
+            Point { x: 48.0, y: 0.0 }
+        );
+        // A device that already reports a horizontal axis keeps it: only the
+        // vertical-only wheel needs the swap.
+        assert_eq!(
+            wheel(12.0, 48.0).with_modifiers(alt).scroll_delta(),
+            Point { x: 12.0, y: 0.0 }
+        );
+    }
+}

--- a/crates/cranpose-foundation/src/nodes/input/rotary.rs
+++ b/crates/cranpose-foundation/src/nodes/input/rotary.rs
@@ -117,6 +117,30 @@ impl RotaryScrollEvent {
         }
     }
 
+    /// Builds a rotary event from a mouse-wheel / trackpad sample already in
+    /// logical pixels.
+    ///
+    /// The final target for rotary input is a Wear OS crown, but the machines
+    /// it is developed on have wheels, so every desktop-class host offers its
+    /// wheel to the rotary handlers first. `vertical` and `horizontal` are in
+    /// the shell's wheel convention — positive when the content should move
+    /// down and right, the direction a wheel turned *up* produces — which is
+    /// the same physical direction as a positive Android detent. Both are
+    /// therefore negated exactly once, like [`from_detents`](Self::from_detents),
+    /// so a wheel turned up and a crown turned up land on the same negative
+    /// [`vertical_scroll_pixels`](Self::vertical_scroll_pixels).
+    ///
+    /// Unlike the detent path, a wheel really does have two axes, so each one
+    /// is carried through on its own rather than fanned out from a single
+    /// value.
+    pub fn from_wheel_pixels(vertical: f32, horizontal: f32, uptime_millis: u64) -> Self {
+        Self {
+            vertical_scroll_pixels: -vertical,
+            horizontal_scroll_pixels: -horizontal,
+            uptime_millis,
+        }
+    }
+
     /// Returns true when neither axis carries a usable scroll amount.
     ///
     /// Non-finite values (NaN/inf from a misbehaving driver) count as empty so
@@ -179,6 +203,32 @@ mod tests {
         assert_eq!(up.vertical_scroll_pixels, -down.vertical_scroll_pixels);
         assert!(up.vertical_scroll_pixels < 0.0);
         assert!(down.vertical_scroll_pixels > 0.0);
+    }
+
+    #[test]
+    fn a_wheel_turned_up_lands_where_a_crown_turned_up_does() {
+        // The two ingresses must agree on direction or the same gesture
+        // scrolls opposite ways on a watch and on the machine it is built on.
+        let wheel = RotaryScrollEvent::from_wheel_pixels(64.0, 0.0, 0);
+        let crown = RotaryScrollEvent::from_detents(1.0, 64.0, 64.0, 0);
+
+        assert_eq!(
+            wheel.vertical_scroll_pixels, crown.vertical_scroll_pixels,
+            "a positive wheel delta and a positive detent are the same physical turn"
+        );
+        assert!(wheel.vertical_scroll_pixels < 0.0);
+    }
+
+    #[test]
+    fn a_wheel_carries_each_axis_on_its_own() {
+        // A crown has one degree of freedom and fans it across both fields; a
+        // wheel has two, and a horizontal nudge must not become a vertical one.
+        let event = RotaryScrollEvent::from_wheel_pixels(12.0, -5.0, 77);
+
+        assert_eq!(event.vertical_scroll_pixels, -12.0);
+        assert_eq!(event.horizontal_scroll_pixels, 5.0);
+        assert_eq!(event.uptime_millis, 77);
+        assert!(RotaryScrollEvent::from_wheel_pixels(0.0, 0.0, 1).is_empty());
     }
 
     #[test]

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -755,16 +755,58 @@ fn flush_pending_clear<B: SurfaceExecutionBackend>(
     }
 }
 
+/// The scale a child layer's own surface renders at, and therefore the scale
+/// every texture handed to that surface has to be built at.
+///
+/// A magnifying layer is composited by mapping its surface through its own
+/// transform, so the texture carries that magnification's worth of detail
+/// instead of resampling a 1x raster upward — which means the child's scale is
+/// **not** the parent's whenever a layer scales. Both the surface and its
+/// backdrop underlay resolve it here so they cannot disagree.
+fn child_surface_target_scale(
+    child: &ChildLayerComposite,
+    root_scale: f32,
+    translation_context: TranslationRenderContext,
+) -> f32 {
+    layer_surface_target_scale(
+        translation_context.inherited_content_translation || child.translated_content_context,
+        translation_context.surface_capture_active,
+        child.surface_requirements,
+        root_scale,
+        child.surface_scale,
+    )
+}
+
+/// Projects the content behind a child layer into an underlay that layer's own
+/// nested backdrops can sample.
+///
+/// Two different scales meet here, and conflating them silently rescales every
+/// backdrop inside the child:
+///
+/// * `parent_scale` maps the parent surface's logical coordinates to its pixels,
+///   and is what `child_dest_quad` — the region of the parent this content is
+///   read from — is expressed against.
+/// * `child_scale` is the scale the child's own surface renders at, which
+///   [`layer_surface_target_scale`] quantizes *up* for a magnifying layer (a
+///   1.03x press lift becomes 1.25x). Everything inside that surface, the
+///   nested backdrop capture included, addresses this texture at `child_scale`,
+///   so that is the resolution it has to be built at.
+///
+/// They are equal for every layer that does not magnify, which is why sharing
+/// one scale looked correct until a glass surface grew a press transform: the
+/// backdrop then showed the world at `1 / child_scale * parent_scale` of its
+/// true size, anchored at the surface origin.
 fn create_projected_child_underlay<B: SurfaceExecutionBackend>(
     backend: &mut B,
     parent_target: &OffscreenTarget,
     parent_underlay: Option<&OffscreenTarget>,
     child_logical_rect: Rect,
     child_dest_quad: [[f32; 2]; 4],
-    root_scale: f32,
+    parent_scale: f32,
+    child_scale: f32,
 ) -> OffscreenTarget {
     let (width, height) =
-        surface_target_size(child_logical_rect, root_scale, backend.max_texture_dim());
+        surface_target_size(child_logical_rect, child_scale, backend.max_texture_dim());
     let underlay = backend.acquire_frame_surface(width, height);
     let child_source_rect = Rect {
         x: 0.0,
@@ -773,7 +815,7 @@ fn create_projected_child_underlay<B: SurfaceExecutionBackend>(
         height: height as f32,
     };
     if let Some(source_pixel_rect) =
-        axis_aligned_quad_rect(scaled_quad(child_dest_quad, root_scale))
+        axis_aligned_quad_rect(scaled_quad(child_dest_quad, parent_scale))
     {
         if let Some(ancestor_underlay) = parent_underlay {
             let composites = [
@@ -807,7 +849,7 @@ fn create_projected_child_underlay<B: SurfaceExecutionBackend>(
     }
     let transform = ProjectiveTransform::from_rect_to_quad(
         child_source_rect,
-        scaled_quad(child_dest_quad, root_scale),
+        scaled_quad(child_dest_quad, parent_scale),
     );
     let dest_quad = target_quad(width, height);
     let parent_composite = ProjectiveSurfaceComposite {
@@ -2100,16 +2142,7 @@ pub(crate) fn render_layer_surface<B: SurfaceExecutionBackend>(
         translation_context.surface_capture_active,
         surface_requirements,
     );
-    let target_scale = layer_surface_target_scale(
-        direct_translated_content_context,
-        translation_context.surface_capture_active,
-        surface_requirements,
-        root_scale,
-        // A scaling layer is composited by mapping this surface through its own
-        // transform, so the texture has to carry that magnification's worth of
-        // detail or the composite just resamples a 1x raster upward.
-        child.surface_scale,
-    );
+    let target_scale = child_surface_target_scale(child, root_scale, translation_context);
     let translation_context = layer_surface_translation_context(
         translation_context,
         activates_nested_capture
@@ -3823,6 +3856,12 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
             );
             flush_pending_clear(backend, &target.view, &mut next_load_op);
         }
+        let child_translation_context = TranslationRenderContext {
+            inherited_content_translation: effective_translated_content_context,
+            translated_content_axes: effective_translated_content_axes,
+            surface_capture_active: translation_context.surface_capture_active,
+            local_picture_capture_active: translation_context.local_picture_capture_active,
+        };
         let child_underlay = child.needs_nested_underlay.then(|| {
             create_projected_child_underlay(
                 backend,
@@ -3831,6 +3870,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                 resolved_child.logical_rect,
                 child_dest_quad,
                 target_scale,
+                child_surface_target_scale(&child, target_scale, child_translation_context),
             )
         });
         let child_surface = render_layer_surface(
@@ -3843,12 +3883,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                 logical_rect_override: Some(resolved_child.logical_rect),
                 capture_clip_override: resolved_child.surface_clip,
                 activates_nested_capture: true,
-                translation_context: TranslationRenderContext {
-                    inherited_content_translation: effective_translated_content_context,
-                    translated_content_axes: effective_translated_content_axes,
-                    surface_capture_active: translation_context.surface_capture_active,
-                    local_picture_capture_active: translation_context.local_picture_capture_active,
-                },
+                translation_context: child_translation_context,
             },
         )?;
 

--- a/crates/cranpose-render/wgpu/tests/effect_semantics.rs
+++ b/crates/cranpose-render/wgpu/tests/effect_semantics.rs
@@ -1097,6 +1097,131 @@ fn bounded_backdrop_capture_only_filters_local_snapshot() {
 }
 
 #[test]
+fn a_magnifying_layers_backdrop_stays_registered_with_the_world_behind_it() {
+    // A glass surface is a window, not a picture: scaling the layer it lives in
+    // must move the glass, never the world seen through it. That only holds if
+    // the underlay the nested backdrop samples is built at the scale that
+    // surface renders at -- and a magnifying layer's surface scale is quantized
+    // UP from the parent's (`magnifying_layer_scale`), so "the parent's scale"
+    // is a whole quarter-step wrong. Built at the parent's scale, the backdrop
+    // showed the world shrunk by parent/child about the surface origin: the
+    // bottom bar's 1.03x press lift pulled the content behind it 20% toward the
+    // bar's top-left corner, most visible as background lines sliding off the
+    // real ones the moment a finger went down.
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!(
+                "skipping magnifying backdrop registration assertions because headless WGPU init failed: {}",
+                err
+            );
+            return;
+        }
+    };
+
+    let root_scale = 2.0;
+    let logical_width = FRAME_WIDTH as f32 / root_scale;
+    let logical_height = FRAME_HEIGHT as f32 / root_scale;
+    let boundary_x = 32.0;
+    // Big enough that the misregistration is unmistakable: the error grows with
+    // the distance from the surface origin, and the boundary sits 20 logical px
+    // into a 40px-wide surface.
+    let glass = Rect {
+        x: 0.0,
+        y: 0.0,
+        width: 40.0,
+        height: 24.0,
+    };
+    // The press lift's shape: a uniform scale about the layer's own center,
+    // built exactly the way the scene builder builds one, so the transform and
+    // the graphics layer agree the way they do in a real frame.
+    let lift = GraphicsLayer {
+        scale: 1.25,
+        ..GraphicsLayer::default()
+    };
+    let magnified = layer(
+        glass,
+        cranpose_render_common::layer_transform::layer_transform_to_parent(
+            glass,
+            Point { x: 12.0, y: 12.0 },
+            &lift,
+        ),
+        lift.clone(),
+        vec![RenderNode::Layer(Box::new(layer(
+            glass,
+            ProjectiveTransform::identity(),
+            GraphicsLayer {
+                // A plain, barely-there blur: this test is about *where* the
+                // backdrop lands, so the effect stays a near-pass-through and
+                // leaves the red/blue boundary sharp enough to locate.
+                backdrop_effect: Some(RenderEffect::blur(0.6)),
+                ..GraphicsLayer::default()
+            },
+            vec![],
+        )))],
+    );
+
+    renderer.scene_mut().graph = Some(RenderGraph::new(layer(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: logical_width,
+            height: logical_height,
+        },
+        ProjectiveTransform::identity(),
+        GraphicsLayer::default(),
+        vec![
+            solid_rect(
+                Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: boundary_x,
+                    height: logical_height,
+                },
+                Color::RED,
+            ),
+            solid_rect(
+                Rect {
+                    x: boundary_x,
+                    y: 0.0,
+                    width: logical_width - boundary_x,
+                    height: logical_height,
+                },
+                Color::BLUE,
+            ),
+            RenderNode::Layer(Box::new(magnified)),
+        ],
+    )));
+
+    let frame = renderer
+        .capture_frame_with_scale(FRAME_WIDTH, FRAME_HEIGHT, root_scale)
+        .expect("magnifying backdrop capture should succeed");
+
+    // Where the red/blue boundary reads through the glass, scanned along the
+    // glass's middle row rather than asserted pixel by pixel, so the blur's
+    // softness does not decide the verdict.
+    let row = (logical_height * 0.5 * root_scale) as u32;
+    let scan_from = ((boundary_x - 14.0) * root_scale) as u32;
+    let scan_to = ((boundary_x + 14.0) * root_scale) as u32;
+    let seen_boundary = (scan_from..scan_to)
+        .find(|x| {
+            let pixel = rgba(&frame, *x, row);
+            pixel[2] > pixel[0]
+        })
+        .unwrap_or_else(|| panic!("no red/blue boundary visible through the glass along row {row}"))
+        as f32;
+    let true_boundary = boundary_x * root_scale;
+
+    // The bug displaced this by 10 device px (5 logical); the blur's own
+    // softness moves it by well under 2.
+    assert!(
+        (seen_boundary - true_boundary).abs() <= 4.0,
+        "the world seen through a magnifying layer's glass must stay where it is: \
+         boundary reads at device x {seen_boundary} but really sits at {true_boundary}"
+    );
+}
+
+#[test]
 fn scaled_sibling_backdrop_sees_prior_backdrop_output() {
     // Regression: two sibling backdrop layers over a sharp red/blue boundary at
     // root_scale = 2. The lower-z backdrop (strong blur) sits to the right of the

--- a/crates/cranpose-ui/src/clipboard_session.rs
+++ b/crates/cranpose-ui/src/clipboard_session.rs
@@ -15,13 +15,43 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+#[cfg(test)]
+use std::cell::Cell;
+
 /// A platform-provided OS clipboard. Installed by the platform runtime so that
 /// in-tree UI (the selection menu) can read/write the system clipboard.
 pub trait PlatformClipboard {
     /// Writes `text` to the OS clipboard.
     fn write_text(&self, text: &str);
     /// Reads the OS clipboard's text, or `None` when empty/unavailable.
+    ///
+    /// A platform whose clipboard cannot be read synchronously answers `None`
+    /// here and takes the paste through [`request_paste`](Self::request_paste)
+    /// instead.
     fn read_text(&self) -> Option<String>;
+
+    /// Whether this platform can complete a paste it cannot answer
+    /// synchronously, so a Paste action stays offered even though
+    /// [`read_text`](Self::read_text) has nothing to show.
+    fn can_request_paste(&self) -> bool {
+        false
+    }
+
+    /// Asks the platform to paste the clipboard into whatever holds focus, for
+    /// platforms that cannot answer [`read_text`](Self::read_text).
+    ///
+    /// Returns `true` when the platform has taken the request — the text lands
+    /// in the focused field through the platform's own paste path, possibly
+    /// after this returns. `false` means the caller should paste
+    /// [`read_text`](Self::read_text) itself, which is what every clipboard
+    /// with a synchronous read does.
+    ///
+    /// This exists because the browser's clipboard is a promise: reading it is
+    /// asynchronous and permissioned, so `Some(text)` is not something a web
+    /// bridge can produce on the call stack of the tap that asked for it.
+    fn request_paste(&self) -> bool {
+        false
+    }
 }
 
 /// Per-app-context clipboard state: an optionally-installed platform clipboard
@@ -65,6 +95,20 @@ impl ClipboardSessionState {
     fn has_platform(&self) -> bool {
         self.platform.borrow().is_some()
     }
+
+    fn can_request_paste(&self) -> bool {
+        self.platform
+            .borrow()
+            .as_ref()
+            .is_some_and(|platform| platform.can_request_paste())
+    }
+
+    fn request_paste(&self) -> bool {
+        self.platform
+            .borrow()
+            .clone()
+            .is_some_and(|platform| platform.request_paste())
+    }
 }
 
 /// Installs the platform OS clipboard for the current app context, replacing any
@@ -95,6 +139,33 @@ pub fn clipboard_read_text() -> Option<String> {
 /// with no clipboard backend registered).
 pub fn has_platform_clipboard() -> bool {
     crate::render_state::with_clipboard_session(|state| state.has_platform())
+}
+
+/// Whether a Paste action should be offered.
+///
+/// True when the clipboard has readable text, and also when the platform can
+/// only answer a paste asynchronously (the browser): a clipboard nobody can
+/// read on the spot is not the same as an empty one, and hiding Paste there
+/// would be wrong every time the user actually has something to paste.
+pub fn clipboard_can_paste() -> bool {
+    crate::render_state::with_clipboard_session(|state| {
+        state.read().is_some() || state.can_request_paste()
+    })
+}
+
+/// Pastes the clipboard into the focused text field — the in-tree Paste action.
+///
+/// Every native clipboard reads synchronously and the paste lands before this
+/// returns. The browser's does not: there the platform takes the request and
+/// completes it through its own paste path once the clipboard promise resolves,
+/// which is why this is a command rather than a read.
+pub fn clipboard_paste_into_focus() {
+    if crate::render_state::with_clipboard_session(|state| state.request_paste()) {
+        return;
+    }
+    if let Some(text) = clipboard_read_text() {
+        crate::text_field_focus::dispatch_paste(&text);
+    }
 }
 
 /// A Compose-style handle to the system clipboard — the framework analogue of
@@ -157,6 +228,12 @@ mod tests {
 
     struct UnavailableClipboard;
 
+    /// A clipboard shaped like the browser's: nothing to read on the call
+    /// stack, but able to complete a paste of its own accord.
+    struct AsyncOnlyClipboard {
+        requests: Cell<usize>,
+    }
+
     impl PlatformClipboard for RecordingClipboard {
         fn write_text(&self, text: &str) {
             *self.value.borrow_mut() = Some(text.to_string());
@@ -171,6 +248,23 @@ mod tests {
 
         fn read_text(&self) -> Option<String> {
             None
+        }
+    }
+
+    impl PlatformClipboard for AsyncOnlyClipboard {
+        fn write_text(&self, _text: &str) {}
+
+        fn read_text(&self) -> Option<String> {
+            None
+        }
+
+        fn can_request_paste(&self) -> bool {
+            true
+        }
+
+        fn request_paste(&self) -> bool {
+            self.requests.set(self.requests.get() + 1);
+            true
         }
     }
 
@@ -202,6 +296,36 @@ mod tests {
 
             clear_platform_clipboard();
             assert!(!clipboard.has_system_clipboard());
+        });
+    }
+
+    #[test]
+    fn a_paste_goes_to_the_platform_when_it_cannot_be_read_on_the_spot() {
+        let context = crate::render_state::AppContext::new();
+        context.enter(|| {
+            let clipboard = Rc::new(AsyncOnlyClipboard {
+                requests: Cell::new(0),
+            });
+            set_platform_clipboard(clipboard.clone());
+
+            // A clipboard nobody can read here and now still offers Paste --
+            // hiding it would hide every real paste the browser can serve.
+            assert!(clipboard_can_paste());
+            clipboard_paste_into_focus();
+            assert_eq!(clipboard.requests.get(), 1);
+        });
+    }
+
+    #[test]
+    fn a_readable_clipboard_pastes_without_asking_the_platform() {
+        let context = crate::render_state::AppContext::new();
+        context.enter(|| {
+            // No platform at all: the in-process fallback is readable, so the
+            // paste must take the synchronous path rather than vanish.
+            assert!(!clipboard_can_paste());
+            clipboard_write_text("pasted");
+            assert!(clipboard_can_paste());
+            clipboard_paste_into_focus();
         });
     }
 

--- a/crates/cranpose-ui/src/widgets/basic_text_field.rs
+++ b/crates/cranpose-ui/src/widgets/basic_text_field.rs
@@ -6,13 +6,15 @@
 #![allow(non_snake_case)]
 
 use crate::bring_into_view::local_bring_into_view_responder;
-use crate::clipboard_session::{clipboard_read_text, clipboard_write_text};
+use crate::clipboard_session::{
+    clipboard_can_paste, clipboard_paste_into_focus, clipboard_write_text,
+};
 use crate::composable;
 use crate::layout::policies::EmptyMeasurePolicy;
 use crate::modifier::Modifier;
 use crate::safe_area::local_ime_insets;
 use crate::text::{measure_text, AnnotatedString, TextStyle};
-use crate::text_field_focus::{dispatch_copy, dispatch_cut, dispatch_paste, dispatch_select_all};
+use crate::text_field_focus::{dispatch_copy, dispatch_cut, dispatch_select_all};
 use crate::text_field_modifier_node::{
     TextFieldElement, TextFieldHandleController, TextFieldHandleMetrics,
 };
@@ -573,7 +575,7 @@ fn SelectionHandles(
         // and rematerializes after release (the widget runs the measured
         // timings; it stays composed while fading).
         if caret_menu_open.value() {
-            let can_paste = clipboard_read_text().is_some();
+            let can_paste = clipboard_can_paste();
             let can_undo = state.can_undo();
             let can_redo = state.can_redo();
             let undo_state = state.clone();
@@ -586,9 +588,7 @@ fn SelectionHandles(
                 can_undo,
                 can_redo,
                 move || {
-                    if let Some(text) = clipboard_read_text() {
-                        dispatch_paste(&text);
-                    }
+                    clipboard_paste_into_focus();
                     caret_menu_open.set(false);
                 },
                 move || {
@@ -699,7 +699,7 @@ fn SelectionHandles(
         // rematerializes after release (the widget runs the measured timings;
         // it stays composed while fading).
         if menu_open.value() {
-            let can_paste = clipboard_read_text().is_some();
+            let can_paste = clipboard_can_paste();
             // A claimed long-press feeds the menu its live finger position:
             // sliding over items highlights them, the release fires.
             let slide_point = if controller.gesture_claimed() {
@@ -741,9 +741,7 @@ fn SelectionHandles(
                     menu_open.set(false);
                 },
                 move || {
-                    if let Some(text) = clipboard_read_text() {
-                        dispatch_paste(&text);
-                    }
+                    clipboard_paste_into_focus();
                     menu_open.set(false);
                 },
                 move || {

--- a/crates/cranpose/Cargo.toml
+++ b/crates/cranpose/Cargo.toml
@@ -183,6 +183,8 @@ accesskit = { version = "0.24.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1"
+# Awaits the Async Clipboard API's promises (`web_clipboard`).
+wasm-bindgen-futures = "0.4"
 wgpu = { version = "29.0", optional = true, default-features = false, features = [
     "std",
     "webgpu",

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -3872,49 +3872,15 @@ fn dispatch_mouse_wheel(
         false
     };
 
-    let mut logical_delta = platform.scroll_delta(delta);
-
-    // Ctrl+wheel is the desktop zoom gesture (mirroring browser pinch
-    // semantics): translate the vertical wheel delta into a multiplicative
-    // zoom step about the cursor instead of scrolling.
-    if current_modifiers.contains(winit::keyboard::ModifiersState::CONTROL) {
-        let zoom_factor = wheel_zoom_factor(logical_delta.y);
-        log::trace!(
-            target: "cranpose::input",
-            "desktop ctrl+wheel zoom factor={zoom_factor:.4}"
-        );
-        let zoom_dirty = app.pointer_zoomed(zoom_factor);
-        return cursor_dirty || zoom_dirty;
-    }
-
-    // Rotary (Wear OS crown / bezel) emulation: offer the wheel to rotary
-    // handlers first so the rotary stack is developable on the desktop. Nothing
-    // consumes rotary unless the app opts in via
-    // `Modifier::on_rotary_scroll_event` or `AppShell::set_on_rotary_scroll`,
-    // so ordinary scrolling is unaffected.
-    let rotary =
-        crate::winit_rotary::rotary_event_from_wheel_delta(logical_delta, wheel_uptime_millis());
-    if app.rotary_scrolled(rotary) {
-        return true;
-    }
-
-    let alt_pressed = current_modifiers.contains(winit::keyboard::ModifiersState::ALT);
-    if alt_pressed {
-        if logical_delta.x.abs() <= f32::EPSILON {
-            logical_delta.x = logical_delta.y;
-        }
-        logical_delta.y = 0.0;
-    }
-
-    log::trace!(
-        target: "cranpose::input",
-        "desktop wheel delta ({:.2},{:.2}) alt={}",
-        logical_delta.x,
-        logical_delta.y,
-        alt_pressed
+    // The whole wheel policy -- zoom, rotary, axis swap, scroll -- lives in the
+    // shell, shared with every other host that has a wheel. This side only
+    // normalizes winit's event into the shell's convention.
+    let wheel = crate::winit_wheel::wheel_scroll_from_winit(
+        platform.scroll_delta(delta),
+        current_modifiers,
+        wheel_uptime_millis(),
     );
-
-    let scroll_dirty = app.pointer_scrolled(logical_delta.x, logical_delta.y);
+    let scroll_dirty = app.wheel_scrolled(wheel);
     cursor_dirty || scroll_dirty
 }
 
@@ -3929,15 +3895,6 @@ fn wheel_uptime_millis() -> u64 {
         .get_or_init(web_time::Instant::now)
         .elapsed()
         .as_millis() as u64
-}
-
-/// Converts a vertical wheel delta (logical px, positive = scroll up) into
-/// a multiplicative zoom factor: one standard wheel notch (~40 logical px)
-/// zooms by ~1.2x, and opposite deltas invert exactly (`f(-d) == 1/f(d)`).
-fn wheel_zoom_factor(delta_y: f32) -> f32 {
-    const NOTCH_LOGICAL_PX: f32 = 40.0;
-    const ZOOM_PER_NOTCH: f32 = 1.2;
-    ZOOM_PER_NOTCH.powf(delta_y / NOTCH_LOGICAL_PX)
 }
 
 fn dispatch_middle_click_paste(

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -208,10 +208,9 @@ mod winit_pointer;
 #[cfg_attr(not(all(feature = "ios", target_os = "ios")), allow(dead_code))]
 mod winit_touch;
 
-/// Mouse-wheel to rotary-input translation, so Wear OS rotary handling is
-/// developable and testable on the desktop.
+/// winit's mouse wheel, normalized into the shell's shared wheel sample.
 #[cfg(feature = "desktop-shell")]
-mod winit_rotary;
+mod winit_wheel;
 
 /// Renderer-agnostic robot testing harness shared by the desktop shells.
 #[cfg(all(
@@ -283,6 +282,15 @@ pub mod web;
     test
 ))]
 mod web_surface_scale;
+
+// The browser's wheel units and sign convention are likewise pure arithmetic,
+// and likewise silent when wrong: compile them under `test` so the host suite
+// pins the direction the web scrolls.
+#[cfg(any(
+    all(feature = "web", feature = "renderer-wgpu", target_arch = "wasm32"),
+    test
+))]
+mod web_wheel;
 
 #[cfg(all(feature = "web", feature = "renderer-wgpu", target_arch = "wasm32"))]
 mod web_accessibility;

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -296,6 +296,9 @@ mod web_wheel;
 mod web_accessibility;
 
 #[cfg(all(feature = "web", feature = "renderer-wgpu", target_arch = "wasm32"))]
+mod web_clipboard;
+
+#[cfg(all(feature = "web", feature = "renderer-wgpu", target_arch = "wasm32"))]
 mod web_services;
 
 // Re-export the renderer-agnostic robot harness so applications and the

--- a/crates/cranpose/src/web.rs
+++ b/crates/cranpose/src/web.rs
@@ -27,7 +27,28 @@ fn web_pointer_source(event: &PointerEvent) -> PointerSource {
     }
 }
 
-const WEB_WHEEL_LINE_DELTA_PIXELS: f32 = 40.0;
+/// The keyboard modifiers held during a mouse-class DOM event.
+///
+/// `WheelEvent` and `PointerEvent` both deref to `MouseEvent`, so one reader
+/// serves every pointer ingress.
+fn web_modifiers(event: &web_sys::MouseEvent) -> cranpose_app_shell::Modifiers {
+    cranpose_app_shell::Modifiers {
+        shift: event.shift_key(),
+        ctrl: event.ctrl_key(),
+        alt: event.alt_key(),
+        meta: event.meta_key(),
+    }
+}
+
+/// Monotonic milliseconds for synthesized rotary events, matching the desktop
+/// host's clock contract: the zero point is the process start and only
+/// differences between samples are meaningful.
+fn wheel_uptime_millis() -> u64 {
+    thread_local! {
+        static EPOCH: web_time::Instant = web_time::Instant::now();
+    }
+    EPOCH.with(|epoch| epoch.elapsed().as_millis() as u64)
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum WebBackendPreference {
@@ -367,49 +388,24 @@ pub async fn run(
             let y = event.offset_y() as f64;
             let logical = platform.borrow().pointer_position(x, y);
 
-            let mut delta_x = event.delta_x() as f32;
-            let mut delta_y = event.delta_y() as f32;
-            match event.delta_mode() {
-                WheelEvent::DOM_DELTA_PIXEL => {}
-                WheelEvent::DOM_DELTA_LINE => {
-                    delta_x *= WEB_WHEEL_LINE_DELTA_PIXELS;
-                    delta_y *= WEB_WHEEL_LINE_DELTA_PIXELS;
-                }
-                WheelEvent::DOM_DELTA_PAGE => {
-                    let page_width = wheel_canvas.client_width().max(1) as f32;
-                    let page_height = wheel_canvas.client_height().max(1) as f32;
-                    delta_x *= page_width;
-                    delta_y *= page_height;
-                }
-                _ => {}
-            }
-
-            // Ctrl+wheel is the browser zoom gesture; trackpad pinches also
-            // arrive as ctrl+wheel events. Translate the vertical delta into
-            // a multiplicative zoom step about the cursor.
-            if event.ctrl_key() {
-                // Browsers report wheel-down/pinch-in as positive delta_y.
-                let zoom_factor = 1.2f32.powf(-delta_y / 40.0);
-                if let Ok(mut app_mut) = app.try_borrow_mut() {
-                    app_mut.set_cursor(logical.x, logical.y);
-                    if app_mut.pointer_zoomed(zoom_factor) {
-                        event.prevent_default();
-                    }
-                    request_frame();
-                }
-                return;
-            }
-
-            if event.alt_key() {
-                if delta_x.abs() <= f32::EPSILON {
-                    delta_x = delta_y;
-                }
-                delta_y = 0.0;
-            }
+            // What the sample means -- zoom, rotary, axis-swapped scroll, or
+            // plain scroll -- is the shell's shared policy; this side only
+            // converts the DOM's units and sign.
+            let wheel = crate::web_wheel::wheel_scroll_from_dom(
+                event.delta_x() as f32,
+                event.delta_y() as f32,
+                event.delta_mode(),
+                crate::web_wheel::WebWheelPage {
+                    width: wheel_canvas.client_width() as f32,
+                    height: wheel_canvas.client_height() as f32,
+                },
+                web_modifiers(&event),
+                wheel_uptime_millis(),
+            );
 
             if let Ok(mut app_mut) = app.try_borrow_mut() {
                 app_mut.set_cursor(logical.x, logical.y);
-                if app_mut.pointer_scrolled(delta_x, delta_y) {
+                if app_mut.wheel_scrolled(wheel) {
                     event.prevent_default();
                 }
                 request_frame();

--- a/crates/cranpose/src/web.rs
+++ b/crates/cranpose/src/web.rs
@@ -336,6 +336,11 @@ pub async fn run(
         move || request_frame()
     });
 
+    // Route the in-tree selection menu's Copy/Cut/Paste through the browser
+    // clipboard; without this they reach only an in-process one, so a copy on
+    // the page could not leave it.
+    crate::web_clipboard::install(&app, request_frame.clone());
+
     // Hidden editable element backing IME composition. Browsers only start
     // IME composition sessions (and mobile browsers only show their virtual
     // keyboard) when an editable element is focused, so text-field focus

--- a/crates/cranpose/src/web_clipboard.rs
+++ b/crates/cranpose/src/web_clipboard.rs
@@ -1,0 +1,134 @@
+//! The browser's clipboard, bridged to the in-tree selection menu.
+//!
+//! The menu's Copy / Cut / Paste live in the widget tree and reach the system
+//! clipboard through
+//! [`PlatformClipboard`](cranpose_ui::clipboard_session::PlatformClipboard).
+//! Without a bridge installed they fall back to an in-process clipboard, so a
+//! copy on the web page could only ever be pasted back into the same page.
+//!
+//! The two directions are not symmetric, because the Async Clipboard API is
+//! not:
+//!
+//! * **Writing** is fire-and-forget. `navigator.clipboard.writeText` returns a
+//!   promise nobody has to wait on, and it succeeds while the page holds a
+//!   transient user activation — which a menu tap is.
+//! * **Reading** cannot be answered on the call stack that asks. `readText`
+//!   returns a promise and, outside Chromium, prompts the user. So this bridge
+//!   reports nothing readable and instead takes the *paste itself*
+//!   ([`request_paste`](cranpose_ui::clipboard_session::PlatformClipboard::request_paste)),
+//!   completing it through the shell's ordinary paste path once the promise
+//!   resolves. `readText` is still called synchronously, inside the tap, so the
+//!   activation is unambiguous; only the await is deferred.
+//!
+//! On a page with no clipboard at all — an insecure origin has no
+//! `navigator.clipboard` — this bridge declines both directions, and the
+//! session's in-process clipboard keeps copy and paste working inside the page.
+
+use cranpose_app_shell::AppShell;
+use cranpose_render_wgpu::WgpuRenderer;
+use cranpose_ui::clipboard_session::PlatformClipboard;
+use std::cell::RefCell;
+use std::rc::{Rc, Weak};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_futures::{spawn_local, JsFuture};
+
+/// Installs the browser clipboard for `app`'s context.
+///
+/// Holds the shell weakly: the clipboard lives in the app context, which the
+/// shell owns, so a strong handle would be a cycle that never drops.
+pub(crate) fn install(app: &Rc<RefCell<AppShell<WgpuRenderer>>>, request_frame: Rc<dyn Fn()>) {
+    let clipboard = Rc::new(WebClipboard {
+        app: Rc::downgrade(app),
+        request_frame,
+    });
+    app.borrow().app_context().enter(move || {
+        cranpose_ui::clipboard_session::set_platform_clipboard(clipboard);
+    });
+}
+
+struct WebClipboard {
+    app: Weak<RefCell<AppShell<WgpuRenderer>>>,
+    request_frame: Rc<dyn Fn()>,
+}
+
+impl WebClipboard {
+    /// The DOM clipboard, or `None` on a page that has none — an insecure
+    /// origin (plain `http://` to anything but localhost) has no
+    /// `navigator.clipboard` at all.
+    fn dom_clipboard() -> Option<web_sys::Clipboard> {
+        let clipboard = web_sys::window()?.navigator().clipboard();
+        (!JsValue::from(clipboard.clone()).is_undefined()).then_some(clipboard)
+    }
+}
+
+impl PlatformClipboard for WebClipboard {
+    fn write_text(&self, text: &str) {
+        let Some(clipboard) = Self::dom_clipboard() else {
+            log::warn!("browser clipboard unavailable (insecure origin?); copy stayed in-page");
+            return;
+        };
+        // Resolving the promise is the browser's business: there is nothing to
+        // report back to a menu that has already closed, and dropping it would
+        // cancel the write.
+        let promise = clipboard.write_text(text);
+        spawn_local(async move {
+            if let Err(error) = JsFuture::from(promise).await {
+                log::warn!("browser clipboard write failed: {error:?}");
+            }
+        });
+    }
+
+    fn read_text(&self) -> Option<String> {
+        // Deliberately not a `readText()`: that is a promise, and this call
+        // wants an answer now. Nothing about the system clipboard is knowable
+        // synchronously here, so the session's in-process copy answers reads
+        // inside the page and `request_paste` answers everything else.
+        None
+    }
+
+    fn can_request_paste(&self) -> bool {
+        Self::dom_clipboard().is_some()
+    }
+
+    fn request_paste(&self) -> bool {
+        let Some(clipboard) = Self::dom_clipboard() else {
+            return false;
+        };
+        // Called inside the tap that asked to paste, so the page's transient
+        // user activation still covers it; only the await is deferred.
+        let promise = clipboard.read_text();
+        let app = self.app.clone();
+        let request_frame = Rc::clone(&self.request_frame);
+        spawn_local(async move {
+            let text = match JsFuture::from(promise).await {
+                Ok(value) => value.as_string().unwrap_or_default(),
+                Err(error) => {
+                    // A denied permission prompt lands here; the user declined
+                    // the paste, which is not the app's problem to report.
+                    log::info!("browser clipboard read declined: {error:?}");
+                    return;
+                }
+            };
+            if text.is_empty() {
+                return;
+            }
+            let Some(shell) = app.upgrade() else {
+                return;
+            };
+            // The tap that asked for this is long finished, so the shell is no
+            // longer borrowed -- but a frame could be in flight, and a paste is
+            // worth dropping rather than panicking over.
+            let pasted = match shell.try_borrow_mut() {
+                Ok(mut shell) => {
+                    shell.on_paste(&text);
+                    true
+                }
+                Err(_) => false,
+            };
+            if pasted {
+                request_frame();
+            }
+        });
+        true
+    }
+}

--- a/crates/cranpose/src/web_wheel.rs
+++ b/crates/cranpose/src/web_wheel.rs
@@ -1,0 +1,150 @@
+//! The DOM's `wheel` event, normalized into the shell's wheel sample.
+//!
+//! Two things separate a browser wheel event from what the shell dispatches,
+//! and both are silent when wrong.
+//!
+//! **Units.** `WheelEvent` reports its delta in whichever of three units it
+//! feels like — pixels, lines, or pages (`deltaMode`) — and only the pixel case
+//! needs no work. A line is worth a notch; a page is worth the canvas.
+//!
+//! **Sign.** The DOM's `deltaY` is positive when the wheel is turned *down*
+//! (the content moves up). The shell's convention, which winit already speaks,
+//! is the opposite: positive means the content moves down and right. So the
+//! browser delta is negated here, at the one point where the DOM's units and
+//! signs are still visible. Without it every scrollable on the web runs
+//! backwards, and a rotary handler turns the wrong way.
+
+use cranpose_app_shell::{Modifiers, WheelScroll};
+use cranpose_ui::Point;
+
+/// Logical pixels one `DOM_DELTA_LINE` step scrolls.
+const WEB_WHEEL_LINE_DELTA_PIXELS: f32 = 40.0;
+
+/// The `deltaMode` values a `WheelEvent` can report, named as the DOM names
+/// them. Mirrored rather than imported so this policy compiles (and its guards
+/// run) on the host as well as on wasm.
+pub(crate) const DOM_DELTA_PIXEL: u32 = 0;
+pub(crate) const DOM_DELTA_LINE: u32 = 1;
+pub(crate) const DOM_DELTA_PAGE: u32 = 2;
+
+/// The size of one `DOM_DELTA_PAGE` step: the canvas's own CSS box.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct WebWheelPage {
+    pub width: f32,
+    pub height: f32,
+}
+
+/// Converts a raw DOM wheel sample into the shell's [`WheelScroll`].
+pub(crate) fn wheel_scroll_from_dom(
+    delta_x: f32,
+    delta_y: f32,
+    delta_mode: u32,
+    page: WebWheelPage,
+    modifiers: Modifiers,
+    uptime_millis: u64,
+) -> WheelScroll {
+    let (unit_x, unit_y) = match delta_mode {
+        DOM_DELTA_PIXEL => (1.0, 1.0),
+        DOM_DELTA_LINE => (WEB_WHEEL_LINE_DELTA_PIXELS, WEB_WHEEL_LINE_DELTA_PIXELS),
+        DOM_DELTA_PAGE => (page.width.max(1.0), page.height.max(1.0)),
+        // Whatever a future browser invents: read it as pixels rather than
+        // dropping the sample.
+        _ => (1.0, 1.0),
+    };
+
+    WheelScroll::new(
+        Point {
+            x: -delta_x * unit_x,
+            y: -delta_y * unit_y,
+        },
+        uptime_millis,
+    )
+    .with_modifiers(modifiers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PAGE: WebWheelPage = WebWheelPage {
+        width: 800.0,
+        height: 600.0,
+    };
+
+    fn dom(delta_x: f32, delta_y: f32, delta_mode: u32) -> WheelScroll {
+        wheel_scroll_from_dom(delta_x, delta_y, delta_mode, PAGE, Modifiers::NONE, 0)
+    }
+
+    #[test]
+    fn a_wheel_turned_down_in_the_browser_scrolls_the_same_way_it_does_on_the_desktop() {
+        // The DOM reports a wheel turned DOWN as a positive deltaY; the shell
+        // and winit call that direction negative. This negation is the whole
+        // reason the two hosts scroll the same way.
+        let down = dom(0.0, 100.0, DOM_DELTA_PIXEL);
+        let up = dom(0.0, -100.0, DOM_DELTA_PIXEL);
+
+        assert_eq!(down.delta.y, -100.0);
+        assert_eq!(up.delta.y, 100.0);
+    }
+
+    #[test]
+    fn the_horizontal_axis_is_negated_with_the_vertical_one() {
+        let right = dom(75.0, 0.0, DOM_DELTA_PIXEL);
+
+        assert_eq!(right.delta.x, -75.0);
+        assert_eq!(right.delta.y, 0.0);
+    }
+
+    #[test]
+    fn line_and_page_modes_are_converted_to_pixels() {
+        assert_eq!(dom(0.0, 3.0, DOM_DELTA_LINE).delta.y, -120.0);
+        assert_eq!(dom(2.0, 0.0, DOM_DELTA_LINE).delta.x, -80.0);
+        assert_eq!(dom(0.0, 1.0, DOM_DELTA_PAGE).delta.y, -PAGE.height);
+        assert_eq!(dom(1.0, 0.0, DOM_DELTA_PAGE).delta.x, -PAGE.width);
+    }
+
+    #[test]
+    fn a_degenerate_page_size_still_scrolls() {
+        // A canvas can report a zero client box before layout settles; a page
+        // scroll then has to move by something rather than silently nothing.
+        let sample = wheel_scroll_from_dom(
+            0.0,
+            1.0,
+            DOM_DELTA_PAGE,
+            WebWheelPage {
+                width: 0.0,
+                height: 0.0,
+            },
+            Modifiers::NONE,
+            0,
+        );
+
+        assert_eq!(sample.delta.y, -1.0);
+    }
+
+    #[test]
+    fn an_unknown_delta_mode_is_read_as_pixels_rather_than_dropped() {
+        assert_eq!(dom(0.0, 12.0, 99).delta.y, -12.0);
+    }
+
+    #[test]
+    fn a_browser_pinch_arrives_as_the_zoom_gesture_and_zooms_in_when_spread() {
+        // Trackpad pinches reach the page as ctrl+wheel, and a pinch OUT
+        // (spread, zoom in) reports a negative deltaY -- which the negation
+        // above turns into the positive delta the shell zooms in on.
+        let spread = wheel_scroll_from_dom(
+            0.0,
+            -40.0,
+            DOM_DELTA_PIXEL,
+            PAGE,
+            Modifiers {
+                ctrl: true,
+                ..Modifiers::NONE
+            },
+            0,
+        );
+
+        assert!(spread.is_zoom());
+        assert!(spread.zoom_factor() > 1.0);
+    }
+}

--- a/crates/cranpose/src/winit_wheel.rs
+++ b/crates/cranpose/src/winit_wheel.rs
@@ -1,40 +1,47 @@
-//! Desktop mouse-wheel to rotary-input translation.
+//! winit's mouse wheel, normalized into the shell's wheel sample.
 //!
-//! The final deployment target for rotary input is a Wear OS watch, but the
-//! development platform is a desktop. Mapping winit's `MouseWheel` onto
-//! [`RotaryScrollEvent`] lets the whole rotary stack be built and eyeballed
-//! without a watch, and keeps a single code path under test on the host.
+//! The desktop host's entire wheel responsibility is this translation: what a
+//! wheel sample *means* — zoom, rotary, axis-swapped scroll, or plain scroll —
+//! is [`AppShell::wheel_scrolled`](cranpose_app_shell::AppShell::wheel_scrolled),
+//! shared with every other host.
 //!
 //! # Sign convention
 //!
-//! winit reports a **positive** vertical wheel delta when the wheel is scrolled
-//! *up / away from the user* — the same physical direction that produces a
-//! **positive** Android `AXIS_SCROLL` detent for a crown. Compose negates the
-//! Android value on its way into `RotaryScrollEvent` (see
-//! [`cranpose_app_shell::RotaryScrollEvent`]), so this translation negates the
-//! winit delta too. A wheel scrolled up and a crown turned up therefore produce
-//! the same **negative** `vertical_scroll_pixels`.
+//! winit reports a **positive** vertical delta when the wheel is scrolled *up /
+//! away from the user* ("the content being scrolled should move down"), which is
+//! exactly the shell's convention, so the delta passes through unchanged. The
+//! browser's is inverted and its host negates; see
+//! [`WheelScroll`](cranpose_app_shell::WheelScroll).
 
-use cranpose_app_shell::RotaryScrollEvent;
+use cranpose_app_shell::{Modifiers, WheelScroll};
 use cranpose_ui::Point;
+use winit::keyboard::ModifiersState;
 
-/// Converts an already-logical wheel delta into a [`RotaryScrollEvent`].
+/// Converts an already-logical wheel delta and winit's modifier state into a
+/// [`WheelScroll`].
 ///
-/// `logical_delta` is the output of
-/// `DesktopWinitPlatform::scroll_delta`, which normalizes both
-/// `MouseScrollDelta::LineDelta` and `MouseScrollDelta::PixelDelta` into
-/// logical pixels while preserving winit's sign. `uptime_millis` is a
-/// monotonic timestamp; only differences between events are meaningful.
-pub(crate) fn rotary_event_from_wheel_delta(
+/// `logical_delta` is the output of `DesktopWinitPlatform::scroll_delta`, which
+/// normalizes both `MouseScrollDelta::LineDelta` and
+/// `MouseScrollDelta::PixelDelta` into logical pixels while preserving winit's
+/// sign. `uptime_millis` is a monotonic timestamp; only differences between
+/// samples are meaningful.
+pub(crate) fn wheel_scroll_from_winit(
     logical_delta: Point,
+    modifiers: ModifiersState,
     uptime_millis: u64,
-) -> RotaryScrollEvent {
-    RotaryScrollEvent::new(-logical_delta.y, -logical_delta.x, uptime_millis)
+) -> WheelScroll {
+    WheelScroll::new(logical_delta, uptime_millis).with_modifiers(Modifiers {
+        shift: modifiers.contains(ModifiersState::SHIFT),
+        ctrl: modifiers.contains(ModifiersState::CONTROL),
+        alt: modifiers.contains(ModifiersState::ALT),
+        meta: modifiers.contains(ModifiersState::META),
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cranpose_app_shell::RotaryScrollEvent;
     use cranpose_platform_desktop_winit::DesktopWinitPlatform;
     use winit::dpi::PhysicalPosition;
     use winit::event::MouseScrollDelta;
@@ -42,9 +49,14 @@ mod tests {
     /// One wheel notch as normalized by `DesktopWinitPlatform`.
     const NOTCH_PIXELS: f32 = 40.0;
 
-    fn rotary_for(delta: MouseScrollDelta, scale_factor: f64) -> RotaryScrollEvent {
+    fn wheel_for(delta: MouseScrollDelta, scale_factor: f64) -> WheelScroll {
         let platform = DesktopWinitPlatform::new(scale_factor);
-        rotary_event_from_wheel_delta(platform.scroll_delta(delta), 0)
+        wheel_scroll_from_winit(platform.scroll_delta(delta), ModifiersState::empty(), 0)
+    }
+
+    fn rotary_for(delta: MouseScrollDelta, scale_factor: f64) -> RotaryScrollEvent {
+        let wheel = wheel_for(delta, scale_factor);
+        RotaryScrollEvent::from_wheel_pixels(wheel.delta.y, wheel.delta.x, wheel.uptime_millis)
     }
 
     #[test]
@@ -123,6 +135,18 @@ mod tests {
     }
 
     #[test]
+    fn a_wheel_scrolled_up_asks_the_content_to_move_down() {
+        // The shell's convention, which winit already speaks: the scrollables
+        // are written against a positive delta walking a ScrollState back
+        // toward zero.
+        let up = wheel_for(MouseScrollDelta::LineDelta(0.0, 1.0), 1.0);
+
+        assert_eq!(up.delta.y, NOTCH_PIXELS);
+        assert!(!up.is_zoom());
+        assert_eq!(up.scroll_delta(), up.delta);
+    }
+
+    #[test]
     fn zero_delta_produces_an_empty_event() {
         let event = rotary_for(MouseScrollDelta::LineDelta(0.0, 0.0), 1.0);
 
@@ -131,8 +155,19 @@ mod tests {
 
     #[test]
     fn uptime_is_carried_through() {
-        let event = rotary_event_from_wheel_delta(Point { x: 0.0, y: 1.0 }, 9_876);
+        let wheel =
+            wheel_scroll_from_winit(Point { x: 0.0, y: 1.0 }, ModifiersState::empty(), 9876);
 
-        assert_eq!(event.uptime_millis, 9_876);
+        assert_eq!(wheel.uptime_millis, 9_876);
+    }
+
+    #[test]
+    fn winit_modifiers_reach_the_shell_policy() {
+        let ctrl = wheel_scroll_from_winit(Point { x: 0.0, y: 40.0 }, ModifiersState::CONTROL, 0);
+        let alt = wheel_scroll_from_winit(Point { x: 0.0, y: 40.0 }, ModifiersState::ALT, 0);
+
+        assert!(ctrl.is_zoom());
+        assert!(!alt.is_zoom());
+        assert_eq!(alt.scroll_delta(), Point { x: 40.0, y: 0.0 });
     }
 }

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -1953,6 +1953,19 @@ fn the_browser_host_shares_the_wheel_policy() {
     );
 }
 
+/// The same unreachable-source problem for the clipboard: with no bridge
+/// installed the in-tree selection menu's Copy reaches an in-process clipboard
+/// that nothing outside the page can read, and every platform but the browser
+/// had one.
+#[test]
+fn the_browser_host_installs_a_platform_clipboard() {
+    assert!(
+        crate_source("src/web.rs").contains("crate::web_clipboard::install("),
+        "the browser host must install a platform clipboard, or the in-tree selection \
+         menu's Copy/Cut never leave the page"
+    );
+}
+
 fn is_crate_root_source(path: &Path) -> bool {
     let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
         return false;

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -1932,6 +1932,27 @@ fn every_store_backend_tells_the_app_rather_than_leaving_it_to_ask() {
     }
 }
 
+/// `web.rs` compiles only for `wasm32`, so nothing in `cargo test` links it —
+/// reading the source is the only guard available on the host, and the
+/// alternative is finding out in a browser. This contract regressed silently
+/// once already: the wheel listener grew its own copy of the desktop's policy,
+/// inverted, and never offered the wheel to rotary at all.
+#[test]
+fn the_browser_host_shares_the_wheel_policy() {
+    let web = crate_source("src/web.rs");
+
+    assert!(
+        web.contains("app_mut.wheel_scrolled(wheel)"),
+        "the browser wheel listener must go through the shell's shared wheel policy, \
+         so zoom, rotary and scroll mean the same thing they do on every other host"
+    );
+    assert!(
+        !web.contains("app_mut.pointer_scrolled("),
+        "the browser host must not reach past wheel_scrolled to the scroll step: that \
+         skips rotary and re-opens the sign question the shared policy settles"
+    );
+}
+
 fn is_crate_root_source(path: &Path) -> bool {
     let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
         return false;

--- a/docs/capability_parity.md
+++ b/docs/capability_parity.md
@@ -25,7 +25,7 @@ never silently pretend.
 | notifier          | ■   | ■ channels + deep-link Java | ■ zero-dep CLI (notify-send/osascript/PowerShell) | ■ Notification API | |
 | network status    | □   | ■ ConnectivityManager Java | ● explicit assumption | ■ `navigator.onLine` | iOS NWPathMonitor still open |
 | device info       | ■   | ● /proc/meminfo | ● linux; □ mac/win | ■ `navigator.deviceMemory` (reflective) | |
-| clipboard         | ■   | ■ ClipboardManager JNI | ■ arboard | ● in-process fallback | web system-write bridge still open |
+| clipboard         | ■   | ■ ClipboardManager JNI | ■ arboard | ■ Async Clipboard API (`web_clipboard`) | web reads are a promise, so the bridge takes the *paste* (`request_paste`) instead of answering `read_text` |
 | back requests     | ■   | ■ back key → `push_back_request` behind `set_back_interception` | □ (apps map keys themselves) | □ | predictive back must stay off (`enableOnBackInvokedCallback=false`) |
 | safe-area insets  | ■   | ■ WindowInsets listener → `local_safe_area_insets` | ● zero | ● zero | replaced cranscan's marker-file bridge |
 | system theme      | ■ `window.theme()` polled | ■ uiMode + ConfigChanged | ■ winit `ThemeChanged` (+ cached env probe) | ■ `prefers-color-scheme` listener | drives LiquidTheme Auto |
@@ -65,7 +65,7 @@ never silently pretend.
 - iOS network monitor (NWPathMonitor) and export-style save dialog.
 - Android camera2 backend for `cranpose_services::camera` (cranscan keeps its
   app-side system-camera round-trip + preview until then).
-- Web system-clipboard write bridge; web camera (getUserMedia).
+- Web camera (getUserMedia).
 - Web launch arguments from the URL query string (`launch_args()` is empty on
   wasm today; the shell would install a snapshot from `location.search`).
 - `local_*()` accessor seams for `camera`/`device_info`/`network`/`background`.


### PR DESCRIPTION
Four reported problems. Three turned out to be one bug each in a place a second implementation had been allowed to grow; the fourth is the README.

Reviewable commit by commit — each stands alone.

## Rotary did not scroll on the web, and neither did anything else, correctly

A wheel sample is not a scroll. It is whichever of four things the modifiers and the tree make it, in a fixed order: a zoom when ctrl is held, a rotary event offered to the Wear OS crown stack, a horizontal scroll when alt is held, and otherwise a scroll. That policy lived in the desktop event loop. The browser listener reimplemented the parts visible from outside and missed the rest, so `Modifier::on_rotary_scroll_event` was dead on the web.

It also passed the DOM's `deltaY` through unnegated. winit's positive means the content moves down; the DOM's means the wheel turned down. **Web scrolling was inverted** in every scrollable, silently.

`AppShell::wheel_scrolled` owns the policy now; each host only normalizes units and sign into a `WheelScroll`. Verified in headless Chromium against the real wasm build: at the top of the page a wheel turned up is declined 0/4, turned down is taken 2/4.

⚠️ **This flips web scroll direction.** It was backwards; it is now the desktop's. Visible to anyone using the deployed demo.

## A copy on the web page could not leave the page

No `PlatformClipboard` was ever installed on web, so the selection menu's Copy/Cut reached only an in-process clipboard.

Writing is now `navigator.clipboard.writeText`. Reading could not be bridged as-is: `read_text` is synchronous and the Async Clipboard API's read is a promise that prompts outside Chromium. Rather than fake it with a mirror that goes stale against anything copied outside the tab, the trait grew `request_paste` — the platform takes the paste and completes it through the shell's own paste path when the promise resolves. Every native backend takes the default and is untouched.

## The world behind the bottom bar rescaled when you pressed it

Not the animation — the renderer. A layer whose transform is not a pure translation renders its surface at `magnifying_layer_scale`, quantized **up** to the next quarter step, so the bar's 1.03× press lift becomes 1.25×. `create_projected_child_underlay` built the backdrop underlay at the *parent's* scale while everything inside the surface addressed it at the child's. The backdrop showed the world at 0.688× anchored to the bar's corner.

Measured on the demo bar, two background tracks read through the glass (device px, rest → pressed):

| | rest | pressed |
|---|---|---|
| before | 55.6 / 107.9 | 44.0 / 80.0 |
| after | 55.6 / 104.4 | 58.4 / 101.4 |

Confirmed by eye on a release desktop build before committing. The new test fails on the old code at device x 54 against a true 64 — the displacement the arithmetic predicts.

## README

The Todo example was not Rust — named arguments, signatures the framework does not have. Replaced with one compiled against this workspace. iOS was documented as unavailable against a real winit-uikit backend that CI builds; version pins said 0.1.28; there was no map of the workspace and nothing about the robot harness.

## Gates

`fmt` · `clippy --workspace --all-targets -D warnings` · `cargo test --workspace` · wasm · Android `:app:assembleRelease` · robot e2e **144/144** (141 GPU under Xvfb + the 3 external captures on software present) · headless Chromium against the real wasm build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)