### PR TITLE
Cull fragments outside the display's visible region

### DIFF
--- a/crates/cranpose-render/wgpu/src/display_clip.rs
+++ b/crates/cranpose-render/wgpu/src/display_clip.rs
@@ -1,0 +1,460 @@
+//! Display clip region: framework-level culling of pixels the display
+//! physically never shows.
+//!
+//! The surface has a VISIBLE REGION — the part of it the panel actually
+//! displays. Everything outside that region is cullable for any app and
+//! any layout, because no layout can make an invisible pixel visible. The
+//! mechanism is fully general: the region's COMPLEMENT is tessellated
+//! into a conservative occluder mesh, drawn first into a small transient
+//! depth attachment on the full-frame pass (depth write on, color writes
+//! off, no discard — early-Z/LRZ eligible), and every content pipeline
+//! runs a depth-tested variant (compare `Less`, write off). Content emits
+//! clip z 0.5 in those variants, the occluder writes 0.0, the clear is
+//! 1.0 — so occluded pixels fail the test before the fragment shader
+//! runs.
+//!
+//! [`DisplayVisibleRegion`] names the region; providers plug in as
+//! variants plus a [`tessellate_complement`] arm, without touching the
+//! cull machinery. The first provider is the round display: Android's
+//! `AConfiguration` screenRound yields [`DisplayVisibleRegion::InscribedCircle`].
+//! Future providers — display cutouts/insets reported by the platform, or
+//! an explicitly declared clip — are new variants. A rectangular display
+//! is [`DisplayVisibleRegion::Full`]: the mechanism is structurally inert,
+//! zero cost, and rendering is bitwise identical to a renderer without
+//! this capability.
+
+use std::borrow::Cow;
+
+/// The region of the surface the display physically shows. The renderer
+/// may refuse to shade anything outside it.
+///
+/// This is PLATFORM (or otherwise host-declared) truth about the display,
+/// never derived from app content — apps cannot invent one for their own
+/// scene; they get the cull for free on any layout.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DisplayVisibleRegion {
+    /// The whole surface is visible (every rectangular display). The cull
+    /// machinery never engages: no depth attachment, no occluder, no
+    /// pipeline variants — bitwise-identical rendering.
+    #[default]
+    Full,
+    /// Only the circle inscribed in the surface rect is visible — the
+    /// round-display panel shape (center at the surface midpoint, radius
+    /// `min(width, height) / 2`).
+    InscribedCircle,
+}
+
+impl DisplayVisibleRegion {
+    /// Whether the region leaves anything to cull at all.
+    pub(crate) fn cullable(self) -> bool {
+        self != Self::Full
+    }
+}
+
+/// Depth format of the display-clip attachment: universally supported,
+/// 2 bytes per pixel (~333 KB transient at 408²), and with
+/// `LoadOp::Clear` + `StoreOp::Discard` it lives and dies in GMEM on tiled
+/// GPUs without ever touching main memory.
+pub(crate) const DISPLAY_CLIP_DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth16Unorm;
+
+/// The clear value of the display-clip depth attachment (far plane).
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const DISPLAY_CLIP_DEPTH_CLEAR: f32 = 1.0;
+
+/// Depth state every CONTENT pipeline uses in its display-clip variant:
+/// test `Less` against the occluder (which wrote 0.0), never write.
+/// `None` for the ordinary no-depth variant, which stays byte-identical
+/// to the pipelines that existed before the cull.
+pub(crate) fn content_depth_state(depth: bool) -> Option<wgpu::DepthStencilState> {
+    depth.then(|| wgpu::DepthStencilState {
+        format: DISPLAY_CLIP_DEPTH_FORMAT,
+        depth_write_enabled: Some(false),
+        depth_compare: Some(wgpu::CompareFunction::Less),
+        stencil: wgpu::StencilState::default(),
+        bias: wgpu::DepthBiasState::default(),
+    })
+}
+
+/// The exact clip-position tail every framework vertex stage emits today.
+/// [`with_content_z`] rewrites it in the display-clip pipeline variants;
+/// the ordinary variants compile the untouched text, so their output
+/// cannot drift by construction.
+const FLAT_Z_TAIL: &str = "(x, y, 0.0, 1.0);";
+const MID_Z_TAIL: &str = "(x, y, 0.5, 1.0);";
+
+/// Rewrites a framework vertex stage's emitted clip z from 0.0 to the
+/// display-clip content depth 0.5 — only for the depth pipeline variant.
+/// 0.5 keeps a wide, unambiguous margin between content and both the
+/// occluder (0.0) and the clear (1.0), which is what lets conservative
+/// early-Z / LRZ hardware reject occluded fragments confidently. (Runtime
+/// user shaders are NOT rewritten; their conventional z 0.0 still fails
+/// `0.0 < 0.0` against the occluder, so they cull correctly, just without
+/// the margin.)
+///
+/// Exact-text substitution, same discipline as `shape_shader_source`: a
+/// drifted literal makes this a silent no-op, so the debug assertion (and
+/// a unit test below) pin the pattern.
+pub(crate) fn with_content_z(source: Cow<'static, str>, depth: bool) -> Cow<'static, str> {
+    if !depth {
+        return source;
+    }
+    debug_assert!(
+        source.contains(FLAT_Z_TAIL),
+        "vertex stage no longer emits `{FLAT_Z_TAIL}`; the display-clip z substitution missed"
+    );
+    Cow::Owned(source.replace(FLAT_Z_TAIL, MID_Z_TAIL))
+}
+
+/// The occluder's own shader: positions arrive pre-baked in NDC, z is the
+/// near plane 0.0, and the fragment stage is trivial — no discard, no
+/// texture reads — so the draw is early-Z friendly and the pipeline masks
+/// off every color write.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const OCCLUDER_SHADER: &str = "\
+@vertex
+fn mask_vs(@location(0) position: vec2<f32>) -> @builtin(position) vec4<f32> {
+    return vec4<f32>(position, 0.0, 1.0);
+}
+
+@fragment
+fn mask_fs() -> @location(0) vec4<f32> {
+    return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+}
+";
+
+/// Triangles per corner fan of the inscribed-circle tessellation. Four
+/// corners × 8 = 32 triangles per frame — the entire per-frame geometry
+/// cost of that region's cull.
+#[cfg(not(target_arch = "wasm32"))]
+const SEGMENTS_PER_CORNER: usize = 8;
+
+/// Conservative tessellations are built against the region inflated by
+/// this margin, so f32 vertex rounding and rasterization snapping can
+/// never push an occluder edge over a pixel the panel actually shows. The
+/// cost is a sub-pixel band of cullable pixels left unculled —
+/// conservative in the safe direction.
+#[cfg(not(target_arch = "wasm32"))]
+const SAFETY_PX: f64 = 0.5;
+
+/// The tessellated complement of a visible region for one surface size.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) struct ComplementMesh {
+    /// Triangle-list vertices, NDC xy.
+    pub(crate) vertices: Vec<[f32; 2]>,
+    /// Approximate pixels the occluder rejects per full-screen layer of
+    /// overdraw: the area outside the visible region. (A tessellation may
+    /// under-cover that area; this is a log figure, not an accounting
+    /// one.)
+    pub(crate) masked_px: u64,
+}
+
+/// Tessellates the COMPLEMENT of `region` on a `width`×`height` surface
+/// into the occluder mesh the depth pre-pass draws.
+///
+/// THE CONTRACT every region arm must uphold: the mesh is CONSERVATIVE —
+/// every triangle lies strictly outside the visible region, so the
+/// occluder can never cover a pixel whose center the display shows.
+/// Under-coverage is the only permitted error (unculled cullable pixels
+/// cost fill, never correctness). An arm that cannot guarantee this for a
+/// given size returns `None` and the caller leaves the cull off.
+///
+/// [`DisplayVisibleRegion::Full`] has an empty complement and always
+/// returns `None`.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn tessellate_complement(
+    region: DisplayVisibleRegion,
+    width: u32,
+    height: u32,
+) -> Option<ComplementMesh> {
+    match region {
+        DisplayVisibleRegion::Full => None,
+        DisplayVisibleRegion::InscribedCircle => {
+            tessellate_inscribed_circle_complement(width, height)
+        }
+    }
+}
+
+/// The inscribed-circle arm of [`tessellate_complement`]: for each of the
+/// four corners, a triangle fan from the corner point to a polyline
+/// CIRCUMSCRIBED about the inscribed circle (every chord tangent to
+/// radius `r + SAFETY_PX`, vertices at `r_safe / cos(Δθ/2)`), clamped to
+/// the corner's tangent cone. Every triangle therefore lies strictly
+/// outside the circle.
+///
+/// The construction is verified numerically before it is accepted: the
+/// distance from the circle center to every triangle must exceed `r`. A
+/// failure returns `None` — fail-safe for exotic surface sizes, per the
+/// contract above.
+#[cfg(not(target_arch = "wasm32"))]
+fn tessellate_inscribed_circle_complement(width: u32, height: u32) -> Option<ComplementMesh> {
+    use std::f64::consts::PI;
+
+    if width < 16 || height < 16 {
+        return None;
+    }
+    let (w, h) = (f64::from(width), f64::from(height));
+    let (cx, cy) = (w / 2.0, h / 2.0);
+    let r = w.min(h) / 2.0;
+    let r_safe = r + SAFETY_PX;
+
+    // Corner order pairs each corner with the quadrant of the circle that
+    // faces it, in atan2-normalized-to-[0, 2π) angles (y grows down, so
+    // e.g. the bottom-right corner faces the (+x, +y) quadrant [0, π/2]).
+    let corners = [
+        (w, h, 0.0),              // bottom-right: quadrant [0, π/2]
+        (0.0, h, PI / 2.0),       // bottom-left:  quadrant [π/2, π]
+        (0.0, 0.0, PI),           // top-left:     quadrant [π, 3π/2]
+        (w, 0.0, 3.0 * PI / 2.0), // top-right:    quadrant [3π/2, 2π]
+    ];
+
+    let mut triangles: Vec<[[f64; 2]; 3]> = Vec::with_capacity(4 * SEGMENTS_PER_CORNER);
+    for (px, py, quadrant_start) in corners {
+        let (dx, dy) = (px - cx, py - cy);
+        let d = dx.hypot(dy);
+        if d <= r_safe {
+            // The corner itself is (numerically) inside the safe circle:
+            // nothing invisible to occlude here.
+            continue;
+        }
+        let mut phi = dy.atan2(dx);
+        if phi < 0.0 {
+            phi += 2.0 * PI;
+        }
+        // Tangent cone: the corner can only "see" (and thus safely fan to)
+        // arc points within ±acos(r_safe/d) of its own direction. For a
+        // square surface that is the whole quadrant; for elongated ones it
+        // shrinks, deliberately under-covering the side bands.
+        let beta = (r_safe / d).acos();
+        let theta_lo = quadrant_start.max(phi - beta);
+        let theta_hi = (quadrant_start + PI / 2.0).min(phi + beta);
+        if theta_hi - theta_lo < 1e-6 {
+            continue;
+        }
+        let step = (theta_hi - theta_lo) / SEGMENTS_PER_CORNER as f64;
+        // Chord between consecutive vertices at radius r_v stays at
+        // distance r_v·cos(step/2) = r_safe from the center: tangent to
+        // the safe circle, strictly outside the real one.
+        let r_v = r_safe / (step / 2.0).cos();
+        let vertex_at = |theta: f64| [cx + r_v * theta.cos(), cy + r_v * theta.sin()];
+        for i in 0..SEGMENTS_PER_CORNER {
+            let a = vertex_at(theta_lo + step * i as f64);
+            let b = vertex_at(theta_lo + step * (i + 1) as f64);
+            triangles.push([[px, py], a, b]);
+        }
+    }
+    if triangles.is_empty() {
+        return None;
+    }
+
+    // Conservative-containment proof, run once per surface size: the
+    // circle center must be strictly farther than r from every triangle.
+    // (The center is inside the circle; if it were inside a triangle the
+    // distance would be 0 and this rejects the whole mesh.)
+    for triangle in &triangles {
+        if distance_point_to_triangle([cx, cy], triangle) <= r {
+            log::warn!(
+                "[display-clip] occluder verification failed at {width}x{height}; cull stays off"
+            );
+            return None;
+        }
+    }
+
+    let to_ndc = |[x, y]: [f64; 2]| [(x / w * 2.0 - 1.0) as f32, (1.0 - y / h * 2.0) as f32];
+    let vertices = triangles
+        .iter()
+        .flat_map(|t| t.iter().copied().map(to_ndc))
+        .collect();
+    let masked_px = (w * h - PI * r * r).max(0.0).round() as u64;
+    Some(ComplementMesh {
+        vertices,
+        masked_px,
+    })
+}
+
+/// Distance from `p` to the closed triangle `t` (0 when inside).
+#[cfg(not(target_arch = "wasm32"))]
+fn distance_point_to_triangle(p: [f64; 2], t: &[[f64; 2]; 3]) -> f64 {
+    // Inside test via consistent edge orientation.
+    let cross = |a: [f64; 2], b: [f64; 2], c: [f64; 2]| {
+        (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])
+    };
+    let d0 = cross(t[0], t[1], p);
+    let d1 = cross(t[1], t[2], p);
+    let d2 = cross(t[2], t[0], p);
+    let has_neg = d0 < 0.0 || d1 < 0.0 || d2 < 0.0;
+    let has_pos = d0 > 0.0 || d1 > 0.0 || d2 > 0.0;
+    if !(has_neg && has_pos) {
+        return 0.0;
+    }
+    distance_point_to_segment(p, t[0], t[1])
+        .min(distance_point_to_segment(p, t[1], t[2]))
+        .min(distance_point_to_segment(p, t[2], t[0]))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn distance_point_to_segment(p: [f64; 2], a: [f64; 2], b: [f64; 2]) -> f64 {
+    let (abx, aby) = (b[0] - a[0], b[1] - a[1]);
+    let (apx, apy) = (p[0] - a[0], p[1] - a[1]);
+    let len_sq = abx * abx + aby * aby;
+    let t = if len_sq > 0.0 {
+        ((apx * abx + apy * aby) / len_sq).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let (dx, dy) = (apx - t * abx, apy - t * aby);
+    dx.hypot(dy)
+}
+
+/// Whether a pixel center is inside the visible region — the reference
+/// predicate the parity suite tests the GPU path against, defined here so
+/// the tests stay parameterized by region rather than hard-coding any one
+/// shape.
+#[cfg(not(target_arch = "wasm32"))]
+#[doc(hidden)]
+pub fn pixel_is_visible(
+    region: DisplayVisibleRegion,
+    width: u32,
+    height: u32,
+    x: u32,
+    y: u32,
+) -> bool {
+    match region {
+        DisplayVisibleRegion::Full => true,
+        DisplayVisibleRegion::InscribedCircle => {
+            let dx = (f64::from(x) + 0.5) - f64::from(width) / 2.0;
+            let dy = (f64::from(y) + 0.5) - f64::from(height) / 2.0;
+            (dx * dx + dy * dy).sqrt() < f64::from(width.min(height)) / 2.0
+        }
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    /// Recovers a vertex's pixel position from its NDC form.
+    fn from_ndc([x, y]: [f32; 2], width: u32, height: u32) -> [f64; 2] {
+        [
+            (f64::from(x) + 1.0) / 2.0 * f64::from(width),
+            (1.0 - f64::from(y)) / 2.0 * f64::from(height),
+        ]
+    }
+
+    fn triangles_of(mesh: &ComplementMesh, width: u32, height: u32) -> Vec<[[f64; 2]; 3]> {
+        mesh.vertices
+            .chunks_exact(3)
+            .map(|t| {
+                [
+                    from_ndc(t[0], width, height),
+                    from_ndc(t[1], width, height),
+                    from_ndc(t[2], width, height),
+                ]
+            })
+            .collect()
+    }
+
+    fn point_in_triangle(p: [f64; 2], t: &[[f64; 2]; 3]) -> bool {
+        distance_point_to_triangle(p, t) == 0.0
+    }
+
+    /// The full region has an empty complement: the mechanism must be
+    /// structurally inert for every rectangular display.
+    #[test]
+    fn full_region_tessellates_to_nothing() {
+        assert!(tessellate_complement(DisplayVisibleRegion::Full, 408, 408).is_none());
+    }
+
+    /// THE tessellation contract, checked at pixel granularity for every
+    /// cullable region: no pixel whose center is visible may be covered
+    /// by any occluder triangle — for square, odd, and elongated
+    /// surfaces.
+    #[test]
+    fn occluder_never_covers_a_visible_pixel() {
+        for region in [DisplayVisibleRegion::InscribedCircle] {
+            for (width, height) in [
+                (408u32, 408u32),
+                (407, 407),
+                (466, 466),
+                (320, 290),
+                (480, 360),
+                (1000, 200),
+                (64, 64),
+            ] {
+                let mesh = tessellate_complement(region, width, height)
+                    .unwrap_or_else(|| panic!("{region:?} must tessellate at {width}x{height}"));
+                let triangles = triangles_of(&mesh, width, height);
+                for y in 0..height {
+                    for x in 0..width {
+                        if !pixel_is_visible(region, width, height, x, y) {
+                            continue;
+                        }
+                        let p = [f64::from(x) + 0.5, f64::from(y) + 0.5];
+                        for triangle in &triangles {
+                            assert!(
+                                !point_in_triangle(p, triangle),
+                                "{region:?} occluder covers visible pixel ({x}, {y}) \
+                                 at {width}x{height}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// The occluder must actually be worth drawing: on a square surface
+    /// the inscribed-circle tessellation covers nearly all of the
+    /// invisible corner region.
+    #[test]
+    fn inscribed_circle_occluder_covers_most_of_the_invisible_region() {
+        let region = DisplayVisibleRegion::InscribedCircle;
+        let (width, height) = (408u32, 408u32);
+        let mesh = tessellate_complement(region, width, height).expect("mesh must build");
+        let triangles = triangles_of(&mesh, width, height);
+        let mut invisible = 0u64;
+        let mut covered = 0u64;
+        for y in 0..height {
+            for x in 0..width {
+                if pixel_is_visible(region, width, height, x, y) {
+                    continue;
+                }
+                invisible += 1;
+                let p = [f64::from(x) + 0.5, f64::from(y) + 0.5];
+                if triangles.iter().any(|t| point_in_triangle(p, t)) {
+                    covered += 1;
+                }
+            }
+        }
+        assert!(
+            covered as f64 >= invisible as f64 * 0.9,
+            "occluder covers {covered} of {invisible} invisible pixels — the cull would be hollow"
+        );
+    }
+
+    /// Pins the exact-text z substitution against shader drift, for every
+    /// vertex stage that draws inside the fused pass.
+    #[test]
+    fn content_z_substitution_matches_every_fused_pass_vertex_stage() {
+        for (name, source) in [
+            ("shape", crate::shaders::SHADER),
+            ("image", crate::shaders::IMAGE_SHADER),
+            ("glyph_atlas", crate::shaders::GLYPH_ATLAS_SHADER),
+            ("fullscreen_quad", crate::shaders::FULLSCREEN_QUAD_VS),
+        ] {
+            assert!(
+                source.contains(FLAT_Z_TAIL),
+                "{name} no longer emits `{FLAT_Z_TAIL}`; display-clip z substitution would no-op"
+            );
+            let substituted = with_content_z(Cow::Borrowed(source), true);
+            assert!(
+                !substituted.contains(FLAT_Z_TAIL) && substituted.contains(MID_Z_TAIL),
+                "{name} substitution failed"
+            );
+            assert_eq!(
+                with_content_z(Cow::Borrowed(source), false),
+                source,
+                "{name} flat variant must be the untouched text"
+            );
+        }
+    }
+}

--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -14,8 +14,9 @@ use cranpose_ui_graphics::{
     BlendMode, RenderEffect, RuntimeShader, TileMode, ROUNDED_ALPHA_MASK_WGSL,
 };
 
+use crate::display_clip;
 use crate::gpu_stats::FrameStats;
-use crate::lazy_resource::LazyGpuResource;
+use crate::lazy_resource::{LazyGpuResource, PassPipeline};
 use std::cell::Cell;
 
 pub(crate) struct EffectRenderer {
@@ -35,9 +36,13 @@ pub(crate) struct EffectRenderer {
     offset_uniform_bind_group_layout: wgpu::BindGroupLayout,
 
     blit_shader: wgpu::ShaderModule,
+    /// Kept for the display-clip blit variants, whose module is compiled
+    /// lazily from this text with the content z rewritten (see
+    /// [`crate::display_clip::with_content_z`]).
+    blit_shader_source: String,
     blit_pipeline_layout: wgpu::PipelineLayout,
-    blit_pipeline: LazyGpuResource<wgpu::RenderPipeline>,
-    blit_pipeline_dst_out: LazyGpuResource<wgpu::RenderPipeline>,
+    blit_pipeline: PassPipeline,
+    blit_pipeline_dst_out: PassPipeline,
     blit_uniform_bind_group_layout: wgpu::BindGroupLayout,
     projective_blit_shader: wgpu::ShaderModule,
     projective_blit_pipeline_layout: wgpu::PipelineLayout,
@@ -421,6 +426,7 @@ fn dst_out_blend_state() -> wgpu::BlendState {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn create_fullscreen_pipeline(
     device: &wgpu::Device,
     label: &'static str,
@@ -429,6 +435,7 @@ fn create_fullscreen_pipeline(
     fragment_entry: &'static str,
     surface_format: wgpu::TextureFormat,
     blend: wgpu::BlendState,
+    depth: bool,
 ) -> wgpu::RenderPipeline {
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
         label: Some(label),
@@ -456,7 +463,7 @@ fn create_fullscreen_pipeline(
             cull_mode: None,
             ..Default::default()
         },
-        depth_stencil: None,
+        depth_stencil: display_clip::content_depth_state(depth),
         multisample: wgpu::MultisampleState::default(),
         multiview_mask: None,
         cache: None,
@@ -612,9 +619,10 @@ impl EffectRenderer {
         let offset_pipeline = LazyGpuResource::new("effect/offset");
 
         // Compile blit pipeline
+        let blit_shader_source = shaders::blit_shader();
         let blit_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Blit Shader"),
-            source: wgpu::ShaderSource::Wgsl(shaders::blit_shader().into()),
+            source: wgpu::ShaderSource::Wgsl(blit_shader_source.clone().into()),
         });
 
         let blit_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -626,8 +634,9 @@ impl EffectRenderer {
             immediate_size: 0,
         });
 
-        let blit_pipeline = LazyGpuResource::new("effect/blit-src-over");
-        let blit_pipeline_dst_out = LazyGpuResource::new("effect/blit-dst-out");
+        let blit_pipeline = PassPipeline::new("effect/blit-src-over", "effect/blit-src-over-depth");
+        let blit_pipeline_dst_out =
+            PassPipeline::new("effect/blit-dst-out", "effect/blit-dst-out-depth");
 
         let projective_blit_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Projective Blit Shader"),
@@ -667,6 +676,7 @@ impl EffectRenderer {
             offset_pipeline,
             offset_uniform_bind_group_layout,
             blit_shader,
+            blit_shader_source,
             blit_pipeline_layout,
             blit_pipeline,
             blit_pipeline_dst_out,
@@ -755,6 +765,7 @@ impl EffectRenderer {
                 "blur_fs",
                 self.surface_format,
                 wgpu::BlendState::REPLACE,
+                false,
             )
         })
     }
@@ -770,6 +781,7 @@ impl EffectRenderer {
                     "blur_rounded_mask_fs",
                     self.surface_format,
                     wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING,
+                    false,
                 )
             })
     }
@@ -784,11 +796,21 @@ impl EffectRenderer {
                 "offset_fs",
                 self.surface_format,
                 wgpu::BlendState::REPLACE,
+                false,
             )
         })
     }
 
-    fn blit_pipeline(&self, device: &wgpu::Device, blend_mode: BlendMode) -> &wgpu::RenderPipeline {
+    /// The composite blit in its two pass flavors: `depth` is true exactly
+    /// when the caller is encoding the display-clip culled fused pass,
+    /// whose variant compiles the blit source with the content z rewritten
+    /// and depth-tests against the visible-region occluder.
+    fn blit_pipeline(
+        &self,
+        device: &wgpu::Device,
+        blend_mode: BlendMode,
+        depth: bool,
+    ) -> &wgpu::RenderPipeline {
         let (resource, label, blend) = match blend_mode {
             BlendMode::DstOut => (
                 &self.blit_pipeline_dst_out,
@@ -801,26 +823,40 @@ impl EffectRenderer {
                 wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING,
             ),
         };
-        resource.get_or_init(self.adapter_backend, || {
+        resource.get_or_init(self.adapter_backend, depth, |depth| {
+            let depth_shader = depth.then(|| {
+                device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                    label: Some("Blit Shader (display clip)"),
+                    source: wgpu::ShaderSource::Wgsl(display_clip::with_content_z(
+                        self.blit_shader_source.clone().into(),
+                        true,
+                    )),
+                })
+            });
             create_fullscreen_pipeline(
                 device,
                 label,
                 &self.blit_pipeline_layout,
-                &self.blit_shader,
+                depth_shader.as_ref().unwrap_or(&self.blit_shader),
                 "blit_fs",
                 self.surface_format,
                 blend,
+                depth,
             )
         })
     }
 
-    fn initialized_blit_pipeline(&self, blend_mode: BlendMode) -> &wgpu::RenderPipeline {
+    fn initialized_blit_pipeline(
+        &self,
+        blend_mode: BlendMode,
+        depth: bool,
+    ) -> &wgpu::RenderPipeline {
         let resource = match blend_mode {
             BlendMode::DstOut => &self.blit_pipeline_dst_out,
             _ => &self.blit_pipeline,
         };
         resource
-            .get()
+            .get(depth)
             .expect("prepared composite must initialize its blit pipeline")
     }
 
@@ -1323,7 +1359,7 @@ impl EffectRenderer {
         if items.is_empty() {
             return true;
         }
-        let Some(prepared) = self.prepare_shader_batch_draws(recorder, device, items) else {
+        let Some(prepared) = self.prepare_shader_batch_draws(recorder, device, items, false) else {
             return false;
         };
 
@@ -1345,17 +1381,21 @@ impl EffectRenderer {
             });
 
         for draw in &prepared {
-            self.draw_prepared_shader_src_over(device, &mut pass, viewport, draw);
+            self.draw_prepared_shader_src_over(device, &mut pass, viewport, draw, false);
         }
 
         true
     }
 
+    /// `pass_depth` names the pass the prepared draws will execute in: true
+    /// exactly for the display-clip culled fused pass, whose shader
+    /// pipelines carry the depth state (see [`ShaderPipelineCache`]).
     pub(crate) fn prepare_shader_batch_draws<'a, C: FrameCommandRecorder>(
         &mut self,
         recorder: &mut C,
         device: &wgpu::Device,
         items: &'a [ShaderCompositeBatchItem<'a>],
+        pass_depth: bool,
     ) -> Option<Vec<PreparedShaderDraw<'a>>> {
         let mut prepared = Vec::with_capacity(items.len());
         for item in items {
@@ -1366,6 +1406,7 @@ impl EffectRenderer {
                 &self.effect_texture_bind_group_layout,
                 &self.effect_uniform_bind_group_layout,
                 RuntimeShaderPipelineMode::PremultipliedSrcOver,
+                pass_depth,
             )?;
             let mut padded = item.shader.uniforms_padded();
             let slot = RuntimeShader::RESERVED_UNIFORM_START;
@@ -1411,6 +1452,7 @@ impl EffectRenderer {
         pass: &mut wgpu::RenderPass<'_>,
         viewport: (u32, u32),
         draw: &PreparedShaderDraw<'_>,
+        pass_depth: bool,
     ) {
         let pipeline = self
             .shader_cache
@@ -1421,6 +1463,7 @@ impl EffectRenderer {
                 &self.effect_texture_bind_group_layout,
                 &self.effect_uniform_bind_group_layout,
                 RuntimeShaderPipelineMode::PremultipliedSrcOver,
+                pass_depth,
             )
             .expect("shader batch pipeline was prevalidated");
         pass.set_pipeline(pipeline);
@@ -1481,6 +1524,7 @@ impl EffectRenderer {
                 &self.effect_texture_bind_group_layout,
                 &self.effect_uniform_bind_group_layout,
                 options.pipeline_mode,
+                false,
             )
             .is_none()
         {
@@ -1507,6 +1551,7 @@ impl EffectRenderer {
             &self.effect_texture_bind_group_layout,
             &self.effect_uniform_bind_group_layout,
             options.pipeline_mode,
+            false,
         ) else {
             return false;
         };
@@ -1762,7 +1807,7 @@ impl EffectRenderer {
                 ..Default::default()
             });
 
-        pass.set_pipeline(self.blit_pipeline(device, options.blend_mode));
+        pass.set_pipeline(self.blit_pipeline(device, options.blend_mode, false));
         pass.set_bind_group(0, texture_bind_group, &[]);
         pass.set_bind_group(1, &uniform_bind_group, &[]);
         if let Some((x, y, w, h)) = options.scissor {
@@ -1784,7 +1829,7 @@ impl EffectRenderer {
             return;
         }
 
-        let prepared = self.prepare_composite_batch_draws(recorder, device, load_op, items);
+        let prepared = self.prepare_composite_batch_draws(recorder, device, load_op, items, false);
 
         let mut pass = recorder
             .encoder()
@@ -1804,20 +1849,25 @@ impl EffectRenderer {
             });
 
         for draw in &prepared {
-            self.draw_prepared_composite(&mut pass, viewport, draw);
+            self.draw_prepared_composite(&mut pass, viewport, draw, false);
         }
     }
 
+    /// `pass_depth` names the pass the prepared draws will execute in: true
+    /// exactly for the display-clip culled fused pass, so the right blit
+    /// variant is initialized here (the draw arm fetches it without a
+    /// device).
     pub(crate) fn prepare_composite_batch_draws<'a, C: FrameCommandRecorder>(
         &mut self,
         recorder: &mut C,
         device: &wgpu::Device,
         load_op: wgpu::LoadOp<wgpu::Color>,
         items: &[CompositeBatchItem<'a>],
+        pass_depth: bool,
     ) -> Vec<PreparedCompositeDraw<'a>> {
         let mut prepared = Vec::with_capacity(items.len());
         for item in items {
-            self.blit_pipeline(device, item.blend_mode);
+            self.blit_pipeline(device, item.blend_mode, pass_depth);
             let options = CompositePassOptions {
                 alpha: item.alpha,
                 load_op,
@@ -1865,8 +1915,9 @@ impl EffectRenderer {
         pass: &mut wgpu::RenderPass<'_>,
         viewport: (u32, u32),
         draw: &PreparedCompositeDraw<'_>,
+        pass_depth: bool,
     ) {
-        pass.set_pipeline(self.initialized_blit_pipeline(draw.blend_mode));
+        pass.set_pipeline(self.initialized_blit_pipeline(draw.blend_mode, pass_depth));
         pass.set_bind_group(0, draw.texture_bind_group, &[]);
         pass.set_bind_group(1, &draw.uniform_bind_group, &[]);
         if let Some((x, y, w, h)) = draw.scissor {

--- a/crates/cranpose-render/wgpu/src/lazy_resource.rs
+++ b/crates/cranpose-render/wgpu/src/lazy_resource.rs
@@ -39,6 +39,51 @@ impl<T> LazyGpuResource<T> {
     }
 }
 
+/// A render pipeline in its two pass flavors: `flat` for passes without a
+/// depth attachment (every pass except the display-clip culled fused pass)
+/// and `depth` for that one pass (content tests depth against the
+/// visible-region occluder, write off). The depth slot stays uninitialized
+/// — truly zero cost — until a cullable visible region actually engages
+/// the cull, and the flat slot is created from the identical inputs it
+/// always was, so full-region targets render bitwise identically.
+pub(crate) struct PassPipeline {
+    flat: LazyGpuResource<wgpu::RenderPipeline>,
+    depth: LazyGpuResource<wgpu::RenderPipeline>,
+}
+
+impl PassPipeline {
+    pub(crate) const fn new(flat_label: &'static str, depth_label: &'static str) -> Self {
+        Self {
+            flat: LazyGpuResource::new(flat_label),
+            depth: LazyGpuResource::new(depth_label),
+        }
+    }
+
+    /// Returns the variant for `depth`, creating it on first use. The
+    /// closure receives the variant it must build, so one call site serves
+    /// both flavors.
+    pub(crate) fn get_or_init(
+        &self,
+        backend: wgpu::Backend,
+        depth: bool,
+        create: impl FnOnce(bool) -> wgpu::RenderPipeline,
+    ) -> &wgpu::RenderPipeline {
+        if depth {
+            self.depth.get_or_init(backend, || create(true))
+        } else {
+            self.flat.get_or_init(backend, || create(false))
+        }
+    }
+
+    pub(crate) fn get(&self, depth: bool) -> Option<&wgpu::RenderPipeline> {
+        if depth {
+            self.depth.get()
+        } else {
+            self.flat.get()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -7,6 +7,7 @@
 
 #[cfg(not(target_arch = "wasm32"))]
 mod cost_tuner;
+mod display_clip;
 mod effect_renderer;
 mod frame_graph;
 mod frame_packet;
@@ -33,6 +34,10 @@ mod surface_requirements;
 #[cfg(test)]
 mod test_support;
 
+#[doc(hidden)]
+#[cfg(not(target_arch = "wasm32"))]
+pub use display_clip::pixel_is_visible as display_clip_pixel_is_visible;
+pub use display_clip::DisplayVisibleRegion;
 #[doc(hidden)]
 pub use frame_packet::{CancelReason, PresentOutcome};
 pub use gpu_stats::FrameStatsSnapshot as RenderStatsSnapshot;
@@ -221,6 +226,14 @@ pub struct WgpuRenderer {
     /// and stamped into each packet, so a packet that straddles a surface
     /// reconfigure is cancelled by the present stage instead of drawn.
     surface_epoch: u64,
+    /// The display's visible region from
+    /// [`set_display_visible_region`][Self::set_display_visible_region]:
+    /// the part of the surface the panel physically shows. Held here so a
+    /// `GpuRenderer` replaced by `init_gpu` inherits it. Never derived
+    /// from app content — only the platform layer (or a host standing in
+    /// for it) may set it.
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+    display_visible_region: DisplayVisibleRegion,
 }
 
 impl WgpuRenderer {
@@ -251,6 +264,7 @@ impl WgpuRenderer {
             gpu_renderer: None,
             renderer_epoch: 0,
             surface_epoch: 0,
+            display_visible_region: DisplayVisibleRegion::Full,
         }
     }
 
@@ -295,6 +309,29 @@ impl WgpuRenderer {
             self.renderer_epoch,
             store_feed_generation,
         ));
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(gpu_renderer) = self.gpu_renderer.as_mut() {
+            gpu_renderer.set_display_visible_region(self.display_visible_region);
+        }
+    }
+
+    /// The display's visible region — the part of this renderer's
+    /// full-screen surface the panel physically shows. Set by the
+    /// platform layer (never by app content); the renderer then culls
+    /// everything outside the region on the full-frame pass, for any app
+    /// and any layout. The round display is the first provider: Android's
+    /// `AConfiguration` screenRound maps to
+    /// [`DisplayVisibleRegion::InscribedCircle`] for a non-multi-window
+    /// activity. Future providers (display cutouts/insets, host-declared
+    /// clips) plug in as new region variants without touching the cull
+    /// machinery. Default [`DisplayVisibleRegion::Full`]: rendering is
+    /// bitwise identical to a renderer without this capability.
+    pub fn set_display_visible_region(&mut self, region: DisplayVisibleRegion) {
+        self.display_visible_region = region;
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(gpu_renderer) = self.gpu_renderer.as_mut() {
+            gpu_renderer.set_display_visible_region(region);
+        }
     }
 
     /// Record that the surface was reconfigured (resize, format change,

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -1,5 +1,6 @@
 //! GPU rendering implementation using WGPU
 
+use crate::display_clip::{self, DisplayVisibleRegion};
 use crate::effect_renderer::{
     projective_dest_bounds_rect, CompositeBatchItem, CompositeSampleMode, EffectRenderer,
     EffectScratchTargetProvider, ProjectiveSurfaceComposite, RoundedCompositeMask,
@@ -15,7 +16,9 @@ use crate::layer_events::{
     collect_effect_ranges, collect_layer_events, LayerEvent, LayerEventKind,
 };
 use crate::layer_surface_cache::LayerSurfaceCache;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::lazy_resource::LazyGpuResource;
+use crate::lazy_resource::PassPipeline;
 #[cfg(test)]
 use crate::normalized_scene::{
     build_scene_window, collect_layer_contents, collect_layer_contents_with_translation_context,
@@ -1345,6 +1348,7 @@ fn shape_shader_source(_batch_limits: ShapeBatchLimits) -> Cow<'static, str> {
     Cow::Borrowed(shaders::SHADER)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn create_shape_pipeline(
     device: &wgpu::Device,
     surface_format: wgpu::TextureFormat,
@@ -1353,10 +1357,14 @@ fn create_shape_pipeline(
     blend_mode: BlendMode,
     batch_limits: ShapeBatchLimits,
     fragment_entry: &'static str,
+    depth: bool,
 ) -> wgpu::RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("Shape Shader"),
-        source: wgpu::ShaderSource::Wgsl(shape_shader_source(batch_limits)),
+        source: wgpu::ShaderSource::Wgsl(display_clip::with_content_z(
+            shape_shader_source(batch_limits),
+            depth,
+        )),
     });
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -1395,7 +1403,7 @@ fn create_shape_pipeline(
             polygon_mode: wgpu::PolygonMode::Fill,
             conservative: false,
         },
-        depth_stencil: None,
+        depth_stencil: display_clip::content_depth_state(depth),
         multisample: wgpu::MultisampleState::default(),
         multiview_mask: None,
         cache: None,
@@ -1415,10 +1423,14 @@ fn create_mesh_shape_pipeline(
     uniform_layout: &wgpu::BindGroupLayout,
     shape_layout: &wgpu::BindGroupLayout,
     batch_limits: ShapeBatchLimits,
+    depth: bool,
 ) -> wgpu::RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("Shape Mesh Shader"),
-        source: wgpu::ShaderSource::Wgsl(shape_shader_source(batch_limits)),
+        source: wgpu::ShaderSource::Wgsl(display_clip::with_content_z(
+            shape_shader_source(batch_limits),
+            depth,
+        )),
     });
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -1455,7 +1467,7 @@ fn create_mesh_shape_pipeline(
             polygon_mode: wgpu::PolygonMode::Fill,
             conservative: false,
         },
-        depth_stencil: None,
+        depth_stencil: display_clip::content_depth_state(depth),
         multisample: wgpu::MultisampleState::default(),
         multiview_mask: None,
         cache: None,
@@ -1470,6 +1482,7 @@ fn create_mesh_shape_pipeline(
 /// same blend per mode — so a draw-time fallback to `vs_main` (the
 /// `CRANPOSE_INSTANCED_QUADS=0` kill switch) changes nothing else.
 #[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
 fn create_instanced_shape_pipeline(
     device: &wgpu::Device,
     surface_format: wgpu::TextureFormat,
@@ -1478,10 +1491,14 @@ fn create_instanced_shape_pipeline(
     blend_mode: BlendMode,
     batch_limits: ShapeBatchLimits,
     fragment_entry: &'static str,
+    depth: bool,
 ) -> wgpu::RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("Shape Instanced Shader"),
-        source: wgpu::ShaderSource::Wgsl(shape_shader_source(batch_limits)),
+        source: wgpu::ShaderSource::Wgsl(display_clip::with_content_z(
+            shape_shader_source(batch_limits),
+            depth,
+        )),
     });
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -1521,7 +1538,7 @@ fn create_instanced_shape_pipeline(
             polygon_mode: wgpu::PolygonMode::Fill,
             conservative: false,
         },
-        depth_stencil: None,
+        depth_stencil: display_clip::content_depth_state(depth),
         multisample: wgpu::MultisampleState::default(),
         multiview_mask: None,
         cache: None,
@@ -1534,10 +1551,14 @@ fn create_image_pipeline(
     uniform_layout: &wgpu::BindGroupLayout,
     image_layout: &wgpu::BindGroupLayout,
     blend_mode: BlendMode,
+    depth: bool,
 ) -> wgpu::RenderPipeline {
     let image_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("Image Shader"),
-        source: wgpu::ShaderSource::Wgsl(shaders::IMAGE_SHADER.into()),
+        source: wgpu::ShaderSource::Wgsl(display_clip::with_content_z(
+            shaders::IMAGE_SHADER.into(),
+            depth,
+        )),
     });
 
     let image_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -1574,7 +1595,7 @@ fn create_image_pipeline(
             polygon_mode: wgpu::PolygonMode::Fill,
             conservative: false,
         },
-        depth_stencil: None,
+        depth_stencil: display_clip::content_depth_state(depth),
         multisample: wgpu::MultisampleState::default(),
         multiview_mask: None,
         cache: None,
@@ -1586,10 +1607,14 @@ fn create_glyph_atlas_pipeline(
     surface_format: wgpu::TextureFormat,
     uniform_layout: &wgpu::BindGroupLayout,
     image_layout: &wgpu::BindGroupLayout,
+    depth: bool,
 ) -> wgpu::RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("Glyph Atlas Shader"),
-        source: wgpu::ShaderSource::Wgsl(shaders::GLYPH_ATLAS_SHADER.into()),
+        source: wgpu::ShaderSource::Wgsl(display_clip::with_content_z(
+            shaders::GLYPH_ATLAS_SHADER.into(),
+            depth,
+        )),
     });
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -1626,7 +1651,77 @@ fn create_glyph_atlas_pipeline(
             polygon_mode: wgpu::PolygonMode::Fill,
             conservative: false,
         },
-        depth_stencil: None,
+        depth_stencil: display_clip::content_depth_state(depth),
+        multisample: wgpu::MultisampleState::default(),
+        multiview_mask: None,
+        cache: None,
+    })
+}
+
+/// Pipeline for the display-clip occluder — the tessellated complement
+/// of the visible region — the first draw of a culled
+/// fused pass: depth write ON at the near plane, color writes fully masked
+/// off, trivial fragment stage with no discard — exactly the shape early-Z
+/// and LRZ hardware accepts as an occluder. The color target must still be
+/// declared (the pass has a color attachment), which is what the empty
+/// write mask is for.
+#[cfg(not(target_arch = "wasm32"))]
+fn create_display_clip_occluder_pipeline(
+    device: &wgpu::Device,
+    surface_format: wgpu::TextureFormat,
+) -> wgpu::RenderPipeline {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("Display Clip Occluder Shader"),
+        source: wgpu::ShaderSource::Wgsl(display_clip::OCCLUDER_SHADER.into()),
+    });
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("Display Clip Occluder Pipeline Layout"),
+        bind_group_layouts: &[],
+        immediate_size: 0,
+    });
+    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("Display Clip Occluder Pipeline"),
+        layout: Some(&pipeline_layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: Some("mask_vs"),
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+            buffers: &[wgpu::VertexBufferLayout {
+                array_stride: (std::mem::size_of::<[f32; 2]>()) as wgpu::BufferAddress,
+                step_mode: wgpu::VertexStepMode::Vertex,
+                attributes: &[wgpu::VertexAttribute {
+                    offset: 0,
+                    shader_location: 0,
+                    format: wgpu::VertexFormat::Float32x2,
+                }],
+            }],
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: Some("mask_fs"),
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+            targets: &[Some(wgpu::ColorTargetState {
+                format: surface_format,
+                blend: None,
+                write_mask: wgpu::ColorWrites::empty(),
+            })],
+        }),
+        primitive: wgpu::PrimitiveState {
+            topology: wgpu::PrimitiveTopology::TriangleList,
+            strip_index_format: None,
+            front_face: wgpu::FrontFace::Ccw,
+            cull_mode: None,
+            unclipped_depth: false,
+            polygon_mode: wgpu::PolygonMode::Fill,
+            conservative: false,
+        },
+        depth_stencil: Some(wgpu::DepthStencilState {
+            format: display_clip::DISPLAY_CLIP_DEPTH_FORMAT,
+            depth_write_enabled: Some(true),
+            depth_compare: Some(wgpu::CompareFunction::Always),
+            stencil: wgpu::StencilState::default(),
+            bias: wgpu::DepthBiasState::default(),
+        }),
         multisample: wgpu::MultisampleState::default(),
         multiview_mask: None,
         cache: None,
