### PR TITLE
Kern with the table the platform font actually carries

### DIFF
--- a/crates/cranpose-render/common/src/gpos_kerning.rs
+++ b/crates/cranpose-render/common/src/gpos_kerning.rs
@@ -1,0 +1,695 @@
+//! Pair kerning read out of a font's `GPOS` table.
+//!
+//! `ab_glyph`'s `kern()` reads the TrueType `kern` table and nothing else. Neither
+//! font this framework actually draws with has one: Android's
+//! `/system/fonts/Roboto-Regular.ttf` carries its pair kerning in `GPOS` only,
+//! and so does the embedded `NotoSansMerged` fallback. Every string Cranpose
+//! measured or drew was therefore unkerned while the platform's own text stack
+//! kerned it — `LY` by −239 font units, `To` by −99, `AV` by −87 on Roboto.
+//!
+//! This reads the `kern` feature's pair-adjustment lookups directly, because
+//! that is the whole of the defect. It is deliberately *not* a shaper: no glyph
+//! substitution, no mark attachment, no cursive joining, no script-aware
+//! reordering. Those are `GSUB`, `mark`/`mkmk` and `curs`, and adopting them
+//! means adopting a shaping engine. What is implemented here is the one thing
+//! the measurement named, and the boundary is stated in
+//! [`GposKerning::parse`].
+//!
+//! Two behaviours are copied from HarfBuzz rather than from the OpenType prose,
+//! because HarfBuzz is what Android runs and therefore what fonts are compiled
+//! against:
+//!
+//! * a `PairPosFormat1` value record's device offset is measured from its
+//!   `PairSet`, not from the subtable. The specification says subtable; every
+//!   `VariationIndex` in Roboto only resolves with `PairSet`, so the ambiguity
+//!   is settled by the font.
+//! * within one lookup the first subtable that covers a pair wins and the rest
+//!   are skipped — including when the value it found is zero. Separate lookups
+//!   accumulate. Dropping zero-valued pairs would let a later subtable answer
+//!   for a pair an earlier one deliberately pinned at zero.
+
+use std::sync::Arc;
+
+use ab_glyph::{v2, CodepointIdIter, Font, FontArc, GlyphId, GlyphSvg, Outline};
+use ttf_parser::{Face, NormalizedCoordinate, Tag};
+
+/// `ValueRecord` field flags, in the order the fields appear in the record.
+const VALUE_FIELDS: [u16; 8] = [
+    0x0001, // XPlacement
+    0x0002, // YPlacement
+    0x0004, // XAdvance
+    0x0008, // YAdvance
+    0x0010, // XPlacementDevice
+    0x0020, // YPlacementDevice
+    0x0040, // XAdvanceDevice
+    0x0080, // YAdvanceDevice
+];
+const X_ADVANCE: u16 = 0x0004;
+const X_ADVANCE_DEVICE: u16 = 0x0040;
+
+/// `deltaFormat` of a `VariationIndex` table, as opposed to a `Device` table.
+const VARIATION_INDEX: u16 = 0x8000;
+
+/// A lookup's worth of pair-adjustment subtables, in application order.
+#[derive(Debug, Clone)]
+struct PairLookup {
+    subtables: Vec<PairSubtable>,
+}
+
+#[derive(Debug, Clone)]
+enum PairSubtable {
+    /// `PairPosFormat1` — an explicit list of pairs.
+    Specific {
+        /// `(first << 16 | second) -> x advance`, sorted by key.
+        pairs: Vec<(u32, f32)>,
+    },
+    /// `PairPosFormat2` — a class matrix gated by the first glyph's coverage.
+    Class {
+        /// First glyphs the subtable applies to, ascending.
+        coverage: Vec<u16>,
+        first: ClassDef,
+        second: ClassDef,
+        second_count: u16,
+        /// `first_count * second_count` x advances, row-major.
+        matrix: Vec<f32>,
+    },
+}
+
+/// A class definition flattened to ascending, non-overlapping ranges.
+#[derive(Debug, Clone, Default)]
+struct ClassDef {
+    ranges: Vec<(u16, u16, u16)>,
+}
+
+impl ClassDef {
+    fn class_of(&self, glyph: u16) -> u16 {
+        match self.ranges.binary_search_by(|(start, end, _)| {
+            if glyph < *start {
+                std::cmp::Ordering::Greater
+            } else if glyph > *end {
+                std::cmp::Ordering::Less
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        }) {
+            Ok(index) => self.ranges[index].2,
+            Err(_) => 0,
+        }
+    }
+
+    /// Collapse a glyph-to-class map into ascending runs of equal class.
+    ///
+    /// Class 0 is the default for anything not listed, so runs of it are
+    /// dropped rather than stored.
+    fn from_pairs(mut pairs: Vec<(u16, u16)>) -> Self {
+        pairs.sort_unstable();
+        let mut ranges: Vec<(u16, u16, u16)> = Vec::new();
+        for (glyph, class) in pairs {
+            if class == 0 {
+                continue;
+            }
+            match ranges.last_mut() {
+                Some((_, end, last_class))
+                    if *last_class == class && glyph == end.saturating_add(1) =>
+                {
+                    *end = glyph;
+                }
+                _ => ranges.push((glyph, glyph, class)),
+            }
+        }
+        Self { ranges }
+    }
+}
+
+/// Every `kern`-feature pair adjustment in a face, resolved for one instance.
+///
+/// "One instance" is load-bearing: on a variable face the values carry
+/// `VariationIndex` deltas, and Roboto's are worth up to 136 font units at the
+/// weights a Wear app asks for. They are resolved once here against the face's
+/// normalized coordinates, so a query is a lookup rather than a delta
+/// evaluation — and two instances of one file get two tables, which is already
+/// how the rest of the font cache treats them.
+#[derive(Debug, Clone, Default)]
+pub struct GposKerning {
+    lookups: Vec<PairLookup>,
+}
+
+impl GposKerning {
+    /// Reads the `kern` feature's pair adjustments out of `face`.
+    ///
+    /// Returns `None` when the face has no `GPOS`, no `kern` feature, or no
+    /// pair-adjustment lookup under it — all of which mean "nothing to add",
+    /// not "something went wrong".
+    ///
+    /// **Feature selection is the union over every script's default language
+    /// system**, rather than the script of the run being measured. HarfBuzz
+    /// picks one script per run, which needs the run's script, which needs
+    /// itemization — the first piece of a shaper. The union is safe in
+    /// practice because a lookup can only fire on a pair it covers, and it is
+    /// exact for the fonts in play: Roboto lists the identical feature set
+    /// under `DFLT`, `latn`, `cyrl` and `grek`. A face that kerned one script
+    /// differently from another through *different* `kern` lookups would need
+    /// the real thing; nothing here does.
+    ///
+    /// Language-specific systems are ignored for the same reason, and so is
+    /// `lookupFlag`: its glyph filters (`IgnoreMarks`, mark attachment classes)
+    /// only bite on runs with marks in them, which is again shaping.
+    pub fn parse(face: &Face<'_>) -> Option<Self> {
+        let gpos = face.raw_face().table(Tag::from_bytes(b"GPOS"))?;
+        let coordinates = face.variation_coordinates();
+        let gdef = face.tables().gdef;
+
+        let script_list = u16_at(gpos, 4)? as usize;
+        let feature_list = u16_at(gpos, 6)? as usize;
+        let lookup_list = u16_at(gpos, 8)? as usize;
+
+        let feature_indices = kern_feature_indices(gpos, script_list, feature_list)?;
+        let mut lookup_indices = Vec::new();
+        for index in feature_indices {
+            for lookup in feature_lookups(gpos, feature_list, index)? {
+                if !lookup_indices.contains(&lookup) {
+                    lookup_indices.push(lookup);
+                }
+            }
+        }
+        lookup_indices.sort_unstable();
+
+        let mut lookups = Vec::new();
+        for index in lookup_indices {
+            let Some(subtables) = pair_lookup(gpos, lookup_list, index, gdef, coordinates) else {
+                continue;
+            };
+            if !subtables.is_empty() {
+                lookups.push(PairLookup { subtables });
+            }
+        }
+
+        (!lookups.is_empty()).then_some(Self { lookups })
+    }
+
+    /// The pair adjustment for `first` followed by `second`, in font units.
+    pub fn kern_unscaled(&self, first: u16, second: u16) -> f32 {
+        let mut total = 0.0;
+        for lookup in &self.lookups {
+            for subtable in &lookup.subtables {
+                if let Some(value) = subtable.lookup(first, second) {
+                    total += value;
+                    // First subtable that covers the pair ends this lookup.
+                    break;
+                }
+            }
+        }
+        total
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.lookups.is_empty()
+    }
+}
+
+impl PairSubtable {
+    fn lookup(&self, first: u16, second: u16) -> Option<f32> {
+        match self {
+            Self::Specific { pairs } => {
+                let key = (u32::from(first) << 16) | u32::from(second);
+                pairs
+                    .binary_search_by_key(&key, |(pair, _)| *pair)
+                    .ok()
+                    .map(|index| pairs[index].1)
+            }
+            Self::Class {
+                coverage,
+                first: first_classes,
+                second: second_classes,
+                second_count,
+                matrix,
+            } => {
+                coverage.binary_search(&first).ok()?;
+                let row = first_classes.class_of(first);
+                let column = second_classes.class_of(second);
+                if column >= *second_count {
+                    return None;
+                }
+                let index = usize::from(row) * usize::from(*second_count) + usize::from(column);
+                matrix.get(index).copied()
+            }
+        }
+    }
+}
+
+fn u16_at(data: &[u8], offset: usize) -> Option<u16> {
+    let bytes = data.get(offset..offset + 2)?;
+    Some(u16::from_be_bytes([bytes[0], bytes[1]]))
+}
+
+fn i16_at(data: &[u8], offset: usize) -> Option<i16> {
+    u16_at(data, offset).map(|value| value as i16)
+}
+
+fn u32_at(data: &[u8], offset: usize) -> Option<u32> {
+    let bytes = data.get(offset..offset + 4)?;
+    Some(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+}
+
+/// Feature indices tagged `kern` under any script's default language system.
+fn kern_feature_indices(gpos: &[u8], script_list: usize, feature_list: usize) -> Option<Vec<u16>> {
+    let script_count = u16_at(gpos, script_list)?;
+    let mut reachable = Vec::new();
+    for index in 0..script_count {
+        let record = script_list + 2 + usize::from(index) * 6;
+        let script = script_list + usize::from(u16_at(gpos, record + 4)?);
+        let default_lang_sys = u16_at(gpos, script)?;
+        if default_lang_sys == 0 {
+            continue;
+        }
+        let lang_sys = script + usize::from(default_lang_sys);
+        let count = u16_at(gpos, lang_sys + 4)?;
+        for slot in 0..count {
+            let feature = u16_at(gpos, lang_sys + 6 + usize::from(slot) * 2)?;
+            if !reachable.contains(&feature) {
+                reachable.push(feature);
+            }
+        }
+    }
+
+    let feature_count = u16_at(gpos, feature_list)?;
+    let mut kern = Vec::new();
+    for index in reachable {
+        if index >= feature_count {
+            continue;
+        }
+        let record = feature_list + 2 + usize::from(index) * 6;
+        let tag = gpos.get(record..record + 4)?;
+        if tag == b"kern" {
+            kern.push(index);
+        }
+    }
+    Some(kern)
+}
+
+fn feature_lookups(gpos: &[u8], feature_list: usize, index: u16) -> Option<Vec<u16>> {
+    let record = feature_list + 2 + usize::from(index) * 6;
+    let feature = feature_list + usize::from(u16_at(gpos, record + 4)?);
+    let count = u16_at(gpos, feature + 2)?;
+    let mut lookups = Vec::with_capacity(usize::from(count));
+    for slot in 0..count {
+        lookups.push(u16_at(gpos, feature + 4 + usize::from(slot) * 2)?);
+    }
+    Some(lookups)
+}
+
+fn pair_lookup(
+    gpos: &[u8],
+    lookup_list: usize,
+    index: u16,
+    gdef: Option<ttf_parser::gdef::Table<'_>>,
+    coordinates: &[NormalizedCoordinate],
+) -> Option<Vec<PairSubtable>> {
+    let count = u16_at(gpos, lookup_list)?;
+    if index >= count {
+        return None;
+    }
+    let lookup = lookup_list + usize::from(u16_at(gpos, lookup_list + 2 + usize::from(index) * 2)?);
+    let kind = u16_at(gpos, lookup)?;
+    let subtable_count = u16_at(gpos, lookup + 4)?;
+
+    let mut subtables = Vec::new();
+    for slot in 0..subtable_count {
+        let mut offset = lookup + usize::from(u16_at(gpos, lookup + 6 + usize::from(slot) * 2)?);
+        let mut resolved = kind;
+        // Lookup type 9 wraps another type so a subtable can sit beyond the
+        // 16-bit offset a lookup record can hold. Roboto does not use it;
+        // plenty of large fonts do.
+        if resolved == 9 {
+            resolved = u16_at(gpos, offset + 2)?;
+            offset += u32_at(gpos, offset + 4)? as usize;
+        }
+        if resolved != 2 {
+            continue;
+        }
+        if let Some(subtable) = pair_subtable(gpos, offset, gdef, coordinates) {
+            subtables.push(subtable);
+        }
+    }
+    Some(subtables)
+}
+
+fn pair_subtable(
+    gpos: &[u8],
+    offset: usize,
+    gdef: Option<ttf_parser::gdef::Table<'_>>,
+    coordinates: &[NormalizedCoordinate],
+) -> Option<PairSubtable> {
+    let format = u16_at(gpos, offset)?;
+    let coverage_offset = offset + usize::from(u16_at(gpos, offset + 2)?);
+    let value_format_1 = u16_at(gpos, offset + 4)?;
+    let value_format_2 = u16_at(gpos, offset + 6)?;
+    let coverage = coverage_glyphs(gpos, coverage_offset)?;
+
+    match format {
+        1 => {
+            let set_count = u16_at(gpos, offset + 8)?;
+            let record_len = 2 + value_size(value_format_1) + value_size(value_format_2);
+            let mut pairs = Vec::new();
+            for slot in 0..set_count {
+                let Some(&first) = coverage.get(usize::from(slot)) else {
+                    continue;
+                };
+                let set = offset + usize::from(u16_at(gpos, offset + 10 + usize::from(slot) * 2)?);
+                let count = u16_at(gpos, set)?;
+                for record in 0..count {
+                    let at = set + 2 + usize::from(record) * record_len;
+                    let Some(second) = u16_at(gpos, at) else {
+                        continue;
+                    };
+                    // HarfBuzz resolves this record's device offsets against
+                    // the PairSet, not the subtable.
+                    let value = x_advance(gpos, at + 2, value_format_1, set, gdef, coordinates);
+                    pairs.push(((u32::from(first) << 16) | u32::from(second), value));
+                }
+            }
+            // Stable, so a font that lists one pair twice keeps the first
+            // record — which is the one HarfBuzz's binary search settles on.
+            pairs.sort_by_key(|(key, _)| *key);
+            pairs.dedup_by_key(|(key, _)| *key);
+            (!pairs.is_empty()).then_some(PairSubtable::Specific { pairs })
+        }
+        2 => {
+            let first = class_def(gpos, offset + usize::from(u16_at(gpos, offset + 8)?))?;
+            let second = class_def(gpos, offset + usize::from(u16_at(gpos, offset + 10)?))?;
+            let first_count = u16_at(gpos, offset + 12)?;
+            let second_count = u16_at(gpos, offset + 14)?;
+            let record_len = value_size(value_format_1) + value_size(value_format_2);
+            let cells = usize::from(first_count) * usize::from(second_count);
+            let mut matrix = Vec::with_capacity(cells);
+            for cell in 0..cells {
+                let at = offset + 16 + cell * record_len;
+                matrix.push(x_advance(
+                    gpos,
+                    at,
+                    value_format_1,
+                    offset,
+                    gdef,
+                    coordinates,
+                ));
+            }
+            Some(PairSubtable::Class {
+                coverage,
+                first,
+                second,
+                second_count,
+                matrix,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// A value record's size in bytes. Only the low byte carries fields.
+fn value_size(format: u16) -> usize {
+    usize::try_from((format & 0xFF).count_ones()).unwrap_or(0) * 2
+}
+
+/// The x advance a value record carries, with its variation delta applied.
+///
+/// A classic `Device` table — per-ppem hinting deltas — is ignored. Skia does
+/// not apply those in the path this framework mirrors, and a delta chosen by
+/// pixel size would make a measurement depend on the size it is taken at.
+fn x_advance(
+    gpos: &[u8],
+    at: usize,
+    format: u16,
+    device_base: usize,
+    gdef: Option<ttf_parser::gdef::Table<'_>>,
+    coordinates: &[NormalizedCoordinate],
+) -> f32 {
+    let mut cursor = at;
+    let mut advance = 0.0f32;
+    for field in VALUE_FIELDS {
+        if format & field == 0 {
+            continue;
+        }
+        if field == X_ADVANCE {
+            advance += f32::from(i16_at(gpos, cursor).unwrap_or(0));
+        }
+        if field == X_ADVANCE_DEVICE {
+            let device = u16_at(gpos, cursor).unwrap_or(0);
+            if device != 0 && !coordinates.is_empty() {
+                let table = device_base + usize::from(device);
+                if u16_at(gpos, table + 4) == Some(VARIATION_INDEX) {
+                    let outer = u16_at(gpos, table).unwrap_or(0);
+                    let inner = u16_at(gpos, table + 2).unwrap_or(0);
+                    advance += gdef
+                        .and_then(|gdef| gdef.glyph_variation_delta(outer, inner, coordinates))
+                        .unwrap_or(0.0);
+                }
+            }
+        }
+        cursor += 2;
+    }
+    advance
+}
+
+/// Glyphs a coverage table covers, in coverage-index order (which the
+/// specification requires to be ascending glyph order).
+fn coverage_glyphs(gpos: &[u8], offset: usize) -> Option<Vec<u16>> {
+    match u16_at(gpos, offset)? {
+        1 => {
+            let count = u16_at(gpos, offset + 2)?;
+            let mut glyphs = Vec::with_capacity(usize::from(count));
+            for index in 0..count {
+                glyphs.push(u16_at(gpos, offset + 4 + usize::from(index) * 2)?);
+            }
+            Some(glyphs)
+        }
+        2 => {
+            let count = u16_at(gpos, offset + 2)?;
+            let mut glyphs = Vec::new();
+            for index in 0..count {
+                let record = offset + 4 + usize::from(index) * 6;
+                let start = u16_at(gpos, record)?;
+                let end = u16_at(gpos, record + 2)?;
+                for glyph in start..=end {
+                    glyphs.push(glyph);
+                }
+            }
+            Some(glyphs)
+        }
+        _ => None,
+    }
+}
+
+fn class_def(gpos: &[u8], offset: usize) -> Option<ClassDef> {
+    let mut pairs: Vec<(u16, u16)> = Vec::new();
+    match u16_at(gpos, offset)? {
+        1 => {
+            let start = u16_at(gpos, offset + 2)?;
+            let count = u16_at(gpos, offset + 4)?;
+            for index in 0..count {
+                let class = u16_at(gpos, offset + 6 + usize::from(index) * 2)?;
+                pairs.push((start.saturating_add(index), class));
+            }
+        }
+        2 => {
+            let count = u16_at(gpos, offset + 2)?;
+            for index in 0..count {
+                let record = offset + 4 + usize::from(index) * 6;
+                let start = u16_at(gpos, record)?;
+                let end = u16_at(gpos, record + 2)?;
+                let class = u16_at(gpos, record + 4)?;
+                for glyph in start..=end {
+                    pairs.push((glyph, class));
+                }
+            }
+        }
+        _ => return Some(ClassDef::default()),
+    }
+    Some(ClassDef::from_pairs(pairs))
+}
+
+/// A face paired with the pair kerning `ab_glyph` cannot read for itself.
+///
+/// This is a `Font` rather than a lookup the call sites reach for, because
+/// there are nine of them across measuring, line breaking, alignment and
+/// drawing, several behind `impl Font` generics that never see a
+/// `SoftwareTextFont`. Overriding `kern_unscaled` puts the rule under every
+/// existing `scaled_font.kern(..)` at once — including any this change did not
+/// go looking for — and keeps a caller from having to remember which width is
+/// the kerned one.
+#[derive(Clone)]
+pub struct KernedFont {
+    font: FontArc,
+    kerning: Option<Arc<GposKerning>>,
+}
+
+impl KernedFont {
+    pub fn new(font: FontArc, kerning: Option<Arc<GposKerning>>) -> Self {
+        Self { font, kerning }
+    }
+
+    /// Reads the GPOS pair kerning for a face instanced at `variations`.
+    ///
+    /// `variations` are the `(tag, user value)` pairs actually applied to the
+    /// face, in the same units the caller handed `set_variation`; normalizing
+    /// them is `ttf_parser`'s job and doing it a second way here would be a
+    /// second answer.
+    pub fn read_kerning(bytes: &[u8], variations: &[([u8; 4], f32)]) -> Option<Arc<GposKerning>> {
+        let mut face = Face::parse(bytes, 0).ok()?;
+        for (tag, value) in variations {
+            face.set_variation(Tag::from_bytes(tag), *value);
+        }
+        GposKerning::parse(&face).map(Arc::new)
+    }
+
+    pub fn font_arc(&self) -> &FontArc {
+        &self.font
+    }
+}
+
+impl Font for KernedFont {
+    fn units_per_em(&self) -> Option<f32> {
+        self.font.units_per_em()
+    }
+
+    fn ascent_unscaled(&self) -> f32 {
+        self.font.ascent_unscaled()
+    }
+
+    fn descent_unscaled(&self) -> f32 {
+        self.font.descent_unscaled()
+    }
+
+    fn line_gap_unscaled(&self) -> f32 {
+        self.font.line_gap_unscaled()
+    }
+
+    fn italic_angle(&self) -> f32 {
+        self.font.italic_angle()
+    }
+
+    fn glyph_id(&self, c: char) -> GlyphId {
+        self.font.glyph_id(c)
+    }
+
+    fn h_advance_unscaled(&self, id: GlyphId) -> f32 {
+        self.font.h_advance_unscaled(id)
+    }
+
+    fn h_side_bearing_unscaled(&self, id: GlyphId) -> f32 {
+        self.font.h_side_bearing_unscaled(id)
+    }
+
+    fn v_advance_unscaled(&self, id: GlyphId) -> f32 {
+        self.font.v_advance_unscaled(id)
+    }
+
+    fn v_side_bearing_unscaled(&self, id: GlyphId) -> f32 {
+        self.font.v_side_bearing_unscaled(id)
+    }
+
+    /// The whole point of the wrapper.
+    ///
+    /// Falls back to the face's own answer when there is no GPOS pair kerning,
+    /// which keeps a font that really does carry a TrueType `kern` table working
+    /// exactly as it did.
+    fn kern_unscaled(&self, first: GlyphId, second: GlyphId) -> f32 {
+        match &self.kerning {
+            Some(kerning) => kerning.kern_unscaled(first.0, second.0),
+            None => self.font.kern_unscaled(first, second),
+        }
+    }
+
+    fn outline(&self, id: GlyphId) -> Option<Outline> {
+        self.font.outline(id)
+    }
+
+    fn glyph_count(&self) -> usize {
+        self.font.glyph_count()
+    }
+
+    fn codepoint_ids(&self) -> CodepointIdIter<'_> {
+        self.font.codepoint_ids()
+    }
+
+    fn glyph_raster_image2(&self, id: GlyphId, pixel_size: u16) -> Option<v2::GlyphImage<'_>> {
+        self.font.glyph_raster_image2(id, pixel_size)
+    }
+
+    fn glyph_svg_image(&self, id: GlyphId) -> Option<GlyphSvg<'_>> {
+        self.font.glyph_svg_image(id)
+    }
+
+    fn font_data(&self) -> &[u8] {
+        self.font.font_data()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NOTO: &[u8] = include_bytes!("../assets/NotoSansMerged.ttf");
+
+    fn face() -> Face<'static> {
+        Face::parse(NOTO, 0).expect("font")
+    }
+
+    fn glyph(face: &Face<'_>, ch: char) -> u16 {
+        face.glyph_index(ch).expect("glyph").0
+    }
+
+    #[test]
+    fn embedded_font_has_no_truetype_kern_table() {
+        // The premise of the whole module: `ab_glyph::Font::kern_unscaled`
+        // reads this table, and it is not there.
+        assert!(face().raw_face().table(Tag::from_bytes(b"kern")).is_none());
+    }
+
+    #[test]
+    fn gpos_kerning_is_found_and_negative_for_a_kerning_pair() {
+        let face = face();
+        let kerning = GposKerning::parse(&face).expect("GPOS kerning");
+        assert!(!kerning.is_empty());
+        let value = kerning.kern_unscaled(glyph(&face, 'A'), glyph(&face, 'V'));
+        assert!(value < 0.0, "AV should tuck, got {value}");
+    }
+
+    #[test]
+    fn unkerned_pairs_are_zero() {
+        let face = face();
+        let kerning = GposKerning::parse(&face).expect("GPOS kerning");
+        assert_eq!(
+            kerning.kern_unscaled(glyph(&face, 'n'), glyph(&face, 'n')),
+            0.0
+        );
+    }
+
+    #[test]
+    fn kerning_is_directional() {
+        let face = face();
+        let kerning = GposKerning::parse(&face).expect("GPOS kerning");
+        let forward = kerning.kern_unscaled(glyph(&face, 'A'), glyph(&face, 'V'));
+        let backward = kerning.kern_unscaled(glyph(&face, 'V'), glyph(&face, 'A'));
+        // Both tuck, but a font is free to tuck them by different amounts, and
+        // a reader that ignored order would return the same number twice.
+        assert!(forward < 0.0 && backward < 0.0);
+    }
+
+    #[test]
+    fn class_def_collapses_runs_and_defaults_to_zero() {
+        let classes = ClassDef::from_pairs(vec![(4, 1), (5, 1), (6, 1), (9, 2), (12, 0)]);
+        assert_eq!(classes.ranges, vec![(4, 6, 1), (9, 9, 2)]);
+        assert_eq!(classes.class_of(5), 1);
+        assert_eq!(classes.class_of(9), 2);
+        assert_eq!(classes.class_of(12), 0);
+        assert_eq!(classes.class_of(0), 0);
+    }
+
+    #[test]
+    fn value_size_counts_only_the_low_byte() {
+        assert_eq!(value_size(0x0000), 0);
+        assert_eq!(value_size(0x0004), 2);
+        assert_eq!(value_size(0x0044), 4);
+        assert_eq!(value_size(0x00FF), 16);
+    }
+}

--- a/crates/cranpose-render/common/src/lib.rs
+++ b/crates/cranpose-render/common/src/lib.rs
@@ -13,6 +13,7 @@ pub mod brush_sampling;
 pub mod font_layout;
 pub mod font_source;
 pub mod geometry;
+pub mod gpos_kerning;
 pub mod graph;
 mod graph_hash;
 pub mod graph_scene;

--- a/crates/cranpose-render/common/src/software_text_raster.rs
+++ b/crates/cranpose-render/common/src/software_text_raster.rs
@@ -22,6 +22,7 @@ use crate::font_layout::{
     align_glyph_to_pixel_grid, line_advance_width, pixel_bounds_from_outlined, vertical_metrics,
     GlyphPixelBounds,
 };
+use crate::gpos_kerning::KernedFont;
 #[cfg(feature = "text-hyphenation")]
 use crate::text_hyphenation::HyphenationDictionaryError;
 use crate::text_hyphenation::HyphenationDictionaryStore;
@@ -48,7 +49,7 @@ pub enum SoftwareTextFontError {
 
 #[derive(Clone)]
 pub struct SoftwareTextFont {
-    font: FontArc,
+    font: KernedFont,
     metadata: SoftwareTextFontMetadata,
     score: TextFontScore,
     content_hash: u64,
@@ -88,11 +89,12 @@ impl SoftwareTextFont {
         bytes.hash(&mut hasher);
         let content_hash = hasher.finish();
         let metadata = software_text_font_metadata(bytes.as_slice());
+        let kerning = KernedFont::read_kerning(bytes.as_slice(), &[]);
         let font = FontArc::try_from_vec(bytes).map_err(|_| SoftwareTextFontError::InvalidFont)?;
         let score =
             text_font_score_from_parts(&font, metadata.ab_glyph_scale_factor, metadata.weight);
         Ok(Self {
-            font,
+            font: KernedFont::new(font, kerning),
             metadata,
             score,
             content_hash,
@@ -126,16 +128,24 @@ impl SoftwareTextFont {
             FontVec::try_from_vec(bytes).map_err(|_| SoftwareTextFontError::InvalidFont)?;
         // Two instances of one variable file draw different outlines, so the
         // axis values have to reach `content_hash` — it is the glyph atlas key.
-        for (tag, value) in apply_declared_variations(&mut font, weight, style) {
+        let variations = apply_declared_variations(&mut font, weight, style);
+        for (tag, value) in &variations {
             tag.hash(&mut hasher);
             value.to_bits().hash(&mut hasher);
         }
         let content_hash = hasher.finish();
 
+        // Read the kerning at the SAME axis position the outlines were
+        // instanced at. Roboto's GPOS pair values carry `VariationIndex`
+        // deltas worth up to 136 font units between wght 400 and wght 700, so
+        // a table read at the default instance would kern a Medium run as if
+        // it were Regular.
+        let kerning = KernedFont::read_kerning(font.font_data(), &variations);
+
         let font = FontArc::from(font);
         let score = text_font_score_from_parts(&font, metadata.ab_glyph_scale_factor, weight);
         Ok(Self {
-            font,
+            font: KernedFont::new(font, kerning),
             metadata,
             score,
             content_hash,

--- a/crates/cranpose-render/common/tests/gpos_kerning_measure.rs
+++ b/crates/cranpose-render/common/tests/gpos_kerning_measure.rs
@@ -1,0 +1,94 @@
+//! Pair kerning, through the production measurer rather than the reader.
+//!
+//! The reader has its own unit tests; what these pin is that the value reaches
+//! a measured width. It used not to: `ab_glyph::Font::kern_unscaled` reads the
+//! TrueType `kern` table, the embedded fallback carries none, and neither does
+//! the Roboto a Wear device ships — so every string measured wide.
+
+#![cfg(feature = "embedded-default-font")]
+
+use cranpose_render_common::gpos_kerning::GposKerning;
+use cranpose_render_common::software_text_raster::{
+    default_software_text_font, SoftwareTextFontSet, SoftwareTextMeasurer,
+    DEFAULT_SOFTWARE_TEXT_FONT_BYTES,
+};
+use cranpose_ui::text::{
+    AnnotatedString, FontFamily, SpanStyle, TextMeasurer, TextStyle, TextUnit,
+};
+
+const FONT_SIZE: f32 = 32.0;
+
+fn measurer() -> SoftwareTextMeasurer {
+    SoftwareTextMeasurer::from_font_set(
+        SoftwareTextFontSet::from_font(default_software_text_font().expect("embedded fallback")),
+        256,
+    )
+}
+
+fn style() -> TextStyle {
+    TextStyle {
+        span_style: SpanStyle {
+            font_size: TextUnit::Sp(FONT_SIZE),
+            font_family: Some(FontFamily::SansSerif),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn width(measurer: &SoftwareTextMeasurer, text: &str) -> f32 {
+    measurer
+        .measure(&AnnotatedString::from(text), &style())
+        .width
+}
+
+/// The kerning the font declares for a pair, in pixels at `FONT_SIZE`.
+fn expected_kern_px(pair: [char; 2]) -> f32 {
+    let face = ttf_parser::Face::parse(DEFAULT_SOFTWARE_TEXT_FONT_BYTES, 0).expect("face");
+    let kerning = GposKerning::parse(&face).expect("the fallback font has GPOS kerning");
+    let first = face.glyph_index(pair[0]).expect("glyph").0;
+    let second = face.glyph_index(pair[1]).expect("glyph").0;
+    kerning.kern_unscaled(first, second) * FONT_SIZE / f32::from(face.units_per_em())
+}
+
+#[test]
+fn a_kerned_pair_is_narrower_than_its_two_glyphs_by_exactly_the_kern() {
+    let measurer = measurer();
+    let kern = expected_kern_px(['A', 'V']);
+    assert!(kern < 0.0, "AV must kern for this test to mean anything");
+
+    let separate = width(&measurer, "A") + width(&measurer, "V");
+    let together = width(&measurer, "AV");
+
+    assert!(
+        (together - (separate + kern)).abs() < 0.01,
+        "AV measured {together}, expected {} = {separate} + {kern}",
+        separate + kern
+    );
+}
+
+#[test]
+fn an_unkerned_pair_is_exactly_its_two_glyphs() {
+    let measurer = measurer();
+    let separate = width(&measurer, "n") + width(&measurer, "n");
+    let together = width(&measurer, "nn");
+    assert!(
+        (together - separate).abs() < 0.01,
+        "nn measured {together}, expected {separate}"
+    );
+}
+
+/// The regression this whole rule exists for: a string of kerning pairs used to
+/// measure as if the font declared none.
+#[test]
+fn kerning_accumulates_across_a_string() {
+    let measurer = measurer();
+    let kerned = width(&measurer, "AVAVAV");
+    let unkerned: f32 = 3.0 * (width(&measurer, "A") + width(&measurer, "V"));
+    let kern = expected_kern_px(['A', 'V']);
+    // Five gaps in "AVAVAV": AV, VA, AV, VA, AV.
+    assert!(
+        kerned < unkerned + 4.0 * kern,
+        "a six-glyph run should carry at least five kerns: {kerned} vs {unkerned}"
+    );
+}


### PR DESCRIPTION
Cranpose applied no kerning at all. `ab_glyph`'s `kern()` reads the legacy
`kern` table; Android's Roboto carries only GPOS, and so does the embedded
`NotoSansMerged` fallback — so this was never one app's problem, every
Cranpose app has been drawing unkerned text next to platform text that is
kerned. Compose kerns `LY` −5 px, `To` −3 px, `AV` −2 px. Over a 20-string
corpus we ran up to +4.48 px wide, and 14 of 20 strings landed on a
different integer width.

This reads the `kern` feature's pair-adjustment lookups directly rather
than taking a shaping crate. `rustybuzz` would bring GSUB, normalization
and complex scripts — far more than the measured defect — and would
replace the glyph pipeline instead of fixing its widths. `ttf_parser` is
already a dependency and supplies the parts that are genuinely hard: table
location, `Face::set_variation` for normalized axis coordinates, and
`gdef::Table::glyph_variation_delta` for the item variation store. A
`KernedFont` wrapper overrides `kern_unscaled`, because there are nine
`scaled_font.kern(..)` call sites across measuring, line breaking,
alignment and drawing, several behind `impl Font` generics that never see
a concrete font type.

Roboto's kern values carry `VariationIndex` deltas — up to 136 font units
between wght 400 and 700 — so the table has to be read at the instanced
axis position or a Medium run is kerned as Regular. Two behaviours follow
HarfBuzz rather than the OpenType prose, and say so in the module: device
offsets in `PairPosFormat1` resolve from the `PairSet`, not the subtable,
and within one lookup the first covering subtable wins even when its value
is zero.

Measured on a Wear emulator against the shipping Compose build, 34 states
at 454x454 density 2. Three states have per-build self-noise of 7-12 mean
levels — a repeat capture of one build differs that much — so they are
excluded rather than averaged. Over the 31 stable states, mean absolute
error falls 2.7282 to 2.4635, a 9.7% improvement, concentrated exactly on
the states that carry text: `title` 5.064 to 4.156, `credits` 11.717 to
10.780, `clear` 2.269 to 1.498, `unlock` 4.084 to 3.262.

Three states lose slightly — `tutorial` 1.234 to 1.530, `paused` 1.398 to
1.657, `map-levels` 1.775 to 1.939 — which is what a correct kern does
where the old error happened to cancel. Roboto's kern feature also
*widens* some capital pairs (`ET` +20, `TT` +16), so a string is not
always narrower. The states with no text move 0.000, which is the null
this should produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)