### PR TITLE
State a parity the driver can actually promise, and stop hand-copying to get it

### DIFF
--- a/crates/cranpose-render/wgpu/tests/solid_fs_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/solid_fs_parity.rs
@@ -166,6 +166,26 @@ fn render_arm(renderer: &mut support::LockedRenderer, graph: &RenderGraph) -> Ve
     passes.pop().unwrap()
 }
 
+/// How far the two entry points may disagree.
+///
+/// Not zero, and it cannot be. `fs_solid` and `fs_main` are two shader
+/// *programs*, and no driver promises they contract floats identically — the
+/// same expression may become an fma in one and a multiply-add in the other
+/// depending on register pressure, which differs precisely because one of them
+/// carries the gradient code. Measured on Linux/Vulkan: **3 bytes apart, worst
+/// 2 levels**, from a 128x128 frame, and unchanged when the coverage math was
+/// factored into a single shared function called by both — the duplication was
+/// not the cause. macOS/Metal, which is where CI runs the workspace tests, sees
+/// zero, which is why this shipped looking exact.
+///
+/// The bound stays three orders of magnitude below what it has to catch: the
+/// negative control for this test — dimming `fs_solid`'s return — moves ~13000
+/// bytes. Anything approaching that is a shading difference, not arithmetic
+/// noise. A divergence visible to anyone would be far larger still.
+const MAX_DIVERGING_BYTES: usize = 16;
+/// Per-byte ceiling: a level or two of rounding, never a visible step.
+const MAX_DIVERGING_LEVEL: u8 = 2;
+
 #[test]
 fn solid_fragment_entry_matches_fs_main() {
     let mut renderer = match support::headless_renderer() {
@@ -194,9 +214,11 @@ fn solid_fragment_entry_matches_fs_main() {
         }
     }
     eprintln!("solid-vs-mixed: differing {differing} (beyond ±1: {beyond_one}) worst {worst}");
-    assert_eq!(
-        differing, 0,
-        "{differing} bytes diverged ({beyond_one} beyond ±1, worst {worst}) — \
-         fs_solid must render solid shapes byte-identically to fs_main"
+    assert!(
+        differing <= MAX_DIVERGING_BYTES && worst <= MAX_DIVERGING_LEVEL,
+        "{differing} bytes diverged ({beyond_one} beyond ±1, worst {worst}), over a bound of \
+         {MAX_DIVERGING_BYTES} bytes and {MAX_DIVERGING_LEVEL} levels — fs_solid must render \
+         solid shapes as fs_main does, and a divergence this size is a shading difference \
+         rather than the compiler contracting floats differently between two programs"
     );
 }

--- a/crates/cranpose-ui-graphics/shaders/shape.wgsl
+++ b/crates/cranpose-ui-graphics/shaders/shape.wgsl
@@ -506,8 +506,16 @@ fn sample_gradient(gradient_start: u32, count: u32, t: f32) -> vec4<f32> {
     return gradient_stops[gradient_start + count - 1u].color;
 }
 
-@fragment
-fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+/// The coverage half of a shape fragment: the clip test, the shape-kind
+/// ladder down to an alpha, and the two discards that end a fragment before
+/// anything is shaded.
+///
+/// Both fragment entry points call this so the arithmetic exists once. It was
+/// duplicated line for line into `fs_solid` on the argument that identical
+/// source in the same order makes the compiler emit identical instructions;
+/// on Vulkan it did not, and `solid_fs_parity` measured three pixels apart by
+/// up to 2/255 (the macOS CI runner, on Metal, saw none of it).
+fn shape_coverage_alpha(input: VertexOutput) -> f32 {
     let world_pos = input.world_pos;
     // Local layer-space pixel coordinate derived from uv, independent of
     // world-space quad deformation (rotation/perspective).
@@ -587,6 +595,19 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         discard;
     }
 
+    return alpha;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    let alpha = shape_coverage_alpha(input);
+
+    // Re-derived rather than threaded out of the coverage pass: both are pure
+    // functions of `input`, so the compiler folds them back together.
+    let world_pos = input.world_pos;
+    let rect_pos = input.rect.xy + input.uv * input.rect.zw;
+
+
     var color = input.color;
     var is_gradient = false;
 
@@ -651,80 +672,18 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     return vec4<f32>(color.rgb, color.a * alpha);
 }
 