@@ -4232,6 +4327,19 @@ fn instanced_quads_enabled() -> bool {
     std::env::var("CRANPOSE_INSTANCED_QUADS").as_deref() != Ok("0")
 }
 
+/// Kill switch for the display clip region cull: default ON wherever the
+/// platform reports a cullable visible region
+/// (`set_display_visible_region`), and `CRANPOSE_ROUND_CULL=0` (or the
+/// `debug.cranpose.round_cull` property on Android) forces it off — the
+/// switch keeps the name of the capability's first provider, the round
+/// display. Read per frame — the parity harness flips it between passes.
+/// While the region is `Full` the variable is never consulted: the cull
+/// is structurally off.
+#[cfg(not(target_arch = "wasm32"))]
+fn display_clip_cull_enabled() -> bool {
+    std::env::var("CRANPOSE_ROUND_CULL").as_deref() != Ok("0")
+}
+
 /// The index pattern of one instanced quad: the exact triangle pair
 /// `vs_main`'s six-slot corner mapping produces — (0, 1, 2)(2, 1, 3), same
 /// diagonal, same winding — shared by every instance.
@@ -4245,12 +4353,12 @@ const INSTANCED_QUAD_INDICES: [u16; 6] = [0, 1, 2, 2, 1, 3];
 /// uniform-mode path) still has its six-vertex draws.
 #[cfg(not(target_arch = "wasm32"))]
 struct InstancedQuadPipelines {
-    pipeline: LazyGpuResource<wgpu::RenderPipeline>,
-    pipeline_dst_out: LazyGpuResource<wgpu::RenderPipeline>,
+    pipeline: PassPipeline,
+    pipeline_dst_out: PassPipeline,
     /// `fs_solid` twin of `pipeline` (SrcOver only): chosen for draws whose
     /// shapes carry no gradient stops, which is nearly every draw of an
     /// arc-heavy scene.
-    pipeline_solid: LazyGpuResource<wgpu::RenderPipeline>,
+    pipeline_solid: PassPipeline,
     /// Static `[0, 1, 2, 2, 1, 3]` u16 index buffer, created once and shared
     /// by every instanced draw.
     index_buffer: wgpu::Buffer,
@@ -4284,6 +4392,11 @@ struct RetainedBundleOpKey {
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 struct RetainedBundleKey {
+    /// Whether the stretch was encoded for the display-clip culled pass:
+    /// such a bundle declares the depth attachment and records
+    /// depth-variant pipelines, so it must never replay into a flat pass
+    /// (or vice versa) — the flag keys the cache apart.
+    depth: bool,
     ops: Vec<RetainedBundleOpKey>,
 }
 
@@ -5128,15 +5241,15 @@ pub struct GpuRenderer {
     surface_format: wgpu::TextureFormat,
     adapter_backend: wgpu::Backend,
     shape_batch_limits: ShapeBatchLimits,
-    pipeline: LazyGpuResource<wgpu::RenderPipeline>,
-    pipeline_dst_out: LazyGpuResource<wgpu::RenderPipeline>,
+    pipeline: PassPipeline,
+    pipeline_dst_out: PassPipeline,
     /// `fs_solid` twin of `pipeline` (SrcOver only), for gradient-free draws.
-    pipeline_solid: LazyGpuResource<wgpu::RenderPipeline>,
+    pipeline_solid: PassPipeline,
     /// `Some` exactly in storage mode: the retained-mesh pipeline (`vs_mesh`
     /// over a vertex buffer) that replay slots with a captured arc mesh draw
     /// through. Uniform-mode devices never host retained slots.
     #[cfg(not(target_arch = "wasm32"))]
-    mesh_pipeline: LazyGpuResource<wgpu::RenderPipeline>,
+    mesh_pipeline: PassPipeline,
     /// `Some` exactly when this renderer latched the instanced-quad path at
     /// construction (storage mode && `CRANPOSE_INSTANCED_QUADS` != 0). Read
     /// ONCE per renderer lifetime — cached retained bundles encode the
@@ -5154,11 +5267,11 @@ pub struct GpuRenderer {
     identity_similarity_buffer: wgpu::Buffer,
     #[cfg(not(target_arch = "wasm32"))]
     replay_slots: ReplaySlotStore,
-    image_pipeline: LazyGpuResource<wgpu::RenderPipeline>,
-    image_pipeline_dst_out: LazyGpuResource<wgpu::RenderPipeline>,
-    glyph_atlas_pipeline: LazyGpuResource<wgpu::RenderPipeline>,
+    image_pipeline: PassPipeline,
+    image_pipeline_dst_out: PassPipeline,
+    glyph_atlas_pipeline: PassPipeline,
     #[cfg(not(target_arch = "wasm32"))]
-    retained_glyph_atlas_pipeline: LazyGpuResource<wgpu::RenderPipeline>,
+    retained_glyph_atlas_pipeline: PassPipeline,
     image_bind_group_layout: wgpu::BindGroupLayout,
     #[cfg(not(target_arch = "wasm32"))]
     retained_glyph_uniform_bind_group_layout: wgpu::BindGroupLayout,
@@ -5303,6 +5416,70 @@ pub struct GpuRenderer {
     /// full-target blit.
     #[cfg(not(target_arch = "wasm32"))]
     static_span: StaticSpanCache,
+    /// Display clip region cull (see [`crate::display_clip`]): the
+    /// platform-provided visible region plus the per-size occluder/depth
+    /// resources. Inert — nothing beyond the enum is ever populated —
+    /// while the region is [`DisplayVisibleRegion::Full`].
+    #[cfg(not(target_arch = "wasm32"))]
+    display_clip: DisplayClipState,
+}
+
+/// Cache key of the display-clip resources: the surface size and the
+/// region whose complement the occluder was tessellated for.
+#[cfg(not(target_arch = "wasm32"))]
+type DisplayClipResourceKey = ((u32, u32), DisplayVisibleRegion);
+
+/// State of the display clip region cull, all renderer-side.
+#[cfg(not(target_arch = "wasm32"))]
+struct DisplayClipState {
+    /// The visible region from
+    /// [`GpuRenderer::set_display_visible_region`] — platform (or host)
+    /// truth about the panel, never derived from app content. `Full` for
+    /// every rectangular display; `InscribedCircle` is the round-display
+    /// provider's value.
+    visible_region: DisplayVisibleRegion,
+    /// The view the current frame's packet renders to, set for the duration
+    /// of [`GpuRenderer::render`]. The fused pass culls only when its
+    /// target IS this view — full-frame-sized offscreen layer surfaces
+    /// must render whole (their content can be transformed into view
+    /// later), so size alone is not the test.
+    frame_root_view: Option<wgpu::TextureView>,
+    /// True exactly while a fused pass that carries the depth attachment is
+    /// being encoded: every pipeline getter consults it to hand out the
+    /// depth-tested variant, which keeps the dozens of draw sites (and the
+    /// retained-bundle builder) untouched.
+    pass_depth: Cell<bool>,
+    /// Depth attachment + occluder geometry for the current (size, region)
+    /// pair, or an inner `None` when the region's complement tessellation
+    /// failed its conservative verification for this size (cull stays
+    /// off; never retried until size or region changes).
+    resources: Option<(DisplayClipResourceKey, Option<DisplayClipResources>)>,
+    occluder_pipeline: LazyGpuResource<wgpu::RenderPipeline>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl DisplayClipState {
+    fn new() -> Self {
+        Self {
+            visible_region: DisplayVisibleRegion::Full,
+            frame_root_view: None,
+            pass_depth: Cell::new(false),
+            resources: None,
+            occluder_pipeline: LazyGpuResource::new("display-clip/occluder"),
+        }
+    }
+}
+
+/// Per-(surface-size, region) GPU resources of the display clip cull.
+#[cfg(not(target_arch = "wasm32"))]
+struct DisplayClipResources {
+    /// `Depth16Unorm`, cleared each culled pass, stored never
+    /// (`StoreOp::Discard`) — transient GMEM residency on tilers.
+    depth_view: wgpu::TextureView,
+    /// The region complement's conservative tessellation, NDC positions,
+    /// triangle list.
+    occluder_vertex_buffer: wgpu::Buffer,
+    occluder_vertex_count: u32,
 }
 
 /// Running totals for retained-slot patch uploads, the paint-bandwidth
@@ -5580,11 +5757,12 @@ impl GpuRenderer {
         #[cfg(not(target_arch = "wasm32"))]
         let replay_slot_store = ReplaySlotStore::new(&device);
 
-        let pipeline = LazyGpuResource::new("shape/src-over");
-        let pipeline_dst_out = LazyGpuResource::new("shape/dst-out");
-        let pipeline_solid = LazyGpuResource::new("shape/solid-src-over");
+        let pipeline = PassPipeline::new("shape/src-over", "shape/src-over-depth");
+        let pipeline_dst_out = PassPipeline::new("shape/dst-out", "shape/dst-out-depth");
+        let pipeline_solid =
+            PassPipeline::new("shape/solid-src-over", "shape/solid-src-over-depth");
         #[cfg(not(target_arch = "wasm32"))]
-        let mesh_pipeline = LazyGpuResource::new("shape/mesh");
+        let mesh_pipeline = PassPipeline::new("shape/mesh", "shape/mesh-depth");
         // The instanced-quad selection is LATCHED here, once per renderer:
         // cached retained bundles encode whichever pipelines this resolves
         // to, so a per-draw env read could let a bundle replay a selection
@@ -5605,9 +5783,18 @@ impl GpuRenderer {
                     .copy_from_slice(bytemuck::cast_slice(&INSTANCED_QUAD_INDICES));
                 index_buffer.unmap();
                 InstancedQuadPipelines {
-                    pipeline: LazyGpuResource::new("shape/instanced-src-over"),
-                    pipeline_dst_out: LazyGpuResource::new("shape/instanced-dst-out"),
-                    pipeline_solid: LazyGpuResource::new("shape/instanced-solid"),
+                    pipeline: PassPipeline::new(
+                        "shape/instanced-src-over",
+                        "shape/instanced-src-over-depth",
+                    ),
+                    pipeline_dst_out: PassPipeline::new(
+                        "shape/instanced-dst-out",
+                        "shape/instanced-dst-out-depth",
+                    ),
+                    pipeline_solid: PassPipeline::new(
+                        "shape/instanced-solid",
+                        "shape/instanced-solid-depth",
+                    ),
                     index_buffer,
                 }
             });
@@ -5635,11 +5822,12 @@ impl GpuRenderer {
                 ],
             });
 
-        let image_pipeline = LazyGpuResource::new("image/src-over");
-        let image_pipeline_dst_out = LazyGpuResource::new("image/dst-out");
-        let glyph_atlas_pipeline = LazyGpuResource::new("glyph/shared");
+        let image_pipeline = PassPipeline::new("image/src-over", "image/src-over-depth");
+        let image_pipeline_dst_out = PassPipeline::new("image/dst-out", "image/dst-out-depth");
+        let glyph_atlas_pipeline = PassPipeline::new("glyph/shared", "glyph/shared-depth");
         #[cfg(not(target_arch = "wasm32"))]
-        let retained_glyph_atlas_pipeline = LazyGpuResource::new("glyph/retained");
+        let retained_glyph_atlas_pipeline =
+            PassPipeline::new("glyph/retained", "glyph/retained-depth");
 
         #[cfg(not(target_arch = "wasm32"))]
         let upload_buffer = device.create_buffer(&wgpu::BufferDescriptor {
@@ -5882,6 +6070,8 @@ impl GpuRenderer {
             fill_area_diag: FillAreaDiag::default(),
             #[cfg(not(target_arch = "wasm32"))]
             static_span: StaticSpanCache::default(),
+            #[cfg(not(target_arch = "wasm32"))]
+            display_clip: DisplayClipState::new(),
         };
         log::info!(
             "[gpu-init] {:?} renderer ready in {:.1} ms (effects {:.1} ms); \
@@ -5893,12 +6083,158 @@ impl GpuRenderer {
         renderer
     }
 
+    /// The display's visible region (see [`crate::display_clip`]): the
+    /// part of the full-screen surface the panel physically shows. Only
+    /// the platform layer (or a host standing in for it) sets this —
+    /// never app content. `Full` — the default — keeps the cull machinery
+    /// structurally inert.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn set_display_visible_region(&mut self, region: DisplayVisibleRegion) {
+        self.display_clip.visible_region = region;
+    }
+
+    /// Whether the pass currently being encoded carries the display-clip
+    /// depth attachment; pipeline getters consult this to hand out the
+    /// depth-tested variant.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn pass_depth(&self) -> bool {
+        self.display_clip.pass_depth.get()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn pass_depth(&self) -> bool {
+        false
+    }
+
+    /// Decides whether the fused pass about to be encoded is the culled
+    /// one and returns its depth view: the visible region must leave
+    /// something to cull, the kill switch must be open, and `target_view`
+    /// must be THIS frame's root target with the pass viewport covering
+    /// it whole. Offscreen layer passes — even full-frame-sized ones —
+    /// never qualify: a layer's content can be transformed into view
+    /// later.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn display_clip_pass_depth_view(
+        &mut self,
+        target_view: &wgpu::TextureView,
+        width: u32,
+        height: u32,
+    ) -> Option<wgpu::TextureView> {
+        if !self.display_clip.visible_region.cullable() {
+            return None;
+        }
+        if self.display_clip.frame_root_view.as_ref() != Some(target_view) {
+            return None;
+        }
+        if !display_clip_cull_enabled() {
+            return None;
+        }
+        self.ensure_display_clip_resources(width, height)
+    }
+
+    /// Returns the depth view for the current (size, region) pair,
+    /// tessellating the region's complement and building its vertex
+    /// buffer and the depth attachment on first use. A tessellation that
+    /// fails its conservative verification pins `None` for the pair: the
+    /// cull stays off rather than ever touching a visible pixel.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn ensure_display_clip_resources(
+        &mut self,
+        width: u32,
+        height: u32,
+    ) -> Option<wgpu::TextureView> {
+        let region = self.display_clip.visible_region;
+        let key = ((width, height), region);
+        if let Some((cached_key, resources)) = &self.display_clip.resources {
+            if *cached_key == key {
+                return resources
+                    .as_ref()
+                    .map(|resources| resources.depth_view.clone());
+            }
+        }
+        let built = display_clip::tessellate_complement(region, width, height).map(|mesh| {
+            let occluder_vertex_buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("Display Clip Occluder Vertices"),
+                size: std::mem::size_of_val(mesh.vertices.as_slice()) as u64,
+                usage: wgpu::BufferUsages::VERTEX,
+                mapped_at_creation: true,
+            });
+            occluder_vertex_buffer
+                .slice(..)
+                .get_mapped_range_mut()
+                .copy_from_slice(bytemuck::cast_slice(&mesh.vertices));
+            occluder_vertex_buffer.unmap();
+            let depth_texture = self.device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("Display Clip Depth"),
+                size: wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: display_clip::DISPLAY_CLIP_DEPTH_FORMAT,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                view_formats: &[],
+            });
+            // Once per (size, region), which is as rate-limited as it
+            // gets. The round display — the capability's first provider —
+            // keeps its own line.
+            match region {
+                DisplayVisibleRegion::InscribedCircle => log::info!(
+                    "[display-clip] round display: corner cull active ({} px masked) at {width}x{height}",
+                    mesh.masked_px,
+                ),
+                _ => log::info!(
+                    "[display-clip] visible-region cull active for {region:?} ({} px masked) at {width}x{height}",
+                    mesh.masked_px,
+                ),
+            }
+            DisplayClipResources {
+                depth_view: depth_texture.create_view(&wgpu::TextureViewDescriptor::default()),
+                occluder_vertex_buffer,
+                occluder_vertex_count: mesh.vertices.len() as u32,
+            }
+        });
+        let view = built.as_ref().map(|resources| resources.depth_view.clone());
+        self.display_clip.resources = Some((key, built));
+        view
+    }
+
+    /// Encodes the region complement's occluder, the first draw of a
+    /// culled fused pass: depth write at the near plane over the
+    /// tessellation, color writes off.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn draw_display_clip_occluder(
+        &self,
+        render_pass: &mut wgpu::RenderPass<'_>,
+        width: u32,
+        height: u32,
+    ) {
+        let Some((((size_w, size_h), _), Some(resources))) = &self.display_clip.resources else {
+            return;
+        };
+        debug_assert_eq!((*size_w, *size_h), (width, height));
+        let pipeline = self
+            .display_clip
+            .occluder_pipeline
+            .get_or_init(self.adapter_backend, || {
+                create_display_clip_occluder_pipeline(&self.device, self.surface_format)
+            });
+        render_pass.set_scissor_rect(0, 0, width, height);
+        render_pass.set_pipeline(pipeline);
+        render_pass.set_vertex_buffer(0, resources.occluder_vertex_buffer.slice(..));
+        render_pass.draw(0..resources.occluder_vertex_count, 0..1);
+        self.frame_stats.add_draw_calls(1);
+    }
+
     fn shape_pipeline(&self, blend_mode: BlendMode) -> &wgpu::RenderPipeline {
         let resource = match blend_mode {
             BlendMode::DstOut => &self.pipeline_dst_out,
             _ => &self.pipeline,
         };
-        resource.get_or_init(self.adapter_backend, || {
+        resource.get_or_init(self.adapter_backend, self.pass_depth(), |depth| {
             create_shape_pipeline(
                 &self.device,
                 self.surface_format,
@@ -5907,6 +6243,7 @@ impl GpuRenderer {
                 blend_mode,
                 self.shape_batch_limits,
                 "fs_main",
+                depth,
             )
         })
     }
@@ -5916,30 +6253,34 @@ impl GpuRenderer {
     /// coverage math is byte-identical, the gradient machinery is compiled
     /// out of the fragment stage.
     fn shape_pipeline_solid(&self) -> &wgpu::RenderPipeline {
-        self.pipeline_solid.get_or_init(self.adapter_backend, || {
-            create_shape_pipeline(
-                &self.device,
-                self.surface_format,
-                &self.uniform_bind_group_layout,
-                &self.shape_bind_group_layout,
-                BlendMode::SrcOver,
-                self.shape_batch_limits,
-                "fs_solid",
-            )
-        })
+        self.pipeline_solid
+            .get_or_init(self.adapter_backend, self.pass_depth(), |depth| {
+                create_shape_pipeline(
+                    &self.device,
+                    self.surface_format,
+                    &self.uniform_bind_group_layout,
+                    &self.shape_bind_group_layout,
+                    BlendMode::SrcOver,
+                    self.shape_batch_limits,
+                    "fs_solid",
+                    depth,
+                )
+            })
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     fn mesh_pipeline(&self) -> &wgpu::RenderPipeline {
-        self.mesh_pipeline.get_or_init(self.adapter_backend, || {
-            create_mesh_shape_pipeline(
-                &self.device,
-                self.surface_format,
-                &self.uniform_bind_group_layout,
-                &self.shape_bind_group_layout,
-                self.shape_batch_limits,
-            )
-        })
+        self.mesh_pipeline
+            .get_or_init(self.adapter_backend, self.pass_depth(), |depth| {
+                create_mesh_shape_pipeline(
+                    &self.device,
+                    self.surface_format,
+                    &self.uniform_bind_group_layout,
+                    &self.shape_bind_group_layout,
+                    self.shape_batch_limits,
+                    depth,
+                )
+            })
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -5952,7 +6293,7 @@ impl GpuRenderer {
             BlendMode::DstOut => &instanced.pipeline_dst_out,
             _ => &instanced.pipeline,
         };
-        resource.get_or_init(self.adapter_backend, || {
+        resource.get_or_init(self.adapter_backend, self.pass_depth(), |depth| {
             create_instanced_shape_pipeline(
                 &self.device,
                 self.surface_format,
@@ -5961,6 +6302,7 @@ impl GpuRenderer {
                 blend_mode,
                 self.shape_batch_limits,
                 "fs_main",
+                depth,
             )
         })
     }
@@ -5973,7 +6315,7 @@ impl GpuRenderer {
     ) -> &'a wgpu::RenderPipeline {
         instanced
             .pipeline_solid
-            .get_or_init(self.adapter_backend, || {
+            .get_or_init(self.adapter_backend, self.pass_depth(), |depth| {
                 create_instanced_shape_pipeline(
                     &self.device,
                     self.surface_format,
@@ -5982,6 +6324,7 @@ impl GpuRenderer {
                     BlendMode::SrcOver,
                     self.shape_batch_limits,
                     "fs_solid",
+                    depth,
                 )
             })
     }
@@ -5991,40 +6334,46 @@ impl GpuRenderer {
             BlendMode::DstOut => &self.image_pipeline_dst_out,
             _ => &self.image_pipeline,
         };
-        resource.get_or_init(self.adapter_backend, || {
+        resource.get_or_init(self.adapter_backend, self.pass_depth(), |depth| {
             create_image_pipeline(
                 &self.device,
                 self.surface_format,
                 &self.uniform_bind_group_layout,
                 &self.image_bind_group_layout,
                 blend_mode,
+                depth,
             )
         })
     }
 
     fn glyph_atlas_pipeline(&self) -> &wgpu::RenderPipeline {
         self.glyph_atlas_pipeline
-            .get_or_init(self.adapter_backend, || {
+            .get_or_init(self.adapter_backend, self.pass_depth(), |depth| {
                 create_glyph_atlas_pipeline(
                     &self.device,
                     self.surface_format,
                     &self.uniform_bind_group_layout,
                     &self.image_bind_group_layout,
+                    depth,
                 )
             })
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     fn retained_glyph_atlas_pipeline(&self) -> &wgpu::RenderPipeline {
-        self.retained_glyph_atlas_pipeline
-            .get_or_init(self.adapter_backend, || {
+        self.retained_glyph_atlas_pipeline.get_or_init(
+            self.adapter_backend,
+            self.pass_depth(),
+            |depth| {
                 create_glyph_atlas_pipeline(
                     &self.device,
                     self.surface_format,
                     &self.retained_glyph_uniform_bind_group_layout,
                     &self.image_bind_group_layout,
+                    depth,
                 )
-            })
+            },
+        )
     }
 
     fn ensure_image_cached(&mut self, image: &ImageBitmap) -> Result<(), String> {
@@ -7734,6 +8083,10 @@ impl GpuRenderer {
             // One engagement per frame: the first fused partition carrying
             // the frame's opaque clear consumes this.
             self.static_span.armed = true;
+            // The frame's root target, held for the graph walk only: the
+            // display clip cull compares fused-pass targets against it so
+            // nothing but the real surface pass is ever culled.
+            self.display_clip.frame_root_view = Some(view.clone());
         }
 
         // Producer-side text layout cache size, carried by the packet — the
@@ -7741,6 +8094,10 @@ impl GpuRenderer {
         // between packet build and the stats block below.
         let text_cache_len = packet.text_cache_len;
         let result = self.render_graph(view, packet, returns);
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.display_clip.frame_root_view = None;
+        }
         let after_graph = Instant::now();
         self.flush_deferred_offscreen_releases();
         #[cfg(not(target_arch = "wasm32"))]
@@ -8959,6 +9316,18 @@ impl GpuRenderer {
                 );
             }
 
+            // Display clip region cull: engages exactly when this fused
+            // pass draws the frame's root surface whole and the platform
+            // reported a cullable visible region (the round display being
+            // the first provider). The pass then carries a transient depth
+            // attachment, the region complement's occluder is drawn first,
+            // and every pipeline below is fetched in its depth-tested
+            // variant (the getters read `pass_depth`). Offscreen/layer
+            // passes never reach this branch with a `Some` here.
+            let display_clip_depth_view =
+                self.display_clip_pass_depth_view(target_view, width, height);
+            let pass_depth = display_clip_depth_view.is_some();
+
             let device = self.device.clone();
             let composite_items: Vec<_> = chunk
                 .iter()
@@ -8982,6 +9351,7 @@ impl GpuRenderer {
                 &device,
                 load_op,
                 &composite_items,
+                pass_depth,
             );
             let shader_items: Vec<_> = chunk
                 .iter()
@@ -9002,7 +9372,7 @@ impl GpuRenderer {
                 .collect();
             let prepared_shaders = self
                 .effect_renderer
-                .prepare_shader_batch_draws(frame_encoder, &device, &shader_items)
+                .prepare_shader_batch_draws(frame_encoder, &device, &shader_items, pass_depth)
                 .ok_or_else(|| "shader composite batch preparation failed".to_string())?;
             if !shader_items.is_empty() {
                 self.effect_renderer.record_composite_pass();
@@ -9037,6 +9407,7 @@ impl GpuRenderer {
                     &device,
                     load_op,
                     std::slice::from_ref(item),
+                    pass_depth,
                 ),
                 None => Vec::new(),
             };
@@ -9080,7 +9451,21 @@ impl GpuRenderer {
                                     store: wgpu::StoreOp::Store,
                                 },
                             })],
-                            depth_stencil_attachment: None,
+                            // Clear + Discard: the display-clip depth
+                            // buffer is born and dies inside this pass — on
+                            // tiled GPUs it never leaves GMEM.
+                            depth_stencil_attachment: display_clip_depth_view.as_ref().map(
+                                |view| wgpu::RenderPassDepthStencilAttachment {
+                                    view,
+                                    depth_ops: Some(wgpu::Operations {
+                                        load: wgpu::LoadOp::Clear(
+                                            crate::display_clip::DISPLAY_CLIP_DEPTH_CLEAR,
+                                        ),
+                                        store: wgpu::StoreOp::Discard,
+                                    }),
+                                    stencil_ops: None,
+                                },
+                            ),
                             timestamp_writes: None,
                             occlusion_query_set: None,
                             multiview_mask: None,
@@ -9094,8 +9479,16 @@ impl GpuRenderer {
                         &mut render_pass,
                         (width, height),
                         draw,
+                        pass_depth,
                     );
                 }
+                if pass_depth {
+                    // The occluder must be the pass's first draw: everything
+                    // after it depth-tests against the region it wrote.
+                    self.draw_display_clip_occluder(&mut render_pass, width, height);
+                    self.display_clip.pass_depth.set(true);
+                }
+
                 for batch in &fused_batches {
                     match batch {
                         FusedSegmentBatch::Shape { batch, blend_mode } => {
@@ -9151,6 +9544,7 @@ impl GpuRenderer {
                                     &mut render_pass,
                                     (width, height),
                                     draw,
+                                    pass_depth,
                                 );
                             }
                         }
@@ -9164,6 +9558,7 @@ impl GpuRenderer {
                                     &mut render_pass,
                                     (width, height),
                                     draw,
+                                    pass_depth,
                                 );
                             }
                         }
@@ -9305,6 +9700,10 @@ impl GpuRenderer {
             })
         })();
 
+        // The depth flag lives exactly as long as the culled pass's encode;
+        // resetting here (not inside the closure) covers the error paths
+        // too, so no later pass can inherit a depth-variant pipeline.
+        self.display_clip.pass_depth.set(false);
         self.scratch_image_vertices = image_vertices;
         self.scratch_image_indices = image_indices;
         self.scratch_image_cmds = image_cmds;
@@ -11596,7 +11995,10 @@ impl GpuRenderer {
                     && self.shape_batch_limits.storage,
             });
         }
-        RetainedBundleKey { ops }
+        RetainedBundleKey {
+            depth: self.pass_depth(),
+            ops,
+        }
     }
 
     /// Encodes `key`'s stretch into a render bundle: the IDENTICAL command
@@ -11615,7 +12017,15 @@ impl GpuRenderer {
                     // textures, pooled layer surfaces — is created with the
                     // renderer's one surface format.
                     color_formats: &[Some(self.surface_format)],
-                    depth_stencil: None,
+                    // A display-clip culled pass carries the depth
+                    // attachment; the bundle only reads it (content
+                    // pipelines test `Less`, write off), hence read-only on
+                    // both aspects.
+                    depth_stencil: key.depth.then_some(wgpu::RenderBundleDepthStencil {
+                        format: display_clip::DISPLAY_CLIP_DEPTH_FORMAT,
+                        depth_read_only: true,
+                        stencil_read_only: true,
+                    }),
                     sample_count: 1,
                     multiview: None,
                 });
@@ -22120,7 +22530,10 @@ mod tests {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn bundle_key(ops: &[RetainedBundleOpKey]) -> RetainedBundleKey {
-        RetainedBundleKey { ops: ops.to_vec() }
+        RetainedBundleKey {
+            depth: false,
+            ops: ops.to_vec(),
+        }
     }
 
     /// The same stretch on consecutive frames reuses its bundle: one
@@ -22169,11 +22582,34 @@ mod tests {
             cache.end_frame();
             assert!(
                 !cache.hit(&RetainedBundleKey {
+                    depth: false,
                     ops: changed.clone()
                 }),
                 "changed key {changed:?} must not reuse the stale bundle"
             );
         }
+    }
+
+    /// A stretch encoded for the display-clip culled pass (depth
+    /// attachment, depth-variant pipelines) must never satisfy the flat
+    /// pass's lookup — and vice versa.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn retained_bundle_cache_keys_depth_variants_apart() {
+        let mut cache: RetainedBundleCacheImpl<u32> = RetainedBundleCacheImpl::new();
+        let ops = vec![bundle_op(3, Some(7), 0, 40)];
+        cache.insert(
+            RetainedBundleKey {
+                depth: false,
+                ops: ops.clone(),
+            },
+            111,
+        );
+        cache.end_frame();
+        assert!(
+            !cache.hit(&RetainedBundleKey { depth: true, ops }),
+            "a flat bundle must not replay into the display-clip culled pass"
+        );
     }
 
     /// Entries a frame does not use are evicted at its end — bundles pin

--- a/crates/cranpose-render/wgpu/src/shader_cache.rs
+++ b/crates/cranpose-render/wgpu/src/shader_cache.rs
@@ -25,7 +25,7 @@ impl RuntimeShaderPipelineMode {
 /// Caches compiled render pipelines for custom WGSL shader effects.
 pub(crate) struct ShaderPipelineCache {
     backend: wgpu::Backend,
-    cache: HashMap<(u64, RuntimeShaderPipelineMode), wgpu::RenderPipeline>,
+    cache: HashMap<(u64, RuntimeShaderPipelineMode, bool), wgpu::RenderPipeline>,
     disabled: HashSet<u64>,
 }
 
@@ -43,6 +43,14 @@ impl ShaderPipelineCache {
     /// The pipeline is cached by the source hash, so repeated calls with
     /// the same shader source (but potentially different uniforms) reuse
     /// the compiled pipeline.
+    ///
+    /// `depth` is true exactly when the pipeline will draw inside the
+    /// display-clip culled fused pass: the variant adds the depth test
+    /// against the visible-region occluder and nothing else. The user's
+    /// WGSL is NOT rewritten — the conventional fullscreen z of 0.0
+    /// already fails `Less` against the occluder's 0.0, so occluded
+    /// pixels cull correctly.
+    #[allow(clippy::too_many_arguments)]
     pub fn get_or_create(
         &mut self,
         device: &wgpu::Device,
@@ -51,9 +59,10 @@ impl ShaderPipelineCache {
         texture_bind_group_layout: &wgpu::BindGroupLayout,
         uniform_bind_group_layout: &wgpu::BindGroupLayout,
         mode: RuntimeShaderPipelineMode,
+        depth: bool,
     ) -> Option<&wgpu::RenderPipeline> {
         let source_hash = shader.source_hash();
-        let cache_key = (source_hash, mode);
+        let cache_key = (source_hash, mode, depth);
         if self.disabled.contains(&source_hash) {
             return None;
         }
@@ -103,7 +112,7 @@ impl ShaderPipelineCache {
                     cull_mode: None,
                     ..Default::default()
                 },
-                depth_stencil: None,
+                depth_stencil: crate::display_clip::content_depth_state(depth),
                 multisample: wgpu::MultisampleState::default(),
                 multiview_mask: None,
                 cache: None,

--- a/crates/cranpose-render/wgpu/tests/round_cull_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/round_cull_parity.rs
@@ -1,0 +1,337 @@
+//! Display clip region cull: byte-exactness is defined over VISIBLE pixels.
+//!
+//! The platform (stood in for here by `set_display_visible_region`) tells
+//! the renderer which region of the surface the panel physically shows;
+//! the renderer culls everything outside it on the full-frame pass. The
+//! suite is parameterized by [`DisplayVisibleRegion`] — the round display
+//! is the first provider (`InscribedCircle`), and a future region variant
+//! joins by extending `CULLABLE_REGIONS`. The contract pinned per region:
+//!
+//! 1. Every pixel the region shows is bitwise identical with the cull on
+//!    and off, for a scene that crosses the region boundary with solid
+//!    shapes, AA arc edges and gradients.
+//! 2. The occluder is conservative: with the cull on, a full-frame opaque
+//!    fill still reaches every visible pixel — the occluder never covers
+//!    one.
+//! 3. Pixels outside the region may differ (that is the cull working),
+//!    and at least one must: an arm that fails to engage would silently
+//!    prove nothing.
+//! 4. `CRANPOSE_ROUND_CULL=0` (the kill switch keeps its first provider's
+//!    name) restores whole-buffer bitwise identity even while the
+//!    platform reports a cullable region.
+//!
+//! Every other suite runs with the cull structurally off (no test surface
+//! declares a region), which this file's default-`Full` arm doubles as
+//! evidence for.
+
+mod support;
+
+use cranpose_render_common::graph::{
+    CachePolicy, DrawRunNode, IsolationReasons, LayerNode, PrimitivePhase, ProjectiveTransform,
+    RenderGraph, RenderNode,
+};
+use cranpose_render_common::raster_cache::LayerRasterCacheHashes;
+use cranpose_render_common::Renderer;
+use cranpose_render_wgpu::{display_clip_pixel_is_visible, DisplayVisibleRegion};
+use cranpose_ui_graphics::{Brush, Color, DrawScope, DrawScopeDefault, GraphicsLayer, Point, Rect};
+
+/// Watch-like square surface: the inscribed circle has radius 204
+/// centered at (204, 204), leaving ~35 kpx of corners outside it.
+const SIZE: u32 = 408;
+const CENTER: f32 = 204.0;
+
+/// Every cullable region the framework currently implements. A new
+/// provider's region joins this list and inherits the whole suite.
+const CULLABLE_REGIONS: [DisplayVisibleRegion; 1] = [DisplayVisibleRegion::InscribedCircle];
+
+/// A scene that deliberately straddles the visible-region boundary for
+/// every region under test: a full-frame background (edges and corners
+/// included), arc rings crossing the inscribed circle, corner-hugging
+/// circles, a gradient sweep across the top-left corner, and a stroked
+/// rect across the right edge.
+fn record_scene(scope: &mut DrawScopeDefault) {
+    scope.draw_rect_at(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: SIZE as f32,
+            height: SIZE as f32,
+        },
+        Brush::solid(Color(0.9, 0.88, 0.82, 1.0)),
+    );
+    scope.draw_rect_at(
+        Rect {
+            x: -40.0,
+            y: -40.0,
+            width: 260.0,
+            height: 260.0,
+        },
+        Brush::linear_gradient(vec![Color(0.9, 0.2, 0.2, 0.9), Color(0.1, 0.3, 0.9, 0.4)]),
+    );
+    for ring in 0..3u32 {
+        let radius = 150.0 + ring as f32 * 26.0;
+        let count = 40;
+        for i in 0..count {
+            let start = i as f32 * (std::f32::consts::TAU / count as f32) + ring as f32 * 0.17;
+            scope.draw_annular_sector(
+                Brush::solid(Color(0.2, 0.4 + (i % 4) as f32 * 0.1, 0.7, 0.95)),
+                Point::new(CENTER, CENTER),
+                radius - 7.0,
+                radius,
+                start,
+                0.11,
+            );
+        }
+    }
+    for (cx, cy) in [(10.0, 10.0), (398.0, 10.0), (10.0, 398.0), (398.0, 398.0)] {
+        scope.draw_circle(
+            Brush::solid(Color(0.95, 0.7, 0.2, 1.0)),
+            Point::new(cx, cy),
+            26.0,
+        );
+    }
+    scope.draw_round_rect_at(
+        Rect {
+            x: 300.0,
+            y: 300.0,
+            width: 120.0,
+            height: 120.0,
+        },
+        Brush::solid(Color(0.2, 0.7, 0.4, 0.85)),
+        cranpose_ui_graphics::CornerRadii::uniform(18.0),
+    );
+    scope.draw_rect_at_stroked(
+        Rect {
+            x: 340.0,
+            y: 120.0,
+            width: 90.0,
+            height: 60.0,
+        },
+        Brush::solid(Color(0.1, 0.1, 0.2, 1.0)),
+        cranpose_ui_graphics::Stroke {
+            width: 4.0,
+            ..Default::default()
+        },
+    );
+}
+
+fn graph_from(record: impl FnOnce(&mut DrawScopeDefault)) -> RenderGraph {
+    let mut scope =
+        DrawScopeDefault::new(cranpose_ui_graphics::Size::new(SIZE as f32, SIZE as f32));
+    record(&mut scope);
+    let bounds = Rect {
+        x: 0.0,
+        y: 0.0,
+        width: SIZE as f32,
+        height: SIZE as f32,
+    };
+    RenderGraph::new(LayerNode {
+        node_id: None,
+        local_bounds: bounds,
+        transform_to_parent: ProjectiveTransform::identity(),
+        content_offset: Point::default(),
+        motion_context_animated: false,
+        translated_content_context: false,
+        translated_content_offset: Point::default(),
+        scene_children_origin: Point::default(),
+        scene_children_layer_translation: Point::default(),
+        graphics_layer: GraphicsLayer::default(),
+        clip_to_bounds: false,
+        shadow_clip: None,
+        hit_test: None,
+        has_hit_targets: false,
+        isolation: IsolationReasons::default(),
+        cache_policy: CachePolicy::None,
+        cache_hashes: LayerRasterCacheHashes::default(),
+        cache_hashes_valid: false,
+        children: vec![RenderNode::DrawRun(DrawRunNode::new(
+            PrimitivePhase::BeforeChildren,
+            scope.into_primitives(),
+        ))],
+    })
+}
+
+/// Warm pass (never compared), then two controls asserted byte-stable; the
+/// second control is the arm's frame — the discipline every parity suite
+/// here follows.
+fn render_arm(renderer: &mut support::LockedRenderer, graph: &RenderGraph) -> Vec<u8> {
+    let mut passes = Vec::new();
+    for _ in 0..3 {
+        renderer.scene_mut().graph = Some(graph.clone());
+        let captured = renderer
+            .capture_frame(SIZE, SIZE)
+            .unwrap_or_else(|err| panic!("capture failed: {err:?}"));
+        assert_eq!((captured.width, captured.height), (SIZE, SIZE));
+        passes.push(captured.pixels);
+    }
+    assert_eq!(
+        passes[1], passes[2],
+        "same-graph control passes must be byte-stable before the cross-arm compare"
+    );
+    passes.pop().unwrap()
+}
+
+/// The reference predicate for one region: whether the display shows the
+/// pixel — the set over which the cull promises bitwise identity.
+fn visible(region: DisplayVisibleRegion, x: u32, y: u32) -> bool {
+    display_clip_pixel_is_visible(region, SIZE, SIZE, x, y)
+}
+
+/// Splits a full-buffer diff into (differing visible pixels, differing
+/// invisible pixels), reporting the first visible offender.
+fn diff_by_region(
+    region: DisplayVisibleRegion,
+    flat: &[u8],
+    culled: &[u8],
+) -> (usize, usize, Option<(u32, u32)>) {
+    assert_eq!(flat.len(), culled.len());
+    let mut visible_diffs = 0usize;
+    let mut invisible_diffs = 0usize;
+    let mut first_visible = None;
+    for y in 0..SIZE {
+        for x in 0..SIZE {
+            let at = ((y * SIZE + x) * 4) as usize;
+            if flat[at..at + 4] == culled[at..at + 4] {
+                continue;
+            }
+            if visible(region, x, y) {
+                visible_diffs += 1;
+                first_visible.get_or_insert((x, y));
+            } else {
+                invisible_diffs += 1;
+            }
+        }
+    }
+    (visible_diffs, invisible_diffs, first_visible)
+}
+
+#[test]
+fn cull_is_bitwise_invisible_on_every_pixel_the_region_shows() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!("skipping display clip parity: headless WGPU init failed: {err}");
+            return;
+        }
+    };
+    let graph = graph_from(record_scene);
+
+    // Arm A: the full region — the structural default every other suite
+    // runs under.
+    let flat = render_arm(&mut renderer, &graph);
+
+    for region in CULLABLE_REGIONS {
+        // Arm B: the platform reports a cullable visible region.
+        renderer.set_display_visible_region(region);
+        let culled = render_arm(&mut renderer, &graph);
+        renderer.set_display_visible_region(DisplayVisibleRegion::Full);
+
+        let (visible_diffs, invisible_diffs, first_visible) =
+            diff_by_region(region, &flat, &culled);
+        assert_eq!(
+            visible_diffs, 0,
+            "{region:?}: cull changed {visible_diffs} pixels the display SHOWS \
+             (first at {first_visible:?}) — the occluder touched a visible pixel"
+        );
+        assert!(
+            invisible_diffs > 0,
+            "{region:?}: no invisible pixel changed: the cull never engaged and \
+             this parity run proved nothing"
+        );
+        eprintln!(
+            "display-clip parity {region:?}: visible diffs 0, invisible diffs {invisible_diffs}"
+        );
+    }
+}
+
+/// Conservative containment, checked through the renderer itself: a
+/// full-frame opaque white fill with the cull ON must still reach every
+/// pixel the region shows. Any visible pixel that is not white was
+/// covered by the occluder.
+#[test]
+fn occluder_never_covers_a_pixel_the_region_shows() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!("skipping display clip containment: headless WGPU init failed: {err}");
+            return;
+        }
+    };
+    let graph = graph_from(|scope| {
+        scope.draw_rect_at(
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: SIZE as f32,
+                height: SIZE as f32,
+            },
+            Brush::solid(Color(1.0, 1.0, 1.0, 1.0)),
+        );
+    });
+
+    for region in CULLABLE_REGIONS {
+        renderer.set_display_visible_region(region);
+        let culled = render_arm(&mut renderer, &graph);
+        renderer.set_display_visible_region(DisplayVisibleRegion::Full);
+
+        let mut covered_visible = 0usize;
+        let mut first = None;
+        let mut culled_invisible = 0usize;
+        for y in 0..SIZE {
+            for x in 0..SIZE {
+                let at = ((y * SIZE + x) * 4) as usize;
+                let white = culled[at..at + 4] == [255, 255, 255, 255];
+                if visible(region, x, y) {
+                    if !white {
+                        covered_visible += 1;
+                        first.get_or_insert((x, y));
+                    }
+                } else if !white {
+                    culled_invisible += 1;
+                }
+            }
+        }
+        assert_eq!(
+            covered_visible, 0,
+            "{region:?}: occluder covered {covered_visible} visible pixels (first at {first:?})"
+        );
+        assert!(
+            culled_invisible > 0,
+            "{region:?}: the full-frame fill survived everywhere invisible: \
+             the occluder drew nothing"
+        );
+        eprintln!(
+            "display-clip containment {region:?}: 0 visible covered, \
+             {culled_invisible} invisible px culled"
+        );
+    }
+}
+
+/// The kill switch: `CRANPOSE_ROUND_CULL=0` restores whole-buffer bitwise
+/// identity even while the platform reports a cullable region.
+#[test]
+fn kill_switch_disables_the_cull_bitwise() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!("skipping display clip kill switch: headless WGPU init failed: {err}");
+            return;
+        }
+    };
+    let graph = graph_from(record_scene);
+
+    let flat = render_arm(&mut renderer, &graph);
+
+    for region in CULLABLE_REGIONS {
+        renderer.set_display_visible_region(region);
+        std::env::set_var("CRANPOSE_ROUND_CULL", "0");
+        let disabled = render_arm(&mut renderer, &graph);
+        std::env::remove_var("CRANPOSE_ROUND_CULL");
+        renderer.set_display_visible_region(DisplayVisibleRegion::Full);
+
+        assert_eq!(
+            flat, disabled,
+            "{region:?}: CRANPOSE_ROUND_CULL=0 must render bitwise identically to Full"
+        );
+    }
+}

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -768,6 +768,31 @@ fn update_android_shell_geometry(
     }
 }
 
