### PR TITLE
Let an app say its live semantics changed, without recomposing

### DIFF
--- a/crates/cranpose-app-shell/src/lib.rs
+++ b/crates/cranpose-app-shell/src/lib.rs
@@ -31,12 +31,12 @@ use cranpose_runtime_std::StdRuntime;
 use cranpose_ui::{
     clear_transient_scroll_motion_contexts, format_layout_tree, format_render_scene,
     format_screen_summary, has_pending_focus_invalidations, has_pending_pointer_repasses,
-    peek_focus_invalidation, peek_layout_invalidation, peek_pointer_invalidation,
-    peek_render_invalidation, process_focus_invalidations, process_pointer_repasses,
-    request_render_invalidation, take_draw_repass_nodes, take_focus_invalidation,
-    take_layout_invalidation, take_pointer_invalidation, take_render_invalidation,
-    HeadlessRenderer, LayoutBox, LayoutNode, LayoutTree, MeasureLayoutOptions, SemanticsTree,
-    SubcomposeLayoutNode,
+    has_pending_semantics_invalidations, peek_focus_invalidation, peek_layout_invalidation,
+    peek_pointer_invalidation, peek_render_invalidation, process_focus_invalidations,
+    process_pointer_repasses, process_semantics_invalidations, request_render_invalidation,
+    take_draw_repass_nodes, take_focus_invalidation, take_layout_invalidation,
+    take_pointer_invalidation, take_render_invalidation, HeadlessRenderer, LayoutBox, LayoutNode,
+    LayoutTree, MeasureLayoutOptions, SemanticsTree, SubcomposeLayoutNode,
 };
 use cranpose_ui_graphics::{Point, Rect, Size};
 use hit_path_tracker::{HitPathTracker, PointerId};
@@ -798,6 +798,13 @@ where
         // composition that wants to render.
         self.has_stale_pixels_in_context()
             || self.composition.runtime_handle().has_pending_ui()
+            // A semantics invalidation is work for the UI thread, not a reason
+            // to repaint: it is serviced by `run_dispatch_queues` and changes no
+            // pixel. It belongs here rather than in `has_stale_pixels_in_context`
+            // so that an app asleep on a still screen still wakes far enough to
+            // republish its tree for a screen reader, without that wake being
+            // counted as a frame the display owes.
+            || has_pending_semantics_invalidations()
             || self.composition.should_render()
     }
 

--- a/crates/cranpose-app-shell/src/shell_frame.rs
+++ b/crates/cranpose-app-shell/src/shell_frame.rs
@@ -406,6 +406,21 @@ where
                 }
             });
         }
+
+        // Process semantics invalidations raised from outside composition.
+        //
+        // Mirrors Compose's `SemanticsModifierNode.invalidateSemantics()`: an
+        // app whose recorder reads state the composition does not observe says
+        // so here, and the flag is bubbled to the root because
+        // `tree_needs_semantics` reads the root alone. Without this a screen
+        // that never relays out — a game drawn on one `Canvas` — publishes its
+        // semantics once and then keeps publishing that same stale tree.
+        if has_pending_semantics_invalidations() {
+            let mut applier = self.composition.applier_mut();
+            process_semantics_invalidations(|node_id| {
+                cranpose_core::bubble_semantics_dirty(&mut *applier, node_id);
+            });
+        }
     }
 
     fn refresh_draw_repasses(&mut self) -> Vec<NodeId> {

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -8817,3 +8817,118 @@ fn a_pointer_inside_a_translated_layer_reports_the_translation() {
          {parent_local:?} / {parent_global:?}"
     );
 }
