### PR TITLE
Survive wgpu validation errors instead of aborting

### DIFF
--- a/crates/cranpose-render/wgpu/src/frame_packet.rs
+++ b/crates/cranpose-render/wgpu/src/frame_packet.rs
@@ -73,6 +73,11 @@ pub enum CancelReason {
     /// retry. Producer state (epochs, viewport) still matched — only the
     /// swapchain was missing.
     SurfaceUnavailable,
+    /// The device reported an uncaptured error (validation/OOM/internal)
+    /// since the previous frame: nothing of this packet is encoded on the
+    /// suspect device. One cancel per poisoning — the gate clears as it
+    /// fires, so the next packet renders (see `DeviceErrorSentry`).
+    DeviceError,
 }
 
 /// What the present stage did with a packet. `NotRun` is the `Default` so a

--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -1039,6 +1039,16 @@ impl WgpuRenderer {
         self.sync_gpu_renderer().map(|r| &*r.device)
     }
 
+    /// Test/diagnostic view of the device-error sentry: lifetime
+    /// uncaptured wgpu errors recorded on the sync renderer's device
+    /// (`CRANPOSE_SURVIVE_GPU_ERRORS` kill switch).
+    #[doc(hidden)]
+    pub fn device_error_count_for_tests(&self) -> u64 {
+        self.sync_gpu_renderer()
+            .map(GpuRenderer::device_error_count)
+            .unwrap_or(0)
+    }
+
     /// Test/diagnostic view of the latched instanced-quad selection: `true`
     /// when the live GPU renderer's ordinary shape draws ride
     /// `vs_shape_instanced` (storage mode && `CRANPOSE_INSTANCED_QUADS` != 0

--- a/crates/cranpose-render/wgpu/src/present_runtime.rs
+++ b/crates/cranpose-render/wgpu/src/present_runtime.rs
@@ -160,6 +160,7 @@ pub(crate) fn encode_present_outcome(outcome: PresentOutcome, frame_id: u64) -> 
         PresentOutcome::Cancelled(CancelReason::SurfaceEpoch) => 3,
         PresentOutcome::Cancelled(CancelReason::Viewport) => 4,
         PresentOutcome::Cancelled(CancelReason::SurfaceUnavailable) => 5,
+        PresentOutcome::Cancelled(CancelReason::DeviceError) => 6,
     };
     (frame_id << 8) | code
 }

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -596,6 +596,56 @@ struct ShapeShadowSurfacePlan {
     pixel_radius: f32,
 }
 
