### PR TITLE
Depth-one present thread: ship the replay ack before acquire

### DIFF
--- a/crates/cranpose-render/wgpu/src/frame_packet.rs
+++ b/crates/cranpose-render/wgpu/src/frame_packet.rs
@@ -68,6 +68,11 @@ pub enum CancelReason {
     SurfaceEpoch,
     /// The packet was lowered for a different surface size.
     Viewport,
+    /// The present stage had no usable surface to draw the packet on: the
+    /// surface was dropped, or acquire failed past its one reconfigure
+    /// retry. Producer state (epochs, viewport) still matched — only the
+    /// swapchain was missing.
+    SurfaceUnavailable,
 }
 
 /// What the present stage did with a packet. `NotRun` is the `Default` so a
@@ -93,6 +98,11 @@ pub(crate) struct ReplayAck {
     /// The generation the confirmations are stamped with — the slot
     /// universe they verifiably exist in.
     pub(crate) generation: u64,
+    /// The staleness ordinal of the batch this answers, echoed back so the
+    /// planner purges exactly THIS batch's unconfirmed requests. With a
+    /// packet rendering and another already published, a later batch's
+    /// requests are live when this ack lands and must survive it.
+    pub(crate) frame: u64,
     pub(crate) confirmations: Vec<ReplayConfirmation>,
 }
 
@@ -172,6 +182,33 @@ pub(crate) struct FramePacket {
     /// for the present backend's frame stats — the present call tree holds
     /// no text layout state to read it from.
     pub(crate) text_cache_len: usize,
+    /// Threaded mode only: the emptied confirmations vec from a previous
+    /// frame's [`ReplayAck`], riding back to the present-side store so it
+    /// recycles the capacity instead of allocating per frame. The sync path
+    /// (and wasm) hands the vec straight back via
+    /// `restore_replay_ack_confirmations` and leaves this `None`.
+    pub(crate) recycled_confirmations: Option<Vec<ReplayConfirmation>>,
+    /// Threaded mode only: set by the present stage's early replay-ops
+    /// consumption (`GpuRenderer::take_replay_ack_early`), which runs
+    /// BEFORE surface acquire so the [`ReplayAck`] reaches the producer in
+    /// time for the very next frame's planning. When set, `replay` has
+    /// been taken (it holds the empty default), the render path must not
+    /// consume it again, and a later cancel must not reclaim it. Always
+    /// `false` as built by the producer and on the sync path.
+    pub(crate) replay_preconsumed: bool,
+}
+
+/// Present-stage timestamps for one consumed packet, in nanoseconds on the
+/// clock the producer injected at runtime start (`0` = stage did not run or
+/// no clock was injected). Carried back in [`RenderReturns`] so the
+/// producer's frame telemetry keeps recording acquire/render/present phases
+/// after those stages move to the present thread. Plain integers so the
+/// packet types stay clock-library-free on every target.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PresentTimings {
+    pub after_acquire_ns: i64,
+    pub after_render_ns: i64,
+    pub after_present_ns: i64,
 }
 
 /// What the present stage hands back to the producer after consuming a
@@ -200,6 +237,10 @@ pub(crate) struct RenderReturns {
     /// planner can re-queue its releases and recycle its buffers. `None`
     /// on the presented path (the ops travel back through `ack` there).
     pub(crate) cancelled_replay: Option<ReplayFrameOps>,
+    /// Present-thread stage timestamps for this packet; all-zero on the
+    /// sync path (the producer already holds the clock there) and on any
+    /// outcome that never reached the swapchain.
+    pub(crate) timings: PresentTimings,
 }
 
 /// Compile-time proof that the packet and every member chain can cross a
@@ -227,6 +268,8 @@ const _: () = {
     assert_send::<RenderReturns>();
     assert_send::<CancelReason>();
     assert_send::<PresentOutcome>();
+    assert_send::<PresentTimings>();
+    assert_send::<Option<Vec<ReplayConfirmation>>>();
 };
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/cranpose-render/wgpu/src/frontend.rs
+++ b/crates/cranpose-render/wgpu/src/frontend.rs
@@ -37,6 +37,11 @@ use cranpose_ui_graphics::Rect;
 use std::rc::Weak;
 use web_time::Instant;
 