+
+// A screen that is one `Canvas`: its layout never changes, its frame loop draws
+// rather than recomposes, and its semantics recorder reads app state the
+// composition does not observe. Before `SemanticsRequester` this shape published
+// its tree once — at boot, before there was anything on screen — and then kept
+// republishing that same stale tree for the rest of the process.
+thread_local! {
+    static LIVE_RECORDER_LABEL: RefCell<String> = const { RefCell::new(String::new()) };
+    static LIVE_RECORDER_REQUESTER: RefCell<Option<cranpose_ui::SemanticsRequester>> =
+        const { RefCell::new(None) };
+}
+
+fn live_recorder_label() -> String {
+    LIVE_RECORDER_LABEL.with(|label| label.borrow().clone())
+}
+
+fn set_live_recorder_label(value: &str) {
+    LIVE_RECORDER_LABEL.with(|label| *label.borrow_mut() = value.to_string());
+}
+
+#[composable]
+fn live_recorder_content() {
+    let requester =
+        cranpose_core::remember(cranpose_ui::SemanticsRequester::new).with(Clone::clone);
+    LIVE_RECORDER_REQUESTER.with(|slot| *slot.borrow_mut() = Some(requester.clone()));
+    Box(
+        Modifier::empty()
+            .size(Size {
+                width: 100.0,
+                height: 100.0,
+            })
+            .semantics_requester(&requester)
+            .semantics(|config| {
+                config.content_description = Some(live_recorder_label());
+            }),
+        BoxSpec::default(),
+        || {},
+    );
+}
+
+#[test]
+fn a_live_semantics_recorder_is_stale_until_its_requester_says_otherwise() {
+    let _guard = test_guard();
+    set_live_recorder_label("boot");
+    LIVE_RECORDER_REQUESTER.with(|slot| *slot.borrow_mut() = None);
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(TestRenderer::default(), root_key, live_recorder_content);
+    shell.set_semantics_enabled(true);
+    shell.process_frame();
+    assert_eq!(
+        shell.semantics_tree().map(semantics_tree_descriptions),
+        Some(vec!["boot".to_string()]),
+        "the first collection publishes what the recorder reported"
+    );
+
+    // The app's own state moved. Nothing recomposed and nothing relaid out, so
+    // without a request the framework has no way to know, and must not guess.
+    set_live_recorder_label("settings");
+    for _ in 0..3 {
+        shell.process_frame();
+    }
+    assert_eq!(
+        shell.semantics_tree().map(semantics_tree_descriptions),
+        Some(vec!["boot".to_string()]),
+        "an unrequested change must not cost a re-collection every frame"
+    );
+
+    // The app says so, and the very next frame republishes.
+    LIVE_RECORDER_REQUESTER.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .expect("the requester is bound during composition")
+            .invalidate()
+    });
+    shell.process_frame();
+    assert_eq!(
+        shell.semantics_tree().map(semantics_tree_descriptions),
+        Some(vec!["settings".to_string()]),
+        "invalidate() must republish without a recomposition or a layout pass"
+    );
+}
+
+#[test]
+fn a_pending_semantics_request_wakes_the_shell_without_dirtying_a_pixel() {
+    let _guard = test_guard();
+    set_live_recorder_label("boot");
+    LIVE_RECORDER_REQUESTER.with(|slot| *slot.borrow_mut() = None);
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(TestRenderer::default(), root_key, live_recorder_content);
+    shell.set_semantics_enabled(true);
+    shell.process_frame();
+    let _ = shell.semantics_tree();
+    while shell.needs_update() {
+        shell.update();
+    }
+    assert!(
+        !shell.needs_redraw(),
+        "the fixture must settle before the request is raised"
+    );
+
+    LIVE_RECORDER_REQUESTER.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .expect("the requester is bound during composition")
+            .invalidate()
+    });
+    assert!(
+        shell.needs_update(),
+        "a queued semantics request is work the UI thread owes"
+    );
+    assert!(
+        !shell.needs_redraw(),
+        "...but it changes no pixel, so it must not schedule a frame"
+    );
+}

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -28,6 +28,7 @@ pub mod round_scaling_list;
 pub mod round_scroll_indicator;
 pub mod safe_area;
 pub mod scroll;
+mod semantics_dispatch;
 mod subcompose_layout;
 pub mod text;
 pub mod text_field_focus;
