### PR TITLE
Move Android haptics delivery off the render thread

### DIFF
--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -69,7 +69,7 @@ fn property_flag(name: &str) -> bool {
 ///
 /// Property names are capped at 32 bytes by `PROP_NAME_MAX`, which is why they
 /// are abbreviations rather than the full variable name.
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 18] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 19] = [
     ("debug.cranpose.gpu_stats", "CRANPOSE_GPU_STATS"),
     ("debug.cranpose.command_feed", "CRANPOSE_COMMAND_FEED"),
     ("debug.cranpose.arc_mesh", "CRANPOSE_ARC_MESH"),
@@ -115,6 +115,7 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 18] = [
         "CRANPOSE_DISABLE_DIRECT_SCENE_RANGE_CACHE",
     ),
     ("debug.cranpose.gpu_backend", "CRANPOSE_ANDROID_GPU_BACKEND"),
+    ("debug.cranpose.async_haptics", "CRANPOSE_ASYNC_HAPTICS"),
 ];
 
 /// Copies the [`PROPERTY_BACKED_ENV_VARS`] properties that are set into the

--- a/crates/cranpose/src/android_haptics_queue.rs
+++ b/crates/cranpose/src/android_haptics_queue.rs
@@ -1,0 +1,314 @@
+//! Bounded handoff between callers of [`cranpose_services::Haptics`] and the
+//! dedicated Android haptics delivery thread.
+//!
+//! Every vibrator call used to run on the calling thread, and a watch profile
+//! put the waveform path's JNI → binder round trip to `VibratorManagerService`
+//! at 0.88 ms per frame on the render thread (946 calls in 975 frames). The
+//! queue moves delivery onto the "cranpose-haptics" thread: callers enqueue
+//! and return.
+//!
+//! The delivery contract, pinned down by the unit test:
+//!
+//! * Discrete effects (perform / one-shot / predefined / cancel) are never
+//!   dropped and arrive in enqueue order; a saturated queue makes the caller
+//!   wait for a slot rather than lose one.
+//! * Waveforms are continuous state, so under saturation the newest wins: when
+//!   the queue is full and its most recent entry is a waveform, the incoming
+//!   waveform replaces it. Only the tail is ever replaced — replacing a
+//!   waveform buried behind later commands would change which command the
+//!   vibrator ends on, because every `Vibrator.vibrate` supersedes the one
+//!   before it.
+//! * After [`HapticQueue::shut_down`] the commands already accepted still
+//!   drain; new ones are handed back for synchronous delivery on the caller.
+//!
+//! Built on the host as well so the ordering/coalescing test runs everywhere.
+
+use cranpose_services::{HapticEffect, HapticFeedback};
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Condvar, Mutex, MutexGuard, PoisonError};
+
+/// One `Haptics` call, carried from the calling thread to the delivery
+/// thread. Waveform payloads are pre-converted to the JNI array element types
+/// on the caller, exactly where the synchronous path converted them.
+pub(crate) enum HapticCommand {
+    /// `Haptics::perform` → `cranposeHaptic`.
+    Perform(HapticFeedback),
+    /// `Haptics::vibrate` → `cranposeHapticOneShot`.
+    OneShot {
+        /// Vibration length in milliseconds; never zero (callers filter).
+        duration_ms: u32,
+        /// 1..=255, or 0 for the device default strength.
+        amplitude: u8,
+    },
+    /// `Haptics::play_pattern` → `cranposeHapticWaveform`.
+    Waveform {
+        /// Alternating off/on step lengths, `long[]` on the Java side.
+        timings_ms: Vec<i64>,
+        /// Per-step strengths, `int[]` on the Java side.
+        amplitudes: Vec<i32>,
+        /// Step index to repeat from, or -1 to play once.
+        repeat: i32,
+    },
+    /// `Haptics::perform_effect` → `cranposeHapticPredefined`.
+    Effect(HapticEffect),
+    /// `Haptics::cancel` → `cranposeHapticCancel`.
+    Cancel,
+}
+
+/// Every how many accepted commands the parity counters go to the log. At the
+/// profiled rate of about one waveform per frame at 60 fps this is one debug
+/// line every ~8.5 seconds — cheap enough to leave on, frequent enough to
+/// prove on-watch that enqueued and delivered stay in lockstep.
+const PARITY_LOG_EVERY: u64 = 512;
+
+struct State {
+    queue: VecDeque<HapticCommand>,
+    shut_down: bool,
+    /// Calls accepted, including waveforms that later coalesced away.
+    enqueued: u64,
+    /// Waveforms superseded in the queue by a newer waveform before delivery.
+    coalesced: u64,
+}
+
+/// The bounded queue. `enqueued == delivered + coalesced + len` at any quiet
+/// moment, which is what the parity log line lets an on-watch session check.
+pub(crate) struct HapticQueue {
+    capacity: usize,
+    state: Mutex<State>,
+    /// Signalled when a command lands or shutdown begins; the delivery thread
+    /// waits here.
+    ready: Condvar,
+    /// Signalled when the delivery thread frees a slot; saturated callers
+    /// wait here.
+    space: Condvar,
+    /// Commands the delivery thread has forwarded over JNI. An atomic rather
+    /// than part of `State` so counting a delivery never contends with the
+    /// render thread's enqueue lock.
+    delivered: AtomicU64,
+}
+
+fn lock(mutex: &Mutex<State>) -> MutexGuard<'_, State> {
+    // A poisoning panic cannot leave this simple state inconsistent; haptics
+    // stay best-effort rather than vanishing for the rest of the session.
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+fn wait<'a>(condvar: &Condvar, guard: MutexGuard<'a, State>) -> MutexGuard<'a, State> {
+    condvar.wait(guard).unwrap_or_else(PoisonError::into_inner)
+}
+
+impl HapticQueue {
+    pub(crate) fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            capacity,
+            state: Mutex::new(State {
+                queue: VecDeque::with_capacity(capacity),
+                shut_down: false,
+                enqueued: 0,
+                coalesced: 0,
+            }),
+            ready: Condvar::new(),
+            space: Condvar::new(),
+            delivered: AtomicU64::new(0),
+        }
+    }
+
+    /// Accepts a command for delivery, returning it to the caller when the
+    /// queue has shut down (the caller then delivers synchronously).
+    ///
+    /// Blocks only when the queue is saturated and the command cannot
+    /// coalesce — eight undelivered discrete effects, which the profiled
+    /// one-command-per-frame rate never approaches.
+    pub(crate) fn enqueue(&self, command: HapticCommand) -> Result<(), HapticCommand> {
+        let mut state = lock(&self.state);
+        loop {
+            if state.shut_down {
+                return Err(command);
+            }
+            if state.queue.len() < self.capacity {
+                state.queue.push_back(command);
+                break;
+            }
+            if matches!(command, HapticCommand::Waveform { .. }) {
+                if let Some(tail @ HapticCommand::Waveform { .. }) = state.queue.back_mut() {
+                    *tail = command;
+                    state.coalesced += 1;
+                    break;
+                }
+            }
+            // A discrete effect must not be dropped and a waveform must not
+            // jump past one: wait for the delivery thread to free a slot.
+            state = wait(&self.space, state);
+        }
+        state.enqueued += 1;
+        if state.enqueued.is_multiple_of(PARITY_LOG_EVERY) {
+            log::debug!(
+                "[haptics] enqueued={} delivered={} coalesced={} queued={}",
+                state.enqueued,
+                self.delivered.load(Ordering::Relaxed),
+                state.coalesced,
+                state.queue.len(),
+            );
+        }
+        drop(state);
+        self.ready.notify_one();
+        Ok(())
+    }
+
+    /// Next command to deliver, blocking while the queue is empty. `None`
+    /// once the queue has shut down and drained: the delivery thread's cue
+    /// to exit.
+    pub(crate) fn dequeue(&self) -> Option<HapticCommand> {
+        let mut state = lock(&self.state);
+        loop {
+            if let Some(command) = state.queue.pop_front() {
+                drop(state);
+                self.space.notify_one();
+                return Some(command);
+            }
+            if state.shut_down {
+                return None;
+            }
+            state = wait(&self.ready, state);
+        }
+    }
+
+    /// Counts a command forwarded over JNI, for the parity log.
+    pub(crate) fn note_delivered(&self) {
+        self.delivered.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Stops accepting commands and wakes both sides: the delivery thread
+    /// drains what was accepted and exits, and a caller blocked on a full
+    /// queue is released with its command handed back. Idempotent.
+    pub(crate) fn shut_down(&self) {
+        lock(&self.state).shut_down = true;
+        self.ready.notify_all();
+        self.space.notify_all();
+    }
+
+    #[cfg(test)]
+    fn stats(&self) -> (u64, u64, u64) {
+        let state = lock(&self.state);
+        (
+            state.enqueued,
+            state.coalesced,
+            self.delivered.load(Ordering::Relaxed),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    /// The delivery contract in one pass: discrete effects survive saturation
+    /// in order, a saturated tail waveform is last-write-wins, shutdown
+    /// drains what was accepted and refuses the rest.
+    #[test]
+    fn ordering_and_coalescing_contract() {
+        let queue = Arc::new(HapticQueue::new(4));
+
+        // Fill to capacity: three discrete commands and a waveform tail.
+        assert!(queue
+            .enqueue(HapticCommand::Perform(HapticFeedback::ImpactLight))
+            .is_ok());
+        assert!(queue
+            .enqueue(HapticCommand::OneShot {
+                duration_ms: 10,
+                amplitude: 0,
+            })
+            .is_ok());
+        assert!(queue.enqueue(HapticCommand::Cancel).is_ok());
+        assert!(queue
+            .enqueue(HapticCommand::Waveform {
+                timings_ms: vec![1],
+                amplitudes: vec![1],
+                repeat: -1,
+            })
+            .is_ok());
+
+        // Saturated with a waveform at the tail: newer waveforms coalesce
+        // into that slot without blocking; the last one written wins.
+        for step in [2i64, 3] {
+            assert!(queue
+                .enqueue(HapticCommand::Waveform {
+                    timings_ms: vec![step],
+                    amplitudes: vec![step as i32],
+                    repeat: if step == 3 { 0 } else { -1 },
+                })
+                .is_ok());
+        }
+
+        // A discrete effect never coalesces and never drops: it waits for the
+        // delivery side to free a slot, then lands at the back.
+        let enqueuer = std::thread::spawn({
+            let queue = Arc::clone(&queue);
+            move || {
+                assert!(queue
+                    .enqueue(HapticCommand::Effect(HapticEffect::Tick))
+                    .is_ok());
+            }
+        });
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let mut delivered = Vec::new();
+        for _ in 0..5 {
+            let command = queue.dequeue().expect("queue is not shut down");
+            queue.note_delivered();
+            delivered.push(command);
+        }
+        enqueuer.join().expect("blocked enqueue completes");
+
+        assert!(matches!(
+            delivered[0],
+            HapticCommand::Perform(HapticFeedback::ImpactLight)
+        ));
+        assert!(matches!(
+            delivered[1],
+            HapticCommand::OneShot {
+                duration_ms: 10,
+                amplitude: 0,
+            }
+        ));
+        assert!(matches!(delivered[2], HapticCommand::Cancel));
+        // Of the three waveforms only the newest survived, payload intact.
+        match &delivered[3] {
+            HapticCommand::Waveform {
+                timings_ms,
+                amplitudes,
+                repeat,
+            } => {
+                assert_eq!(timings_ms, &[3]);
+                assert_eq!(amplitudes, &[3]);
+                assert_eq!(*repeat, 0);
+            }
+            _ => panic!("expected the coalesced waveform"),
+        }
+        assert!(matches!(
+            delivered[4],
+            HapticCommand::Effect(HapticEffect::Tick)
+        ));
+
+        // Shutdown: what was accepted drains, what comes later is handed
+        // back, and the drained queue reports the exit signal.
+        assert!(queue.enqueue(HapticCommand::Cancel).is_ok());
+        queue.shut_down();
+        assert!(matches!(
+            queue.enqueue(HapticCommand::Perform(HapticFeedback::Success)),
+            Err(HapticCommand::Perform(HapticFeedback::Success))
+        ));
+        assert!(matches!(queue.dequeue(), Some(HapticCommand::Cancel)));
+        queue.note_delivered();
+        assert!(queue.dequeue().is_none());
+
+        // Parity: every accepted command was delivered or coalesced.
+        let (enqueued, coalesced, delivered) = queue.stats();
+        assert_eq!(enqueued, 8);
+        assert_eq!(coalesced, 2);
+        assert_eq!(delivered, enqueued - coalesced);
+    }
+}

--- a/crates/cranpose/src/android_services.rs
+++ b/crates/cranpose/src/android_services.rs
@@ -11,6 +11,7 @@
 //! applies them via [`apply_pending_platform_signals`].
 #![allow(unsafe_code)]
 
+use crate::android_haptics_queue::{HapticCommand, HapticQueue};
 use crate::android_jni::{clear_pending_android_jni_exception, with_android_activity_env};
 use crate::android_launch_args::decode_launch_arguments;
 use cranpose_services::{
@@ -25,7 +26,7 @@ use jni::{jni_sig, jni_str, EnvUnowned, Outcome};
 use std::cell::Cell;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 // --- Cross-thread signal parking (UI thread → native loop) -------------------
 
@@ -59,9 +60,16 @@ pub(crate) fn wake_native_loop() {
 /// activity handle.
 pub(crate) fn register(app: android_activity::AndroidApp) {
     let _ = LOOP_WAKER.set(Mutex::new(Some(app.create_waker())));
+    let haptics_queue = if async_haptics_enabled() {
+        spawn_haptics_thread(app.clone())
+    } else {
+        log::info!("CRANPOSE_ASYNC_HAPTICS=0: haptics stay on the calling thread");
+        None
+    };
     set_platform_haptics(Rc::new(AndroidHaptics {
         app: app.clone(),
         amplitude_control: Cell::new(None),
+        queue: haptics_queue,
     }));
     set_platform_share_sheet(Rc::new(AndroidShareSheet { app: app.clone() }));
     set_platform_notifier(Rc::new(AndroidNotifier { app: app.clone() }));
@@ -162,6 +170,22 @@ pub(crate) fn apply_pending_platform_signals(
 
 // --- Haptics ------------------------------------------------------------------
 
+/// Queue depth for the asynchronous dispatch. Small on purpose: at the
+/// profiled rate of about one waveform per frame the queue only ever holds
+/// what one slow binder call backs up, and past that waveforms coalesce.
+const HAPTIC_QUEUE_CAPACITY: usize = 8;
+
+/// Kill switch for the asynchronous dispatch: `CRANPOSE_ASYNC_HAPTICS=0`
+/// (reachable on a device as `debug.cranpose.async_haptics` through the
+/// property bridge in [`crate::android_frame_telemetry`]) keeps every
+/// vibrator call on the calling thread, the pre-queue behaviour.
+fn async_haptics_enabled() -> bool {
+    match std::env::var("CRANPOSE_ASYNC_HAPTICS") {
+        Ok(value) => !matches!(value.trim(), "0" | "false" | "off" | "no"),
+        Err(_) => true,
+    }
+}
+
 /// The Android vibrator, reached through `CranposeActivity`.
 ///
 /// `perform` routes through `View.performHapticFeedback` so the OS's own
@@ -169,36 +193,116 @@ pub(crate) fn apply_pending_platform_signals(
 /// paths address `Vibrator`/`VibrationEffect` directly, which is what a game
 /// designing its own set of distinct feels needs; each one is a single JNI
 /// call carrying primitives or a primitive array.
+///
+/// The vibrator methods run the `VibratorManagerService` binder call on the
+/// calling thread, and a watch profile measured that at 0.88 ms per frame on
+/// the render thread (946 waveform calls in 975 frames). Delivery therefore
+/// normally happens on the dedicated "cranpose-haptics" thread: the trait
+/// methods enqueue into `queue` and return immediately. When `queue` is
+/// `None` (kill switch, or the thread failed to start) every call delivers
+/// synchronously, exactly as before the queue existed.
 struct AndroidHaptics {
     app: android_activity::AndroidApp,
     /// `Vibrator.hasAmplitudeControl()`, queried once and cached: the answer
     /// cannot change for the life of the process, and the query costs a JNI
     /// round trip that UI code should not repeat.
     amplitude_control: Cell<Option<bool>>,
+    /// Handoff to the "cranpose-haptics" delivery thread, or `None` for the
+    /// synchronous path.
+    queue: Option<Arc<HapticQueue>>,
 }
 
 impl AndroidHaptics {
-    fn call(
-        &self,
-        what: &'static str,
-        run: impl FnOnce(&mut jni::Env<'_>, JObject<'_>) -> Result<(), String>,
-    ) {
-        if let Err(error) = with_android_activity_env(&self.app, run) {
-            log::debug!("Android {what} failed: {error}");
+    fn dispatch(&self, command: HapticCommand) {
+        let command = match &self.queue {
+            Some(queue) => match queue.enqueue(command) {
+                Ok(()) => return,
+                // The delivery thread is gone (shutdown, or it panicked and
+                // its exit guard closed the queue); deliver on this thread so
+                // the call is not lost.
+                Err(command) => command,
+            },
+            None => command,
+        };
+        deliver_haptic_command(&self.app, &command);
+    }
+}
+
+impl Drop for AndroidHaptics {
+    fn drop(&mut self) {
+        // Lets the delivery thread drain what it already accepted and exit
+        // cleanly. Not joined: drop runs on the render thread and the worker
+        // may be inside a binder call.
+        if let Some(queue) = &self.queue {
+            queue.shut_down();
         }
     }
 }
 
-impl Haptics for AndroidHaptics {
-    fn perform(&self, feedback: HapticFeedback) {
-        let kind: jint = match feedback {
-            HapticFeedback::ImpactLight | HapticFeedback::Selection => 0,
-            HapticFeedback::ImpactMedium => 1,
-            HapticFeedback::ImpactHeavy => 2,
-            HapticFeedback::Success => 3,
-            HapticFeedback::Warning | HapticFeedback::Error => 4,
-        };
-        self.call("haptic", |env, activity| {
+/// Starts the "cranpose-haptics" delivery thread, returning the queue the
+/// backend enqueues into, or `None` when the thread could not start.
+fn spawn_haptics_thread(app: android_activity::AndroidApp) -> Option<Arc<HapticQueue>> {
+    let queue = Arc::new(HapticQueue::new(HAPTIC_QUEUE_CAPACITY));
+    let worker_queue = Arc::clone(&queue);
+    match std::thread::Builder::new()
+        .name("cranpose-haptics".to_owned())
+        .spawn(move || run_haptics_thread(app, worker_queue))
+    {
+        Ok(_) => Some(queue),
+        Err(error) => {
+            log::warn!(
+                "cranpose-haptics thread failed to start; haptics stay synchronous: {error}"
+            );
+            None
+        }
+    }
+}
+
+/// Delivery loop for the "cranpose-haptics" thread.
+///
+/// The first `with_android_activity_env` call attaches the thread to the JVM
+/// once (`attach_current_thread` only checks a thread-local after that), and
+/// the attachment is released automatically when the thread exits after the
+/// queue shuts down and drains — so the render thread pays neither the attach
+/// nor the binder round trip.
+fn run_haptics_thread(app: android_activity::AndroidApp, queue: Arc<HapticQueue>) {
+    // Closes the queue even if delivery panics, so a caller blocked on a
+    // saturated queue is released (and falls back to synchronous delivery)
+    // instead of hanging the render thread forever.
+    struct ShutDownOnExit(Arc<HapticQueue>);
+    impl Drop for ShutDownOnExit {
+        fn drop(&mut self) {
+            self.0.shut_down();
+        }
+    }
+    let _guard = ShutDownOnExit(Arc::clone(&queue));
+    while let Some(command) = queue.dequeue() {
+        deliver_haptic_command(&app, &command);
+        queue.note_delivered();
+    }
+    log::debug!("cranpose-haptics thread exited after shutdown");
+}
+
+/// Forwards one haptic command to the activity — the single JNI path shared
+/// by the delivery thread and the synchronous fallback, so the two cannot
+/// drift apart.
+fn deliver_haptic_command(app: &android_activity::AndroidApp, command: &HapticCommand) {
+    let what = match command {
+        HapticCommand::Perform(_) => "haptic",
+        HapticCommand::OneShot { .. } => "haptic one-shot",
+        HapticCommand::Waveform { .. } => "haptic waveform",
+        HapticCommand::Effect(_) => "haptic effect",
+        HapticCommand::Cancel => "haptic cancel",
+    };
+    let result = with_android_activity_env(app, |env, activity| match command {
+        HapticCommand::Perform(feedback) => {
+            let kind: jint = match feedback {
+                HapticFeedback::ImpactLight | HapticFeedback::Selection => 0,
+                HapticFeedback::ImpactMedium => 1,
+                HapticFeedback::ImpactHeavy => 2,
+                HapticFeedback::Success => 3,
+                HapticFeedback::Warning | HapticFeedback::Error => 4,
+            };
             env.call_method(
                 &activity,
                 jni_str!("cranposeHaptic"),
@@ -210,65 +314,50 @@ impl Haptics for AndroidHaptics {
                 error.to_string()
             })?;
             Ok(())
-        });
-    }
-
-    fn vibrate(&self, duration_ms: u32, amplitude: u8) {
-        if duration_ms == 0 {
-            return;
         }
-        // `VibrationEffect.createOneShot` takes DEFAULT_AMPLITUDE (-1) or
-        // 1..=255; 0 means "device default" in the framework API, so it is
-        // translated here rather than rejected by the platform.
-        let amplitude: jint = if amplitude == 0 {
-            -1
-        } else {
-            jint::from(amplitude)
-        };
-        let duration = jlong::from(duration_ms);
-        self.call("haptic one-shot", move |env, activity| {
+        HapticCommand::OneShot {
+            duration_ms,
+            amplitude,
+        } => {
+            // `VibrationEffect.createOneShot` takes DEFAULT_AMPLITUDE (-1) or
+            // 1..=255; 0 means "device default" in the framework API, so it is
+            // translated here rather than rejected by the platform.
+            let amplitude: jint = if *amplitude == 0 {
+                -1
+            } else {
+                jint::from(*amplitude)
+            };
             env.call_method(
                 &activity,
                 jni_str!("cranposeHapticOneShot"),
                 jni_sig!("(JI)V"),
-                &[JValue::Long(duration), JValue::Int(amplitude)],
+                &[
+                    JValue::Long(jlong::from(*duration_ms)),
+                    JValue::Int(amplitude),
+                ],
             )
             .map_err(|error| {
                 clear_pending_android_jni_exception(env);
                 error.to_string()
             })?;
             Ok(())
-        });
-    }
-
-    fn play_pattern(&self, pattern: &HapticPattern) {
-        let timings: Vec<jlong> = pattern
-            .timings_ms()
-            .iter()
-            .map(|step| jlong::from(*step))
-            .collect();
-        let amplitudes: Vec<jint> = pattern
-            .amplitudes()
-            .iter()
-            .map(|level| jint::from(*level))
-            .collect();
-        let repeat: jint = pattern
-            .repeat()
-            .and_then(|index| jint::try_from(index).ok())
-            .unwrap_or(-1);
-
-        self.call("haptic waveform", move |env, activity| {
+        }
+        HapticCommand::Waveform {
+            timings_ms,
+            amplitudes,
+            repeat,
+        } => {
             let timing_array = env
-                .new_long_array(timings.len())
+                .new_long_array(timings_ms.len())
                 .map_err(|error| error.to_string())?;
             timing_array
-                .set_region(env, 0, &timings)
+                .set_region(env, 0, timings_ms)
                 .map_err(|error| error.to_string())?;
             let amplitude_array = env
                 .new_int_array(amplitudes.len())
                 .map_err(|error| error.to_string())?;
             amplitude_array
-                .set_region(env, 0, &amplitudes)
+                .set_region(env, 0, amplitudes)
                 .map_err(|error| error.to_string())?;
             let timing_obj: &JObject = timing_array.as_ref();
             let amplitude_obj: &JObject = amplitude_array.as_ref();
@@ -279,7 +368,7 @@ impl Haptics for AndroidHaptics {
                 &[
                     JValue::Object(timing_obj),
                     JValue::Object(amplitude_obj),
-                    JValue::Int(repeat),
+                    JValue::Int(*repeat),
                 ],
             )
             .map_err(|error| {
@@ -287,19 +376,16 @@ impl Haptics for AndroidHaptics {
                 error.to_string()
             })?;
             Ok(())
-        });
-    }
-
-    fn perform_effect(&self, effect: HapticEffect) {
-        // Matches `VibrationEffect.EFFECT_*`, which the activity re-maps by
-        // name so the constants stay owned by the platform.
-        let id: jint = match effect {
-            HapticEffect::Click => 0,
-            HapticEffect::DoubleClick => 1,
-            HapticEffect::Tick => 2,
-            HapticEffect::HeavyClick => 3,
-        };
-        self.call("haptic effect", move |env, activity| {
+        }
+        HapticCommand::Effect(effect) => {
+            // Matches `VibrationEffect.EFFECT_*`, which the activity re-maps
+            // by name so the constants stay owned by the platform.
+            let id: jint = match effect {
+                HapticEffect::Click => 0,
+                HapticEffect::DoubleClick => 1,
+                HapticEffect::Tick => 2,
+                HapticEffect::HeavyClick => 3,
+            };
             env.call_method(
                 &activity,
                 jni_str!("cranposeHapticPredefined"),
@@ -311,11 +397,8 @@ impl Haptics for AndroidHaptics {
                 error.to_string()
             })?;
             Ok(())
-        });
-    }
-
-    fn cancel(&self) {
-        self.call("haptic cancel", |env, activity| {
+        }
+        HapticCommand::Cancel => {
             env.call_method(
                 &activity,
                 jni_str!("cranposeHapticCancel"),
@@ -327,7 +410,53 @@ impl Haptics for AndroidHaptics {
                 error.to_string()
             })?;
             Ok(())
+        }
+    });
+    if let Err(error) = result {
+        log::debug!("Android {what} failed: {error}");
+    }
+}
+
+impl Haptics for AndroidHaptics {
+    fn perform(&self, feedback: HapticFeedback) {
+        self.dispatch(HapticCommand::Perform(feedback));
+    }
+
+    fn vibrate(&self, duration_ms: u32, amplitude: u8) {
+        if duration_ms == 0 {
+            return;
+        }
+        self.dispatch(HapticCommand::OneShot {
+            duration_ms,
+            amplitude,
         });
+    }
+
+    fn play_pattern(&self, pattern: &HapticPattern) {
+        self.dispatch(HapticCommand::Waveform {
+            timings_ms: pattern
+                .timings_ms()
+                .iter()
+                .map(|step| i64::from(*step))
+                .collect(),
+            amplitudes: pattern
+                .amplitudes()
+                .iter()
+                .map(|level| i32::from(*level))
+                .collect(),
+            repeat: pattern
+                .repeat()
+                .and_then(|index| i32::try_from(index).ok())
+                .unwrap_or(-1),
+        });
+    }
+
+    fn perform_effect(&self, effect: HapticEffect) {
+        self.dispatch(HapticCommand::Effect(effect));
+    }
+
+    fn cancel(&self) {
+        self.dispatch(HapticCommand::Cancel);
     }
 
     fn has_amplitude_control(&self) -> bool {

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -35,6 +35,13 @@ mod android_font_scale;
 mod android_frame_rate;
 #[cfg(all(feature = "android", target_os = "android"))]
 mod android_frame_telemetry;
+/// The bounded command queue behind the Android haptics delivery thread.
+/// Built on the host as well so its ordering/coalescing test runs everywhere.
+#[cfg(any(
+    test,
+    all(feature = "android", feature = "renderer-wgpu", target_os = "android")
+))]
+mod android_haptics_queue;
 #[cfg_attr(not(all(feature = "android", target_os = "android")), allow(dead_code))]
 mod android_host_window;
 mod android_input;


### PR DESCRIPTION
The game vibrates roughly once per frame, and every call was a synchronous JNI → Kotlin → binder round trip to VibratorManagerService on the render thread: **0.88 ms/frame measured** (946 calls in 975 frames, stickyprof.data; release estimate 0.3–0.6 ms).

Delivery moves to a dedicated `cranpose-haptics` thread behind a bounded queue (8 slots). Contract, pinned by a host-run unit test: discrete effects are never dropped and stay FIFO (a saturated caller waits); waveforms coalesce newest-wins but only at the queue tail (replacing a buried waveform would change which command the vibrator ends on); shutdown drains accepted commands and falls back to synchronous delivery. JVM attach happens once per thread via the existing helper. Parity provable on-watch via a rate-limited enqueued/delivered/coalesced debug line.

Kill switch: `CRANPOSE_ASYNC_HAPTICS=0` / `debug.cranpose.async_haptics`.

Verified on the remote M3 build host: host lib tests (75, incl. the new ordering/coalescing contract test), the 59 static gates, and `cargo ndk` arm64 check of the target-gated code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2