+/// Direct scenes kept for recycling: one per packet that can be in flight
+/// (depth-one publishing allows one rendering and one waiting) plus the one
+/// being filled. Beyond that the buffers are dropped rather than hoarded.
+const MAX_RETAINED_DIRECT_SCENES: usize = 3;
+
 #[derive(Clone, Debug)]
 pub(crate) struct DevOverlayCache {
     pub(crate) text: String,
@@ -59,7 +64,13 @@ pub(crate) struct RendererFrontend {
     /// Last frame's direct-root scene, kept so its (potentially multi-MB)
     /// draw vectors are reused instead of reallocated every frame. Returned
     /// by the present stage through [`RenderReturns`].
-    pub(crate) retained_direct_scene: Option<CompositorScene>,
+    /// Recycled direct-root scenes. Depth-one publishing keeps up to two
+    /// packets in flight (one rendering, one waiting), so ONE spare scene
+    /// would leave the producer allocating a fresh multi-megabyte
+    /// `CompositorScene` on every other frame — the mmap churn the
+    /// recycling exists to prevent. The pool holds one scene per in-flight
+    /// packet plus the one being filled.
+    pub(crate) retained_direct_scenes: Vec<CompositorScene>,
     pub(crate) direct_scene_capacity: SceneCapacityHint,
     /// Monotone id stamped on each [`FramePacket`] this producer publishes.
     pub(crate) frame_sequence: u64,
@@ -80,7 +91,7 @@ impl RendererFrontend {
             root_scale: 1.0,
             dev_overlay_cache: None,
             dev_overlay_graph: None,
-            retained_direct_scene: None,
+            retained_direct_scenes: Vec::new(),
             direct_scene_capacity: SceneCapacityHint::default(),
             frame_sequence: 0,
             layer_surface_rect_cache: HashMap::new(),
@@ -182,8 +193,8 @@ impl RendererFrontend {
             &mut self.layer_surface_requirements_cache,
         ) {
             let recycled_scene = self
-                .retained_direct_scene
-                .take()
+                .retained_direct_scenes
+                .pop()
                 .unwrap_or_else(|| CompositorScene::with_capacity(self.direct_scene_capacity));
             #[cfg(not(target_arch = "wasm32"))]
             crate::shape_replay::SHAPE_REPLAY
@@ -215,7 +226,9 @@ impl RendererFrontend {
                 // frame.
                 #[cfg(not(target_arch = "wasm32"))]
                 crate::shape_replay::SHAPE_REPLAY.with(|state| state.borrow_mut().retire_all());
-                self.retained_direct_scene = Some(collected.scene);
+                if self.retained_direct_scenes.len() < MAX_RETAINED_DIRECT_SCENES {
+                    self.retained_direct_scenes.push(collected.scene);
+                }
                 None
             }
         } else {
@@ -295,6 +308,8 @@ impl RendererFrontend {
             overlay,
             replay,
             text_cache_len: self.text_state.text_cache_len(),
+            recycled_confirmations: None,
+            replay_preconsumed: false,
         };
         let after_build = Instant::now();
         if let Some(total_ms) = should_log_wgpu_render_stage(build_start, after_build) {
@@ -325,12 +340,15 @@ impl RendererFrontend {
             frame_id: _,
             outcome: _,
             cancelled_replay,
+            timings: _,
         } = returns;
         if let Some(scene) = scene {
             // The packet's scene buffers return to the producer pool — for
             // a heavy animated frame they are megabytes of Vec. A cancelled
             // packet returns its scene the same way as a presented one.
-            self.retained_direct_scene = Some(scene);
+            if self.retained_direct_scenes.len() < MAX_RETAINED_DIRECT_SCENES {
+                self.retained_direct_scenes.push(scene);
+            }
         }
         #[cfg(not(target_arch = "wasm32"))]
         {
@@ -536,7 +554,7 @@ mod tests {
         );
         assert_eq!(packet.frame_id, 1);
         assert!(
-            frontend.retained_direct_scene.is_none(),
+            frontend.retained_direct_scenes.is_empty(),
             "the non-direct gate rejects before any direct scene is collected"
         );
     }
@@ -584,7 +602,7 @@ mod tests {
             "the surface source must carry the collected root content"
         );
         assert!(
-            frontend.retained_direct_scene.is_some(),
+            !frontend.retained_direct_scenes.is_empty(),
             "rejected collect must stash the scene for recycling"
         );
         assert_eq!(packet.frame_id, 1);
@@ -635,7 +653,7 @@ mod tests {
             .build_frame_packet(320, 240, false, 0, 0)
             .expect("direct root must lower into a packet");
         assert!(
-            frontend.retained_direct_scene.is_none(),
+            frontend.retained_direct_scenes.is_empty(),
             "the packet owns the scene while the present stage renders it"
         );
 
@@ -649,7 +667,7 @@ mod tests {
         });
         assert!(confirmations.is_none(), "no ack means nothing to recycle");
         assert!(
-            frontend.retained_direct_scene.is_some(),
+            !frontend.retained_direct_scenes.is_empty(),
             "apply_returns must stash the scene for the next build"
         );
 
@@ -658,7 +676,7 @@ mod tests {
             .expect("recycled scene must feed the next frame");
         assert_eq!(next.frame_id, 2);
         assert!(
-            frontend.retained_direct_scene.is_none(),
+            frontend.retained_direct_scenes.is_empty(),
             "the next build must take the recycled scene"
         );
     }

--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -19,6 +19,8 @@ mod lazy_resource;
 mod normalized_scene;
 mod offscreen;
 mod pipeline;
+#[cfg(not(target_arch = "wasm32"))]
+mod present_runtime;
 mod render;
 mod run_entry;
 mod scene;
@@ -38,6 +40,7 @@ mod test_support;
 #[cfg(not(target_arch = "wasm32"))]
 pub use display_clip::pixel_is_visible as display_clip_pixel_is_visible;
 pub use display_clip::DisplayVisibleRegion;
+pub use frame_packet::PresentTimings;
 #[doc(hidden)]
 pub use frame_packet::{CancelReason, PresentOutcome};
 pub use gpu_stats::FrameStatsSnapshot as RenderStatsSnapshot;
@@ -67,7 +70,13 @@ use cranpose_render_common::{
 use cranpose_ui::{LayoutTree, TextMeasurer};
 use cranpose_ui_graphics::{Rect, Size};
 use frame_packet::RenderReturns;
+#[cfg(not(target_arch = "wasm32"))]
+use frame_packet::ReplayConfirmation;
 use frontend::{DevOverlayCache, RendererFrontend};
+#[cfg(not(target_arch = "wasm32"))]
+use present_runtime::{
+    PresentControl, PresentHandle, PresentMsg, PresentRuntimeInit, PresentState,
+};
 use render::GpuRenderer;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -203,6 +212,35 @@ pub fn headless_text_measurer_with_fonts(fonts: &[&[u8]]) -> Rc<dyn TextMeasurer
     Rc::new(SoftwareTextMeasurer::from_fonts_or_default(fonts, 8192))
 }
 
+/// Which present stage a [`WgpuRenderer`] drives.
+///
+/// `Sync` is today's synchronous path (desktop, web, iOS, tests): the
+/// producer builds a packet and consumes it in the same call. `Threaded`
+/// is the Android depth-one runtime: the `GpuRenderer` lives on the
+/// present thread and only a `PresentHandle` stays here. Boxed because a
+/// `GpuRenderer` is kilobytes of retained state, moved only at init.
+enum PresentBackend {
+    /// No GPU yet (`init_gpu`/`init_gpu_threaded` not called).
+    None,
+    /// The synchronous present stage, consumed in `render`.
+    Sync(Box<GpuRenderer>),
+    /// The spawned (or inline-for-tests) present runtime.
+    #[cfg(not(target_arch = "wasm32"))]
+    Threaded(PresentHandle),
+}
+
+/// What [`WgpuRenderer::publish_frame`] did.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PublishOutcome {
+    /// No scene graph exists; nothing to lower.
+    NoGraph,
+    /// The depth-one slot is occupied (or the renderer is not in threaded
+    /// mode): NO packet was built — backpressure lands before lowering.
+    NoCredit,
+    /// A packet was built and handed to the present runtime.
+    Published,
+}
+
 /// WGPU-based renderer for GPU-accelerated 2D rendering.
 ///
 /// This renderer supports:
@@ -215,7 +253,12 @@ pub struct WgpuRenderer {
     /// frame into a [`frame_packet::FramePacket`].
     frontend: RendererFrontend,
     /// Present stage: consumes packets and draws; it never lowers.
-    gpu_renderer: Option<GpuRenderer>,
+    backend: PresentBackend,
+    /// Threaded mode: the emptied ack-confirmations buffer drained from
+    /// the planner, parked here until the next packet carries it back to
+    /// the present-side store (capacity round-trip, no per-frame alloc).
+    #[cfg(not(target_arch = "wasm32"))]
+    pending_recycled_confirmations: Option<Vec<ReplayConfirmation>>,
     /// Which `GpuRenderer` instance packets are currently built against:
     /// bumped by every [`init_gpu`][Self::init_gpu] (first init → 1) and
     /// stamped into each packet, so a packet that outlives its renderer is
@@ -261,11 +304,122 @@ impl WgpuRenderer {
                 text_system.render_state(),
                 text_system.software_fonts(),
             ),
-            gpu_renderer: None,
+            backend: PresentBackend::None,
+            #[cfg(not(target_arch = "wasm32"))]
+            pending_recycled_confirmations: None,
             renderer_epoch: 0,
             surface_epoch: 0,
             display_visible_region: DisplayVisibleRegion::Full,
         }
+    }
+
+    /// The synchronous present backend, when that is what is live.
+    fn sync_gpu_renderer(&self) -> Option<&GpuRenderer> {
+        match &self.backend {
+            PresentBackend::Sync(gpu_renderer) => Some(gpu_renderer.as_ref()),
+            _ => None,
+        }
+    }
+
+    fn sync_gpu_renderer_mut(&mut self) -> Option<&mut GpuRenderer> {
+        match &mut self.backend {
+            PresentBackend::Sync(gpu_renderer) => Some(gpu_renderer.as_mut()),
+            _ => None,
+        }
+    }
+
+    /// The threaded present handle, when that is what is live.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn present_handle_mut(&mut self) -> Option<&mut PresentHandle> {
+        match &mut self.backend {
+            PresentBackend::Threaded(handle) => Some(handle),
+            _ => None,
+        }
+    }
+
+    /// Retire whatever present backend is live before a replacement init:
+    /// drain and fold in any pending threaded returns (their buffers are
+    /// still recyclable), shut the runtime down, and run the planner's
+    /// renderer-replacement hygiene — retained slots retired, confirmations
+    /// revoked, feed generation bumped — exactly as `init_gpu` always did
+    /// for a live sync renderer.
+    fn retire_live_backend(&mut self) {
+        #[allow(unused_mut)]
+        let mut backend = std::mem::replace(&mut self.backend, PresentBackend::None);
+        if matches!(backend, PresentBackend::None) {
+            return;
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            if let PresentBackend::Threaded(handle) = &mut backend {
+                // Early acks first (they precede their frames' returns);
+                // the imminent `renderer_replaced` revokes every
+                // confirmation anyway, but the buffers are still worth
+                // recycling.
+                while let Some((ack, recycled)) = handle.try_drain_ack() {
+                    let confirmations = crate::shape_replay::SHAPE_REPLAY
+                        .with(|state| state.borrow_mut().apply_ack(ack, recycled));
+                    self.stash_recycled_confirmations(confirmations);
+                }
+                while let Some(returns) = handle.try_drain() {
+                    if let Some(confirmations) = self.frontend.apply_returns(returns) {
+                        self.stash_recycled_confirmations(confirmations);
+                    }
+                }
+                handle.shutdown();
+            }
+            crate::shape_replay::SHAPE_REPLAY.with(|state| state.borrow_mut().renderer_replaced());
+            log::warn!(
+                "[command-feed] renderer replaced: retained slots retired, \
+                 confirmations revoked, feed generation bumped"
+            );
+        }
+        drop(backend);
+    }
+
+    /// Park a planner-drained confirmations buffer for the next packet,
+    /// keeping the larger capacity if one is somehow already parked.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn stash_recycled_confirmations(&mut self, confirmations: Vec<ReplayConfirmation>) {
+        match &self.pending_recycled_confirmations {
+            Some(parked) if parked.capacity() >= confirmations.capacity() => {}
+            _ => self.pending_recycled_confirmations = Some(confirmations),
+        }
+    }
+
+    /// Threaded mode: fold every pending early [`ReplayAck`] into the
+    /// planner (`frame_packet::ReplayAck` — confirmations register feed
+    /// slots, the batch's emptied buffers recycle). The present thread
+    /// sends these BEFORE surface acquire, so draining here — ahead of
+    /// the next `build_frame_packet` — gives a capture the same one-frame
+    /// confirmation latency the synchronous path has. Returns how many
+    /// acks were applied; no-op outside threaded mode.
+    ///
+    /// `pub` + hidden for the contract tests, which pin the ack arriving
+    /// AHEAD of its frame's returns; the renderer's own callers are
+    /// `publish_frame` and `drain_present_returns_with`
+    /// (`retire_live_backend` drains the channel inline while the backend
+    /// is detached).
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn drain_replay_acks(&mut self) -> usize {
+        let mut drained = 0;
+        loop {
+            let (ack, recycled) = {
+                let PresentBackend::Threaded(handle) = &mut self.backend else {
+                    break;
+                };
+                match handle.try_drain_ack() {
+                    Some(batch) => batch,
+                    None => break,
+                }
+            };
+            drained += 1;
+            let confirmations = crate::shape_replay::SHAPE_REPLAY
+                .with(|state| state.borrow_mut().apply_ack(ack, recycled));
+            self.stash_recycled_confirmations(confirmations);
+        }
+        drained
     }
 
     /// Initialize GPU resources with a WGPU device and queue.
@@ -284,14 +438,7 @@ impl WgpuRenderer {
         surface_format: wgpu::TextureFormat,
         adapter_backend: wgpu::Backend,
     ) {
-        #[cfg(not(target_arch = "wasm32"))]
-        if self.gpu_renderer.is_some() {
-            crate::shape_replay::SHAPE_REPLAY.with(|state| state.borrow_mut().renderer_replaced());
-            log::warn!(
-                "[command-feed] renderer replaced: retained slots retired, \
-                 confirmations revoked, feed generation bumped"
-            );
-        }
+        self.retire_live_backend();
         self.renderer_epoch = self.renderer_epoch.wrapping_add(1);
         // The new store adopts the producer's CURRENT feed generation —
         // read after `renderer_replaced` bumped it, so packets planned
@@ -300,7 +447,7 @@ impl WgpuRenderer {
         let store_feed_generation = pipeline::retained_feed_generation();
         #[cfg(target_arch = "wasm32")]
         let store_feed_generation = 0;
-        self.gpu_renderer = Some(GpuRenderer::new(
+        self.backend = PresentBackend::Sync(Box::new(GpuRenderer::new(
             device,
             queue,
             surface_format,
@@ -308,10 +455,13 @@ impl WgpuRenderer {
             self.frontend.text_fonts.clone(),
             self.renderer_epoch,
             store_feed_generation,
-        ));
+        )));
         #[cfg(not(target_arch = "wasm32"))]
-        if let Some(gpu_renderer) = self.gpu_renderer.as_mut() {
-            gpu_renderer.set_display_visible_region(self.display_visible_region);
+        {
+            let region = self.display_visible_region;
+            if let Some(gpu_renderer) = self.sync_gpu_renderer_mut() {
+                gpu_renderer.set_display_visible_region(region);
+            }
         }
     }
 
@@ -326,11 +476,102 @@ impl WgpuRenderer {
     /// clips) plug in as new region variants without touching the cull
     /// machinery. Default [`DisplayVisibleRegion::Full`]: rendering is
     /// bitwise identical to a renderer without this capability.
+    ///
+    /// Threaded mode routes the region to the present thread as a control
+    /// message; the message queue is FIFO, so it lands before any packet
+    /// published after this call — the same ordering the sync path's
+    /// direct call has.
     pub fn set_display_visible_region(&mut self, region: DisplayVisibleRegion) {
         self.display_visible_region = region;
         #[cfg(not(target_arch = "wasm32"))]
-        if let Some(gpu_renderer) = self.gpu_renderer.as_mut() {
-            gpu_renderer.set_display_visible_region(region);
+        match &mut self.backend {
+            PresentBackend::Sync(gpu_renderer) => {
+                gpu_renderer.set_display_visible_region(region);
+            }
+            PresentBackend::Threaded(handle) => {
+                handle.send_display_visible_region(region);
+            }
+            PresentBackend::None => {}
+        }
+    }
+
+    /// [`init_gpu`][Self::init_gpu] for the threaded present runtime
+    /// (Android): the same epoch bump and planner replacement hygiene, but
+    /// instead of constructing a `GpuRenderer` here, everything it needs —
+    /// all owned, all `Send` — crosses to a spawned present thread that
+    /// constructs its own (its `Rc` caches are thread-confined). Frames
+    /// then flow through [`publish_frame`][Self::publish_frame] /
+    /// [`drain_present_returns`][Self::drain_present_returns] under the
+    /// depth-one credit protocol instead of [`render`][Self::render].
+    ///
+    /// * `waker` — wakes the producer's event loop after every returns
+    ///   send (the Android frame waker).
+    /// * `clock` — producer's monotonic nanosecond clock, so present-side
+    ///   [`PresentTimings`] share the producer telemetry's clock domain;
+    ///   `None` leaves timings at zero.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn init_gpu_threaded(
+        &mut self,
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        surface_format: wgpu::TextureFormat,
+        adapter_backend: wgpu::Backend,
+        waker: Arc<dyn Fn() + Send + Sync>,
+        clock: Option<Arc<dyn Fn() -> i64 + Send + Sync>>,
+    ) -> Result<(), WgpuRendererError> {
+        self.retire_live_backend();
+        self.renderer_epoch = self.renderer_epoch.wrapping_add(1);
+        // As in `init_gpu`: read AFTER the hygiene bump.
+        let store_feed_generation = pipeline::retained_feed_generation();
+        let init = PresentRuntimeInit {
+            device,
+            queue,
+            surface_format,
+            adapter_backend,
+            text_fonts: self.frontend.text_fonts.clone(),
+            renderer_epoch: self.renderer_epoch,
+            store_feed_generation,
+            clock,
+            display_visible_region: self.display_visible_region,
+        };
+        let handle = PresentHandle::spawn(init, waker).map_err(WgpuRendererError::Wgpu)?;
+        self.backend = PresentBackend::Threaded(handle);
+        Ok(())
+    }
+
+    /// [`init_gpu_threaded`][Self::init_gpu_threaded] without the thread:
+    /// the state machine and its message queue are handed back for the
+    /// test to pump by hand — the same prepare/validate/present protocol,
+    /// deterministically observable.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn init_gpu_inline_for_tests(
+        &mut self,
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        surface_format: wgpu::TextureFormat,
+        adapter_backend: wgpu::Backend,
+    ) -> InlinePresentRuntime {
+        self.retire_live_backend();
+        self.renderer_epoch = self.renderer_epoch.wrapping_add(1);
+        let store_feed_generation = pipeline::retained_feed_generation();
+        let init = PresentRuntimeInit {
+            device,
+            queue,
+            surface_format,
+            adapter_backend,
+            text_fonts: self.frontend.text_fonts.clone(),
+            renderer_epoch: self.renderer_epoch,
+            store_feed_generation,
+            clock: None,
+            display_visible_region: self.display_visible_region,
+        };
+        let (handle, state, msg_rx) = PresentHandle::new_inline(init, Arc::new(|| {}));
+        self.backend = PresentBackend::Threaded(handle);
+        InlinePresentRuntime {
+            state,
+            msg_rx,
+            shutdown_seen: false,
         }
     }
 
@@ -364,9 +605,10 @@ impl WgpuRenderer {
         width: u32,
         height: u32,
     ) -> Result<(), WgpuRendererError> {
-        let Some(gpu_renderer) = self.gpu_renderer.as_mut() else {
+        let PresentBackend::Sync(gpu_renderer) = &mut self.backend else {
             return Err(WgpuRendererError::Wgpu(
-                "GPU renderer not initialized. Call init_gpu() first.".to_string(),
+                "GPU renderer not initialized for synchronous rendering. Call init_gpu() first."
+                    .to_string(),
             ));
         };
         let packet = self
@@ -416,9 +658,10 @@ impl WgpuRenderer {
         height: u32,
         root_scale: f32,
     ) -> Result<CapturedFrame, WgpuRendererError> {
-        let Some(gpu_renderer) = self.gpu_renderer.as_mut() else {
+        let PresentBackend::Sync(gpu_renderer) = &mut self.backend else {
             return Err(WgpuRendererError::Wgpu(
-                "GPU renderer not initialized. Call init_gpu() first.".to_string(),
+                "GPU renderer not initialized for synchronous rendering. Call init_gpu() first."
+                    .to_string(),
             ));
         };
         let packet = self
@@ -454,16 +697,307 @@ impl WgpuRenderer {
         })
     }
 
-    pub fn last_frame_stats(&self) -> Option<RenderStatsSnapshot> {
-        self.gpu_renderer
+    /// Threaded mode: whether the depth-one slot has room for a packet.
+    /// The Android loop checks this BEFORE `shell.update()` so
+    /// backpressure lands before the expensive update/lowering work.
+    /// Always `true` on the sync path, which has no slot to fill.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn has_frame_credit(&self) -> bool {
+        match &self.backend {
+            PresentBackend::Threaded(handle) => handle.has_credit(),
+            PresentBackend::Sync(_) | PresentBackend::None => true,
+        }
+    }
+
+    /// Threaded mode: lower the current scene into a packet and hand it to
+    /// the present runtime. Credit is checked FIRST — a `NoCredit` return
+    /// means no packet was built at all (`frame_sequence` does not
+    /// advance). Returns `NoCredit` (with an error log) when the renderer
+    /// is not in threaded mode.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn publish_frame(&mut self, width: u32, height: u32) -> PublishOutcome {
+        // Fold in every early replay ack BEFORE lowering: the collect
+        // inside `build_frame_packet` is where the bypass gate and
+        // `feed_slots` are read, so an ack applied here serves the very
+        // frame about to be planned — the same one-frame confirmation
+        // latency the sync path has (see `PresentState::consume_packet`).
+        self.drain_replay_acks();
+        let PresentBackend::Threaded(handle) = &mut self.backend else {
+            log::error!("publish_frame called without a threaded present runtime");
+            return PublishOutcome::NoCredit;
+        };
+        if !handle.has_credit() {
+            return PublishOutcome::NoCredit;
+        }
+        let replay_supported = handle
+            .status()
+            .replay_supported
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let Some(mut packet) = self.frontend.build_frame_packet(
+            width,
+            height,
+            replay_supported,
+            self.renderer_epoch,
+            self.surface_epoch,
+        ) else {
+            return PublishOutcome::NoGraph;
+        };
+        packet.recycled_confirmations = self.pending_recycled_confirmations.take();
+        match handle.publish(packet) {
+            Ok(()) => PublishOutcome::Published,
+            Err(mut packet) => {
+                // The runtime is gone (panic/shutdown race). Recover every
+                // buffer the packet carried instead of leaking it.
+                if let Some(confirmations) = packet.recycled_confirmations.take() {
+                    self.pending_recycled_confirmations = Some(confirmations);
+                }
+                let mut returns = RenderReturns::default();
+                let _ = GpuRenderer::cancel_packet(
+                    *packet,
+                    CancelReason::SurfaceUnavailable,
+                    &mut returns,
+                );
+                if let Some(confirmations) = self.frontend.apply_returns(returns) {
+                    self.stash_recycled_confirmations(confirmations);
+                }
+                log::error!("present runtime unavailable; frame recovered, not published");
+                PublishOutcome::NoCredit
+            }
+        }
+    }
+
+    /// Threaded mode: fold every pending [`RenderReturns`] back into
+    /// producer state (scene recycling, replay ack, planner re-queue of
+    /// cancelled plans) and free the publish credit. Returns how many were
+    /// drained. No-op outside threaded mode.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn drain_present_returns(&mut self) -> usize {
+        self.drain_present_returns_with(&mut |_, _, _| {})
+    }
+
+    /// [`drain_present_returns`][Self::drain_present_returns], reporting
+    /// each drained frame's id, outcome and present-thread timings — the
+    /// Android loop feeds its frame telemetry from this.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn drain_present_returns_with(
+        &mut self,
+        on_return: &mut dyn FnMut(u64, PresentOutcome, PresentTimings),
+    ) -> usize {
+        // Acks first: a frame's early ack always precedes its returns, and
+        // draining both here keeps the ack channel empty across idle
+        // iterations that never reach `publish_frame`.
+        self.drain_replay_acks();
+        let mut drained = 0;
+        loop {
+            // Scoped so the handle borrow ends before `apply_returns`
+            // needs the frontend through `&mut self`.
+            let returns = {
+                let PresentBackend::Threaded(handle) = &mut self.backend else {
+                    break;
+                };
+                match handle.try_drain() {
+                    Some(returns) => returns,
+                    None => break,
+                }
+            };
+            drained += 1;
+            let frame_id = returns.frame_id;
+            let outcome = returns.outcome;
+            let timings = returns.timings;
+            if let Some(confirmations) = self.frontend.apply_returns(returns) {
+                self.stash_recycled_confirmations(confirmations);
+            }
+            on_return(frame_id, outcome, timings);
+        }
+        drained
+    }
+
+    /// Threaded mode: install a (re)created surface on the present thread
+    /// and wait for the acknowledgement. The caller must have bumped the
+    /// surface epoch first ([`note_surface_reconfigured`]
+    /// [Self::note_surface_reconfigured]) when the message invalidates
+    /// in-flight packets; the message carries the current epoch.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn present_replace_surface(
+        &mut self,
+        surface: wgpu::Surface<'static>,
+        config: wgpu::SurfaceConfiguration,
+    ) -> bool {
+        let surface_epoch = self.surface_epoch;
+        let Some(handle) = self.present_handle_mut() else {
+            log::error!("present_replace_surface called without a threaded present runtime");
+            return false;
+        };
+        handle.send_control_and_wait(
+            move |ack| PresentControl::ReplaceSurface {
+                surface,
+                config,
+                surface_epoch,
+                ack,
+            },
+            "replace surface",
+        )
+    }
+
+    /// Threaded mode: reconfigure the present thread's surface (resize)
+    /// and wait for the acknowledgement. Same epoch contract as
+    /// [`present_replace_surface`][Self::present_replace_surface].
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn present_reconfigure(&mut self, config: wgpu::SurfaceConfiguration) -> bool {
+        let surface_epoch = self.surface_epoch;
+        let Some(handle) = self.present_handle_mut() else {
+            log::error!("present_reconfigure called without a threaded present runtime");
+            return false;
+        };
+        handle.send_control_and_wait(
+            move |ack| PresentControl::Reconfigure {
+                config,
+                surface_epoch,
+                ack,
+            },
+            "reconfigure surface",
+        )
+    }
+
+    /// Threaded mode: drop the present thread's surface (the window died;
+    /// the renderer survives for the next one) and wait for the
+    /// acknowledgement. Bump the epoch first so in-flight packets cancel.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn present_drop_surface(&mut self) -> bool {
+        let Some(handle) = self.present_handle_mut() else {
+            log::error!("present_drop_surface called without a threaded present runtime");
+            return false;
+        };
+        handle.send_control_and_wait(|ack| PresentControl::DropSurface { ack }, "drop surface")
+    }
+
+    /// Threaded mode: drain outstanding returns, stop the present thread
+    /// and join it. The renderer returns to the uninitialized state.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn shutdown_present_runtime(&mut self) {
+        if matches!(self.backend, PresentBackend::Threaded(_)) {
+            self.retire_live_backend();
+        }
+    }
+
+    /// Test hook: attach the present runtime's offscreen surrogate target
+    /// so packets render headlessly, and wait for the acknowledgement.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn present_attach_offscreen_for_tests(&mut self, width: u32, height: u32) -> bool {
+        let Some(handle) = self.present_handle_mut() else {
+            return false;
+        };
+        handle.send_control_and_wait(
+            move |ack| PresentControl::AttachOffscreenTargetForTests { width, height, ack },
+            "attach offscreen target",
+        )
+    }
+
+    /// Test hook: send the offscreen-target attach WITHOUT waiting for
+    /// the ack — the inline mode has no thread to ack until pumped.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn send_attach_offscreen_unacked_for_tests(
+        &mut self,
+        width: u32,
+        height: u32,
+    ) -> Option<std::sync::mpsc::Receiver<()>> {
+        let handle = self.present_handle_mut()?;
+        handle.send_control_unacked(move |ack| PresentControl::AttachOffscreenTargetForTests {
+            width,
+            height,
+            ack,
+        })
+    }
+
+    /// Test hook: send a `Reconfigure` WITHOUT waiting for the ack,
+    /// returning the ack receiver — the inline protocol tests assert the
+    /// invalidation-before-ack ordering with it.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn send_reconfigure_unacked_for_tests(
+        &mut self,
+        config: wgpu::SurfaceConfiguration,
+    ) -> Option<std::sync::mpsc::Receiver<()>> {
+        let surface_epoch = self.surface_epoch;
+        let handle = self.present_handle_mut()?;
+        handle.send_control_unacked(move |ack| PresentControl::Reconfigure {
+            config,
+            surface_epoch,
+            ack,
+        })
+    }
+
+    /// Test hook: send a `DropSurface` WITHOUT waiting for the ack.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn send_drop_surface_unacked_for_tests(&mut self) -> Option<std::sync::mpsc::Receiver<()>> {
+        let handle = self.present_handle_mut()?;
+        handle.send_control_unacked(|ack| PresentControl::DropSurface { ack })
+    }
+
+    /// The producer's monotone packet sequence: the `frame_id` stamped on
+    /// the most recently lowered packet. After a `Published` outcome this
+    /// is the published frame's id (the Android loop keys its telemetry on
+    /// it); it also proves a `NoCredit` publish never lowered a frame.
+    pub fn last_published_frame_id(&self) -> u64 {
+        self.frontend.frame_sequence
+    }
+
+    /// Test hook: park a recycled-confirmations buffer with `capacity` as
+    /// if a previous frame's ack had been drained — the capacity
+    /// round-trip test's deterministic seed (a real confirmed capture
+    /// needs the multi-frame verification heuristics).
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn seed_recycled_confirmations_for_tests(&mut self, capacity: usize) {
+        self.pending_recycled_confirmations = Some(Vec::with_capacity(capacity));
+    }
+
+    /// Test inspector: capacity of the parked recycled-confirmations
+    /// buffer (`None` when nothing is parked — e.g. right after a publish
+    /// carried it back to the store).
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn pending_recycled_confirmations_capacity_for_tests(&self) -> Option<usize> {
+        self.pending_recycled_confirmations
             .as_ref()
+            .map(Vec::capacity)
+    }
+
+    /// Test inspector: the shared present-status snapshot's
+    /// (needs_frame_warmup, replay_supported, presented_frames) triple.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn present_status_snapshot_for_tests(&self) -> Option<(bool, bool, u64)> {
+        match &self.backend {
+            PresentBackend::Threaded(handle) => {
+                let status = handle.status();
+                Some((
+                    status
+                        .needs_frame_warmup
+                        .load(std::sync::atomic::Ordering::Relaxed),
+                    status
+                        .replay_supported
+                        .load(std::sync::atomic::Ordering::Relaxed),
+                    status
+                        .presented_frames
+                        .load(std::sync::atomic::Ordering::Relaxed),
+                ))
+            }
+            _ => None,
+        }
+    }
+
+    pub fn last_frame_stats(&self) -> Option<RenderStatsSnapshot> {
+        self.sync_gpu_renderer()
             .and_then(GpuRenderer::last_frame_stats)
     }
 
     pub fn debug_cpu_allocation_stats(&self) -> DebugCpuAllocationStats {
         let mut stats = self
-            .gpu_renderer
-            .as_ref()
+            .sync_gpu_renderer()
             .map(GpuRenderer::debug_cpu_allocation_stats)
             .unwrap_or_default();
         stats.scene_graph_node_count = self
@@ -497,8 +1031,10 @@ impl WgpuRenderer {
     }
 
     /// Return the WGPU device when GPU resources are initialized.
+    /// Sync backend only (desktop/web reconfigure paths); the threaded
+    /// runtime owns its device on the present thread.
     pub fn try_device(&self) -> Option<&wgpu::Device> {
-        self.gpu_renderer.as_ref().map(|r| &*r.device)
+        self.sync_gpu_renderer().map(|r| &*r.device)
     }
 
     /// Test/diagnostic view of the latched instanced-quad selection: `true`
@@ -508,8 +1044,7 @@ impl WgpuRenderer {
     #[cfg(not(target_arch = "wasm32"))]
     #[doc(hidden)]
     pub fn instanced_quads_active(&self) -> bool {
-        self.gpu_renderer
-            .as_ref()
+        self.sync_gpu_renderer()
             .is_some_and(GpuRenderer::instanced_quads_active)
     }
 
@@ -518,8 +1053,7 @@ impl WgpuRenderer {
     #[cfg(not(target_arch = "wasm32"))]
     #[doc(hidden)]
     pub fn replay_slot_mesh_stats(&self) -> (usize, usize) {
-        self.gpu_renderer
-            .as_ref()
+        self.sync_gpu_renderer()
             .map(GpuRenderer::replay_slot_mesh_stats)
             .unwrap_or((0, 0))
     }
@@ -530,8 +1064,7 @@ impl WgpuRenderer {
     #[cfg(not(target_arch = "wasm32"))]
     #[doc(hidden)]
     pub fn replay_slot_mesh_engagement(&self) -> (usize, usize, usize) {
-        self.gpu_renderer
-            .as_ref()
+        self.sync_gpu_renderer()
             .map(GpuRenderer::replay_slot_mesh_engagement)
             .unwrap_or((0, 0, 0))
     }
@@ -541,8 +1074,7 @@ impl WgpuRenderer {
     #[cfg(not(target_arch = "wasm32"))]
     #[doc(hidden)]
     pub fn retained_bundle_stats(&self) -> (u64, u64) {
-        self.gpu_renderer
-            .as_ref()
+        self.sync_gpu_renderer()
             .map(GpuRenderer::retained_bundle_stats)
             .unwrap_or((0, 0))
     }
@@ -553,8 +1085,7 @@ impl WgpuRenderer {
     #[cfg(not(target_arch = "wasm32"))]
     #[doc(hidden)]
     pub fn rim_meshes_emitted(&self) -> u64 {
-        self.gpu_renderer
-            .as_ref()
+        self.sync_gpu_renderer()
             .map(GpuRenderer::rim_meshes_emitted)
             .unwrap_or(0)
     }
@@ -566,8 +1097,7 @@ impl WgpuRenderer {
     #[cfg(not(target_arch = "wasm32"))]
     #[doc(hidden)]
     pub fn static_span_stats(&self) -> (u64, u64) {
-        self.gpu_renderer
-            .as_ref()
+        self.sync_gpu_renderer()
             .map(GpuRenderer::static_span_stats)
             .unwrap_or((0, 0))
     }
@@ -579,8 +1109,7 @@ impl WgpuRenderer {
     #[cfg(not(target_arch = "wasm32"))]
     #[doc(hidden)]
     pub fn replay_generation_drops_for_tests(&self) -> u64 {
-        self.gpu_renderer
-            .as_ref()
+        self.sync_gpu_renderer()
             .map(GpuRenderer::replay_generation_drops)
             .unwrap_or(0)
     }
@@ -595,8 +1124,7 @@ impl WgpuRenderer {
     #[cfg(not(target_arch = "wasm32"))]
     #[doc(hidden)]
     pub fn replay_ops_roundtrip_for_tests(&mut self, generation_skew: u64) -> usize {
-        self.gpu_renderer
-            .as_mut()
+        self.sync_gpu_renderer_mut()
             .expect("GPU renderer not initialized")
             .replay_ops_roundtrip_for_tests(generation_skew)
     }
@@ -612,10 +1140,15 @@ impl WgpuRenderer {
         width: u32,
         height: u32,
     ) -> Option<HeldFramePacket> {
-        let replay_supported = self
-            .gpu_renderer
-            .as_ref()
-            .is_some_and(GpuRenderer::replay_supported);
+        let replay_supported = match &self.backend {
+            PresentBackend::Sync(gpu_renderer) => gpu_renderer.replay_supported(),
+            #[cfg(not(target_arch = "wasm32"))]
+            PresentBackend::Threaded(handle) => handle
+                .status()
+                .replay_supported
+                .load(std::sync::atomic::Ordering::Relaxed),
+            PresentBackend::None => false,
+        };
         self.frontend
             .build_frame_packet(
                 width,
@@ -638,9 +1171,10 @@ impl WgpuRenderer {
         height: u32,
         packet: HeldFramePacket,
     ) -> Result<PresentOutcome, WgpuRendererError> {
-        let Some(gpu_renderer) = self.gpu_renderer.as_mut() else {
+        let PresentBackend::Sync(gpu_renderer) = &mut self.backend else {
             return Err(WgpuRendererError::Wgpu(
-                "GPU renderer not initialized. Call init_gpu() first.".to_string(),
+                "GPU renderer not initialized for synchronous rendering. Call init_gpu() first."
+                    .to_string(),
             ));
         };
         let frontend = &mut self.frontend;
@@ -665,7 +1199,7 @@ impl WgpuRenderer {
     /// the cancellation contract's proof the packet's scene came back.
     #[doc(hidden)]
     pub fn has_retained_direct_scene_for_tests(&self) -> bool {
-        self.frontend.retained_direct_scene.is_some()
+        !self.frontend.retained_direct_scenes.is_empty()
     }
 }
 
@@ -673,6 +1207,74 @@ impl WgpuRenderer {
 /// cancellation-protocol tests only.
 #[doc(hidden)]
 pub struct HeldFramePacket(frame_packet::FramePacket);
+
+/// The present runtime's state machine WITHOUT its thread, handed out by
+/// [`WgpuRenderer::init_gpu_inline_for_tests`]: the protocol tests pump
+/// the message queue by hand and inspect present-side state directly.
+#[cfg(not(target_arch = "wasm32"))]
+#[doc(hidden)]
+pub struct InlinePresentRuntime {
+    state: PresentState,
+    msg_rx: std::sync::mpsc::Receiver<PresentMsg>,
+    shutdown_seen: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl InlinePresentRuntime {
+    /// Process every pending message exactly like one wakeful pass of the
+    /// present thread's loop (controls drained against the waiting packet
+    /// first, then the packet consumes). Returns `false` once `Shutdown`
+    /// has been processed.
+    pub fn pump(&mut self) -> bool {
+        if self.shutdown_seen {
+            return false;
+        }
+        while let Ok(msg) = self.msg_rx.try_recv() {
+            if !self.state.run_once(msg) {
+                self.shutdown_seen = true;
+                return false;
+            }
+        }
+        self.state.consume_waiting();
+        true
+    }
+
+    /// Whether a packet sits unconsumed in the depth-one slot (only
+    /// observable between a partial pump's steps; `pump` always consumes).
+    pub fn has_waiting_packet(&self) -> bool {
+        self.state.has_waiting_packet()
+    }
+
+    /// Receive and process exactly one queued message (no packet
+    /// consumption) — for tests that need to interleave control against a
+    /// waiting packet.
+    pub fn step_one_message(&mut self) -> bool {
+        if self.shutdown_seen {
+            return false;
+        }
+        match self.msg_rx.try_recv() {
+            Ok(msg) => {
+                if !self.state.run_once(msg) {
+                    self.shutdown_seen = true;
+                }
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Consume the waiting packet, if any, exactly like the thread loop's
+    /// idle branch.
+    pub fn consume_waiting(&mut self) {
+        self.state.consume_waiting();
+    }
+
+    /// Store-side ack confirmations buffer capacity — the threaded
+    /// capacity round-trip's observable end state.
+    pub fn store_ack_confirmations_capacity(&self) -> usize {
+        self.state.store_ack_confirmations_capacity()
+    }
+}
 
 impl Default for WgpuRenderer {
     fn default() -> Self {
@@ -801,9 +1403,18 @@ impl Renderer for WgpuRenderer {
     }
 
     fn needs_frame_warmup(&self) -> bool {
-        self.gpu_renderer
-            .as_ref()
-            .is_some_and(GpuRenderer::needs_frame_warmup)
+        match &self.backend {
+            PresentBackend::Sync(gpu_renderer) => gpu_renderer.needs_frame_warmup(),
+            // The producer reads this every loop iteration; in threaded
+            // mode it is the present thread's atomic snapshot, never the
+            // renderer itself.
+            #[cfg(not(target_arch = "wasm32"))]
+            PresentBackend::Threaded(handle) => handle
+                .status()
+                .needs_frame_warmup
+                .load(std::sync::atomic::Ordering::Relaxed),
+            PresentBackend::None => false,
+        }
     }
 }
 

--- a/crates/cranpose-render/wgpu/src/present_runtime.rs
+++ b/crates/cranpose-render/wgpu/src/present_runtime.rs
@@ -1,0 +1,886 @@
+//! The present runtime (pipeline step 7b): the depth-one packet slot and
+//! the thread that owns the present stage on Android.
+//!
+//! The producer ([`WgpuRenderer`](crate::WgpuRenderer)) publishes at most
+//! one [`FramePacket`] into the runtime and may not publish another until
+//! the packet's [`RenderReturns`] have been drained — backpressure lands
+//! BEFORE the expensive update/lowering work, not after. The runtime
+//! exclusively owns the `GpuRenderer` (constructed ON the present thread —
+//! its `Rc` caches are thread-confined), the surface, surface
+//! configuration, acquisition, encoding, submission and `present()`.
+//!
+//! Surface lifecycle changes arrive as typed [`PresentControl`] messages.
+//! An invalidating control message (replace/reconfigure/drop) is
+//! acknowledged ONLY AFTER any packet waiting in the slot has been
+//! cancelled and its returns sent, so the producer can trust that nothing
+//! stale renders once it publishes under the new epoch.
+//!
+//! The same state machine runs without a thread: tests construct
+//! [`PresentState`] inline (via `WgpuRenderer::init_gpu_inline_for_tests`)
+//! and pump the message queue by hand, so every protocol path is
+//! observable deterministically.
+
+use crate::display_clip::DisplayVisibleRegion;
+use crate::frame_packet::{
+    CancelReason, FramePacket, PresentOutcome, PresentTimings, RenderReturns, ReplayAck,
+    ReplayFrameOps,
+};
+use crate::render::GpuRenderer;
+use cranpose_render_common::software_text_raster::SoftwareTextFontSet;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{
+    channel, sync_channel, Receiver, RecvTimeoutError, Sender, SyncSender, TryRecvError,
+    TrySendError,
+};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Wakes the producer's event loop after the runtime sends returns (the
+/// Android frame waker: `Send + Sync`, installed at runtime init).
+pub(crate) type PresentWaker = Arc<dyn Fn() + Send + Sync>;
+
+/// Producer-injected monotonic clock, nanoseconds. Injected (rather than
+/// read locally) so present-thread timestamps live in the SAME clock
+/// domain as the producer's frame telemetry; `None` leaves every
+/// [`PresentTimings`] stage at `0`.
+pub(crate) type PresentClock = Arc<dyn Fn() -> i64 + Send + Sync>;
+
+/// How long the producer waits for a control acknowledgement. The ack is
+/// near-immediate in a healthy runtime (the present thread never blocks on
+/// anything but `get_current_texture`), so this is generous on purpose:
+/// hitting it means the runtime is wedged, which is logged, not fatal.
+pub(crate) const CONTROL_ACK_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// One frame's [`ReplayAck`] plus the batch's emptied op buffers, sent to
+/// the producer on its own channel as soon as the store consumed the ops —
+/// BEFORE surface acquire and everything after it — so the confirmations
+/// reach the very next frame's planning (see `consume_packet`).
+pub(crate) type ReplayAckBatch = (ReplayAck, ReplayFrameOps);
+
+/// Everything the present thread needs to construct its own
+/// [`GpuRenderer`]; every member is `Send` (proven below).
+pub(crate) struct PresentRuntimeInit {
+    pub(crate) device: Arc<wgpu::Device>,
+    pub(crate) queue: Arc<wgpu::Queue>,
+    pub(crate) surface_format: wgpu::TextureFormat,
+    pub(crate) adapter_backend: wgpu::Backend,
+    pub(crate) text_fonts: SoftwareTextFontSet,
+    pub(crate) renderer_epoch: u64,
+    pub(crate) store_feed_generation: u64,
+    pub(crate) clock: Option<PresentClock>,
+    /// The producer's current display visible region, inherited at
+    /// construction exactly as `init_gpu` hands it to a fresh sync
+    /// renderer; later changes arrive as
+    /// [`PresentControl::SetDisplayVisibleRegion`].
+    pub(crate) display_visible_region: DisplayVisibleRegion,
+}
+
+/// Surface-lifecycle control messages. Each invalidation carries the NEW
+/// surface epoch stamped by the producer (`note_surface_reconfigured` is
+/// the counter authority) and an ack the runtime fires only after the
+/// waiting packet — if any — has been cancelled and its returns sent.
+pub(crate) enum PresentControl {
+    /// Install a (re)created surface; also delivers the initial surface.
+    ReplaceSurface {
+        surface: wgpu::Surface<'static>,
+        config: wgpu::SurfaceConfiguration,
+        surface_epoch: u64,
+        ack: SyncSender<()>,
+    },
+    /// Reconfigure the current surface (resize) without replacing it.
+    Reconfigure {
+        config: wgpu::SurfaceConfiguration,
+        surface_epoch: u64,
+        ack: SyncSender<()>,
+    },
+    /// The window died (`TerminateWindow`): the surface drops, the
+    /// renderer and its caches live on for the next window.
+    DropSurface { ack: SyncSender<()> },
+    /// The platform's display visible region changed (round-display
+    /// providers etc.). Not invalidating and ack-less: the channel is FIFO,
+    /// so it applies before any packet published after the producer's call
+    /// — the same ordering the sync path's direct renderer call has.
+    SetDisplayVisibleRegion { region: DisplayVisibleRegion },
+    /// Test-only surrogate swapchain: packets render into an offscreen
+    /// texture of this size instead of a real surface, so the protocol is
+    /// testable headlessly. Invalidating, like `ReplaceSurface`.
+    #[doc(hidden)]
+    AttachOffscreenTargetForTests {
+        width: u32,
+        height: u32,
+        ack: SyncSender<()>,
+    },
+    /// Drop the surface, drop the renderer (both on the present thread),
+    /// exit the loop.
+    Shutdown,
+}
+
+/// One message from the producer. Control and packets ride one FIFO so
+/// the runtime can block on a single receiver; priority is enforced by the
+/// waiting-packet slot: a packet is held, every already-queued control
+/// message is processed against it (cancelling it if invalidating), and
+/// only then does it render.
+// A packet moves through here once per frame; boxing it to appease
+// `large_enum_variant` would buy the smaller enum with a per-frame
+// allocation, which the packet protocol exists to avoid.
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum PresentMsg {
+    Control(PresentControl),
+    Packet(FramePacket),
+}
+
+/// Producer-readable snapshot of present-thread state. Every producer read
+/// is `Relaxed`: each field is an independent monotone-ish signal, not a
+/// synchronization point.
+#[derive(Default)]
+pub(crate) struct PresentStatus {
+    /// Mirror of `GpuRenderer::needs_frame_warmup`, updated after every
+    /// consumed packet — the producer reads it every loop iteration via
+    /// `AppShell::needs_redraw` and must never touch the renderer.
+    pub(crate) needs_frame_warmup: AtomicBool,
+    /// Immutable capability, published once when the runtime constructs
+    /// its renderer.
+    pub(crate) replay_supported: AtomicBool,
+    /// Lifetime count of packets that reached `PresentOutcome::Presented`.
+    pub(crate) presented_frames: AtomicU64,
+    /// The last consumed packet's outcome, encoded with its frame id — see
+    /// [`encode_present_outcome`].
+    pub(crate) last_present_outcome: AtomicU64,
+    /// `frame_id` of the last packet whose draw errored (`0` = never).
+    pub(crate) last_error_frame: AtomicU64,
+}
+
+/// Encode an outcome + frame id into one atomic word: outcome code in the
+/// low 8 bits, frame id (wrapping) above.
+pub(crate) fn encode_present_outcome(outcome: PresentOutcome, frame_id: u64) -> u64 {
+    let code: u64 = match outcome {
+        PresentOutcome::NotRun => 0,
+        PresentOutcome::Presented => 1,
+        PresentOutcome::Cancelled(CancelReason::RendererEpoch) => 2,
+        PresentOutcome::Cancelled(CancelReason::SurfaceEpoch) => 3,
+        PresentOutcome::Cancelled(CancelReason::Viewport) => 4,
+        PresentOutcome::Cancelled(CancelReason::SurfaceUnavailable) => 5,
+    };
+    (frame_id << 8) | code
+}
+
+/// The present stage's state machine: one `GpuRenderer` (constructed here,
+/// on whichever thread runs this), the current surface + configuration,
+/// the runtime's own surface-epoch copy, and the depth-one waiting slot.
+pub(crate) struct PresentState {
+    gpu_renderer: GpuRenderer,
+    device: Arc<wgpu::Device>,
+    surface: Option<wgpu::Surface<'static>>,
+    config: Option<wgpu::SurfaceConfiguration>,
+    /// Test-only surrogate swapchain (see
+    /// [`PresentControl::AttachOffscreenTargetForTests`]).
+    offscreen_target: Option<(u32, u32)>,
+    /// The renderer epoch this runtime was built under; packets from
+    /// another instance cancel before any GPU work.
+    renderer_epoch: u64,
+    /// The runtime's copy of the surface epoch, updated by control
+    /// messages; a waiting packet stamped with an older value cancels.
+    surface_epoch: u64,
+    /// THE depth-one slot: the packet received but not yet consumed.
+    waiting_packet: Option<FramePacket>,
+    returns_tx: SyncSender<RenderReturns>,
+    /// The early replay-ack channel: one [`ReplayAckBatch`] per consumed
+    /// Direct packet, sent BEFORE surface acquire so the producer's next
+    /// planning sees this frame's confirmations (the confirmation-latency
+    /// fix that made depth-one overlap pay — see `consume_packet`).
+    acks_tx: SyncSender<ReplayAckBatch>,
+    status: Arc<PresentStatus>,
+    waker: PresentWaker,
+    clock: Option<PresentClock>,
+}
+
+impl PresentState {
+    pub(crate) fn new(
+        init: PresentRuntimeInit,
+        returns_tx: SyncSender<RenderReturns>,
+        acks_tx: SyncSender<ReplayAckBatch>,
+        status: Arc<PresentStatus>,
+        waker: PresentWaker,
+    ) -> Self {
+        let PresentRuntimeInit {
+            device,
+            queue,
+            surface_format,
+            adapter_backend,
+            text_fonts,
+            renderer_epoch,
+            store_feed_generation,
+            clock,
+            display_visible_region,
+        } = init;
+        // The renderer is constructed HERE — on the present thread when
+        // spawned, inline in tests — because its Rc caches are
+        // thread-confined and must never move.
+        let mut gpu_renderer = GpuRenderer::new(
+            device.clone(),
+            queue,
+            surface_format,
+            adapter_backend,
+            text_fonts,
+            renderer_epoch,
+            store_feed_generation,
+        );
+        // Inherited exactly as `init_gpu` hands the producer's stored
+        // region to a fresh sync renderer.
+        gpu_renderer.set_display_visible_region(display_visible_region);
+        // `replay_supported` is immutable after construction: published
+        // once, read by every producer-side packet build.
+        status
+            .replay_supported
+            .store(gpu_renderer.replay_supported(), Ordering::Relaxed);
+        Self {
+            gpu_renderer,
+            device,
+            surface: None,
+            config: None,
+            offscreen_target: None,
+            renderer_epoch,
+            surface_epoch: 0,
+            waiting_packet: None,
+            returns_tx,
+            acks_tx,
+            status,
+            waker,
+            clock,
+        }
+    }
+
+    /// The blocking runtime loop: park on the message queue while the slot
+    /// is empty; while a packet waits, drain every already-queued message
+    /// (control first, by construction) and only then consume the packet.
+    pub(crate) fn run(mut self, rx: Receiver<PresentMsg>) {
+        loop {
+            let msg = if self.waiting_packet.is_some() {
+                match rx.try_recv() {
+                    Ok(msg) => Some(msg),
+                    Err(TryRecvError::Empty) => None,
+                    Err(TryRecvError::Disconnected) => break,
+                }
+            } else {
+                match rx.recv() {
+                    Ok(msg) => Some(msg),
+                    Err(_) => break,
+                }
+            };
+            match msg {
+                Some(msg) => {
+                    if !self.run_once(msg) {
+                        break;
+                    }
+                }
+                None => self.consume_waiting(),
+            }
+        }
+        // Falling out of the loop drops the surface and the GpuRenderer on
+        // this thread — the shutdown contract.
+    }
+
+    /// Process one message. Returns `false` when the runtime must exit.
+    pub(crate) fn run_once(&mut self, msg: PresentMsg) -> bool {
+        match msg {
+            PresentMsg::Control(control) => self.handle_control(control),
+            PresentMsg::Packet(packet) => {
+                if self.waiting_packet.is_some() {
+                    // Legal at depth two: the producer published N+1 while
+                    // N still waited. Consume the older one first — FIFO
+                    // order is the protocol, and neither packet may be
+                    // overwritten or dropped.
+                    self.consume_waiting();
+                }
+                self.waiting_packet = Some(packet);
+                true
+            }
+        }
+    }
+
+    pub(crate) fn has_waiting_packet(&self) -> bool {
+        self.waiting_packet.is_some()
+    }
+
+    /// Consume the waiting packet, if any: validate, acquire late, render,
+    /// present, send returns.
+    pub(crate) fn consume_waiting(&mut self) {
+        if let Some(packet) = self.waiting_packet.take() {
+            self.consume_packet(packet);
+        }
+    }
+
+    fn handle_control(&mut self, control: PresentControl) -> bool {
+        match control {
+            PresentControl::ReplaceSurface {
+                surface,
+                config,
+                surface_epoch,
+                ack,
+            } => {
+                self.surface_epoch = surface_epoch;
+                // Invalidation-before-ack: the waiting packet's returns
+                // are sent BEFORE the producer's ack fires, so a producer
+                // that publishes under the new epoch after the ack can
+                // never race a stale render.
+                self.cancel_waiting(CancelReason::SurfaceEpoch);
+                surface.configure(&self.device, &config);
+                self.surface = Some(surface);
+                self.config = Some(config);
+                self.offscreen_target = None;
+                let _ = ack.send(());
+                true
+            }
+            PresentControl::Reconfigure {
+                config,
+                surface_epoch,
+                ack,
+            } => {
+                self.surface_epoch = surface_epoch;
+                self.cancel_waiting(CancelReason::SurfaceEpoch);
+                if let Some(surface) = self.surface.as_ref() {
+                    surface.configure(&self.device, &config);
+                }
+                if self.offscreen_target.is_some() {
+                    self.offscreen_target = Some((config.width, config.height));
+                }
+                self.config = Some(config);
+                let _ = ack.send(());
+                true
+            }
+            PresentControl::DropSurface { ack } => {
+                // The surface dies; the renderer and its caches live on
+                // for the next window. A waiting packet cannot render at
+                // all — cancel it directly, no GPU touched.
+                self.cancel_waiting(CancelReason::SurfaceUnavailable);
+                self.surface = None;
+                self.config = None;
+                self.offscreen_target = None;
+                let _ = ack.send(());
+                true
+            }
+            PresentControl::SetDisplayVisibleRegion { region } => {
+                // A packet published before this change must draw under
+                // the region it was built for, exactly as on the sync path
+                // (where the region call sits between two render calls) —
+                // so the waiting packet consumes first, then the region
+                // applies to everything after it.
+                self.consume_waiting();
+                self.gpu_renderer.set_display_visible_region(region);
+                true
+            }
+            PresentControl::AttachOffscreenTargetForTests { width, height, ack } => {
+                self.cancel_waiting(CancelReason::SurfaceEpoch);
+                self.surface = None;
+                self.config = None;
+                self.offscreen_target = Some((width, height));
+                let _ = ack.send(());
+                true
+            }
+            PresentControl::Shutdown => {
+                // A packet still waiting at shutdown is cancelled so its
+                // buffers travel back if the producer is still listening.
+                self.cancel_waiting(CancelReason::SurfaceUnavailable);
+                false
+            }
+        }
+    }
+
+    /// The CPU-only validity gate, mirroring `GpuRenderer::render`'s head
+    /// so a doomed packet never reaches `get_current_texture`.
+    fn validate(&self, packet: &FramePacket) -> Option<CancelReason> {
+        if packet.renderer_epoch != self.renderer_epoch {
+            Some(CancelReason::RendererEpoch)
+        } else if packet.surface_epoch != self.surface_epoch {
+            Some(CancelReason::SurfaceEpoch)
+        } else if let Some((width, height)) = self.target_size() {
+            (packet.viewport != (width, height)).then_some(CancelReason::Viewport)
+        } else {
+            Some(CancelReason::SurfaceUnavailable)
+        }
+    }
+
+    fn target_size(&self) -> Option<(u32, u32)> {
+        if self.surface.is_some() {
+            self.config
+                .as_ref()
+                .map(|config| (config.width, config.height))
+        } else {
+            self.offscreen_target
+        }
+    }
+
+    /// Cancel the waiting packet (if any) with the validation head's
+    /// reason, falling back to `fallback` when the packet would otherwise
+    /// still validate — an invalidating control message must cancel it
+    /// regardless.
+    fn cancel_waiting(&mut self, fallback: CancelReason) {
+        if let Some(packet) = self.waiting_packet.take() {
+            let reason = self.validate(&packet).unwrap_or(fallback);
+            self.cancel_packet(packet, reason);
+        }
+    }
+
+    /// Refuse a packet without touching the GPU. The recycled
+    /// confirmations buffer is adopted into the store first (capacity must
+    /// not leak with the packet), then the 7a cancel path returns every
+    /// buffer through `returns`.
+    fn cancel_packet(&mut self, mut packet: FramePacket, reason: CancelReason) {
+        if let Some(confirmations) = packet.recycled_confirmations.take() {
+            self.gpu_renderer
+                .restore_replay_ack_confirmations(confirmations);
+        }
+        let mut returns = RenderReturns::default();
+        let _ = GpuRenderer::cancel_packet(packet, reason, &mut returns);
+        self.finish_returns(returns);
+    }
+
+    fn consume_packet(&mut self, mut packet: FramePacket) {
+        if let Some(reason) = self.validate(&packet) {
+            self.cancel_packet(packet, reason);
+            return;
+        }
+        // EARLY REPLAY ACK — the fix for the confirmation latency that
+        // sank the first 7b attempt. The store consumes the (validated)
+        // packet's replay plan NOW, before `get_current_texture` can block
+        // on the swapchain, and the ack leaves immediately on its own
+        // channel: the producer, which starts building frame N+1 the
+        // moment it publishes N, drains this channel right before N+1's
+        // planning and sees N's confirmations — the same one-frame
+        // latency the synchronous path has. Left to ride the returns (as
+        // parked), every capture took TWO frames to confirm and each
+        // recapture re-materialized ~17k primitives instead of replaying
+        // ~35 retained spans. The recycled confirmations buffer is
+        // adopted first so the store's ack reuses its capacity.
+        if let Some(confirmations) = packet.recycled_confirmations.take() {
+            self.gpu_renderer
+                .restore_replay_ack_confirmations(confirmations);
+        }
+        if let Some(batch) = self.gpu_renderer.take_replay_ack_early(&mut packet) {
+            self.send_ack(batch);
+        }
+        let (width, height) = packet.viewport;
+        if self.surface.is_some() {
+            self.render_to_surface(packet, width, height);
+        } else if self.offscreen_target.is_some() {
+            self.render_offscreen(packet, width, height);
+        } else {
+            // Unreachable: `validate` refused surfaceless packets above.
+            self.cancel_packet(packet, CancelReason::SurfaceUnavailable);
+        }
+    }
+
+    /// Ship one early [`ReplayAckBatch`] to the producer. No waker: an ack
+    /// gates nothing — the producer that is awake folds it in before its
+    /// next planning, and one that is asleep has nothing to plan.
+    fn send_ack(&mut self, batch: ReplayAckBatch) {
+        match self.acks_tx.try_send(batch) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                // Impossible under the depth-one credit protocol (at most
+                // one ack per in-flight packet). Dropping loses recycled
+                // buffer capacity and one frame's confirmations — the
+                // planner re-requests, correctness holds; scream so the
+                // protocol break is seen.
+                log::error!("[present-runtime] ack channel full; depth-one credit violated");
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                // Producer gone (shutdown race); nothing to confirm into.
+            }
+        }
+    }
+
+    /// LATE ACQUIRE: the swapchain texture is acquired only after the
+    /// epoch validation, immediately before the render call — the move of
+    /// the acquire out of the producer loop that step 7b exists for.
+    fn render_to_surface(&mut self, packet: FramePacket, width: u32, height: u32) {
+        let frame = match self.acquire_with_one_retry() {
+            Some(frame) => frame,
+            None => {
+                // Acquire failed past its one reconfigure retry: the
+                // packet's buffers must return — never drop.
+                self.cancel_packet(packet, CancelReason::SurfaceUnavailable);
+                return;
+            }
+        };
+        let after_acquire_ns = self.now();
+        let view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let mut returns = RenderReturns::default();
+        let result = self.gpu_renderer.render(
+            &view,
+            width,
+            height,
+            packet,
+            self.surface_epoch,
+            &mut returns,
+        );
+        let after_render_ns = self.now();
+        // Present even on a draw error, mirroring the old sync loop: an
+        // acquired frame that is never presented can stall the swapchain.
+        frame.present();
+        returns.timings = PresentTimings {
+            after_acquire_ns,
+            after_render_ns,
+            after_present_ns: self.now(),
+        };
+        if let Err(error) = result {
+            log::error!("[present-runtime] render error: {error}");
+            self.status
+                .last_error_frame
+                .store(returns.frame_id.max(1), Ordering::Relaxed);
+        }
+        self.finish_returns(returns);
+    }
+
+    /// The `current_surface_texture` semantics, runtime-owned: Ready →
+    /// render+present; Lost/Outdated → reconfigure with the CURRENT config
+    /// and retry ONCE; Timeout/Occluded/Validation → give up this frame.
+    fn acquire_with_one_retry(&mut self) -> Option<wgpu::SurfaceTexture> {
+        let surface = self.surface.as_ref()?;
+        match Self::acquire(surface) {
+            AcquireOutcome::Ready(frame) => Some(frame),
+            AcquireOutcome::Skip => None,
+            AcquireOutcome::Reconfigure => {
+                let config = self.config.as_ref()?;
+                surface.configure(&self.device, config);
+                match Self::acquire(surface) {
+                    AcquireOutcome::Ready(frame) => Some(frame),
+                    _ => None,
+                }
+            }
+        }
+    }
+
+    fn acquire(surface: &wgpu::Surface<'static>) -> AcquireOutcome {
+        match surface.get_current_texture() {
+            wgpu::CurrentSurfaceTexture::Success(frame) => AcquireOutcome::Ready(frame),
+            wgpu::CurrentSurfaceTexture::Suboptimal(frame) => {
+                log::debug!("[present-runtime] surface suboptimal, rendering current frame");
+                AcquireOutcome::Ready(frame)
+            }
+            wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated => {
+                AcquireOutcome::Reconfigure
+            }
+            wgpu::CurrentSurfaceTexture::Timeout => {
+                log::debug!("[present-runtime] surface timeout, skipping frame");
+                AcquireOutcome::Skip
+            }
+            wgpu::CurrentSurfaceTexture::Occluded => {
+                log::debug!("[present-runtime] surface occluded, skipping frame");
+                AcquireOutcome::Skip
+            }
+            wgpu::CurrentSurfaceTexture::Validation => {
+                log::error!("[present-runtime] surface validation error, skipping frame");
+                AcquireOutcome::Skip
+            }
+        }
+    }
+
+    /// Test-only: consume a packet against the offscreen surrogate target
+    /// so the full render path runs headlessly.
+    fn render_offscreen(&mut self, packet: FramePacket, width: u32, height: u32) {
+        let texture = self.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Present Runtime Offscreen Test Target"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: self.gpu_renderer.surface_format(),
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let after_acquire_ns = self.now();
+        let mut returns = RenderReturns::default();
+        let result = self.gpu_renderer.render(
+            &view,
+            width,
+            height,
+            packet,
+            self.surface_epoch,
+            &mut returns,
+        );
+        let after_render_ns = self.now();
+        returns.timings = PresentTimings {
+            after_acquire_ns,
+            after_render_ns,
+            after_present_ns: self.now(),
+        };
+        if let Err(error) = result {
+            log::error!("[present-runtime] offscreen render error: {error}");
+            self.status
+                .last_error_frame
+                .store(returns.frame_id.max(1), Ordering::Relaxed);
+        }
+        self.finish_returns(returns);
+    }
+
+    /// The tail every consumed packet shares: refresh the warmup snapshot,
+    /// record the outcome, send the returns, wake the producer.
+    fn finish_returns(&mut self, returns: RenderReturns) {
+        self.status
+            .needs_frame_warmup
+            .store(self.gpu_renderer.needs_frame_warmup(), Ordering::Relaxed);
+        if returns.outcome == PresentOutcome::Presented {
+            self.status.presented_frames.fetch_add(1, Ordering::Relaxed);
+        }
+        self.status.last_present_outcome.store(
+            encode_present_outcome(returns.outcome, returns.frame_id),
+            Ordering::Relaxed,
+        );
+        match self.returns_tx.try_send(returns) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                // Impossible under the depth-one credit protocol (at most
+                // one in-flight packet plus one invalidation cancel).
+                // Dropping the returns loses recycled buffers, not
+                // correctness; scream so the protocol break is seen.
+                log::error!("[present-runtime] returns channel full; depth-one credit violated");
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                // Producer gone (shutdown race); nothing to recycle into.
+            }
+        }
+        (self.waker)();
+    }
+
+    fn now(&self) -> i64 {
+        self.clock.as_ref().map(|clock| clock()).unwrap_or(0)
+    }
+
+    /// Test inspector: the store-side ack confirmations buffer's capacity,
+    /// proving the threaded recycle path hands capacity back to the store.
+    pub(crate) fn store_ack_confirmations_capacity(&self) -> usize {
+        self.gpu_renderer.replay_ack_confirmations_capacity()
+    }
+}
+
+enum AcquireOutcome {
+    Ready(wgpu::SurfaceTexture),
+    Reconfigure,
+    Skip,
+}
+
+/// The producer's handle to a spawned (or inline) present runtime: the
+/// message sender, the returns receiver, the shared status snapshot and
+/// the local outstanding-packet count that implements depth-one credit.
+pub(crate) struct PresentHandle {
+    msg_tx: Sender<PresentMsg>,
+    returns_rx: Receiver<RenderReturns>,
+    /// Early replay acks, one per consumed Direct packet, arriving ahead
+    /// of the packet's returns (see `PresentState::consume_packet`).
+    acks_rx: Receiver<ReplayAckBatch>,
+    status: Arc<PresentStatus>,
+    thread: Option<std::thread::JoinHandle<()>>,
+    /// Packets published and not yet drained. Credit = `outstanding < 1`:
+    /// the producer must drain a frame's returns before building the next.
+    outstanding: u32,
+}
+
+impl PresentHandle {
+    /// Spawn the runtime thread; the `GpuRenderer` is constructed on it.
+    pub(crate) fn spawn(init: PresentRuntimeInit, waker: PresentWaker) -> Result<Self, String> {
+        let (msg_tx, msg_rx) = channel::<PresentMsg>();
+        // Capacity 2: one rendering and one invalidation-cancelled packet
+        // can both complete before the producer drains.
+        let (returns_tx, returns_rx) = sync_channel::<RenderReturns>(2);
+        // Acks: at most one per in-flight packet; 4 leaves headroom for a
+        // drain that raced a publish.
+        let (acks_tx, acks_rx) = sync_channel::<ReplayAckBatch>(4);
+        let status = Arc::new(PresentStatus::default());
+        let thread_status = Arc::clone(&status);
+        let thread = std::thread::Builder::new()
+            .name("cranpose-present".to_string())
+            .spawn(move || {
+                PresentState::new(init, returns_tx, acks_tx, thread_status, waker).run(msg_rx);
+            })
+            .map_err(|error| format!("failed to spawn present thread: {error}"))?;
+        Ok(Self {
+            msg_tx,
+            returns_rx,
+            acks_rx,
+            status,
+            thread: Some(thread),
+            outstanding: 0,
+        })
+    }
+
+    /// Build the runtime WITHOUT a thread: the state machine and its
+    /// message receiver are handed back for the test to pump by hand.
+    pub(crate) fn new_inline(
+        init: PresentRuntimeInit,
+        waker: PresentWaker,
+    ) -> (Self, PresentState, Receiver<PresentMsg>) {
+        let (msg_tx, msg_rx) = channel::<PresentMsg>();
+        let (returns_tx, returns_rx) = sync_channel::<RenderReturns>(2);
+        let (acks_tx, acks_rx) = sync_channel::<ReplayAckBatch>(4);
+        let status = Arc::new(PresentStatus::default());
+        let state = PresentState::new(init, returns_tx, acks_tx, Arc::clone(&status), waker);
+        (
+            Self {
+                msg_tx,
+                returns_rx,
+                acks_rx,
+                status,
+                thread: None,
+                outstanding: 0,
+            },
+            state,
+            msg_rx,
+        )
+    }
+
+    pub(crate) fn status(&self) -> &PresentStatus {
+        &self.status
+    }
+
+    /// One packet rendering AND one waiting (tofable §4) — the credit that
+    /// makes the stages overlap. Allowing only one packet in flight would
+    /// idle the producer for the whole of present (acquire, encode, submit,
+    /// vsync) and idle the present thread for the whole of the next
+    /// producer frame: the serial chain the pipeline exists to break, with
+    /// a thread hop added. Two lets the producer lower frame N+1 while the
+    /// present thread draws N, so throughput becomes max(producer, present)
+    /// instead of their sum. It is still bounded: the producer stalls at
+    /// two, so it can never run away from the screen.
+    pub(crate) fn has_credit(&self) -> bool {
+        self.outstanding < 2
+    }
+
+    /// Publish a packet into the depth-one slot. On failure (runtime gone)
+    /// the packet is handed back — boxed, cold path only — so the caller
+    /// can recover its buffers.
+    pub(crate) fn publish(&mut self, packet: FramePacket) -> Result<(), Box<FramePacket>> {
+        debug_assert!(self.has_credit(), "publish without credit");
+        match self.msg_tx.send(PresentMsg::Packet(packet)) {
+            Ok(()) => {
+                self.outstanding += 1;
+                Ok(())
+            }
+            Err(error) => {
+                let PresentMsg::Packet(packet) = error.0 else {
+                    unreachable!("publish only sends packets");
+                };
+                Err(Box::new(packet))
+            }
+        }
+    }
+
+    /// Non-blocking drain of one returns value.
+    pub(crate) fn try_drain(&mut self) -> Option<RenderReturns> {
+        match self.returns_rx.try_recv() {
+            Ok(returns) => {
+                self.outstanding = self.outstanding.saturating_sub(1);
+                Some(returns)
+            }
+            Err(_) => None,
+        }
+    }
+
+    /// Non-blocking drain of one early replay ack. Does NOT release
+    /// publish credit — the ack precedes its frame's returns, which still
+    /// carry the scene buffers and the outcome.
+    pub(crate) fn try_drain_ack(&mut self) -> Option<ReplayAckBatch> {
+        self.acks_rx.try_recv().ok()
+    }
+
+    /// Route a display-visible-region change to the present thread's
+    /// renderer. Ack-less: FIFO ordering against later publishes is the
+    /// contract (see [`PresentControl::SetDisplayVisibleRegion`]).
+    pub(crate) fn send_display_visible_region(&self, region: DisplayVisibleRegion) {
+        if self
+            .msg_tx
+            .send(PresentMsg::Control(
+                PresentControl::SetDisplayVisibleRegion { region },
+            ))
+            .is_err()
+        {
+            log::error!("[present-runtime] set display visible region: runtime is gone");
+        }
+    }
+
+    /// Send a control message and wait (bounded) for its acknowledgement.
+    /// Returns whether the ack arrived; a timeout is logged and survivable
+    /// (the producer's epoch bump already protects correctness).
+    pub(crate) fn send_control_and_wait(
+        &self,
+        build: impl FnOnce(SyncSender<()>) -> PresentControl,
+        what: &str,
+    ) -> bool {
+        let ack_rx = match self.send_control_unacked(build) {
+            Some(ack_rx) => ack_rx,
+            None => {
+                log::error!("[present-runtime] {what}: runtime is gone");
+                return false;
+            }
+        };
+        match ack_rx.recv_timeout(CONTROL_ACK_TIMEOUT) {
+            Ok(()) => true,
+            Err(RecvTimeoutError::Timeout) => {
+                log::error!(
+                    "[present-runtime] {what}: no ack within {CONTROL_ACK_TIMEOUT:?}; \
+                     present thread wedged?"
+                );
+                false
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                log::error!("[present-runtime] {what}: runtime exited before ack");
+                false
+            }
+        }
+    }
+
+    /// Send a control message and hand back the ack receiver without
+    /// waiting — the inline test mode's building block (there is no thread
+    /// to ack until the test pumps).
+    pub(crate) fn send_control_unacked(
+        &self,
+        build: impl FnOnce(SyncSender<()>) -> PresentControl,
+    ) -> Option<Receiver<()>> {
+        let (ack_tx, ack_rx) = sync_channel::<()>(1);
+        self.msg_tx
+            .send(PresentMsg::Control(build(ack_tx)))
+            .ok()
+            .map(|_| ack_rx)
+    }
+
+    /// Send `Shutdown` and join the thread (spawned mode). Pending returns
+    /// are left to the caller to drain BEFORE calling this.
+    pub(crate) fn shutdown(&mut self) {
+        let _ = self
+            .msg_tx
+            .send(PresentMsg::Control(PresentControl::Shutdown));
+        if let Some(thread) = self.thread.take() {
+            if thread.join().is_err() {
+                log::error!("[present-runtime] present thread panicked");
+            }
+        }
+    }
+}
+
+impl Drop for PresentHandle {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Compile-time proof that everything crossing into the present thread is
+/// `Send`, member by member (mirrors `frame_packet.rs`).
+const _: () = {
+    const fn assert_send<T: Send>() {}
+    assert_send::<PresentRuntimeInit>();
+    assert_send::<PresentControl>();
+    assert_send::<PresentMsg>();
+    assert_send::<PresentWaker>();
+    assert_send::<Option<PresentClock>>();
+    assert_send::<Arc<PresentStatus>>();
+    assert_send::<SyncSender<RenderReturns>>();
+    assert_send::<SyncSender<ReplayAckBatch>>();
+    assert_send::<DisplayVisibleRegion>();
+};

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -8199,10 +8199,17 @@ impl GpuRenderer {
         view: &wgpu::TextureView,
         width: u32,
         height: u32,
-        packet: FramePacket,
+        mut packet: FramePacket,
         surface_epoch: u64,
         returns: &mut RenderReturns,
     ) -> Result<(), String> {
+        // Threaded mode rides the emptied ack-confirmations buffer back to
+        // the store inside the next packet ([`FramePacket::recycled_confirmations`]);
+        // adopt it before the validity gate so even a cancelled packet
+        // cannot leak the capacity. Sync callers always carry `None`.
+        if let Some(confirmations) = packet.recycled_confirmations.take() {
+            self.restore_replay_ack_confirmations(confirmations);
+        }
         // Packet validity gate — BEFORE consume_replay_ops and any
         // encoding. A packet built against another renderer instance,
         // another surface configuration, or another viewport is cancelled
@@ -8355,7 +8362,13 @@ impl GpuRenderer {
     /// re-queue (its releases name still-live store slots; dropping them
     /// would leak pool ids forever). A cancel is a protocol outcome, not a
     /// draw error, so the render call returns `Ok(())`.
-    fn cancel_packet(
+    ///
+    /// `pub(crate)` for the present runtime, which must cancel a packet
+    /// that cannot render at all (surface dropped) without touching the
+    /// GPU. Callers that bypass [`render`][Self::render] must take the
+    /// packet's `recycled_confirmations` first — this refuses the packet
+    /// without a store to adopt them into.
+    pub(crate) fn cancel_packet(
         packet: FramePacket,
         reason: CancelReason,
         returns: &mut RenderReturns,
@@ -8370,6 +8383,8 @@ impl GpuRenderer {
             overlay: _,
             replay,
             text_cache_len: _,
+            recycled_confirmations: _,
+            replay_preconsumed,
         } = packet;
         match root {
             PacketRoot::Direct(root) => {
@@ -8378,17 +8393,20 @@ impl GpuRenderer {
                 // packet's replay plan came from the planner and must go
                 // back to it unconsumed — a Surface packet only ever
                 // carries the empty default plan, which has nothing to
-                // reclaim.
+                // reclaim. A plan the present stage already consumed
+                // (`take_replay_ack_early`) is not here to reclaim: the
+                // store honored it and its ack is on the way to the
+                // planner, so `replay` holds only the taken-out default.
                 returns.scene = Some(root.scene);
                 #[cfg(not(target_arch = "wasm32"))]
-                {
+                if !replay_preconsumed {
                     returns.cancelled_replay = Some(replay);
                 }
             }
             PacketRoot::Surface(_) => {}
         }
         #[cfg(target_arch = "wasm32")]
-        let _ = replay;
+        let _ = (replay, replay_preconsumed);
         returns.ack = None;
         returns.frame_id = frame_id;
         returns.outcome = PresentOutcome::Cancelled(reason);
@@ -8657,19 +8675,24 @@ impl GpuRenderer {
         // equivalent to the in-store drain this replaces, because both
         // application points sit after this frame's graph build and before
         // the next collect, which is where the bypass gate and `feed_slots`
-        // are read.
+        // are read. The threaded present runtime consumes EARLIER
+        // (`take_replay_ack_early`, before surface acquire) and marks the
+        // packet, so this block must not feed the taken-out default plan
+        // to the store.
         #[cfg(not(target_arch = "wasm32"))]
         let mut packet = packet;
         #[cfg(not(target_arch = "wasm32"))]
-        if let PacketRoot::Direct(root) = &packet.root {
-            let ops = std::mem::take(&mut packet.replay);
-            let (ack, recycled) = self.consume_replay_ops(
-                ops,
-                &root.scene.shapes,
-                &root.scene.brushes,
-                packet.root_scale,
-            );
-            returns.ack = Some((ack, recycled));
+        if !packet.replay_preconsumed {
+            if let PacketRoot::Direct(root) = &packet.root {
+                let ops = std::mem::take(&mut packet.replay);
+                let (ack, recycled) = self.consume_replay_ops(
+                    ops,
+                    &root.scene.shapes,
+                    &root.scene.brushes,
+                    packet.root_scale,
+                );
+                returns.ack = Some((ack, recycled));
+            }
         }
 
         let FramePacket {
@@ -8682,6 +8705,8 @@ impl GpuRenderer {
             overlay,
             replay: _,
             text_cache_len: _,
+            recycled_confirmations: _,
+            replay_preconsumed: _,
         } = packet;
 
         let mut backend = RecordingSurfaceBackend {
@@ -11531,6 +11556,53 @@ impl GpuRenderer {
         let _ = confirmations;
     }
 
+    /// The surface format this renderer was constructed for — the present
+    /// runtime's offscreen test target must match it.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn surface_format(&self) -> wgpu::TextureFormat {
+        self.surface_format
+    }
+
+    /// Test inspector for the threaded confirmations round-trip: the
+    /// store-side ack buffer's current capacity.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn replay_ack_confirmations_capacity(&self) -> usize {
+        self.replay_ack_confirmations.capacity()
+    }
+
+    /// EARLY present-side consumption of a validated packet's replay plan
+    /// (threaded runtime only): identical store work to the render-time
+    /// block in `render_graph_recorded`, but runnable BEFORE surface
+    /// acquire, so the [`crate::frame_packet::ReplayAck`] can travel to the
+    /// producer without waiting out the swapchain — a capture confirmed
+    /// here is available to the very next frame's planning, the same
+    /// one-frame latency the synchronous path has. Marks the packet so the
+    /// render path does not consume the taken-out default plan, and so a
+    /// later cancel does not reclaim it. `None` for Surface roots, which
+    /// never touch the planner. The caller must have validated the packet
+    /// (epochs, viewport) first: this executes against the live store.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn take_replay_ack_early(
+        &mut self,
+        packet: &mut FramePacket,
+    ) -> Option<(
+        crate::frame_packet::ReplayAck,
+        crate::frame_packet::ReplayFrameOps,
+    )> {
+        if packet.replay_preconsumed {
+            return None;
+        }
+        let PacketRoot::Direct(root) = &packet.root else {
+            return None;
+        };
+        let ops = std::mem::take(&mut packet.replay);
+        let root_scale = packet.root_scale;
+        let (ack, recycled) =
+            self.consume_replay_ops(ops, &root.scene.shapes, &root.scene.brushes, root_scale);
+        packet.replay_preconsumed = true;
+        Some((ack, recycled))
+    }
+
     /// Present-side consumption of one frame's [`ReplayFrameOps`]: frees
     /// the plan's releases, then honors its capture requests against the
     /// scene they were recorded for, answering with a [`ReplayAck`] of
@@ -11556,6 +11628,10 @@ impl GpuRenderer {
         crate::frame_packet::ReplayAck,
         crate::frame_packet::ReplayFrameOps,
     ) {
+        // The batch's own staleness ordinal, echoed in the ack so the
+        // planner purges exactly this batch's unconfirmed requests even
+        // when another batch is already in flight behind it.
+        let acked_frame = ops.frame;
         if ops.generation < self.store_feed_generation {
             // Fail-closed: ops planned under an OLDER slot universe name
             // slots this store does not hold. Drop the batch whole —
@@ -11579,6 +11655,7 @@ impl GpuRenderer {
             return (
                 crate::frame_packet::ReplayAck {
                     generation: self.store_feed_generation,
+                    frame: acked_frame,
                     confirmations: Vec::new(),
                 },
                 ops,
@@ -11643,6 +11720,7 @@ impl GpuRenderer {
         (
             crate::frame_packet::ReplayAck {
                 generation,
+                frame: acked_frame,
                 confirmations,
             },
             ops,

--- a/crates/cranpose-render/wgpu/src/shape_replay.rs
+++ b/crates/cranpose-render/wgpu/src/shape_replay.rs
@@ -367,7 +367,15 @@ impl ShapeReplayState {
                 ack.generation,
             );
         }
-        self.awaiting_confirmation.clear();
+        // Purge only THIS batch's leftovers — requests the store did not
+        // confirm can never be confirmed later. A batch published while
+        // this one rendered carries the next frame ordinal and its
+        // requests must outlive this ack, so the purge keys on the frame
+        // the ack echoes (unique among in-flight batches) rather than
+        // clearing the map: the drop path deliberately acks under the
+        // store's generation, so generation alone cannot identify a batch.
+        self.awaiting_confirmation
+            .retain(|_, requested| requested.frame != ack.frame);
         self.recycled_ops = recycled;
         ack.confirmations
     }
@@ -573,6 +581,7 @@ mod tests {
 
         let ack = ReplayAck {
             generation,
+            frame: ops.frame,
             confirmations: vec![(key, 9)],
         };
         let returned = state.apply_ack(ack, ReplayFrameOps::default());
@@ -630,6 +639,7 @@ mod tests {
         cranpose_render_common::scene_builder::set_retained_feed_epoch(Some(generation));
         let ack = ReplayAck {
             generation,
+            frame: ops.frame,
             confirmations: vec![(key, 11)],
         };
         state.apply_ack(ack, ReplayFrameOps::default());

--- a/crates/cranpose-render/wgpu/tests/present_runtime_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/present_runtime_contract.rs
@@ -1,0 +1,711 @@
+//! Pipeline step 7b: the present runtime's depth-one protocol. Credit
+//! gates packet building (backpressure BEFORE lowering), an invalidating
+//! control message cancels the waiting packet and sends its returns
+//! BEFORE it is acknowledged, a dead surface refuses packets with their
+//! buffers intact, the recycled ack-confirmations buffer rides the next
+//! packet back to the store, the store's replay ack leaves on its own
+//! channel ahead of the frame's returns, and the producer's warmup read
+//! is the present thread's atomic snapshot — never the renderer.
+//!
+//! Most tests drive the state machine INLINE (no thread) through
+//! `init_gpu_inline_for_tests`, pumping the message queue by hand so
+//! every ordering is deterministic; one smoke test runs the real spawned
+//! thread end to end.
+
+mod support;
+
+use std::sync::{Arc, MutexGuard};
+use std::time::{Duration, Instant};
+
+use cranpose_core::NodeId;
+use cranpose_render_common::graph::{
+    CachePolicy, DrawCommandId, DrawPrimitiveNode, IsolationReasons, LayerNode, PrimitiveEntry,
+    PrimitiveNode, PrimitivePhase, ProjectiveTransform, RenderGraph, RenderNode,
+};
+use cranpose_render_common::raster_cache::LayerRasterCacheHashes;
+use cranpose_render_common::style_shared::DrawPlacement;
+use cranpose_render_common::Renderer;
+use cranpose_render_wgpu::{CancelReason, PresentOutcome, PublishOutcome, WgpuRenderer};
+use cranpose_ui_graphics::{Brush, Color, GraphicsLayer, Point, Rect};
+
+const WIDTH: u32 = 128;
+const HEIGHT: u32 = 96;
+
+fn test_layer(node_id: Option<NodeId>, children: Vec<RenderNode>) -> LayerNode {
+    LayerNode {
+        node_id,
+        local_bounds: Rect {
+            x: 0.0,
+            y: 0.0,
+            width: WIDTH as f32,
+            height: HEIGHT as f32,
+        },
+        transform_to_parent: ProjectiveTransform::identity(),
+        motion_context_animated: false,
+        translated_content_context: false,
+        translated_content_offset: Point::default(),
+        content_offset: Point::default(),
+        scene_children_origin: Point::default(),
+        scene_children_layer_translation: Point::default(),
+        graphics_layer: GraphicsLayer::default(),
+        clip_to_bounds: false,
+        shadow_clip: None,
+        hit_test: None,
+        has_hit_targets: false,
+        isolation: IsolationReasons::default(),
+        cache_policy: CachePolicy::None,
+        cache_hashes: LayerRasterCacheHashes::default(),
+        cache_hashes_valid: false,
+        children,
+    }
+}
+
+fn rect_primitive(rect: Rect, color: Color) -> RenderNode {
+    RenderNode::Primitive(PrimitiveEntry {
+        phase: PrimitivePhase::BeforeChildren,
+        node: PrimitiveNode::Draw(DrawPrimitiveNode {
+            primitive: cranpose_ui_graphics::DrawPrimitive::Rect {
+                rect,
+                brush: Brush::solid(color),
+                stroke: None,
+            },
+            clip: None,
+        }),
+    })
+}
+
+/// A direct-eligible root: its packets carry a `PacketRoot::Direct` scene,
+/// which is what the cancel/recycle assertions observe.
+fn direct_graph() -> RenderGraph {
+    RenderGraph::new(test_layer(
+        Some(7_700),
+        vec![rect_primitive(
+            Rect {
+                x: 16.0,
+                y: 12.0,
+                width: 64.0,
+                height: 48.0,
+            },
+            Color(0.2, 0.7, 0.3, 1.0),
+        )],
+    ))
+}
+
+/// A root whose CHILD carries a shadow: the first render must miss the
+/// shadow shape cache, which is one of the warmup triggers.
+fn shadowed_child_graph() -> RenderGraph {
+    let mut child = test_layer(Some(7_701), vec![]);
+    child.local_bounds = Rect {
+        x: 24.0,
+        y: 20.0,
+        width: 48.0,
+        height: 32.0,
+    };
+    child.graphics_layer.shadow_elevation = 6.0;
+    RenderGraph::new(test_layer(
+        Some(7_702),
+        vec![RenderNode::Layer(Box::new(child))],
+    ))
+}
+
+fn command_for(node_id: usize) -> DrawCommandId {
+    DrawCommandId {
+        node_id,
+        command_index: 0,
+        placement: DrawPlacement::Behind,
+    }
+}
+
+fn surface_config(width: u32, height: u32) -> wgpu::SurfaceConfiguration {
+    wgpu::SurfaceConfiguration {
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        format: wgpu::TextureFormat::Bgra8UnormSrgb,
+        width,
+        height,
+        present_mode: wgpu::PresentMode::Fifo,
+        alpha_mode: wgpu::CompositeAlphaMode::Auto,
+        view_formats: vec![],
+        desired_maximum_frame_latency: 2,
+    }
+}
+
+/// An UNINITIALIZED renderer plus the device/queue the test hands to the
+/// runtime itself (unlike `support::headless_renderer`, which claims them
+/// for a sync `init_gpu`).
+#[allow(clippy::type_complexity)]
+fn threaded_parts() -> Result<
+    (
+        MutexGuard<'static, ()>,
+        WgpuRenderer,
+        Arc<wgpu::Device>,
+        Arc<wgpu::Queue>,
+        wgpu::Backend,
+    ),
+    String,
+> {
+    let lock = support::gpu_test_lock();
+    let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
+    instance_descriptor.backends = wgpu::Backends::all();
+    let instance = wgpu::Instance::new(instance_descriptor);
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::LowPower,
+        compatible_surface: None,
+        force_fallback_adapter: false,
+    }))
+    .map_err(|err| format!("adapter request failed: {err:?}"))?;
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("Present Runtime Contract Test Device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::default(),
+        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        memory_hints: wgpu::MemoryHints::default(),
+        trace: wgpu::Trace::Off,
+    }))
+    .map_err(|err| format!("device request failed: {err:?}"))?;
+    Ok((
+        lock,
+        WgpuRenderer::new(&[support::TEST_FONT]),
+        Arc::new(device),
+        Arc::new(queue),
+        adapter.get_info().backend,
+    ))
+}
+
+/// Inline runtime with the offscreen surrogate target attached, so the
+/// full validate → render path runs headlessly.
+macro_rules! inline_runtime_or_skip {
+    ($name:literal) => {{
+        match threaded_parts() {
+            Ok(parts) => parts,
+            Err(err) => {
+                eprintln!("skipping {}: headless WGPU init failed: {err}", $name);
+                return;
+            }
+        }
+    }};
+}
+
+fn drain_outcomes(renderer: &mut WgpuRenderer) -> Vec<(u64, PresentOutcome)> {
+    let mut outcomes = Vec::new();
+    renderer.drain_present_returns_with(&mut |frame_id, outcome, _| {
+        outcomes.push((frame_id, outcome));
+    });
+    outcomes
+}
+
+/// 7b-1: depth-one credit — one packet rendering AND one waiting. Two
+/// publishes fit (that pair is what lets the producer lower N+1 while the
+/// present thread draws N); the THIRD reports `NoCredit` WITHOUT lowering
+/// a packet, and credit returns as frames drain.
+#[test]
+fn depth_one_credit_gates_publish_before_lowering() {
+    let (_lock, mut renderer, device, queue, backend) = inline_runtime_or_skip!("depth-one credit");
+    let mut runtime = renderer.init_gpu_inline_for_tests(
+        device,
+        queue,
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+        backend,
+    );
+    let ack = renderer
+        .send_attach_offscreen_unacked_for_tests(WIDTH, HEIGHT)
+        .expect("inline runtime must accept controls");
+    runtime.pump();
+    ack.try_recv().expect("attach must ack after the pump");
+
+    renderer.scene_mut().graph = Some(direct_graph());
+    assert!(renderer.has_frame_credit());
+    assert_eq!(
+        renderer.publish_frame(WIDTH, HEIGHT),
+        PublishOutcome::Published
+    );
+    assert_eq!(renderer.last_published_frame_id(), 1);
+    assert!(
+        renderer.has_frame_credit(),
+        "one rendering plus one waiting: the second credit is what makes \
+         the producer and present stages overlap"
+    );
+    assert_eq!(
+        renderer.publish_frame(WIDTH, HEIGHT),
+        PublishOutcome::Published
+    );
+    assert_eq!(renderer.last_published_frame_id(), 2);
+    assert!(
+        !renderer.has_frame_credit(),
+        "two packets in flight is the bound; the producer stalls here so \
+         it can never run away from the screen"
+    );
+    assert_eq!(
+        renderer.publish_frame(WIDTH, HEIGHT),
+        PublishOutcome::NoCredit,
+        "both slots are occupied"
+    );
+    assert_eq!(
+        renderer.last_published_frame_id(),
+        2,
+        "a NoCredit publish must not build a packet: backpressure lands \
+         before the lowering work"
+    );
+
+    runtime.pump();
+    runtime.pump();
+    assert_eq!(
+        drain_outcomes(&mut renderer),
+        vec![
+            (1, PresentOutcome::Presented),
+            (2, PresentOutcome::Presented)
+        ],
+        "the offscreen surrogate must render both packets, in publish order"
+    );
+    assert!(
+        renderer.has_frame_credit(),
+        "drained returns free the publish credit"
+    );
+    assert_eq!(
+        renderer.publish_frame(WIDTH, HEIGHT),
+        PublishOutcome::Published
+    );
+    assert_eq!(renderer.last_published_frame_id(), 3);
+}
+
+/// 7b-2: invalidation before republish. With a packet waiting in the
+/// slot, a `Reconfigure` cancels it — its returns are sent BEFORE the ack
+/// fires — and a packet published under the new epoch renders.
+#[test]
+fn reconfigure_cancels_waiting_packet_before_ack() {
+    let (_lock, mut renderer, device, queue, backend) =
+        inline_runtime_or_skip!("invalidation-before-ack");
+    let mut runtime = renderer.init_gpu_inline_for_tests(
+        device,
+        queue,
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+        backend,
+    );
+    let ack = renderer
+        .send_attach_offscreen_unacked_for_tests(WIDTH, HEIGHT)
+        .expect("inline runtime must accept controls");
+    runtime.pump();
+    ack.try_recv().expect("attach must ack after the pump");
+    renderer.scene_mut().graph = Some(direct_graph());
+
+    assert_eq!(
+        renderer.publish_frame(WIDTH, HEIGHT),
+        PublishOutcome::Published
+    );
+    // Producer-side resize while frame 1 waits: epoch bump first, then
+    // the control message stamped with the new epoch.
+    renderer.note_surface_reconfigured();
+    let ack = renderer
+        .send_reconfigure_unacked_for_tests(surface_config(WIDTH * 2, HEIGHT * 2))
+        .expect("inline runtime must accept controls");
+    assert!(
+        ack.try_recv().is_err(),
+        "no ack may fire before the runtime processed the invalidation"
+    );
+
+    // One pump: the runtime stashes the waiting packet, processes the
+    // queued Reconfigure against it (cancel + returns + ack, in that
+    // order), and has nothing left to consume.
+    runtime.pump();
+    assert_eq!(
+        drain_outcomes(&mut renderer),
+        vec![(1, PresentOutcome::Cancelled(CancelReason::SurfaceEpoch))],
+        "the waiting packet must cancel for its stale surface epoch"
+    );
+    ack.try_recv()
+        .expect("the ack must have fired — after the cancelled returns were sent");
+    assert!(
+        renderer.has_retained_direct_scene_for_tests(),
+        "the cancelled packet's scene must return to the producer pool"
+    );
+
+    // The producer republishes under the new epoch at the new size and
+    // the frame renders.
+    assert_eq!(
+        renderer.publish_frame(WIDTH * 2, HEIGHT * 2),
+        PublishOutcome::Published
+    );
+    runtime.pump();
+    assert_eq!(
+        drain_outcomes(&mut renderer),
+        vec![(2, PresentOutcome::Presented)],
+        "a packet published under the new epoch must render"
+    );
+}
+
+/// 7b-3: `DropSurface` with a packet waiting. The packet cannot render at
+/// all: it cancels — pinned: `Cancelled(SurfaceUnavailable)`, the runtime
+/// cancels it directly without touching the GPU — with its scene AND its
+/// replay plan returned (planner re-queue proof, like 7a's). A packet
+/// published after the drop cancels too (`SurfaceEpoch`: the producer's
+/// bump outran the runtime's copy, which `DropSurface` — carrying no
+/// epoch — never updates).
+#[test]
+fn drop_surface_cancels_waiting_packet_with_buffers_returned() {
+    let (_lock, mut renderer, device, queue, backend) =
+        inline_runtime_or_skip!("drop-surface cancel");
+    let mut runtime = renderer.init_gpu_inline_for_tests(
+        device,
+        queue,
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+        backend,
+    );
+    let ack = renderer
+        .send_attach_offscreen_unacked_for_tests(WIDTH, HEIGHT)
+        .expect("inline runtime must accept controls");
+    runtime.pump();
+    ack.try_recv().expect("attach must ack after the pump");
+    renderer.scene_mut().graph = Some(direct_graph());
+    cranpose_render_wgpu::inject_feed_capture_for_tests(command_for(7_731), 0, 0, 1);
+
+    assert_eq!(
+        renderer.publish_frame(WIDTH, HEIGHT),
+        PublishOutcome::Published
+    );
+    let (_, awaiting) = cranpose_render_wgpu::planner_replay_queue_stats_for_tests();
+    assert_eq!(awaiting, 1, "the packet's plan must carry the capture");
+
+    // TerminateWindow flow: epoch bump, then the surface dies.
+    renderer.note_surface_reconfigured();
+    let ack = renderer
+        .send_drop_surface_unacked_for_tests()
+        .expect("inline runtime must accept controls");
+    runtime.pump();
+    assert_eq!(
+        drain_outcomes(&mut renderer),
+        vec![(
+            1,
+            PresentOutcome::Cancelled(CancelReason::SurfaceUnavailable)
+        )],
+        "a packet waiting when the surface died cancels as SurfaceUnavailable"
+    );
+    ack.try_recv().expect("drop must ack after the cancel");
+    assert!(
+        renderer.has_retained_direct_scene_for_tests(),
+        "the cancelled packet's scene must return to the producer pool"
+    );
+    let (_, awaiting) = cranpose_render_wgpu::planner_replay_queue_stats_for_tests();
+    assert_eq!(
+        awaiting, 0,
+        "the cancelled frame's awaiting entries must purge — no ack can \
+         ever confirm them"
+    );
+    let (captures_cap, _, _) = cranpose_render_wgpu::recycled_ops_capacities_for_tests();
+    assert!(
+        captures_cap >= 1,
+        "the cancelled batch's capture buffer must recycle with capacity intact"
+    );
+
+    // Publishing against the dead surface refuses the packet whole too.
+    assert_eq!(
+        renderer.publish_frame(WIDTH, HEIGHT),
+        PublishOutcome::Published
+    );
+    runtime.pump();
+    assert_eq!(
+        drain_outcomes(&mut renderer),
+        vec![(2, PresentOutcome::Cancelled(CancelReason::SurfaceEpoch))],
+        "after the drop the producer's epoch is ahead of the runtime's \
+         (DropSurface carries none), so the next packet cancels for it"
+    );
+    assert!(renderer.has_retained_direct_scene_for_tests());
+}
+
+/// 7b-4: the confirmations capacity round-trip. In threaded mode the
+/// planner-drained ack confirmations vec cannot return to the store
+/// synchronously; it rides the NEXT packet and the store adopts it as its
+/// ack backing buffer — capacity preserved, no per-frame allocation.
+#[test]
+fn confirmations_capacity_rides_next_packet_back_to_store() {
+    let (_lock, mut renderer, device, queue, backend) =
+        inline_runtime_or_skip!("confirmations round-trip");
+    let mut runtime = renderer.init_gpu_inline_for_tests(
+        device,
+        queue,
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+        backend,
+    );
+    let ack = renderer
+        .send_attach_offscreen_unacked_for_tests(WIDTH, HEIGHT)
+        .expect("inline runtime must accept controls");
+    runtime.pump();
+    ack.try_recv().expect("attach must ack after the pump");
+    renderer.scene_mut().graph = Some(direct_graph());
+
+    // A previous frame's drained ack buffer, parked with real capacity
+    // (seeded: producing a genuinely confirmed capture requires the
+    // multi-frame verification heuristics, which are not this contract).
+    const SEEDED_CAPACITY: usize = 7;
+    renderer.seed_recycled_confirmations_for_tests(SEEDED_CAPACITY);
+
+    // The publish carries the parked buffer into the packet...
+    assert_eq!(
+        renderer.publish_frame(WIDTH, HEIGHT),
+        PublishOutcome::Published
+    );
+    assert_eq!(
+        renderer.pending_recycled_confirmations_capacity_for_tests(),
+        None,
+        "the packet must take the parked buffer with it"
+    );
+    // ...the store adopts it, and the SAME frame's ack immediately takes
+    // it back out as its confirmations buffer (the store holds the
+    // capacity only between adoption and consumption — afterwards its
+    // backing slot is the taken-out empty)...
+    runtime.pump();
+    assert_eq!(
+        runtime.store_ack_confirmations_capacity(),
+        0,
+        "the frame's ack must have taken the adopted buffer out of the store"
+    );
+    // ...and the drain parks it producer-side again. Capacity arriving
+    // back here is THE proof of the full revolution: without the store
+    // adoption the ack would have carried a fresh zero-capacity vec.
+    assert_eq!(renderer.drain_present_returns(), 1);
+    assert_eq!(
+        renderer.pending_recycled_confirmations_capacity_for_tests(),
+        Some(SEEDED_CAPACITY),
+        "the drained ack must park the buffer with its capacity preserved \
+         through store adoption and the planner drain — no per-frame alloc"
+    );
+
+    // Second revolution: the cycle is self-sustaining.
+    assert_eq!(
+        renderer.publish_frame(WIDTH, HEIGHT),
+        PublishOutcome::Published
+    );
+    assert_eq!(
+        renderer.pending_recycled_confirmations_capacity_for_tests(),
+        None
+    );
+    runtime.pump();
+    assert_eq!(renderer.drain_present_returns(), 1);
+    assert_eq!(
+        renderer.pending_recycled_confirmations_capacity_for_tests(),
+        Some(SEEDED_CAPACITY)
+    );
+}
+
+/// 7b-7: the early replay ack. The store answers a Direct packet's replay
+/// plan on the ack channel BEFORE the frame draws (pre-acquire in the
+/// threaded runtime) — the confirmation-latency fix that makes depth-one
+/// overlap pay: the producer folds the ack in ahead of its next planning,
+/// the same one-frame latency the synchronous path has. Pinned here as
+/// protocol shape: the ack is drainable while the frame's returns are
+/// still queued, arrives exactly once, and the returns no longer carry
+/// an ack to double-apply.
+#[test]
+fn early_replay_ack_precedes_returns() {
+    let (_lock, mut renderer, device, queue, backend) = inline_runtime_or_skip!("early replay ack");
+    let mut runtime = renderer.init_gpu_inline_for_tests(
+        device,
+        queue,
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+        backend,
+    );
+    let ack = renderer
+        .send_attach_offscreen_unacked_for_tests(WIDTH, HEIGHT)
+        .expect("inline runtime must accept controls");
+    runtime.pump();
+    ack.try_recv().expect("attach must ack after the pump");
+    renderer.scene_mut().graph = Some(direct_graph());
+
+    // Seeded capacity is the tracer: it can only come back to the
+    // producer inside the frame's ReplayAck (store adoption → ack buffer
+    // → planner drain), so its arrival IS the ack's arrival.
+    const SEEDED_CAPACITY: usize = 5;
+    renderer.seed_recycled_confirmations_for_tests(SEEDED_CAPACITY);
+    assert_eq!(
+        renderer.publish_frame(WIDTH, HEIGHT),
+        PublishOutcome::Published
+    );
+    runtime.pump();
+
+    assert_eq!(
+        renderer.drain_replay_acks(),
+        1,
+        "the frame's ack must be available WITHOUT draining its returns"
+    );
+    assert_eq!(
+        renderer.pending_recycled_confirmations_capacity_for_tests(),
+        Some(SEEDED_CAPACITY),
+        "the ack alone must complete the capacity round-trip"
+    );
+    assert_eq!(
+        drain_outcomes(&mut renderer),
+        vec![(1, PresentOutcome::Presented)],
+        "the returns still arrive whole behind the ack"
+    );
+    assert_eq!(
+        renderer.drain_replay_acks(),
+        0,
+        "exactly one ack per consumed Direct packet"
+    );
+    assert_eq!(
+        renderer.pending_recycled_confirmations_capacity_for_tests(),
+        Some(SEEDED_CAPACITY),
+        "the returns carry no second ack; nothing double-applies"
+    );
+}
+
+/// 7b-5: the warmup snapshot. The present thread mirrors
+/// `needs_frame_warmup` into the shared atomic after every consumed
+/// packet, and the producer's `Renderer` trait read reports exactly that
+/// atomic — there is no `GpuRenderer` on the producer side to consult.
+#[test]
+fn needs_frame_warmup_reads_present_thread_atomic() {
+    let (_lock, mut renderer, device, queue, backend) = inline_runtime_or_skip!("warmup atomic");
+    let mut runtime = renderer.init_gpu_inline_for_tests(
+        device,
+        queue,
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+        backend,
+    );
+    let ack = renderer
+        .send_attach_offscreen_unacked_for_tests(WIDTH, HEIGHT)
+        .expect("inline runtime must accept controls");
+    runtime.pump();
+    ack.try_recv().expect("attach must ack after the pump");
+
+    assert!(
+        !renderer.needs_frame_warmup(),
+        "before any frame the snapshot must read false"
+    );
+
+    // A first shadow render misses the shadow shape cache — one of the
+    // warmup triggers — so the present thread must raise the atomic.
+    renderer.scene_mut().graph = Some(shadowed_child_graph());
+    assert_eq!(
+        renderer.publish_frame(WIDTH, HEIGHT),
+        PublishOutcome::Published
+    );
+    runtime.pump();
+    assert_eq!(renderer.drain_present_returns(), 1);
+
+    let (atomic_warmup, _, _) = renderer
+        .present_status_snapshot_for_tests()
+        .expect("threaded mode must expose the status snapshot");
+    assert!(
+        atomic_warmup,
+        "the first shadow frame's cache miss must raise the warmup snapshot"
+    );
+    assert_eq!(
+        renderer.needs_frame_warmup(),
+        atomic_warmup,
+        "the producer trait read must be exactly the atomic"
+    );
+
+    // Warmup frames decay as the caches stop missing; the trait read must
+    // follow the atomic down without ever touching present state.
+    for _ in 0..4 {
+        if !renderer.needs_frame_warmup() {
+            break;
+        }
+        assert_eq!(
+            renderer.publish_frame(WIDTH, HEIGHT),
+            PublishOutcome::Published
+        );
+        runtime.pump();
+        assert_eq!(renderer.drain_present_returns(), 1);
+    }
+    let (atomic_warmup, _, _) = renderer
+        .present_status_snapshot_for_tests()
+        .expect("threaded mode must expose the status snapshot");
+    assert_eq!(renderer.needs_frame_warmup(), atomic_warmup);
+    assert!(
+        !atomic_warmup,
+        "warmup must settle once the shadow cache stops missing"
+    );
+}
+
+/// 7b-6: real-thread smoke. The spawned runtime constructs its renderer
+/// on its own thread, refuses a surfaceless packet with buffers returned,
+/// acknowledges controls across the thread boundary, renders against the
+/// offscreen surrogate, wakes the producer through the injected waker,
+/// and shuts down joinable.
+#[test]
+fn real_thread_runtime_smoke() {
+    let (_lock, mut renderer, device, queue, backend) =
+        inline_runtime_or_skip!("real-thread smoke");
+    let (wake_tx, wake_rx) = std::sync::mpsc::channel::<()>();
+    renderer
+        .init_gpu_threaded(
+            device,
+            queue,
+            wgpu::TextureFormat::Bgra8UnormSrgb,
+            backend,
+            Arc::new(move || {
+                let _ = wake_tx.send(());
+            }),
+            None,
+        )
+        .expect("present thread must spawn");
+    renderer.scene_mut().graph = Some(direct_graph());
+
+    // No surface attached: the packet must come back cancelled, buffers
+    // intact, and the waker must have fired.
+    assert_eq!(
+        renderer.publish_frame(WIDTH, HEIGHT),
+        PublishOutcome::Published
+    );
+    wake_rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("the present thread must wake the producer after returns");
+    let outcomes = drain_with_timeout(&mut renderer, 1);
+    assert_eq!(
+        outcomes,
+        vec![(
+            1,
+            PresentOutcome::Cancelled(CancelReason::SurfaceUnavailable)
+        )],
+        "a surfaceless runtime must refuse the packet, not drop it"
+    );
+    assert!(renderer.has_retained_direct_scene_for_tests());
+
+    // Control ack round-trips across the thread; a publish under the new
+    // epoch against the offscreen target renders for real.
+    renderer.note_surface_reconfigured();
+    assert!(
+        renderer.present_reconfigure(surface_config(WIDTH, HEIGHT)),
+        "reconfigure must be acknowledged"
+    );
+    assert!(
+        renderer.present_attach_offscreen_for_tests(WIDTH, HEIGHT),
+        "offscreen attach must be acknowledged"
+    );
+    assert_eq!(
+        renderer.publish_frame(WIDTH, HEIGHT),
+        PublishOutcome::Published
+    );
+    let outcomes = drain_with_timeout(&mut renderer, 1);
+    assert_eq!(
+        outcomes,
+        vec![(2, PresentOutcome::Presented)],
+        "the real present thread must render against the offscreen target"
+    );
+    let (_, _, presented_frames) = renderer
+        .present_status_snapshot_for_tests()
+        .expect("threaded mode must expose the status snapshot");
+    assert_eq!(presented_frames, 1);
+
+    renderer.shutdown_present_runtime();
+    assert!(
+        !renderer.needs_frame_warmup(),
+        "after shutdown the renderer reads as uninitialized"
+    );
+}
+
+/// Polls the returns channel until `count` returns arrived or a generous
+/// deadline passed — the real-thread test's only nondeterminism absorber.
+fn drain_with_timeout(renderer: &mut WgpuRenderer, count: usize) -> Vec<(u64, PresentOutcome)> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut outcomes = Vec::new();
+    while outcomes.len() < count && Instant::now() < deadline {
+        renderer.drain_present_returns_with(&mut |frame_id, outcome, _| {
+            outcomes.push((frame_id, outcome));
+        });
+        if outcomes.len() < count {
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+    outcomes
+}

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -18,7 +18,7 @@ use cranpose_app_shell::{
     default_root_key, AppShell, KeyEvent, PlatformFrameDriver, PointerSource,
 };
 use cranpose_platform_android::AndroidPlatform;
-use cranpose_render_wgpu::WgpuRenderer;
+use cranpose_render_wgpu::{PresentOutcome, PublishOutcome, WgpuRenderer};
 use cranpose_ui::{Point, Size};
 use ndk::native_window::NativeWindow;
 use std::time::{Duration, Instant};
@@ -34,9 +34,24 @@ use std::{
 };
 
 /// GPU resources for the current Android surface and its reusable WGPU device.
+///
+/// In threaded present mode (`CRANPOSE_PRESENT_THREAD`, step 7b) the
+/// `wgpu::Surface` itself is NOT held here: it is created on this thread
+/// and immediately moved to the present runtime (`ReplaceSurface`), which
+/// exclusively owns acquisition, encoding and `present()`. The producer
+/// keeps the device/queue for window recreation, its own copy of the
+/// surface configuration (it stamps resizes into the `Reconfigure` control
+/// messages), and the present bookkeeping. In the default synchronous mode
+/// the surface lives in `surface`, exactly as before.
 struct GpuResources {
-    surface: wgpu::Surface<'static>,
-    native_window_ptr: NonNull<c_void>,
+    /// The synchronous path's surface. `None` in threaded present mode
+    /// (the present runtime owns it) — the modes never mix within one run.
+    surface: Option<wgpu::Surface<'static>>,
+    /// The window the current surface belongs to; `None` after
+    /// `TerminateWindow`/`SurfaceDestroyed` in threaded mode, when the
+    /// runtime dropped the surface but the device lives on for the next
+    /// window (the sync path drops the whole resources struct instead).
+    native_window_ptr: Option<NonNull<c_void>>,
     adapter: Arc<wgpu::Adapter>,
     device: Arc<wgpu::Device>,
     queue: Arc<wgpu::Queue>,
@@ -44,10 +59,20 @@ struct GpuResources {
     backend: wgpu::Backend,
     config: wgpu::SurfaceConfiguration,
     _native_window: Option<NativeWindow>,
-    /// Set when the surface is (re)created and cleared after a successful
-    /// present, forcing the first frame to reach the screen even when `update()`
-    /// reports no visual work (mirrors the desktop/web `surface_dirty` flag).
+    /// Set when the surface is (re)created or reconfigured (every control
+    /// send) and cleared after a successful present, forcing the first
+    /// frame to reach the screen even when `update()` reports no visual
+    /// work (mirrors the desktop/web `surface_dirty` flag).
     surface_dirty: bool,
+}
+
+impl GpuResources {
+    /// Whether a window's surface currently exists — locally (sync mode)
+    /// or on the present runtime (threaded mode). Both modes key this off
+    /// the window pointer, which is `Some` exactly while a surface lives.
+    fn has_surface(&self) -> bool {
+        self.native_window_ptr.is_some()
+    }
 }
 
 /// Pending input event to be processed outside poll_events callback.
@@ -793,14 +818,21 @@ fn apply_display_visible_region(
     });
 }
 
-/// Renders a single frame. Returns true if out of memory (should exit).
+/// Renders a single frame (synchronous mode). Returns true if out of
+/// memory (should exit).
 fn render_once(
     resources: &mut GpuResources,
     shell: &mut AppShell<WgpuRenderer>,
     telemetry: &mut crate::android_frame_telemetry::AndroidFrameTelemetry,
     timings: &mut crate::android_frame_telemetry::FrameTimings,
 ) -> bool {
-    match current_surface_texture(&resources.surface, "android") {
+    let Some(surface) = resources.surface.as_ref() else {
+        // Sync mode always holds its surface while resources exist; this
+        // arm is unreachable there and threaded mode never calls here.
+        telemetry.note_idle_iteration();
+        return false;
+    };
+    match current_surface_texture(surface, "android") {
         SurfaceFrame::Ready(frame) => {
             timings.after_acquire_ns = telemetry.now();
             let view = frame
@@ -824,9 +856,7 @@ fn render_once(
             let (width, height) = shell.buffer_size();
             resources.config.width = width;
             resources.config.height = height;
-            resources
-                .surface
-                .configure(&resources.device, &resources.config);
+            surface.configure(&resources.device, &resources.config);
             // The reconfigured surface has not presented yet. Unlike web/desktop,
             // the android render block is gated behind `shell.needs_update()`, so
             // marking the shell dirty is what both wakes the looper and re-enters
@@ -844,8 +874,87 @@ fn render_once(
     }
 }
 
+/// Folds one drained batch of present-runtime returns into the loop's
+/// bookkeeping: presented frames complete their telemetry record and clear
+/// `surface_dirty`; refused frames (cancelled/errored) re-dirty the
+/// surface and re-mark the shell so the next iteration republishes —
+/// the depth-one replacement for `render_once`'s Reconfigure/Skip arms.
+/// Returns the instant the latest drained frame presented at (present
+/// thread's timestamp, mapped into this thread's `Instant` domain), for
+/// the catch-up pacing bookkeeping the sync path feeds directly.
+fn drain_present_returns_into_loop(
+    shell: &mut AppShell<WgpuRenderer>,
+    gpu_resources: &mut Option<GpuResources>,
+    telemetry: &mut crate::android_frame_telemetry::AndroidFrameTelemetry,
+    pending_present_timings: &mut Vec<(u64, crate::android_frame_telemetry::FrameTimings)>,
+) -> Option<web_time::Instant> {
+    let mut presented = false;
+    let mut refused = false;
+    let mut presented_at_ns = 0i64;
+    shell
+        .renderer()
+        .drain_present_returns_with(&mut |frame_id, outcome, timings| {
+            // Depth-one publishing keeps up to TWO frames in flight (one
+            // rendering, one waiting), so the producer timestamps are a
+            // small id-keyed list, not a single slot — a slot would be
+            // overwritten by frame N+1's publish before frame N's returns
+            // drain, and every record would be lost in steady overlap.
+            let producer_timings = pending_present_timings
+                .iter()
+                .position(|(id, _)| *id == frame_id)
+                .map(|index| pending_present_timings.remove(index).1);
+            match outcome {
+                PresentOutcome::Presented => {
+                    presented = true;
+                    presented_at_ns = timings.after_present_ns;
+                    if let Some(mut frame_timings) = producer_timings {
+                        frame_timings.after_acquire_ns = timings.after_acquire_ns;
+                        frame_timings.after_render_ns = timings.after_render_ns;
+                        frame_timings.after_present_ns = timings.after_present_ns;
+                        telemetry.record_frame(&frame_timings);
+                    }
+                }
+                // A cancelled or errored frame never reached the screen;
+                // its buffers already recycled through `apply_returns`.
+                PresentOutcome::Cancelled(_) | PresentOutcome::NotRun => {
+                    refused = true;
+                    telemetry.note_idle_iteration();
+                }
+            }
+        });
+    if presented {
+        if let Some(resources) = gpu_resources.as_mut() {
+            resources.surface_dirty = false;
+        }
+    }
+    if refused {
+        if let Some(resources) = gpu_resources.as_mut() {
+            resources.surface_dirty = true;
+        }
+        shell.mark_dirty();
+    }
+    presented.then(|| {
+        // The present happened on the present thread up to a few ms before
+        // this drain; back-date the pacing timestamp by its age so the
+        // catch-up detector measures present-to-present cadence, not
+        // drain-to-drain jitter. Both timestamps share `monotonic_nanos`.
+        let now = web_time::Instant::now();
+        let age_ns = telemetry.now().saturating_sub(presented_at_ns);
+        if presented_at_ns > 0 && age_ns > 0 {
+            now.checked_sub(Duration::from_nanos(age_ns as u64))
+                .unwrap_or(now)
+        } else {
+            now
+        }
+    })
+}
+
 struct AndroidGpuSetup {
     resources: GpuResources,
+    /// A freshly created surface for the present runtime (`ReplaceSurface`
+    /// carries it); `None` when the runtime already holds this window's
+    /// surface and only needs a `Reconfigure`.
+    surface: Option<wgpu::Surface<'static>>,
     renderer_needs_init: bool,
 }
 
@@ -944,6 +1053,54 @@ impl AndroidWgpuContext {
     }
 }
 
+/// Starts (or restarts) the threaded present runtime for the Android
+/// renderer: device/queue/format/backend cross to the present thread —
+/// which constructs its own `GpuRenderer` — the frame driver's waker wakes
+/// the looper after every present, and the telemetry clock keeps
+/// present-side timings in the producer's monotonic clock domain.
+fn init_gpu_threaded_for_android(
+    renderer: &mut WgpuRenderer,
+    resources: &GpuResources,
+    frame_driver: &AndroidFrameDriver,
+) -> Result<(), AndroidSurfaceError> {
+    renderer
+        .init_gpu_threaded(
+            resources.device.clone(),
+            resources.queue.clone(),
+            resources.surface_format,
+            resources.backend,
+            Arc::new(frame_driver.frame_waker()),
+            Some(Arc::new(crate::android_frame_telemetry::monotonic_nanos)),
+        )
+        .map_err(|error| AndroidSurfaceError::PresentRuntime(format!("{error:?}")))
+}
+
+/// `TerminateWindow`/`SurfaceDestroyed`: the surface dies but the device,
+/// queue and present runtime (with its warmed caches) survive for the next
+/// window — the same-device recreation path. The epoch bump comes first so
+/// any in-flight packet cancels, and `DropSurface` is acked only after a
+/// waiting packet's returns were sent. Without a shell there is no runtime
+/// holding a surface, so the resources just drop (as before 7b).
+fn drop_present_surface(
+    gpu_resources: &mut Option<GpuResources>,
+    app_shell: &mut Option<AppShell<WgpuRenderer>>,
+) {
+    match (gpu_resources.as_mut(), app_shell.as_mut()) {
+        (Some(resources), Some(shell)) => {
+            let renderer = shell.renderer();
+            renderer.note_surface_reconfigured();
+            renderer.present_drop_surface();
+            resources.native_window_ptr = None;
+            resources._native_window = None;
+            resources.surface_dirty = true;
+        }
+        _ => {
+            *gpu_resources = None;
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn initialize_android_rendering<F>(
     instance: &wgpu::Instance,
     existing_resources: Option<GpuResources>,
@@ -957,11 +1114,12 @@ fn initialize_android_rendering<F>(
     width: u32,
     height: u32,
     density: f32,
+    present_thread: bool,
 ) -> Result<(GpuResources, Option<Size>), AndroidSurfaceError>
 where
     F: FnMut() + 'static,
 {
-    let setup = create_android_gpu_resources(
+    let mut setup = create_android_gpu_resources(
         instance,
         existing_resources,
         native_window_ptr,
@@ -973,12 +1131,16 @@ where
     if app_shell.is_none() {
         let fonts = settings.resolve_font_set();
         let mut renderer = WgpuRenderer::with_font_set(fonts);
-        renderer.init_gpu(
-            setup.resources.device.clone(),
-            setup.resources.queue.clone(),
-            setup.resources.surface_format,
-            setup.resources.backend,
-        );
+        if present_thread {
+            init_gpu_threaded_for_android(&mut renderer, &setup.resources, frame_driver)?;
+        } else {
+            renderer.init_gpu(
+                setup.resources.device.clone(),
+                setup.resources.queue.clone(),
+                setup.resources.surface_format,
+                setup.resources.backend,
+            );
+        }
 
         let content_clone = content.clone();
         let density = density.max(f32::EPSILON);
@@ -1007,16 +1169,62 @@ where
         log::info!("App shell created");
     } else if setup.renderer_needs_init {
         if let Some(shell) = app_shell {
-            shell.renderer().init_gpu(
-                setup.resources.device.clone(),
-                setup.resources.queue.clone(),
-                setup.resources.surface_format,
-                setup.resources.backend,
-            );
+            if present_thread {
+                init_gpu_threaded_for_android(shell.renderer(), &setup.resources, frame_driver)?;
+            } else {
+                shell.renderer().init_gpu(
+                    setup.resources.device.clone(),
+                    setup.resources.queue.clone(),
+                    setup.resources.surface_format,
+                    setup.resources.backend,
+                );
+            }
             log::info!("Renderer reinitialized with new Android GPU pipeline resources");
         }
     } else {
         log::debug!("Reused Android WGPU device and renderer resources for surface update");
+    }
+
+    if present_thread {
+        // Hand the surface to the present runtime. Every message that
+        // changes the surface's identity or configuration bumps the surface
+        // epoch FIRST so any packet still in flight cancels instead of
+        // drawing, and the send waits for the runtime's ack: nothing
+        // publishes under the new epoch until the runtime holds the new
+        // state (tofable §4).
+        if let Some(shell) = app_shell.as_mut() {
+            let renderer = shell.renderer();
+            renderer.note_surface_reconfigured();
+            match setup.surface.take() {
+                Some(surface) => {
+                    renderer.present_replace_surface(surface, setup.resources.config.clone());
+                }
+                // Same-window reuse: the runtime already holds the surface;
+                // only the configuration travels.
+                None => {
+                    renderer.present_reconfigure(setup.resources.config.clone());
+                }
+            }
+            setup.resources.surface_dirty = true;
+        }
+    } else {
+        // Synchronous mode: the surface stays on this thread, configured
+        // here exactly as it was before the present runtime existed (the
+        // configure moved a few lines later than its historical spot in
+        // `create_android_gpu_resources`; nothing reads the surface in
+        // between).
+        match setup.surface.take() {
+            Some(surface) => {
+                surface.configure(&setup.resources.device, &setup.resources.config);
+                setup.resources.surface = Some(surface);
+            }
+            // Same-window reuse: reconfigure the surface already held.
+            None => {
+                if let Some(surface) = setup.resources.surface.as_ref() {
+                    surface.configure(&setup.resources.device, &setup.resources.config);
+                }
+            }
+        }
     }
 
     if let Some(shell) = app_shell {
@@ -1047,6 +1255,7 @@ fn initialize_android_rendering_with_backend_fallback<F>(
     width: u32,
     height: u32,
     density: f32,
+    present_thread: bool,
 ) -> Result<(GpuResources, Option<Size>), AndroidSurfaceError>
 where
     F: FnMut() + 'static,
@@ -1065,6 +1274,7 @@ where
             width,
             height,
             density,
+            present_thread,
         );
     }
 
@@ -1081,6 +1291,7 @@ where
         width,
         height,
         density,
+        present_thread,
     ) {
         Err(AndroidSurfaceError::RequestAdapter(error)) => {
             // Keep the two backends in separate instances. On Android emulators
@@ -1104,6 +1315,7 @@ where
                 width,
                 height,
                 density,
+                present_thread,
             )
         }
         result => result,
@@ -1119,17 +1331,19 @@ fn create_android_gpu_resources(
     height: u32,
 ) -> Result<AndroidGpuSetup, AndroidSurfaceError> {
     if let Some(mut resources) = existing_resources {
-        if resources.native_window_ptr == native_window_ptr {
+        if resources.native_window_ptr == Some(native_window_ptr) {
+            // Same window: the surface already exists (held locally in sync
+            // mode, on the present runtime in threaded mode); only the
+            // configuration is updated here and (re)applied by the caller —
+            // locally or through a `Reconfigure` control message.
             resources.config.width = width;
             resources.config.height = height;
-            resources
-                .surface
-                .configure(&resources.device, &resources.config);
             if let Some(native_window_owner) = native_window_owner {
                 resources._native_window = Some(native_window_owner);
             }
             return Ok(AndroidGpuSetup {
                 resources,
+                surface: None,
                 renderer_needs_init: false,
             });
         }
@@ -1167,13 +1381,16 @@ fn create_android_gpu_resources(
 
     let device = Arc::new(device);
     let queue = Arc::new(queue);
+    // The runtime configures the surface when `ReplaceSurface` delivers it
+    // together with this config.
     let config = create_android_surface_config(&surface, &adapter, width, height)?;
-    surface.configure(&device, &config);
 
     Ok(AndroidGpuSetup {
         resources: GpuResources {
-            surface,
-            native_window_ptr,
+            // Sync mode adopts the surface in `initialize_android_rendering`;
+            // threaded mode ships it to the present runtime instead.
+            surface: None,
+            native_window_ptr: Some(native_window_ptr),
             adapter,
             device,
             queue,
@@ -1183,6 +1400,7 @@ fn create_android_gpu_resources(
             _native_window: native_window_owner,
             surface_dirty: true,
         },
+        surface: Some(surface),
         renderer_needs_init: true,
     })
 }
@@ -1197,13 +1415,14 @@ fn create_android_gpu_resources_for_existing_device(
 ) -> Result<AndroidGpuSetup, AndroidSurfaceError> {
     let surface = create_android_wgpu_surface(instance, native_window_ptr)?;
     let config = create_android_surface_config(&surface, &existing.adapter, width, height)?;
-    surface.configure(&existing.device, &config);
     let renderer_needs_init = config.format != existing.surface_format;
 
     Ok(AndroidGpuSetup {
         resources: GpuResources {
-            surface,
-            native_window_ptr,
+            // Sync mode adopts the surface in `initialize_android_rendering`;
+            // threaded mode ships it to the present runtime instead.
+            surface: None,
+            native_window_ptr: Some(native_window_ptr),
             adapter: existing.adapter.clone(),
             device: existing.device.clone(),
             queue: existing.queue.clone(),
@@ -1213,6 +1432,7 @@ fn create_android_gpu_resources_for_existing_device(
             _native_window: native_window_owner,
             surface_dirty: true,
         },
+        surface: Some(surface),
         renderer_needs_init,
     })
 }
@@ -1498,6 +1718,20 @@ pub fn run(
     // environment-gated telemetry is reachable on device.
     crate::android_frame_telemetry::seed_env_from_system_properties();
 
+    // Threaded present runtime (pipeline step 7b), default OFF: the frame
+    // is split at the packet boundary and acquire/encode/submit/present
+    // move to a dedicated present thread, overlapping with the producer's
+    // update/lowering of the next frame. Kill switch CRANPOSE_PRESENT_THREAD
+    // (`adb shell setprop debug.cranpose.present_thread 1`); read once —
+    // the mode must not change while a renderer is live.
+    let present_thread = matches!(
+        std::env::var("CRANPOSE_PRESENT_THREAD").as_deref(),
+        Ok("1") | Ok("true") | Ok("on")
+    );
+    if present_thread {
+        log::info!("[present-runtime] threaded present enabled (CRANPOSE_PRESENT_THREAD)");
+    }
+
     // Register the SAF document picker as the platform file picker. Requires the
     // app's activity to be `dev.cranpose.android.CranposeActivity`.
     crate::android_file_picker::register(app.clone());
@@ -1644,12 +1878,37 @@ pub fn run(
     let mut behind_deadline = false;
     let mut catchup_coasts = 0u32;
 
+    // The producer-side timestamps of the frames currently in flight on
+    // the present thread (depth-one publishing: one rendering plus one
+    // waiting), completed with the runtime's acquire/render/present
+    // timestamps when each frame's returns drain. Threaded present mode
+    // only; the sync path records its telemetry in `render_once` as
+    // always.
+    let mut pending_present_timings =
+        Vec::<(u64, crate::android_frame_telemetry::FrameTimings)>::with_capacity(2);
+
     // Main event loop
     loop {
         let mut frame_timings = crate::android_frame_telemetry::FrameTimings {
             iteration_start_ns: frame_telemetry.now(),
             ..Default::default()
         };
+
+        // Drain present-runtime returns FIRST — before the frame schedule
+        // reads `needs_redraw` (fresh warmup state) and before the credit
+        // gate below, so a completed frame frees its publish credit for
+        // this very iteration. No-op (and `None`) in sync mode, which has
+        // no present runtime to drain.
+        let drained_present_at = match app_shell.as_mut() {
+            Some(shell) => drain_present_returns_into_loop(
+                shell,
+                &mut gpu_resources,
+                &mut frame_telemetry,
+                &mut pending_present_timings,
+            ),
+            None => None,
+        };
+
         let pending_confirmation_timeout = pending_host_window_confirmation.map(|pending| {
             android_host_window::HOST_WINDOW_CONFIRMATION_TIMEOUT
                 .checked_sub(pending.requested_at.elapsed())
@@ -1659,7 +1918,12 @@ pub fn run(
         // A frame deadline with no surface asks for a frame nothing will draw,
         // and an app with a running animation asks for one every turn of the
         // loop, which is a spun core for as long as the app is off screen.
-        let no_surface = gpu_resources.is_none();
+        // In sync mode a surfaceless window drops the whole resources
+        // struct; in threaded mode the device survives `TerminateWindow`
+        // with `native_window_ptr` cleared — both count as "no surface".
+        let no_surface = gpu_resources
+            .as_ref()
+            .is_none_or(|resources| !resources.has_surface());
         match app_shell.as_ref() {
             Some(shell) if !no_surface => {
                 shell.schedule_platform_frame(&android_frame_driver);
@@ -1804,6 +2068,7 @@ pub fn run(
                                     width,
                                     height,
                                     density,
+                                    present_thread,
                                 ) {
                                     Ok((resources, actual_size)) => {
                                         if let Some(actual_size) = actual_size {
@@ -1878,7 +2143,11 @@ pub fn run(
                     MainEvent::TerminateWindow { .. } => {
                         log::info!("Window terminated");
                         if overlay_window_options.is_none() {
-                            gpu_resources = None;
+                            if present_thread {
+                                drop_present_surface(&mut gpu_resources, &mut app_shell);
+                            } else {
+                                gpu_resources = None;
+                            }
                         }
                     }
                     MainEvent::WindowResized { .. } => {
@@ -1906,9 +2175,19 @@ pub fn run(
                                     if width > 0 && height > 0 {
                                         resources.config.width = width;
                                         resources.config.height = height;
-                                        resources
-                                            .surface
-                                            .configure(&resources.device, &resources.config);
+                                        if present_thread {
+                                            // Epoch bump first (in-flight packets
+                                            // cancel), then the runtime applies the
+                                            // new configuration and acks before
+                                            // anything publishes under the new
+                                            // epoch.
+                                            let renderer = shell.renderer();
+                                            renderer.note_surface_reconfigured();
+                                            renderer.present_reconfigure(resources.config.clone());
+                                            resources.surface_dirty = true;
+                                        } else if let Some(surface) = resources.surface.as_ref() {
+                                            surface.configure(&resources.device, &resources.config);
+                                        }
 
                                         // Set buffer_size to physical pixels
                                         shell.set_buffer_size(width, height);
@@ -2069,6 +2348,7 @@ pub fn run(
                                 width,
                                 height,
                                 density,
+                                present_thread,
                             ) {
                                 Ok((resources, actual_size)) => {
                                     if let Some(actual_size) = actual_size {
@@ -2113,6 +2393,7 @@ pub fn run(
                             width,
                             height,
                             density,
+                            present_thread,
                         ) {
                             Ok((resources, actual_size)) => {
                                 if let Some(actual_size) = actual_size {
@@ -2137,7 +2418,11 @@ pub fn run(
                 }
                 android_overlay_window::AndroidOverlayWindowEvent::SurfaceDestroyed => {
                     if overlay_window_options.is_some() {
-                        gpu_resources = None;
+                        if present_thread {
+                            drop_present_surface(&mut gpu_resources, &mut app_shell);
+                        } else {
+                            gpu_resources = None;
+                        }
                     }
                 }
                 android_overlay_window::AndroidOverlayWindowEvent::Pointer { action, x, y } => {
@@ -2391,9 +2676,18 @@ pub fn run(
             };
         }
 
-        // Render outside event callback if needed
+        // Render outside event callback if needed. In threaded present mode
+        // the depth-one credit gate wraps the WHOLE update block: without
+        // credit (a frame is still in flight on the present thread) the
+        // producer skips even `shell.update()` — backpressure lands before
+        // the expensive update/lowering work, and the present thread's
+        // completion wakes the looper through the frame waker. In sync mode
+        // `has_frame_credit` is constant `true` and this is today's block.
         if let (Some(resources), Some(shell)) = (&mut gpu_resources, &mut app_shell) {
-            if shell.needs_update() {
+            if resources.has_surface()
+                && shell.needs_update()
+                && shell.renderer().has_frame_credit()
+            {
                 let update_result = android_host_window::with_android_host_window_registry(
                     &host_window_registry,
                     || shell.update(),
@@ -2422,7 +2716,28 @@ pub fn run(
                     update_result.visual_changed,
                     shell.needs_redraw(),
                 ) {
-                    if render_once(resources, shell, &mut frame_telemetry, &mut frame_timings) {
+                    if present_thread {
+                        let (width, height) = shell.buffer_size();
+                        match shell.renderer().publish_frame(width, height) {
+                            PublishOutcome::Published => {
+                                // The runtime finishes acquire/render/present;
+                                // this frame's producer timestamps wait for its
+                                // returns to complete the telemetry record.
+                                pending_present_timings.push((
+                                    shell.renderer().last_published_frame_id(),
+                                    frame_timings,
+                                ));
+                            }
+                            PublishOutcome::NoGraph | PublishOutcome::NoCredit => {
+                                frame_telemetry.note_idle_iteration();
+                            }
+                        }
+                    } else if render_once(
+                        resources,
+                        shell,
+                        &mut frame_telemetry,
+                        &mut frame_timings,
+                    ) {
                         break; // Out of memory, exit
                     }
                 } else {
@@ -2438,9 +2753,17 @@ pub fn run(
         // Catch-up pacing bookkeeping (see the note above the loop):
         // `after_present_ns` is stamped only by a successful present, and
         // `FrameTimings` is fresh per iteration, so a nonzero value is the
-        // exact "this iteration presented" signal.
-        if frame_timings.after_present_ns != 0 {
-            let now = web_time::Instant::now();
+        // exact "this iteration presented" signal (sync mode). In threaded
+        // mode presents complete on the present thread and are observed
+        // when their returns drain at the head of the iteration, carrying
+        // the back-dated present instant; the two signals are exclusive
+        // (one mode per run).
+        let presented_at = if frame_timings.after_present_ns != 0 {
+            Some(web_time::Instant::now())
+        } else {
+            drained_present_at
+        };
+        if let Some(now) = presented_at {
             behind_deadline = catchup_pacing
                 && last_present_at.is_some_and(|previous| {
                     // Display-reported period first (vsync-probe builds),
@@ -2474,5 +2797,12 @@ pub fn run(
                 behind_deadline = false;
             }
         }
+    }
+
+    // Loop exited (`Destroy`): stop the present thread. Outstanding
+    // returns drain into the frontend and the thread joins; the surface
+    // and the GpuRenderer die on the present thread, as they lived.
+    if let Some(shell) = app_shell.as_mut() {
+        shell.renderer().shutdown_present_runtime();
     }
 }

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -73,8 +73,9 @@ fn property_flag(name: &str) -> bool {
 /// any length — so a name may run right up to or past that pre-O limit, as
 /// `debug.cranpose.retained_mesh_px2` does; every deployment target is far
 /// past O.)
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 23] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 24] = [
     ("debug.cranpose.gpu_stats", "CRANPOSE_GPU_STATS"),
+    ("debug.cranpose.present_thread", "CRANPOSE_PRESENT_THREAD"),
     ("debug.cranpose.command_feed", "CRANPOSE_COMMAND_FEED"),
     ("debug.cranpose.arc_mesh", "CRANPOSE_ARC_MESH"),
     ("debug.cranpose.rim_mesh", "CRANPOSE_RIM_MESH"),

--- a/crates/cranpose/src/android_surface.rs
+++ b/crates/cranpose/src/android_surface.rs
@@ -15,6 +15,8 @@ pub(crate) enum AndroidSurfaceError {
     NoSurfaceFormat,
     #[error("Android WGPU surface reports no supported alpha modes")]
     NoAlphaMode,
+    #[error("failed to start Android present runtime: {0}")]
+    PresentRuntime(String),
 }
 
 pub(crate) fn create_android_wgpu_surface(


### PR DESCRIPTION
Revival of the parked present-thread overlap (7b), with its serializer named and fixed.

The parked attempt (b2ae2d13) lost three ways: (1) publish credit released only with RenderReturns, sent after present() — full serialization plus a thread hop; (2) a single pooled CompositorScene, so two in-flight packets malloc'd multi-MB every other frame; (3) the ReplayAck rode home inside RenderReturns, behind acquire+encode+submit+present, so frame N's confirmations never reached frame N+1's planning and every recapture re-materialized ~17k primitives instead of replaying ~35 retained spans. (1) and (2) were fixed at the parked tip but never measured; both are carried.

The new fix for (3): the present thread consumes a validated packet's replay ops BEFORE get_current_texture (GpuRenderer::take_replay_ack_early, packet-flagged against double-consume and cancel-reclaim) and ships the ack immediately on its own channel; the producer drains it at the head of publish_frame, right before the collect that reads the bypass gate — restoring the sync path's one-frame confirmation latency under overlap. Contract test 7b-7 pins this and was verified red with the pre-acquire consume reverted.

Kill switch CRANPOSE_PRESENT_THREAD (default OFF = today's sync loop, byte-equivalent incl. pacing) + debug.cranpose.present_thread (PROPERTY_BACKED_ENV_VARS 23→24). Post-parked main reconciled: round-cull region crosses via init + ordered control message; catch-up pacing feeds from drained returns with age-corrected instants; and a revival-found fix — the single pending-telemetry slot would have dropped all frame telemetry at credit=2 (now an id-keyed list bounded by credit).

Verified on samarch: full cranpose-render-wgpu suite (25 binaries), cranpose host tests, armv7 android check, clippy warning-identical to main, fmt clean.

Why now: with the 2026-08-14 stage map (record-side ≈ 8-9 ms, encode+GPU ≈ 9-10 ms, CPU at 100-106%, fill program closed), depth-one overlap computes to ~11-13 ms ≈ 60+ fps potential. On-watch A/B follows the merge; default stays OFF until it wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2