@@ -105,8 +106,8 @@ pub use modifier::{
     FocusDirection, FocusRequester, GlassMaterial, GraphicsLayer, LayerShape, Modifier,
     ModifierNodeSlices, ModifierNodeSlicesDebugStats, Point, PointerEvent, PointerEventKind,
     PointerInputScope, PointerSource, Rect, RenderEffect, ResolvedBackground, ResolvedModifiers,
-    RotaryInputModifierNode, RotaryScrollEvent, RoundedCornerShape, RuntimeShader, Shadow,
-    ShadowScope, Size, TransformOrigin,
+    RotaryInputModifierNode, RotaryScrollEvent, RoundedCornerShape, RuntimeShader,
+    SemanticsRequester, Shadow, ShadowScope, Size, TransformOrigin,
 };
 pub use modifier_nodes::{
     AlphaElement, AlphaNode, BackgroundElement, BackgroundNode, ClickableElement, ClickableNode,
@@ -147,6 +148,10 @@ pub use render_state::{
 };
 pub use renderer::{HeadlessRenderer, PaintLayer, RecordedRenderScene, RenderOp};
 pub use scroll::{ScrollElement, ScrollNode, ScrollSettlePolicy, ScrollState};
+pub use semantics_dispatch::{
+    clear_semantics_invalidations, has_pending_semantics_invalidations,
+    process_semantics_invalidations, schedule_semantics_invalidation,
+};
 pub use zoom::ZoomState;
 // Test utilities for fling velocity verification (only with test-helpers feature)
 #[cfg(feature = "test-helpers")]

--- a/crates/cranpose-ui/src/modifier/mod.rs
+++ b/crates/cranpose-ui/src/modifier/mod.rs
@@ -62,7 +62,10 @@ pub use local::{ModifierLocalKey, ModifierLocalReadScope};
 #[allow(unused_imports)]
 pub use pointer_input::{AwaitPointerEventScope, PointerInputScope};
 pub use rotary_input::RotaryInputModifierNode;
-pub use semantics::{collect_semantics_from_chain, collect_semantics_from_modifier};
+pub use semantics::{
+    collect_semantics_from_chain, collect_semantics_from_modifier, SemanticsRequester,
+    SemanticsRequesterElement,
+};
 pub use slices::{
     collect_modifier_slices, collect_modifier_slices_into, collect_slices_from_modifier,
     ModifierNodeSlices, ModifierNodeSlicesDebugStats,
@@ -522,6 +525,19 @@ impl Modifier {
     /// this component from application code.
     pub fn focus_requester(self, requester: &FocusRequester) -> Self {
         let element = FocusRequesterElement::new(requester.token());
+        let modifier = Modifier::from_parts(vec![modifier_element(element)]);
+        self.then(modifier)
+    }
+
+    /// Binds a [`SemanticsRequester`] to this node, so an app can mark the
+    /// node's semantics for re-collection without recomposing or laying out.
+    ///
+    /// Pair it with [`semantics`](Self::semantics) on the same node when the
+    /// recorder reads state the composition does not observe — app state behind
+    /// a `RefCell`, a game's own model — which is the case a recorder cannot
+    /// signal for itself.
+    pub fn semantics_requester(self, requester: &SemanticsRequester) -> Self {
+        let element = SemanticsRequesterElement::new(requester.clone());
         let modifier = Modifier::from_parts(vec![modifier_element(element)]);
         self.then(modifier)
     }

--- a/crates/cranpose-ui/src/modifier/semantics.rs
+++ b/crates/cranpose-ui/src/modifier/semantics.rs
@@ -1,13 +1,114 @@
+use std::cell::Cell;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 
+use cranpose_core::NodeId;
 use cranpose_foundation::{
-    DelegatableNode, ModifierNode, ModifierNodeChain, ModifierNodeElement, NodeCapabilities,
-    NodeState, SemanticsConfiguration, SemanticsNode as SemanticsNodeTrait,
+    DelegatableNode, ModifierNode, ModifierNodeChain, ModifierNodeContext, ModifierNodeElement,
+    NodeCapabilities, NodeState, SemanticsConfiguration, SemanticsNode as SemanticsNodeTrait,
 };
 
 use super::{Modifier, ModifierChainHandle};
+use crate::render_state::AppContextId;
+
+/// A handle an app holds to say that what its semantics recorder would report
+/// has changed.
+///
+/// A `.semantics()` recorder is re-run on every collection, so it always reports
+/// the app's current answer. It cannot say *when* that answer changed, and a
+/// tree is only re-collected when some node marks its semantics dirty — which
+/// until now meant attaching a node, rebuilding its modifier chain, or a layout
+/// pass. A screen that is one `Canvas` does none of those: its layout never
+/// changes and its frame loop draws rather than recomposes, so the tree it
+/// published at boot was the tree a screen reader kept reading.
+///
+/// This is the way out, and it is Jetpack Compose's:
+/// `SemanticsModifierNode.invalidateSemantics()`. Remember one requester, hang
+/// it on the same node as the recorder, and call [`invalidate`] when the content
+/// changes — no recomposition, no layout pass.
+///
+/// ```ignore
+/// let semantics = remember(SemanticsRequester::new).with(Clone::clone);
+/// // ... in the composition:
+/// Modifier::empty()
+///     .semantics_requester(&semantics)
+///     .semantics(move |config| { /* reads live app state */ })
+/// // ... and in the frame loop, guarded by a revision so an unchanged tree is
+/// // not republished every frame:
+/// if revision != last_revision {
+///     last_revision = revision;
+///     semantics.invalidate();
+/// }
+/// ```
+///
+/// [`invalidate`]: SemanticsRequester::invalidate
+#[derive(Clone, Default)]
+pub struct SemanticsRequester {
+    /// Which node, in which app context, the recorder is attached to — learned
+    /// at attach time, because that is when a modifier node is told either.
+    ///
+    /// Shared rather than copied so that a requester cloned into a frame loop
+    /// before the first composition still learns the node when one attaches.
+    /// The app context is carried alongside the node so that `invalidate` can be
+    /// called from a frame loop or an event callback that is inside no context
+    /// at all, and still reach the right queue rather than a neighbour's.
+    binding: Rc<Cell<Option<SemanticsBinding>>>,
+}
+
+#[derive(Clone, Copy)]
+struct SemanticsBinding {
+    app_context: AppContextId,
+    node_id: NodeId,
+}
+
+impl SemanticsRequester {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Marks the attached node's semantics for re-collection on the next frame.
+    ///
+    /// Idempotent within a frame and cheap: the node joins a set the shell
+    /// drains once per frame. Before the node attaches, and after it detaches,
+    /// this does nothing — there is no tree to mark.
+    pub fn invalidate(&self) {
+        if let Some(binding) = self.binding.get() {
+            crate::semantics_dispatch::schedule_semantics_invalidation_in(
+                binding.app_context,
+                binding.node_id,
+            );
+        }
+    }
+
+    /// The layout node this requester is bound to, if it is attached.
+    pub fn node_id(&self) -> Option<NodeId> {
+        self.binding.get().map(|binding| binding.node_id)
+    }
+
+    fn bind(&self, binding: Option<SemanticsBinding>) {
+        self.binding.set(binding);
+    }
+
+    /// The binding for the node and context this call is running inside.
+    ///
+    /// `None` when either is unknown, which is the honest answer for a node the
+    /// applier has not given an id: a request naming no node cannot be serviced.
+    fn binding_here(node_id: Option<NodeId>) -> Option<SemanticsBinding> {
+        Some(SemanticsBinding {
+            app_context: crate::render_state::current_app_context_id_opt()?,
+            node_id: node_id?,
+        })
+    }
+}
+
+impl fmt::Debug for SemanticsRequester {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SemanticsRequester")
+            .field("node_id", &self.node_id())
+            .finish()
+    }
+}
 
 pub struct SemanticsModifierNode {
     recorder: Rc<dyn Fn(&mut SemanticsConfiguration)>,
@@ -36,6 +137,106 @@ impl ModifierNode for SemanticsModifierNode {
 
     fn as_semantics_node_mut(&mut self) -> Option<&mut dyn SemanticsNodeTrait> {
         Some(self)
+    }
+}
+
+/// Binds a [`SemanticsRequester`] to the layout node it is attached to.
+///
+/// Carries no capability of its own: it neither records semantics nor takes part
+/// in any pass. All it does is learn the node id, which a modifier node is only
+/// told at attach time.
+pub struct SemanticsRequesterNode {
+    state: NodeState,
+    requester: SemanticsRequester,
+}
+
+impl SemanticsRequesterNode {
+    pub(crate) fn new(requester: SemanticsRequester) -> Self {
+        Self {
+            state: NodeState::new(),
+            requester,
+        }
+    }
+}
+
+impl DelegatableNode for SemanticsRequesterNode {
+    fn node_state(&self) -> &NodeState {
+        &self.state
+    }
+}
+
+impl ModifierNode for SemanticsRequesterNode {
+    fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
+        self.state.set_attached(true);
+        self.requester
+            .bind(SemanticsRequester::binding_here(context.node_id()));
+    }
+
+    fn on_detach(&mut self) {
+        self.state.set_attached(false);
+        // Requests raised after this point would name a node that is gone, and
+        // the queue is keyed by node id, so unbind rather than leave a stale one.
+        self.requester.bind(None);
+    }
+}
+
+/// Modifier element for [`SemanticsRequester`].
+#[derive(Clone)]
+pub struct SemanticsRequesterElement {
+    requester: SemanticsRequester,
+}
+
+impl SemanticsRequesterElement {
+    pub(crate) fn new(requester: SemanticsRequester) -> Self {
+        Self { requester }
+    }
+}
+
+impl fmt::Debug for SemanticsRequesterElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SemanticsRequesterElement")
+    }
+}
+
+impl PartialEq for SemanticsRequesterElement {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.requester.binding, &other.requester.binding)
+    }
+}
+
+impl Eq for SemanticsRequesterElement {}
+
+impl Hash for SemanticsRequesterElement {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Rc::as_ptr(&self.requester.binding).hash(state);
+    }
+}
+
+impl ModifierNodeElement for SemanticsRequesterElement {
+    type Node = SemanticsRequesterNode;
+
+    fn create(&self) -> Self::Node {
+        SemanticsRequesterNode::new(self.requester.clone())
+    }
+
+    fn update(&self, node: &mut Self::Node) {
+        // A recomposition that hands over a different requester moves the
+        // binding with it: the old one must stop naming this node, and the new
+        // one must start.
+        if !Rc::ptr_eq(&node.requester.binding, &self.requester.binding) {
+            let bound = node.requester.binding.get();
+            node.requester.bind(None);
+            node.requester = self.requester.clone();
+            node.requester.bind(bound);
+        }
+    }
+
+    fn inspector_name(&self) -> &'static str {
+        "semanticsRequester"
+    }
+
+    fn capabilities(&self) -> NodeCapabilities {
+        NodeCapabilities::NONE
     }
 }
 

