### PR TITLE
Draw dynamic circle rims as band meshes instead of their full quads

### DIFF
--- a/crates/cranpose-render/common/src/software_text_raster.rs
+++ b/crates/cranpose-render/common/src/software_text_raster.rs
@@ -4670,7 +4670,9 @@ fn build_stroke_mask(
 
     let alpha: Vec<f32> = pixmap
         .data()
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .map(|pixel| pixel[3] as f32 / 255.0)
         .collect();
 

--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -498,6 +498,18 @@ impl WgpuRenderer {
             .unwrap_or((0, 0))
     }
 
+    /// Test/diagnostic view of the transient rim mesh path: lifetime count
+    /// of dynamic circle rims drawn as band meshes instead of full bounding
+    /// quads (`CRANPOSE_RIM_MESH` kill switch).
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn rim_meshes_emitted(&self) -> u64 {
+        self.gpu_renderer
+            .as_ref()
+            .map(GpuRenderer::rim_meshes_emitted)
+            .unwrap_or(0)
+    }
+
     /// Test/diagnostic view of the present store's lifetime count of
     /// replay-ops batches dropped by the generation check. Surface (non
     /// direct) frames must never move it: their packets carry the default

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -2457,6 +2457,170 @@ fn arc_mesh_band(shape: &ShapeData) -> Option<ArcMeshBand> {
     })
 }
 
+/// Kill switch for the transient rim band mesh, mirroring
+/// [`arc_mesh_enabled`]'s property bridge: `CRANPOSE_RIM_MESH=0` (or the
+/// `debug.cranpose.rim_mesh` property on Android) makes the fused shape
+/// prepare skip rim detection entirely, so a device A/B needs no rebuild.
+/// Default ON — unlike the retained arc mesh, the rim path is indexed
+/// band-boundary geometry from the start, so the vertex-amplification
+/// regression that demoted `CRANPOSE_ARC_MESH` to opt-in does not apply.
+/// Read once per fused-chunk prepare (cheap), not per shape.
+#[cfg(not(target_arch = "wasm32"))]
+fn rim_mesh_enabled() -> bool {
+    !matches!(std::env::var("CRANPOSE_RIM_MESH").as_deref(), Ok("0"))
+}
+
+/// Fixed capacity of the per-frame transient rim mesh vertex buffer, in
+/// vertices. The buffers are never recreated mid-frame — draws are encoded
+/// before submit, so a reallocation would orphan already-encoded rims — and
+/// overflow means "skip the rim, draw it as a quad", never truncation.
+/// MEGA's arena meshes 2-3 rims per frame at ~80 vertices each (measured on
+/// the Pixel Watch 3 via the emit log below), so ~100 rims of headroom; the
+/// rate-limited warn below is the tell if a scene ever exceeds it.
+#[cfg(not(target_arch = "wasm32"))]
+const RIM_MESH_VERTEX_CAPACITY: usize = 8192;
+/// Fixed capacity of the per-frame transient rim mesh index buffer, in
+/// `u32` indices.
+#[cfg(not(target_arch = "wasm32"))]
+const RIM_MESH_INDEX_CAPACITY: usize = 32768;
+
+/// A dynamic shape inside a fused chunk that draws as a band mesh instead of
+/// its full bounding quad: `shape_index` is the shape's position within the
+/// whole fused upload (the index `vs_mesh` reads into the storage shape
+/// array), `first_index..first_index + index_count` its span of the frame's
+/// transient rim index buffer.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+#[derive(Clone, Copy, Debug)]
+struct RimDraw {
+    shape_index: u32,
+    first_index: u32,
+    index_count: u32,
+}
+
+/// Rate-limited overflow warning: silent skipping would hide a scene whose
+/// rims permanently miss the fast path, while warning every frame would
+/// flood the watch's logcat.
+#[cfg(not(target_arch = "wasm32"))]
+fn rim_mesh_capacity_warn() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static OVERFLOWS: AtomicU64 = AtomicU64::new(0);
+    let count = OVERFLOWS.fetch_add(1, Ordering::Relaxed);
+    if count.is_multiple_of(512) {
+        log::warn!(
+            "[rim-mesh] transient buffers full; rim falls back to quad expansion \
+             (lifetime overflows {})",
+            count + 1,
+        );
+    }
+}
+
+/// Band parameters of a DYNAMIC stroked round-rect whose outline is
+/// geometrically a circle — an arena "rim". Everything else returns `None`
+/// and rasterizes through the ordinary quad expansion.
+///
+/// Derivation: `ShapeData::rect` for a stroked shape is the stroke-inflated
+/// box (geometry plus half the stroke width on each side), so the geometry
+/// half-extent is `geom_half = (rect.w - stroke_width) / 2`. When the corner
+/// radius equals that half-extent the outline is a circle of radius
+/// `geom_half`, and `sdf_stroked_rounded_rect` degenerates exactly to an
+/// annulus: its outer offset rounded-rect (`half_size` = `geom_half + hw`,
+/// radius `geom_half + hw`) is the circle of radius `geom_half + sw/2`, its
+/// inner offset the circle of radius `geom_half - sw/2` — centerline
+/// `geom_half`, half-width `sw/2`. The bevel-join chamfer plane can only CUT
+/// pixels from that annulus (`max(dist, chamfer)`), never add any, so for
+/// every join style the shader's kept set is a subset of the annulus band.
+/// [`emit_arc_band_mesh`] adds its own `ARC_MESH_MARGIN`, treats
+/// `sweep >= TAU` as closed, and clips to the quad box, so containment
+/// (mesh ⊇ every pixel with `|dist| < 0.5`, mesh ⊆ quad box) follows from
+/// the same argument the retained arc mesh documents.
+///
+/// The CIRCLE gate is what keeps this correct: a false positive on a rounded
+/// SQUARE ring would under-cover its flat spans and damage pixels, so the
+/// radius must match `geom_half` to within 0.01 px (a deviation that small
+/// stays inside the mesh margin's 0.5 px float-slop budget).
+#[cfg(not(target_arch = "wasm32"))]
+fn rim_mesh_band(shape: &ShapeData) -> Option<ArcMeshBand> {
+    // Mirror the fragment shader's flag decode (`u32(max(x, 0.0))`).
+    let flags = shape.stroke_params[1].max(0.0) as u32;
+    if flags & 3 != SHAPE_KIND_STROKE {
+        return None;
+    }
+    // Solid brushes only — same narrow byte-exactness surface as
+    // `arc_mesh_band`.
+    if shape.brush_type != 0 {
+        return None;
+    }
+    // A live clip is a hard `world_pos` comparison in the fragment shader;
+    // meshed rims interpolate `world_pos` across different triangles and one
+    // ulp at the clip boundary flips whole pixels.
+    if shape.clip_rect[2] > 0.0 && shape.clip_rect[3] > 0.0 {
+        return None;
+    }
+    let [x, y, w, h] = shape.rect;
+    if !(w > 0.0 && h > 0.0) {
+        return None;
+    }
+    // The quad must be an axis-aligned box, tolerance zero — the identical
+    // check `arc_mesh_band` makes (compare quad corners against each other,
+    // never against `rect`, which differs by an ulp under non-dyadic root
+    // scales).
+    let [left, top, right, _] = shape.quad01;
+    let [bl_x, bottom, br_x, br_y] = shape.quad23;
+    let axis_aligned = shape.quad01[3] == top
+        && bl_x == left
+        && br_x == right
+        && br_y == bottom
+        && left < right
+        && top < bottom;
+    if !axis_aligned {
+        return None;
+    }
+    // Big shapes only: the win is proportional to the discarded quad area,
+    // and small quads are cheaper than the extra pipeline switches.
+    if w * h < 65536.0 {
+        return None;
+    }
+    // A circle's box is square, bitwise.
+    if w.to_bits() != h.to_bits() {
+        return None;
+    }
+    // All four corner radii bitwise equal, finite and positive.
+    let [r0, r1, r2, r3] = shape.radii;
+    if r0.to_bits() != r1.to_bits() || r0.to_bits() != r2.to_bits() || r0.to_bits() != r3.to_bits()
+    {
+        return None;
+    }
+    if !r0.is_finite() || r0 <= 0.0 {
+        return None;
+    }
+    let sw = shape.stroke_params[0];
+    if !sw.is_finite() || sw <= 0.0 {
+        return None;
+    }
+    // Finiteness before the circle gate: with every operand finite the
+    // radius comparison below cannot see a NaN.
+    let geom_half = (w - sw) * 0.5;
+    let center = [x + w * 0.5, y + h * 0.5];
+    let inner = geom_half - sw * 0.5;
+    let outer = geom_half + sw * 0.5;
+    let finite =
+        center[0].is_finite() && center[1].is_finite() && inner.is_finite() && outer.is_finite();
+    if !finite || outer <= 0.0 {
+        return None;
+    }
+    // The circle gate (see the doc comment).
+    if (r0 - geom_half).abs() > 0.01 {
+        return None;
+    }
+    Some(ArcMeshBand {
+        center,
+        inner,
+        outer,
+        start: 0.0,
+        sweep: cranpose_ui_graphics::TAU,
+    })
+}
+
 /// Emits the quad `vs_main` would expand for this shape as four shared
 /// vertices plus the index pattern (0, 1, 2)(2, 1, 3) — the identical corner
 /// order, corner uvs and positions straight from the captured quad, so a