+/// Hands the renderer the platform's truth about the display panel's
+/// visible region. The round display is the first provider of that
+/// region: when `AConfiguration` reports a round screen AND this activity
+/// owns the whole display (a multi-window activity's surface is not the
+/// panel, so its inscribed circle would mean nothing), the visible region
+/// is the surface's inscribed circle; otherwise the full surface. The
+/// renderer then culls the pixels the panel physically never shows — a
+/// framework capability for any app and any layout; app content never
+/// participates in this decision.
+fn apply_display_visible_region(
+    app: &android_activity::AndroidApp,
+    app_shell: &mut Option<AppShell<WgpuRenderer>>,
+) {
+    let Some(shell) = app_shell else {
+        return;
+    };
+    let round = crate::android_display::display_is_round(app)
+        && !android_activity_in_multi_window_mode(app);
+    shell.renderer().set_display_visible_region(if round {
+        cranpose_render_wgpu::DisplayVisibleRegion::InscribedCircle
+    } else {
+        cranpose_render_wgpu::DisplayVisibleRegion::Full
+    });
+}
+
 /// Renders a single frame. Returns true if out of memory (should exit).
 fn render_once(
     resources: &mut GpuResources,
@@ -1840,6 +1865,7 @@ pub fn run(
                                         }
 
                                         gpu_resources = Some(resources);
+                                        apply_display_visible_region(&app, &mut app_shell);
                                         log::info!("Rendering initialized successfully");
                                     }
                                     Err(error) => {
@@ -2000,6 +2026,11 @@ pub fn run(
                                 );
                             }
                         }
