### PR TITLE
One producer chunk per lane: the fine split was for a present stage that never came

### DIFF
--- a/crates/cranpose-render/wgpu/src/stage_executor.rs
+++ b/crates/cranpose-render/wgpu/src/stage_executor.rs
@@ -51,9 +51,14 @@ pub(crate) enum Stage {
 /// wake, and one core does it faster alone.
 const MIN_POOLED_ITEMS: usize = 256;
 
-/// Producer fan-outs split into this many chunks per lane; the bound on
-/// present-stage queue delay is one such chunk's execution time.
-const PRODUCER_CHUNK_FACTOR: usize = 4;
+/// Producer fan-outs split into this many chunks per lane. Finer chunking
+/// (the factor was 4) existed to bound present-stage queue delay, but no
+/// present stage submits today — the depth-one pipeline lost on-device —
+/// while every extra chunk is a cross-thread wake: a hot-watch profile
+/// showed the render thread spending 19% of its time in
+/// `pthread_cond_signal` alone. One chunk per lane is the coarsest split
+/// that still uses every core.
+const PRODUCER_CHUNK_FACTOR: usize = 1;
 
 #[derive(Default)]
 struct TelemetryCounters {


### PR DESCRIPTION
`PRODUCER_CHUNK_FACTOR = 4` split every producer fan-out four ways per
lane so that a present stage's queue delay was bounded by one chunk's
execution time. Nothing submits present work today, and the depth-one
pipeline that would have measured slower on the watch in every
configuration tried — that approach is parked, not pending.

What the fine split still costs is real: every extra chunk is a
cross-thread wake, and a hot-watch profile puts **19% of the render
thread in `pthread_cond_signal` alone**. One chunk per lane is the
coarsest split that still uses every core.

One constant and its comment; no behaviour depends on the factor beyond
how the same work is divided.

This existed only as a local branch and had never been proposed — it is
the one piece of unlanded work among the experiment branches on this
fork that is not a diagnostic build or a measured regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)