@@ -2736,7 +2900,9 @@ fn emit_arc_band_mesh(
 #[cfg(not(target_arch = "wasm32"))]
 fn triangles_shoelace_area(vertices: &[MeshVertex], indices: &[u32]) -> f64 {
     indices
-        .chunks_exact(3)
+        .as_chunks::<3>()
+        .0
+        .iter()
         .map(|tri| {
             let [a, b, c] = [
                 vertices[tri[0] as usize].position,
@@ -3921,6 +4087,33 @@ pub struct GpuRenderer {
     /// the fused segment pass (`CRANPOSE_RETAINED_BUNDLES` kill switch).
     #[cfg(not(target_arch = "wasm32"))]
     retained_bundle_cache: RetainedBundleCache,
+    /// Per-frame scratch for transient rim band meshes (`rim_mesh_band`):
+    /// appended per fused chunk, cleared at the top of every frame. Index
+    /// values are absolute into the frame's vertex list, so later chunks
+    /// append without rebasing.
+    #[cfg(not(target_arch = "wasm32"))]
+    rim_mesh_vertices: Vec<MeshVertex>,
+    #[cfg(not(target_arch = "wasm32"))]
+    rim_mesh_indices: Vec<u32>,
+    /// Fixed-capacity GPU twins of the rim scratch vecs, created lazily on
+    /// the first rim ([`RIM_MESH_VERTEX_CAPACITY`] /
+    /// [`RIM_MESH_INDEX_CAPACITY`]). NEVER recreated mid-frame: draws are
+    /// encoded before submit, so a replacement buffer would orphan every
+    /// already-encoded rim draw.
+    #[cfg(not(target_arch = "wasm32"))]
+    rim_mesh_vertex_buffer: Option<wgpu::Buffer>,
+    #[cfg(not(target_arch = "wasm32"))]
+    rim_mesh_index_buffer: Option<wgpu::Buffer>,
+    /// Counts of scratch vertices/indices already uploaded this frame, so
+    /// each fused chunk uploads only its newly appended region.
+    #[cfg(not(target_arch = "wasm32"))]
+    rim_mesh_uploaded_vertices: usize,
+    #[cfg(not(target_arch = "wasm32"))]
+    rim_mesh_uploaded_indices: usize,
+    /// Lifetime count of rims drawn as band meshes — the test hook behind
+    /// [`Self::rim_meshes_emitted`].
+    #[cfg(not(target_arch = "wasm32"))]
+    rim_meshes_emitted: u64,
 }
 
 /// Running totals for retained-slot patch uploads, the paint-bandwidth
@@ -4472,6 +4665,20 @@ impl GpuRenderer {
             replay_generation_drops: 0,
             #[cfg(not(target_arch = "wasm32"))]
             retained_bundle_cache: RetainedBundleCache::new(),
+            #[cfg(not(target_arch = "wasm32"))]
+            rim_mesh_vertices: Vec::new(),
+            #[cfg(not(target_arch = "wasm32"))]
+            rim_mesh_indices: Vec::new(),
+            #[cfg(not(target_arch = "wasm32"))]
+            rim_mesh_vertex_buffer: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            rim_mesh_index_buffer: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            rim_mesh_uploaded_vertices: 0,
+            #[cfg(not(target_arch = "wasm32"))]
+            rim_mesh_uploaded_indices: 0,
+            #[cfg(not(target_arch = "wasm32"))]
+            rim_meshes_emitted: 0,
         }
     }
 
@@ -6289,6 +6496,14 @@ impl GpuRenderer {
         #[cfg(not(target_arch = "wasm32"))]
         {
             self.retained_glyph_uniform_cursor = 0;
+            // Transient rim meshes live for exactly one frame: the scratch
+            // restarts here and every fused chunk appends after the region
+            // already uploaded (the GPU buffers themselves are fixed-capacity
+            // and persist).
+            self.rim_mesh_vertices.clear();
+            self.rim_mesh_indices.clear();
+            self.rim_mesh_uploaded_vertices = 0;
+            self.rim_mesh_uploaded_indices = 0;
         }
 
         // Producer-side text layout cache size, carried by the packet — the
@@ -7183,6 +7398,16 @@ impl GpuRenderer {
             }
             let after_shape_prepare = Instant::now();
 
+            // Transient rim band meshes: scan the freshly converted shapes
+            // (still in `scratch_shape_data` after
+            // `prepare_shapes_batch_direct`) for huge circle rims and give
+            // each a band mesh covering ring ± AA margin instead of its full
+            // bounding quad. Kill switch read once per chunk; the mesh
+            // pipeline exists in storage mode only and blends SrcOver only,
+            // hence the two extra gates at the batch arm below.
+            let rim_mesh_on = rim_mesh_enabled();
+            let mut chunk_rims: Vec<RimDraw> = Vec::new();
+
             let mut fused_batches = Vec::with_capacity(chunk.batches.len());
             let mut shape_cursor = 0_u32;
             let mut composite_cursor = 0usize;
@@ -7205,6 +7430,64 @@ impl GpuRenderer {
                         }
                         let shape_count = end - start;
                         if shape_count > 0 {
+                            if rim_mesh_on
+                                && self.instanced_quads.is_some()
+                                && blend_mode == BlendMode::SrcOver
+                            {
+                                for offset in 0..shape_count {
+                                    // The index `vs_mesh` reads into the
+                                    // storage shape array: position within
+                                    // the whole fused upload (shape_refs
+                                    // order == scratch_shape_data order).
+                                    let global_index = shape_cursor + offset as u32;
+                                    let converted = &self.scratch_shape_data[global_index as usize];
+                                    let Some(band) = rim_mesh_band(converted) else {
+                                        continue;
+                                    };
+                                    let vertex_mark = self.rim_mesh_vertices.len();
+                                    let index_mark = self.rim_mesh_indices.len();
+                                    if emit_arc_band_mesh(
+                                        converted,
+                                        global_index,
+                                        &band,
+                                        &mut self.rim_mesh_vertices,
+                                        &mut self.rim_mesh_indices,
+                                    )
+                                    .is_none()
+                                    {
+                                        // Nothing emitted (fully clipped) —
+                                        // the quad path draws it as today.
+                                        self.rim_mesh_vertices.truncate(vertex_mark);
+                                        self.rim_mesh_indices.truncate(index_mark);
+                                        continue;
+                                    }
+                                    if self.rim_mesh_vertices.len() > RIM_MESH_VERTEX_CAPACITY
+                                        || self.rim_mesh_indices.len() > RIM_MESH_INDEX_CAPACITY
+                                    {
+                                        // Whole-rim rollback, never a
+                                        // truncation: a partial band would
+                                        // break the containment invariant.
+                                        self.rim_mesh_vertices.truncate(vertex_mark);
+                                        self.rim_mesh_indices.truncate(index_mark);
+                                        rim_mesh_capacity_warn();
+                                        continue;
+                                    }
+                                    chunk_rims.push(RimDraw {
+                                        shape_index: global_index,
+                                        first_index: index_mark as u32,
+                                        index_count: (self.rim_mesh_indices.len() - index_mark)
+                                            as u32,
+                                    });
+                                    self.rim_meshes_emitted += 1;
+                                    if self.rim_meshes_emitted % 600 == 1 {
+                                        log::debug!(
+                                            "[rim-mesh] {} rims meshed lifetime ({} verts live this frame)",
+                                            self.rim_meshes_emitted,
+                                            self.rim_mesh_vertices.len(),
+                                        );
+                                    }
+                                }
+                            }
                             fused_batches.push(FusedSegmentBatch::Shape {
                                 batch: PreparedShapeBatch {
                                     vertex_start: shape_cursor * 6,
@@ -7344,6 +7627,9 @@ impl GpuRenderer {
                     }
                 }
             }
+            if !chunk_rims.is_empty() {
+                self.upload_transient_rim_meshes();
+            }
             let after_batch_prepare = Instant::now();
 
             if !image_indices.is_empty() {
@@ -7461,6 +7747,7 @@ impl GpuRenderer {
                                 *batch,
                                 width,
                                 height,
+                                &chunk_rims,
                             );
                         }
                         FusedSegmentBatch::Image {
@@ -7706,6 +7993,7 @@ impl GpuRenderer {
                                 prepared,
                                 width,
                                 height,
+                                &[],
                             );
                         }
                         pass_count = pass_count.saturating_add(1);
@@ -8740,6 +9028,7 @@ impl GpuRenderer {
                     prepared_shape,
                     width,
                     height,
+                    &[],
                 );
             }
 
@@ -9935,6 +10224,71 @@ impl GpuRenderer {
         self.retained_bundle_cache.stats()
     }
 
+    /// Test/diagnostic view of the transient rim mesh path: lifetime count
+    /// of rims drawn as band meshes instead of full bounding quads.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn rim_meshes_emitted(&self) -> u64 {
+        self.rim_meshes_emitted
+    }
+
+    /// Uploads the region of the transient rim mesh scratch appended since
+    /// the previous upload — chunks later in the frame append after regions
+    /// whose draws are already encoded, so earlier bytes are never
+    /// rewritten and the fixed-capacity buffers are never recreated
+    /// mid-frame. The executor-owned upload lands at the head of the next
+    /// submit, which is where this frame's passes execute.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn upload_transient_rim_meshes(&mut self) {
+        let device = self.device.clone();
+        let mut upload_stats = crate::frame_graph::FrameCommandStats::default();
+        if self.rim_mesh_vertices.len() > self.rim_mesh_uploaded_vertices {
+            let vertex_buffer = self.rim_mesh_vertex_buffer.get_or_insert_with(|| {
+                device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("Rim Mesh Vertex Buffer"),
+                    size: (RIM_MESH_VERTEX_CAPACITY * std::mem::size_of::<MeshVertex>()) as u64,
+                    usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+                    mapped_at_creation: false,
+                })
+            });
+            upload_stats.upload_bytes += self
+                .frame_graph_executor
+                .upload_buffer(
+                    &self.queue,
+                    vertex_buffer,
+                    (self.rim_mesh_uploaded_vertices * std::mem::size_of::<MeshVertex>()) as u64,
+                    bytemuck::cast_slice(
+                        &self.rim_mesh_vertices[self.rim_mesh_uploaded_vertices..],
+                    ),
+                )
+                .upload_bytes;
+            self.rim_mesh_uploaded_vertices = self.rim_mesh_vertices.len();
+        }
+        if self.rim_mesh_indices.len() > self.rim_mesh_uploaded_indices {
+            let index_buffer = self.rim_mesh_index_buffer.get_or_insert_with(|| {
+                device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("Rim Mesh Index Buffer"),
+                    size: (RIM_MESH_INDEX_CAPACITY * std::mem::size_of::<u32>()) as u64,
+                    usage: wgpu::BufferUsages::INDEX | wgpu::BufferUsages::COPY_DST,
+                    mapped_at_creation: false,
+                })
+            });
+            upload_stats.upload_bytes += self
+                .frame_graph_executor
+                .upload_buffer(
+                    &self.queue,
+                    index_buffer,
+                    (self.rim_mesh_uploaded_indices * std::mem::size_of::<u32>()) as u64,
+                    bytemuck::cast_slice(&self.rim_mesh_indices[self.rim_mesh_uploaded_indices..]),
+                )
+                .upload_bytes;
+            self.rim_mesh_uploaded_indices = self.rim_mesh_indices.len();
+        }
+        if upload_stats.upload_bytes > 0 {
+            self.frame_stats.record_command_stats(upload_stats);
+        }
+    }
+
     fn draw_prepared_shapes(
         &self,
         render_pass: &mut wgpu::RenderPass<'_>,
@@ -9942,7 +10296,10 @@ impl GpuRenderer {
         batch: PreparedShapeBatch,
         width: u32,
         height: u32,
+        rims: &[RimDraw],
     ) {
+        #[cfg(target_arch = "wasm32")]
+        let _ = rims;
         self.frame_stats.bump_shapes();
         self.frame_stats.add_draw_calls(1);
         render_pass.set_scissor_rect(0, 0, width, height);
@@ -9966,11 +10323,16 @@ impl GpuRenderer {
                 batch.vertex_start,
                 batch.vertex_count,
             );
-            if blend_mode == BlendMode::SrcOver && !batch.has_gradient {
-                render_pass.set_pipeline(self.instanced_pipeline_solid(instanced));
-            } else {
-                render_pass.set_pipeline(self.instanced_pipeline(instanced, blend_mode));
-            }
+            // The same selection the preamble and every post-rim restore
+            // make — factored so the two sites cannot disagree.
+            let set_instanced_pipeline = |render_pass: &mut wgpu::RenderPass<'_>| {
+                if blend_mode == BlendMode::SrcOver && !batch.has_gradient {
+                    render_pass.set_pipeline(self.instanced_pipeline_solid(instanced));
+                } else {
+                    render_pass.set_pipeline(self.instanced_pipeline(instanced, blend_mode));
+                }
+            };
+            set_instanced_pipeline(render_pass);
             render_pass.set_bind_group(0, uniform_bind_group, &[]);
             // Dynamic offset 0: ordinary batches read the identity
             // similarity transform.
@@ -9979,7 +10341,62 @@ impl GpuRenderer {
             let shape_count = batch.vertex_count / 6;
             render_pass
                 .set_index_buffer(instanced.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
-            render_pass.draw_indexed(0..6, 0, first_shape..first_shape + shape_count);
+            // Rims arrive in ascending shape order (step 4 walks the fused
+            // upload front to back), so this batch's rims are one contiguous
+            // run of the slice.
+            debug_assert!(
+                rims.windows(2)
+                    .all(|pair| pair[0].shape_index < pair[1].shape_index),
+                "rim draws must arrive in ascending shape order"
+            );
+            let rim_start = rims.partition_point(|rim| rim.shape_index < first_shape);
+            let rim_end = rims.partition_point(|rim| rim.shape_index < first_shape + shape_count);
+            let batch_rims = &rims[rim_start..rim_end];
+            let rim_buffers = match (&self.rim_mesh_vertex_buffer, &self.rim_mesh_index_buffer) {
+                (Some(vertex_buffer), Some(index_buffer)) if !batch_rims.is_empty() => {
+                    Some((vertex_buffer, index_buffer))
+                }
+                _ => None,
+            };
+            let Some((rim_vertex_buffer, rim_index_buffer)) = rim_buffers else {
+                render_pass.draw_indexed(0..6, 0, first_shape..first_shape + shape_count);
+                return;
+            };
+            // Split the instance range around each rim, in exact shape
+            // order, so z is untouched: instances before the rim, the rim's
+            // band mesh through `vs_mesh`, instances after. Bind groups
+            // persist across `set_pipeline` because the mesh and instanced
+            // pipelines share identical bind group layouts (uniform layout +
+            // shape layout, dynamic similarity offset included), so only the
+            // pipeline and index/vertex buffers are re-set per switch.
+            let mut draw_calls = 0u32;
+            let mut cursor = first_shape;
+            for rim in batch_rims {
+                if cursor < rim.shape_index {
+                    render_pass.draw_indexed(0..6, 0, cursor..rim.shape_index);
+                    draw_calls += 1;
+                }
+                render_pass.set_pipeline(self.mesh_pipeline());
+                render_pass.set_vertex_buffer(0, rim_vertex_buffer.slice(..));
+                render_pass.set_index_buffer(rim_index_buffer.slice(..), wgpu::IndexFormat::Uint32);
+                render_pass.draw_indexed(
+                    rim.first_index..rim.first_index + rim.index_count,
+                    0,
+                    0..1,
+                );
+                draw_calls += 1;
+                set_instanced_pipeline(render_pass);
+                render_pass
+                    .set_index_buffer(instanced.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+                cursor = rim.shape_index + 1;
+            }
+            if cursor < first_shape + shape_count {
+                render_pass.draw_indexed(0..6, 0, cursor..first_shape + shape_count);
+                draw_calls += 1;
+            }
+            // One draw call was already counted at the top of the fn.
+            self.frame_stats
+                .add_draw_calls(draw_calls.saturating_sub(1));
             return;
         }
         if blend_mode == BlendMode::SrcOver && !batch.has_gradient {
@@ -10055,7 +10472,7 @@ impl GpuRenderer {
                     occlusion_query_set: None,
                     multiview_mask: None,
                 });
-        self.draw_prepared_shapes(&mut render_pass, blend_mode, batch, width, height);
+        self.draw_prepared_shapes(&mut render_pass, blend_mode, batch, width, height, &[]);
     }
 
     fn draw_prepared_images(
@@ -11991,7 +12408,7 @@ impl GpuRenderer {
         match self.surface_format {
             wgpu::TextureFormat::Rgba8Unorm | wgpu::TextureFormat::Rgba8UnormSrgb => Ok(()),
             wgpu::TextureFormat::Bgra8Unorm | wgpu::TextureFormat::Bgra8UnormSrgb => {
-                for pixel in pixels.chunks_exact_mut(4) {
+                for pixel in pixels.as_chunks_mut::<4>().0 {
                     pixel.swap(0, 2);
                 }
                 Ok(())
@@ -12859,7 +13276,7 @@ fn source_axis_uv(start: f32, extent: f32, image_extent: f32) -> Option<(f32, f3
 
 fn apply_filter_to_bitmap(image: &ImageBitmap, filter: ColorFilter) -> Result<ImageBitmap, String> {
     let mut filtered = Vec::with_capacity(image.pixels().len());
-    for pixel in image.pixels().chunks_exact(4) {
+    for pixel in image.pixels().as_chunks::<4>().0 {
         let rgba = [
             pixel[0] as f32 / 255.0,
             pixel[1] as f32 / 255.0,
@@ -18182,7 +18599,9 @@ mod tests {
                     [p[0] as f64, p[1] as f64]
                 };
                 let triangles: Vec<[[f64; 2]; 3]> = indices
-                    .chunks_exact(3)
+                    .as_chunks::<3>()
+                    .0
+                    .iter()
                     .map(|tri| [position(tri[0]), position(tri[1]), position(tri[2])])
                     .collect();
 
@@ -18323,7 +18742,7 @@ mod tests {
             // Inner vertices ride the dilated inner radius, outer vertices
             // the pushed-out chord radius — sanity that pairs are ordered
             // (inner, outer).
-            for pair in vertices.chunks_exact(2) {
+            for pair in vertices.as_chunks::<2>().0 {
                 let radius = |v: &MeshVertex| {
                     let dx = v.position[0] - 250.0;
                     let dy = v.position[1] - 250.0;
@@ -18414,6 +18833,98 @@ mod tests {
         let converted = converted_arc_shape(arc, 1.0);
         let shapes = vec![converted; 100];
         assert!(build_arc_mesh_vertices(&shapes).is_none());
+    }
+
+    /// A converted circle rim, hand-built in `ShapeData` terms: `rect` is the
+    /// stroke-inflated 300×300 box, the geometry is 292×292, and the corner
+    /// radius (300 − 8) / 2 = 146 equals the geometry half-extent — a circle.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn rim_test_shape_data() -> ShapeData {
+        let mut shape = ShapeData::zeroed();
+        shape.rect = [40.0, 40.0, 300.0, 300.0];
+        shape.radii = [146.0; 4];
+        shape.stroke_params = [
+            8.0,
+            pack_shape_flags(SHAPE_KIND_STROKE, StrokeCap::Butt, StrokeJoin::Miter),
+            0.0,
+            0.0,
+        ];
+        shape.quad01 = [40.0, 40.0, 340.0, 40.0];
+        shape.quad23 = [40.0, 340.0, 340.0, 340.0];
+        shape.color = [1.0, 1.0, 1.0, 1.0];
+        shape
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn rim_mesh_band_accepts_only_huge_solid_unclipped_circle_rims() {
+        let band = rim_mesh_band(&rim_test_shape_data()).expect("circle rim must qualify");
+        assert_eq!(band.center, [190.0, 190.0]);
+        assert_eq!(band.inner, 142.0);
+        assert_eq!(band.outer, 150.0);
+        assert_eq!(band.start, 0.0);
+        assert!(
+            band.sweep >= cranpose_ui_graphics::TAU,
+            "a rim band is a closed ring"
+        );
+        // And it actually meshes through the shared emitter.
+        let mut vertices = Vec::new();
+        let mut indices = Vec::new();
+        emit_arc_band_mesh(
+            &rim_test_shape_data(),
+            7,
+            &band,
+            &mut vertices,
+            &mut indices,
+        )
+        .expect("rim must mesh");
+        assert!(vertices.iter().all(|vertex| vertex.shape_idx == 7));
+
+        // Rounded SQUARE ring: radius well below the geometry half-extent.
+        // Meshing it would under-cover the flat spans — the false positive
+        // the circle gate exists to prevent.
+        let mut square = rim_test_shape_data();
+        square.radii = [100.0; 4];
+        assert!(rim_mesh_band(&square).is_none());
+
+        // Non-square box.
+        let mut oblong = rim_test_shape_data();
+        oblong.rect = [40.0, 40.0, 300.0, 200.0];
+        assert!(rim_mesh_band(&oblong).is_none());
+
+        // Gradient brush.
+        let mut gradient = rim_test_shape_data();
+        gradient.brush_type = 1;
+        assert!(rim_mesh_band(&gradient).is_none());
+
+        // Live clip.
+        let mut clipped = rim_test_shape_data();
+        clipped.clip_rect = [0.0, 0.0, 400.0, 400.0];
+        assert!(rim_mesh_band(&clipped).is_none());
+
+        // Small (100 × 100 < 65536 px²), even as a perfect circle.
+        let mut small = rim_test_shape_data();
+        small.rect = [40.0, 40.0, 100.0, 100.0];
+        small.quad01 = [40.0, 40.0, 140.0, 40.0];
+        small.quad23 = [40.0, 140.0, 140.0, 140.0];
+        small.radii = [46.0; 4];
+        assert!(rim_mesh_band(&small).is_none());
+
+        // Fill kind, not stroke.
+        let mut fill = rim_test_shape_data();
+        fill.stroke_params[1] =
+            pack_shape_flags(SHAPE_KIND_FILL, StrokeCap::Butt, StrokeJoin::Miter);
+        assert!(rim_mesh_band(&fill).is_none());
+
+        // Zero stroke width.
+        let mut hairline = rim_test_shape_data();
+        hairline.stroke_params[0] = 0.0;
+        assert!(rim_mesh_band(&hairline).is_none());
+
+        // Mismatched corner radii.
+        let mut uneven = rim_test_shape_data();
+        uneven.radii[2] = 145.0;
+        assert!(rim_mesh_band(&uneven).is_none());
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/crates/cranpose-render/wgpu/tests/rim_mesh_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/rim_mesh_parity.rs
@@ -1,0 +1,227 @@
+//! Pixel parity for the transient rim band mesh.
+//!
+//! A huge stroked round-rect whose corner radius equals its geometry
+//! half-extent is a circle ring — an arena "rim". The fused shape path
+//! detects such shapes per frame (`rim_mesh_band`) and rasterizes only the
+//! annulus band ± the antialiasing margin through the retained-mesh
+//! machinery (`vs_mesh` + `fs_main`), instead of the ~100k-px bounding quad
+//! whose fragments the stroked-round-rect SDF almost entirely discards.
+//!
+//! The bar is ZERO differing bytes against the quad-expansion arm: for a
+//! radius equal to the half-extent the SDF degenerates exactly to an
+//! annulus, the band mesh contains every pixel with `|dist| < 0.5`
+//! (over-inclusion is free — the SDF discards those pixels identically),
+//! and `fs_solid` is pinned byte-exact against `fs_main` by
+//! `solid_fs_parity`. Arm separation is by the `CRANPOSE_RIM_MESH` kill
+//! switch, which is read per fused-chunk prepare — no renderer relatch is
+//! involved, but each arm still renders a throwaway warm pass plus two
+//! byte-stable controls (the same-position-control discipline
+//! `command_feed_parity` documents).
+//!
+//! The scene surrounds the rim with small solid circles on BOTH z sides,
+//! several overlapping the ring itself, so the draw split (instances below
+//! the rim, band mesh, instances above) is exercised and any z-order
+//! mistake shows up as differing bytes.
+
+mod support;
+
+use cranpose_render_common::graph::{
+    CachePolicy, DrawRunNode, IsolationReasons, LayerNode, PrimitivePhase, ProjectiveTransform,
+    RenderGraph, RenderNode,
+};
+use cranpose_render_common::raster_cache::LayerRasterCacheHashes;
+use cranpose_render_common::Renderer;
+use cranpose_ui_graphics::{
+    Brush, Color, CornerRadii, DrawScope, DrawScopeDefault, GraphicsLayer, Point, Rect, Stroke,
+};
+
+const SIZE: u32 = 400;
+/// The rim's geometry rect: 320 × 320 at (40, 40). The emitted shape is
+/// inflated by half the 8 px stroke (device box 328 × 328 ≈ 107k px², past
+/// the 65536 px² gate), and the corner radius 160 equals the geometry
+/// half-extent — the outline is a circle of diameter 320 about (200, 200).
+const RIM_RECT: Rect = Rect {
+    x: 40.0,
+    y: 40.0,
+    width: 320.0,
+    height: 320.0,
+};
+const RIM_STROKE_WIDTH: f32 = 8.0;
+const RIM_RADIUS: f32 = 160.0;
+
+fn record_scene(scope: &mut DrawScopeDefault) {
+    scope.draw_rect_at(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: SIZE as f32,
+            height: SIZE as f32,
+        },
+        Brush::solid(Color(0.03, 0.03, 0.06, 1.0)),
+    );
+    // Neighbors BELOW the rim in z, several sitting on the ring itself so
+    // the rim must cover them.
+    for i in 0..5u32 {
+        let angle = i as f32 * (std::f32::consts::TAU / 5.0);
+        scope.draw_circle(
+            Brush::solid(Color(0.9, 0.5, 0.2, 1.0)),
+            Point::new(
+                200.0 + angle.cos() * RIM_RADIUS,
+                200.0 + angle.sin() * RIM_RADIUS,
+            ),
+            7.0,
+        );
+    }
+    // The rim itself: a solid stroked circle round-rect, SrcOver, no clip.
+    scope.draw_round_rect_at_stroked(
+        RIM_RECT,
+        Brush::solid(Color(0.35, 0.75, 0.95, 1.0)),
+        CornerRadii::uniform(RIM_RADIUS),
+        Stroke {
+            width: RIM_STROKE_WIDTH,
+            ..Default::default()
+        },
+    );
+    // Neighbors ABOVE the rim in z: semi-transparent and overlapping the
+    // band, so a draw-order mistake changes blended bytes, not just AA
+    // fringes.
+    for i in 0..5u32 {
+        let angle = (i as f32 + 0.5) * (std::f32::consts::TAU / 5.0);
+        scope.draw_circle(
+            Brush::solid(Color(0.4, 0.95, 0.55, 0.8)),
+            Point::new(
+                200.0 + angle.cos() * RIM_RADIUS,
+                200.0 + angle.sin() * RIM_RADIUS,
+            ),
+            6.0,
+        );
+    }
+    for m in 0..6u32 {
+        scope.draw_circle(
+            Brush::solid(Color(1.0, 0.85, 0.4, 0.9)),
+            Point::new(30.0 + m as f32 * 68.0, 14.0),
+            5.0,
+        );
+    }
+}
+
+fn rim_graph() -> RenderGraph {
+    let mut scope =
+        DrawScopeDefault::new(cranpose_ui_graphics::Size::new(SIZE as f32, SIZE as f32));
+    record_scene(&mut scope);
+    let bounds = Rect {
+        x: 0.0,
+        y: 0.0,
+        width: SIZE as f32,
+        height: SIZE as f32,
+    };
+    RenderGraph::new(LayerNode {
+        node_id: None,
+        local_bounds: bounds,
+        transform_to_parent: ProjectiveTransform::identity(),
+        content_offset: Point::default(),
+        motion_context_animated: false,
+        translated_content_context: false,
+        translated_content_offset: Point::default(),
+        scene_children_origin: Point::default(),
+        scene_children_layer_translation: Point::default(),
+        graphics_layer: GraphicsLayer::default(),
+        clip_to_bounds: false,
+        shadow_clip: None,
+        hit_test: None,
+        has_hit_targets: false,
+        isolation: IsolationReasons::default(),
+        cache_policy: CachePolicy::None,
+        cache_hashes: LayerRasterCacheHashes::default(),
+        cache_hashes_valid: false,
+        children: vec![RenderNode::DrawRun(DrawRunNode::new(
+            PrimitivePhase::BeforeChildren,
+            scope.into_primitives(),
+        ))],
+    })
+}
+
+/// Warm pass (never compared), then two controls asserted byte-stable; the
+/// second control is the arm's frame.
+fn render_arm(renderer: &mut support::LockedRenderer, graph: &RenderGraph) -> Vec<u8> {
+    let mut passes = Vec::new();
+    for _ in 0..3 {
+        renderer.scene_mut().graph = Some(graph.clone());
+        let captured = renderer
+            .capture_frame(SIZE, SIZE)
+            .unwrap_or_else(|err| panic!("capture failed: {err:?}"));
+        assert_eq!((captured.width, captured.height), (SIZE, SIZE));
+        passes.push(captured.pixels);
+    }
+    assert_eq!(
+        passes[1], passes[2],
+        "same-graph control passes must be byte-stable before the cross-arm compare"
+    );
+    passes.pop().unwrap()
+}
+
+#[test]
+fn rim_band_mesh_matches_the_quad_expansion() {
+    // Arm A must run under the DEFAULT switch state.
+    std::env::remove_var("CRANPOSE_RIM_MESH");
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!("skipping rim mesh parity: headless WGPU init failed: {err}");
+            return;
+        }
+    };
+    if !renderer.instanced_quads_active() {
+        // The rim path exists only where the instanced/storage shape path
+        // does; a uniform-mode device draws every rim as a quad already.
+        eprintln!("skipping rim mesh parity: instanced quads inactive (uniform mode)");
+        return;
+    }
+
+    let graph = rim_graph();
+
+    let emitted_before = renderer.rim_meshes_emitted();
+    let meshed = render_arm(&mut renderer, &graph);
+    let emitted_meshed = renderer.rim_meshes_emitted();
+    assert!(
+        emitted_meshed > emitted_before,
+        "arm A must actually draw the rim as a band mesh (counter stayed at {emitted_before})"
+    );
+
+    // The switch is read per fused-chunk prepare, so no renderer relatch is
+    // needed; one throwaway frame after flipping keeps the arms' warm
+    // discipline identical anyway.
+    std::env::set_var("CRANPOSE_RIM_MESH", "0");
+    let quad = render_arm(&mut renderer, &graph);
+    let emitted_after_off = renderer.rim_meshes_emitted();
+    std::env::remove_var("CRANPOSE_RIM_MESH");
+    assert_eq!(
+        emitted_after_off, emitted_meshed,
+        "arm B must draw every rim through the quad expansion"
+    );
+
+    assert_eq!(meshed.len(), quad.len());
+    let mut differing = 0usize;
+    let mut beyond_one = 0usize;
+    let mut worst = 0u8;
+    for (a, b) in meshed.iter().zip(&quad) {
+        let diff = a.abs_diff(*b);
+        if diff > 0 {
+            differing += 1;
+            worst = worst.max(diff);
+            if diff > 1 {
+                beyond_one += 1;
+            }
+        }
+    }
+    eprintln!(
+        "rim-meshed-vs-quad: differing {differing} (beyond ±1: {beyond_one}) worst {worst}; \
+         rims meshed {}",
+        emitted_meshed - emitted_before
+    );
+    assert_eq!(
+        differing, 0,
+        "{differing} bytes diverged ({beyond_one} beyond ±1, worst {worst}) — \
+         the rim band mesh must rasterize byte-identically to the bounding quad"
+    );
+}

--- a/crates/cranpose-render/wgpu/tests/swipe_to_dismiss_lazy.rs
+++ b/crates/cranpose-render/wgpu/tests/swipe_to_dismiss_lazy.rs
@@ -13,7 +13,9 @@ const FRAME_HEIGHT: u32 = 480;
 
 fn bright_text_pixels(pixels: &[u8]) -> usize {
     pixels
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .filter(|pixel| pixel[0] > 120 && pixel[1] > 90 && pixel[2] > 40)
         .count()
 }

--- a/crates/cranpose-render/wgpu/tests/wear_scaling_list_pixels.rs
+++ b/crates/cranpose-render/wgpu/tests/wear_scaling_list_pixels.rs
@@ -41,7 +41,9 @@ fn colors() -> WearColors {
 fn lit_pixel_count(frame: &CapturedFrame) -> usize {
     frame
         .pixels
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .filter(|pixel| pixel[0] > 16 || pixel[1] > 16 || pixel[2] > 16)
         .count()
 }

--- a/crates/cranpose-ui-graphics/src/fx_hash.rs
+++ b/crates/cranpose-ui-graphics/src/fx_hash.rs
@@ -40,15 +40,12 @@ impl FxHasher {
 impl Hasher for FxHasher {
     #[inline]
     fn write(&mut self, bytes: &[u8]) {
-        let mut chunks = bytes.chunks_exact(8);
-        for chunk in &mut chunks {
-            let mut word = [0u8; 8];
-            word.copy_from_slice(chunk);
-            self.fold(u64::from_le_bytes(word));
+        let (chunks, tail) = bytes.as_chunks::<8>();
+        for chunk in chunks {
+            self.fold(u64::from_le_bytes(*chunk));
         }
         // The tail is folded together with its own length, so `[1]` and `[1, 0]`
         // stay distinct even though both pad to the same word.
-        let tail = chunks.remainder();
         if !tail.is_empty() {
             let mut word = [0u8; 8];
             word[..tail.len()].copy_from_slice(tail);

--- a/crates/cranpose-ui-graphics/src/image.rs
+++ b/crates/cranpose-ui-graphics/src/image.rs
@@ -208,7 +208,11 @@ impl ImageBitmap {
         }
 
         let id = bitmap_content_id(width, height, pixels);
-        let opaque = pixels.chunks_exact(4).all(|pixel| pixel[3] == u8::MAX);
+        let opaque = pixels
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .all(|pixel| pixel[3] == u8::MAX);
         Ok(Self {
             width,
             height,

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -69,10 +69,11 @@ fn property_flag(name: &str) -> bool {
 ///
 /// Property names are capped at 32 bytes by `PROP_NAME_MAX`, which is why they
 /// are abbreviations rather than the full variable name.
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 16] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 17] = [
     ("debug.cranpose.gpu_stats", "CRANPOSE_GPU_STATS"),
     ("debug.cranpose.command_feed", "CRANPOSE_COMMAND_FEED"),
     ("debug.cranpose.arc_mesh", "CRANPOSE_ARC_MESH"),
+    ("debug.cranpose.rim_mesh", "CRANPOSE_RIM_MESH"),
     ("debug.cranpose.instanced_quads", "CRANPOSE_INSTANCED_QUADS"),
     (
         "debug.cranpose.retained_bundles",


### PR DESCRIPTION
MEGA's arena rims are stroked round-rects whose corner radius equals the geometry half-extent — circles. Each rasterized its full ~158k-px bounding quad through `sdf_stroked_rounded_rect` (the most expensive SDF branch) discarding ~99% of fragments. The fused shape prepare now detects these rims on the converted `ShapeData` and draws them through the existing `vs_mesh` pipeline as transient annulus band meshes, splitting the instanced draw around each rim to preserve z-order. Byte-exact by construction (annulus degeneration argument in the code docs) and by test: `rim_mesh_parity` renders the same scene on/off and asserts identical bytes plus an engagement counter. Kill switch: `CRANPOSE_RIM_MESH=0` / `debug.cranpose.rim_mesh`.

**Measured, Pixel Watch 3, MEGA bench arena** (10 s windows, one per thermal cycle, cool-gated ≤36.8 °C, arms are twin binaries differing only in the compiled default):

| arm | fps |
|---|---|
| rims meshed | 47.4, 47.4, 47.6, 48.4, 51.5 (new record) |
| rims quad (control) | 37.1, 37.3, 38.1, 38.3, 38.7 |

≈ **+10 fps**. Logcat emit telemetry confirms 2–3 rims meshed/frame at ~80 verts each, zero buffer overflows. An occasional heavier game phase reads ~34 fps with rims on; a capacity-×4 twin reproduced it unchanged while meshing the same 2–3 rims, so it tracks scene content (which the slower control never reaches inside a 10 s window), not rim-path cost.

Local gates: fmt, versions, `cranpose-render-wgpu` full test suite (21 suites), crate clippy — green. Full workspace suite left to CI (local disk incident).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2