### PR TITLE
Give gradient-free shape draws a fragment stage without the gradients

### DIFF
--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -4553,17 +4553,19 @@ impl GpuRenderer {
         &'a self,
         instanced: &'a InstancedQuadPipelines,
     ) -> &'a wgpu::RenderPipeline {
-        instanced.pipeline_solid.get_or_init(self.adapter_backend, || {
-            create_instanced_shape_pipeline(
-                &self.device,
-                self.surface_format,
-                &self.uniform_bind_group_layout,
-                &self.shape_bind_group_layout,
-                BlendMode::SrcOver,
-                self.shape_batch_limits,
-                "fs_solid",
-            )
-        })
+        instanced
+            .pipeline_solid
+            .get_or_init(self.adapter_backend, || {
+                create_instanced_shape_pipeline(
+                    &self.device,
+                    self.surface_format,
+                    &self.uniform_bind_group_layout,
+                    &self.shape_bind_group_layout,
+                    BlendMode::SrcOver,
+                    self.shape_batch_limits,
+                    "fs_solid",
+                )
+            })
     }
 
     fn image_pipeline(&self, blend_mode: BlendMode) -> &wgpu::RenderPipeline {
@@ -9715,9 +9717,7 @@ impl GpuRenderer {
                 Some(instanced) => {
                     render_pass.set_pipeline(self.instanced_pipeline(instanced, BlendMode::SrcOver))
                 }
-                None if !slot.has_gradient => {
-                    render_pass.set_pipeline(self.shape_pipeline_solid())
-                }
+                None if !slot.has_gradient => render_pass.set_pipeline(self.shape_pipeline_solid()),
                 None => render_pass.set_pipeline(self.shape_pipeline(BlendMode::SrcOver)),
             },
         }
@@ -9842,9 +9842,7 @@ impl GpuRenderer {
                     Some(instanced) => {
                         encoder.set_pipeline(self.instanced_pipeline(instanced, BlendMode::SrcOver))
                     }
-                    None if !slot.has_gradient => {
-                        encoder.set_pipeline(self.shape_pipeline_solid())
-                    }
+                    None if !slot.has_gradient => encoder.set_pipeline(self.shape_pipeline_solid()),
                     None => encoder.set_pipeline(self.shape_pipeline(BlendMode::SrcOver)),
                 },
             }

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -1345,6 +1345,7 @@ fn create_shape_pipeline(
     shape_layout: &wgpu::BindGroupLayout,
     blend_mode: BlendMode,
     batch_limits: ShapeBatchLimits,
+    fragment_entry: &'static str,
 ) -> wgpu::RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("Shape Shader"),
