### PR TITLE
Package the library cargo just built, and measure draw-scope text at the size the style names

### DIFF
--- a/apps/android-demo/android/app/build.gradle.kts
+++ b/apps/android-demo/android/app/build.gradle.kts
@@ -170,9 +170,21 @@ tasks.register<Exec>("buildRustDebug") {
     inputs.file("../../../../apps/desktop-demo-platform/Cargo.toml")
     inputs.file("../../../../Cargo.toml")
     inputs.file("../../../../Cargo.lock")
-    
-    // Always run this task - let Cargo handle its own incremental builds
-    // This prevents Gradle/Cargo caching conflicts
+
+    // cargo-ndk writes the .so here and `jniLibs.directories` above reads it
+    // back, so this directory is this task's output and has to say so.
+    // Without it Gradle never learns the directory changed: the merge and
+    // package tasks that depend on this one check the snapshot taken before
+    // cargo ran, report UP-TO-DATE, and the APK ships the PREVIOUS build's
+    // library. The failure is silent and reads as a device bug -- what runs on
+    // screen is one build behind what is on disk, so a fix "does not work on
+    // device" until some unrelated change forces a repackage.
+    outputs.dir(rootProject.file("target/android"))
+
+    // Always run this task - let Cargo handle its own incremental builds.
+    // This prevents Gradle/Cargo caching conflicts, and is separate from the
+    // output declaration above: it only forces THIS task to run again, and
+    // says nothing about what the task changed on disk.
     outputs.upToDateWhen { false }
 
     // Check cargo-ndk availability
@@ -213,6 +225,10 @@ tasks.register<Exec>("buildRustRelease") {
     inputs.file("../../../../apps/desktop-demo-platform/Cargo.toml")
     inputs.file("../../../../Cargo.toml")
     inputs.file("../../../../Cargo.lock")
+    // The directory cargo-ndk writes and `jniLibs.directories` reads. See
+    // `buildRustDebug`: undeclared, it leaves the packaging tasks looking at a
+    // pre-cargo snapshot and the APK ships the previous build's library.
+    outputs.dir(rootProject.file("target/android"))
     outputs.upToDateWhen { false }
 
     // Check cargo-ndk availability
@@ -243,8 +259,15 @@ tasks.register<Exec>("buildRustRelease") {
 
 // Wire Rust builds to Android build variants
 afterEvaluate {
-    // Wire Rust builds to merge native libs tasks
-    tasks.matching { it.name.startsWith("merge") && it.name.contains("NativeLibs") }.configureEach {
+    // Both merge tasks read `target/android`: `mergeJniLibFolders` collects the
+    // source directories and `mergeNativeLibs` collects the libraries in them.
+    // Wiring only the second leaves the first racing the cargo build, which
+    // Gradle reports as an implicit dependency once the cargo tasks declare the
+    // directory as their output.
+    tasks.matching {
+        it.name.startsWith("merge") &&
+            (it.name.contains("NativeLibs") || it.name.contains("JniLibFolders"))
+    }.configureEach {
         if (name.contains("Debug", ignoreCase = true)) {
             dependsOn("buildRustDebug")
         } else if (name.contains("Release", ignoreCase = true)) {

--- a/apps/isolated-demo/android/app/build.gradle.kts
+++ b/apps/isolated-demo/android/app/build.gradle.kts
@@ -78,6 +78,18 @@ tasks.register<Exec>("buildRustDebug") {
     inputs.file("../../Cargo.toml")
     inputs.file("../../Cargo.lock")
 
+    // cargo-ndk writes the .so here and `jniLibs.directories` above reads it
+    // back, so this directory is this task's output and has to say so.
+    // Without it Gradle never learns the directory changed: the merge and
+    // package tasks that depend on this one check the snapshot taken before
+    // cargo ran, report UP-TO-DATE, and the APK ships the PREVIOUS build's
+    // library. The failure is silent and reads as a device bug -- what runs on
+    // screen is one build behind what is on disk, so a fix "does not work on
+    // device" until some unrelated change forces a repackage.
+    outputs.dir(rootProject.file("target/android"))
+
+    // Separate from the output declaration above: this only forces THIS task
+    // to run again, and says nothing about what the task changed on disk.
     outputs.upToDateWhen { false }
 
     doFirst {
@@ -103,6 +115,14 @@ tasks.register<Exec>("buildRustRelease") {
     description = "Build Rust library for Android (release, all ABIs)"
     group = "rust"
 
+    // The directory cargo-ndk writes and `jniLibs.directories` reads. See
+    // `buildRustDebug`: undeclared, it leaves the packaging tasks looking at a
+    // pre-cargo snapshot and the APK ships the previous build's library.
+    outputs.dir(rootProject.file("target/android"))
+    // Cargo owns incrementality here; a task with a declared output would
+    // otherwise be skipped whenever that output happened to be unchanged.
+    outputs.upToDateWhen { false }
+
     doFirst {
         checkCargoNdk()
     }
@@ -127,7 +147,15 @@ tasks.register<Exec>("buildRustRelease") {
 }
 
 afterEvaluate {
-    tasks.matching { it.name.startsWith("merge") && it.name.contains("NativeLibs") }.configureEach {
+    // Both merge tasks read `target/android`: `mergeJniLibFolders` collects the
+    // source directories and `mergeNativeLibs` collects the libraries in them.
+    // Wiring only the second leaves the first racing the cargo build, which
+    // Gradle reports as an implicit dependency once the cargo tasks declare the
+    // directory as their output.
+    tasks.matching {
+        it.name.startsWith("merge") &&
+            (it.name.contains("NativeLibs") || it.name.contains("JniLibFolders"))
+    }.configureEach {
         if (name.contains("Debug", ignoreCase = true)) {
             dependsOn("buildRustDebug")
         } else if (name.contains("Release", ignoreCase = true)) {

--- a/crates/cranpose-ui/src/text/draw_scope_text.rs
+++ b/crates/cranpose-ui/src/text/draw_scope_text.rs
@@ -57,10 +57,15 @@ pub fn text_style_for_draw_style(style: &DrawTextStyle) -> TextStyle {
 
 /// Measures draw-scope text against the app's fonts.
 ///
-/// Every call lands in [`super::measure_text`], which is the same entry point
-/// the `Text` composable's layout uses and is backed by the app context's
-/// metrics cache — so measuring an unchanged string every frame is a hash
-/// lookup, not a shaping pass.
+/// Every call lands in [`super::measure::measure_resolved_text`], backed by the
+/// app context's metrics cache — so measuring an unchanged string every frame
+/// is a hash lookup, not a shaping pass.
+///
+/// "Resolved" is the whole point: a [`DrawTextStyle`] states final sizes, and a
+/// scene lowers a text primitive with `style.resolved_font_size()` untouched,
+/// so the system font scale must not be folded in here. It is applied where an
+/// unresolved size lives instead — the `Text` composable's `Sp` values — and
+/// that path carries the scaled style through to the renderer with it.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct AppContextTextMeasurer;
 
@@ -86,13 +91,13 @@ impl DrawTextMeasurer for AppContextTextMeasurer {
 
         let text_style = text_style_for_draw_style(style);
         let annotated = super::shared_plain_annotated_string(text);
-        let metrics = super::measure_text(&annotated, &text_style);
+        let metrics = super::measure::measure_resolved_text(&annotated, &text_style);
         let line_height = if metrics.line_height.is_finite() && metrics.line_height > 0.0 {
             metrics.line_height
         } else {
             estimate_text_measurement(text, style).line_height
         };
-        let first_baseline = super::measure::first_baseline(&text_style)
+        let first_baseline = super::measure::resolved_first_baseline(&text_style)
             .unwrap_or_else(|| estimate_text_measurement(text, style).first_baseline);
 
         if text.is_empty() {

--- a/crates/cranpose-ui/src/text/measure.rs
+++ b/crates/cranpose-ui/src/text/measure.rs
@@ -676,6 +676,37 @@ pub fn measure_text(text: &crate::text::AnnotatedString, style: &TextStyle) -> T
     })
 }
 
+/// Measures `text` at the sizes `style` literally carries — no system font
+/// scale applied.
+///
+/// Use this for a style that is already resolved, which on the drawing side
+/// means every style: a
+/// [`DrawScope`](cranpose_ui_graphics::DrawScope) text run is described by a
+/// flat [`cranpose_ui_graphics::TextStyle`] whose sizes are final, and a scene
+/// lowers that run with `style.resolved_font_size()` and nothing else. Scaling
+/// here would report a box the rasterizer never fills, and every wrap, centring
+/// and hit rect a caller derives from the measurement would be out by the
+/// setting — on the devices where it is not 1.0 and nowhere else.
+///
+/// The `Text` composable is the other case and keeps [`measure_text`]: its
+/// style carries real [`crate::text::TextUnit::Sp`] sizes, and its prepared
+/// layout hands the SCALED style on to the renderer, so both sides move
+/// together there.
+pub(crate) fn measure_resolved_text(
+    text: &crate::text::AnnotatedString,
+    style: &TextStyle,
+) -> TextMetrics {
+    crate::render_state::with_text_service(|service| service.measure(None, text, style))
+}
+
+/// [`first_baseline`] for an already-resolved style — see
+/// [`measure_resolved_text`] for why the drawing side does not scale.
+pub(crate) fn resolved_first_baseline(style: &TextStyle) -> Option<f32> {
+    crate::render_state::with_text_service(|service| {
+        service.with_measurer(|m| m.first_baseline(style))
+    })
+}
+
 /// The tight glyph box `(top_offset, height)` of a `style` text line inside
 /// its line slot (see [`TextMeasurer::glyph_line_box`]). Falls back to the
 /// full slot when the active measurer has no font metrics.

--- a/crates/cranpose-ui/tests/draw_scope_text_integration.rs
+++ b/crates/cranpose-ui/tests/draw_scope_text_integration.rs
@@ -10,8 +10,8 @@ use std::rc::Rc;
 
 use cranpose_ui::text::{AnnotatedString, TextLayoutResult};
 use cranpose_ui::{
-    collect_slices_from_modifier, execute_draw_commands, set_text_measurer, AppContext,
-    DrawCommand, Modifier, TextMeasurer, TextMetrics, TextStyle,
+    collect_slices_from_modifier, execute_draw_commands, set_font_scale, set_text_measurer,
+    AppContext, DrawCommand, Modifier, TextMeasurer, TextMetrics, TextStyle,
 };
 use cranpose_ui_graphics::{
     estimate_text_measurement, Brush, Color, DrawPrimitive, DrawScope, Point, Rect, Size,
@@ -203,6 +203,99 @@ fn an_unchanged_string_measures_once_across_repeated_frames() {
         measured.borrow().len(),
         1,
         "a stable string must be shaped once and served from the metrics cache after that"
+    );
+}
+
+/// Reports one em of advance per character, so the font size a measurement was
+/// taken at is readable straight off the width.
+struct EmWidthMeasurer;
+
+impl TextMeasurer for EmWidthMeasurer {
+    fn measure(&self, text: &AnnotatedString, style: &TextStyle) -> TextMetrics {
+        let font_size = style.resolve_font_size(14.0);
+        TextMetrics {
+            width: text.text.chars().count() as f32 * font_size,
+            height: font_size,
+            line_height: font_size,
+            line_count: 1,
+        }
+    }
+
+    fn first_baseline(&self, style: &TextStyle) -> Option<f32> {
+        Some(style.resolve_font_size(14.0) * 0.8)
+    }
+
+    fn get_offset_for_position(
+        &self,
+        _text: &AnnotatedString,
+        _style: &TextStyle,
+        _x: f32,
+        _y: f32,
+    ) -> usize {
+        0
+    }
+
+    fn get_cursor_x_for_offset(
+        &self,
+        _text: &AnnotatedString,
+        _style: &TextStyle,
+        _offset: usize,
+    ) -> f32 {
+        0.0
+    }
+
+    fn layout(&self, text: &AnnotatedString, style: &TextStyle) -> TextLayoutResult {
+        let font_size = style.resolve_font_size(14.0);
+        TextLayoutResult::monospaced(&text.text, font_size, font_size)
+    }
+}
+
+/// A draw scope's text is measured at the size the style names, whatever the
+/// system font scale is.
+///
+/// The rasterizer takes its font size straight off the primitive's
+/// `DrawTextStyle` — that style is documented as fully resolved, and a scene is
+/// lowered with `text.style.resolved_font_size()` and nothing else. So a
+/// measurement that quietly multiplied by the system font scale would hand the
+/// caller a box the glyphs never fill: every wrap decision, every centred label
+/// and every hit rect computed from `measure_text` would be out by exactly that
+/// factor, on the devices where the setting is not 1.0 and nowhere else.
+///
+/// A `Text` composable is the other case and stays scaled: its style carries
+/// real `Sp` sizes, and its prepared layout hands the SCALED style on to the
+/// renderer, so both sides move together there.
+#[test]
+fn draw_scope_text_is_measured_at_the_size_the_style_names() {
+    const FONT_SIZE: f32 = 10.0;
+    const TEXT: &str = "ABCD";
+
+    let app_context = AppContext::new();
+    let commands: Vec<DrawCommand> = collect_slices_from_modifier(&Modifier::empty().draw_behind(
+        |scope: &mut dyn DrawScope| {
+            scope.draw_text_from(
+                Point::ZERO,
+                Brush::solid(Color::WHITE),
+                TEXT,
+                &DrawTextStyle::new(FONT_SIZE),
+            );
+        },
+    ))
+    .draw_commands()
+    .to_vec();
+
+    let primitives = app_context.enter(|| {
+        set_text_measurer(EmWidthMeasurer);
+        set_font_scale(2.0);
+        execute_draw_commands(&commands, Size::new(500.0, 100.0))
+    });
+
+    let text = text_primitive(&primitives);
+    // The size the renderer will rasterize at, untouched by the setting.
+    assert_eq!(text.style.font_size, FONT_SIZE);
+    assert_eq!(
+        text.rect.width,
+        TEXT.chars().count() as f32 * FONT_SIZE,
+        "the block the caller was told about must be the block the glyphs fill"
     );
 }
 

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -1932,6 +1932,85 @@ fn every_store_backend_tells_the_app_rather_than_leaving_it_to_ask() {
     }
 }
 
+/// Every Gradle task that runs `cargo ndk` must declare the directory it writes
+/// as an output.
+///
+/// The `.so` lands in a directory the Android plugin has already been told to
+/// read as `jniLibs`, and the merge/package tasks depend on the cargo task, so
+/// the ordering looks right. It is not enough: a task that writes files outside
+/// its declared outputs leaves Gradle's file-system snapshot of that directory
+/// untouched, so the packaging tasks downstream check a pre-cargo snapshot,
+/// report UP-TO-DATE, and build the APK around the PREVIOUS run's library.
+///
+/// Nothing about that is visible from the build log — it says BUILD SUCCESSFUL
+/// — and nothing is visible on device either, beyond code behaving as it did
+/// one build ago. It costs whole debugging sessions: a fix verified on the host
+/// "does not reproduce" on the phone or the watch, which reads as a
+/// platform-specific defect and sends the search into the framework. Run the
+/// build twice and the symptom evaporates, which makes it look intermittent on
+/// top of that.
+///
+/// `outputs.upToDateWhen { false }` does not cover this. It decides whether the
+/// cargo task itself re-runs; it says nothing about what the task changed.
+#[test]
+fn gradle_cargo_tasks_declare_the_jni_library_directory_they_write() {
+    let gradle_files = [
+        "apps/android-demo/android/app/build.gradle.kts",
+        "apps/isolated-demo/android/app/build.gradle.kts",
+    ];
+
+    for relative in gradle_files {
+        let source = workspace_source(relative);
+        assert!(
+            source.contains("jniLibs.directories.add(\"../target/android\")"),
+            "{relative} should still read the cargo-ndk output directory as jniLibs"
+        );
+
+        let mut checked = 0usize;
+        for task in source.split("tasks.register<Exec>(").skip(1) {
+            let body = task
+                .split("\ntasks.register")
+                .next()
+                .unwrap_or(task)
+                .split("\nafterEvaluate")
+                .next()
+                .unwrap_or(task);
+            if !body.contains("cargo ndk") {
+                continue;
+            }
+            checked += 1;
+            let name = body.split('"').nth(1).unwrap_or("<unnamed>");
+            assert!(
+                body.contains("outputs.dir(rootProject.file(\"target/android\"))"),
+                "{relative}: task {name} runs cargo ndk without declaring \
+                 outputs.dir(rootProject.file(\"target/android\")), so Gradle keeps a stale \
+                 snapshot of the jniLibs directory and the APK ships the previous build's .so"
+            );
+            assert!(
+                body.contains("outputs.upToDateWhen { false }"),
+                "{relative}: task {name} declares an output directory, so it also needs \
+                 outputs.upToDateWhen {{ false }} or Gradle will skip the cargo build whenever \
+                 that directory happens to be unchanged"
+            );
+        }
+        assert!(
+            checked >= 2,
+            "{relative}: expected the debug and release cargo-ndk tasks to be checked, saw {checked}"
+        );
+
+        // `mergeJniLibFolders` collects the source directories and
+        // `mergeNativeLibs` collects the libraries inside them; both read the
+        // directory cargo writes, so both have to wait for it. Wiring only one
+        // is what Gradle reports as an implicit dependency once the output is
+        // declared above.
+        assert!(
+            source.contains("it.name.contains(\"JniLibFolders\")"),
+            "{relative}: the cargo build must be wired to mergeJniLibFolders as well as \
+             mergeNativeLibs -- both consume the directory it writes"
+        );
+    }
+}
+
 fn is_crate_root_source(path: &Path) -> bool {
     let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
         return false;


### PR DESCRIPTION
Two defects found while chasing a text bug that only reproduced on a physical Pixel Watch 3. Neither was the thing being blamed, and one of them is why the other one was blamed.

## 1. The Android build packages the previous run's `.so`

Both demo apps build their Rust with a `cargo ndk` `Exec` task and let the Android plugin collect the library from `target/android` as a jniLibs source directory. The task ordered itself before `mergeNativeLibs` and declared **no outputs**, on the reasoning that Cargo owns incrementality.

Ordering is not the same as telling Gradle what changed. A task that writes files outside its declared outputs leaves Gradle's snapshot of that directory untouched, so the packaging tasks downstream compare against the snapshot taken *before* cargo ran, report `UP-TO-DATE`, and build the APK around the **previous** run's library.

Reproduced downstream, on the app that consumes this scaffolding, by marker string:

| after one `assembleDebug` following a Rust change | marker present? |
| --- | --- |
| `target/android/armeabi-v7a/libcranorbit_wear.so` | yes |
| `lib/armeabi-v7a/libcranorbit_wear.so` inside the APK it produced | **no** |

Nothing about this is visible: the log says `BUILD SUCCESSFUL`, and the only symptom is a device running code one build old. It cost a day — a text wrap fix, committed and installed on a watch, kept drawing the old layout, and the framework's text measurer was blamed. The measurer was exact to five decimal places; the watch was running the build before the fix.

Declaring the directory as the task's output is the whole fix, and it immediately surfaced a second miss Gradle had been quiet about: `mergeJniLibFolders` reads the same directory and was wired to nothing at all. Both merge tasks now wait for the cargo build. `outputs.upToDateWhen { false }` stays and now has to — with an output declared, a task without it would be skipped whenever that directory happened to be unchanged.

## 2. Draw-scope text is measured at the wrong size when the font scale is not 1.0

`DrawScope::measure_text` ran the caller's style through `text::measure_text`, which multiplies every `Sp` size by the system font scale. The rasterizer does no such thing — a scene lowers a text primitive with `text.style.resolved_font_size()` and nothing else. At any font scale other than 1.0, the box a caller was told about and the glyphs that later fill it were out by exactly that factor.

A `DrawTextStyle` is documented as fully resolved, so the scale had nothing to apply to. The damage is all in layout: anything derived from `measure_text` — a wrap, a centred label, a hit rect, a row height — came out scaled while the drawn glyphs did not, so text wrapped early into rows too tall for it and every position downstream shifted. It shows up only where the setting is not 1.0, which is a device somebody else is holding.

The `Text` composable is the other case and is left alone: its style carries real `Sp` sizes and `prepare_text_layout` hands the **scaled** style on to the renderer with the metrics, so both sides move together. That path is what makes the contract legible — whatever the rasterizer is given must already be resolved — and it is why this is fixed on the measuring side rather than by teaching the renderer to scale.

## Tests

Both fixes come with a regression test that fails without them:

- `draw_scope_text_is_measured_at_the_size_the_style_names` — at font scale 2.0, asserts the primitive's rect is the box the renderer will fill (`left: 80.0, right: 40.0` before the fix).
- `gradle_cargo_tasks_declare_the_jni_library_directory_they_write` — asserts every shipped `cargo ndk` task declares `outputs.dir(rootProject.file("target/android"))`, keeps `upToDateWhen { false }` beside it, and that both merge tasks are wired to it.

## Gates

`cargo fmt --check`, `cargo test --profile ci --workspace` (114 suites), `cargo clippy --workspace --all-targets -- -D warnings -A clippy::question_mark`, the iOS-sim clippy pass, the `--no-default-features` builds, `cargo check --workspace --all-features`, and `build-web.sh --release` all pass. `cargo xtask dependency-budget --strict` reports duplicate `objc2*` on macOS on pristine main too — host artifact, it is a Linux-runner gate.

Verified on the physical Pixel Watch 3: the address that had been clipped off both edges of the screen now wraps onto two lines, from a single build and a single install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)