### PR TITLE
Centre every line of a wrapped ListHeader, not just the block

### DIFF
--- a/crates/cranpose-render/common/src/software_text_raster.rs
+++ b/crates/cranpose-render/common/src/software_text_raster.rs
@@ -6725,6 +6725,47 @@ mod line_alignment_tests {
     }
 
     #[test]
+    fn a_wrapped_list_header_centres_both_its_lines() {
+        // The style an app actually gets, not one assembled for the test:
+        // `ListHeader` owns its text style, so if the alignment is not on the
+        // spec then nothing downstream can put it back. Compose provides
+        // `LocalTextConfiguration(TextAlign.Center)` around the header's
+        // content -- `ListHeaderKt` in compose-material3-1.6.2.aar -- and the
+        // Credits screen is where that shows: `ORBIT BREAKER` wraps, and with
+        // a block-only centring `ORBIT` sat 25 px left of the `BREAKER` under
+        // it.
+        let font = default_software_text_font().expect("bundled default font");
+        let style = cranpose_ui::widgets::wear::list_header::ListHeaderSpec::default()
+            .text_style
+            .resolve(Color(1.0, 1.0, 1.0, 1.0));
+        let rect = Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 400.0,
+            height: 80.0,
+        };
+        let image = rasterize_text_to_image(
+            "wwwwwwwwwwww\nww",
+            rect,
+            &style,
+            Color(1.0, 1.0, 1.0, 1.0),
+            20.0,
+            1.0,
+            &font,
+        )
+        .expect("header image");
+        let long = ink_columns(&image, 0..(image.height() / 2)).expect("first line ink");
+        let short =
+            ink_columns(&image, (image.height() / 2)..image.height()).expect("second line ink");
+        let long_centre = (long.0 + long.1) as f32 * 0.5;
+        let short_centre = (short.0 + short.1) as f32 * 0.5;
+        assert!(
+            (long_centre - short_centre).abs() <= 2.0,
+            "a wrapped header's lines must share a centre: {long:?} vs {short:?}"
+        );
+    }
+
+    #[test]
     fn a_wrapped_line_is_centred_under_the_one_above_it_not_left_under_it() {
         // `TextAlign` is a paragraph property and Compose applies it to every
         // line. The scene builder centres the block; without a per-line offset

--- a/crates/cranpose-ui/src/widgets/wear/list_header.rs
+++ b/crates/cranpose-ui/src/widgets/wear/list_header.rs
@@ -9,11 +9,23 @@
 //! comes to 47dp, which the floor rounds up to 48dp, and the surplus is split
 //! by re-centring the padded content in the taller box rather than being added
 //! below it. That is a one-pixel difference and it is on every header.
+//!
+//! The third is the alignment, and it only shows on a header long enough to
+//! wrap. `ListHeader` provides `LocalTextConfiguration` with
+//! `TextAlign.Center` alongside its `Arrangement.Center` — read out of
+//! `ListHeaderKt` in `compose-material3-1.6.2.aar`, where the neighbouring
+//! `ListSubHeader` provides `TextAlign.Start` — so **every** line of a wrapped
+//! header is centred in the block, not just placed under the start of the
+//! first. Centring the block alone is invisible on a one-line header and wrong
+//! on a two-line one: on a 384 px Credits screen, `ORBIT BREAKER` wraps after
+//! `ORBIT` and Compose puts that line at x 147, while a block-only centring
+//! puts it at x 121, 25 px to the left of the `BREAKER` under it.
 
 #![allow(non_snake_case)]
 
 use crate::composable;
 use crate::modifier::Modifier;
+use crate::text::paragraph::TextAlign;
 use crate::widgets::wear::density::WearDensity;
 use crate::widgets::wear::theme::{WearColors, WearTextStyle};
 use crate::widgets::{Layout, Text};
@@ -38,7 +50,12 @@ impl Default for ListHeaderSpec {
     fn default() -> Self {
         Self {
             colors: WearColors::default(),
-            text_style: WearTextStyle::TITLE_MEDIUM,
+            // `TITLE_MEDIUM` is `ListHeaderTokens`; the alignment is the
+            // `LocalTextConfiguration` the widget provides around it. It lives
+            // on the spec rather than being forced at the call site so a
+            // caller who overrides `text_style` overrides the alignment too,
+            // the way overriding `LocalTextConfiguration` does in Compose.
+            text_style: WearTextStyle::TITLE_MEDIUM.aligned(TextAlign::Center),
             min_height: 48.0,
             padding_start: 14.0,
             padding_top: 16.0,
@@ -203,6 +220,14 @@ mod tests {
         assert_eq!(spec.padding_end, 14.0);
         assert_eq!(spec.padding_top, 16.0);
         assert_eq!(spec.padding_bottom, 12.0);
-        assert_eq!(spec.text_style, WearTextStyle::TITLE_MEDIUM);
+        // The type token, plus the alignment the widget provides around it:
+        // Compose's ListHeader wraps its content in LocalTextConfiguration
+        // with TextAlign.Center, so the style an app actually gets is the
+        // centred one. Asserting the bare token here would pass while every
+        // real header wrapped its second line to the left.
+        assert_eq!(
+            spec.text_style,
+            WearTextStyle::TITLE_MEDIUM.aligned(TextAlign::Center)
+        );
     }
 }


### PR DESCRIPTION
## What

`ListHeader` gave its `Text` no alignment, so a header long enough to wrap had every line start at the block's left edge instead of centred in it.

## Why it is a defect

Compose provides `LocalTextConfiguration` with `TextAlign.Center` around a `ListHeader`'s content, alongside its `Arrangement.Center`. Read out of `ListHeaderKt` in `compose-material3-1.6.2.aar` — the neighbouring `ListSubHeader` provides `TextAlign.Start`, so the two are deliberately different and this is not a guess about what looks reasonable.

`text_align_fraction` returns 0 for a start alignment, which makes `annotated_line_alignment_offsets` return `None`, which leaves every line at the block's left edge. On a one-line header that is invisible — the measure policy centres the block and the single line fills it — so nothing caught it until a header wrapped.

## Measured

On a 384 px Wear screen where `ORBIT BREAKER` wraps after `ORBIT`:

| | first line | second line |
|---|---|---|
| Compose | x 147..238 (centre 192.5) | x 123..263 (centre 193.0) |
| Cranpose, before | x 121..213 (centre **167.0**) | x 122..262 (centre 192.0) |
| widths | 91 vs 92 | 140 vs 140 |

Same width, 25 px to the left, under a `BREAKER` that was centred.

## The fix

The alignment goes on `ListHeaderSpec` rather than being forced at the `Text` call, so a caller who overrides `text_style` overrides the alignment with it — which is what overriding `LocalTextConfiguration` does in Compose.

## Test

`a_wrapped_list_header_centres_both_its_lines` drives the style an app actually gets (`ListHeaderSpec::default().text_style`) rather than one assembled in the test, because the defect was in the spec: any test that builds its own centred style passes while every real header is wrong.

Reinstating the defect fails it — `a wrapped header's lines must share a centre: (0, 193) vs (0, 31)` — and the fix turns it green with the other three line-alignment tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)