### PR TITLE
Carry solid brushes as Copy values through emit and scene

### DIFF
--- a/crates/cranpose-render/common/src/primitive_emit.rs
+++ b/crates/cranpose-render/common/src/primitive_emit.rs
@@ -15,7 +15,8 @@ use crate::layer_transform::{
     apply_layer_to_rect, layer_uniform_scale,
 };
 use crate::style_shared::{
-    apply_layer_to_brush, apply_layer_to_color, compose_color_filters, scale_corner_radii,
+    apply_layer_to_color, compose_color_filters, resolve_layer_brush, scale_corner_radii,
+    ResolvedBrush,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -28,7 +29,10 @@ pub struct ShapeDrawParams {
     pub rect: Rect,
     pub local_rect: Rect,
     pub quad: [[f32; 2]; 4],
-    pub brush: Brush,
+    /// Layer-resolved at emit time. Solid — effectively every shape of a
+    /// heavy animated frame — is an inline color; only gradients carry a
+    /// cloned [`Brush`].
+    pub brush: ResolvedBrush,
     pub shape: Option<RoundedCornerShape>,
     /// `Some` means "stroke the outline of `local_rect`/`shape`" instead of
     /// filling it. The width is already in `local_rect` units (the layer scale
@@ -227,7 +231,7 @@ pub fn rect_shape_params(
         rect: quad_bounds(quad),
         local_rect,
         quad,
-        brush: apply_layer_to_brush(brush.clone(), layer),
+        brush: resolve_layer_brush(brush, layer),
         shape: None,
         stroke,
         arc: None,
@@ -260,7 +264,7 @@ pub fn round_rect_shape_params(
         rect: quad_bounds(quad),
         local_rect,
         quad,
-        brush: apply_layer_to_brush(brush.clone(), layer),
+        brush: resolve_layer_brush(brush, layer),
         shape: Some(shape),
         stroke,
         arc: None,
@@ -320,7 +324,7 @@ pub fn arc_shape_params(
         rect: quad_bounds(quad),
         local_rect: out_rect,
         quad,
-        brush: apply_layer_to_brush(brush.clone(), layer),
+        brush: resolve_layer_brush(brush, layer),
         shape: None,
         stroke: None,
         arc: Some(arc.scaled_about(arc_center, scale)),

--- a/crates/cranpose-render/common/src/style_shared.rs
+++ b/crates/cranpose-render/common/src/style_shared.rs
@@ -194,6 +194,59 @@ pub fn apply_layer_to_brush(brush: Brush, layer: &GraphicsLayer) -> Brush {
     }
 }
 
+/// A layer-resolved brush, split at the solid/gradient boundary.
+///
+/// The per-frame shape emit produces one of these for every draw: the solid
+/// case — effectively all of a heavy animated scene — carries its color
+/// inline, so emitting a shape neither clones a `Brush` nor leaves an enum
+/// with heap-carrying variants for frame teardown to walk. Only the rare
+/// gradient still travels as a cloned [`Brush`].
+#[derive(Clone, Debug, PartialEq)]
+pub enum ResolvedBrush {
+    Solid(Color),
+    /// A non-solid brush (gradients), already layer-resolved.
+    Other(Brush),
+}
+
+impl ResolvedBrush {
+    pub fn from_brush(brush: Brush) -> Self {
+        match brush {
+            Brush::Solid(color) => Self::Solid(color),
+            other => Self::Other(other),
+        }
+    }
+
+    /// The plain `Brush` this resolved form stands for — same values,
+    /// reassembled for consumers that keep speaking `Brush`.
+    pub fn into_brush(self) -> Brush {
+        match self {
+            Self::Solid(color) => Brush::Solid(color),
+            Self::Other(brush) => brush,
+        }
+    }
+}
+
+/// [`apply_layer_to_brush`] without the solid-brush clone: the borrowed
+/// brush's color is copied (or layer-adjusted) inline, and only gradients
+/// are cloned. Produces exactly the values `apply_layer_to_brush` would —
+/// both branches below mirror its fast path and its `Solid` arm verbatim.
+pub fn resolve_layer_brush(brush: &Brush, layer: &GraphicsLayer) -> ResolvedBrush {
+    match brush {
+        Brush::Solid(color) => {
+            if layer.alpha == 1.0
+                && layer.color_filter.is_none()
+                && layer_scale_x(layer) == 1.0
+                && layer_scale_y(layer) == 1.0
+            {
+                ResolvedBrush::Solid(*color)
+            } else {
+                ResolvedBrush::Solid(apply_layer_to_color(*color, layer))
+            }
+        }
+        other => ResolvedBrush::Other(apply_layer_to_brush(other.clone(), layer)),
+    }
+}
+
 pub fn scale_corner_radii(radii: CornerRadii, scale: f32) -> CornerRadii {
     CornerRadii {
         top_left: radii.top_left * scale,

--- a/crates/cranpose-render/pixels/src/pipeline.rs
+++ b/crates/cranpose-render/pixels/src/pipeline.rs
@@ -1156,7 +1156,7 @@ pub(crate) fn push_draw_primitive(
         fn push_shape(&mut self, params: ShapeDrawParams) {
             self.scene.push_shape_with_stroke_and_arc(
                 params.rect,
-                params.brush,
+                params.brush.into_brush(),
                 params.shape,
                 params.stroke,
                 params.arc,
@@ -1238,7 +1238,7 @@ fn push_shadow_primitive(
                 rect: params.rect,
                 snap_anchor: None,
                 snap_to_pixel_grid: false,
-                brush: params.brush,
+                brush: params.brush.into_brush(),
                 shape: params.shape,
                 // A stroked or arc caster must cast a stroked or arc shadow.
                 stroke: params.stroke,

--- a/crates/cranpose-render/wgpu/src/normalized_scene.rs
+++ b/crates/cranpose-render/wgpu/src/normalized_scene.rs
@@ -32,7 +32,7 @@ use cranpose_render_common::primitive_emit::{
     arc_shape_params, rect_shape_params, resolve_clip, resolve_primitive_clip,
     round_rect_shape_params, PrimitiveClipSpace, ShapeDrawParams,
 };
-use cranpose_ui_graphics::{DrawPrimitive, GraphicsLayer, Point, Rect, RenderEffect};
+use cranpose_ui_graphics::{Brush, DrawPrimitive, GraphicsLayer, Point, Rect, RenderEffect};
 
 const NORMALIZED_SCENE_AFFINE_TOLERANCE: f32 = 1e-4;
 const MOTION_STABLE_CAPTURE_MIN_LEADING_GUARD: f32 = 64.0;
@@ -2514,6 +2514,9 @@ impl TranslateBy for CompositorScene {
 
 pub(crate) struct SceneWindowSource<'a> {
     pub(crate) shapes: &'a [DrawShape],
+    /// The brush table the shapes' gradient handles index — the owning
+    /// scene's `brushes`.
+    pub(crate) brushes: &'a [Brush],
     pub(crate) images: &'a [ImageDraw],
     pub(crate) texts: &'a [TextDraw],
     pub(crate) shadow_draws: &'a [ShadowDraw],
@@ -2533,11 +2536,15 @@ pub(crate) fn build_scene_window(
     window_rect: Rect,
 ) -> CompositorScene {
     let mut scene = CompositorScene::new();
+    // Windowed shapes keep their gradient handles, so the window carries the
+    // whole (gradients-only, tiny) source table — indices stay valid without
+    // remapping.
+    scene.brushes.extend_from_slice(source.brushes);
     let mut shape_map = vec![None; source.shapes.len()];
     for (source_index, shape) in source.shapes.iter().enumerate() {
         if shape.z_index >= z_start && shape.z_index < z_end {
             shape_map[source_index] = Some(scene.shapes.len());
-            scene.shapes.push(shape.clone());
+            scene.shapes.push(*shape);
         }
     }
     let mut image_map = vec![None; source.images.len()];

--- a/crates/cranpose-render/wgpu/src/pipeline.rs
+++ b/crates/cranpose-render/wgpu/src/pipeline.rs
@@ -95,7 +95,7 @@ fn shadow_shape(
             local_rect: rect,
             quad: rect_to_quad(rect),
             snap_anchor: None,
-            brush: Brush::solid(color),
+            brush: crate::scene::SceneBrush::Solid(color),
             shape,
             stroke: None,
             arc: None,
@@ -137,6 +137,7 @@ pub(crate) fn push_layer_shadow(
         );
         scene.push_shadow_draw(ShadowDraw {
             shapes: vec![shadow_shape(ambient_pass.rect, ambient, resolved_shape)],
+            brushes: vec![],
             texts: vec![],
             blur_radius: ambient_pass.blur_radius,
             clip,
@@ -153,6 +154,7 @@ pub(crate) fn push_layer_shadow(
         );
         scene.push_shadow_draw(ShadowDraw {
             shapes: vec![shadow_shape(spot_pass.rect, spot, resolved_shape)],
+            brushes: vec![],
             texts: vec![],
             blur_radius: spot_pass.blur_radius,
             clip,
@@ -821,6 +823,7 @@ impl TextStyleDrawSink for CompositorScene {
     ) {
         self.push_shadow_draw(ShadowDraw {
             shapes: vec![],
+            brushes: vec![],
             texts: vec![TextDraw {
                 node_id,
                 rect,
@@ -2179,6 +2182,7 @@ fn push_shadow_primitive(
         layer_bounds: Rect,
         layer: &GraphicsLayer,
         blend_mode: BlendMode,
+        brushes: &mut Vec<Brush>,
     ) -> Option<(DrawShape, BlendMode)> {
         let params = draw_shape_params_for_primitive(prim, layer_bounds, layer, None, blend_mode)?;
         Some((
@@ -2187,7 +2191,9 @@ fn push_shadow_primitive(
                 local_rect: params.local_rect,
                 quad: params.quad,
                 snap_anchor: None,
-                brush: params.brush,
+                // A rare gradient caster interns into the shadow draw's own
+                // table, so the draw stays self-contained wherever it travels.
+                brush: crate::scene::intern_brush_into(brushes, params.brush),
                 shape: params.shape,
                 // Shadows silhouette the *rendered* shape, so a stroked or arc
                 // caster must cast a stroked or arc shadow, not a filled box.
@@ -2209,22 +2215,28 @@ fn push_shadow_primitive(
             blur_radius,
             blend_mode,
         } => {
+            let mut brushes = Vec::new();
             let Some(shape_pair) =
-                shape_pair_for_primitive(*shape, layer_bounds, layer, blend_mode)
+                shape_pair_for_primitive(*shape, layer_bounds, layer, blend_mode, &mut brushes)
             else {
                 return;
             };
             let mut shapes = vec![shape_pair];
             if let Some(cutout) = cutout {
-                let Some(cutout_pair) =
-                    shape_pair_for_primitive(*cutout, layer_bounds, layer, BlendMode::DstOut)
-                else {
+                let Some(cutout_pair) = shape_pair_for_primitive(
+                    *cutout,
+                    layer_bounds,
+                    layer,
+                    BlendMode::DstOut,
+                    &mut brushes,
+                ) else {
                     return;
                 };
                 shapes.push(cutout_pair);
             }
             scene.push_shadow_draw(ShadowDraw {
                 shapes,
+                brushes,
                 texts: vec![],
                 blur_radius,
                 clip,
@@ -2238,13 +2250,19 @@ fn push_shadow_primitive(
             blend_mode,
             clip_rect,
         } => {
-            let Some(fill_pair) = shape_pair_for_primitive(*fill, layer_bounds, layer, blend_mode)
+            let mut brushes = Vec::new();
+            let Some(fill_pair) =
+                shape_pair_for_primitive(*fill, layer_bounds, layer, blend_mode, &mut brushes)
             else {
                 return;
             };
-            let Some(cutout_pair) =
-                shape_pair_for_primitive(*cutout, layer_bounds, layer, BlendMode::DstOut)
-            else {
+            let Some(cutout_pair) = shape_pair_for_primitive(
+                *cutout,
+                layer_bounds,
+                layer,
+                BlendMode::DstOut,
+                &mut brushes,
+            ) else {
                 return;
             };
             let abs_clip = Rect {
@@ -2256,6 +2274,7 @@ fn push_shadow_primitive(
             let transformed_clip = apply_layer_to_rect(abs_clip, layer_bounds, layer);
             scene.push_shadow_draw(ShadowDraw {
                 shapes: vec![fill_pair, cutout_pair],
+                brushes,
                 texts: vec![],
                 blur_radius,
                 clip: clip.map_or(Some(transformed_clip), |parent_clip| {
@@ -2443,7 +2462,7 @@ mod tests {
             "ambient shadow should clearly expand width"
         );
         let ambient_peak_alpha = match &ambient_shape.brush {
-            Brush::Solid(color) => color.a(),
+            crate::scene::SceneBrush::Solid(color) => color.a(),
             _ => 0.0,
         };
         assert!(
@@ -2458,7 +2477,7 @@ mod tests {
             spot_shape.rect.y > bounds.y,
             "spot shadow should be offset downward from source bounds"
         );
-        let Brush::Solid(spot_color) = &spot_shape.brush else {
+        let crate::scene::SceneBrush::Solid(spot_color) = &spot_shape.brush else {
             panic!("spot shadow must use solid color");
         };
         assert!(spot_color.a() > 0.02, "spot alpha should remain visible");
@@ -2883,7 +2902,7 @@ mod tests {
             1,
             "span background should emit one shape"
         );
-        let Brush::Solid(background) = &scene.shapes[0].brush else {
+        let crate::scene::SceneBrush::Solid(background) = &scene.shapes[0].brush else {
             panic!("background draw should use a solid brush");
         };
         assert_eq!(*background, Color(0.2, 0.3, 0.52, 0.55));
@@ -3561,7 +3580,7 @@ mod tests {
         );
 
         assert_eq!(scene.shapes.len(), 1, "one underline expected");
-        let Brush::Solid(color) = scene.shapes[0].brush else {
+        let crate::scene::SceneBrush::Solid(color) = scene.shapes[0].brush else {
             panic!("span color decoration should resolve to solid brush");
         };
         assert!((color.r() - 1.0).abs() < 1e-6);

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -28,7 +28,7 @@ use crate::offscreen::OffscreenTarget;
 use crate::rect_to_quad;
 use crate::scene::{
     BackdropLayer, CompositorScene, DrawOp, DrawOpKind, DrawShape, EffectLayer, ImageDraw,
-    RetainedDraw, ShadowDraw, SimilarityTransform, SnapAnchor, TextDraw,
+    RetainedDraw, SceneBrush, ShadowDraw, SimilarityTransform, SnapAnchor, TextDraw,
 };
 use crate::shaders;
 #[cfg(test)]
@@ -1050,6 +1050,7 @@ fn hash_shadow_device_rect<H: Hasher>(
 
 fn hash_shape_shadow_item<H: Hasher>(
     shape: &DrawShape,
+    brushes: &[Brush],
     blend_mode: BlendMode,
     origin_x: f32,
     origin_y: f32,
@@ -1071,7 +1072,7 @@ fn hash_shape_shadow_item<H: Hasher>(
         }
         None => 0u8.hash(state),
     }
-    shape.brush.render_hash().hash(state);
+    shape.brush.render_hash(brushes).hash(state);
     match shape.shape {
         Some(corner_shape) => {
             1u8.hash(state);
@@ -1090,7 +1091,11 @@ fn hash_shape_shadow_item<H: Hasher>(
     shape.blend_mode.hash(state);
 }
 
-fn shape_shadow_content_hash(shapes: &[(DrawShape, BlendMode)], root_scale: f32) -> u64 {
+fn shape_shadow_content_hash(
+    shapes: &[(DrawShape, BlendMode)],
+    brushes: &[Brush],
+    root_scale: f32,
+) -> u64 {
     let mut hasher = FxHasher::default();
     // Anchor the hash to the shapes' own (unfloored) bounds so rigid translation
     // cancels out exactly. Anchoring to floored device-pixel bounds would leak
@@ -1107,6 +1112,7 @@ fn shape_shadow_content_hash(shapes: &[(DrawShape, BlendMode)], root_scale: f32)
     for (shape, blend_mode) in shapes {
         hash_shape_shadow_item(
             shape,
+            brushes,
             *blend_mode,
             origin.x,
             origin.y,
@@ -1119,12 +1125,13 @@ fn shape_shadow_content_hash(shapes: &[(DrawShape, BlendMode)], root_scale: f32)
 
 fn shape_shadow_surface_cache_key(
     shapes: &[(DrawShape, BlendMode)],
+    brushes: &[Brush],
     device_bounds: DevicePixelBounds,
     pixel_radius: f32,
     root_scale: f32,
 ) -> Option<ShadowSurfaceCacheKey> {
     (root_scale.is_finite() && root_scale > 0.0).then(|| ShadowSurfaceCacheKey {
-        content_hash: shape_shadow_content_hash(shapes, root_scale),
+        content_hash: shape_shadow_content_hash(shapes, brushes, root_scale),
         pixel_size: [device_bounds.width, device_bounds.height],
         root_scale_bits: root_scale.to_bits(),
         blur_radius_bits: pixel_radius.to_bits(),
@@ -1753,12 +1760,15 @@ pub(crate) fn shape_convert_worker_count() -> usize {
     1
 }
 
-fn shape_gradient_stop_count(shape: &DrawShape) -> usize {
-    match &shape.brush {
-        Brush::Solid(_) => 0,
-        Brush::LinearGradient { colors, .. }
-        | Brush::RadialGradient { colors, .. }
-        | Brush::SweepGradient { colors, .. } => colors.len(),
+fn shape_gradient_stop_count(shape: &DrawShape, brushes: &[Brush]) -> usize {
+    match shape.brush {
+        SceneBrush::Solid(_) => 0,
+        SceneBrush::Gradient(index) => match &brushes[index as usize] {
+            Brush::Solid(_) => 0,
+            Brush::LinearGradient { colors, .. }
+            | Brush::RadialGradient { colors, .. }
+            | Brush::SweepGradient { colors, .. } => colors.len(),
+        },
     }
 }
 
@@ -1768,6 +1778,7 @@ fn shape_gradient_stop_count(shape: &DrawShape) -> usize {
 /// gradient buffer; `gradient_out` is exactly its span of that buffer.
 fn convert_shape_into_slots(
     shape: &DrawShape,
+    brushes: &[Brush],
     root_scale: f32,
     gradient_start: u32,
     shape_out: &mut ShapeData,
@@ -1851,69 +1862,72 @@ fn convert_shape_into_slots(
     };
     let mut gradient_params = [0.0f32; 4];
     let (brush_type, gradient_count, gradient_tile_mode) = match &shape.brush {
-        Brush::Solid(_) => (0u32, 0u32, gradient_tile_mode_value(TileMode::Clamp)),
-        Brush::LinearGradient {
-            colors,
-            stops,
-            start,
-            end,
-            tile_mode,
-        } => {
-            let count = fill_gradient_entries(colors, stops.as_deref());
-            gradient_params = [
-                canonicalize_brush_coordinate(resolve_gradient_point(
-                    device_local_rect.x,
-                    device_local_rect.width,
-                    start.x * root_scale,
-                )),
-                canonicalize_brush_coordinate(resolve_gradient_point(
-                    device_local_rect.y,
-                    device_local_rect.height,
-                    start.y * root_scale,
-                )),
-                canonicalize_brush_coordinate(resolve_gradient_point(
-                    device_local_rect.x,
-                    device_local_rect.width,
-                    end.x * root_scale,
-                )),
-                canonicalize_brush_coordinate(resolve_gradient_point(
-                    device_local_rect.y,
-                    device_local_rect.height,
-                    end.y * root_scale,
-                )),
-            ];
-            (1u32, count, gradient_tile_mode_value(*tile_mode))
-        }
-        Brush::RadialGradient {
-            colors,
-            stops,
-            center,
-            radius,
-            tile_mode,
-        } => {
-            let count = fill_gradient_entries(colors, stops.as_deref());
-            gradient_params = [
-                canonicalize_brush_coordinate(device_local_rect.x + center.x * root_scale),
-                canonicalize_brush_coordinate(device_local_rect.y + center.y * root_scale),
-                (radius * root_scale).max(f32::EPSILON),
-                0.0,
-            ];
-            (2u32, count, gradient_tile_mode_value(*tile_mode))
-        }
-        Brush::SweepGradient {
-            colors,
-            stops,
-            center,
-        } => {
-            let count = fill_gradient_entries(colors, stops.as_deref());
-            gradient_params = [
-                canonicalize_brush_coordinate(device_local_rect.x + center.x * root_scale),
-                canonicalize_brush_coordinate(device_local_rect.y + center.y * root_scale),
-                0.0,
-                0.0,
-            ];
-            (3u32, count, gradient_tile_mode_value(TileMode::Clamp))
-        }
+        SceneBrush::Solid(_) => (0u32, 0u32, gradient_tile_mode_value(TileMode::Clamp)),
+        SceneBrush::Gradient(index) => match &brushes[*index as usize] {
+            Brush::Solid(_) => (0u32, 0u32, gradient_tile_mode_value(TileMode::Clamp)),
+            Brush::LinearGradient {
+                colors,
+                stops,
+                start,
+                end,
+                tile_mode,
+            } => {
+                let count = fill_gradient_entries(colors, stops.as_deref());
+                gradient_params = [
+                    canonicalize_brush_coordinate(resolve_gradient_point(
+                        device_local_rect.x,
+                        device_local_rect.width,
+                        start.x * root_scale,
+                    )),
+                    canonicalize_brush_coordinate(resolve_gradient_point(
+                        device_local_rect.y,
+                        device_local_rect.height,
+                        start.y * root_scale,
+                    )),
+                    canonicalize_brush_coordinate(resolve_gradient_point(
+                        device_local_rect.x,
+                        device_local_rect.width,
+                        end.x * root_scale,
+                    )),
+                    canonicalize_brush_coordinate(resolve_gradient_point(
+                        device_local_rect.y,
+                        device_local_rect.height,
+                        end.y * root_scale,
+                    )),
+                ];
+                (1u32, count, gradient_tile_mode_value(*tile_mode))
+            }
+            Brush::RadialGradient {
+                colors,
+                stops,
+                center,
+                radius,
+                tile_mode,
+            } => {
+                let count = fill_gradient_entries(colors, stops.as_deref());
+                gradient_params = [
+                    canonicalize_brush_coordinate(device_local_rect.x + center.x * root_scale),
+                    canonicalize_brush_coordinate(device_local_rect.y + center.y * root_scale),
+                    (radius * root_scale).max(f32::EPSILON),
+                    0.0,
+                ];
+                (2u32, count, gradient_tile_mode_value(*tile_mode))
+            }
+            Brush::SweepGradient {
+                colors,
+                stops,
+                center,
+            } => {
+                let count = fill_gradient_entries(colors, stops.as_deref());
+                gradient_params = [
+                    canonicalize_brush_coordinate(device_local_rect.x + center.x * root_scale),
+                    canonicalize_brush_coordinate(device_local_rect.y + center.y * root_scale),
+                    0.0,
+                    0.0,
+                ];
+                (3u32, count, gradient_tile_mode_value(TileMode::Clamp))
+            }
+        },
     };
 
     // A stroked rect/round-rect was emitted with `local_rect` already
@@ -2003,15 +2017,18 @@ fn convert_shape_into_slots(
     };
 
     let color = match &shape.brush {
-        Brush::Solid(c) => [c.r(), c.g(), c.b(), c.a()],
-        Brush::LinearGradient { colors, .. } => {
-            let first = colors.first().unwrap_or(&Color(1.0, 1.0, 1.0, 1.0));
-            [first.r(), first.g(), first.b(), first.a()]
-        }
-        Brush::RadialGradient { colors, .. } | Brush::SweepGradient { colors, .. } => {
-            let first = colors.first().unwrap_or(&Color(1.0, 1.0, 1.0, 1.0));
-            [first.r(), first.g(), first.b(), first.a()]
-        }
+        SceneBrush::Solid(c) => [c.r(), c.g(), c.b(), c.a()],
+        SceneBrush::Gradient(index) => match &brushes[*index as usize] {
+            Brush::Solid(c) => [c.r(), c.g(), c.b(), c.a()],
+            Brush::LinearGradient { colors, .. } => {
+                let first = colors.first().unwrap_or(&Color(1.0, 1.0, 1.0, 1.0));
+                [first.r(), first.g(), first.b(), first.a()]
+            }
+            Brush::RadialGradient { colors, .. } | Brush::SweepGradient { colors, .. } => {
+                let first = colors.first().unwrap_or(&Color(1.0, 1.0, 1.0, 1.0));
+                [first.r(), first.g(), first.b(), first.a()]
+            }
+        },
     };
 
     *shape_out = ShapeData {
@@ -2059,6 +2076,7 @@ fn quad_area_diag_enabled() -> bool {
 /// hand-off keeps the parallel path free of any synchronization.
 fn convert_shapes_into_outputs(
     shape_refs: &[&DrawShape],
+    brushes: &[Brush],
     gradient_offsets: &[u32],
     root_scale: f32,
     shape_data_out: &mut [ShapeData],
@@ -2119,7 +2137,7 @@ fn convert_shapes_into_outputs(
         top_other.sort_by(|a, b| b.0.total_cmp(&a.0));
         for &(area, index) in top_other.iter().take(4) {
             let shape = shape_refs[index];
-            let brush = match &shape.brush {
+            let brush = match shape.brush.resolve(brushes).as_ref() {
                 cranpose_ui_graphics::Brush::Solid(color) => format!("solid a={:.2}", color.3),
                 cranpose_ui_graphics::Brush::LinearGradient { colors, .. } => {
                     format!("linear n={}", colors.len())
@@ -2160,6 +2178,7 @@ fn convert_shapes_into_outputs(
             let gradient_end = gradient_offsets[idx + 1];
             convert_shape_into_slots(
                 shape,
+                brushes,
                 root_scale,
                 gradient_start,
                 &mut shape_data_out[idx],
@@ -2199,6 +2218,7 @@ fn convert_shapes_into_outputs(
                     let local_end = (chunk_offsets[j + 1] - gradient_base) as usize;
                     convert_shape_into_slots(
                         shape,
+                        brushes,
                         root_scale,
                         gradient_start,
                         &mut shape_data_chunk[j],
@@ -5009,6 +5029,7 @@ impl GpuRenderer {
         )?;
         let key = shape_shadow_surface_cache_key(
             &shadow.shapes,
+            &shadow.brushes,
             plan.source_device_bounds,
             plan.pixel_radius,
             root_scale,
@@ -5087,6 +5108,7 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
         &mut self,
         target: &OffscreenTarget,
         shapes: &[DrawShape],
+        brushes: &[Brush],
         images: &[ImageDraw],
         texts: &[TextDraw],
         shadow_draws: &[ShadowDraw],
@@ -5135,6 +5157,7 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
                     self.render_non_effect_segment(
                         &target.view,
                         shapes,
+                        brushes,
                         images,
                         texts,
                         shadow_draws,
@@ -5167,6 +5190,7 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
                         let effective_backdrop_underlay = if backdrop_underlay.is_some()
                             && backdrop_underlay_is_covered_by_local_content(
                                 shapes,
+                                brushes,
                                 images,
                                 shadow_draws,
                                 draw_ops,
@@ -5198,6 +5222,7 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
                             self,
                             target,
                             shapes,
+                            brushes,
                             images,
                             texts,
                             shadow_draws,
@@ -5219,6 +5244,7 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
                 self.render_non_effect_segment(
                     &target.view,
                     shapes,
+                    brushes,
                     images,
                     texts,
                     shadow_draws,
@@ -5853,6 +5879,7 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
         &mut self,
         target_view: &wgpu::TextureView,
         shapes: &[DrawShape],
+        brushes: &[Brush],
         images: &[ImageDraw],
         texts: &[TextDraw],
         shadow_draws: &[ShadowDraw],
@@ -5869,6 +5896,7 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
         self.render_non_effect_segment_with_composites(
             target_view,
             shapes,
+            brushes,
             images,
             texts,
             shadow_draws,
@@ -5891,6 +5919,7 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
         &mut self,
         target_view: &wgpu::TextureView,
         shapes: &[DrawShape],
+        brushes: &[Brush],
         images: &[ImageDraw],
         texts: &[TextDraw],
         shadow_draws: &[ShadowDraw],
@@ -5985,6 +6014,7 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
             z_start..z_end,
             &ordered_items,
             shapes,
+            brushes,
             images,
             SegmentDiagCounts {
                 raw_shadow_items,
@@ -6005,6 +6035,7 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
                 &merged_composites,
                 shader_composites,
                 shapes,
+                brushes,
                 images,
                 texts,
                 shadow_draws,
@@ -6027,6 +6058,7 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
         &mut self,
         target: &OffscreenTarget,
         shapes: &[DrawShape],
+        brushes: &[Brush],
         images: &[ImageDraw],
         texts: &[TextDraw],
         shadow_draws: &[ShadowDraw],
@@ -6045,6 +6077,7 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
         self.render_range_with_layer_events_to_target_recorded(
             target,
             shapes,
+            brushes,
             images,
             texts,
             shadow_draws,
@@ -6900,8 +6933,12 @@ impl GpuRenderer {
         #[cfg(not(target_arch = "wasm32"))]
         if let PacketRoot::Direct(root) = &packet.root {
             let ops = std::mem::take(&mut packet.replay);
-            let (ack, recycled) =
-                self.consume_replay_ops(ops, &root.scene.shapes, packet.root_scale);
+            let (ack, recycled) = self.consume_replay_ops(
+                ops,
+                &root.scene.shapes,
+                &root.scene.brushes,
+                packet.root_scale,
+            );
             returns.ack = Some((ack, recycled));
         }
 
@@ -7167,6 +7204,7 @@ impl GpuRenderer {
         composites: &[(usize, CompositeBatchItem<'_>)],
         shader_composites: &[(usize, ShaderCompositeBatchItem<'_>)],
         shapes: &[DrawShape],
+        brushes: &[Brush],
         images: &[ImageDraw],
         texts: &[TextDraw],
         shadow_draws: &[ShadowDraw],
@@ -7194,6 +7232,7 @@ impl GpuRenderer {
                         composites,
                         shader_composites,
                         shapes,
+                        brushes,
                         images,
                         texts,
                         retained_draws,
@@ -7261,6 +7300,7 @@ impl GpuRenderer {
         composites: &[(usize, CompositeBatchItem<'_>)],
         shader_composites: &[(usize, ShaderCompositeBatchItem<'_>)],
         shapes: &[DrawShape],
+        brushes: &[Brush],
         images: &[ImageDraw],
         texts: &[TextDraw],
         retained_draws: &[RetainedDraw],
@@ -7273,6 +7313,7 @@ impl GpuRenderer {
         let Some(partitions) = native_segment_fusion_partitions(
             ordered_items,
             shapes,
+            brushes,
             chunk,
             self.shape_batch_limits,
         )?
@@ -7291,6 +7332,7 @@ impl GpuRenderer {
                 composites,
                 shader_composites,
                 shapes,
+                brushes,
                 images,
                 texts,
                 retained_draws,
@@ -7324,6 +7366,7 @@ impl GpuRenderer {
         composites: &[(usize, CompositeBatchItem<'_>)],
         shader_composites: &[(usize, ShaderCompositeBatchItem<'_>)],
         shapes: &[DrawShape],
+        brushes: &[Brush],
         images: &[ImageDraw],
         texts: &[TextDraw],
         retained_draws: &[RetainedDraw],
@@ -7386,6 +7429,7 @@ impl GpuRenderer {
                 let Some((_, upload_base)) = self.prepare_shapes_batch_direct(
                     frame_encoder,
                     shape_refs.iter().copied(),
+                    brushes,
                     root_scale,
                     viewport,
                     &mut direct_shape_uploads,
@@ -7426,7 +7470,8 @@ impl GpuRenderer {
                                     "shape batch contains non-shape draw item: {item:?}"
                                 ));
                             };
-                            has_gradient |= shape_gradient_stop_count(&shapes[*shape_index]) > 0;
+                            has_gradient |=
+                                shape_gradient_stop_count(&shapes[*shape_index], brushes) > 0;
                         }
                         let shape_count = end - start;
                         if shape_count > 0 {
@@ -7886,6 +7931,7 @@ impl GpuRenderer {
         composites: &[(usize, CompositeBatchItem<'_>)],
         shader_composites: &[(usize, ShaderCompositeBatchItem<'_>)],
         shapes: &[DrawShape],
+        brushes: &[Brush],
         images: &[ImageDraw],
         texts: &[TextDraw],
         retained_draws: &[RetainedDraw],
@@ -7905,6 +7951,7 @@ impl GpuRenderer {
             composites,
             shader_composites,
             shapes,
+            brushes,
             images,
             texts,
             retained_draws,
@@ -7955,6 +8002,7 @@ impl GpuRenderer {
                                 SegmentDrawItem::Shape(shape_index) => Some(&shapes[*shape_index]),
                                 _ => None,
                             }),
+                            brushes,
                             root_scale,
                             viewport,
                             &mut staged_uploads,
@@ -8672,6 +8720,7 @@ impl GpuRenderer {
                     frame_encoder,
                     target_view,
                     std::iter::once(shape),
+                    &shadow.brushes,
                     *blend_mode,
                     width,
                     height,
@@ -8799,6 +8848,7 @@ impl GpuRenderer {
             frame_encoder,
             &source.view,
             &shadow.shapes,
+            &shadow.brushes,
             bounds_w,
             bounds_h,
             viewport_offset,
@@ -8952,6 +9002,7 @@ impl GpuRenderer {
         frame_encoder: &mut C,
         source_view: &wgpu::TextureView,
         shapes: &[(DrawShape, BlendMode)],
+        brushes: &[Brush],
         width: u32,
         height: u32,
         viewport_offset: [f32; 2],
@@ -8990,6 +9041,7 @@ impl GpuRenderer {
                     .iter()
                     .map(|(shape, _blend_mode)| shape)
                     .filter(|shape| shape_draw_is_visible_in_viewport(shape, viewport, root_scale)),
+                brushes,
                 root_scale,
                 viewport,
                 &mut staged_uploads,
@@ -9061,8 +9113,13 @@ impl GpuRenderer {
         let bounds_w = device_bounds.width;
         let bounds_h = device_bounds.height;
         let viewport_offset = [device_bounds.x, device_bounds.y];
-        let cache_key =
-            shape_shadow_surface_cache_key(&shadow.shapes, device_bounds, pixel_radius, root_scale);
+        let cache_key = shape_shadow_surface_cache_key(
+            &shadow.shapes,
+            &shadow.brushes,
+            device_bounds,
+            pixel_radius,
+            root_scale,
+        );
 
         if let Some(key) = cache_key {
             if let Some(cached) = self.cached_shadow_surface(&key) {
@@ -9134,6 +9191,7 @@ impl GpuRenderer {
             frame_encoder,
             &source.view,
             &shadow.shapes,
+            &shadow.brushes,
             bounds_w,
             bounds_h,
             viewport_offset,
@@ -9214,6 +9272,7 @@ impl GpuRenderer {
     fn prepare_shapes_batch<'a, I>(
         &mut self,
         layer_shapes: I,
+        brushes: &[Brush],
         root_scale: f32,
         viewport: ViewportUniformParams,
         staged_uploads: &mut StagedBufferUploads,
@@ -9243,7 +9302,7 @@ impl GpuRenderer {
         let mut total_gradient_stops = 0u32;
         gradient_offsets.push(0);
         for shape in &shape_refs {
-            total_gradient_stops += shape_gradient_stop_count(shape) as u32;
+            total_gradient_stops += shape_gradient_stop_count(shape, brushes) as u32;
             gradient_offsets.push(total_gradient_stops);
         }
 
@@ -9256,6 +9315,7 @@ impl GpuRenderer {
 
         convert_shapes_into_outputs(
             &shape_refs,
+            brushes,
             &gradient_offsets,
             root_scale,
             &mut self.scratch_shape_data,
@@ -9338,6 +9398,7 @@ impl GpuRenderer {
         &mut self,
         frame_encoder: &mut C,
         layer_shapes: I,
+        brushes: &[Brush],
         root_scale: f32,
         viewport: ViewportUniformParams,
         staged_uploads: &mut StagedBufferUploads,
@@ -9357,7 +9418,7 @@ impl GpuRenderer {
         let mut total_gradient_stops = 0u32;
         gradient_offsets.push(0);
         for shape in &shape_refs {
-            total_gradient_stops += shape_gradient_stop_count(shape) as u32;
+            total_gradient_stops += shape_gradient_stop_count(shape, brushes) as u32;
             gradient_offsets.push(total_gradient_stops);
         }
 
@@ -9378,6 +9439,7 @@ impl GpuRenderer {
             .resize(total_gradient_stops as usize, GradientStop::zeroed());
         convert_shapes_into_outputs(
             &shape_refs,
+            brushes,
             &gradient_offsets,
             root_scale,
             &mut self.scratch_shape_data,
@@ -9503,6 +9565,7 @@ impl GpuRenderer {
         &mut self,
         mut ops: crate::frame_packet::ReplayFrameOps,
         shapes: &[DrawShape],
+        brushes: &[Brush],
         root_scale: f32,
     ) -> (
         crate::frame_packet::ReplayAck,
@@ -9578,7 +9641,7 @@ impl GpuRenderer {
                 continue;
             };
             let refs: Vec<&DrawShape> = slice.iter().collect();
-            let Some(gpu_slot) = self.capture_replay_slot(&refs, root_scale) else {
+            let Some(gpu_slot) = self.capture_replay_slot(&refs, brushes, root_scale) else {
                 continue;
             };
             confirmations.push((capture.key, gpu_slot));
@@ -9622,7 +9685,7 @@ impl GpuRenderer {
         let generation = self.store_feed_generation.wrapping_add(generation_skew);
         let ops = crate::shape_replay::SHAPE_REPLAY
             .with(|state| state.borrow_mut().take_frame_ops(generation));
-        let (ack, recycled) = self.consume_replay_ops(ops, &[], 1.0);
+        let (ack, recycled) = self.consume_replay_ops(ops, &[], &[], 1.0);
         let confirmed = ack.confirmations.len();
         self.replay_ack_confirmations = crate::shape_replay::SHAPE_REPLAY
             .with(|state| state.borrow_mut().apply_ack(ack, recycled));
@@ -9736,6 +9799,7 @@ impl GpuRenderer {
     pub(crate) fn capture_replay_slot(
         &mut self,
         shape_refs: &[&DrawShape],
+        brushes: &[Brush],
         root_scale: f32,
     ) -> Option<u32> {
         if !self.shape_batch_limits.storage || shape_refs.is_empty() {
@@ -9748,7 +9812,7 @@ impl GpuRenderer {
         let mut total_gradient_stops = 0u32;
         gradient_offsets.push(0);
         for shape in shape_refs {
-            total_gradient_stops += shape_gradient_stop_count(shape) as u32;
+            total_gradient_stops += shape_gradient_stop_count(shape, brushes) as u32;
             gradient_offsets.push(total_gradient_stops);
         }
 
@@ -9756,6 +9820,7 @@ impl GpuRenderer {
         let mut gradients = vec![GradientStop::zeroed(); (total_gradient_stops as usize).max(1)];
         convert_shapes_into_outputs(
             shape_refs,
+            brushes,
             &gradient_offsets,
             root_scale,
             &mut shape_data,
@@ -10424,6 +10489,7 @@ impl GpuRenderer {
         frame_encoder: &mut C,
         target_view: &wgpu::TextureView,
         layer_shapes: I,
+        brushes: &[Brush],
         blend_mode: BlendMode,
         width: u32,
         height: u32,
@@ -10442,6 +10508,7 @@ impl GpuRenderer {
         let Some(batch) = self.prepare_shapes_batch(
             layer_shapes
                 .filter(|shape| shape_draw_is_visible_in_viewport(shape, viewport, root_scale)),
+            brushes,
             root_scale,
             viewport,
             &mut staged_uploads,
@@ -12673,12 +12740,15 @@ impl PreparedGlyphBatch {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn gradient_stop_count_for_shape(shape: &DrawShape) -> usize {
-    match &shape.brush {
-        Brush::Solid(_) => 0,
-        Brush::LinearGradient { colors, .. }
-        | Brush::RadialGradient { colors, .. }
-        | Brush::SweepGradient { colors, .. } => colors.len(),
+fn gradient_stop_count_for_shape(shape: &DrawShape, brushes: &[Brush]) -> usize {
+    match shape.brush {
+        SceneBrush::Solid(_) => 0,
+        SceneBrush::Gradient(index) => match &brushes[index as usize] {
+            Brush::Solid(_) => 0,
+            Brush::LinearGradient { colors, .. }
+            | Brush::RadialGradient { colors, .. }
+            | Brush::SweepGradient { colors, .. } => colors.len(),
+        },
     }
 }
 
@@ -12686,6 +12756,7 @@ fn gradient_stop_count_for_shape(shape: &DrawShape) -> usize {
 fn native_segment_fusion_budget(
     ordered_items: &[(usize, SegmentDrawItem)],
     shapes: &[DrawShape],
+    brushes: &[Brush],
     chunk: &SegmentDrawChunkPlan,
     batch_limits: ShapeBatchLimits,
 ) -> Result<Option<NativeSegmentFusionBudget>, String> {
@@ -12705,7 +12776,7 @@ fn native_segment_fusion_budget(
             let shape = &shapes[*shape_index];
             shape_count = shape_count.saturating_add(1);
             gradient_stop_count =
-                gradient_stop_count.saturating_add(gradient_stop_count_for_shape(shape));
+                gradient_stop_count.saturating_add(gradient_stop_count_for_shape(shape, brushes));
         }
     }
 
@@ -12745,10 +12816,12 @@ fn push_native_segment_fusion_partition(
 fn native_segment_fusion_partitions(
     ordered_items: &[(usize, SegmentDrawItem)],
     shapes: &[DrawShape],
+    brushes: &[Brush],
     chunk: &SegmentDrawChunkPlan,
     batch_limits: ShapeBatchLimits,
 ) -> Result<Option<Vec<NativeSegmentFusionPartition>>, String> {
-    if let Some(budget) = native_segment_fusion_budget(ordered_items, shapes, chunk, batch_limits)?
+    if let Some(budget) =
+        native_segment_fusion_budget(ordered_items, shapes, brushes, chunk, batch_limits)?
     {
         return Ok(Some(vec![NativeSegmentFusionPartition {
             chunk: chunk.clone(),
@@ -12782,7 +12855,7 @@ fn native_segment_fusion_partitions(
                     item
                 ));
             };
-            let gradient_stop_count = gradient_stop_count_for_shape(&shapes[shape_index]);
+            let gradient_stop_count = gradient_stop_count_for_shape(&shapes[shape_index], brushes);
             if gradient_stop_count > batch_limits.max_gradient_stops {
                 return Ok(None);
             }
@@ -13008,6 +13081,7 @@ fn maybe_print_segment_diag(
     z_range: Range<usize>,
     ordered_items: &[(usize, SegmentDrawItem)],
     shapes: &[DrawShape],
+    brushes: &[Brush],
     images: &[ImageDraw],
     counts: SegmentDiagCounts,
     batch_limits: ShapeBatchLimits,
@@ -13040,7 +13114,8 @@ fn maybe_print_segment_diag(
         let SegmentRenderCommand::DrawChunk(chunk) = command else {
             continue;
         };
-        match native_segment_fusion_partitions(ordered_items, shapes, chunk, batch_limits) {
+        match native_segment_fusion_partitions(ordered_items, shapes, brushes, chunk, batch_limits)
+        {
             Ok(Some(partitions)) => native_partitions += partitions.len(),
             Ok(None) | Err(_) => native_unfused_chunks += 1,
         }
@@ -14337,7 +14412,7 @@ mod tests {
             },
             quad: [[0.0, 0.0], [8.0, 0.0], [0.0, 8.0], [8.0, 8.0]],
             snap_anchor: None,
-            brush: Brush::solid(Color::BLACK),
+            brush: SceneBrush::Solid(Color::BLACK),
             shape: None,
             stroke: None,
             arc: None,
@@ -14351,7 +14426,7 @@ mod tests {
     #[test]
     fn shape_shadow_content_hash_ignores_viewport_translation() {
         fn translate_shape(shape: &DrawShape, dx: f32, dy: f32) -> DrawShape {
-            let mut translated = shape.clone();
+            let mut translated = *shape;
             translated.rect.x += dx;
             translated.rect.y += dy;
             translated.local_rect.x += dx;
@@ -14405,23 +14480,20 @@ mod tests {
         let translated_cutout = translate_shape(&cutout, dx, dy);
 
         let root_scale = 1.25;
-        let first_shapes = vec![
-            (first.clone(), BlendMode::SrcOver),
-            (cutout, BlendMode::DstOut),
-        ];
+        let first_shapes = vec![(first, BlendMode::SrcOver), (cutout, BlendMode::DstOut)];
         let translated_shapes = vec![
-            (translated.clone(), BlendMode::SrcOver),
+            (translated, BlendMode::SrcOver),
             (translated_cutout, BlendMode::DstOut),
         ];
 
-        let first_hash = shape_shadow_content_hash(&first_shapes, root_scale);
-        let translated_hash = shape_shadow_content_hash(&translated_shapes, root_scale);
+        let first_hash = shape_shadow_content_hash(&first_shapes, &[], root_scale);
+        let translated_hash = shape_shadow_content_hash(&translated_shapes, &[], root_scale);
 
         assert_eq!(first_hash, translated_hash);
 
         let mut changed_shapes = translated_shapes;
         changed_shapes[0].0.rect.width += 1.0;
-        let changed_hash = shape_shadow_content_hash(&changed_shapes, root_scale);
+        let changed_hash = shape_shadow_content_hash(&changed_shapes, &[], root_scale);
 
         assert_ne!(first_hash, changed_hash);
     }
@@ -14458,6 +14530,7 @@ mod tests {
                     .expect("surface plan");
             shape_shadow_surface_cache_key(
                 &shapes,
+                &[],
                 plan.source_device_bounds,
                 pixel_radius,
                 root_scale,
@@ -14517,6 +14590,7 @@ mod tests {
             .expect("surface plan");
             shape_shadow_surface_cache_key(
                 &shapes,
+                &[],
                 plan.source_device_bounds,
                 plan.pixel_radius,
                 root_scale,
@@ -14574,6 +14648,7 @@ mod tests {
     fn test_shadow_draw(shapes: Vec<(DrawShape, BlendMode)>) -> ShadowDraw {
         ShadowDraw {
             shapes,
+            brushes: vec![],
             texts: vec![],
             blur_radius: 8.0,
             clip: None,
@@ -18029,6 +18104,7 @@ mod tests {
         let window = build_scene_window(
             SceneWindowSource {
                 shapes: &[test_shape(4, BlendMode::SrcOver), shape],
+                brushes: &[],
                 images: &[image],
                 texts: &[text],
                 shadow_draws: &[shadow],
@@ -18341,6 +18417,7 @@ mod tests {
         };
         let shadow_draws = vec![ShadowDraw {
             shapes: vec![(shadow_shape, BlendMode::SrcOver)],
+            brushes: vec![],
             texts: Vec::new(),
             blur_radius: 8.0,
             clip: None,
@@ -18391,6 +18468,7 @@ mod tests {
         };
         let shadow_draws = vec![ShadowDraw {
             shapes: vec![(shadow_shape, BlendMode::SrcOver)],
+            brushes: vec![],
             texts: Vec::new(),
             blur_radius: 8.0,
             clip: None,
@@ -18535,7 +18613,7 @@ mod tests {
         ];
         shape.arc = Some(arc);
         let mut converted = ShapeData::zeroed();
-        convert_shape_into_slots(&shape, root_scale, 0, &mut converted, &mut []);
+        convert_shape_into_slots(&shape, &[], root_scale, 0, &mut converted, &mut []);
         converted
     }
 
@@ -18653,7 +18731,7 @@ mod tests {
     fn arc_mesh_passthrough_replicates_the_quad_expansion() {
         let shape = test_shape(0, BlendMode::SrcOver);
         let mut converted = ShapeData::zeroed();
-        convert_shape_into_slots(&shape, 1.0, 0, &mut converted, &mut []);
+        convert_shape_into_slots(&shape, &[], 1.0, 0, &mut converted, &mut []);
         let build =
             build_arc_mesh_vertices(std::slice::from_ref(&converted)).expect("within budget");
         assert_eq!(build.meshed_arcs, 0);
@@ -19263,6 +19341,7 @@ mod tests {
         let budget = native_segment_fusion_budget(
             &ordered_items,
             &shapes,
+            &[],
             &segment,
             ShapeBatchLimits::desktop(),
         )
@@ -19303,6 +19382,7 @@ mod tests {
         let budget = native_segment_fusion_budget(
             &ordered_items,
             &shapes,
+            &[],
             &segment,
             ShapeBatchLimits::desktop(),
         )
@@ -19316,7 +19396,11 @@ mod tests {
     fn native_segment_fusion_budget_rejects_gradient_uniform_overflow() {
         let ordered_items = vec![(0, SegmentDrawItem::Shape(0))];
         let mut shape = test_shape(0, BlendMode::SrcOver);
-        shape.brush = Brush::linear_gradient(vec![Color::BLACK; MAX_GRADIENT_STOPS + 1]);
+        let brushes = vec![Brush::linear_gradient(vec![
+            Color::BLACK;
+            MAX_GRADIENT_STOPS + 1
+        ])];
+        shape.brush = SceneBrush::Gradient(0);
         let shapes = vec![shape];
         let segment = chunk(&[SegmentBatchPlan::Shape {
             start: 0,
@@ -19327,6 +19411,7 @@ mod tests {
         let budget = native_segment_fusion_budget(
             &ordered_items,
             &shapes,
+            &brushes,
             &segment,
             ShapeBatchLimits::desktop(),
         )
@@ -19363,6 +19448,7 @@ mod tests {
         let partitions = native_segment_fusion_partitions(
             &ordered_items,
             &shapes,
+            &[],
             &segment,
             ShapeBatchLimits::desktop(),
         )
@@ -19410,9 +19496,10 @@ mod tests {
             (2, SegmentDrawItem::Shape(2)),
         ];
         let mut shapes = Vec::new();
+        let brushes = vec![Brush::linear_gradient(vec![Color::BLACK; STOPS_PER_SHAPE])];
         for index in 0..3 {
             let mut shape = test_shape(index, BlendMode::SrcOver);
-            shape.brush = Brush::linear_gradient(vec![Color::BLACK; STOPS_PER_SHAPE]);
+            shape.brush = SceneBrush::Gradient(0);
             shapes.push(shape);
         }
         let segment = chunk(&[SegmentBatchPlan::Shape {
@@ -19424,6 +19511,7 @@ mod tests {
         let partitions = native_segment_fusion_partitions(
             &ordered_items,
             &shapes,
+            &brushes,
             &segment,
             ShapeBatchLimits::desktop(),
         )
@@ -19492,6 +19580,7 @@ mod tests {
         let partitions = native_segment_fusion_partitions(
             &ordered_items,
             &shapes,
+            &[],
             &segment,
             ShapeBatchLimits::desktop(),
         )
@@ -19551,6 +19640,7 @@ mod tests {
         let partitions = native_segment_fusion_partitions(
             &ordered_items,
             &shapes,
+            &[],
             &segment,
             ShapeBatchLimits::desktop(),
         )

--- a/crates/cranpose-render/wgpu/src/scene.rs
+++ b/crates/cranpose-render/wgpu/src/scene.rs
@@ -3,6 +3,7 @@
 use crate::surface_requirements::SurfaceRequirementSet;
 use cranpose_core::NodeId;
 pub use cranpose_render_common::graph_scene::{ClickAction, HitRegion, Scene};
+use cranpose_render_common::style_shared::ResolvedBrush;
 use cranpose_ui::{TextLayoutOptions, TextStyle};
 use cranpose_ui_graphics::{
     ArcGeometry, BlendMode, Brush, Color, ColorFilter, ImageBitmap, ImageSampling, Point, Rect,
@@ -55,13 +56,63 @@ pub(crate) struct PendingFeedCapture {
     pub frame: u64,
 }
 
-#[derive(Clone)]
+/// A shape's paint, in the form the scene stores: solid colors inline, the
+/// rare gradient as an index into the owning [`CompositorScene::brushes`]
+/// table. `Copy` on purpose — it is what lets a frame's `Vec<DrawShape>`
+/// clear by truncation instead of walking ~17k `Brush` destructors, and what
+/// keeps every per-shape copy on the emit path free of clone/drop glue.
+/// Handles never outlive their scene's frame: the table is rebuilt with the
+/// scene each collect, so a stale index cannot exist by construction.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum SceneBrush {
+    Solid(Color),
+    /// Index into the owning scene's `brushes` table (non-solid brushes
+    /// only).
+    Gradient(u32),
+}
+
+/// [`CompositorScene::intern_brush`] against a bare table — shadow draws
+/// carry their own.
+pub(crate) fn intern_brush_into(table: &mut Vec<Brush>, brush: ResolvedBrush) -> SceneBrush {
+    match brush {
+        ResolvedBrush::Solid(color) => SceneBrush::Solid(color),
+        ResolvedBrush::Other(brush) => {
+            let index = table.len() as u32;
+            table.push(brush);
+            SceneBrush::Gradient(index)
+        }
+    }
+}
+
+impl SceneBrush {
+    /// The full `Brush` view, for consumers that need gradient payloads.
+    /// `brushes` must be the owning scene's table.
+    pub fn resolve<'a>(&self, brushes: &'a [Brush]) -> std::borrow::Cow<'a, Brush> {
+        match *self {
+            SceneBrush::Solid(color) => std::borrow::Cow::Owned(Brush::Solid(color)),
+            SceneBrush::Gradient(index) => std::borrow::Cow::Borrowed(&brushes[index as usize]),
+        }
+    }
+
+    /// The same value [`cranpose_ui_graphics::RenderHash`] produces for the
+    /// `Brush` this stands for — cache keys must not change because the
+    /// scene's storage form did.
+    pub fn render_hash(&self, brushes: &[Brush]) -> u64 {
+        use cranpose_ui_graphics::RenderHash as _;
+        match *self {
+            SceneBrush::Solid(color) => Brush::Solid(color).render_hash(),
+            SceneBrush::Gradient(index) => brushes[index as usize].render_hash(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
 pub(crate) struct DrawShape {
     pub rect: Rect,
     pub local_rect: Rect,
     pub quad: [[f32; 2]; 4],
     pub snap_anchor: Option<SnapAnchor>,
-    pub brush: Brush,
+    pub brush: SceneBrush,
     pub shape: Option<RoundedCornerShape>,
     /// `Some` strokes the outline of `local_rect`/`shape` instead of filling
     /// it. `local_rect` and `quad` are already inflated by half the width.
@@ -264,6 +315,11 @@ pub(crate) struct ShadowDraw {
     /// Shapes to render to offscreen target before blur.
     /// Each shape carries its own blend mode (SrcOver for fill, DstOut for cutout).
     pub shapes: Vec<(DrawShape, BlendMode)>,
+    /// The table this draw's [`SceneBrush::Gradient`] handles index. A
+    /// shadow travels between scenes whole (window builds, retained
+    /// captures), so it carries its own — empty for the usual solid-color
+    /// casters, so no per-frame allocation in the common case.
+    pub brushes: Vec<Brush>,
     /// Texts to render to offscreen target before blur.
     pub texts: Vec<TextDraw>,
     /// Gaussian blur radius in pixels.
@@ -309,6 +365,11 @@ pub(crate) struct BackdropLayer {
 
 pub(crate) struct CompositorScene {
     pub shapes: Vec<DrawShape>,
+    /// Non-solid brushes referenced by [`SceneBrush::Gradient`] handles in
+    /// this scene's shapes (shadow-draw shapes included). Rebuilt with the
+    /// scene every frame; a handle is only meaningful against the table of
+    /// the scene that owns the shape.
+    pub brushes: Vec<Brush>,
     pub images: Vec<ImageDraw>,
     pub texts: Vec<TextDraw>,
     pub shadow_draws: Vec<ShadowDraw>,
@@ -348,6 +409,7 @@ thread_local! {
 /// The emptied-but-still-allocated vectors of a dropped [`CompositorScene`].
 struct SceneBuffers {
     shapes: Vec<DrawShape>,
+    brushes: Vec<Brush>,
     images: Vec<ImageDraw>,
     texts: Vec<TextDraw>,
     shadow_draws: Vec<ShadowDraw>,
@@ -366,6 +428,7 @@ impl Drop for CompositorScene {
             self.clear();
             pool.push(SceneBuffers {
                 shapes: std::mem::take(&mut self.shapes),
+                brushes: std::mem::take(&mut self.brushes),
                 images: std::mem::take(&mut self.images),
                 texts: std::mem::take(&mut self.texts),
                 shadow_draws: std::mem::take(&mut self.shadow_draws),
@@ -386,6 +449,7 @@ impl CompositorScene {
         if let Some(buffers) = SCENE_BUFFER_POOL.with(|pool| pool.borrow_mut().pop()) {
             return Self {
                 shapes: buffers.shapes,
+                brushes: buffers.brushes,
                 images: buffers.images,
                 texts: buffers.texts,
                 shadow_draws: buffers.shadow_draws,
@@ -398,6 +462,7 @@ impl CompositorScene {
         }
         Self {
             shapes: Vec::with_capacity(hint.shapes),
+            brushes: Vec::new(),
             images: Vec::with_capacity(hint.images),
             texts: Vec::with_capacity(hint.texts),
             shadow_draws: Vec::with_capacity(hint.shadow_draws),
@@ -423,6 +488,7 @@ impl CompositorScene {
 
     pub fn clear(&mut self) {
         self.shapes.clear();
+        self.brushes.clear();
         self.images.clear();
         self.texts.clear();
         self.shadow_draws.clear();
@@ -462,6 +528,13 @@ impl CompositorScene {
         });
     }
 
+    /// Stores a layer-resolved brush in this scene's form: solid colors
+    /// inline, anything else appended to the `brushes` table behind a
+    /// handle. Gradient handles are only valid against this scene.
+    pub fn intern_brush(&mut self, brush: ResolvedBrush) -> SceneBrush {
+        intern_brush_into(&mut self.brushes, brush)
+    }
+
     pub fn push_shape(
         &mut self,
         rect: Rect,
@@ -498,7 +571,7 @@ impl CompositorScene {
             rect,
             local_rect,
             quad,
-            brush,
+            ResolvedBrush::from_brush(brush),
             shape,
             None,
             None,
@@ -514,7 +587,7 @@ impl CompositorScene {
         rect: Rect,
         local_rect: Rect,
         quad: [[f32; 2]; 4],
-        brush: Brush,
+        brush: ResolvedBrush,
         shape: Option<RoundedCornerShape>,
         stroke: Option<Stroke>,
         arc: Option<ArcGeometry>,
@@ -522,6 +595,7 @@ impl CompositorScene {
         blend_mode: BlendMode,
         motion_context_animated: bool,
     ) {
+        let brush = self.intern_brush(brush);
         let z_index = self.next_z;
         self.next_z += 1;
         let index = self.shapes.len();

--- a/crates/cranpose-render/wgpu/src/surface_executor/backend.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/backend.rs
@@ -10,7 +10,7 @@ use crate::surface_requirements::SurfaceRequirementSet;
 use cranpose_core::NodeId;
 use cranpose_render_common::graph::LayerNode;
 use cranpose_render_common::raster_cache::LayerRasterCacheKey;
-use cranpose_ui_graphics::{BlendMode, LayerShape, Rect, RenderEffect, RuntimeShader};
+use cranpose_ui_graphics::{BlendMode, Brush, LayerShape, Rect, RenderEffect, RuntimeShader};
 use std::ops::Range;
 use std::rc::Rc;
 
@@ -149,6 +149,7 @@ pub(crate) trait SurfaceExecutionBackend {
         &mut self,
         target_view: &wgpu::TextureView,
         shapes: &[DrawShape],
+        brushes: &[Brush],
         images: &[ImageDraw],
         texts: &[TextDraw],
         shadow_draws: &[ShadowDraw],
@@ -167,6 +168,7 @@ pub(crate) trait SurfaceExecutionBackend {
         &mut self,
         target_view: &wgpu::TextureView,
         shapes: &[DrawShape],
+        brushes: &[Brush],
         images: &[ImageDraw],
         texts: &[TextDraw],
         shadow_draws: &[ShadowDraw],
@@ -187,6 +189,7 @@ pub(crate) trait SurfaceExecutionBackend {
         &mut self,
         target: &OffscreenTarget,
         shapes: &[DrawShape],
+        brushes: &[Brush],
         images: &[ImageDraw],
         texts: &[TextDraw],
         shadow_draws: &[ShadowDraw],

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -25,7 +25,7 @@ use crate::offscreen::OffscreenTarget;
 use crate::render::{has_backdrop_layer_in_range, scissor_rect_for_rect};
 use crate::scene::{
     BackdropLayer, CompositorScene, DrawOp, DrawOpKind, DrawShape, EffectLayer, ImageDraw,
-    ShadowDraw, SnapAnchor, TextDraw,
+    SceneBrush, ShadowDraw, SnapAnchor, TextDraw,
 };
 use crate::surface_plan::{
     composite_sample_mode_for_effect_layer, composite_sample_mode_for_requirements,
@@ -295,6 +295,13 @@ fn clip_contains_rect(clip: Option<Rect>, rect: Rect) -> bool {
     clip.is_none_or(|clip| rect_contains_rect(clip, rect))
 }
 
+fn scene_brush_is_opaque(brush: SceneBrush, brushes: &[Brush]) -> bool {
+    match brush {
+        SceneBrush::Solid(color) => brush_is_opaque(&Brush::Solid(color)),
+        SceneBrush::Gradient(index) => brush_is_opaque(&brushes[index as usize]),
+    }
+}
+
 fn brush_is_opaque(brush: &Brush) -> bool {
     const OPAQUE_ALPHA: f32 = 0.999;
     match brush {
@@ -307,10 +314,10 @@ fn brush_is_opaque(brush: &Brush) -> bool {
     }
 }
 
-fn shape_opaque_covers_rect(shape: &DrawShape, rect: Rect) -> bool {
+fn shape_opaque_covers_rect(shape: &DrawShape, brushes: &[Brush], rect: Rect) -> bool {
     shape.blend_mode == BlendMode::SrcOver
         && shape.shape.is_none()
-        && brush_is_opaque(&shape.brush)
+        && scene_brush_is_opaque(shape.brush, brushes)
         && clip_contains_rect(shape.clip, rect)
         && axis_aligned_quad_rect(shape.quad).is_some_and(|bounds| rect_contains_rect(bounds, rect))
 }
@@ -372,6 +379,7 @@ fn prior_layer_event_intersects_rect(
 #[allow(clippy::too_many_arguments)]
 fn scene_range_has_opaque_cover_before(
     shapes: &[DrawShape],
+    brushes: &[Brush],
     images: &[ImageDraw],
     shadow_draws: &[ShadowDraw],
     draw_ops: &[DrawOp],
@@ -393,7 +401,7 @@ fn scene_range_has_opaque_cover_before(
             DrawOpKind::Shape(index) => {
                 if shapes
                     .get(index)
-                    .is_some_and(|shape| shape_opaque_covers_rect(shape, rect))
+                    .is_some_and(|shape| shape_opaque_covers_rect(shape, brushes, rect))
                 {
                     return true;
                 }
@@ -420,8 +428,10 @@ fn scene_range_has_opaque_cover_before(
     false
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn backdrop_underlay_is_covered_by_local_content(
     shapes: &[DrawShape],
+    brushes: &[Brush],
     images: &[ImageDraw],
     shadow_draws: &[ShadowDraw],
     draw_ops: &[DrawOp],
@@ -437,6 +447,7 @@ pub(crate) fn backdrop_underlay_is_covered_by_local_content(
         && rect.height > 0.0
         && scene_range_has_opaque_cover_before(
             shapes,
+            brushes,
             images,
             shadow_draws,
             draw_ops,
@@ -476,6 +487,7 @@ fn layer_source_uses_external_backdrop_underlay(
 
         !backdrop_underlay_is_covered_by_local_content(
             &local_scene.shapes,
+            &local_scene.brushes,
             &local_scene.images,
             &local_scene.shadow_draws,
             &local_scene.draw_ops,
@@ -982,6 +994,7 @@ fn render_scene_range_to_target<B: SurfaceExecutionBackend>(
         backend.render_range_with_layer_events_to_target(
             target,
             &scene.shapes,
+            &scene.brushes,
             &scene.images,
             &scene.texts,
             &scene.shadow_draws,
@@ -1001,6 +1014,7 @@ fn render_scene_range_to_target<B: SurfaceExecutionBackend>(
         backend.render_non_effect_segment(
             &target.view,
             &scene.shapes,
+            &scene.brushes,
             &scene.images,
             &scene.texts,
             &scene.shadow_draws,
@@ -1280,6 +1294,7 @@ fn create_direct_root_child_underlay<B: SurfaceExecutionBackend>(
     let window_scene = build_scene_window(
         SceneWindowSource {
             shapes: &local_scene.shapes,
+            brushes: &local_scene.brushes,
             images: &local_scene.images,
             texts: &local_scene.texts,
             shadow_draws: &local_scene.shadow_draws,
@@ -1394,6 +1409,7 @@ fn render_effect_layer_to_view<B: SurfaceExecutionBackend>(
     backend: &mut B,
     target_view: &wgpu::TextureView,
     shapes: &[DrawShape],
+    brushes: &[Brush],
     images: &[ImageDraw],
     texts: &[TextDraw],
     shadow_draws: &[ShadowDraw],
@@ -1443,6 +1459,7 @@ fn render_effect_layer_to_view<B: SurfaceExecutionBackend>(
     let window_scene = build_scene_window(
         SceneWindowSource {
             shapes,
+            brushes,
             images,
             texts,
             shadow_draws,
@@ -1472,6 +1489,7 @@ fn render_effect_layer_to_view<B: SurfaceExecutionBackend>(
     let render_result = backend.render_range_with_layer_events_to_target(
         &source,
         &window_scene.shapes,
+        &window_scene.brushes,
         &window_scene.images,
         &window_scene.texts,
         &window_scene.shadow_draws,
@@ -1681,6 +1699,7 @@ fn render_range_with_layer_events_to_view<B: SurfaceExecutionBackend>(
             backend.render_non_effect_segment(
                 target_view,
                 &scene.shapes,
+                &scene.brushes,
                 &scene.images,
                 &scene.texts,
                 &scene.shadow_draws,
@@ -1720,6 +1739,7 @@ fn render_range_with_layer_events_to_view<B: SurfaceExecutionBackend>(
                     backend,
                     target_view,
                     &scene.shapes,
+                    &scene.brushes,
                     &scene.images,
                     &scene.texts,
                     &scene.shadow_draws,
@@ -1740,6 +1760,7 @@ fn render_range_with_layer_events_to_view<B: SurfaceExecutionBackend>(
         backend.render_non_effect_segment(
             target_view,
             &scene.shapes,
+            &scene.brushes,
             &scene.images,
             &scene.texts,
             &scene.shadow_draws,
@@ -2624,7 +2645,7 @@ fn log_direct_scene_draw_op_detail(scene: &CompositorScene, draw_op: &DrawOp) {
                     shape.clip.is_some(),
                     shape.blend_mode,
                     shape.motion_context_animated,
-                    shape.brush.render_hash(),
+                    shape.brush.render_hash(&scene.brushes),
                 );
             }
         }
@@ -2811,7 +2832,7 @@ fn hash_draw_op<H: Hasher>(scene: &CompositorScene, draw_op: &DrawOp, state: &mu
     match draw_op.kind {
         DrawOpKind::Shape(index) => {
             if let Some(shape) = scene.shapes.get(index) {
-                hash_draw_shape(shape, state);
+                hash_draw_shape(shape, &scene.brushes, state);
             }
         }
         DrawOpKind::Image(index) => {
@@ -2845,12 +2866,12 @@ fn hash_draw_op<H: Hasher>(scene: &CompositorScene, draw_op: &DrawOp, state: &mu
     }
 }
 
-fn hash_draw_shape<H: Hasher>(shape: &DrawShape, state: &mut H) {
+fn hash_draw_shape<H: Hasher>(shape: &DrawShape, brushes: &[Brush], state: &mut H) {
     hash_rect(shape.rect, state);
     hash_rect(shape.local_rect, state);
     hash_quad(shape.quad, state);
     hash_snap_anchor(shape.snap_anchor, state);
-    shape.brush.render_hash().hash(state);
+    shape.brush.render_hash(brushes).hash(state);
     shape
         .shape
         .map(|shape| shape.radii().render_hash())
@@ -2946,7 +2967,7 @@ fn hash_render_string_contents<H: Hasher>(text: &cranpose_ui::text::RenderString
 fn hash_shadow_draw<H: Hasher>(shadow: &ShadowDraw, state: &mut H) {
     shadow.shapes.len().hash(state);
     for (shape, blend_mode) in &shadow.shapes {
-        hash_draw_shape(shape, state);
+        hash_draw_shape(shape, &shadow.brushes, state);
         blend_mode.hash(state);
     }
     shadow.texts.len().hash(state);
@@ -3327,6 +3348,7 @@ fn render_non_effect_range_with_pending_composites<B: SurfaceExecutionBackend>(
         backend.render_non_effect_segment(
             target_view,
             &scene.shapes,
+            &scene.brushes,
             &scene.images,
             &scene.texts,
             &scene.shadow_draws,
@@ -3357,6 +3379,7 @@ fn render_non_effect_range_with_pending_composites<B: SurfaceExecutionBackend>(
     backend.render_non_effect_segment_with_composites(
         target_view,
         &scene.shapes,
+        &scene.brushes,
         &scene.images,
         &scene.texts,
         &scene.shadow_draws,
@@ -3506,6 +3529,7 @@ fn cached_direct_scene_range_surface<B: SurfaceExecutionBackend>(
         let window_scene = build_scene_window(
             SceneWindowSource {
                 shapes: &scene.shapes,
+                brushes: &scene.brushes,
                 images: &scene.images,
                 texts: &scene.texts,
                 shadow_draws: &scene.shadow_draws,
@@ -3520,6 +3544,7 @@ fn cached_direct_scene_range_surface<B: SurfaceExecutionBackend>(
         let render_result = backend.render_non_effect_segment(
             &target.view,
             &window_scene.shapes,
+            &window_scene.brushes,
             &window_scene.images,
             &window_scene.texts,
             &window_scene.shadow_draws,
@@ -3771,6 +3796,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                 backend.render_non_effect_segment_with_composites(
                     &target.view,
                     &local_scene.shapes,
+                    &local_scene.brushes,
                     &local_scene.images,
                     &local_scene.texts,
                     &local_scene.shadow_draws,
@@ -3799,6 +3825,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                 backend.render_range_with_layer_events_to_target(
                     &target,
                     &local_scene.shapes,
+                    &local_scene.brushes,
                     &local_scene.images,
                     &local_scene.texts,
                     &local_scene.shadow_draws,
@@ -3955,6 +3982,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
             let effective_backdrop_underlay = if backdrop_underlay.is_some()
                 && backdrop_underlay_is_covered_by_local_content(
                     &local_scene.shapes,
+                    &local_scene.brushes,
                     &local_scene.images,
                     &local_scene.shadow_draws,
                     &local_scene.draw_ops,
@@ -4124,6 +4152,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
             backend.render_non_effect_segment_with_composites(
                 &target.view,
                 &local_scene.shapes,
+                &local_scene.brushes,
                 &local_scene.images,
                 &local_scene.texts,
                 &local_scene.shadow_draws,
@@ -4152,6 +4181,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
             backend.render_range_with_layer_events_to_target(
                 &target,
                 &local_scene.shapes,
+                &local_scene.brushes,
                 &local_scene.images,
                 &local_scene.texts,
                 &local_scene.shadow_draws,
@@ -4545,6 +4575,7 @@ pub(crate) fn render_effect_layer_to_target<B: SurfaceExecutionBackend>(
     backend: &mut B,
     target: &OffscreenTarget,
     shapes: &[DrawShape],
+    brushes: &[Brush],
     images: &[ImageDraw],
     texts: &[TextDraw],
     shadow_draws: &[ShadowDraw],
@@ -4596,6 +4627,7 @@ pub(crate) fn render_effect_layer_to_target<B: SurfaceExecutionBackend>(
     let window_scene = build_scene_window(
         SceneWindowSource {
             shapes,
+            brushes,
             images,
             texts,
             shadow_draws,
@@ -4638,6 +4670,7 @@ pub(crate) fn render_effect_layer_to_target<B: SurfaceExecutionBackend>(
     let render_result = backend.render_range_with_layer_events_to_target(
         &source,
         &window_scene.shapes,
+        &window_scene.brushes,
         &window_scene.images,
         &window_scene.texts,
         &window_scene.shadow_draws,
@@ -5408,7 +5441,7 @@ mod tests {
         minimum_surface_scale_for_composite, quad_bounds_rect, rects_intersect,
         render_string_scene_hash, retained_render_effect_hash, snapped_backdrop_geometry,
         surface_target_size, visible_backdrop_capture_rect, BackdropPrefixChildContribution,
-        DirectChunkRunCoalescer, DEFAULT_DIRECT_SCENE_RANGE_CACHE_BYTES,
+        DirectChunkRunCoalescer, SceneBrush, DEFAULT_DIRECT_SCENE_RANGE_CACHE_BYTES,
         MAX_DIRECT_SCENE_RANGE_CACHE_DRAW_OPS, MAX_MOTION_SENSITIVE_DIRECT_SCENE_CACHE_DRAW_BYTES,
         MIN_DIRECT_SCENE_RANGE_CACHE_DRAW_OPS,
     };
@@ -5577,7 +5610,7 @@ mod tests {
             local_rect: rect,
             quad: crate::rect_to_quad(rect),
             snap_anchor: None,
-            brush: Brush::solid(color),
+            brush: SceneBrush::Solid(color),
             shape: None,
             stroke: None,
             arc: None,
@@ -5963,6 +5996,7 @@ mod tests {
 
         assert!(backdrop_underlay_is_covered_by_local_content(
             &[],
+            &[],
             &[cover],
             &[],
             &draw_ops,
@@ -5995,6 +6029,7 @@ mod tests {
         }];
 
         assert!(!backdrop_underlay_is_covered_by_local_content(
+            &[],
             &[],
             &[cover],
             &[],
@@ -6231,9 +6266,9 @@ mod tests {
             first_shape.local_rect = first_shape.rect;
             first_shape.quad = crate::rect_to_quad(first_shape.rect);
 
-            let mut second_shape = first_shape.clone();
+            let mut second_shape = first_shape;
             if z_index == 0 {
-                second_shape.brush = Brush::solid(Color::RED);
+                second_shape.brush = SceneBrush::Solid(Color::RED);
             }
 
             let first_index = first.shapes.len();
@@ -6303,9 +6338,9 @@ mod tests {
             first_shape.rect.x = z_index as f32 * 20.0;
             first_shape.local_rect = first_shape.rect;
             first_shape.quad = crate::rect_to_quad(first_shape.rect);
-            let mut second_shape = first_shape.clone();
+            let mut second_shape = first_shape;
             if z_index == changed_z {
-                second_shape.brush = Brush::solid(Color::RED);
+                second_shape.brush = SceneBrush::Solid(Color::RED);
             }
 
             let first_index = first.shapes.len();


### PR DESCRIPTION
Watch profile churn: Brush drop-glue 0.24 ms/frame + a slice of jemalloc 0.71 and memcpy 0.91. The churn lives in the emit→scene leg (the record tape has been Copy POD since the compact-records step): `*_shape_params` cloned `Brush` per shape and `DrawShape.brush: Brush` made ~17k-element scene vectors walk drop glue at every teardown.

`ResolvedBrush` (emit) and `SceneBrush` (scene: inline solid color or a u32 handle into a per-frame `CompositorScene.brushes` table, rebuilt each collect so stale handles cannot exist) make `DrawShape` fully Copy — scene clears become drop-free truncations, each shape ~56 bytes smaller through every copy pass. `SceneBrush::render_hash` reproduces `Brush::render_hash` bit-for-bit so all cache keys are unchanged; gradient interning order matches serial and parallel emit. Shadow draws carry their own (usually empty) table because they leave their owning scene.

Left on cloned Brush (documented in commit): materialized DrawPrimitive buffers, text spans, the pixels backend sink.

**Est 0.3–0.6 ms/frame.** Tests on the remote Linux host: 705/706 — the one failure is that host's documented environmental ±1 green-channel pixel test, identical on pristine main; every parity suite green (command_feed, arc/rim/solid/instanced/retained, render_contract, ui-graphics 184, wgpu lib 415, pixels 204). Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2