### PR TITLE
Revive the solid varying trim behind an opt-in, locations preserved

### DIFF
--- a/crates/cranpose-render/wgpu/src/display_clip.rs
+++ b/crates/cranpose-render/wgpu/src/display_clip.rs
@@ -437,6 +437,10 @@ mod tests {
     fn content_z_substitution_matches_every_fused_pass_vertex_stage() {
         for (name, source) in [
             ("shape", crate::shaders::SHADER),
+            // The trimmed solid entries are appended to the shape source
+            // under `CRANPOSE_SOLID_TRIM_VARYINGS`; their z tails must take
+            // the same rewrite so the trimmed depth pipelines cull too.
+            ("shape_solid_trim", crate::shaders::SOLID_TRIM_APPENDIX),
             ("image", crate::shaders::IMAGE_SHADER),
             ("glyph_atlas", crate::shaders::GLYPH_ATLAS_SHADER),
             ("fullscreen_quad", crate::shaders::FULLSCREEN_QUAD_VS),

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -1333,53 +1333,73 @@ fn gradient_tile_mode_value(tile_mode: TileMode) -> u32 {
     }
 }
 
+/// The base text the shape rewrites below start from: `shape.wgsl` alone, or
+/// — under `CRANPOSE_SOLID_TRIM_VARYINGS` — `shape.wgsl` with the trimmed
+/// solid entries appended. Appending happens BEFORE the storage/array
+/// rewrites so the paint-select injection and the batch-limit resizes land
+/// in the trimmed entries exactly as they land in `vs_main` (the
+/// substitution tests pin five landings); with the trim off the text is the
+/// borrowed shipping constant, byte-identical to what always compiled.
+fn shape_shader_base(solid_trim: bool) -> Cow<'static, str> {
+    if solid_trim {
+        return Cow::Owned(format!(
+            "{}\n{}",
+            shaders::SHADER,
+            shaders::SOLID_TRIM_APPENDIX
+        ));
+    }
+    Cow::Borrowed(shaders::SHADER)
+}
+
 #[cfg(not(target_arch = "wasm32"))]
-fn shape_shader_source(batch_limits: ShapeBatchLimits) -> Cow<'static, str> {
+fn shape_shader_source(batch_limits: ShapeBatchLimits, solid_trim: bool) -> Cow<'static, str> {
+    let base = shape_shader_base(solid_trim);
     // These literals must stay in sync with `shape.wgsl`; a mismatch makes
     // the substitution silently no-op and leaves the shader sized for the
     // downlevel floor.
     if batch_limits.storage {
         return Cow::Owned(
-            shaders::SHADER
-                .replace(
-                    "var<uniform> shape_data: array<ShapeData, 102>;",
-                    "var<storage, read> shape_data: array<ShapeData>;",
-                )
-                .replace(
-                    "var<uniform> gradient_stops: array<GradientStop, 256>;",
-                    // Also inject the retained-paint array here: one mutable
-                    // color per shape, read when `similarity.paint_select`
-                    // is set, so recolor patches upload 16-byte colors
-                    // instead of whole ShapeData records. The base text
-                    // never declares it — uniform-mode devices cannot bind
-                    // storage and never host retained slots.
-                    "var<storage, read> gradient_stops: array<GradientStop>;\n\n\
+            base.replace(
+                "var<uniform> shape_data: array<ShapeData, 102>;",
+                "var<storage, read> shape_data: array<ShapeData>;",
+            )
+            .replace(
+                "var<uniform> gradient_stops: array<GradientStop, 256>;",
+                // Also inject the retained-paint array here: one mutable
+                // color per shape, read when `similarity.paint_select`
+                // is set, so recolor patches upload 16-byte colors
+                // instead of whole ShapeData records. The base text
+                // never declares it — uniform-mode devices cannot bind
+                // storage and never host retained slots.
+                "var<storage, read> gradient_stops: array<GradientStop>;\n\n\
                      @group(1) @binding(3)\n\
                      var<storage, read> paint: array<vec4<f32>>;",
-                )
-                .replace(
-                    "output.color = shape.color;",
-                    "output.color = \
+            )
+            .replace(
+                "output.color = shape.color;",
+                "output.color = \
                      select(shape.color, paint[shape_idx], similarity.paint_select > 0.5);",
-                ),
+            ),
         );
     }
     Cow::Owned(
-        shaders::SHADER
-            .replace(
-                "array<ShapeData, 102>",
-                &format!("array<ShapeData, {}>", batch_limits.max_shapes_per_batch),
-            )
-            .replace(
-                "array<GradientStop, 256>",
-                &format!("array<GradientStop, {}>", batch_limits.max_gradient_stops),
-            ),
+        base.replace(
+            "array<ShapeData, 102>",
+            &format!("array<ShapeData, {}>", batch_limits.max_shapes_per_batch),
+        )
+        .replace(
+            "array<GradientStop, 256>",
+            &format!("array<GradientStop, {}>", batch_limits.max_gradient_stops),
+        ),
     )
 }
 
 #[cfg(target_arch = "wasm32")]
