### PR TITLE
Gate the retained capture mesh by shape size and turn it on

### DIFF
--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -524,6 +524,18 @@ impl WgpuRenderer {
             .unwrap_or((0, 0))
     }
 
+    /// Test/diagnostic view of the retained capture size gate, summed over
+    /// live slots holding a mesh: (arc bands meshed, stroked-circle rim
+    /// bands meshed, passthrough quads).
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn replay_slot_mesh_engagement(&self) -> (usize, usize, usize) {
+        self.gpu_renderer
+            .as_ref()
+            .map(GpuRenderer::replay_slot_mesh_engagement)
+            .unwrap_or((0, 0, 0))
+    }
+
     /// Test/diagnostic view of the retained bundle cache: lifetime
     /// (rebuilds, cached executes).
     #[cfg(not(target_arch = "wasm32"))]

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -2377,9 +2377,9 @@ struct ReplaySlot {
     /// bytes ever could.
     paint_mirror: Vec<[f32; 4]>,
     /// Conservative capture-space arc/ring mesh, built once at capture.
-    /// `None` when the kill switch is off, the slot meshed no arcs, or the
-    /// vertex budget overflowed — those slots replay through the quad-expansion
-    /// six-vertices-per-shape path.
+    /// `None` when the kill switch is off, the slot meshed no shapes (none
+    /// over the size gate), or the vertex budget overflowed — those slots
+    /// replay through the quad-expansion six-vertices-per-shape path.
     mesh: Option<ReplaySlotMesh>,
     /// Which capture created this slot's buffers, from the store's global
     /// monotone counter. Retained bundle keys carry it so a slot id that is
@@ -2400,9 +2400,10 @@ struct ReplaySlot {
 }
 
 /// Vertex geometry a retained slot replays instead of per-shape quads: arc
-/// bands get trapezoid strips covering only their antialiasing footprint,
-/// every other shape gets a passthrough pair of triangles identical to the
-/// quad expansion. See [`build_arc_mesh_vertices`].
+/// and stroked-circle rim bands over the size gate get trapezoid strips
+/// covering only their antialiasing footprint, every other shape gets a
+/// passthrough pair of triangles identical to the quad expansion. See
+/// [`build_arc_mesh_vertices`].
 #[cfg(not(target_arch = "wasm32"))]
 struct ReplaySlotMesh {
     vertex_buffer: wgpu::Buffer,
@@ -2417,6 +2418,13 @@ struct ReplaySlotMesh {
     /// draws `index_prefix[first]..index_prefix[first + count]` — one
     /// `draw_indexed` per op, identical shape order, z untouched.
     index_prefix: Vec<u32>,
+    /// Capture engagement counts for the test/diagnostic view
+    /// ([`GpuRenderer::replay_slot_mesh_engagement`]): shapes meshed as arc
+    /// bands, shapes meshed as stroked-circle rim bands, and shapes that
+    /// took the passthrough quad (gate-rejected or non-band).
+    meshed_arcs: usize,
+    meshed_rims: usize,
+    passthrough: usize,
 }
 
 /// Vertex of a retained slot's conservative arc mesh: capture-device-space
@@ -2451,14 +2459,22 @@ impl MeshVertex {
 /// A/B needs no rebuild. Read per capture — captures are rare.
 #[cfg(not(target_arch = "wasm32"))]
 fn arc_mesh_enabled() -> bool {
-    // Opt-in (CRANPOSE_ARC_MESH=1 / debug.cranpose.arc_mesh): the Gate 0
-    // off-charger watch A/B measured the non-indexed mesh 5-7 fps SLOWER
-    // than plain quads on the Adreno 702 — the 4-6x vertex amplification
-    // outweighs the fragment savings on a small binning GPU (big desktop
-    // GPUs and the at-vsync-ceiling Huawei masked it). Default returns to
-    // quad expansion until indexed band-boundary geometry removes the
-    // amplification; then the A/B is repeated.
-    matches!(std::env::var("CRANPOSE_ARC_MESH").as_deref(), Ok(v) if v != "0")
+    // Default ON because of the SIZE GATE ([`retained_mesh_min_px2`]), not
+    // because indexed geometry alone fixed anything: the off-charger watch
+    // A/Bs measured the retained mesh 4-11 fps SLOWER than plain quads on
+    // the Adreno 702 when it meshed ALL ~14k retained arcs — indexed
+    // band-boundary geometry included. Thousands of tiny meshes amplify
+    // vertex and binning work past whatever fragment slack they recover on
+    // a small binning GPU (big desktop GPUs and the at-vsync-ceiling Huawei
+    // masked it). The fill-truth instrument says where the recoverable
+    // slack actually lives: 0.45 Mpx/frame of retained slack out of 1.7
+    // total, dominated by a handful of huge shapes (a 210k-px² ring quad
+    // carrying 180k px² slack — 86% — and ~19k-px² stroked-circle rims at
+    // 94%), while the thousands of small brick arcs measure ~100-800 px²
+    // each. Gated to big shapes only — the regime the shipping
+    // [`rim_mesh_band`] path already proved WINS on this same GPU — the
+    // mesh recovers the slack without the amplification, so ON is safe.
+    !matches!(std::env::var("CRANPOSE_ARC_MESH").as_deref(), Ok("0"))
 }
 
 /// Dilation applied to the band's half-thickness before meshing, in capture
@@ -2498,6 +2514,60 @@ const ARC_MESH_BUDGET_FLOOR_BYTES: usize = 4096 * std::mem::size_of::<MeshVertex
 #[cfg(not(target_arch = "wasm32"))]
 fn arc_mesh_bytes(vertices: usize, indices: usize) -> usize {
     vertices * std::mem::size_of::<MeshVertex>() + indices * std::mem::size_of::<u32>()
+}
+
+/// Default size gate for the retained capture mesh, in capture-space px² of
+/// a shape's bounding quad: shapes below it take the passthrough quad even
+/// when they qualify geometrically.
+///
+/// The default follows from the trade's own economics, not from any one
+/// scene. A band mesh costs a roughly shape-size-independent overhead — up
+/// to [`ARC_MESH_MAX_SEGMENTS`] trapezoids of vertex work plus the extra
+/// primitives' setup and bin-list traffic on a tiling GPU — while what it
+/// can recover scales with the shape's quad area times its discard-slack
+/// fraction (an arc or ring band fills only O(perimeter x thickness) of
+/// its box, so the slack fraction RISES with size: big bands are almost
+/// all slack, tiny ones barely any). Fixed cost against area-proportional
+/// benefit crosses zero at some quad size; 16384 px² (a 128 px square)
+/// puts the gate an order of magnitude above the measured loss regime and
+/// an order below the measured win regime, so it is margin, not tuning:
+/// on the Adreno 702 meshing ~14k retained ~100-800 px² shapes lost
+/// 4-11 fps, while the same mesher over only large shapes wins on the same
+/// GPU (the shipping [`rim_mesh_band`] path, gated at 65536 px²), and
+/// fill-truth's top retained slack sits at ~19k px² and up (86-94% slack).
+/// Any app whose retained content mixes the two populations lands on the
+/// same split; a device where the crossover measurably differs A/Bs the
+/// threshold through the override below without a rebuild.
+#[cfg(not(target_arch = "wasm32"))]
+const RETAINED_MESH_MIN_PX2_DEFAULT: usize = 16384;
+/// Clamp for the `CRANPOSE_RETAINED_MESH_PX2` override: below ~1k px² the
+/// tiny-mesh amplification regime demonstrably returns, and above 256k px²
+/// the gate exceeds a whole 512x512 quad — both ends are "you no longer
+/// mean the size gate", not useful A/B settings.
+#[cfg(not(target_arch = "wasm32"))]
+const RETAINED_MESH_MIN_PX2_RANGE: std::ops::RangeInclusive<usize> = 1024..=262144;
+
+/// The retained capture mesh's size gate in px², default
+/// [`RETAINED_MESH_MIN_PX2_DEFAULT`], overridable for device A/Bs via
+/// `CRANPOSE_RETAINED_MESH_PX2` (the `debug.cranpose.retained_mesh_px2`
+/// property on Android), clamped to [`RETAINED_MESH_MIN_PX2_RANGE`]. Read
+/// per capture like [`arc_mesh_enabled`] — captures are rare.
+#[cfg(not(target_arch = "wasm32"))]
+fn retained_mesh_min_px2() -> f64 {
+    parse_retained_mesh_min_px2(std::env::var("CRANPOSE_RETAINED_MESH_PX2").ok().as_deref())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn parse_retained_mesh_min_px2(value: Option<&str>) -> f64 {
+    value
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .map(|px2| {
+            px2.clamp(
+                *RETAINED_MESH_MIN_PX2_RANGE.start(),
+                *RETAINED_MESH_MIN_PX2_RANGE.end(),
+            )
+        })
+        .unwrap_or(RETAINED_MESH_MIN_PX2_DEFAULT) as f64
 }
 
 /// Band parameters of a captured arc that qualifies for a conservative mesh:
@@ -2582,9 +2652,9 @@ fn arc_mesh_band(shape: &ShapeData) -> Option<ArcMeshBand> {
 /// [`arc_mesh_enabled`]'s property bridge: `CRANPOSE_RIM_MESH=0` (or the
 /// `debug.cranpose.rim_mesh` property on Android) makes the fused shape
 /// prepare skip rim detection entirely, so a device A/B needs no rebuild.
-/// Default ON — unlike the retained arc mesh, the rim path is indexed
-/// band-boundary geometry from the start, so the vertex-amplification
-/// regression that demoted `CRANPOSE_ARC_MESH` to opt-in does not apply.
+/// Default ON — the rim path only ever meshed a handful of huge shapes per
+/// frame, which is the regime that WINS on the watch GPU (and the proof the
+/// retained mesh's size gate is built on; see [`arc_mesh_enabled`]).
 /// Read once per fused-chunk prepare (cheap), not per shape.
 #[cfg(not(target_arch = "wasm32"))]
 fn rim_mesh_enabled() -> bool {
@@ -2635,9 +2705,13 @@ fn rim_mesh_capacity_warn() {
     }
 }
 
-/// Band parameters of a DYNAMIC stroked round-rect whose outline is
-/// geometrically a circle — an arena "rim". Everything else returns `None`
-/// and rasterizes through the ordinary quad expansion.
+/// Band parameters of a stroked round-rect whose outline is geometrically a
+/// circle — an arena "rim". Everything else returns `None` and rasterizes
+/// through the ordinary quad expansion. Two callers, each behind its own
+/// size gate: the DYNAMIC fused path via [`rim_mesh_band`], and the
+/// retained capture builder ([`build_arc_mesh_vertices`]) via
+/// [`retained_mesh_min_px2`] — retained slots hold big static ring circles
+/// the dynamic path never sees.
 ///
 /// Derivation: `ShapeData::rect` for a stroked shape is the stroke-inflated
 /// box (geometry plus half the stroke width on each side), so the geometry
@@ -2660,7 +2734,7 @@ fn rim_mesh_capacity_warn() {
 /// radius must match `geom_half` to within 0.01 px (a deviation that small
 /// stays inside the mesh margin's 0.5 px float-slop budget).
 #[cfg(not(target_arch = "wasm32"))]
-fn rim_mesh_band(shape: &ShapeData) -> Option<ArcMeshBand> {
+fn rim_band_geometry(shape: &ShapeData) -> Option<ArcMeshBand> {
     // Mirror the fragment shader's flag decode (`u32(max(x, 0.0))`).
     let flags = shape.stroke_params[1].max(0.0) as u32;
     if flags & 3 != SHAPE_KIND_STROKE {
@@ -2694,11 +2768,6 @@ fn rim_mesh_band(shape: &ShapeData) -> Option<ArcMeshBand> {
         && left < right
         && top < bottom;
     if !axis_aligned {
-        return None;
-    }
-    // Big shapes only: the win is proportional to the discarded quad area,
-    // and small quads are cheaper than the extra pipeline switches.
-    if w * h < 65536.0 {
         return None;
     }
     // A circle's box is square, bitwise.
@@ -2740,6 +2809,18 @@ fn rim_mesh_band(shape: &ShapeData) -> Option<ArcMeshBand> {
         start: 0.0,
         sweep: cranpose_ui_graphics::TAU,
     })
+}
+
+/// [`rim_band_geometry`] behind the DYNAMIC path's size gate. Big shapes
+/// only: the win is proportional to the discarded quad area, and small
+/// quads are cheaper than the extra pipeline switches.
+#[cfg(not(target_arch = "wasm32"))]
+fn rim_mesh_band(shape: &ShapeData) -> Option<ArcMeshBand> {
+    let [_, _, w, h] = shape.rect;
+    if w * h < 65536.0 {
+        return None;
+    }
+    rim_band_geometry(shape)
 }
 
 /// Kill switch for the opaque static leading-span cache, mirroring
@@ -4216,20 +4297,22 @@ struct ArcMeshBuild {
     /// `indices[index_prefix[i]..index_prefix[i + 1]]`.
     index_prefix: Vec<u32>,
     meshed_arcs: usize,
+    meshed_rims: usize,
     meshed_segments: usize,
     passthrough: usize,
     quad_area: f64,
     mesh_area: f64,
 }
 
-/// Builds a slot's conservative indexed mesh: arc bands become
-/// vertex-sharing trapezoid strips, every other shape a passthrough quad
-/// (four vertices, six indices), in the exact capture shape order. Returns
-/// `None` when the byte budget overflows — the caller warns and the whole
-/// slot replays through the quad-expansion path (silent truncation would
-/// break the containment invariant).
+/// Builds a slot's conservative indexed mesh: arc bands and stroked-circle
+/// rims whose bounding quad reaches `min_mesh_px2` become vertex-sharing
+/// trapezoid strips; every other shape — including gate-rejected small arcs
+/// — a passthrough quad (four vertices, six indices), in the exact capture
+/// shape order. Returns `None` when the byte budget overflows — the caller
+/// warns and the whole slot replays through the quad-expansion path (silent
+/// truncation would break the containment invariant).
 #[cfg(not(target_arch = "wasm32"))]
-fn build_arc_mesh_vertices(shape_data: &[ShapeData]) -> Option<ArcMeshBuild> {
+fn build_arc_mesh_vertices(shape_data: &[ShapeData], min_mesh_px2: f64) -> Option<ArcMeshBuild> {
     let budget_bytes =
         (shape_data.len() * ARC_MESH_BUDGET_BYTES_PER_SHAPE).max(ARC_MESH_BUDGET_FLOOR_BYTES);
     let mut build = ArcMeshBuild {
@@ -4237,6 +4320,7 @@ fn build_arc_mesh_vertices(shape_data: &[ShapeData]) -> Option<ArcMeshBuild> {
         indices: Vec::new(),
         index_prefix: Vec::with_capacity(shape_data.len() + 1),
         meshed_arcs: 0,
+        meshed_rims: 0,
         meshed_segments: 0,
         passthrough: 0,
         quad_area: 0.0,
@@ -4245,7 +4329,23 @@ fn build_arc_mesh_vertices(shape_data: &[ShapeData]) -> Option<ArcMeshBuild> {
     build.index_prefix.push(0);
     for (index, shape) in shape_data.iter().enumerate() {
         let start = build.indices.len();
-        let meshed = arc_mesh_band(shape).and_then(|band| {
+        let quad_px2 = quad_shoelace_area(shape);
+        // THE SIZE GATE (see [`arc_mesh_enabled`] for the measured history):
+        // only shapes whose submitted quad is big enough to carry real
+        // fill-truth slack are worth a mesh; below the gate the trapezoid
+        // strip's vertex and binning amplification costs the watch GPU more
+        // than the discarded fragments ever did. The two band shapes are
+        // mutually exclusive by kind bits (`SHAPE_KIND_ARC` vs
+        // `SHAPE_KIND_STROKE`), so the `or_else` never shadows one with the
+        // other.
+        let band = if quad_px2 >= min_mesh_px2 {
+            arc_mesh_band(shape)
+                .map(|band| (band, false))
+                .or_else(|| rim_band_geometry(shape).map(|band| (band, true)))
+        } else {
+            None
+        };
+        let meshed = band.and_then(|(band, is_rim)| {
             emit_arc_band_mesh(
                 shape,
                 index as u32,
@@ -4253,10 +4353,15 @@ fn build_arc_mesh_vertices(shape_data: &[ShapeData]) -> Option<ArcMeshBuild> {
                 &mut build.vertices,
                 &mut build.indices,
             )
+            .map(|segments| (segments, is_rim))
         });
         match meshed {
-            Some(segments) => {
-                build.meshed_arcs += 1;
+            Some((segments, is_rim)) => {
+                if is_rim {
+                    build.meshed_rims += 1;
+                } else {
+                    build.meshed_arcs += 1;
+                }
                 build.meshed_segments += segments;
             }
             None => {
@@ -4268,7 +4373,7 @@ fn build_arc_mesh_vertices(shape_data: &[ShapeData]) -> Option<ArcMeshBuild> {
             return None;
         }
         build.index_prefix.push(build.indices.len() as u32);
-        build.quad_area += quad_shoelace_area(shape);
+        build.quad_area += quad_px2;
         build.mesh_area += triangles_shoelace_area(&build.vertices, &build.indices[start..]);
     }
     Some(build)
@@ -11671,8 +11776,9 @@ impl GpuRenderer {
         // triangle area.
         let mut mesh_fill_records: Option<Vec<FillDiagShapeRecord>> = None;
         let mesh = if arc_mesh_enabled() {
-            match build_arc_mesh_vertices(&shape_data) {
+            match build_arc_mesh_vertices(&shape_data, retained_mesh_min_px2()) {
                 Some(build) => {
+                    let meshed_shapes = build.meshed_arcs + build.meshed_rims;
                     let cut = if build.quad_area > 0.0 {
                         (1.0 - build.mesh_area / build.quad_area) * 100.0
                     } else {
@@ -11682,12 +11788,14 @@ impl GpuRenderer {
                     // console, and captures are rare — one line per slot
                     // lifetime. The unique-vert/index counts against the
                     // six-per-shape quad baseline are the vertex-amplification
-                    // instrument P1b exists for.
+                    // instrument P1b exists for; the meshed/passthrough split
+                    // is the size gate's own engagement instrument.
                     log::warn!(
-                        "[arc-mesh] slot {id}: {} arcs meshed ({} segs), {} passthrough; \
-                         {} unique verts / {} indices (quad path: {} verts); \
-                         quad_px {:.0} -> mesh_px {:.0} (-{:.1}%)",
+                        "[arc-mesh] slot {id}: {} arcs + {} rims meshed ({} segs), \
+                         {} passthrough; {} unique verts / {} indices \
+                         (quad path: {} verts); quad_px {:.0} -> mesh_px {:.0} (-{:.1}%)",
                         build.meshed_arcs,
+                        build.meshed_rims,
                         build.meshed_segments,
                         build.passthrough,
                         build.vertices.len(),
@@ -11697,7 +11805,7 @@ impl GpuRenderer {
                         build.mesh_area,
                         cut,
                     );
-                    if build.meshed_arcs > 0 && fill_area_diag_enabled() {
+                    if meshed_shapes > 0 && fill_area_diag_enabled() {
                         mesh_fill_records = Some(fill_diag_capture_records(
                             &shape_data,
                             Some((&build.vertices, &build.indices, &build.index_prefix)),
@@ -11705,7 +11813,7 @@ impl GpuRenderer {
                     }
                     // A slot that meshed nothing gains nothing over the
                     // indexless quad path — skip the buffers.
-                    (build.meshed_arcs > 0).then(|| {
+                    (meshed_shapes > 0).then(|| {
                         let vertex_buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
                             label: Some("Replay Mesh Vertex Buffer"),
                             size: (std::mem::size_of::<MeshVertex>() * build.vertices.len()) as u64,
@@ -11732,6 +11840,9 @@ impl GpuRenderer {
                             vertex_buffer,
                             index_buffer,
                             index_prefix: build.index_prefix,
+                            meshed_arcs: build.meshed_arcs,
+                            meshed_rims: build.meshed_rims,
+                            passthrough: build.passthrough,
                         }
                     })
                 }
@@ -11860,6 +11971,25 @@ impl GpuRenderer {
             .filter(|slot| slot.mesh.is_some())
             .count();
         (meshed, self.replay_slots.slots.len())
+    }
+
+    /// Test/diagnostic view of the capture size gate, summed over live slots
+    /// that hold a mesh: (shapes meshed as arc bands, shapes meshed as
+    /// stroked-circle rim bands, shapes on the passthrough quad).
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn replay_slot_mesh_engagement(&self) -> (usize, usize, usize) {
+        self.replay_slots
+            .slots
+            .values()
+            .filter_map(|slot| slot.mesh.as_ref())
+            .fold((0, 0, 0), |(arcs, rims, passthrough), mesh| {
+                (
+                    arcs + mesh.meshed_arcs,
+                    rims + mesh.meshed_rims,
+                    passthrough + mesh.passthrough,
+                )
+            })
     }
 
     /// Draws one retained replay batch — `retained`'s shape range of its
@@ -20632,9 +20762,13 @@ mod tests {
         let shape = test_shape(0, BlendMode::SrcOver);
         let mut converted = ShapeData::zeroed();
         convert_shape_into_slots(&shape, &[], 1.0, 0, &mut converted, &mut []);
-        let build =
-            build_arc_mesh_vertices(std::slice::from_ref(&converted)).expect("within budget");
+        let build = build_arc_mesh_vertices(
+            std::slice::from_ref(&converted),
+            RETAINED_MESH_MIN_PX2_DEFAULT as f64,
+        )
+        .expect("within budget");
         assert_eq!(build.meshed_arcs, 0);
+        assert_eq!(build.meshed_rims, 0);
         assert_eq!(build.passthrough, 1);
         // Four shared corner vertices, six indices — amplification-free.
         assert_eq!(build.vertices.len(), 4);
@@ -20810,7 +20944,149 @@ mod tests {
         );
         let converted = converted_arc_shape(arc, 1.0);
         let shapes = vec![converted; 100];
-        assert!(build_arc_mesh_vertices(&shapes).is_none());
+        assert!(build_arc_mesh_vertices(&shapes, RETAINED_MESH_MIN_PX2_DEFAULT as f64).is_none());
+    }
+
+    /// The size gate, boundary-exact: a shape meshes when its quad area is
+    /// AT LEAST the threshold and passes through below it — with the
+    /// engagement counters saying which happened — and the arc and rim
+    /// acceptances both sit behind the same gate.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn retained_mesh_size_gate_engages_exactly_per_threshold() {
+        use cranpose_ui_graphics::ArcGeometry;
+        // A big ring (quad ~322 px square ≈ 104k px²), a small brick arc
+        // (quad well under 1024 px²), and a big stroked-circle rim
+        // (90k-px² quad) in one capture.
+        let big_ring = converted_arc_shape(
+            ArcGeometry::new(
+                Point::new(204.0, 204.0),
+                140.0,
+                160.0,
+                0.0,
+                cranpose_ui_graphics::TAU,
+                StrokeCap::Butt,
+            ),
+            1.0,
+        );
+        let small_arc = converted_arc_shape(
+            ArcGeometry::new(
+                Point::new(204.0, 204.0),
+                12.0,
+                18.0,
+                0.3,
+                0.5,
+                StrokeCap::Butt,
+            ),
+            1.0,
+        );
+        let rim = rim_test_shape_data();
+        let shapes = [big_ring, small_arc, rim];
+        let big_px2 = quad_shoelace_area(&shapes[0]);
+        let small_px2 = quad_shoelace_area(&shapes[1]);
+        let rim_px2 = quad_shoelace_area(&shapes[2]);
+        assert!(small_px2 < 1024.0 && big_px2 > rim_px2 && rim_px2 > 16384.0);
+
+        // Default gate: both big shapes mesh, the brick arc passes through.
+        let build = build_arc_mesh_vertices(&shapes, RETAINED_MESH_MIN_PX2_DEFAULT as f64)
+            .expect("within budget");
+        assert_eq!(
+            (build.meshed_arcs, build.meshed_rims, build.passthrough),
+            (1, 1, 1)
+        );
+
+        // ≥, not >: a threshold bitwise AT a shape's quad area still meshes
+        // it...
+        let build = build_arc_mesh_vertices(&shapes, big_px2).expect("within budget");
+        assert_eq!(
+            (build.meshed_arcs, build.meshed_rims, build.passthrough),
+            (1, 0, 2)
+        );
+        // ...and one ulp above it does not.
+        let build =
+            build_arc_mesh_vertices(&shapes, big_px2 + big_px2 * f64::EPSILON).expect("budget");
+        assert_eq!(
+            (build.meshed_arcs, build.meshed_rims, build.passthrough),
+            (0, 0, 3)
+        );
+
+        // A threshold between the rim and the ring gates them apart.
+        let build = build_arc_mesh_vertices(&shapes, (rim_px2 + big_px2) * 0.5).expect("budget");
+        assert_eq!(
+            (build.meshed_arcs, build.meshed_rims, build.passthrough),
+            (1, 0, 2)
+        );
+
+        // A gate-rejected shape is a passthrough quad — four vertices, six
+        // indices, positions bitwise the captured quad corners.
+        let everything_gated =
+            build_arc_mesh_vertices(&shapes, big_px2 * 2.0).expect("within budget");
+        assert_eq!(everything_gated.passthrough, 3);
+        assert_eq!(everything_gated.vertices.len(), 12);
+        assert_eq!(everything_gated.index_prefix, vec![0, 6, 12, 18]);
+    }
+
+    /// The env override's parse-and-clamp: unset and garbage read the
+    /// default, in-range values pass through, and both clamp ends hold.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn retained_mesh_px2_override_parses_and_clamps() {
+        assert_eq!(
+            parse_retained_mesh_min_px2(None),
+            RETAINED_MESH_MIN_PX2_DEFAULT as f64
+        );
+        assert_eq!(
+            parse_retained_mesh_min_px2(Some("not a number")),
+            RETAINED_MESH_MIN_PX2_DEFAULT as f64
+        );
+        assert_eq!(
+            parse_retained_mesh_min_px2(Some("-5")),
+            RETAINED_MESH_MIN_PX2_DEFAULT as f64
+        );
+        assert_eq!(parse_retained_mesh_min_px2(Some(" 40000 ")), 40000.0);
+        assert_eq!(
+            parse_retained_mesh_min_px2(Some("0")),
+            *RETAINED_MESH_MIN_PX2_RANGE.start() as f64
+        );
+        assert_eq!(
+            parse_retained_mesh_min_px2(Some("99999999")),
+            *RETAINED_MESH_MIN_PX2_RANGE.end() as f64
+        );
+    }
+
+    /// The retained builder accepts stroked-circle rims through
+    /// [`rim_band_geometry`]: the emitted mesh is the closed annulus band
+    /// (every vertex inside the dilated ring, none inside the hole), counted
+    /// as a rim, while the same shape under the gate stays a quad.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn retained_capture_meshes_big_stroked_circle_rims_as_annuli() {
+        let rim = rim_test_shape_data();
+        let build = build_arc_mesh_vertices(
+            std::slice::from_ref(&rim),
+            RETAINED_MESH_MIN_PX2_DEFAULT as f64,
+        )
+        .expect("within budget");
+        assert_eq!(
+            (build.meshed_arcs, build.meshed_rims, build.passthrough),
+            (0, 1, 0)
+        );
+        assert!(build.meshed_segments >= ARC_MESH_MIN_SEGMENTS);
+        // The annulus, not the quad: the mesh area is far below the 90k-px²
+        // bounding quad and every vertex sits in the dilated band's radial
+        // range (clip-plane vertices included — the quad box touches the
+        // outer circle only near the axes, inside the band).
+        assert!(build.mesh_area < 0.2 * build.quad_area);
+        let band = rim_band_geometry(&rim).expect("rim must qualify");
+        for vertex in &build.vertices {
+            let dx = vertex.position[0] - band.center[0];
+            let dy = vertex.position[1] - band.center[1];
+            let radius = (dx * dx + dy * dy).sqrt();
+            assert!(
+                radius >= band.inner - ARC_MESH_MARGIN - 1e-3,
+                "vertex at radius {radius} fell inside the annulus hole"
+            );
+        }
     }
 
     /// A converted circle rim, hand-built in `ShapeData` terms: `rect` is the

--- a/crates/cranpose-render/wgpu/tests/arc_mesh_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/arc_mesh_parity.rs
@@ -2,10 +2,15 @@
 //!
 //! Renders the same churning retained scene as `command_feed_parity` under
 //! two capture regimes — `CRANPOSE_ARC_MESH=0` (plain quad expansion) and
-//! `CRANPOSE_ARC_MESH=1` (the opt-in conservative mesh, indexed since P1b)
-//! — and compares same-position passes. The instanced-quad selection is
-//! pinned OFF for the whole test so both arms match the regime this envelope
-//! was measured under (see the note at the top of the test body).
+//! `CRANPOSE_ARC_MESH=1` (the conservative mesh: indexed since P1b,
+//! size-gated and default-ON since Stage 3) — and compares same-position
+//! passes. Each sector ring is backed by a full annulus whose quad clears
+//! the retained size gate, so the mesh arm still meshes under the default
+//! threshold while the ~1.3k tiny sector bricks take the passthrough quad —
+//! the engagement split the gate exists for, asserted below. The
+//! instanced-quad selection is pinned OFF for the whole test so both arms
+//! match the regime this envelope was measured under (see the note at the
+//! top of the test body).
 //!
 //! THE MEASURED ENVELOPE, AND WHY IT IS NOT ZERO. The design bar was
 //! byte-identical output, on the argument that any vertex stream carrying
@@ -92,6 +97,17 @@ fn record_frame(frame: usize) -> DrawScopeDefault {
     {
         let radius = radius * breathing;
         let band = band * breathing;
+        // A full backing annulus under each sector ring, rotating with it:
+        // its ~32k-90k px² quad clears the retained size gate, so the mesh
+        // arm keeps meshing now that the tiny sectors below pass through.
+        scope.draw_annular_sector(
+            Brush::solid(Color(0.08, 0.12, 0.22, 1.0)),
+            Point::new(CENTER, CENTER),
+            radius - band,
+            radius,
+            speed * frame as f32,
+            std::f32::consts::TAU,
+        );
         let count = 420usize;
         let sweep = std::f32::consts::TAU / count as f32 * 0.8;
         for i in 0..count {
@@ -262,6 +278,22 @@ fn retained_arc_mesh_stays_within_the_interpolation_envelope() {
         mesh_slots < total_slots,
         "the quad arm's slots must have captured without meshes \
          ({mesh_slots} of {total_slots} meshed)"
+    );
+    // The size gate's engagement split: the big backing annuli meshed, the
+    // ~1.3k tiny sector bricks per capture took the passthrough quad (the
+    // regime that meshed them wholesale measured 4-11 fps slower on the
+    // watch), and nothing in this scene is a stroked-circle rim.
+    let (arcs_meshed, rims_meshed, passthrough) = renderer.replay_slot_mesh_engagement();
+    eprintln!("arc-mesh engagement: {arcs_meshed} arcs, {rims_meshed} rims, {passthrough} quads");
+    assert!(
+        arcs_meshed >= 1,
+        "the backing annuli must clear the size gate"
+    );
+    assert_eq!(rims_meshed, 0, "no shape here is a stroked-circle rim");
+    assert!(
+        passthrough > arcs_meshed,
+        "the tiny sector bricks must stay on the passthrough quad \
+         ({passthrough} quads vs {arcs_meshed} meshed)"
     );
 
     for (frame, (quad, mesh)) in quad_frames.iter().zip(&mesh_frames).enumerate() {

--- a/crates/cranpose-render/wgpu/tests/retained_bundle_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/retained_bundle_parity.rs
@@ -58,9 +58,11 @@ const FRAMES: usize = 16;
 const JOLT_FRAME: usize = 8;
 
 /// One frame of the synthetic boss through the RECORDING path: rings
-/// rotating at distinct speeds under a breathing scale, churning sparks,
-/// recoloring twinkles, movers whose count changes every frame — plus a
-/// non-similar band jolt at `JOLT_FRAME` to force mid-sequence recaptures.
+/// rotating at distinct speeds under a breathing scale (each backed by a
+/// full annulus big enough for the retained mesh size gate), churning
+/// sparks, recoloring twinkles, movers whose count changes every frame —
+/// plus a non-similar band jolt at `JOLT_FRAME` to force mid-sequence
+/// recaptures.
 fn record_frame(frame: usize) -> DrawScopeDefault {
     let mut scope =
         DrawScopeDefault::new(cranpose_ui_graphics::Size::new(SIZE as f32, SIZE as f32));
@@ -94,6 +96,19 @@ fn record_frame(frame: usize) -> DrawScopeDefault {
         // Thickening the band while the radius breathes is NOT a similarity
         // of the captured geometry: the span must recapture.
         let band = band * breathing * if frame >= JOLT_FRAME { 1.35 } else { 1.0 };
+        // A full backing annulus under each sector ring: its ~32k-90k px²
+        // quad clears the retained size gate, so pre-jolt captures still
+        // land WITH meshes now that the tiny sectors pass through — and it
+        // thickens with the same jolt, so its span recaptures mid-sequence
+        // (meshless, ARC_MESH is off from the jolt) like the rest.
+        scope.draw_annular_sector(
+            Brush::solid(Color(0.08, 0.12, 0.22, 1.0)),
+            Point::new(CENTER, CENTER),
+            radius - band,
+            radius,
+            speed * frame as f32,
+            std::f32::consts::TAU,
+        );
         let count = 420usize;
         let sweep = std::f32::consts::TAU / count as f32 * 0.8;
         for i in 0..count {

--- a/crates/cranpose-render/wgpu/tests/sized_retained_mesh_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/sized_retained_mesh_parity.rs
@@ -1,0 +1,398 @@
+//! Pixel parity and gate engagement for the SIZE-GATED retained capture
+//! mesh (Stage 3 of the fill-reduction program).
+//!
+//! The scene is the fill-truth top-slack dump made concrete: one big ring
+//! (the 86%-slack "quad 210000, lit 30000" shape class), a big
+//! stroked-circle rim (the 94%-slack rrect-stroke circles the dynamic
+//! `rim_mesh_band` path never sees because they are retained), and a brick
+//! wall of tiny arcs (the ~100-800 px² quads whose wholesale meshing
+//! measured 4-11 fps SLOWER on the Adreno 702). The bulk of the scene is
+//! byte-stable across frames, so the feed retains it and replays it at
+//! IDENTITY — bitwise identity: `arc_anchor_transform` on byte-identical
+//! content divides equal radii (exactly 1.0) and subtracts equal angles
+//! (exactly 0.0), and multiplying by those is exact under any fma
+//! contraction, so `arc_mesh_parity`'s rotated-frame vertex divergence is
+//! out of the picture and both arms rasterize bit-equal vertex positions.
+//! A trailing row of movers churns every frame so the command feed
+//! exercises its real retained-span machinery instead of a degenerate
+//! all-static command.
+//!
+//! THE MEASURED IDENTITY BAR. Bit-equal vertices do not make the two arms
+//! byte-equal wherever a band actually meshes: the fragment's `rect_pos`
+//! is interpolated from the `uv` ATTRIBUTE, whose per-triangle plane
+//! equations the rasterizer derives from each triangulation's own
+//! vertices, and a trapezoid's CPU-rounded uv over a ~10 px baseline
+//! carries an ulp of slope the 370 px quad does not. That is invisible
+//! until the SDF's smoothstep output sits within that ulp of a unorm8
+//! rounding boundary — single-level flips confined to a meshed band's own
+//! AA ring. Measured at identity on BOTH CI rasterizer families, same
+//! signature: Intel/ANV Vulkan 892 differing bytes, Metal 930, worst ±1
+//! everywhere, EVERY flip on the rim band's AA radii (the arc ring
+//! measured zero on both — welcome, but the bar does not depend on it:
+//! the annulus check admits both bands). So the asserted bar is: dynamic frames
+//! byte-exact; retained frames byte-exact at every pixel OUTSIDE the two
+//! meshed bands' dilated annuli (passthrough quads are geometry-identical
+//! and must not drift at all), and ±1 at most on the bands, count-capped
+//! at ~4x the measured ceiling.
+//!
+//! Three capture regimes over the same scene, each under its own command
+//! identity (the mesh is built at capture; flipping the environment after
+//! capture changes nothing):
+//!
+//! * quad arm (`CRANPOSE_ARC_MESH=0`) — plain quad expansion;
+//! * mesh arm (`CRANPOSE_ARC_MESH=1`, default gate) — asserts (a) the
+//!   identity bar above against the quad arm on same-position passes, (b)
+//!   the gate's exact engagement split (1 arc + 1 rim meshed, every brick
+//!   on the passthrough quad), (c) the rim acceptance actually engaged — a
+//!   meshed rim band, not a passthrough — via the engagement counters;
+//! * gated arm (`CRANPOSE_RETAINED_MESH_PX2` at its clamp ceiling) — the
+//!   threshold rejects even the big shapes, the capture meshes nothing and
+//!   keeps no mesh buffers, and the engagement counters do not move.
+//!
+//! `CRANPOSE_STATIC_SPAN` is pinned OFF so the leading static shapes stay
+//! on the compared draw paths instead of collapsing into a span blit, and
+//! `CRANPOSE_INSTANCED_QUADS` is pinned OFF (latched at construction) so
+//! the quad arm draws through `vs_main`, the regime the identity byte-bar
+//! was measured under.
+
+mod support;
+
+use cranpose_render_common::graph::{
+    CachePolicy, DrawCommandId, DrawRunNode, IsolationReasons, LayerNode, PrimitivePhase,
+    ProjectiveTransform, RenderGraph, RenderNode,
+};
+use cranpose_render_common::raster_cache::LayerRasterCacheHashes;
+use cranpose_render_common::style_shared::DrawPlacement;
+use cranpose_render_common::Renderer;
+use cranpose_ui_graphics::{
+    Brush, Color, CommandReplayState, CornerRadii, DrawScope, DrawScopeDefault, GraphicsLayer,
+    Point, Rect, Stroke,
+};
+
+const SIZE: u32 = 408;
+const CENTER: f32 = 204.0;
+const FRAMES: usize = 6;
+
+/// The big ring: a full annulus, band 140..160 about the center. Its
+/// bounding quad is ~322 px square (~104k px², far past the 16384 px²
+/// default gate) while its band covers only ~19k px² — the top-slack shape
+/// class.
+const RING_INNER: f32 = 140.0;
+const RING_OUTER: f32 = 160.0;
+
+/// The big rim: a stroked round-rect whose corner radius equals its
+/// geometry half-extent — a circle of radius 180 about the center, stroke
+/// 10. The emitted shape is the stroke-inflated 370 px box (~137k px²
+/// quad), and `rim_band_geometry` must accept it at capture even though the
+/// dynamic rim path never sees retained shapes.
+const RIM_RECT: Rect = Rect {
+    x: 24.0,
+    y: 24.0,
+    width: 360.0,
+    height: 360.0,
+};
+const RIM_RADIUS: f32 = 180.0;
+const RIM_STROKE_WIDTH: f32 = 10.0;
+
+/// Tiny brick arcs on three inner orbits: every quad is well under the
+/// gate's 1024 px² clamp floor, so no threshold in the legal range ever
+/// meshes one — and together they push the recording past the 512-record
+/// floor (`MIN_REPLAY_COMMAND_RECORDS`) below which the feed retains
+/// nothing at all.
+const BRICK_ORBITS: usize = 3;
+const BRICKS_PER_ORBIT: usize = 180;
+const BRICK_COUNT: usize = BRICK_ORBITS * BRICKS_PER_ORBIT;
+
+fn record_frame(frame: usize) -> DrawScopeDefault {
+    let mut scope =
+        DrawScopeDefault::new(cranpose_ui_graphics::Size::new(SIZE as f32, SIZE as f32));
+    // Static bulk first, movers last, so the byte-stable leading run stays
+    // contiguous for the feed's retained span.
+    scope.draw_rect_at(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: SIZE as f32,
+            height: SIZE as f32,
+        },
+        Brush::solid(Color(0.02, 0.02, 0.05, 1.0)),
+    );
+    scope.draw_annular_sector(
+        Brush::solid(Color(0.3, 0.5, 0.8, 1.0)),
+        Point::new(CENTER, CENTER),
+        RING_INNER,
+        RING_OUTER,
+        0.0,
+        std::f32::consts::TAU,
+    );
+    for orbit in 0..BRICK_ORBITS {
+        let mid = 62.0 + orbit as f32 * 14.0;
+        for i in 0..BRICKS_PER_ORBIT {
+            let start =
+                i as f32 * (std::f32::consts::TAU / BRICKS_PER_ORBIT as f32) + orbit as f32 * 0.07;
+            scope.draw_annular_sector(
+                Brush::solid(Color(0.9, 0.6 + ((i + orbit) % 4) as f32 * 0.08, 0.3, 1.0)),
+                Point::new(CENTER, CENTER),
+                mid - 3.0,
+                mid + 3.0,
+                start,
+                0.012,
+            );
+        }
+    }
+    scope.draw_round_rect_at_stroked(
+        RIM_RECT,
+        Brush::solid(Color(0.35, 0.75, 0.95, 1.0)),
+        CornerRadii::uniform(RIM_RADIUS),
+        Stroke {
+            width: RIM_STROKE_WIDTH,
+            ..Default::default()
+        },
+    );
+    // Semi-transparent circles OVER both bands: a z-order mistake in the
+    // mesh replay changes blended bytes, not just AA fringes.
+    for i in 0..5u32 {
+        let angle = (i as f32 + 0.5) * (std::f32::consts::TAU / 5.0);
+        scope.draw_circle(
+            Brush::solid(Color(0.4, 0.95, 0.55, 0.8)),
+            Point::new(
+                CENTER + angle.cos() * RIM_RADIUS,
+                CENTER + angle.sin() * RIM_RADIUS,
+            ),
+            6.0,
+        );
+        scope.draw_circle(
+            Brush::solid(Color(1.0, 0.85, 0.4, 0.7)),
+            Point::new(
+                CENTER + angle.cos() * (RING_INNER + 10.0),
+                CENTER + angle.sin() * (RING_INNER + 10.0),
+            ),
+            5.0,
+        );
+    }
+    // The churn: movers whose count and position change every frame, drawn
+    // last so the static leading run keeps retaining.
+    for m in 0..(2 + frame % 3) {
+        let x = 26.0 + frame as f32 * 9.0 + m as f32 * 15.0;
+        scope.draw_circle(
+            Brush::solid(Color(1.0, 1.0, 1.0, 1.0)),
+            Point::new(x, 18.0),
+            4.0,
+        );
+    }
+    scope
+}
+
+/// Records every frame once through one live `CommandReplayState`, exactly
+/// as `arc_mesh_parity` does; `node_id` keys the command identity so each
+/// arm retains into its own slots.
+fn build_sequence(node_id: usize) -> Vec<RenderGraph> {
+    let mut state = CommandReplayState::default();
+    let command = DrawCommandId {
+        node_id,
+        command_index: 0,
+        placement: DrawPlacement::Behind,
+    };
+    (0..FRAMES)
+        .map(|frame| {
+            let scope = record_frame(frame);
+            let outcome = state.advance(scope.recorded());
+            let center = state.center();
+            let (finished, replay) = scope.finish_replay(center, outcome, &mut |_| false);
+            let bounds = Rect {
+                x: 0.0,
+                y: 0.0,
+                width: SIZE as f32,
+                height: SIZE as f32,
+            };
+            RenderGraph::new(LayerNode {
+                node_id: None,
+                local_bounds: bounds,
+                transform_to_parent: ProjectiveTransform::identity(),
+                content_offset: Point::default(),
+                motion_context_animated: false,
+                translated_content_context: false,
+                translated_content_offset: Point::default(),
+                scene_children_origin: Point::default(),
+                scene_children_layer_translation: Point::default(),
+                graphics_layer: GraphicsLayer::default(),
+                clip_to_bounds: false,
+                shadow_clip: None,
+                hit_test: None,
+                has_hit_targets: false,
+                isolation: IsolationReasons::default(),
+                cache_policy: CachePolicy::None,
+                cache_hashes: LayerRasterCacheHashes::default(),
+                cache_hashes_valid: false,
+                children: vec![RenderNode::DrawRun(DrawRunNode::for_command_replayed(
+                    PrimitivePhase::BeforeChildren,
+                    Some(command),
+                    std::rc::Rc::new(finished.primitives),
+                    replay.map(Box::new),
+                ))],
+            })
+        })
+        .collect()
+}
+
+fn render_sequence(renderer: &mut support::LockedRenderer, graphs: &[RenderGraph]) -> Vec<Vec<u8>> {
+    graphs
+        .iter()
+        .enumerate()
+        .map(|(frame, graph)| {
+            renderer.scene_mut().graph = Some(graph.clone());
+            let captured = renderer
+                .capture_frame(SIZE, SIZE)
+                .unwrap_or_else(|err| panic!("frame {frame} capture failed: {err:?}"));
+            assert_eq!((captured.width, captured.height), (SIZE, SIZE));
+            captured.pixels
+        })
+        .collect()
+}
+
+fn clear_env() {
+    std::env::remove_var("CRANPOSE_ARC_MESH");
+    std::env::remove_var("CRANPOSE_RETAINED_MESH_PX2");
+    std::env::remove_var("CRANPOSE_COMMAND_FEED");
+    std::env::remove_var("CRANPOSE_SIMILARITY_REPLAY");
+    std::env::remove_var("CRANPOSE_INSTANCED_QUADS");
+    std::env::remove_var("CRANPOSE_STATIC_SPAN");
+}
+
+#[test]
+fn size_gated_retained_mesh_holds_identity_parity_and_gates_per_threshold() {
+    // Latched at construction — must be set before the renderer exists.
+    std::env::set_var("CRANPOSE_INSTANCED_QUADS", "0");
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            std::env::remove_var("CRANPOSE_INSTANCED_QUADS");
+            eprintln!("skipping sized retained mesh parity: headless WGPU init failed: {err}");
+            return;
+        }
+    };
+    std::env::set_var("CRANPOSE_SIMILARITY_REPLAY", "1");
+    std::env::set_var("CRANPOSE_COMMAND_FEED", "1");
+    std::env::set_var("CRANPOSE_STATIC_SPAN", "0");
+
+    let graphs_quad = build_sequence(7);
+    let graphs_mesh = build_sequence(8);
+    let graphs_gated = build_sequence(9);
+
+    // Warm passes: each arm captures its own slots under its own regime.
+    std::env::set_var("CRANPOSE_ARC_MESH", "0");
+    let _capture_quad = render_sequence(&mut renderer, &graphs_quad);
+    std::env::set_var("CRANPOSE_ARC_MESH", "1");
+    let _capture_mesh = render_sequence(&mut renderer, &graphs_mesh);
+
+    // Same-position control passes (the discipline `command_feed_parity`
+    // documents: never compare a pre-retention pass against a later one).
+    std::env::set_var("CRANPOSE_ARC_MESH", "0");
+    let quad_frames = render_sequence(&mut renderer, &graphs_quad);
+    std::env::set_var("CRANPOSE_ARC_MESH", "1");
+    let mesh_frames = render_sequence(&mut renderer, &graphs_mesh);
+
+    // (b) + (c): the gate's exact engagement. Only the mesh arm's slots
+    // hold a mesh, so the counters are its capture verbatim: exactly the
+    // big ring meshed as an arc band, exactly the big rim meshed as a rim
+    // band (the acceptance the dynamic path cannot provide), and every
+    // brick arc — small in the precise px² sense — on the passthrough quad.
+    let (mesh_slots, total_slots) = renderer.replay_slot_mesh_stats();
+    let (arcs_meshed, rims_meshed, passthrough) = renderer.replay_slot_mesh_engagement();
+    eprintln!(
+        "sized-mesh slots: {mesh_slots} of {total_slots}; engagement: \
+         {arcs_meshed} arcs, {rims_meshed} rims, {passthrough} quads"
+    );
+    assert!(mesh_slots >= 1, "the mesh arm must hold meshed slots");
+    assert!(
+        mesh_slots < total_slots,
+        "the quad arm's slots must have captured without meshes"
+    );
+    assert_eq!(
+        (arcs_meshed, rims_meshed),
+        (1, 1),
+        "the size gate must mesh exactly the big ring and the big rim"
+    );
+    assert!(
+        passthrough >= BRICK_COUNT,
+        "every brick arc must take the passthrough quad ({passthrough} quads)"
+    );
+
+    // The gated arm: at the clamp ceiling even the big shapes fall under
+    // the threshold, the capture meshes nothing, and a slot that meshed
+    // nothing keeps no mesh buffers — so neither the slot count nor the
+    // engagement counters move.
+    std::env::set_var("CRANPOSE_RETAINED_MESH_PX2", "262144");
+    let _capture_gated = render_sequence(&mut renderer, &graphs_gated);
+    let _gated_frames = render_sequence(&mut renderer, &graphs_gated);
+    std::env::remove_var("CRANPOSE_RETAINED_MESH_PX2");
+    let (mesh_slots_after, total_slots_after) = renderer.replay_slot_mesh_stats();
+    assert_eq!(
+        mesh_slots_after, mesh_slots,
+        "a ceiling threshold must keep every new capture on the quad path"
+    );
+    assert!(
+        total_slots_after > total_slots,
+        "the gated arm must actually have captured slots of its own"
+    );
+    assert_eq!(
+        renderer.replay_slot_mesh_engagement(),
+        (arcs_meshed, rims_meshed, passthrough),
+        "a meshless capture must not move the engagement counters"
+    );
+
+    clear_env();
+    assert!(
+        !renderer.instanced_quads_active(),
+        "the pinned-off selection must have latched at construction"
+    );
+
+    // (a) The identity bar (see the module docs): dynamic frames byte-exact;
+    // retained frames byte-exact everywhere OUTSIDE the meshed bands, with
+    // single-level flips admitted ON a band's dilated annulus only, capped
+    // at ~4x the measured ~900-byte ceiling. The radius is measured at the
+    // pixel center; the 4 px dilation covers the band's AA feather, its
+    // mesh margin and the half-pixel of the center offset with room over.
+    let on_meshed_band = |index: usize| {
+        let pixel = index / 4;
+        let (x, y) = (pixel % SIZE as usize, pixel / SIZE as usize);
+        let radius = ((x as f32 + 0.5 - CENTER).powi(2) + (y as f32 + 0.5 - CENTER).powi(2)).sqrt();
+        let rim_half = RIM_STROKE_WIDTH * 0.5;
+        (RING_INNER - 4.0..=RING_OUTER + 4.0).contains(&radius)
+            || (RIM_RADIUS - rim_half - 4.0..=RIM_RADIUS + rim_half + 4.0).contains(&radius)
+    };
+    for (frame, (quad, mesh)) in quad_frames.iter().zip(&mesh_frames).enumerate() {
+        assert_eq!(quad.len(), mesh.len());
+        let mut differing = 0usize;
+        let mut worst = 0u8;
+        let mut off_band = 0usize;
+        for (index, (a, b)) in quad.iter().zip(mesh).enumerate() {
+            let diff = a.abs_diff(*b);
+            if diff > 0 {
+                differing += 1;
+                worst = worst.max(diff);
+                if !on_meshed_band(index) {
+                    off_band += 1;
+                }
+            }
+        }
+        eprintln!("frame {frame}: differing {differing} worst {worst} off-band {off_band}");
+        if frame < 2 {
+            assert_eq!(
+                differing, 0,
+                "frame {frame}: dynamic frames must be byte-exact"
+            );
+        } else {
+            assert_eq!(
+                off_band, 0,
+                "frame {frame}: {off_band} bytes diverged OUTSIDE the meshed bands — \
+                 passthrough content must be byte-exact at identity"
+            );
+            assert!(
+                worst <= 1 && differing < 4096,
+                "frame {frame}: {differing} bytes diverged (worst {worst}) — beyond \
+                 the single-level in-band interpolation envelope"
+            );
+        }
+    }
+}

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -67,14 +67,22 @@ fn property_flag(name: &str) -> bool {
 /// allowlist of properties into the environment closes that gap without giving
 /// either side a new configuration format to learn.
 ///
-/// Property names are capped at 32 bytes by `PROP_NAME_MAX`, which is why they
-/// are abbreviations rather than the full variable name.
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 22] = [
+/// Property names are capped at 32 bytes by `PROP_NAME_MAX` on pre-O Android,
+/// which is why they are abbreviations rather than the full variable name.
+/// (Since Android O the cap is gone — `__system_property_get` takes names of
+/// any length — so a name may run right up to or past that pre-O limit, as
+/// `debug.cranpose.retained_mesh_px2` does; every deployment target is far
+/// past O.)
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 23] = [
     ("debug.cranpose.gpu_stats", "CRANPOSE_GPU_STATS"),
     ("debug.cranpose.command_feed", "CRANPOSE_COMMAND_FEED"),
     ("debug.cranpose.arc_mesh", "CRANPOSE_ARC_MESH"),
     ("debug.cranpose.rim_mesh", "CRANPOSE_RIM_MESH"),
     ("debug.cranpose.round_cull", "CRANPOSE_ROUND_CULL"),
+    (
+        "debug.cranpose.retained_mesh_px2",
+        "CRANPOSE_RETAINED_MESH_PX2",
+    ),
     ("debug.cranpose.catchup_pacing", "CRANPOSE_CATCHUP_PACING"),
     ("debug.cranpose.instanced_quads", "CRANPOSE_INSTANCED_QUADS"),
     (


### PR DESCRIPTION
The retained capture mesh (trapezoid band strips replacing quad expansion) measured 4-11 fps SLOWER on a small binning GPU when it meshed every retained arc: thousands of ~100-800 px² shapes amplify vertex and bin-list work past the fragment slack they recover. But the fill-truth instrument shows the recoverable slack concentrated in a handful of huge shapes (a 210k-px² ring quad at 86% slack, ~19k-px² stroked rims at 94%) — the exact regime the shipping dynamic rim-mesh path already proved wins on the same GPU.

This PR makes the mesher content-conditional on shape size, which is what lets it default ON:

- `build_arc_mesh_vertices` gains a size gate: a shape meshes only when its quad's shoelace area ≥ the threshold; below it (or non-band) it emits an indexed passthrough quad (4 vertices).
- Stroked-circle rims are now accepted by the retained builder too: `rim_mesh_band` split into `rim_band_geometry` (pure geometry) + the dynamic path's 65536 px² wrapper, so retained captures can mesh the big static ring circles the per-frame path never sees.
- Default 16384 px², justified by the trade's economics (size-independent mesh overhead vs area-proportional slack recovery; slack fraction rises with size). Override: `CRANPOSE_RETAINED_MESH_PX2` / `debug.cranpose.retained_mesh_px2`, clamped 1024..=262144.
- `arc_mesh_enabled()` default flips ON; kill switch `CRANPOSE_ARC_MESH=0` unchanged.
- Engagement counters (`replay_slot_mesh_engagement`) expose the arc/rim/passthrough split for tests and diagnostics.

Tests: new `sized_retained_mesh_parity.rs` (big ring + 540-brick wall + big rim retained, bitwise-identical outside the meshed bands' dilated annuli, ±1 in-band — the measured re-tessellation floor on both CI rasterizer families, documented in the suite); boundary-exact gate unit tests; arc/bundle parity scenes gained gate-clearing shapes so their mesh arms stay non-vacuous.

Generality: any ring-heavy visualization (gauges, progress dials, watch faces) with retained content hits the same big-band/small-band split; the threshold A/Bs without a rebuild on any device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2