-// `fs_main` for a draw that is known to contain only solid brushes: the
-// coverage math is copied line for line (same expressions, same order, so
-// the compiler emits the same instructions for the alpha it shares with
-// `fs_main`), and everything downstream of coverage — gradient projection,
-// stop interpolation, tile remapping, dither — is gone. A solid fragment
-// through `fs_main` already takes none of those branches at runtime; what
-// this entry removes is their cost of existing: the register footprint and
-// the gradient-stop indexing the shader core must budget for on every
-// fragment of an arc-heavy scene. The batch chooses this entry only when
-// its gradient stop count is zero, so `brush_type` could only ever be 0
-// here.
+/// `fs_main` for a draw known to contain only solid brushes.
+///
+/// Coverage is the shared function above, so this entry differs from `fs_main`
+/// by exactly what it leaves out: gradient projection, stop interpolation, tile
+/// remapping and dither. A solid fragment through `fs_main` takes none of those
+/// branches at runtime anyway; what this removes is their cost of existing —
+/// the register footprint and gradient-stop indexing the shader core budgets
+/// for on every fragment of an arc-heavy scene. A batch selects this entry only
+/// when its gradient stop count is zero, so `brush_type` could only ever be 0.
 @fragment
 fn fs_solid(input: VertexOutput) -> @location(0) vec4<f32> {
-    let world_pos = input.world_pos;
-    let rect_pos = input.rect.xy + input.uv * input.rect.zw;
-
-    let clip_w = input.clip_rect.z;
-    let clip_h = input.clip_rect.w;
-    if (clip_w > 0.0 && clip_h > 0.0) {
-        let clip_left = input.clip_rect.x;
-        let clip_top = input.clip_rect.y;
-        let clip_right = clip_left + clip_w;
-        let clip_bottom = clip_top + clip_h;
-
-        if (world_pos.x < clip_left || world_pos.x > clip_right ||
-            world_pos.y < clip_top || world_pos.y > clip_bottom) {
-            discard;
-        }
-    }
-
-    let rect_center = input.rect.xy + input.rect.zw * 0.5;
-    let half_size = input.rect.zw * 0.5;
-    let local_pos = rect_pos - rect_center;
-
-    let flags = u32(max(input.stroke_params.y, 0.0));
-    let shape_kind = flags & 3u;
-    let stroke_cap = (flags >> 2u) & 3u;
-    let stroke_join = (flags >> 4u) & 3u;
-
-    let has_radii = (input.radii[0] > 0.0 || input.radii[1] > 0.0 ||
-                     input.radii[2] > 0.0 || input.radii[3] > 0.0);
-    var alpha: f32;
-    if (shape_kind == SHAPE_KIND_ARC) {
-        let dist = sdf_arc_band(
-            rect_pos,
-            input.arc_params.xy,
-            input.stroke_params.w,
-            input.stroke_params.z,
-            input.radii.xy,
-            input.radii.zw,
-            stroke_cap,
-        );
-        alpha = 1.0 - smoothstep(-0.5, 0.5, dist);
-    } else if (shape_kind == SHAPE_KIND_STROKE) {
-        let dist = sdf_stroked_rounded_rect(
-            local_pos,
-            half_size,
-            input.radii,
-            input.stroke_params.x * 0.5,
-            stroke_join,
-        );
-        alpha = 1.0 - smoothstep(-0.5, 0.5, dist);
-    } else if (has_radii) {
-        let dist = sdf_rounded_rect(local_pos, half_size, input.radii);
-        alpha = 1.0 - smoothstep(-0.5, 0.5, dist);
-    } else {
-        let cov_x = clamp(half_size.x + 0.5 - abs(local_pos.x), 0.0, 1.0);
-        let cov_y = clamp(half_size.y + 0.5 - abs(local_pos.y), 0.0, 1.0);
-        alpha = cov_x * cov_y;
-    }
-
-    if (alpha < 0.001) {
-        discard;
-    }
-
-    return vec4<f32>(input.color.rgb, input.color.a * alpha);
+    let alpha = shape_coverage_alpha(input);
+    let color = input.color;
+    return vec4<f32>(color.rgb, color.a * alpha);
 }


### PR DESCRIPTION
Closes half of #400.

`solid_fs_parity` **fails on Linux/Vulkan and has since it landed** — 3 bytes apart, worst 2 levels, deterministic. CI never saw it because the workspace test job runs on macOS, where the number is zero.

## The duplication was not the cause, and I checked rather than assumed

`fs_solid` hand-copied ~50 lines of `fs_main` on the argument that identical source in the same order makes the compiler emit identical instructions. That is a testable claim, so this tests it: coverage is now one `shape_coverage_alpha()` called by both entry points, and **the divergence is unchanged**.

Two fragment entry points are two programs. No driver promises they contract floats identically — the same expression can become an fma in one and a multiply-add in the other depending on register pressure, which differs precisely because one carries the gradient code.

## What the assertion says now

At most 16 diverging bytes, none by more than 2 levels, with the measurement and the reasoning written on the constants.

The guard keeps all of its power — verified, not asserted:

| | bytes differing | worst |
|---|---|---|
| today, Linux/Vulkan | 3 | 2 |
| bound | 16 | 2 |
| negative control (`fs_solid` dimmed 2%) | **12993** | 3 |

Three orders of magnitude of headroom, and a difference anyone could actually see would be larger still. The engagement counter proving arm A takes the new path is untouched.

## The refactor stays either way

Fifty duplicated lines are over the repo's own copy-paste bar. The extraction is byte-neutral: the entire wgpu suite passes with identical output, which is the evidence that the compiler inlines it exactly as the hand-copy intended.

## Not touched

`wear_layer_alpha_pixels` also fails on Vulkan, for a related but distinct reason — its non-discriminating row (scale 1.0, alpha 1.0, where both models agree) is one level low in green, so it is base colour rounding rather than evidence about layer alpha. Widening it to ±1 would make its discriminating row match **both** models and the test would stop discriminating. Analysis and a suggested fix (anchor to the measured alpha-1.0 row instead of an absolute CPU triple) are in #400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)