-fn shape_shader_source(_batch_limits: ShapeBatchLimits) -> Cow<'static, str> {
-    Cow::Borrowed(shaders::SHADER)
+fn shape_shader_source(_batch_limits: ShapeBatchLimits, solid_trim: bool) -> Cow<'static, str> {
+    // wasm keeps the downlevel array lengths verbatim. The trim flag is
+    // env-driven and a browser has no environment to set it in, but the arm
+    // stays honest for any embedder that reaches it.
+    shape_shader_base(solid_trim)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1390,13 +1410,15 @@ fn create_shape_pipeline(
     shape_layout: &wgpu::BindGroupLayout,
     blend_mode: BlendMode,
     batch_limits: ShapeBatchLimits,
+    solid_trim: bool,
+    vertex_entry: &'static str,
     fragment_entry: &'static str,
     depth: bool,
 ) -> wgpu::RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("Shape Shader"),
         source: wgpu::ShaderSource::Wgsl(display_clip::with_content_z(
-            shape_shader_source(batch_limits),
+            shape_shader_source(batch_limits, solid_trim),
             depth,
         )),
     });
@@ -1412,10 +1434,10 @@ fn create_shape_pipeline(
         layout: Some(&pipeline_layout),
         vertex: wgpu::VertexState {
             module: &shader,
-            entry_point: Some("vs_main"),
+            entry_point: Some(vertex_entry),
             compilation_options: wgpu::PipelineCompilationOptions::default(),
-            // No vertex buffer: `vs_main` pulls quad corners from ShapeData
-            // by `vertex_index`.
+            // No vertex buffer: `vs_main` (and its trimmed twin `vs_solid`)
+            // pulls quad corners from ShapeData by `vertex_index`.
             buffers: &[],
         },
         fragment: Some(wgpu::FragmentState {
@@ -1461,8 +1483,10 @@ fn create_mesh_shape_pipeline(
 ) -> wgpu::RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("Shape Mesh Shader"),
+        // Mesh slots may carry gradients, so this family always compiles the
+        // full interface — the trimmed entries never pair with `vs_mesh`.
         source: wgpu::ShaderSource::Wgsl(display_clip::with_content_z(
-            shape_shader_source(batch_limits),
+            shape_shader_source(batch_limits, false),
             depth,
         )),
     });
@@ -1524,13 +1548,15 @@ fn create_instanced_shape_pipeline(
     shape_layout: &wgpu::BindGroupLayout,
     blend_mode: BlendMode,
     batch_limits: ShapeBatchLimits,
+    solid_trim: bool,
+    vertex_entry: &'static str,
     fragment_entry: &'static str,
     depth: bool,
 ) -> wgpu::RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("Shape Instanced Shader"),
         source: wgpu::ShaderSource::Wgsl(display_clip::with_content_z(
-            shape_shader_source(batch_limits),
+            shape_shader_source(batch_limits, solid_trim),
             depth,
         )),
     });
