### PR TITLE
Waive segment-surface warmup for candidates whose capture pays within a frame

### DIFF
--- a/crates/cranpose-render/wgpu/src/segment_surface.rs
+++ b/crates/cranpose-render/wgpu/src/segment_surface.rs
@@ -111,7 +111,8 @@ const MAX_SEGMENT_SURFACE_ENTRY_BYTES: u64 = 4 * 1024 * 1024;
 
 /// Frames a key must be observed before its churn window is trusted. Below
 /// this the segment draws direct — a segment that dies young never pays a
-/// capture.
+/// capture — unless the waiver (`waiver_ratio`) admits a never-recolored
+/// candidate whose capture pays for itself within about one frame.
 const ADMISSION_WARMUP_FRAMES: u32 = 8;
 
 /// An entry unseen for this many frames is dropped in the periodic sweep.
@@ -137,6 +138,16 @@ fn env_f32(name: &str, default: f32) -> f32 {
         .unwrap_or(default)
 }
 
+/// As [`env_f32`], except zero is a meaningful value (a kill switch), not a
+/// malformed one.
+fn env_f32_zero_ok(name: &str, default: f32) -> f32 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<f32>().ok())
+        .filter(|value| value.is_finite() && *value >= 0.0)
+        .unwrap_or(default)
+}
+
 /// Per-frame snapshot of the module's tunables.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct SegmentSurfaceConfig {