--- a/crates/cranpose-ui/src/render_state.rs
+++ b/crates/cranpose-ui/src/render_state.rs
@@ -42,6 +42,7 @@ pub struct AppContext {
     layout_node_registry: crate::widgets::nodes::layout_node::LayoutNodeRegistryState,
     pointer_dispatch: crate::pointer_dispatch::PointerDispatchState,
     focus_dispatch: crate::focus_dispatch::FocusInvalidationState,
+    semantics_dispatch: crate::semantics_dispatch::SemanticsInvalidationState,
     cursor_animation: crate::cursor_animation::CursorAnimationState,
     text_field_focus: crate::text_field_focus::TextFieldFocusState,
     text_input_session: crate::text_input_session::PlatformTextInputState,
@@ -164,6 +165,7 @@ impl AppContext {
             ),
             pointer_dispatch: crate::pointer_dispatch::PointerDispatchState::new(),
             focus_dispatch: crate::focus_dispatch::FocusInvalidationState::new(),
+            semantics_dispatch: crate::semantics_dispatch::SemanticsInvalidationState::new(),
             cursor_animation: crate::cursor_animation::CursorAnimationState::new(),
             text_field_focus: crate::text_field_focus::TextFieldFocusState::new(),
             text_input_session: crate::text_input_session::PlatformTextInputState::new(),
@@ -456,6 +458,33 @@ pub(crate) fn with_focus_dispatch<R>(
 ) -> R {
     let context = require_current_app_context("focus dispatch access");
     f(&context.focus_dispatch)
+}
+
+pub(crate) fn with_semantics_dispatch<R>(
+    f: impl FnOnce(&crate::semantics_dispatch::SemanticsInvalidationState) -> R,
+) -> R {
+    let context = require_current_app_context("semantics dispatch access");
+    f(&context.semantics_dispatch)
+}
+
+/// Runs `f` against the semantics queue of the app context `id` names.
+///
+/// Addressed by id rather than by whatever context happens to be current,
+/// because the caller is an app's own frame loop or an event callback, which may
+/// well be outside any context — and because the answer must be the queue the
+/// node actually belongs to, never a neighbouring app's. A context that is gone
+/// drops the request instead of panicking: shutdown order is not something a
+/// requester holder can see.
+pub(crate) fn with_semantics_dispatch_by_app_context(
+    id: AppContextId,
+    f: impl FnOnce(&crate::semantics_dispatch::SemanticsInvalidationState),
+) {
+    with_app_context_by_id(id, |context| f(&context.semantics_dispatch));
+}
+
+/// The identity of the current app context, or `None` outside one.
+pub(crate) fn current_app_context_id_opt() -> Option<AppContextId> {
+    current_app_context().map(|context| context.id)
 }
 
 pub(crate) fn with_cursor_animation<R>(

--- a/crates/cranpose-ui/src/semantics_dispatch.rs
+++ b/crates/cranpose-ui/src/semantics_dispatch.rs
@@ -1,0 +1,202 @@
+//! Semantics invalidations raised from outside composition.
+//!
+//! A `.semantics()` recorder is re-run whenever the tree is collected, so a
+//! recorder that reads live app state always reports the app's current answer.
+//! What it could not do until now is say *when* that answer changed: the tree is
+//! only re-collected when a node marks its semantics dirty, and the only things
+//! that did so were attaching a node, updating its modifier chain (which needs a
+//! recomposition) and a layout pass.
+//!
+//! An app whose screen is one `Canvas` has none of those. Its layout never
+//! changes and its frame loop drives draws rather than recompositions, so the
+//! semantics tree was published once — at boot, before there was anything on
+//! screen — and never again. Every later screen inherited whatever the tree
+//! happened to hold at the last pass, which for a screen reader means reading
+//! out controls the user is no longer looking at.
+//!
+//! This is the missing half, and it mirrors Jetpack Compose's
+//! `SemanticsModifierNode.invalidateSemantics()`: a node can be marked for
+//! re-collection directly, with no recomposition and no layout pass. The queue
+//! is drained by the app shell each frame with the applier in hand, which is
+//! where the dirty flag can actually be bubbled to the root that
+//! [`crate::tree_needs_semantics`] reads.
+//!
+//! Structured like [`crate::focus_dispatch`], for the same reason: the request
+//! arrives on the app's own thread at an arbitrary moment, and the tree may only
+//! be touched at a defined point in the frame.
+
+use cranpose_core::NodeId;
+use std::cell::RefCell;
+use std::collections::HashSet;
+
+/// Layout nodes whose semantics need re-collecting.
+struct SemanticsInvalidationManager {
+    dirty_nodes: HashSet<NodeId>,
+    is_processing: bool,
+}
+
+impl SemanticsInvalidationManager {
+    fn new() -> Self {
+        Self {
+            dirty_nodes: HashSet::new(),
+            is_processing: false,
+        }
+    }
+
+    fn schedule_invalidation(&mut self, node_id: NodeId) {
+        self.dirty_nodes.insert(node_id);
+    }
+
+    fn has_pending_invalidation(&self) -> bool {
+        !self.dirty_nodes.is_empty()
+    }
+
+    fn take_pending_for_processing(&mut self) -> Option<Vec<NodeId>> {
+        if self.is_processing {
+            return None;
+        }
+
+        self.is_processing = true;
+        Some(self.dirty_nodes.drain().collect())
+    }
+
+    fn finish_processing<I>(&mut self, remaining: I)
+    where
+        I: IntoIterator<Item = NodeId>,
+    {
+        self.dirty_nodes.extend(remaining);
+        self.is_processing = false;
+    }
+
+    fn clear(&mut self) {
+        self.dirty_nodes.clear();
+    }
+}
+
+pub(crate) struct SemanticsInvalidationState {
+    manager: RefCell<SemanticsInvalidationManager>,
+}
+
+impl SemanticsInvalidationState {
+    pub(crate) fn new() -> Self {
+        Self {
+            manager: RefCell::new(SemanticsInvalidationManager::new()),
+        }
+    }
+
+    fn schedule_invalidation(&self, node_id: NodeId) {
+        self.manager.borrow_mut().schedule_invalidation(node_id);
+    }
+
+    fn has_pending_invalidation(&self) -> bool {
+        self.manager.borrow().has_pending_invalidation()
+    }
+
+    fn process_invalidations<F>(&self, processor: F)
+    where
+        F: FnMut(NodeId),
+    {
+        let Some(nodes) = self.manager.borrow_mut().take_pending_for_processing() else {
+            return;
+        };
+
+        self.process_pending_nodes(nodes, processor);
+    }
+
+    fn clear(&self) {
+        self.manager.borrow_mut().clear();
+    }
+
+    fn process_pending_nodes<F>(&self, nodes: Vec<NodeId>, mut processor: F)
+    where
+        F: FnMut(NodeId),
+    {
+        let mut remaining = nodes.into_iter();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            for node_id in remaining.by_ref() {
+                processor(node_id);
+            }
+        }));
+
+        self.manager.borrow_mut().finish_processing(remaining);
+
+        if let Err(payload) = result {
+            std::panic::resume_unwind(payload);
+        }
+    }
+}
+
+/// Marks `node_id`'s semantics for re-collection on the next frame of the app
+/// context that is current.
+///
+/// [`crate::SemanticsRequester::invalidate`] uses the by-id form instead: it
+/// remembers the context its node attached in, so a request raised from a frame
+/// loop or an event callback outside any context still reaches the right queue.
+pub fn schedule_semantics_invalidation(node_id: NodeId) {
+    crate::render_state::with_semantics_dispatch(|state| {
+        state.schedule_invalidation(node_id);
+    });
+}
+
+pub(crate) fn schedule_semantics_invalidation_in(
+    app_context: crate::render_state::AppContextId,
+    node_id: NodeId,
+) {
+    crate::render_state::with_semantics_dispatch_by_app_context(app_context, |state| {
+        state.schedule_invalidation(node_id);
+    });
+}
+
+/// Whether any semantics invalidations are waiting to be serviced.
+pub fn has_pending_semantics_invalidations() -> bool {
+    crate::render_state::with_semantics_dispatch(|state| state.has_pending_invalidation())
+}
+
+/// Services every pending semantics invalidation.
+///
+/// The host calls this once per frame with the applier available, and bubbles
+/// the dirty flag from each node to the root.
+pub fn process_semantics_invalidations<F>(processor: F)
+where
+    F: FnMut(NodeId),
+{
+    crate::render_state::with_semantics_dispatch(|state| state.process_invalidations(processor));
+}
+
+/// Drops every pending semantics invalidation without servicing it.
+pub fn clear_semantics_invalidations() {
+    crate::render_state::with_semantics_dispatch(|state| state.clear());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_scheduled_node_is_handed_to_the_processor_once() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        clear_semantics_invalidations();
+
+        schedule_semantics_invalidation(7);
+        schedule_semantics_invalidation(7);
+        schedule_semantics_invalidation(9);
+        assert!(has_pending_semantics_invalidations());
+
+        let mut seen = Vec::new();
+        process_semantics_invalidations(|node_id| seen.push(node_id));
+        seen.sort_unstable();
+        assert_eq!(seen, vec![7, 9]);
+        assert!(!has_pending_semantics_invalidations());
+    }
+
+    #[test]
+    fn nothing_is_pending_until_something_asks() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        clear_semantics_invalidations();
+        assert!(!has_pending_semantics_invalidations());
+
+        let mut seen = 0;
+        process_semantics_invalidations(|_| seen += 1);
+        assert_eq!(seen, 0);
+    }
+}


