### PR TITLE
An animated shader inside a scroll must keep animating (#328)

### DIFF
--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -4005,9 +4005,7 @@ fn layer_raster_cache_candidate(
         && surface_requirements
             .surface_requirements
             .has_isolating_requirement()
-        && !layer
-            .effect()
-            .is_some_and(RenderEffect::contains_runtime_shader);
+        && !surface_requirements.contains_runtime_shader;
     let cache_is_allowed = layer.cache_policy == CachePolicy::Auto
         || (allow_runtime_cache && surface_requirements.has_renderer_forced_surface())
         || runtime_cache_is_safe;
@@ -4017,10 +4015,9 @@ fn layer_raster_cache_candidate(
     if layer_uses_external_backdrop_input(layer, has_backdrop_underlay) {
         return None;
     }
-    if layer
-        .effect()
-        .is_some_and(RenderEffect::contains_runtime_shader)
-    {
+    // Not just this layer's own effect: a shader anywhere below it makes the
+    // whole subtree change every frame with nothing in any hash to say so.
+    if surface_requirements.contains_runtime_shader {
         return None;
     }
 

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -2195,7 +2195,7 @@ fn child_layer_raster_cache_candidate(
         && surface_requirements
             .surface_requirements
             .has_isolating_requirement()
-        && !child.effect_contains_runtime_shader;
+        && !surface_requirements.contains_runtime_shader;
     let cache_is_allowed = child.cache_policy == CachePolicy::Auto
         || (allow_runtime_cache && surface_requirements.has_renderer_forced_surface())
         || runtime_cache_is_safe;
@@ -2205,11 +2205,13 @@ fn child_layer_raster_cache_candidate(
     if has_backdrop_underlay && child.contains_descendant_backdrop {
         return None;
     }
-    // RuntimeShader effects produce different output every frame (animated
-    // uniforms like time). Caching their layer surfaces is
-    // counterproductive: every frame generates a new unique cache key that
-    // fills the LRU with stale textures.
-    if child.effect_contains_runtime_shader {
+    // A RuntimeShader produces different output every frame from uniforms no
+    // content hash carries, so nothing can invalidate a texture it was
+    // rastered into. Caching the shader's own layer would only fill the LRU
+    // with stale entries; caching an ANCESTOR of one freezes the effect
+    // outright, because the ancestor stays a hit forever and replays whatever
+    // frame it first rastered. The whole subtree is therefore uncacheable.
+    if surface_requirements.contains_runtime_shader {
         return None;
     }
 

--- a/crates/cranpose-render/wgpu/src/surface_plan.rs
+++ b/crates/cranpose-render/wgpu/src/surface_plan.rs
@@ -7,7 +7,7 @@ use cranpose_render_common::graph::{
 };
 use cranpose_render_common::layer_composition::layer_requires_isolation;
 use cranpose_render_common::layer_transform::layer_uniform_scale;
-use cranpose_ui_graphics::{BlendMode, Brush, CompositingStrategy, Point, Rect};
+use cranpose_ui_graphics::{BlendMode, Brush, CompositingStrategy, Point, Rect, RenderEffect};
 
 const SURFACE_PLAN_AFFINE_TOLERANCE: f32 = 1e-4;
 
@@ -18,6 +18,16 @@ pub(crate) struct LayerSurfaceRequirements {
     pub(crate) contains_translated_content: bool,
     pub(crate) translated_content_axes: TranslatedContentAxes,
     pub(crate) contains_backdrop_content: bool,
+    /// Whether this layer or anything under it draws through a runtime shader.
+    ///
+    /// A runtime shader's output changes every frame from uniforms that are
+    /// deliberately excluded from every content hash — including them would
+    /// mint a new cache key per frame and fill the LRU with stale textures. So
+    /// no hash can tell an ancestor that the subtree changed, and an ancestor
+    /// that raster-caches replays the shader frozen at whatever frame it first
+    /// rastered. Every cache admission therefore consults the whole subtree,
+    /// not just the layer's own effect.
+    pub(crate) contains_runtime_shader: bool,
 }
 
 impl LayerSurfaceRequirements {
@@ -432,6 +442,14 @@ pub(crate) fn layer_surface_requirements_cached(
     let mut contains_translated_content = layer.translated_content_context;
     let mut translated_content_axes = translated_content_axes_for_layer(layer);
     let mut contains_backdrop_content = layer.backdrop().is_some();
+    // Render effects only, which is the skip this widens: a backdrop shader
+    // reads the scene behind it, and that path has its own admission rules
+    // (`layer_uses_external_backdrop_input`, the underlay checks) written
+    // against a hash that does see the scene. Folding backdrops in here would
+    // make every ancestor of every glass surface uncacheable on a guess.
+    let mut contains_runtime_shader = layer
+        .effect()
+        .is_some_and(RenderEffect::contains_runtime_shader);
     let mut has_direct_safe_primitive = false;
     let mut has_isolating_child_layer = false;
     let mut has_pixel_sensitive_content = false;
@@ -476,6 +494,7 @@ pub(crate) fn layer_surface_requirements_cached(
                 translated_content_axes =
                     translated_content_axes.union(child_requirements.translated_content_axes);
                 contains_backdrop_content |= child_requirements.contains_backdrop_content;
+                contains_runtime_shader |= child_requirements.contains_runtime_shader;
                 if child_requirements
                     .surface_requirements
                     .contains(SurfaceRequirement::PixelStableComposite)
@@ -518,6 +537,7 @@ pub(crate) fn layer_surface_requirements_cached(
         contains_translated_content,
         translated_content_axes,
         contains_backdrop_content,
+        contains_runtime_shader,
     };
     layer_surface_requirements_cache.insert(cache_key, requirements);
     requirements

--- a/crates/cranpose-render/wgpu/tests/raster_cache.rs
+++ b/crates/cranpose-render/wgpu/tests/raster_cache.rs
@@ -289,3 +289,137 @@ fn text_glyph_atlas_reuses_identical_content_across_node_ids() {
         "first repeated text node should populate atlas glyphs: {stats:?}"
     );
 }
+
+/// A shader whose only job is to paint uniform 0 into the red channel, so a
+/// frame that failed to re-run it is visible as a pixel that did not move.
+const ANIMATED_SHADER_WGSL: &str = r#"
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn fullscreen_vs(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+    var output: VertexOutput;
+    let x = f32(i32(vertex_index & 1u) * 2 - 1);
+    let y = f32(i32(vertex_index >> 1u) * 2 - 1);
+    output.uv = vec2<f32>(x * 0.5 + 0.5, 1.0 - (y * 0.5 + 0.5));
+    output.position = vec4<f32>(x, y, 0.0, 1.0);
+    return output;
+}
+
+@group(0) @binding(0) var input_texture: texture_2d<f32>;
+@group(0) @binding(1) var input_sampler: sampler;
+@group(1) @binding(0) var<uniform> u: array<vec4<f32>, 64>;
+
+@fragment
+fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(u[0][0], 0.0, 0.0, 1.0);
+}
+"#;
+
+/// A clipped, cacheable container -- the shape a `vertical_scroll` produces --
+/// wrapping a layer whose render effect is an animated runtime shader.
+fn shader_inside_cached_container_graph(time: f32) -> RenderGraph {
+    let shaded_bounds = Rect {
+        x: 0.0,
+        y: 0.0,
+        width: 64.0,
+        height: 48.0,
+    };
+    let mut shader = cranpose_ui_graphics::RuntimeShader::new(ANIMATED_SHADER_WGSL);
+    shader.set_float(0, time);
+    let mut shaded = test_layer(
+        Some(30_001),
+        CachePolicy::Auto,
+        shaded_bounds,
+        ProjectiveTransform::translation(8.0, 8.0),
+        vec![RenderNode::Primitive(PrimitiveEntry {
+            phase: PrimitivePhase::BeforeChildren,
+            node: PrimitiveNode::Draw(DrawPrimitiveNode {
+                primitive: cranpose_ui_graphics::DrawPrimitive::Rect {
+                    rect: shaded_bounds,
+                    brush: Brush::solid(Color(0.0, 0.0, 0.0, 1.0)),
+                    stroke: None,
+                },
+                clip: None,
+            }),
+        })],
+    );
+    shaded.graphics_layer.render_effect =
+        Some(cranpose_ui_graphics::RenderEffect::runtime_shader(shader));
+
+    // The container clips, which is what makes it isolated and therefore
+    // raster-cacheable -- exactly how a scroll container ends up cached.
+    let mut container = test_layer(
+        Some(30_000),
+        CachePolicy::Auto,
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 96.0,
+            height: 80.0,
+        },
+        ProjectiveTransform::translation(4.0, 4.0),
+        vec![RenderNode::Layer(Box::new(shaded))],
+    );
+    container.clip_to_bounds = true;
+    container.isolation.shape_clip = true;
+
+    RenderGraph::new(test_layer(
+        Some(30_002),
+        CachePolicy::None,
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 128.0,
+            height: 96.0,
+        },
+        ProjectiveTransform::identity(),
+        vec![RenderNode::Layer(Box::new(container))],
+    ))
+}
+
+#[test]
+fn an_animated_shader_keeps_animating_inside_a_cacheable_container() {
+    // A runtime shader's own layer is never raster-cached -- its uniforms
+    // change every frame, so the cache would only fill with stale textures.
+    // That skip stops at the shader's own layer, and an ancestor that caches
+    // (any clipped container: every scroll is one) hashes its content from
+    // each child's `effect_hash`, which deliberately excludes the uniforms.
+    // The ancestor is then a cache hit forever and replays a texture with the
+    // shader baked in at t=0: the effect is frozen, at zero changed pixels,
+    // while an identical one outside the container animates.
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!(
+                "skipping animated-shader cache assertion because headless WGPU init failed: {}",
+                err
+            );
+            return;
+        }
+    };
+
+    renderer.scene_mut().graph = Some(shader_inside_cached_container_graph(0.0));
+    let first = renderer
+        .capture_frame(128, 96)
+        .expect("first shader capture should succeed");
+
+    renderer.scene_mut().graph = Some(shader_inside_cached_container_graph(1.0));
+    let second = renderer
+        .capture_frame(128, 96)
+        .expect("second shader capture should succeed");
+
+    let changed = first
+        .pixels
+        .chunks_exact(4)
+        .zip(second.pixels.chunks_exact(4))
+        .filter(|(a, b)| a != b)
+        .count();
+    assert!(
+        changed > 0,
+        "an animated shader inside a cacheable container must still animate: \
+         the container cannot cache a subtree whose output changes every frame"
+    );
+}


### PR DESCRIPTION
Closes #328.

The issue's root-cause analysis is correct and this takes the fix it proposes.

A `RuntimeShader`'s output changes every frame from uniforms no content hash carries — deliberately, since hashing them would mint a cache key per frame and fill the LRU with stale textures. The raster cache already refuses to cache such a layer. **That refusal stopped at the shader's own layer.**

Anything that clips is isolated, and anything isolated is cacheable — every scroll container is one. The ancestor hashes its content from each child's `effect_hash`, which excludes the uniforms, so it is a cache hit forever and replays a texture with the shader baked in at t=0.

"Contains a runtime shader" is now a subtree fact, rolled up through `LayerSurfaceRequirements` beside `contains_backdrop_content` and `contains_translated_content`, and both raster-cache admission sites consult the subtree.

## Scope

Render effects only, matching the skip it widens. A backdrop shader reads the scene behind it and its admission is already decided by rules written against a hash that *does* see that scene; folding backdrops in here would make every ancestor of every glass surface uncacheable on a guess, and nothing reported says it needs to be. Whether an animated **backdrop** shader has the same freeze is a separate question with its own evidence to gather — worth filing if anyone hits it.

## Test

`an_animated_shader_keeps_animating_inside_a_cacheable_container` builds a clipped, cacheable container around a shader whose only job is to paint uniform 0, and asks whether two frames one uniform apart differ. **Counts 0 changed pixels without the fix** — the exact symptom the issue reports — and passes with it. The existing cache-reuse tests still pass, so ordinary layers still cache.

## Not addressed

The issue's closing "related observation" — that a bare frame-clock loop does not keep the desktop loop in `Poll` when otherwise idle — is a different subsystem (frame pacing, not caching) and is left alone here. Note that #377's fix has since reworked exactly that path, so it may already behave differently; worth re-checking against current `main` before filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)