@@ -144,6 +155,12 @@ pub(crate) struct SegmentSurfaceConfig {
     /// Admit while `surface_px <= cost_ratio * member_px` — see the module
     /// economics comment for the derivation of the default.
     pub cost_ratio: f32,
+    /// During warmup only: a candidate never observed to recolor may be
+    /// admitted immediately while `surface_px <= waiver_ratio * member_px`
+    /// — a strictly tighter bar than `cost_ratio`, payback within about
+    /// one frame. At or below zero the waiver is off and warmup admits
+    /// nothing, as before.
+    pub waiver_ratio: f32,
     /// Admit while the key's recolored-frame rate over its observation
     /// window stays at or below this. Default sits far inside the measured
     /// bimodal gap (rings 0.0, twinkles ~0.9).
@@ -159,6 +176,7 @@ impl SegmentSurfaceConfig {
         Self {
             enabled: segment_surface_enabled(),
             cost_ratio: env_f32("CRANPOSE_SEGMENT_SURFACE_COST_RATIO", 3.0),
+            waiver_ratio: env_f32_zero_ok("CRANPOSE_SEGMENT_SURFACE_WAIVER_RATIO", 1.0),
             recolor_rate: env_f32("CRANPOSE_SEGMENT_SURFACE_RECOLOR_RATE", 0.125),
             scale_eps: env_f32("CRANPOSE_SEGMENT_SURFACE_SCALE_EPS", 0.05),
         }
@@ -169,6 +187,7 @@ impl SegmentSurfaceConfig {
         Self {
             enabled: true,
             cost_ratio: 3.0,
+            waiver_ratio: 1.0,
             recolor_rate: 0.125,
             scale_eps: 0.05,
         }
@@ -346,6 +365,10 @@ impl AdmissionTrack {
         self.observed >= ADMISSION_WARMUP_FRAMES
     }
 
+    fn has_recolored(&self) -> bool {
+        self.window != 0
+    }
+
     fn recolor_rate(&self) -> f32 {
         let considered = self.observed.min(64);
         if considered == 0 {
@@ -391,6 +414,7 @@ pub(crate) struct SegmentSurfaceStats {
     pub rejected_economics: u64,
     pub rejected_capacity: u64,
     pub evictions: u64,
+    pub waived_captures: u64,
 }
 
 /// A capture the frame must encode for a `Composite` decision: the claimed
@@ -570,6 +594,20 @@ impl SegmentSurfaceCache {
         track.note_frame(frame, dirty);
         let warm = track.warm();
         let rate = track.recolor_rate();
+        // Warmup waiver: at bootstrap frame rates the warmup window is
+        // wall-SECONDS during which every frame redraws the whole scene
+        // direct, so a candidate with no recolor history may capture
+        // before the window fills when the capture pays for itself within
+        // about one frame (the tighter `waiver_ratio` bar below). Waste is
+        // bounded: a churny key has no recolor history at bootstrap and
+        // can waive at most once — its first recolor invalidates the entry
+        // in that same frame, within ~2 frames its rate crosses the churn
+        // gate and the key leaves the cache — and `SEGMENT_CAPTURE_SLOTS`
+        // caps any one frame's capture cost.
+        let waived = !warm
+            && !track.has_recolored()
+            && config.waiver_ratio > 0.0
+            && !self.entries.contains_key(&key);
 
         // A live entry serves the frame unless something invalidates it.
         let (stale, drifted) = match self.entries.get_mut(&key) {
@@ -592,8 +630,9 @@ impl SegmentSurfaceCache {
 
         // Anything below needs a (re)capture. Gate on churn first: a stale
         // entry whose segment now churns must LEAVE the cache, not
-        // recapture forever.
-        if !warm || rate > config.recolor_rate {
+        // recapture forever. A waived candidate falls through to buy in at
+        // the tighter bar.
+        if (!warm && !waived) || rate > config.recolor_rate {
             if stale || drifted {
                 self.remove(&key);
             }
@@ -629,9 +668,14 @@ impl SegmentSurfaceCache {
         let byte_size = rect.byte_size();
         let surface_px = rect.width as f32 * rect.height as f32;
         let member_px_priced = member_px.is_finite() && member_px > 0.0;
+        let admit_ratio = if waived {
+            config.waiver_ratio
+        } else {
+            config.cost_ratio
+        };
         if byte_size > MAX_SEGMENT_SURFACE_ENTRY_BYTES
             || !member_px_priced
-            || surface_px > config.cost_ratio * member_px
+            || surface_px > admit_ratio * member_px
         {
             self.remove(&key);
             self.stats.rejected_economics += 1;
@@ -650,13 +694,16 @@ impl SegmentSurfaceCache {
         let capture_index = self.capture_cursor;
         self.capture_cursor += 1;
         self.stats.captures += 1;
+        if waived {
+            self.stats.waived_captures += 1;
+        }
         // Always-on engagement proof for device logs, mirroring the
         // [command-replay] health line: captures are rare (one per admitted
         // segment per invalidation), so one warn per capture is bounded by
         // the mechanism itself, and an on-watch A/B arm that never prints
         // this line provably measured a vacuous mechanism.
         log::warn!(
-            "[segment-surface] capture #{}: composites {} dirty {} rejected churn {} econ {} cap {} evictions {}",
+            "[segment-surface] capture #{}: composites {} dirty {} rejected churn {} econ {} cap {} evictions {} waived {}",
             self.stats.captures,
             self.stats.composites,
             self.stats.dirty_recaptures,
@@ -664,6 +711,7 @@ impl SegmentSurfaceCache {
             self.stats.rejected_economics,
             self.stats.rejected_capacity,
             self.stats.evictions,
+            self.stats.waived_captures,
         );
         if stale && dirty {
             self.stats.dirty_recaptures += 1;
@@ -855,6 +903,12 @@ mod tests {
     #[test]
     fn decide_admits_only_warm_clean_segments_that_pay() {
         let mut cache = SegmentSurfaceCache::default();
+        // Waiver held shut: the warmup count itself is what this test
+        // pins; the waiver's own admissions are pinned below.
+        let config = SegmentSurfaceConfig {
+            waiver_ratio: 0.0,
+            ..SegmentSurfaceConfig::test_default()
+        };
         let key = SegmentSurfaceKey {
             slot: 3,
             first_shape: 0,
@@ -868,12 +922,12 @@ mod tests {
         // Cold: direct, no capture, until the observation that completes
         // the warmup window.
         for _ in 0..ADMISSION_WARMUP_FRAMES - 1 {
-            cache.advance_frame_for_tests(SegmentSurfaceConfig::test_default());
+            cache.advance_frame_for_tests(config);
             let decision = cache.decide(key, 7, false, 1.0, || Some((rect, 40_000.0)));
             assert_eq!(decision, SegmentSurfaceDecision::Direct);
         }
         // Warm and clean: capture.
-        cache.advance_frame_for_tests(SegmentSurfaceConfig::test_default());
+        cache.advance_frame_for_tests(config);
         let decision = cache.decide(key, 7, false, 1.0, || Some((rect, 40_000.0)));
         assert_eq!(
             decision,
@@ -892,7 +946,7 @@ mod tests {
             shape_count: 3,
         };
         for _ in 0..ADMISSION_WARMUP_FRAMES + 1 {
-            cache.advance_frame_for_tests(SegmentSurfaceConfig::test_default());
+            cache.advance_frame_for_tests(config);
             let _ = cache.decide(sparse, 9, false, 1.0, || Some((rect, 2_000.0)));
         }
         assert!(cache.stats.rejected_economics > 0);
@@ -918,5 +972,135 @@ mod tests {
         }
         assert_eq!(cache.stats.captures, 0);
         assert!(cache.stats.rejected_churn > 0);
+    }
+
+    #[test]
+    fn warmup_waiver_admits_a_paying_static_candidate_immediately() {
+        let mut cache = SegmentSurfaceCache::default();
+        let key = SegmentSurfaceKey {
+            slot: 6,
+            first_shape: 0,
+            shape_count: 420,
+        };
+        let rect = CaptureRect {
+            origin: [0.0, 0.0],
+            width: 300,
+            height: 300,
+        };
+        // 90k surface px against 120k member px: the capture pays for
+        // itself within one frame, and the key has never recolored — the
+        // waiver must not wait out the warmup window.
+        cache.advance_frame_for_tests(SegmentSurfaceConfig::test_default());
+        let mut decision = cache.decide(key, 7, false, 1.0, || Some((rect, 120_000.0)));
+        if decision == SegmentSurfaceDecision::Direct {
+            cache.advance_frame_for_tests(SegmentSurfaceConfig::test_default());
+            decision = cache.decide(key, 7, false, 1.0, || Some((rect, 120_000.0)));
+        }
+        assert_eq!(
+            decision,
+            SegmentSurfaceDecision::Composite {
+                capture: Some(CapturePlan {
+                    index: 0,
+                    rect,
+                    member_px: 120_000.0,
+                })
+            },
+            "a paying, never-recolored candidate must capture by the second frame"
+        );
+        assert_eq!(cache.stats.waived_captures, 1);
+    }
+
+    #[test]
+    fn warmup_waiver_skips_a_recolored_candidate() {
+        let mut cache = SegmentSurfaceCache::default();
+        let key = SegmentSurfaceKey {
+            slot: 6,
+            first_shape: 0,
+            shape_count: 420,
+        };
+        let rect = CaptureRect {
+            origin: [0.0, 0.0],
+            width: 300,
+            height: 300,
+        };
+        // One recolor on the first observed frame disqualifies the key
+        // from waiving for the rest of the warmup window, paying
+        // economics notwithstanding.
+        for frame in 0..ADMISSION_WARMUP_FRAMES - 1 {
+            cache.advance_frame_for_tests(SegmentSurfaceConfig::test_default());
+            let decision = cache.decide(key, 7, frame == 0, 1.0, || Some((rect, 120_000.0)));
+            assert_eq!(decision, SegmentSurfaceDecision::Direct);
+        }
+        assert_eq!(cache.stats.captures, 0);
+        assert_eq!(cache.stats.waived_captures, 0);
+    }
+
+    #[test]
+    fn warmup_waiver_respects_its_economics_bar() {
+        let mut cache = SegmentSurfaceCache::default();
+        let key = SegmentSurfaceKey {
+            slot: 6,
+            first_shape: 0,
+            shape_count: 420,
+        };
+        let rect = CaptureRect {
+            origin: [0.0, 0.0],
+            width: 300,
+            height: 300,
+        };
+        // 90k surface px against 40k member px sits between the bars:
+        // over the waiver's 1.0, under the steady-state 3.0 — direct
+        // through warmup, admitted once warm.
+        for _ in 0..ADMISSION_WARMUP_FRAMES - 1 {
+            cache.advance_frame_for_tests(SegmentSurfaceConfig::test_default());
+            let decision = cache.decide(key, 7, false, 1.0, || Some((rect, 40_000.0)));
+            assert_eq!(decision, SegmentSurfaceDecision::Direct);
+        }
+        cache.advance_frame_for_tests(SegmentSurfaceConfig::test_default());
+        let decision = cache.decide(key, 7, false, 1.0, || Some((rect, 40_000.0)));
+        assert_eq!(
+            decision,
+            SegmentSurfaceDecision::Composite {
+                capture: Some(CapturePlan {
+                    index: 0,
+                    rect,
+                    member_px: 40_000.0,
+                })
+            }
+        );
+        assert_eq!(cache.stats.waived_captures, 0);
+    }
+
+    #[test]
+    fn zero_waiver_ratio_disables_the_waiver() {
+        let mut cache = SegmentSurfaceCache::default();
+        let config = SegmentSurfaceConfig {
+            waiver_ratio: 0.0,
+            ..SegmentSurfaceConfig::test_default()
+        };
+        let key = SegmentSurfaceKey {
+            slot: 6,
+            first_shape: 0,
+            shape_count: 420,
+        };
+        let rect = CaptureRect {
+            origin: [0.0, 0.0],
+            width: 300,
+            height: 300,
+        };
+        // The candidate would waive on economics; the kill switch must
+        // hold warmup admission exactly where it was.
+        for _ in 0..ADMISSION_WARMUP_FRAMES - 1 {
+            cache.advance_frame_for_tests(config);
+            let decision = cache.decide(key, 7, false, 1.0, || Some((rect, 120_000.0)));
+            assert_eq!(decision, SegmentSurfaceDecision::Direct);
+        }
+        cache.advance_frame_for_tests(config);
+        let decision = cache.decide(key, 7, false, 1.0, || Some((rect, 120_000.0)));
+        assert!(matches!(
+            decision,
+            SegmentSurfaceDecision::Composite { capture: Some(_) }
+        ));
+        assert_eq!(cache.stats.waived_captures, 0);
     }
 }

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -73,7 +73,7 @@ fn property_flag(name: &str) -> bool {
 /// any length — so a name may run right up to or past that pre-O limit, as
 /// `debug.cranpose.retained_mesh_px2` does; every deployment target is far
 /// past O.)
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 30] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 31] = [
     ("debug.cranpose.gpu_stats", "CRANPOSE_GPU_STATS"),
     ("debug.cranpose.present_thread", "CRANPOSE_PRESENT_THREAD"),
     ("debug.cranpose.command_feed", "CRANPOSE_COMMAND_FEED"),
@@ -140,6 +140,10 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 30] = [
     (
         "debug.cranpose.seg_surface_scale",
         "CRANPOSE_SEGMENT_SURFACE_SCALE_EPS",
+    ),
+    (
+        "debug.cranpose.segment_surface_waiver",
+        "CRANPOSE_SEGMENT_SURFACE_WAIVER_RATIO",
     ),
     ("debug.cranpose.solid_trim", "CRANPOSE_SOLID_TRIM_VARYINGS"),
     (


### PR DESCRIPTION
## The problem (measured on the Pixel Watch 3)

A fresh MEGA arena's first ~8 wall-seconds run at 1–11 fps: every frame re-converts and re-fills the whole ~17k-shape scene while the segment-surface cache refuses to admit anything for `ADMISSION_WARMUP_FRAMES = 8` frames per key. The warmup counts frames, not time — at bootstrap frame rates 8 frames is up to 8 seconds of wall clock — so the cache sits out exactly the window where it is most needed. The warmup exists to keep short-lived and churny segments from paying captures, but the economics are already measurable per candidate, and a huge static ring segment pays for its capture within a single frame.

## The waiver

During warmup, a candidate that has never been observed to recolor may be admitted immediately iff `surface_px <= waiver_ratio * member_px` — a strictly TIGHTER bar than the steady-state `cost_ratio` (3.0): payback within about one frame. Defaults and switches:

- `waiver_ratio` defaults to **1.0**, loaded from `CRANPOSE_SEGMENT_SURFACE_WAIVER_RATIO` (Android property `debug.cranpose.segment_surface_waiver`, added to `PROPERTY_BACKED_ENV_VARS`).
- `waiver_ratio <= 0.0` disables the waiver entirely — behavior is then bit-for-bit today's admission at frame 8.
- Everything downstream of the churn gate is the existing flow (capture-slot check → `plan()` → economics → budget → capture); the only difference while waived is the tighter economics ratio.
- `SegmentSurfaceStats` gains `waived_captures`, appended to the `[segment-surface] capture #...` engagement warn line as `waived {}`.

## Bounded waste (why a churny segment cannot be hurt)

A churny (twinkle) segment has no recolor history at bootstrap and may waive once; its first recolor triggers the existing same-frame invalidation, its rate then exceeds the churn gate within ~2 frames, and the key exits the cache. The waste is bounded at one capture per churny key, and `SEGMENT_CAPTURE_SLOTS` (8/frame) bounds any one frame's capture cost.

## Red-run proof

`warmup_waiver_admits_a_paying_static_candidate_immediately` run against unmodified `main` (f384b4e3), with the two references to the not-yet-existing `waiver_ratio` / `waived_captures` fields omitted so it compiles there — the behavioral assertion is what goes red:

```
running 1 test
test segment_surface::tests::warmup_waiver_admits_a_paying_static_candidate_immediately ... FAILED

---- segment_surface::tests::warmup_waiver_admits_a_paying_static_candidate_immediately stdout ----

thread 'segment_surface::tests::warmup_waiver_admits_a_paying_static_candidate_immediately' (2751332) panicked at crates/cranpose-render/wgpu/src/segment_surface.rs:945:9:
assertion `left == right` failed: a paying, never-recolored candidate must capture by the second frame
  left: Direct
 right: Composite { capture: Some(CapturePlan { index: 0, rect: CaptureRect { origin: [0.0, 0.0], width: 300, height: 300 }, member_px: 120000.0 }) }

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 453 filtered out; finished in 0.00s
```

With the fix the same test passes, plus:

- `warmup_waiver_skips_a_recolored_candidate` — one recolor on the first observed frame disqualifies the key; Direct through warmup as today.
- `warmup_waiver_respects_its_economics_bar` — 90k surface px against 40k member px sits between the bars (over 1.0×, under 3.0×): Direct through warmup, admitted at frame 8 on the steady-state bar, `waived_captures == 0`.
- `zero_waiver_ratio_disables_the_waiver` — a candidate that would waive stays Direct until frame 8 with the kill switch at 0.

## Gates

- `cargo test -p cranpose-render-wgpu` — 456 lib tests and every integration suite green, including the three `segment_surface_parity` GPU suites on lavapipe (unaffected at the default ratio: the synthetic scene's segments all price above 1.0× member px, so nothing waives there).
- `cargo clippy -p cranpose-render-wgpu --all-targets` — clean.
- `cargo check -p cranpose` (host) and `cargo check -p cranpose --features android,renderer-wgpu --target aarch64-linux-android` — green (the latter is what actually compiles the android-gated property table).

## Existing-test sweep

`decide_admits_only_warm_clean_segments_that_pay` now holds `waiver_ratio: 0.0` so the warmup count itself remains the thing it pins — its 40k-member / 90k-surface candidate would otherwise fall through to the waiver's economics path during warmup. No churn, economics, or budget assertion was weakened.

## One deliberate deviation

Loading the ratio through the existing `env_f32` would filter `0` as malformed and fall back to the default, making the documented kill switch unreachable from the env/property; a sibling `env_f32_zero_ok` accepts zero for this variable only, leaving every existing variable's parsing untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
