### PR TITLE
Keep catch-up pacing armed across the idle iteration it creates

### DIFF
--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -1615,6 +1615,7 @@ pub fn run(
     }
     let mut last_present_at: Option<web_time::Instant> = None;
     let mut behind_deadline = false;
+    let mut catchup_coasts = 0u32;
 
     // Main event loop
     loop {
@@ -2418,9 +2419,23 @@ pub fn run(
                     // presentation jitter from triggering catch-up.
                     now.duration_since(previous).as_nanos() as i64 > period + period / 16
                 });
+            catchup_coasts = 0;
             last_present_at = Some(now);
-        } else {
-            behind_deadline = false;
+        } else if behind_deadline {
+            // Frame telemetry caught the original reset-on-any-idle rule
+            // defeating catch-up once per frame: a zero-poll iteration can
+            // land before the update clock has advanced, skip its present
+            // as "nothing changed", and the reset then handed the NEXT
+            // iteration back to the choreographer — a measured p50 10.9 ms
+            // poll sleep per presented frame at 33 fps. Behind-deadline now
+            // survives a bounded number of non-presenting iterations; the
+            // bound keeps the original guarantee that an idle app skipping
+            // presents for identical frames returns to vsync pacing after
+            // at most a few immediate polls instead of busy-looping.
+            catchup_coasts += 1;
+            if catchup_coasts >= 3 {
+                behind_deadline = false;
+            }
         }
     }
 }


### PR DESCRIPTION
Frame telemetry on the watch caught #395's catch-up pacing being defeated once per frame in heavy scenes: the zero poll returns before the update clock advances, that iteration skips its present as "nothing changed", and the reset-on-any-idle rule handed the next iteration back to the choreographer. Measured shape at 33 fps: **poll p50 10.9 ms** + update 9.3 + render 8.4 inside a 29.7 ms period — a whole vsync wait wasted per frame.

Behind-deadline now coasts through up to three consecutive non-presenting iterations before resetting. The busy-loop guarantee holds in bounded form: an idle app skipping identical presents returns to vsync pacing after at most three immediate polls.

**Telemetry, same watch, same scene family, before → after:** poll mean 8.67 → **0.03 ms** (p50 10.89 → 0.02); the frame period is now pure work (update 8.9 + render 9.4 + present 3.7). Same kill switch as #395 (`CRANPOSE_CATCHUP_PACING`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2