@@ -1370,7 +1371,7 @@ fn create_shape_pipeline(
         },
         fragment: Some(wgpu::FragmentState {
             module: &shader,
-            entry_point: Some("fs_main"),
+            entry_point: Some(fragment_entry),
             compilation_options: wgpu::PipelineCompilationOptions::default(),
             targets: &[Some(wgpu::ColorTargetState {
                 format: surface_format,
@@ -1469,6 +1470,7 @@ fn create_instanced_shape_pipeline(
     shape_layout: &wgpu::BindGroupLayout,
     blend_mode: BlendMode,
     batch_limits: ShapeBatchLimits,
+    fragment_entry: &'static str,
 ) -> wgpu::RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("Shape Instanced Shader"),
@@ -1495,7 +1497,7 @@ fn create_instanced_shape_pipeline(
         },
         fragment: Some(wgpu::FragmentState {
             module: &shader,
-            entry_point: Some("fs_main"),
+            entry_point: Some(fragment_entry),
             compilation_options: wgpu::PipelineCompilationOptions::default(),
             targets: &[Some(wgpu::ColorTargetState {
                 format: surface_format,
@@ -2269,6 +2271,11 @@ struct ReplaySlot {
     /// released and recaptured — new bind group, new buffers, same id — can
     /// never be drawn through a bundle recorded against the old capture.
     capture_epoch: u64,
+    /// Whether any captured shape carries gradient stops. False routes the
+    /// slot's quad-expansion draws through the `fs_solid` pipelines; fixed
+    /// for the life of the capture, so bundle keys need nothing beyond the
+    /// capture epoch they already carry.
+    has_gradient: bool,
 }
 
 /// Vertex geometry a retained slot replays instead of per-shape quads: arc
@@ -2894,6 +2901,10 @@ const INSTANCED_QUAD_INDICES: [u16; 6] = [0, 1, 2, 2, 1, 3];
 struct InstancedQuadPipelines {
     pipeline: LazyGpuResource<wgpu::RenderPipeline>,
     pipeline_dst_out: LazyGpuResource<wgpu::RenderPipeline>,
+    /// `fs_solid` twin of `pipeline` (SrcOver only): chosen for draws whose
+    /// shapes carry no gradient stops, which is nearly every draw of an
+    /// arc-heavy scene.
+    pipeline_solid: LazyGpuResource<wgpu::RenderPipeline>,
     /// Static `[0, 1, 2, 2, 1, 3]` u16 index buffer, created once and shared
     /// by every instanced draw.
     index_buffer: wgpu::Buffer,
@@ -3773,6 +3784,8 @@ pub struct GpuRenderer {
     shape_batch_limits: ShapeBatchLimits,
     pipeline: LazyGpuResource<wgpu::RenderPipeline>,
     pipeline_dst_out: LazyGpuResource<wgpu::RenderPipeline>,
+    /// `fs_solid` twin of `pipeline` (SrcOver only), for gradient-free draws.
+    pipeline_solid: LazyGpuResource<wgpu::RenderPipeline>,
     /// `Some` exactly in storage mode: the retained-mesh pipeline (`vs_mesh`
     /// over a vertex buffer) that replay slots with a captured arc mesh draw
     /// through. Uniform-mode devices never host retained slots.
@@ -4179,6 +4192,7 @@ impl GpuRenderer {
 
         let pipeline = LazyGpuResource::new("shape/src-over");
         let pipeline_dst_out = LazyGpuResource::new("shape/dst-out");
+        let pipeline_solid = LazyGpuResource::new("shape/solid-src-over");
         #[cfg(not(target_arch = "wasm32"))]
         let mesh_pipeline = LazyGpuResource::new("shape/mesh");
         // The instanced-quad selection is LATCHED here, once per renderer:
@@ -4203,6 +4217,7 @@ impl GpuRenderer {
                 InstancedQuadPipelines {
                     pipeline: LazyGpuResource::new("shape/instanced-src-over"),
                     pipeline_dst_out: LazyGpuResource::new("shape/instanced-dst-out"),
+                    pipeline_solid: LazyGpuResource::new("shape/instanced-solid"),
                     index_buffer,
                 }
             });
@@ -4340,6 +4355,7 @@ impl GpuRenderer {
             shape_batch_limits,
             pipeline,
             pipeline_dst_out,
+            pipeline_solid,
             #[cfg(not(target_arch = "wasm32"))]
             mesh_pipeline,
             #[cfg(not(target_arch = "wasm32"))]
@@ -4472,6 +4488,25 @@ impl GpuRenderer {
                 &self.shape_bind_group_layout,
                 blend_mode,
                 self.shape_batch_limits,
+                "fs_main",
+            )
+        })
+    }
+
+    /// The `fs_solid` twin of [`Self::shape_pipeline`], SrcOver only. Callers
+    /// pick it exactly when the draw's shapes carry zero gradient stops; the
+    /// coverage math is byte-identical, the gradient machinery is compiled
+    /// out of the fragment stage.
+    fn shape_pipeline_solid(&self) -> &wgpu::RenderPipeline {
+        self.pipeline_solid.get_or_init(self.adapter_backend, || {
+            create_shape_pipeline(
+                &self.device,
+                self.surface_format,
+                &self.uniform_bind_group_layout,
+                &self.shape_bind_group_layout,
+                BlendMode::SrcOver,
+                self.shape_batch_limits,
+                "fs_solid",
             )
         })
     }
@@ -4507,6 +4542,26 @@ impl GpuRenderer {
                 &self.shape_bind_group_layout,
                 blend_mode,
                 self.shape_batch_limits,
+                "fs_main",
+            )
+        })
+    }
+
+    /// The `fs_solid` twin of [`Self::instanced_pipeline`], SrcOver only.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn instanced_pipeline_solid<'a>(
+        &'a self,
+        instanced: &'a InstancedQuadPipelines,
+    ) -> &'a wgpu::RenderPipeline {
+        instanced.pipeline_solid.get_or_init(self.adapter_backend, || {
+            create_instanced_shape_pipeline(
+                &self.device,
+                self.surface_format,
+                &self.uniform_bind_group_layout,
+                &self.shape_bind_group_layout,
+                BlendMode::SrcOver,
+                self.shape_batch_limits,
+                "fs_solid",
             )
         })
     }
@@ -7137,12 +7192,14 @@ impl GpuRenderer {
                         end,
                         blend_mode,
                     } => {
+                        let mut has_gradient = false;
                         for (_, item) in &ordered_items[start..end] {
-                            if !matches!(item, SegmentDrawItem::Shape(_)) {
+                            let SegmentDrawItem::Shape(shape_index) = item else {
                                 return Err(format!(
                                     "shape batch contains non-shape draw item: {item:?}"
                                 ));
-                            }
+                            };
+                            has_gradient |= shape_gradient_stop_count(&shapes[*shape_index]) > 0;
                         }
                         let shape_count = end - start;
                         if shape_count > 0 {
@@ -7150,6 +7207,7 @@ impl GpuRenderer {
                                 batch: PreparedShapeBatch {
                                     vertex_start: shape_cursor * 6,
                                     vertex_count: shape_count as u32 * 6,
+                                    has_gradient,
                                 },
                                 blend_mode,
                             });
@@ -8970,6 +9028,7 @@ impl GpuRenderer {
         Some(PreparedShapeBatch {
             vertex_start: 0,
             vertex_count: shape_count as u32 * 6,
+            has_gradient: total_gradient_stops > 0,
             #[cfg(target_arch = "wasm32")]
             shape_slot,
             #[cfg(target_arch = "wasm32")]
@@ -9092,6 +9151,7 @@ impl GpuRenderer {
             PreparedShapeBatch {
                 vertex_start: 0,
                 vertex_count: shape_count as u32 * 6,
+                has_gradient: total_gradient_stops > 0,
             },
             upload_base,
         ))
@@ -9567,6 +9627,7 @@ impl GpuRenderer {
                 paint_mirror: paint,
                 mesh,
                 capture_epoch,
+                has_gradient: total_gradient_stops > 0,
             },
         );
         Some(id)
@@ -9648,8 +9709,14 @@ impl GpuRenderer {
         match &mesh {
             Some((_, mesh_pipeline)) => render_pass.set_pipeline(mesh_pipeline),
             None => match &self.instanced_quads {
+                Some(instanced) if !slot.has_gradient => {
+                    render_pass.set_pipeline(self.instanced_pipeline_solid(instanced))
+                }
                 Some(instanced) => {
                     render_pass.set_pipeline(self.instanced_pipeline(instanced, BlendMode::SrcOver))
+                }
+                None if !slot.has_gradient => {
+                    render_pass.set_pipeline(self.shape_pipeline_solid())
                 }
                 None => render_pass.set_pipeline(self.shape_pipeline(BlendMode::SrcOver)),
             },
@@ -9765,9 +9832,18 @@ impl GpuRenderer {
             let mesh = slot.mesh.as_ref().map(|mesh| (mesh, self.mesh_pipeline()));
             match &mesh {
                 Some((_, mesh_pipeline)) => encoder.set_pipeline(mesh_pipeline),
+                // The solid-vs-gradient choice is fixed per capture, and the
+                // op key already carries the capture epoch, so a cached
+                // bundle can never encode a stale pipeline for a slot id.
                 None => match &self.instanced_quads {
+                    Some(instanced) if !slot.has_gradient => {
+                        encoder.set_pipeline(self.instanced_pipeline_solid(instanced))
+                    }
                     Some(instanced) => {
                         encoder.set_pipeline(self.instanced_pipeline(instanced, BlendMode::SrcOver))
+                    }
+                    None if !slot.has_gradient => {
+                        encoder.set_pipeline(self.shape_pipeline_solid())
                     }
                     None => encoder.set_pipeline(self.shape_pipeline(BlendMode::SrcOver)),
                 },
@@ -9892,7 +9968,11 @@ impl GpuRenderer {
                 batch.vertex_start,
                 batch.vertex_count,
             );
-            render_pass.set_pipeline(self.instanced_pipeline(instanced, blend_mode));
+            if blend_mode == BlendMode::SrcOver && !batch.has_gradient {
+                render_pass.set_pipeline(self.instanced_pipeline_solid(instanced));
+            } else {
+                render_pass.set_pipeline(self.instanced_pipeline(instanced, blend_mode));
+            }
             render_pass.set_bind_group(0, uniform_bind_group, &[]);
             // Dynamic offset 0: ordinary batches read the identity
             // similarity transform.
@@ -9904,7 +9984,11 @@ impl GpuRenderer {
             render_pass.draw_indexed(0..6, 0, first_shape..first_shape + shape_count);
             return;
         }
-        render_pass.set_pipeline(self.shape_pipeline(blend_mode));
+        if blend_mode == BlendMode::SrcOver && !batch.has_gradient {
+            render_pass.set_pipeline(self.shape_pipeline_solid());
+        } else {
+            render_pass.set_pipeline(self.shape_pipeline(blend_mode));
+        }
         render_pass.set_bind_group(0, uniform_bind_group, &[]);
         // Dynamic offset 0: ordinary batches read the identity similarity
         // transform.
@@ -12128,6 +12212,9 @@ struct PreparedShapeBatch {
     /// multiples of 6 so `vs_main`'s `vertex_index / 6` lands on whole shapes.
     vertex_start: u32,
     vertex_count: u32,
+    /// Whether any shape in the batch carries gradient stops. False routes
+    /// a SrcOver draw through the `fs_solid` pipeline.
+    has_gradient: bool,
     #[cfg(target_arch = "wasm32")]
     shape_slot: usize,
     #[cfg(target_arch = "wasm32")]

--- a/crates/cranpose-render/wgpu/tests/solid_fs_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/solid_fs_parity.rs
@@ -1,0 +1,202 @@
+//! Pixel parity for the `fs_solid` fragment entry.
+//!
+//! A batch whose shapes carry no gradient stops draws through `fs_solid`,
+//! whose coverage math is copied from `fs_main` line for line. The
+//! `instanced_quad_parity` precedent says textually identical bodies in one
+//! module contract identically on this compiler, so the bar here is ZERO
+//! differing bytes. If a toolchain update ever splits the contraction, this
+//! fails with a handful of ±1 bytes on AA edges — re-measure and pin the
+//! envelope per the `arc_mesh_parity` discipline; anything larger is a real
+//! defect (wrong entry point wiring, a batch misrouted).
+//!
+//! Arm separation is by scene composition, not environment: the solid arm
+//! is the scene as recorded; the mixed arm appends one 8×8 rect painted
+//! with a two-stop, all-transparent linear gradient. Every stop has alpha
+//! zero, so its SrcOver blend leaves every destination byte unchanged —
+//! but its stops flip the batch's `has_gradient`, forcing the WHOLE batch
+//! (the identical solid shapes included) back through `fs_main`. The
+//! primitives are hand-built `DrawRunNode::new` runs with no command id,
+//! so no feed, no retention, no replay slots: every pass renders through
+//! the fresh-batch path, the exact pipeline-selection site under test.
+
+mod support;
+
+use cranpose_render_common::graph::{
+    CachePolicy, DrawRunNode, IsolationReasons, LayerNode, PrimitivePhase, ProjectiveTransform,
+    RenderGraph, RenderNode,
+};
+use cranpose_render_common::raster_cache::LayerRasterCacheHashes;
+use cranpose_render_common::Renderer;
+use cranpose_ui_graphics::{Brush, Color, DrawScope, DrawScopeDefault, GraphicsLayer, Point, Rect};
+
+const SIZE: u32 = 256;
+const CENTER: f32 = 128.0;
+
+/// Solid shapes through all four fragment coverage branches: plain rect,
+/// rounded rect, stroked rect, and arc bands with both cap styles.
+fn record_solid_scene(scope: &mut DrawScopeDefault) {
+    scope.draw_rect_at(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: SIZE as f32,
+            height: SIZE as f32,
+        },
+        Brush::solid(Color(0.02, 0.02, 0.05, 1.0)),
+    );
+    for ring in 0..3u32 {
+        let radius = 40.0 + ring as f32 * 28.0;
+        let count = 48;
+        for i in 0..count {
+            let start = i as f32 * (std::f32::consts::TAU / count as f32) + ring as f32 * 0.11;
+            scope.draw_annular_sector(
+                Brush::solid(Color(0.3, 0.5 + (i % 5) as f32 * 0.08, 0.8, 1.0)),
+                Point::new(CENTER, CENTER),
+                radius - 6.0,
+                radius,
+                start,
+                0.09,
+            );
+        }
+    }
+    for m in 0..7u32 {
+        scope.draw_circle(
+            Brush::solid(Color(1.0, 0.85, 0.4, 0.9)),
+            Point::new(24.0 + m as f32 * 32.0, 20.0),
+            5.5,
+        );
+    }
+    scope.draw_round_rect_at(
+        Rect {
+            x: 30.0,
+            y: 220.0,
+            width: 80.0,
+            height: 24.0,
+        },
+        Brush::solid(Color(0.8, 0.3, 0.4, 1.0)),
+        cranpose_ui_graphics::CornerRadii::uniform(8.0),
+    );
+    scope.draw_rect_at_stroked(
+        Rect {
+            x: 140.0,
+            y: 218.0,
+            width: 84.0,
+            height: 28.0,
+        },
+        Brush::solid(Color(0.4, 0.9, 0.6, 1.0)),
+        cranpose_ui_graphics::Stroke {
+            width: 3.0,
+            ..Default::default()
+        },
+    );
+}
+
+/// The invisible gradient: two stops, both alpha zero. Its SrcOver blend is
+/// `dst + src * 0`, byte-neutral on every pixel it covers, but its stops
+/// force the batch onto `fs_main`.
+fn record_transparent_gradient(scope: &mut DrawScopeDefault) {
+    scope.draw_rect_at(
+        Rect {
+            x: 4.0,
+            y: 120.0,
+            width: 8.0,
+            height: 8.0,
+        },
+        Brush::linear_gradient(vec![Color(1.0, 0.0, 0.0, 0.0), Color(0.0, 1.0, 0.0, 0.0)]),
+    );
+}
+
+fn graph_for(with_gradient: bool) -> RenderGraph {
+    let mut scope =
+        DrawScopeDefault::new(cranpose_ui_graphics::Size::new(SIZE as f32, SIZE as f32));
+    record_solid_scene(&mut scope);
+    if with_gradient {
+        record_transparent_gradient(&mut scope);
+    }
+    let bounds = Rect {
+        x: 0.0,
+        y: 0.0,
+        width: SIZE as f32,
+        height: SIZE as f32,
+    };
+    RenderGraph::new(LayerNode {
+        node_id: None,
+        local_bounds: bounds,
+        transform_to_parent: ProjectiveTransform::identity(),
+        content_offset: Point::default(),
+        motion_context_animated: false,
+        translated_content_context: false,
+        translated_content_offset: Point::default(),
+        scene_children_origin: Point::default(),
+        scene_children_layer_translation: Point::default(),
+        graphics_layer: GraphicsLayer::default(),
+        clip_to_bounds: false,
+        shadow_clip: None,
+        hit_test: None,
+        has_hit_targets: false,
+        isolation: IsolationReasons::default(),
+        cache_policy: CachePolicy::None,
+        cache_hashes: LayerRasterCacheHashes::default(),
+        cache_hashes_valid: false,
+        children: vec![RenderNode::DrawRun(DrawRunNode::new(
+            PrimitivePhase::BeforeChildren,
+            scope.into_primitives(),
+        ))],
+    })
+}
+
+/// Warm pass (never compared — first-render cache warmup renders
+/// differently, the same-position-control trap `command_feed_parity`
+/// documents), then two controls asserted byte-stable; the second control
+/// is the arm's frame.
+fn render_arm(renderer: &mut support::LockedRenderer, graph: &RenderGraph) -> Vec<u8> {
+    let mut passes = Vec::new();
+    for _ in 0..3 {
+        renderer.scene_mut().graph = Some(graph.clone());
+        let captured = renderer
+            .capture_frame(SIZE, SIZE)
+            .unwrap_or_else(|err| panic!("capture failed: {err:?}"));
+        assert_eq!((captured.width, captured.height), (SIZE, SIZE));
+        passes.push(captured.pixels);
+    }
+    assert_eq!(
+        passes[1], passes[2],
+        "same-graph control passes must be byte-stable before the cross-arm compare"
+    );
+    passes.pop().unwrap()
+}
+
+#[test]
+fn solid_fragment_entry_matches_fs_main() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!("skipping solid fs parity: headless WGPU init failed: {err}");
+            return;
+        }
+    };
+
+    let solid = render_arm(&mut renderer, &graph_for(false));
+    let mixed = render_arm(&mut renderer, &graph_for(true));
+
+    assert_eq!(solid.len(), mixed.len());
+    let mut differing = 0usize;
+    let mut beyond_one = 0usize;
+    let mut worst = 0u8;
+    for (a, b) in solid.iter().zip(&mixed) {
+        let diff = a.abs_diff(*b);
+        if diff > 0 {
+            differing += 1;
+            worst = worst.max(diff);
+            if diff > 1 {
+                beyond_one += 1;
+            }
+        }
+    }
+    eprintln!("solid-vs-mixed: differing {differing} (beyond ±1: {beyond_one}) worst {worst}");
+    assert_eq!(
+        differing, 0,
+        "{differing} bytes diverged ({beyond_one} beyond ±1, worst {worst}) — \
+         fs_solid must render solid shapes byte-identically to fs_main"
+    );
+}

--- a/crates/cranpose-ui-graphics/shaders/shape.wgsl
+++ b/crates/cranpose-ui-graphics/shaders/shape.wgsl
@@ -650,3 +650,81 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
 
     return vec4<f32>(color.rgb, color.a * alpha);
 }
+
+// `fs_main` for a draw that is known to contain only solid brushes: the
+// coverage math is copied line for line (same expressions, same order, so
+// the compiler emits the same instructions for the alpha it shares with
+// `fs_main`), and everything downstream of coverage — gradient projection,
+// stop interpolation, tile remapping, dither — is gone. A solid fragment
+// through `fs_main` already takes none of those branches at runtime; what
+// this entry removes is their cost of existing: the register footprint and
+// the gradient-stop indexing the shader core must budget for on every
+// fragment of an arc-heavy scene. The batch chooses this entry only when
+// its gradient stop count is zero, so `brush_type` could only ever be 0
+// here.
+@fragment
+fn fs_solid(input: VertexOutput) -> @location(0) vec4<f32> {
+    let world_pos = input.world_pos;
+    let rect_pos = input.rect.xy + input.uv * input.rect.zw;
+
+    let clip_w = input.clip_rect.z;
+    let clip_h = input.clip_rect.w;
+    if (clip_w > 0.0 && clip_h > 0.0) {
+        let clip_left = input.clip_rect.x;
+        let clip_top = input.clip_rect.y;
+        let clip_right = clip_left + clip_w;
+        let clip_bottom = clip_top + clip_h;
+
+        if (world_pos.x < clip_left || world_pos.x > clip_right ||
+            world_pos.y < clip_top || world_pos.y > clip_bottom) {
+            discard;
+        }
+    }
+
+    let rect_center = input.rect.xy + input.rect.zw * 0.5;
+    let half_size = input.rect.zw * 0.5;
+    let local_pos = rect_pos - rect_center;
+
+    let flags = u32(max(input.stroke_params.y, 0.0));
+    let shape_kind = flags & 3u;
+    let stroke_cap = (flags >> 2u) & 3u;
+    let stroke_join = (flags >> 4u) & 3u;
+
+    let has_radii = (input.radii[0] > 0.0 || input.radii[1] > 0.0 ||
+                     input.radii[2] > 0.0 || input.radii[3] > 0.0);
+    var alpha: f32;
+    if (shape_kind == SHAPE_KIND_ARC) {
+        let dist = sdf_arc_band(
+            rect_pos,
+            input.arc_params.xy,
+            input.stroke_params.w,
+            input.stroke_params.z,
+            input.radii.xy,
+            input.radii.zw,
+            stroke_cap,
+        );
+        alpha = 1.0 - smoothstep(-0.5, 0.5, dist);
+    } else if (shape_kind == SHAPE_KIND_STROKE) {
+        let dist = sdf_stroked_rounded_rect(
+            local_pos,
+            half_size,
+            input.radii,
+            input.stroke_params.x * 0.5,
+            stroke_join,
+        );
+        alpha = 1.0 - smoothstep(-0.5, 0.5, dist);
+    } else if (has_radii) {
+        let dist = sdf_rounded_rect(local_pos, half_size, input.radii);
+        alpha = 1.0 - smoothstep(-0.5, 0.5, dist);
+    } else {
+        let cov_x = clamp(half_size.x + 0.5 - abs(local_pos.x), 0.0, 1.0);
+        let cov_y = clamp(half_size.y + 0.5 - abs(local_pos.y), 0.0, 1.0);
+        alpha = cov_x * cov_y;
+    }
+
+    if (alpha < 0.001) {
+        discard;
+    }
+
+    return vec4<f32>(input.color.rgb, input.color.a * alpha);
+}


### PR DESCRIPTION
MEGA on the Pixel Watch 3 is GPU-bound at dock temperatures, and 15.1k of its 17k per-frame shapes are solid arcs drawn through a fragment shader that budgets registers and gradient-stop indexing for a path they never take.

`fs_solid` copies `fs_main`'s coverage math line for line and ends at the solid return. Batches, fused sub-batches and retained slots select it exactly when their gradient stop count is zero, SrcOver only; a slot's choice is fixed at capture, so cached bundles stay valid under the capture epoch their keys already carry.

**Watch, temp-matched 20 s windows (dock):** 32.38 → **36.80 fps** @ 38.9 °C start (+13.6 %), 24.26 → 24.82 @ ~40 °C, 22.45 → 22.71 @ ~41.4 °C. CPU rose 84.9 → 90.0 % at the cool window — less present-fence blocking, more frames. Mid-window screenshots pixel-correct.

**Exactness:** `solid_fs_parity` pins ZERO differing bytes — the arms are split by scene composition (an 8×8 rect with a two-stop all-transparent linear gradient is SrcOver byte-neutral but forces the whole batch back through `fs_main`), and dimming `fs_solid`'s return makes it fail by 13k bytes, so the selection provably engages.

A second step (trimming the gradient varyings out of the solid pipelines' vertex outputs) measured unstable on the Adreno 702 — the app dies silently once retained slots engage — and is deliberately NOT in this PR; the branch `wip/pipeline-7b-on-wear` history has the reverted attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2