### PR TITLE
Stop sleeping to the next vsync after a frame that already missed one

### DIFF
--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -1600,6 +1600,22 @@ pub fn run(
     const MAX_EXIT_ATTEMPTS: u32 = 3;
     let mut exit_attempts = 0u32;
 
+    // Catch-up pacing (kill switch CRANPOSE_CATCHUP_PACING=0 /
+    // debug.cranpose.catchup_pacing): when the previous iteration's present
+    // landed more than a refresh period after the one before it, the frame
+    // already missed its vsync — sleeping until the NEXT choreographer tick
+    // would round that miss up to a whole extra period, turning an 18 ms
+    // frame into a 33 ms one. Behind-deadline iterations poll immediately
+    // instead; `Fifo` present back-pressure paces them. Any iteration that
+    // does not present resets to vsync pacing, so an idle app that skips
+    // presents can never busy-loop on the zero poll.
+    let catchup_pacing = !matches!(std::env::var("CRANPOSE_CATCHUP_PACING").as_deref(), Ok("0"));
+    if catchup_pacing {
+        log::info!("[pacing] catch-up pacing enabled");
+    }
+    let mut last_present_at: Option<web_time::Instant> = None;
+    let mut behind_deadline = false;
+
     // Main event loop
     loop {
         let mut frame_timings = crate::android_frame_telemetry::FrameTimings {
@@ -1681,7 +1697,12 @@ pub fn run(
             // turns an idle app into a busy loop. Fall back to the zero poll
             // when the display cannot wake us, so a device without a
             // choreographer keeps the behaviour it had.
-            if crate::android_vsync::request_wake_at_next_vsync() {
+            if behind_deadline {
+                // The last present already missed its vsync (see the
+                // catch-up pacing note above the loop); every behind
+                // iteration presents, so the busy-loop hazard cannot arise.
+                Some(Duration::ZERO)
+            } else if crate::android_vsync::request_wake_at_next_vsync() {
                 idle_timeout
             } else {
                 Some(Duration::ZERO)
@@ -2374,6 +2395,32 @@ pub fn run(
             }
         } else {
             frame_telemetry.note_idle_iteration();
+        }
+
+        // Catch-up pacing bookkeeping (see the note above the loop):
+        // `after_present_ns` is stamped only by a successful present, and
+        // `FrameTimings` is fresh per iteration, so a nonzero value is the
+        // exact "this iteration presented" signal.
+        if frame_timings.after_present_ns != 0 {
+            let now = web_time::Instant::now();
+            behind_deadline = catchup_pacing
+                && last_present_at.is_some_and(|previous| {
+                    // Display-reported period first (vsync-probe builds),
+                    // then the always-on estimate from consecutive
+                    // choreographer callback deltas, then the 60 Hz default.
+                    let reported = crate::android_frame_telemetry::vsync_period_ns();
+                    let period = if reported > 0 {
+                        reported
+                    } else {
+                        crate::android_vsync::observed_vsync_period_ns().unwrap_or(16_666_667)
+                    };
+                    // period/16 of slack (~1 ms at 60 Hz) keeps at-rate
+                    // presentation jitter from triggering catch-up.
+                    now.duration_since(previous).as_nanos() as i64 > period + period / 16
+                });
+            last_present_at = Some(now);
+        } else {
+            behind_deadline = false;
         }
     }
 }

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -69,11 +69,12 @@ fn property_flag(name: &str) -> bool {
 ///
 /// Property names are capped at 32 bytes by `PROP_NAME_MAX`, which is why they
 /// are abbreviations rather than the full variable name.
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 17] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 18] = [
     ("debug.cranpose.gpu_stats", "CRANPOSE_GPU_STATS"),
     ("debug.cranpose.command_feed", "CRANPOSE_COMMAND_FEED"),
     ("debug.cranpose.arc_mesh", "CRANPOSE_ARC_MESH"),
     ("debug.cranpose.rim_mesh", "CRANPOSE_RIM_MESH"),
+    ("debug.cranpose.catchup_pacing", "CRANPOSE_CATCHUP_PACING"),
     ("debug.cranpose.instanced_quads", "CRANPOSE_INSTANCED_QUADS"),
     (
         "debug.cranpose.retained_bundles",

--- a/crates/cranpose/src/android_vsync.rs
+++ b/crates/cranpose/src/android_vsync.rs
@@ -86,9 +86,39 @@ pub(crate) fn request_wake_at_next_vsync() -> bool {
     true
 }
 
-unsafe extern "C" fn on_vsync(_frame_time_ns: i64, _data: *mut c_void) {
+unsafe extern "C" fn on_vsync(frame_time_ns: i64, _data: *mut c_void) {
     CALLBACK_POSTED.store(false, Ordering::Release);
+    let previous = LAST_VSYNC_NS.swap(frame_time_ns, Ordering::Relaxed);
+    if previous != 0 {
+        let delta = frame_time_ns - previous;
+        // Only single-period deltas train the estimate: catch-up iterations
+        // skip arming the choreographer, so consecutive callbacks can be
+        // many periods apart and those gaps must not stretch the period.
+        if (4_000_000..50_000_000).contains(&delta) {
+            VSYNC_PERIOD_NS.store(delta, Ordering::Relaxed);
+        }
+    }
     if let Some(waker) = WAKER.get() {
         waker();
+    }
+}
+
+use std::sync::atomic::AtomicI64;
+
+/// Timestamp of the most recent choreographer callback, for period
+/// measurement in [`observed_vsync_period_ns`].
+static LAST_VSYNC_NS: AtomicI64 = AtomicI64::new(0);
+/// Most recent single-period delta between consecutive choreographer
+/// callbacks; 0 until two callbacks have been observed.
+static VSYNC_PERIOD_NS: AtomicI64 = AtomicI64::new(0);
+
+/// The display's refresh period as measured between consecutive
+/// choreographer callbacks, if two have been seen. Reflects
+/// SurfaceFlinger's `frameRateOverride` pinning automatically, which a
+/// panel-mode query would not.
+pub(crate) fn observed_vsync_period_ns() -> Option<i64> {
+    match VSYNC_PERIOD_NS.load(Ordering::Relaxed) {
+        0 => None,
+        period => Some(period),
     }
 }


### PR DESCRIPTION
The Android frame loop unconditionally re-armed the choreographer and slept in epoll after every present — including presents that already landed more than a refresh period after the previous one. A ~18 ms frame chain therefore cost a full 33.3 ms period. The Pixel Watch 3's MEGA scene ran at exactly the mix that arithmetic predicts: **47.5 fps = 73.7% one-period + 26.3% two-period frames**, with 2.8 ms/frame of measured epoll idle on the render thread (simpleperf, `--trace-offcpu`).

Behind-deadline iterations (present-to-present interval > period + 1/16 slack) now poll immediately; `Fifo` present back-pressure paces them. Any iteration that does not present resets to vsync pacing, so the busy-loop hazard the original comment guards against cannot arise. Refresh period: display-reported when the vsync probe runs, else consecutive choreographer callback deltas (single-period gated), else 16.67 ms.

Kill switch: `CRANPOSE_CATCHUP_PACING=0` / `debug.cranpose.catchup_pacing`.

**Measured, Pixel Watch 3, MEGA bench arena** (on-wrist strict-alternation 10 s windows, twin binaries differing only in this default):

| pair | pacing on | control |
|---|---|---|
| 1 | 38.27 | 31.65 |
| 2 | 32.29 | 23.14 |

**+7 to +9 fps**, converging to no-effect only past ~42 °C throttle (chains > 2 periods), as the mechanism predicts. Cool-docked confirmation windows to follow; scheduling-only change, no pixel path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2