### PR TITLE
Keep the everyday macOS jobs off the mac somebody is working on

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
   checks:
     name: fmt + tests + clippy (mac)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, macOS, idle-mac]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
@@ -111,7 +111,7 @@ jobs:
   feature-smoke:
     name: ${{ matrix.feature }} feature (mac)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, macOS, idle-mac]
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -132,7 +132,7 @@ jobs:
   property-smoke:
     name: property smoke (mac)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, macOS, idle-mac]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -152,7 +152,7 @@ jobs:
   criterion-smoke:
     name: criterion smoke (mac)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, macOS, idle-mac]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Three runs were queued behind the macs while one of them was in use by hand.

There are two macOS runners — `dmitriis-mac-Cranpose` and `mac-idle-Cranpose` — and `runs-on: [self-hosted, macOS]` matches either, so the jobs that run on **every push** keep landing on whichever is free, including the one someone is working on.

The four `rust.yml` macOS jobs now ask for the `idle-mac` label.

## What deliberately does not move

The iOS build, publish, release and Pages jobs stay on the shared `[self-hosted, macOS, ARM64]` pool:

- they need Xcode and signing identities, and nothing here verifies the spare has them;
- they run rarely, not on every push, so they are not what competes for the machine;
- keeping two eligible runners means a release is never blocked by a single machine being offline.

Pinning everything to one runner would trade a queueing problem for a single point of failure on exactly the jobs where that hurts most.

This PR's own CI is the test: its macOS jobs carry the new label, so they should be picked up by the idle runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)