### PR DESCRIPTION
A semantics tree is re-collected on node attach, on a modifier-chain
rebuild, or on a layout pass. An app that is one long-lived `Canvas` has
none of those: it publishes once, at attach, when its tree is still empty,
and never again. cranorbit is exactly that shape, and its screen reader
saw nothing on Title, Settings or Credits until something unrelated forced
a layout — its arena worked only by accident, because starting a run flips
the keep-screen-on flag.

Recomposition was not the missing piece. `SemanticsElement::always_update()`
is already `true`, so `needs_update` holds whatever `eq` returns and a
recomposition does republish correctly. The app simply never recomposes
that scope, by design — it builds the pointer-input handler and the whole
content lambda — and nothing else could mark the node.

So this adds the half Compose already has. `SemanticsRequester` is a handle
hung on the node with `.semantics_requester()`; `invalidate()` marks it for
re-collection with no recomposition and no layout pass. It is shaped like
`FocusRequester`, queued like `focus_dispatch`, and drained in
`run_dispatch_queues`, where the applier is in hand.

Two details worth the review's attention. The requester remembers the app
context as well as the node, because callers are frame loops that run
inside no context. And a pending request goes in `needs_ui_update_in_context`
rather than `has_stale_pixels_in_context`: it must wake a sleeping app
without counting as a frame the display is owed.

Verified on a Wear emulator from cold launch, with an accessibility dump
rather than a unit test: Title went from one bare `View` with no
description to a screen node plus four RadioButtons with the selected one
marked; Settings from nothing to its header and three switches with the
right checked state; and going back to Title no longer leaves Settings'
switches in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)