+/// Shared record of the device's uncaptured errors (validation, OOM,
+/// internal), written by the handler [`GpuRenderer::new`] installs via
+/// `Device::on_uncaptured_error` and read at the head of every
+/// [`GpuRenderer::render`].
+///
+/// wgpu's default handler panics on the reporting thread. Mid-encode that
+/// unwind runs the drop glue of live pass/encoder objects, whose own error
+/// reports re-enter the same panicking handler — a second panic inside the
+/// first's unwind aborts the process, and the tombstone carries neither
+/// message (a real device's validation failure was lost exactly this way).
+/// This handler never panics: it counts, logs the full error, and poisons;
+/// the render path answers with one cancelled packet per poisoning — the
+/// acquire path's give-up-this-frame semantics, not a latch.
+/// `CRANPOSE_SURVIVE_GPU_ERRORS=0` restores the fatal default
+/// ([`survive_gpu_errors_enabled`]).
+#[derive(Default)]
+struct DeviceErrorSentry {
+    /// Lifetime uncaptured errors on this device.
+    errors: std::sync::atomic::AtomicU64,
+    /// Set by the handler, taken (cleared) by the next frame's gate.
+    poisoned: std::sync::atomic::AtomicBool,
+}
+
+impl DeviceErrorSentry {
+    /// Never panics: this runs where the default handler would have
+    /// aborted the process (see the type doc).
+    fn record(&self, error: &wgpu::Error) {
+        use std::sync::atomic::Ordering;
+        self.poisoned.store(true, Ordering::Release);
+        let count = self.errors.fetch_add(1, Ordering::Relaxed) + 1;
+        // The full error every time it prints; rate-limited by count
+        // because one broken frame reports a follow-up error per
+        // subsequent encoder call. Power-of-two occurrences (1, 2, 4,
+        // 8, …) keep the first reports verbatim and decay the repeats
+        // without a clock; the count carries the volume.
+        if count.is_power_of_two() {
+            log::error!("[gpu-device] uncaptured wgpu error #{count}: {error}");
+        }
+    }
+
+    fn take_poison(&self) -> bool {
+        self.poisoned
+            .swap(false, std::sync::atomic::Ordering::AcqRel)
+    }
+
+    fn error_count(&self) -> u64 {
+        self.errors.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
 #[derive(Default)]
 struct RendererWarningState {
     unsupported_effect_reported: Cell<bool>,
@@ -4546,6 +4596,18 @@ fn solid_trim_varyings_enabled() -> bool {
     std::env::var("CRANPOSE_SOLID_TRIM_VARYINGS").as_deref() == Ok("1")
 }
 
+/// Kill switch for surviving uncaptured device errors: default ON,
+/// `CRANPOSE_SURVIVE_GPU_ERRORS=0` (or the
+/// `debug.cranpose.survive_gpu_errors` property on Android) restores
+/// wgpu's fatal default handler, which panics with the error message on
+/// the reporting thread — the pre-fix behavior, kept reachable so a
+/// debugging session can die loudly at the first error instead of
+/// logging past it. Read once, at [`GpuRenderer`] construction, where the
+/// handler is installed; it changes nothing off the error path.
+fn survive_gpu_errors_enabled() -> bool {
+    std::env::var("CRANPOSE_SURVIVE_GPU_ERRORS").as_deref() != Ok("0")
+}
+
 /// Kill switch for the display clip region cull: default ON wherever the
 /// platform reports a cullable visible region
 /// (`set_display_visible_region`), and `CRANPOSE_ROUND_CULL` (or the
@@ -5486,6 +5548,12 @@ impl ImageBatchBuffers {
 pub struct GpuRenderer {
     pub(crate) device: Arc<wgpu::Device>,
     pub(crate) queue: Arc<wgpu::Queue>,
+    /// Uncaptured-error record shared with the handler installed on
+    /// `device` at construction ([`DeviceErrorSentry`];
+    /// `CRANPOSE_SURVIVE_GPU_ERRORS` kill switch). Poisoned by any
+    /// uncaptured error; the head of [`Self::render`] answers each
+    /// poisoning with one cancelled packet.
+    device_errors: Arc<DeviceErrorSentry>,
     /// This instance's renderer epoch, stamped by `init_gpu` at
     /// construction. A packet whose `renderer_epoch` differs was built
     /// against another instance and is cancelled at the head of
@@ -5894,6 +5962,16 @@ impl GpuRenderer {
         // and the per-pipeline `[gpu-pipeline]` lines cannot say what the
         // renderer costs to build when it builds no pipelines at all.
         let construction_started = Instant::now();
+        // Installed before this renderer's first device call, so even a
+        // construction-time validation error is survived. Replaces wgpu's
+        // fatal default handler — see [`DeviceErrorSentry`] for the
+        // double-panic abort this prevents and
+        // [`survive_gpu_errors_enabled`] for the kill switch.
+        let device_errors = Arc::new(DeviceErrorSentry::default());
+        if survive_gpu_errors_enabled() {
+            let sentry = Arc::clone(&device_errors);
+            device.on_uncaptured_error(Arc::new(move |error| sentry.record(&error)));
+        }
         let shape_batch_limits = ShapeBatchLimits::for_device(&device);
         let uniform_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -6193,6 +6271,7 @@ impl GpuRenderer {
         let renderer = Self {
             device,
             queue,
+            device_errors,
             renderer_epoch,
             #[cfg(not(target_arch = "wasm32"))]
             store_feed_generation,
@@ -8356,6 +8435,15 @@ impl GpuRenderer {
         };
         if let Some(reason) = cancel_reason {
             return Self::cancel_packet(packet, reason, returns);
+        }
+        // Device-error gate — same protocol as the validity gate above: an
+        // uncaptured error recorded since the last frame cancels this
+        // packet whole, so nothing is encoded on the suspect device. The
+        // take clears the poison, so the NEXT packet renders — one skipped
+        // frame per poisoning, the acquire path's give-up-this-frame
+        // semantics ([`DeviceErrorSentry`]).
+        if self.device_errors.take_poison() {
+            return Self::cancel_packet(packet, CancelReason::DeviceError, returns);
         }
         returns.frame_id = packet.frame_id;
         log::trace!("🎨 Rendering graph to {}x{}", width, height);
@@ -13095,6 +13183,14 @@ impl GpuRenderer {
     #[doc(hidden)]
     pub fn rim_meshes_emitted(&self) -> u64 {
         self.rim_meshes_emitted
+    }
+
+    /// Test/diagnostic view of the device-error sentry: lifetime
+    /// uncaptured wgpu errors recorded on this renderer's device
+    /// (`CRANPOSE_SURVIVE_GPU_ERRORS` kill switch).
+    #[doc(hidden)]
+    pub fn device_error_count(&self) -> u64 {
+        self.device_errors.error_count()
     }
 
     /// Test/diagnostic view of the static leading-span cache: lifetime

--- a/crates/cranpose-render/wgpu/src/scene.rs
+++ b/crates/cranpose-render/wgpu/src/scene.rs
@@ -420,8 +420,17 @@ struct SceneBuffers {
 
 impl Drop for CompositorScene {
     fn drop(&mut self) {
-        SCENE_BUFFER_POOL.with(|pool| {
-            let mut pool = pool.borrow_mut();
+        // Pooling only — correctness never depends on it, so both
+        // fallible steps stay fallible. This drop also runs during unwind
+        // (a panicking frame drops its scene), where `with` on a
+        // torn-down TLS or `borrow_mut` on a pool the panicking frame
+        // still holds would panic a second time — and a panic inside an
+        // unwind aborts the process, eating the original message. An
+        // unavailable pool just lets the buffers deallocate.
+        let _ = SCENE_BUFFER_POOL.try_with(|pool| {
+            let Ok(mut pool) = pool.try_borrow_mut() else {
+                return;
+            };
             if pool.len() >= SCENE_BUFFER_POOL_LIMIT {
                 return;
             }
@@ -769,3 +778,27 @@ impl Default for CompositorScene {
 }
 
 use crate::rect_to_quad;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The double-panic half of the survive-GPU-errors work: a
+    /// `CompositorScene` dropped while the buffer pool is unavailable —
+    /// here, mutably borrowed, as it is when the borrowing frame itself
+    /// panics and unwinds — must skip pooling, not panic. A panic in
+    /// this drop during a real unwind aborts the process and eats the
+    /// original error.
+    #[test]
+    fn scene_drop_skips_pooling_when_the_pool_is_held() {
+        let scene = CompositorScene::new();
+        SCENE_BUFFER_POOL.with(|pool| {
+            let _held = pool.borrow_mut();
+            let dropped = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop(scene)));
+            assert!(
+                dropped.is_ok(),
+                "dropping a scene under a held pool borrow must not panic"
+            );
+        });
+    }
+}

--- a/crates/cranpose-render/wgpu/tests/device_error_survival.rs
+++ b/crates/cranpose-render/wgpu/tests/device_error_survival.rs
@@ -1,0 +1,196 @@
+//! GPU robustness: an uncaptured wgpu device error must be survived —
+//! recorded, logged, and answered with one skipped frame — never a panic.
+//! wgpu's default uncaptured handler panics on the reporting thread;
+//! mid-encode that unwind runs the drop glue of live pass/encoder
+//! objects, whose follow-up error reports re-enter the same panicking
+//! handler, and the second panic inside the first's unwind aborts the
+//! process with the original validation message unlogged. The framework
+//! therefore installs a logging handler at `GpuRenderer` construction
+//! (`CRANPOSE_SURVIVE_GPU_ERRORS` kill switch), poisons the renderer,
+//! cancels exactly one packet (`CancelReason::DeviceError`, buffers
+//! returned whole), and renders on.
+//!
+//! Red without the fix: the deliberate validation error below reaches the
+//! default handler and this suite dies at `create_texture` with
+//! `wgpu error: Validation Error`.
+
+mod support;
+
+use cranpose_core::NodeId;
+use cranpose_render_common::graph::{
+    CachePolicy, DrawPrimitiveNode, IsolationReasons, LayerNode, PrimitiveEntry, PrimitiveNode,
+    PrimitivePhase, ProjectiveTransform, RenderGraph, RenderNode,
+};
+use cranpose_render_common::raster_cache::LayerRasterCacheHashes;
+use cranpose_render_common::Renderer;
+use cranpose_render_wgpu::{CancelReason, PresentOutcome};
+use cranpose_ui_graphics::{Brush, Color, GraphicsLayer, Point, Rect};
+
+const WIDTH: u32 = 128;
+const HEIGHT: u32 = 96;
+
+fn test_layer(node_id: Option<NodeId>, children: Vec<RenderNode>) -> LayerNode {
+    LayerNode {
+        node_id,
+        local_bounds: Rect {
+            x: 0.0,
+            y: 0.0,
+            width: WIDTH as f32,
+            height: HEIGHT as f32,
+        },
+        transform_to_parent: ProjectiveTransform::identity(),
+        motion_context_animated: false,
+        translated_content_context: false,
+        translated_content_offset: Point::default(),
+        content_offset: Point::default(),
+        scene_children_origin: Point::default(),
+        scene_children_layer_translation: Point::default(),
+        graphics_layer: GraphicsLayer::default(),
+        clip_to_bounds: false,
+        shadow_clip: None,
+        hit_test: None,
+        has_hit_targets: false,
+        isolation: IsolationReasons::default(),
+        cache_policy: CachePolicy::None,
+        cache_hashes: LayerRasterCacheHashes::default(),
+        cache_hashes_valid: false,
+        children,
+    }
+}
+
+fn rect_primitive(rect: Rect, color: Color) -> RenderNode {
+    RenderNode::Primitive(PrimitiveEntry {
+        phase: PrimitivePhase::BeforeChildren,
+        node: PrimitiveNode::Draw(DrawPrimitiveNode {
+            primitive: cranpose_ui_graphics::DrawPrimitive::Rect {
+                rect,
+                brush: Brush::solid(color),
+                stroke: None,
+            },
+            clip: None,
+        }),
+    })
+}
+
+fn direct_graph() -> RenderGraph {
+    RenderGraph::new(test_layer(
+        Some(9_400),
+        vec![rect_primitive(
+            Rect {
+                x: 16.0,
+                y: 12.0,
+                width: 64.0,
+                height: 48.0,
+            },
+            Color(0.2, 0.7, 0.3, 1.0),
+        )],
+    ))
+}
+
+fn target_view(renderer: &support::LockedRenderer, width: u32, height: u32) -> wgpu::TextureView {
+    let device = renderer
+        .try_device()
+        .expect("renderer GPU device was not initialized");
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Device Error Survival Render Target"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Bgra8UnormSrgb,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    });
+    texture.create_view(&wgpu::TextureViewDescriptor::default())
+}
+
+/// A genuine wgpu validation error — recorded, one packet cancelled with
+/// `CancelReason::DeviceError` (its scene returned to the producer pool),
+/// and the packet after that presents: one skipped frame per poisoning,
+/// no panic anywhere.
+#[test]
+fn uncaptured_device_error_poisons_one_frame_then_recovers() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!("skipping device-error survival: headless WGPU init failed: {err}");
+            return;
+        }
+    };
+    renderer.scene_mut().graph = Some(direct_graph());
+    let view = target_view(&renderer, WIDTH, HEIGHT);
+
+    // Healthy first: a clean device presents and has recorded nothing.
+    let packet = renderer
+        .build_frame_packet_for_tests(WIDTH, HEIGHT)
+        .expect("direct graph must lower into a packet");
+    let outcome = renderer
+        .render_held_packet_for_tests(&view, WIDTH, HEIGHT, packet)
+        .expect("the pre-error packet must draw");
+    assert_eq!(outcome, PresentOutcome::Presented);
+    assert_eq!(
+        renderer.device_error_count_for_tests(),
+        0,
+        "a clean frame must record no device errors"
+    );
+
+    // A zero-width texture is a wgpu validation error, reported through
+    // the device's uncaptured-error path. Without the installed handler
+    // this call panics in wgpu's fatal default handler — the red run.
+    let device = renderer
+        .try_device()
+        .expect("renderer GPU device was not initialized");
+    let _ = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Deliberate Validation Error (zero width)"),
+        size: wgpu::Extent3d {
+            width: 0,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Bgra8UnormSrgb,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
+    });
+    assert!(
+        renderer.device_error_count_for_tests() >= 1,
+        "the uncaptured-error handler must record the validation error"
+    );
+
+    // The frame after the error skips whole — cancelled before any
+    // encoding, buffers returned — and clears the poison on the way out.
+    let packet = renderer
+        .build_frame_packet_for_tests(WIDTH, HEIGHT)
+        .expect("the post-error build must lower normally");
+    let outcome = renderer
+        .render_held_packet_for_tests(&view, WIDTH, HEIGHT, packet)
+        .expect("a device-error skip is a protocol outcome, not a draw error");
+    assert_eq!(
+        outcome,
+        PresentOutcome::Cancelled(CancelReason::DeviceError),
+        "the frame after an uncaptured device error must cancel, not encode"
+    );
+    assert!(
+        renderer.has_retained_direct_scene_for_tests(),
+        "the cancelled packet's scene must return to the producer pool"
+    );
+
+    // One skip per poisoning: the next packet renders.
+    let packet = renderer
+        .build_frame_packet_for_tests(WIDTH, HEIGHT)
+        .expect("the recovery build must lower normally");
+    let outcome = renderer
+        .render_held_packet_for_tests(&view, WIDTH, HEIGHT, packet)
+        .expect("the recovery packet must draw");
+    assert_eq!(
+        outcome,
+        PresentOutcome::Presented,
+        "one skipped frame per poisoning — the next packet must present"
+    );
+}

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -73,7 +73,7 @@ fn property_flag(name: &str) -> bool {
 /// any length — so a name may run right up to or past that pre-O limit, as
 /// `debug.cranpose.retained_mesh_px2` does; every deployment target is far
 /// past O.)
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 29] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 30] = [
     ("debug.cranpose.gpu_stats", "CRANPOSE_GPU_STATS"),
     ("debug.cranpose.present_thread", "CRANPOSE_PRESENT_THREAD"),
     ("debug.cranpose.command_feed", "CRANPOSE_COMMAND_FEED"),
@@ -142,6 +142,10 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 29] = [
         "CRANPOSE_SEGMENT_SURFACE_SCALE_EPS",
     ),
     ("debug.cranpose.solid_trim", "CRANPOSE_SOLID_TRIM_VARYINGS"),
+    (
+        "debug.cranpose.survive_gpu_errors",
+        "CRANPOSE_SURVIVE_GPU_ERRORS",
+    ),
 ];
 
 /// Copies the [`PROPERTY_BACKED_ENV_VARS`] properties that are set into the


### PR DESCRIPTION
## The double-panic mechanism

An uncaptured device error (validation/OOM/internal) reaches wgpu's default handler, which **panics on the reporting thread** (`wgpu error: {err}`). When the erroring call sits mid-encode, that unwind runs the drop glue of live pass/encoder objects, whose own follow-up error reports re-enter the same panicking default handler — and a second panic inside the first's unwind **aborts the process**. The tombstone then carries neither message; a real device crash's validation diagnosis was lost exactly this way. The same shape existed app-side of wgpu too: `CompositorScene::drop` re-borrows the thread-local scene buffer pool, so a frame that panicked while holding the borrow double-panicked in its own unwind.

## What poisons

`GpuRenderer::new` installs a non-panicking `on_uncaptured_error` handler **before its first device call** (so even construction-time errors are survived). Every uncaptured error:

- is counted and logged **in full** at `log::error!`, rate-limited to power-of-two occurrences (1, 2, 4, 8, …) with the running count in the line — one broken frame reports a follow-up error per subsequent encoder call, so repeats decay without a clock;
- poisons a `DeviceErrorSentry` shared between the handler and the render path.

One installation covers the sync, threaded, and offscreen paths: all of them construct through `GpuRenderer::new` and consume through `GpuRenderer::render`.

## What recovers

The head of `GpuRenderer::render` — right after the existing packet-validity gate, through the existing cancel protocol, no parallel mechanism — answers each poisoning with **one cancelled packet**: `CancelReason::DeviceError`, nothing encoded on the suspect device, every buffer returned whole through `RenderReturns`. The take clears the poison, so the next packet renders: the acquire path's give-up-this-frame semantics (`Timeout`/`Occluded` → skip), not a latch. A persistent error therefore degrades to alternating skip/attempt with rate-limited logs instead of a dead app — and instead of an abort.

`CompositorScene::drop` now uses `try_with` + `try_borrow_mut` and skips pooling when the pool is unavailable (held borrow, torn-down TLS): pooling is an optimization, and a panic in that drop during a real unwind is the same double-panic abort.

Kill switch: `CRANPOSE_SURVIVE_GPU_ERRORS=0` (property `debug.cranpose.survive_gpu_errors`, added to `PROPERTY_BACKED_ENV_VARS`) restores the fatal default handler for sessions that want to die loudly at the first error. Default ON — it changes nothing off the error path.

## Red/green proof

`tests/device_error_survival.rs` — `uncaptured_device_error_poisons_one_frame_then_recovers` provokes a genuine validation error (zero-width `create_texture`) on the renderer's device, then asserts: recorded by the sentry, next packet `Cancelled(DeviceError)` with its scene returned to the producer pool, packet after that `Presented`.

With the handler install reverted in source (and identically with `CRANPOSE_SURVIVE_GPU_ERRORS=0`):

```
test uncaptured_device_error_poisons_one_frame_then_recovers ... FAILED

thread '…' panicked at …/wgpu-29.0.3/src/backend/wgpu_core.rs:1632:26:
wgpu error: Validation Error

Caused by:
  In Device::create_texture, label = 'Deliberate Validation Error (zero width)'
    Dimension X is zero
```

`scene::tests::scene_drop_skips_pooling_when_the_pool_is_held` drops a scene under a held pool borrow. With the old Drop reinstated:

```
thread '…' panicked at crates/cranpose-render/wgpu/src/scene.rs:431:33:
RefCell already borrowed
```

Both green with the fix. Full gates on samarch-1: `cargo test -p cranpose-render-wgpu` all suites green (452 lib + 24 integration suites), `cargo clippy -p cranpose-render-wgpu --all-targets` clean, `cargo check -p cranpose` green on host and `aarch64-linux-android`. (`wasm32-unknown-unknown` fails to build `getrandom` identically on unmodified `main` — environmental, untouched by this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2