@@ -1546,7 +1572,7 @@ fn create_instanced_shape_pipeline(
         layout: Some(&pipeline_layout),
         vertex: wgpu::VertexState {
             module: &shader,
-            entry_point: Some("vs_shape_instanced"),
+            entry_point: Some(vertex_entry),
             compilation_options: wgpu::PipelineCompilationOptions::default(),
             // No vertex buffer: like `vs_main`, the corners come from
             // ShapeData; only the shape index source differs
@@ -4504,6 +4530,22 @@ fn instanced_quads_enabled() -> bool {
     std::env::var("CRANPOSE_INSTANCED_QUADS").as_deref() != Ok("0")
 }
 
+/// Trimmed-varying solid pipelines: default OFF, `CRANPOSE_SOLID_TRIM_VARYINGS=1`
+/// (or the `debug.cranpose.solid_trim` property on Android) opts in. When on,
+/// the two `fs_solid` pipeline families compile `vs_solid` /
+/// `vs_solid_instanced` + `fs_solid_trim` — the inter-stage interface without
+/// the eight gradient scalars `fs_solid` never reads (see
+/// `shape_solid_trim.wgsl` for the location discipline). Read at pipeline
+/// build like every lazy pipeline — the property is seeded into the
+/// environment before the render loop starts, and the `PassPipeline` slots
+/// cache the first build, so retained bundles and direct draws always encode
+/// the same selection. Kill switch first: the previous attempt (16a5d312,
+/// reverted in 371dd06a) died on a watch undiagnosed, so the trim ships dark
+/// until a Vulkan-validated device session clears it.
+fn solid_trim_varyings_enabled() -> bool {
+    std::env::var("CRANPOSE_SOLID_TRIM_VARYINGS").as_deref() == Ok("1")
+}
+
 /// Kill switch for the display clip region cull: default ON wherever the
 /// platform reports a cullable visible region
 /// (`set_display_visible_region`), and `CRANPOSE_ROUND_CULL` (or the
@@ -6468,6 +6510,8 @@ impl GpuRenderer {
                 &self.shape_bind_group_layout,
                 blend_mode,
                 self.shape_batch_limits,
+                false,
+                "vs_main",
                 "fs_main",
                 depth,
             )
@@ -6477,10 +6521,20 @@ impl GpuRenderer {
     /// The `fs_solid` twin of [`Self::shape_pipeline`], SrcOver only. Callers
     /// pick it exactly when the draw's shapes carry zero gradient stops; the
     /// coverage math is byte-identical, the gradient machinery is compiled
-    /// out of the fragment stage.
+    /// out of the fragment stage. Under `CRANPOSE_SOLID_TRIM_VARYINGS`
+    /// (re-read per build, see [`solid_trim_varyings_enabled`]) the build
+    /// compiles the trimmed-interface entries instead; either variant encodes
+    /// identically — same layouts, same blend, no vertex buffers — so every
+    /// caller, retained bundles included, is oblivious to the selection.
     fn shape_pipeline_solid(&self) -> &wgpu::RenderPipeline {
         self.pipeline_solid
             .get_or_init(self.adapter_backend, self.pass_depth(), |depth| {
+                let solid_trim = solid_trim_varyings_enabled();
+                let (vertex_entry, fragment_entry) = if solid_trim {
+                    ("vs_solid", "fs_solid_trim")
+                } else {
+                    ("vs_main", "fs_solid")
+                };
                 create_shape_pipeline(
                     &self.device,
                     self.surface_format,
@@ -6488,7 +6542,9 @@ impl GpuRenderer {
                     &self.shape_bind_group_layout,
                     BlendMode::SrcOver,
                     self.shape_batch_limits,
-                    "fs_solid",
+                    solid_trim,
+                    vertex_entry,
+                    fragment_entry,
                     depth,
                 )
             })
@@ -6527,6 +6583,8 @@ impl GpuRenderer {
                 &self.shape_bind_group_layout,
                 blend_mode,
                 self.shape_batch_limits,
+                false,
+                "vs_shape_instanced",
                 "fs_main",
                 depth,
             )
@@ -6534,6 +6592,8 @@ impl GpuRenderer {
     }
 
     /// The `fs_solid` twin of [`Self::instanced_pipeline`], SrcOver only.
+    /// Trims its varyings under `CRANPOSE_SOLID_TRIM_VARYINGS` exactly like
+    /// [`Self::shape_pipeline_solid`].
     #[cfg(not(target_arch = "wasm32"))]
     fn instanced_pipeline_solid<'a>(
         &'a self,
@@ -6542,6 +6602,12 @@ impl GpuRenderer {
         instanced
             .pipeline_solid
             .get_or_init(self.adapter_backend, self.pass_depth(), |depth| {
+                let solid_trim = solid_trim_varyings_enabled();
+                let (vertex_entry, fragment_entry) = if solid_trim {
+                    ("vs_solid_instanced", "fs_solid_trim")
+                } else {
+                    ("vs_shape_instanced", "fs_solid")
+                };
                 create_instanced_shape_pipeline(
                     &self.device,
                     self.surface_format,
@@ -6549,7 +6615,9 @@ impl GpuRenderer {
                     &self.shape_bind_group_layout,
                     BlendMode::SrcOver,
                     self.shape_batch_limits,
-                    "fs_solid",
+                    solid_trim,
+                    vertex_entry,
+                    fragment_entry,
                     depth,
                 )
             })
@@ -22493,7 +22561,8 @@ mod tests {
 
     #[test]
     fn storage_shape_shader_swaps_the_arrays_to_runtime_sized_storage() {
-        let source = shape_shader_source(ShapeBatchLimits::for_storage_binding_size(128 << 20));
+        let source =
+            shape_shader_source(ShapeBatchLimits::for_storage_binding_size(128 << 20), false);
         assert!(
             source.contains("var<storage, read> shape_data: array<ShapeData>;"),
             "storage-mode shader must declare a runtime-sized shape array"
@@ -22549,13 +22618,117 @@ mod tests {
     }
 
     #[test]
+    fn solid_trim_keeps_the_full_struct_locations_with_the_dropped_slots_vacant() {
+        // Suspect #1 from the reverted first trim (16a5d312 / 371dd06a): the
+        // survivors were renumbered densely. Every surviving varying line in
+        // `VertexOutputSolid` must be byte-identical to its `VertexOutput`
+        // line — same index, same interpolation, same type — and the two
+        // dropped slots must stay vacant.
+        let appendix = shaders::SOLID_TRIM_APPENDIX;
+        for line in [
+            "@location(0) color: vec4<f32>,",
+            "@location(1) uv: vec2<f32>,",
+            "@location(2) world_pos: vec2<f32>,",
+            "@location(3) @interpolate(flat) rect: vec4<f32>,",
+            "@location(4) @interpolate(flat) radii: vec4<f32>,",
+            "@location(6) @interpolate(flat) clip_rect: vec4<f32>,",
+            "@location(7) @interpolate(flat) stroke_params: vec4<f32>,",
+            "@location(8) @interpolate(flat) arc_params: vec4<f32>,",
+        ] {
+            assert!(
+                shaders::SHADER.contains(line),
+                "`{line}` drifted out of VertexOutput; realign the trimmed \
+                 struct line for line before touching anything else"
+            );
+            assert!(
+                appendix.contains(line),
+                "`{line}` must appear verbatim in VertexOutputSolid — the \
+                 surviving varyings keep the full struct's location indices"
+            );
+        }
+        assert!(
+            !appendix.contains("@location(5)"),
+            "location 5 is gradient_params' slot and must stay VACANT — \
+             dense renumbering is the reverted attempt's suspect #1"
+        );
+        assert!(
+            !appendix.contains("@location(9)"),
+            "location 9 is brush's slot and must stay VACANT — dense \
+             renumbering is the reverted attempt's suspect #1"
+        );
+        assert!(
+            !appendix.contains("output.gradient_params") && !appendix.contains("output.brush"),
+            "the trimmed vertex entries must not write the dropped varyings"
+        );
+    }
+
+    #[test]
+    fn solid_trim_source_reaches_every_injection_and_validates() {
+        // The trimmed entries are appended BEFORE `shape_shader_source`'s
+        // rewrites, so the storage rewrite's paint-select injection must land
+        // in all five vertex entries — a solid entry that missed it would
+        // freeze every recolor on the retained slots it draws.
+        let storage =
+            shape_shader_source(ShapeBatchLimits::for_storage_binding_size(128 << 20), true);
+        for entry in [
+            "fn vs_solid(",
+            "fn vs_solid_instanced(",
+            "fn fs_solid_trim(",
+        ] {
+            assert!(
+                storage.contains(entry),
+                "trimmed storage source must carry `{entry}`"
+            );
+        }
+        assert_eq!(
+            storage
+                .matches("select(shape.color, paint[shape_idx], similarity.paint_select > 0.5)")
+                .count(),
+            5,
+            "vs_main, vs_shape_instanced, vs_mesh, vs_solid and \
+             vs_solid_instanced must all read paint under the paint_select \
+             flag"
+        );
+
+        // Both variants a native device can compile must be valid WGSL, flat
+        // and with the display-clip z rewrite applied.
+        let uniform = shape_shader_source(ShapeBatchLimits::desktop(), true);
+        for source in [&storage, &uniform] {
+            for depth in [false, true] {
+                let text = display_clip::with_content_z(Cow::Owned(source.to_string()), depth);
+                let module = naga::front::wgsl::parse_str(&text)
+                    .expect("trimmed shape shader must parse as WGSL");
+                naga::valid::Validator::new(
+                    naga::valid::ValidationFlags::all(),
+                    naga::valid::Capabilities::all(),
+                )
+                .validate(&module)
+                .expect("trimmed shape shader must validate for WebGPU");
+            }
+        }
+    }
+
+    #[test]
+    fn solid_trim_flag_reads_the_documented_variable() {
+        // The parity suite's trimmed arms set exactly this variable; a name
+        // drift here would leave them silently comparing full against full.
+        std::env::remove_var("CRANPOSE_SOLID_TRIM_VARYINGS");
+        assert!(!solid_trim_varyings_enabled(), "the trim must default OFF");
+        std::env::set_var("CRANPOSE_SOLID_TRIM_VARYINGS", "1");
+        assert!(solid_trim_varyings_enabled());
+        std::env::set_var("CRANPOSE_SOLID_TRIM_VARYINGS", "0");
+        assert!(!solid_trim_varyings_enabled());
+        std::env::remove_var("CRANPOSE_SOLID_TRIM_VARYINGS");
+    }
+
+    #[test]
     fn uniform_shape_shader_keeps_the_in_record_color_and_no_paint_binding() {
         // The base text serves WebGL-class uniform devices, which can bind
         // no storage buffers: the paint array and its select must exist only
         // in the storage-mode rewrite.
         for source in [
             Cow::Borrowed(shaders::SHADER),
-            shape_shader_source(ShapeBatchLimits::desktop()),
+            shape_shader_source(ShapeBatchLimits::desktop(), false),
         ] {
             assert!(
                 !source.contains("paint: array"),
@@ -22639,7 +22812,7 @@ mod tests {
     #[test]
     fn native_shape_shader_source_uses_native_batch_limits() {
         let limits = ShapeBatchLimits::desktop();
-        let source = shape_shader_source(limits);
+        let source = shape_shader_source(limits, false);
 
         assert!(source.contains(&format!(
             "array<ShapeData, {}>",

--- a/crates/cranpose-render/wgpu/src/shaders.rs
+++ b/crates/cranpose-render/wgpu/src/shaders.rs
@@ -2,6 +2,13 @@
 
 pub const SHADER: &str = cranpose_ui_graphics::framework_shaders::SHAPE_WGSL;
 
+/// Trimmed-varying solid entries (`CRANPOSE_SOLID_TRIM_VARYINGS` opt-in):
+/// `shape_shader_source` appends this to [`SHADER`] when the trim is on, so
+/// the default build's modules stay byte-identical to the shipping text.
+/// Never compiled alone.
+pub const SOLID_TRIM_APPENDIX: &str =
+    cranpose_ui_graphics::framework_shaders::SHAPE_SOLID_TRIM_WGSL;
+
 pub const IMAGE_SHADER: &str = cranpose_ui_graphics::framework_shaders::IMAGE_WGSL;
 
 pub const GLYPH_ATLAS_SHADER: &str = cranpose_ui_graphics::framework_shaders::GLYPH_ATLAS_WGSL;
@@ -201,6 +208,26 @@ mod tests {
         if let Err(err) = validate_glsl_portability(super::SHADER, "fs_main", ShaderStage::Fragment)
         {
             panic!("shape.wgsl fragment stage must lower to GLSL ES 300: {err}");
+        }
+    }
+
+    #[test]
+    fn trimmed_shape_shader_validates_for_webgpu_and_lowers_to_glsl() {
+        // The trimmed solid entries ride appended to the base text
+        // (`CRANPOSE_SOLID_TRIM_VARYINGS`). A desktop GL context with the
+        // flag set would lower exactly these two entry points at pipeline
+        // build, so the gap-preserving locations must survive the GLSL
+        // backend too, not just WebGPU validation.
+        let source = format!("{}\n{}", super::SHADER, super::SOLID_TRIM_APPENDIX);
+        if let Err(err) = validate_wgsl_module(&source) {
+            panic!("shape.wgsl + shape_solid_trim.wgsl must validate for WebGPU: {err}");
+        }
+        if let Err(err) = validate_glsl_portability(&source, "vs_solid", ShaderStage::Vertex) {
+            panic!("trimmed solid vertex stage must lower to GLSL ES 300: {err}");
+        }
+        if let Err(err) = validate_glsl_portability(&source, "fs_solid_trim", ShaderStage::Fragment)
+        {
+            panic!("trimmed solid fragment stage must lower to GLSL ES 300: {err}");
         }
     }
 

--- a/crates/cranpose-render/wgpu/tests/segment_surface_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/segment_surface_parity.rs
@@ -260,6 +260,11 @@ fn set_common_env() {
     // the module unit tests pin the gate — so they widen the ratio to
     // admit all three rings.
     std::env::set_var("CRANPOSE_SEGMENT_SURFACE_COST_RATIO", "6.0");
+    // The cache defaults ON since the watch A/B earned the flip, so every
+    // baseline arm must hold the kill switch shut EXPLICITLY — an unset
+    // variable now measures cache against cache and proves nothing. The
+    // active arms open it with "1" right before their cached run.
+    std::env::set_var("CRANPOSE_SEGMENT_SURFACE", "0");
 }
 
 fn clear_env() {
@@ -303,7 +308,7 @@ fn identity_segments_composite_within_one_level_and_recolor_recaptures_same_fram
     assert_eq!(
         stats_before,
         (0, 0, 0, 0, 0),
-        "the cache must stay silent while the kill switch is off"
+        "the cache must stay silent while the kill switch is held shut"
     );
 
     std::env::set_var("CRANPOSE_SEGMENT_SURFACE", "1");

--- a/crates/cranpose-render/wgpu/tests/solid_fs_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/solid_fs_parity.rs
@@ -18,6 +18,10 @@
 //! primitives are hand-built `DrawRunNode::new` runs with no command id,
 //! so no feed, no retention, no replay slots: every pass renders through
 //! the fresh-batch path, the exact pipeline-selection site under test.
+//!
+//! `trimmed_varyings_do_not_move_a_byte` is the one environmental exception:
+//! `CRANPOSE_SOLID_TRIM_VARYINGS` latches at pipeline build, so its arms are
+//! whole fresh renderers, per the `instanced_quad_parity` discipline.
 
 mod support;
 
@@ -27,6 +31,7 @@ use cranpose_render_common::graph::{
 };
 use cranpose_render_common::raster_cache::LayerRasterCacheHashes;
 use cranpose_render_common::Renderer;
+use cranpose_render_wgpu::DisplayVisibleRegion;
 use cranpose_ui_graphics::{Brush, Color, DrawScope, DrawScopeDefault, GraphicsLayer, Point, Rect};
 
 const SIZE: u32 = 256;
@@ -221,4 +226,101 @@ fn solid_fragment_entry_matches_fs_main() {
          solid shapes as fs_main does, and a divergence this size is a shading difference \
          rather than the compiler contracting floats differently between two programs"
     );
+}
+
+/// One trim arm: a fresh renderer (the instanced selection latches at
+/// construction, the trim at first solid pipeline build), captured three
+/// ways — the solid scene flat, the solid scene under the display-clip cull
+/// (the depth-variant pipelines), and the mixed scene (the gradient batch
+/// that must keep riding `fs_main` untouched). The renderer drops before the
+/// caller starts the next arm, releasing the GPU lock.
+fn capture_trim_arm() -> Option<(Vec<u8>, Vec<u8>, Vec<u8>)> {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!("skipping trim parity arm: headless WGPU init failed: {err}");
+            return None;
+        }
+    };
+    let flat = render_arm(&mut renderer, &graph_for(false));
+    let mixed = render_arm(&mut renderer, &graph_for(true));
+    renderer.set_display_visible_region(DisplayVisibleRegion::InscribedCircle);
+    std::env::set_var("CRANPOSE_ROUND_CULL", "1");
+    let culled = render_arm(&mut renderer, &graph_for(false));
+    std::env::remove_var("CRANPOSE_ROUND_CULL");
+    renderer.set_display_visible_region(DisplayVisibleRegion::Full);
+    Some((flat, culled, mixed))
+}
+
+/// Zero-byte compare with a diff report worth reading on failure.
+fn assert_no_byte_moved(label: &str, full: &[u8], trimmed: &[u8]) {
+    assert_eq!(full.len(), trimmed.len(), "{label}: capture sizes differ");
+    let mut differing = 0usize;
+    let mut worst = 0u8;
+    for (a, b) in full.iter().zip(trimmed) {
+        let diff = a.abs_diff(*b);
+        if diff > 0 {
+            differing += 1;
+            worst = worst.max(diff);
+        }
+    }
+    assert_eq!(
+        differing, 0,
+        "{label}: {differing} bytes diverged (worst {worst}) between the full \
+         and trimmed varying interfaces — the trim only removes varyings \
+         `fs_solid` never read and reuses the one shared coverage function, \
+         so ANY movement is a wiring defect (renumbered location, misrouted \
+         entry point), not float-contraction noise"
+    );
+}
+
+/// The step-2 bar: `CRANPOSE_SOLID_TRIM_VARYINGS` must not move a byte.
+///
+/// Unlike `solid_fragment_entry_matches_fs_main` above — which compares two
+/// different fragment PROGRAMS and pins a measured contraction envelope —
+/// this compares the same shared coverage body over identically interpolated
+/// inputs, so the bar is zero, on every vertex path: six-vertex `vs_solid`
+/// (`CRANPOSE_INSTANCED_QUADS=0`), instanced `vs_solid_instanced` (default),
+/// and the display-clip depth variants of both (the culled arm). The mixed
+/// captures double as the negative control's negative: a gradient batch must
+/// render identically because it never touches the trimmed pipelines.
+#[test]
+fn trimmed_varyings_do_not_move_a_byte() {
+    for instanced in ["0", "1"] {
+        std::env::set_var("CRANPOSE_INSTANCED_QUADS", instanced);
+        std::env::remove_var("CRANPOSE_SOLID_TRIM_VARYINGS");
+        let Some((full_flat, full_culled, full_mixed)) = capture_trim_arm() else {
+            std::env::remove_var("CRANPOSE_INSTANCED_QUADS");
+            return;
+        };
+        // The culled capture must actually have culled something, or its
+        // compare proves nothing about the depth-variant pipelines.
+        assert_ne!(
+            full_flat, full_culled,
+            "instanced={instanced}: the display-clip cull never engaged"
+        );
+
+        std::env::set_var("CRANPOSE_SOLID_TRIM_VARYINGS", "1");
+        let trimmed = capture_trim_arm();
+        std::env::remove_var("CRANPOSE_SOLID_TRIM_VARYINGS");
+        std::env::remove_var("CRANPOSE_INSTANCED_QUADS");
+        let (trim_flat, trim_culled, trim_mixed) =
+            trimmed.expect("headless WGPU init failed mid-suite");
+
+        assert_no_byte_moved(
+            &format!("instanced={instanced} flat"),
+            &full_flat,
+            &trim_flat,
+        );
+        assert_no_byte_moved(
+            &format!("instanced={instanced} culled"),
+            &full_culled,
+            &trim_culled,
+        );
+        assert_no_byte_moved(
+            &format!("instanced={instanced} mixed"),
+            &full_mixed,
+            &trim_mixed,
+        );
+    }
 }

--- a/crates/cranpose-ui-graphics/shaders/shape_solid_trim.wgsl
+++ b/crates/cranpose-ui-graphics/shaders/shape_solid_trim.wgsl
@@ -1,0 +1,172 @@
+// Trimmed-varying twins of the solid draw path — `CRANPOSE_SOLID_TRIM_VARYINGS`
+// opt-in (`debug.cranpose.solid_trim` on Android). This file is never compiled
+// alone: `shape_shader_source` appends it to `shape.wgsl` only when the trim
+// is on, so the default build's shader modules stay byte-identical to the
+// text that ships today — that is the kill switch.
+//
+// Why: `gradient_params` and `brush` exist only to feed `fs_main`'s gradient
+// branches, and a batch reaches the solid pipelines exactly when its gradient
+// stop count is zero. The full interface therefore interpolates eight flat
+// scalars per fragment that the fragment stage never reads — parameter-store
+// space and fragment input bandwidth spent on precisely the overdraw-heavy
+// scenes the solid path exists for. These entries drop them.
+//
+// LOCATION DISCIPLINE — the rule this file exists to encode: the surviving
+// varyings KEEP the location indices they hold in `VertexOutput`, and
+// locations 5 and 9 stay VACANT. The first attempt at this trim (16a5d312,
+// reverted in 371dd06a) renumbered the survivors densely (clip_rect 6 -> 5,
+// stroke_params 7 -> 6, arc_params 8 -> 7) and a watch died with it on; the
+// crash was never diagnosed and the renumbering was suspect #1. With the
+// indices preserved, every pipeline in the app agrees on which location
+// carries which semantic, so a driver that keys its interpolant setup by
+// location sees one layout everywhere. WebGPU permits the gaps. Do not
+// densify them.
+//
+// SUBSTITUTION CONTRACTS — this text is appended BEFORE `shape_shader_source`
+// runs its rewrites and BEFORE `with_content_z`, so both exact-text
+// substitutions must land here the way they land in `vs_main`. (Neither
+// literal may appear in a comment with its trailing semicolon, or the
+// rewrite would edit the comment and the landing counts would drift.)
+// * the `output.color = shape.color` assignment — the storage rewrite
+//   injects the retained-paint select through that line. A solid entry it
+//   missed would freeze every recolor on the retained slots it draws (the
+//   substitution test counts five landings).
+// * the clip-position tail `(x, y, 0.0, 1.0)` — the display-clip depth
+//   variants rewrite that tail to z 0.5; the trimmed depth pipelines cull
+//   against the occluder like every other content pipeline.
+
+// The solid pipelines' inter-stage interface: `VertexOutput` minus
+// `gradient_params` (its location 5 left vacant) and `brush` (its location 9
+// left vacant). See LOCATION DISCIPLINE above before touching an index.
+struct VertexOutputSolid {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+    @location(1) uv: vec2<f32>,
+    @location(2) world_pos: vec2<f32>,
+    @location(3) @interpolate(flat) rect: vec4<f32>,
+    @location(4) @interpolate(flat) radii: vec4<f32>,
+    // location 5 is `gradient_params`' slot in `VertexOutput` — VACANT.
+    @location(6) @interpolate(flat) clip_rect: vec4<f32>,
+    @location(7) @interpolate(flat) stroke_params: vec4<f32>,
+    @location(8) @interpolate(flat) arc_params: vec4<f32>,
+    // location 9 is `brush`'s slot in `VertexOutput` — VACANT.
+}
+
+// BIT-EXACTNESS REQUIREMENT: every expression below is copied verbatim from
+// `vs_main`; only the two dropped varying writes are gone. Dropping unused
+// outputs cannot change the interpolation of the ones that remain, so the
+// solid pipelines rasterize the same fragments with the same inputs and
+// `solid_fs_parity` holds the trimmed-vs-full bar at ZERO differing bytes.
+@vertex
+fn vs_solid(@builtin(vertex_index) vertex_idx: u32) -> VertexOutputSolid {
+    var output: VertexOutputSolid;
+
+    let shape_idx = vertex_idx / 6u;
+    let slot = vertex_idx % 6u;
+    var corner: u32;
+    switch slot {
+        case 0u: { corner = 0u; }
+        case 1u, 4u: { corner = 1u; }
+        case 2u, 3u: { corner = 2u; }
+        default: { corner = 3u; }
+    }
+
+    let shape = shape_data[shape_idx];
+    var position: vec2<f32>;
+    switch corner {
+        case 0u: { position = shape.quad01.xy; }
+        case 1u: { position = shape.quad01.zw; }
+        case 2u: { position = shape.quad23.xy; }
+        default: { position = shape.quad23.zw; }
+    }
+
+    let rel = position - similarity.center;
+    position = similarity.center + vec2<f32>(
+        rel.x * similarity.rot.x - rel.y * similarity.rot.y,
+        rel.x * similarity.rot.y + rel.y * similarity.rot.x,
+    ) * similarity.scale;
+
+    let x = ((position.x - uniforms.viewport_offset.x) / uniforms.viewport.x) * 2.0 - 1.0;
+    let y = 1.0 - ((position.y - uniforms.viewport_offset.y) / uniforms.viewport.y) * 2.0;
+
+    output.clip_position = vec4<f32>(x, y, 0.0, 1.0);
+    output.color = shape.color;
+    output.uv = vec2<f32>(f32(corner & 1u), f32(corner >> 1u));
+    output.world_pos = position;
+    output.rect = shape.rect;
+    output.radii = shape.radii;
+    output.clip_rect = shape.clip_rect;
+    output.stroke_params = shape.stroke_params;
+    output.arc_params = shape.arc_params;
+
+    return output;
+}
+
+// `vs_shape_instanced` minus the two dropped varying writes; the same
+// verbatim-copy rule as `vs_solid`. Storage mode only, like its full-fat
+// twin; in the uniform variant it is dead code, which keeps the appended
+// text valid there too.
+@vertex
+fn vs_solid_instanced(
+    @builtin(vertex_index) corner_idx: u32,
+    @builtin(instance_index) instance_idx: u32,
+) -> VertexOutputSolid {
+    var output: VertexOutputSolid;
+
+    let shape_idx = instance_idx;
+    let corner = corner_idx;
+
+    let shape = shape_data[shape_idx];
+    var position: vec2<f32>;
+    switch corner {
+        case 0u: { position = shape.quad01.xy; }
+        case 1u: { position = shape.quad01.zw; }
+        case 2u: { position = shape.quad23.xy; }
+        default: { position = shape.quad23.zw; }
+    }
+
+    let rel = position - similarity.center;
+    position = similarity.center + vec2<f32>(
+        rel.x * similarity.rot.x - rel.y * similarity.rot.y,
+        rel.x * similarity.rot.y + rel.y * similarity.rot.x,
+    ) * similarity.scale;
+
+    let x = ((position.x - uniforms.viewport_offset.x) / uniforms.viewport.x) * 2.0 - 1.0;
+    let y = 1.0 - ((position.y - uniforms.viewport_offset.y) / uniforms.viewport.y) * 2.0;
+
+    output.clip_position = vec4<f32>(x, y, 0.0, 1.0);
+    output.color = shape.color;
+    output.uv = vec2<f32>(f32(corner & 1u), f32(corner >> 1u));
+    output.world_pos = position;
+    output.rect = shape.rect;
+    output.radii = shape.radii;
+    output.clip_rect = shape.clip_rect;
+    output.stroke_params = shape.stroke_params;
+    output.arc_params = shape.arc_params;
+
+    return output;
+}
+
+// `fs_solid` behind the trimmed interface. The coverage pass MUST stay the
+// shared `shape_coverage_alpha` — never a copy: its doc comment records a
+// line-for-line duplicate measuring 2/255 apart on Vulkan. The full
+// `VertexOutput` it takes is rebuilt member by member from the trimmed
+// input; the two dropped members stay zero-initialized and are dead —
+// `shape_coverage_alpha` reads neither — so the coverage arithmetic runs the
+// one shared body over bit-identical inputs.
+@fragment
+fn fs_solid_trim(input: VertexOutputSolid) -> @location(0) vec4<f32> {
+    var full: VertexOutput;
+    full.clip_position = input.clip_position;
+    full.color = input.color;
+    full.uv = input.uv;
+    full.world_pos = input.world_pos;
+    full.rect = input.rect;
+    full.radii = input.radii;
+    full.clip_rect = input.clip_rect;
+    full.stroke_params = input.stroke_params;
+    full.arc_params = input.arc_params;
+    let alpha = shape_coverage_alpha(full);
+    let color = input.color;
+    return vec4<f32>(color.rgb, color.a * alpha);
+}

--- a/crates/cranpose-ui-graphics/src/framework_shaders.rs
+++ b/crates/cranpose-ui-graphics/src/framework_shaders.rs
@@ -7,6 +7,10 @@
 /// Batched shape shader. The uniform array lengths in the source are the
 /// wasm/downlevel defaults; native pipelines rewrite them per device class.
 pub const SHAPE_WGSL: &str = include_str!("../shaders/shape.wgsl");
+/// Trimmed-varying solid entries (`CRANPOSE_SOLID_TRIM_VARYINGS` opt-in),
+/// appended to [`SHAPE_WGSL`] by the shape pipeline builders when the trim
+/// is on. Never compiled alone.
+pub const SHAPE_SOLID_TRIM_WGSL: &str = include_str!("../shaders/shape_solid_trim.wgsl");
 pub const IMAGE_WGSL: &str = include_str!("../shaders/image.wgsl");
 pub const GLYPH_ATLAS_WGSL: &str = include_str!("../shaders/glyph_atlas.wgsl");
 

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -73,7 +73,7 @@ fn property_flag(name: &str) -> bool {
 /// any length — so a name may run right up to or past that pre-O limit, as
 /// `debug.cranpose.retained_mesh_px2` does; every deployment target is far
 /// past O.)
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 28] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 29] = [
     ("debug.cranpose.gpu_stats", "CRANPOSE_GPU_STATS"),
     ("debug.cranpose.present_thread", "CRANPOSE_PRESENT_THREAD"),
     ("debug.cranpose.command_feed", "CRANPOSE_COMMAND_FEED"),
@@ -141,6 +141,7 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 28] = [
         "debug.cranpose.seg_surface_scale",
         "CRANPOSE_SEGMENT_SURFACE_SCALE_EPS",
     ),
+    ("debug.cranpose.solid_trim", "CRANPOSE_SOLID_TRIM_VARYINGS"),
 ];
 
 /// Copies the [`PROPERTY_BACKED_ENV_VARS`] properties that are set into the


### PR DESCRIPTION
Revival of the reverted fs_solid step 2 with the crash suspect eliminated: the surviving varyings keep the full VertexOutput location indices (5 and 9 stay vacant) — the reverted commit's dense renumbering is documented in the shader header as prime suspect, with a unit test rejecting any @location(5)/@location(9) and pinning surviving lines byte-identical to the full struct's.

Opt-in CRANPOSE_SOLID_TRIM_VARYINGS=1 / debug.cranpose.solid_trim (table 28→29), default OFF compiles the byte-identical shipping shader text. Every current pipeline family reconciled: both solid families trim under the flag (flat + depth, quad + instanced); mesh and fs_main families stay full deliberately; capture paths share the same getters so no divergent interface can exist; fs_solid_trim calls the one shared shape_coverage_alpha (never copies coverage math).

New bar test: zero differing bytes trim-vs-full across six-vertex, instanced, and the display-clip depth variants (culled arm engagement asserted) — red-run verified with a planted 0.9 dim (196,608 diverged bytes), restored green.

Second commit hardens segment_surface_parity baselines against the default-ON flip (found independently on pristine main; complements 415d0ac4's support-level pin).

Gates: 26 wgpu suites green --no-fail-fast on real Vulkan, clippy -D warnings clean, fmt clean, armv7 check clean. Validation order before any watch use: Pixel 9 Pro with Vulkan validation layers, then cool-watch A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2