+                        // Multi-window transitions arrive as configuration
+                        // changes too, and they gate the renderer's
+                        // round-display corner cull: re-read the platform
+                        // truth.
+                        apply_display_visible_region(&app, &mut app_shell);
                     }
                     _ => {}
                 },
@@ -2044,6 +2075,7 @@ pub fn run(
                                         current_host_window_size = actual_size;
                                     }
                                     gpu_resources = Some(resources);
+                                    apply_display_visible_region(&app, &mut app_shell);
                                 }
                                 Err(error) => {
                                     log::error!(
@@ -2087,6 +2119,7 @@ pub fn run(
                                     current_host_window_size = actual_size;
                                 }
                                 gpu_resources = Some(resources);
+                                apply_display_visible_region(&app, &mut app_shell);
                                 log::info!(
                                     "Android overlay surface ready at {}x{} px ({:.2}x density)",
                                     width,

--- a/crates/cranpose/src/android_display.rs
+++ b/crates/cranpose/src/android_display.rs
@@ -1,0 +1,53 @@
+//! Platform truth about the physical display panel.
+//!
+//! One question today: is the display round? The renderer's round-display
+//! corner cull hangs off this answer — the FRAMEWORK learns the panel shape
+//! from the OS configuration and culls what a round panel physically never
+//! shows, for any app and any layout. No screen-shape assumption may
+//! originate from app content, which is why this module is the only source
+//! of the flag.
+
+#![allow(unsafe_code)]
+
+use std::sync::OnceLock;
+
+/// Whether the display this activity's configuration describes is
+/// physically round: `AConfiguration`'s screenRound field is
+/// `ACONFIGURATION_SCREENROUND_YES`.
+///
+/// Read through the raw NDK call. The safe wrappers exist but are feature-
+/// gated behind `api-level-30` (`ndk` 0.9), and `android-activity` 0.6.1's
+/// re-export does not even compile with the feature on (it forgets to
+/// import `ScreenRound`). The C symbol itself is `__INTRODUCED_IN(30)`, so
+/// it is resolved once via `dlsym` instead of linked: on an older device
+/// the platform cannot report roundness and this returns `false` — the
+/// cull stays structurally off rather than the process failing to load.
+pub(crate) fn display_is_round(app: &android_activity::AndroidApp) -> bool {
+    type GetScreenRound = unsafe extern "C" fn(*mut ndk_sys::AConfiguration) -> libc::c_int;
+    static GETTER: OnceLock<Option<GetScreenRound>> = OnceLock::new();
+    let getter = GETTER.get_or_init(|| {
+        let symbol = unsafe {
+            libc::dlsym(
+                libc::RTLD_DEFAULT,
+                c"AConfiguration_getScreenRound".as_ptr(),
+            )
+        };
+        if symbol.is_null() {
+            return None;
+        }
+        // SAFETY: the symbol, when present, is libandroid's
+        // `AConfiguration_getScreenRound`, whose C signature is exactly
+        // `int32_t (AConfiguration*)`.
+        Some(unsafe { std::mem::transmute::<*mut libc::c_void, GetScreenRound>(symbol) })
+    });
+    let Some(getter) = getter else {
+        return false;
+    };
+    // `copy()` snapshots the live ConfigurationRef under its lock; the
+    // snapshot owns its AConfiguration for the duration of the call.
+    let config = app.config().copy();
+    // SAFETY: `ptr()` is the snapshot's valid AConfiguration; the getter
+    // only reads it.
+    let round = unsafe { getter(config.ptr().as_ptr()) };
+    round == ndk_sys::ACONFIGURATION_SCREENROUND_YES as libc::c_int
+}

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -74,6 +74,7 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 21] = [
     ("debug.cranpose.command_feed", "CRANPOSE_COMMAND_FEED"),
     ("debug.cranpose.arc_mesh", "CRANPOSE_ARC_MESH"),
     ("debug.cranpose.rim_mesh", "CRANPOSE_RIM_MESH"),
+    ("debug.cranpose.round_cull", "CRANPOSE_ROUND_CULL"),
     ("debug.cranpose.catchup_pacing", "CRANPOSE_CATCHUP_PACING"),
     ("debug.cranpose.instanced_quads", "CRANPOSE_INSTANCED_QUADS"),
     (

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -27,6 +27,8 @@ mod android_accessibility;
 mod android_accessibility_wire;
 #[cfg(all(feature = "android", target_os = "android"))]
 mod android_app_info;
+#[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
+mod android_display;
 #[cfg(all(feature = "android", target_os = "android"))]
 mod android_finish;
 #[cfg(all(feature = "android", target_os = "android"))]

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -1247,6 +1247,11 @@ fn unsafe_code_stays_in_reviewed_platform_boundary_modules() {
     let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let source_dir = crate_dir.join("src");
     let allowed = [
+        // The display-shape read behind the renderer's visible-region cull:
+        // one `dlsym`-resolved `AConfiguration_getScreenRound` call (the
+        // symbol is API 30+, so it must not be linked) and the call through
+        // it.
+        "android_display.rs",
         // The display refresh-rate vote: `dlsym`/`dlopen` resolution of the
         // `ANativeWindow_setFrameRate*` NDK symbols and the calls through
         // them, mirroring how HWUI votes the panel's frame rate.
@@ -1440,6 +1445,11 @@ fn workspace_ffi_boundaries_are_explicit() {
         .expect("cranpose crate should live under workspace crates directory");
     let source_roots = ["crates", "apps", "xtask"];
     let allowed = [
+        // The display-shape read behind the renderer's visible-region cull:
+        // one `dlsym`-resolved `AConfiguration_getScreenRound` call (the
+        // symbol is API 30+, so it must not be linked) and the call through
+        // it.
+        "crates/cranpose/src/android_display.rs",
         // The display refresh-rate vote: `dlsym`/`dlopen` resolution of the
         // `ANativeWindow_setFrameRate*` NDK symbols and the calls through
         // them, mirroring how HWUI votes the panel's frame rate.


### PR DESCRIPTION
General framework capability: the renderer models the part of the surface the panel physically shows (`DisplayVisibleRegion`) and depth-occludes everything outside it on the full-frame pass. Round displays are the first provider — `AConfiguration_getScreenRound` (dlsym, API-30-safe, multi-window-gated) maps to `InscribedCircle`; rectangular displays map to `Full` and the machinery is structurally inert (bitwise-identical rendering). Future providers (cutouts, insets, app-declared clips for any layout) plug into the same region → complement-tessellation → depth-occluder path; the tessellation contract (strictly outside the visible region, under-coverage the only permitted error) binds every region arm.

Mechanics: transient GMEM-resident Depth16 attachment on the fused pass, occluder drawn first (color-writes-empty, discard-free, LRZ-eligible), lazily built depth twins (Less, write-off) for every pipeline in the pass, retained-bundle keys carry the depth bit. Kill switch `CRANPOSE_ROUND_CULL=0` / `debug.cranpose.round_cull`.

Parity: bitwise equality on every visible pixel with the cull on vs off (region-parameterized test, green on Metal and the Linux GPU host); conservative containment and kill-switch whole-buffer identity pinned. Workspace suite green remotely. Measured corner fill on the watch: 0.13–0.14 Mpx/frame of 1.7 (~8%); this stage also answers whether Adreno 702 early-Z survives discard-bearing fragment shaders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2