### PR TITLE
Persistent pipeline cache: stop compiling shaders on the render thread at launch

### DIFF
--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -451,7 +451,6 @@ fn dst_out_blend_state() -> wgpu::BlendState {
 }
 
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 fn create_fullscreen_pipeline(
     device: &wgpu::Device,
     cache: Option<&wgpu::PipelineCache>,

--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -22,6 +22,9 @@ use std::cell::Cell;
 pub(crate) struct EffectRenderer {
     offscreen_pool: OffscreenPool,
     pub shader_cache: ShaderPipelineCache,
+    /// The device's shared pipeline cache (see `GpuRenderer`); every lazy
+    /// effect pipeline creation passes it.
+    pipeline_cache: Option<wgpu::PipelineCache>,
 
     blur_shader: wgpu::ShaderModule,
     blur_rounded_mask_shader: wgpu::ShaderModule,
@@ -448,8 +451,10 @@ fn dst_out_blend_state() -> wgpu::BlendState {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn create_fullscreen_pipeline(
     device: &wgpu::Device,
+    cache: Option<&wgpu::PipelineCache>,
     label: &'static str,
     layout: &wgpu::PipelineLayout,
     shader: &wgpu::ShaderModule,
@@ -460,8 +465,9 @@ fn create_fullscreen_pipeline(
 ) -> wgpu::RenderPipeline {
     crate::render::create_render_pipeline_logged(
         device,
+        cache,
         &format!("effect {label} entry={fragment_entry} depth={depth}"),
-        &wgpu::RenderPipelineDescriptor {
+        wgpu::RenderPipelineDescriptor {
             label: Some(label),
             layout: Some(layout),
             vertex: wgpu::VertexState {
@@ -495,8 +501,10 @@ fn create_fullscreen_pipeline(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn create_projective_pipeline(
     device: &wgpu::Device,
+    cache: Option<&wgpu::PipelineCache>,
     label: &'static str,
     layout: &wgpu::PipelineLayout,
     shader: &wgpu::ShaderModule,
@@ -506,8 +514,9 @@ fn create_projective_pipeline(
 ) -> wgpu::RenderPipeline {
     crate::render::create_render_pipeline_logged(
         device,
+        cache,
         &format!("effect {label} depth={depth}"),
-        &wgpu::RenderPipelineDescriptor {
+        wgpu::RenderPipelineDescriptor {
             label: Some(label),
             layout: Some(layout),
             vertex: wgpu::VertexState {
@@ -552,6 +561,7 @@ fn create_projective_pipeline(
 impl EffectRenderer {
     pub fn new(
         device: &wgpu::Device,
+        pipeline_cache: Option<wgpu::PipelineCache>,
         surface_format: wgpu::TextureFormat,
         adapter_backend: wgpu::Backend,
     ) -> Self {
@@ -700,7 +710,8 @@ impl EffectRenderer {
         });
         Self {
             offscreen_pool: OffscreenPool::new(device, surface_format),
-            shader_cache: ShaderPipelineCache::new(adapter_backend),
+            shader_cache: ShaderPipelineCache::new(adapter_backend, pipeline_cache.clone()),
+            pipeline_cache,
             blur_shader,
             blur_rounded_mask_shader,
             blur_pipeline_layout,
@@ -795,6 +806,7 @@ impl EffectRenderer {
         self.blur_pipeline.get_or_init(self.adapter_backend, || {
             create_fullscreen_pipeline(
                 device,
+                self.pipeline_cache.as_ref(),
                 "Blur Pipeline",
                 &self.blur_pipeline_layout,
                 &self.blur_shader,
@@ -811,6 +823,7 @@ impl EffectRenderer {
             .get_or_init(self.adapter_backend, || {
                 create_fullscreen_pipeline(
                     device,
+                    self.pipeline_cache.as_ref(),
                     "Blur Rounded Mask Pipeline",
                     &self.blur_pipeline_layout,
                     &self.blur_rounded_mask_shader,
@@ -826,6 +839,7 @@ impl EffectRenderer {
         self.offset_pipeline.get_or_init(self.adapter_backend, || {
             create_fullscreen_pipeline(
                 device,
+                self.pipeline_cache.as_ref(),
                 "Offset Pipeline",
                 &self.offset_pipeline_layout,
                 &self.offset_shader,
@@ -871,6 +885,7 @@ impl EffectRenderer {
             });
             create_fullscreen_pipeline(
                 device,
+                self.pipeline_cache.as_ref(),
                 label,
                 &self.blit_pipeline_layout,
                 depth_shader.as_ref().unwrap_or(&self.blit_shader),
@@ -931,6 +946,7 @@ impl EffectRenderer {
             });
             create_projective_pipeline(
                 device,
+                self.pipeline_cache.as_ref(),
                 label,
                 &self.projective_blit_pipeline_layout,
                 depth_shader

--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -458,37 +458,41 @@ fn create_fullscreen_pipeline(
     blend: wgpu::BlendState,
     depth: bool,
 ) -> wgpu::RenderPipeline {
-    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-        label: Some(label),
-        layout: Some(layout),
-        vertex: wgpu::VertexState {
-            module: shader,
-            entry_point: Some("fullscreen_vs"),
-            buffers: &[],
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
+    crate::render::create_render_pipeline_logged(
+        device,
+        &format!("effect {label} entry={fragment_entry} depth={depth}"),
+        &wgpu::RenderPipelineDescriptor {
+            label: Some(label),
+            layout: Some(layout),
+            vertex: wgpu::VertexState {
+                module: shader,
+                entry_point: Some("fullscreen_vs"),
+                buffers: &[],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: shader,
+                entry_point: Some(fragment_entry),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: Some(blend),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleStrip,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                ..Default::default()
+            },
+            depth_stencil: display_clip::content_depth_state(depth),
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
         },
-        fragment: Some(wgpu::FragmentState {
-            module: shader,
-            entry_point: Some(fragment_entry),
-            targets: &[Some(wgpu::ColorTargetState {
-                format: surface_format,
-                blend: Some(blend),
-                write_mask: wgpu::ColorWrites::ALL,
-            })],
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-        }),
-        primitive: wgpu::PrimitiveState {
-            topology: wgpu::PrimitiveTopology::TriangleStrip,
-            strip_index_format: None,
-            front_face: wgpu::FrontFace::Ccw,
-            cull_mode: None,
-            ..Default::default()
-        },
-        depth_stencil: display_clip::content_depth_state(depth),
-        multisample: wgpu::MultisampleState::default(),
-        multiview_mask: None,
-        cache: None,
-    })
+    )
 }
 
 fn create_projective_pipeline(
@@ -500,45 +504,49 @@ fn create_projective_pipeline(
     blend: wgpu::BlendState,
     depth: bool,
 ) -> wgpu::RenderPipeline {
-    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-        label: Some(label),
-        layout: Some(layout),
-        vertex: wgpu::VertexState {
-            module: shader,
-            entry_point: Some("projective_blit_vs"),
-            buffers: &[wgpu::VertexBufferLayout {
-                array_stride: std::mem::size_of::<ProjectiveBlitVertex>() as u64,
-                step_mode: wgpu::VertexStepMode::Vertex,
-                attributes: &[wgpu::VertexAttribute {
-                    offset: 0,
-                    shader_location: 0,
-                    format: wgpu::VertexFormat::Float32x2,
+    crate::render::create_render_pipeline_logged(
+        device,
+        &format!("effect {label} depth={depth}"),
+        &wgpu::RenderPipelineDescriptor {
+            label: Some(label),
+            layout: Some(layout),
+            vertex: wgpu::VertexState {
+                module: shader,
+                entry_point: Some("projective_blit_vs"),
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<ProjectiveBlitVertex>() as u64,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 0,
+                        format: wgpu::VertexFormat::Float32x2,
+                    }],
                 }],
-            }],
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: shader,
+                entry_point: Some("projective_blit_fs"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: Some(blend),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleStrip,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                ..Default::default()
+            },
+            depth_stencil: display_clip::content_depth_state(depth),
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
         },
-        fragment: Some(wgpu::FragmentState {
-            module: shader,
-            entry_point: Some("projective_blit_fs"),
-            targets: &[Some(wgpu::ColorTargetState {
-                format: surface_format,
-                blend: Some(blend),
-                write_mask: wgpu::ColorWrites::ALL,
-            })],
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-        }),
-        primitive: wgpu::PrimitiveState {
-            topology: wgpu::PrimitiveTopology::TriangleStrip,
-            strip_index_format: None,
-            front_face: wgpu::FrontFace::Ccw,
-            cull_mode: None,
-            ..Default::default()
-        },
-        depth_stencil: display_clip::content_depth_state(depth),
-        multisample: wgpu::MultisampleState::default(),
-        multiview_mask: None,
-        cache: None,
-    })
+    )
 }
 
 impl EffectRenderer {

--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -20,6 +20,8 @@ mod normalized_scene;
 mod offscreen;
 mod pipeline;
 #[cfg(not(target_arch = "wasm32"))]
+mod pipeline_disk_cache;
+#[cfg(not(target_arch = "wasm32"))]
 mod present_runtime;
 mod render;
 mod run_entry;

--- a/crates/cranpose-render/wgpu/src/pipeline_disk_cache.rs
+++ b/crates/cranpose-render/wgpu/src/pipeline_disk_cache.rs
@@ -1,0 +1,132 @@
+//! On-disk persistence for the device pipeline cache.
+//!
+//! Every render pipeline in this crate is created lazily on the render
+//! thread, and on a mobile driver the backend compile inside that create is
+//! enormous: a Pixel Watch 3 spends 2.0 s of its first six seconds in six
+//! such calls (`[pipeline-create]` measured 661 ms for one), each swallowed
+//! as one silent sub-second frame. A [`wgpu::PipelineCache`] handed to every
+//! creation lets the driver reuse compiled code across creates within one
+//! process; writing its blob to disk lets the next launch skip the compiles
+//! outright. The platform layer names the file — keyed by adapter identity,
+//! so a driver update starts cold instead of loading a stale blob (wgpu
+//! additionally validates the header and falls back to empty) — and this
+//! module only loads and stores it.
+//!
+//! `CRANPOSE_PIPELINE_DISK_CACHE=0` is the kill switch (on Android via the
+//! `debug.cranpose.pipeline_disk_cache` property). Platforms that never set
+//! `CRANPOSE_PIPELINE_CACHE_FILE`, and devices whose adapter was not granted
+//! [`wgpu::Features::PIPELINE_CACHE`], keep today's behavior exactly.
+
+use std::path::{Path, PathBuf};
+
+use web_time::Instant;
+
+fn disk_cache_enabled() -> bool {
+    std::env::var("CRANPOSE_PIPELINE_DISK_CACHE").as_deref() != Ok("0")
+}
+
+/// The blob's path, or `None` when persistence is off — by kill switch or
+/// because the platform never named a file.
+pub(crate) fn file_path() -> Option<PathBuf> {
+    if !disk_cache_enabled() {
+        return None;
+    }
+    match std::env::var_os("CRANPOSE_PIPELINE_CACHE_FILE") {
+        Some(path) if !path.is_empty() => Some(PathBuf::from(path)),
+        _ => None,
+    }
+}
+
+/// Creates the device's pipeline cache, seeded from disk when a blob exists.
+/// `None` exactly when the device lacks [`wgpu::Features::PIPELINE_CACHE`] —
+/// an in-memory cache is worth having even without a disk file, since the
+/// shape pipeline family shares most of its module across permutations.
+pub(crate) fn load(device: &wgpu::Device) -> Option<wgpu::PipelineCache> {
+    if !device.features().contains(wgpu::Features::PIPELINE_CACHE) {
+        return None;
+    }
+    let path = file_path();
+    let data = path.as_deref().and_then(|path| match std::fs::read(path) {
+        Ok(bytes) => Some(bytes),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            log::warn!("[pipeline-cache] unreadable {path:?}: {error}");
+            None
+        }
+    });
+    let loaded = data.as_ref().map(Vec::len);
+    // The contract is that `data` came from `PipelineCache::get_data` on a
+    // matching adapter: `persist` below writes exactly that into a file the
+    // platform layer keys by adapter identity, so a driver update swaps
+    // files instead of feeding a stale blob back.
+    // SAFETY: `data` is `persist`'s own `get_data` output, and `fallback:
+    // true` has wgpu validate the header and fall back to an empty cache.
+    #[allow(unsafe_code)]
+    let cache = unsafe {
+        device.create_pipeline_cache(&wgpu::PipelineCacheDescriptor {
+            label: Some("cranpose pipeline disk cache"),
+            data: data.as_deref(),
+            fallback: true,
+        })
+    };
+    match loaded {
+        Some(bytes) => log::info!("[pipeline-cache] loaded {bytes} B from disk"),
+        None => log::info!("[pipeline-cache] cold (no blob on disk)"),
+    }
+    Some(cache)
+}
+
+/// Writes the cache blob if it changed. Called off the render thread; both
+/// `get_data` and concurrent pipeline creation are internally synchronized
+/// by the driver.
+pub(crate) fn persist(cache: &wgpu::PipelineCache, path: &Path) {
+    let started = Instant::now();
+    let Some(data) = cache.get_data() else {
+        return;
+    };
+    if let Ok(existing) = std::fs::read(path) {
+        if existing == data {
+            return;
+        }
+    }
+    if let Some(parent) = path.parent() {
+        if let Err(error) = std::fs::create_dir_all(parent) {
+            log::warn!("[pipeline-cache] create_dir_all {parent:?}: {error}");
+            return;
+        }
+    }
+    // Write-then-rename so a launch never reads a half-written blob.
+    let tmp = path.with_extension("tmp");
+    let written = std::fs::write(&tmp, &data).and_then(|()| std::fs::rename(&tmp, path));
+    match written {
+        Ok(()) => log::info!(
+            "[pipeline-cache] persisted {} B in {:.1} ms",
+            data.len(),
+            crate::render::instant_ms(started, Instant::now()),
+        ),
+        Err(error) => log::warn!("[pipeline-cache] write {path:?}: {error}"),
+    }
+}
+
+/// Persistence schedule: one thread, two sweeps. The first runs after the
+/// base pipeline set exists on a cold launch (the watch finishes it inside
+/// eight seconds even at bootstrap frame rates), the second late enough to
+/// catch stragglers a scene pulls in lazily — effect blits, `DstOut`
+/// variants, runtime shaders. `persist` compares content, so an unchanged
+/// cache costs one `get_data` and no write.
+pub(crate) fn spawn_persist_schedule(cache: wgpu::PipelineCache) {
+    let Some(path) = file_path() else {
+        return;
+    };
+    let spawned = std::thread::Builder::new()
+        .name("cranpose-pl-cache".into())
+        .spawn(move || {
+            std::thread::sleep(std::time::Duration::from_secs(8));
+            persist(&cache, &path);
+            std::thread::sleep(std::time::Duration::from_secs(20));
+            persist(&cache, &path);
+        });
+    if let Err(error) = spawned {
+        log::warn!("[pipeline-cache] persist thread failed to spawn: {error}");
+    }
+}

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -1452,6 +1452,24 @@ fn shape_shader_source(_batch_limits: ShapeBatchLimits, solid_trim: bool) -> Cow
     shape_shader_base(solid_trim)
 }
 
+/// Runs one `create_render_pipeline` call under a timer and logs the result.
+/// First-use creation happens on the render thread behind `get_or_init`,
+/// where a driver backend compile is whole missed frames on slow devices;
+/// the tag names the permutation so a stalled launch names its pipelines.
+pub(crate) fn create_render_pipeline_logged(
+    device: &wgpu::Device,
+    tag: &str,
+    descriptor: &wgpu::RenderPipelineDescriptor<'_>,
+) -> wgpu::RenderPipeline {
+    let started = Instant::now();
+    let pipeline = device.create_render_pipeline(descriptor);
+    log::info!(
+        "[pipeline-create] {tag} {:.1}ms",
+        instant_ms(started, Instant::now())
+    );
+    pipeline
+}
+
 #[allow(clippy::too_many_arguments)]
 fn create_shape_pipeline(
     device: &wgpu::Device,
@@ -1479,41 +1497,45 @@ fn create_shape_pipeline(
         immediate_size: 0,
     });
 
-    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-        label: Some("Render Pipeline"),
-        layout: Some(&pipeline_layout),
-        vertex: wgpu::VertexState {
-            module: &shader,
-            entry_point: Some(vertex_entry),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            // No vertex buffer: `vs_main` (and its trimmed twin `vs_solid`)
-            // pulls quad corners from ShapeData by `vertex_index`.
-            buffers: &[],
+    create_render_pipeline_logged(
+        device,
+        &format!("shape entry={fragment_entry} blend={blend_mode:?} depth={depth}"),
+        &wgpu::RenderPipelineDescriptor {
+            label: Some("Render Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some(vertex_entry),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                // No vertex buffer: `vs_main` (and its trimmed twin `vs_solid`)
+                // pulls quad corners from ShapeData by `vertex_index`.
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some(fragment_entry),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: Some(blend_state_for_mode(blend_mode)),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                unclipped_depth: false,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                conservative: false,
+            },
+            depth_stencil: display_clip::content_depth_state(depth),
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
         },
-        fragment: Some(wgpu::FragmentState {
-            module: &shader,
-            entry_point: Some(fragment_entry),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            targets: &[Some(wgpu::ColorTargetState {
-                format: surface_format,
-                blend: Some(blend_state_for_mode(blend_mode)),
-                write_mask: wgpu::ColorWrites::ALL,
-            })],
-        }),
-        primitive: wgpu::PrimitiveState {
-            topology: wgpu::PrimitiveTopology::TriangleList,
-            strip_index_format: None,
-            front_face: wgpu::FrontFace::Ccw,
-            cull_mode: None,
-            unclipped_depth: false,
-            polygon_mode: wgpu::PolygonMode::Fill,
-            conservative: false,
-        },
-        depth_stencil: display_clip::content_depth_state(depth),
-        multisample: wgpu::MultisampleState::default(),
-        multiview_mask: None,
-        cache: None,
-    })
+    )
 }
 
 /// Storage-mode pipeline for retained slots that captured a conservative arc
@@ -1547,39 +1569,43 @@ fn create_mesh_shape_pipeline(
         immediate_size: 0,
     });
 
-    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-        label: Some("Retained Mesh Pipeline"),
-        layout: Some(&pipeline_layout),
-        vertex: wgpu::VertexState {
-            module: &shader,
-            entry_point: Some("vs_mesh"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            buffers: &[MeshVertex::desc()],
+    create_render_pipeline_logged(
+        device,
+        &format!("mesh depth={depth}"),
+        &wgpu::RenderPipelineDescriptor {
+            label: Some("Retained Mesh Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_mesh"),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                buffers: &[MeshVertex::desc()],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: Some(blend_state_for_mode(BlendMode::SrcOver)),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                unclipped_depth: false,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                conservative: false,
+            },
+            depth_stencil: display_clip::content_depth_state(depth),
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
         },
-        fragment: Some(wgpu::FragmentState {
-            module: &shader,
-            entry_point: Some("fs_main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            targets: &[Some(wgpu::ColorTargetState {
-                format: surface_format,
-                blend: Some(blend_state_for_mode(BlendMode::SrcOver)),
-                write_mask: wgpu::ColorWrites::ALL,
-            })],
-        }),
-        primitive: wgpu::PrimitiveState {
-            topology: wgpu::PrimitiveTopology::TriangleList,
-            strip_index_format: None,
-            front_face: wgpu::FrontFace::Ccw,
-            cull_mode: None,
-            unclipped_depth: false,
-            polygon_mode: wgpu::PolygonMode::Fill,
-            conservative: false,
-        },
-        depth_stencil: display_clip::content_depth_state(depth),
-        multisample: wgpu::MultisampleState::default(),
-        multiview_mask: None,
-        cache: None,
-    })
+    )
 }
 
 /// Storage-mode pipeline for ordinary shape batches drawn as instanced
@@ -1617,42 +1643,46 @@ fn create_instanced_shape_pipeline(
         immediate_size: 0,
     });
 
-    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-        label: Some("Instanced Render Pipeline"),
-        layout: Some(&pipeline_layout),
-        vertex: wgpu::VertexState {
-            module: &shader,
-            entry_point: Some(vertex_entry),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            // No vertex buffer: like `vs_main`, the corners come from
-            // ShapeData; only the shape index source differs
-            // (`instance_index` instead of `vertex_index / 6`).
-            buffers: &[],
+    create_render_pipeline_logged(
+        device,
+        &format!("instanced entry={fragment_entry} blend={blend_mode:?} depth={depth}"),
+        &wgpu::RenderPipelineDescriptor {
+            label: Some("Instanced Render Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some(vertex_entry),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                // No vertex buffer: like `vs_main`, the corners come from
+                // ShapeData; only the shape index source differs
+                // (`instance_index` instead of `vertex_index / 6`).
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some(fragment_entry),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: Some(blend_state_for_mode(blend_mode)),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                unclipped_depth: false,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                conservative: false,
+            },
+            depth_stencil: display_clip::content_depth_state(depth),
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
         },
-        fragment: Some(wgpu::FragmentState {
-            module: &shader,
-            entry_point: Some(fragment_entry),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            targets: &[Some(wgpu::ColorTargetState {
-                format: surface_format,
-                blend: Some(blend_state_for_mode(blend_mode)),
-                write_mask: wgpu::ColorWrites::ALL,
-            })],
-        }),
-        primitive: wgpu::PrimitiveState {
-            topology: wgpu::PrimitiveTopology::TriangleList,
-            strip_index_format: None,
-            front_face: wgpu::FrontFace::Ccw,
-            cull_mode: None,
-            unclipped_depth: false,
-            polygon_mode: wgpu::PolygonMode::Fill,
-            conservative: false,
-        },
-        depth_stencil: display_clip::content_depth_state(depth),
-        multisample: wgpu::MultisampleState::default(),
-        multiview_mask: None,
-        cache: None,
-    })
+    )
 }
 
 fn create_image_pipeline(
@@ -1677,39 +1707,43 @@ fn create_image_pipeline(
         immediate_size: 0,
     });
 
-    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-        label: Some("Image Pipeline"),
-        layout: Some(&image_pipeline_layout),
-        vertex: wgpu::VertexState {
-            module: &image_shader,
-            entry_point: Some("image_vs_main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            buffers: &[Vertex::desc()],
+    create_render_pipeline_logged(
+        device,
+        &format!("image blend={blend_mode:?} depth={depth}"),
+        &wgpu::RenderPipelineDescriptor {
+            label: Some("Image Pipeline"),
+            layout: Some(&image_pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &image_shader,
+                entry_point: Some("image_vs_main"),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                buffers: &[Vertex::desc()],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &image_shader,
+                entry_point: Some("image_fs_main"),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: Some(blend_state_for_mode(blend_mode)),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                unclipped_depth: false,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                conservative: false,
+            },
+            depth_stencil: display_clip::content_depth_state(depth),
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
         },
-        fragment: Some(wgpu::FragmentState {
-            module: &image_shader,
-            entry_point: Some("image_fs_main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            targets: &[Some(wgpu::ColorTargetState {
-                format: surface_format,
-                blend: Some(blend_state_for_mode(blend_mode)),
-                write_mask: wgpu::ColorWrites::ALL,
-            })],
-        }),
-        primitive: wgpu::PrimitiveState {
-            topology: wgpu::PrimitiveTopology::TriangleList,
-            strip_index_format: None,
-            front_face: wgpu::FrontFace::Ccw,
-            cull_mode: None,
-            unclipped_depth: false,
-            polygon_mode: wgpu::PolygonMode::Fill,
-            conservative: false,
-        },
-        depth_stencil: display_clip::content_depth_state(depth),
-        multisample: wgpu::MultisampleState::default(),
-        multiview_mask: None,
-        cache: None,
-    })
+    )
 }
 
 fn create_glyph_atlas_pipeline(
@@ -1733,39 +1767,43 @@ fn create_glyph_atlas_pipeline(
         immediate_size: 0,
     });
 
-    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-        label: Some("Glyph Atlas Pipeline"),
-        layout: Some(&pipeline_layout),
-        vertex: wgpu::VertexState {
-            module: &shader,
-            entry_point: Some("glyph_atlas_vs_main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            buffers: &[Vertex::desc()],
+    create_render_pipeline_logged(
+        device,
+        &format!("glyph-atlas depth={depth}"),
+        &wgpu::RenderPipelineDescriptor {
+            label: Some("Glyph Atlas Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("glyph_atlas_vs_main"),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                buffers: &[Vertex::desc()],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("glyph_atlas_fs_main"),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: Some(blend_state_for_mode(BlendMode::SrcOver)),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                unclipped_depth: false,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                conservative: false,
+            },
+            depth_stencil: display_clip::content_depth_state(depth),
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
         },
-        fragment: Some(wgpu::FragmentState {
-            module: &shader,
-            entry_point: Some("glyph_atlas_fs_main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            targets: &[Some(wgpu::ColorTargetState {
-                format: surface_format,
-                blend: Some(blend_state_for_mode(BlendMode::SrcOver)),
-                write_mask: wgpu::ColorWrites::ALL,
-            })],
-        }),
-        primitive: wgpu::PrimitiveState {
-            topology: wgpu::PrimitiveTopology::TriangleList,
-            strip_index_format: None,
-            front_face: wgpu::FrontFace::Ccw,
-            cull_mode: None,
-            unclipped_depth: false,
-            polygon_mode: wgpu::PolygonMode::Fill,
-            conservative: false,
-        },
-        depth_stencil: display_clip::content_depth_state(depth),
-        multisample: wgpu::MultisampleState::default(),
-        multiview_mask: None,
-        cache: None,
-    })
+    )
 }
 
 /// Pipeline for the display-clip occluder — the tessellated complement
@@ -1789,53 +1827,57 @@ fn create_display_clip_occluder_pipeline(
         bind_group_layouts: &[],
         immediate_size: 0,
     });
-    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-        label: Some("Display Clip Occluder Pipeline"),
-        layout: Some(&pipeline_layout),
-        vertex: wgpu::VertexState {
-            module: &shader,
-            entry_point: Some("mask_vs"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            buffers: &[wgpu::VertexBufferLayout {
-                array_stride: (std::mem::size_of::<[f32; 2]>()) as wgpu::BufferAddress,
-                step_mode: wgpu::VertexStepMode::Vertex,
-                attributes: &[wgpu::VertexAttribute {
-                    offset: 0,
-                    shader_location: 0,
-                    format: wgpu::VertexFormat::Float32x2,
+    create_render_pipeline_logged(
+        device,
+        "occluder",
+        &wgpu::RenderPipelineDescriptor {
+            label: Some("Display Clip Occluder Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("mask_vs"),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: (std::mem::size_of::<[f32; 2]>()) as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 0,
+                        format: wgpu::VertexFormat::Float32x2,
+                    }],
                 }],
-            }],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("mask_fs"),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::empty(),
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                unclipped_depth: false,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                conservative: false,
+            },
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: display_clip::DISPLAY_CLIP_DEPTH_FORMAT,
+                depth_write_enabled: Some(true),
+                depth_compare: Some(wgpu::CompareFunction::Always),
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
         },
-        fragment: Some(wgpu::FragmentState {
-            module: &shader,
-            entry_point: Some("mask_fs"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            targets: &[Some(wgpu::ColorTargetState {
-                format: surface_format,
-                blend: None,
-                write_mask: wgpu::ColorWrites::empty(),
-            })],
-        }),
-        primitive: wgpu::PrimitiveState {
-            topology: wgpu::PrimitiveTopology::TriangleList,
-            strip_index_format: None,
-            front_face: wgpu::FrontFace::Ccw,
-            cull_mode: None,
-            unclipped_depth: false,
-            polygon_mode: wgpu::PolygonMode::Fill,
-            conservative: false,
-        },
-        depth_stencil: Some(wgpu::DepthStencilState {
-            format: display_clip::DISPLAY_CLIP_DEPTH_FORMAT,
-            depth_write_enabled: Some(true),
-            depth_compare: Some(wgpu::CompareFunction::Always),
-            stencil: wgpu::StencilState::default(),
-            bias: wgpu::DepthBiasState::default(),
-        }),
-        multisample: wgpu::MultisampleState::default(),
-        multiview_mask: None,
-        cache: None,
-    })
+    )
 }
 
 #[repr(C)]

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -9589,7 +9589,7 @@ impl GpuRenderer {
         let mut rendered_any = false;
         let mut pass_count = 0_u32;
         let mut next_load_op = load_op;
-        let encode_started = std::time::Instant::now();
+        let encode_started = Instant::now();
         let mut partition_count = 0_u64;
         for partition in partitions {
             partition_count += 1;

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -1456,13 +1456,15 @@ fn shape_shader_source(_batch_limits: ShapeBatchLimits, solid_trim: bool) -> Cow
 /// First-use creation happens on the render thread behind `get_or_init`,
 /// where a driver backend compile is whole missed frames on slow devices;
 /// the tag names the permutation so a stalled launch names its pipelines.
-pub(crate) fn create_render_pipeline_logged(
+pub(crate) fn create_render_pipeline_logged<'a>(
     device: &wgpu::Device,
+    cache: Option<&'a wgpu::PipelineCache>,
     tag: &str,
-    descriptor: &wgpu::RenderPipelineDescriptor<'_>,
+    mut descriptor: wgpu::RenderPipelineDescriptor<'a>,
 ) -> wgpu::RenderPipeline {
+    descriptor.cache = cache;
     let started = Instant::now();
-    let pipeline = device.create_render_pipeline(descriptor);
+    let pipeline = device.create_render_pipeline(&descriptor);
     log::info!(
         "[pipeline-create] {tag} {:.1}ms",
         instant_ms(started, Instant::now())
@@ -1470,9 +1472,149 @@ pub(crate) fn create_render_pipeline_logged(
     pipeline
 }
 
+/// `CRANPOSE_PIPELINE_PREWARM=0` (property `debug.cranpose.pipeline_prewarm`)
+/// keeps first-use creation as the only compile path.
+#[cfg(not(target_arch = "wasm32"))]
+fn pipeline_prewarm_enabled() -> bool {
+    std::env::var("CRANPOSE_PIPELINE_PREWARM").as_deref() != Ok("0")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct PipelinePrewarmInputs {
+    device: Arc<wgpu::Device>,
+    cache: Option<wgpu::PipelineCache>,
+    surface_format: wgpu::TextureFormat,
+    uniform_layout: wgpu::BindGroupLayout,
+    shape_layout: wgpu::BindGroupLayout,
+    image_layout: wgpu::BindGroupLayout,
+    batch_limits: ShapeBatchLimits,
+    instanced: bool,
+}
+
+/// Builds the pipelines a first frame reaches for — off the render thread,
+/// concurrent with app startup — and drops them. The point is the shared
+/// device pipeline cache: the render thread's own `get_or_init` creates then
+/// find the driver's compiled code instead of paying for it mid-frame
+/// (measured on a Pixel Watch 3: 661 + 496 + 552 ms for the three shape
+/// pipelines alone, each one swallowed frame). The set is the framework's
+/// own base family with the flags the accessors would latch — same inputs,
+/// same permutations, so the cache keys match. Spawned only when the device
+/// has a pipeline cache; without one, warming another thread's `wgpu`
+/// objects would leave nothing behind for the render thread to find.
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_pipeline_prewarm(inputs: PipelinePrewarmInputs) {
+    if !pipeline_prewarm_enabled() {
+        return;
+    }
+    let spawned = std::thread::Builder::new()
+        .name("cranpose-pl-warm".into())
+        .spawn(move || {
+            let started = Instant::now();
+            let cache = inputs.cache.as_ref();
+            let device = &inputs.device;
+            let solid_trim = solid_trim_varyings_enabled();
+            let mut built = 0_u32;
+            if inputs.instanced {
+                let (vertex_entry, fragment_entry) = if solid_trim {
+                    ("vs_solid_instanced", "fs_solid_trim")
+                } else {
+                    ("vs_shape_instanced", "fs_solid")
+                };
+                drop(create_instanced_shape_pipeline(
+                    device,
+                    cache,
+                    inputs.surface_format,
+                    &inputs.uniform_layout,
+                    &inputs.shape_layout,
+                    BlendMode::SrcOver,
+                    inputs.batch_limits,
+                    solid_trim,
+                    vertex_entry,
+                    fragment_entry,
+                    false,
+                ));
+                drop(create_instanced_shape_pipeline(
+                    device,
+                    cache,
+                    inputs.surface_format,
+                    &inputs.uniform_layout,
+                    &inputs.shape_layout,
+                    BlendMode::SrcOver,
+                    inputs.batch_limits,
+                    false,
+                    "vs_shape_instanced",
+                    "fs_main",
+                    false,
+                ));
+            } else {
+                let (vertex_entry, fragment_entry) = if solid_trim {
+                    ("vs_solid", "fs_solid_trim")
+                } else {
+                    ("vs_main", "fs_solid")
+                };
+                drop(create_shape_pipeline(
+                    device,
+                    cache,
+                    inputs.surface_format,
+                    &inputs.uniform_layout,
+                    &inputs.shape_layout,
+                    BlendMode::SrcOver,
+                    inputs.batch_limits,
+                    solid_trim,
+                    vertex_entry,
+                    fragment_entry,
+                    false,
+                ));
+                drop(create_shape_pipeline(
+                    device,
+                    cache,
+                    inputs.surface_format,
+                    &inputs.uniform_layout,
+                    &inputs.shape_layout,
+                    BlendMode::SrcOver,
+                    inputs.batch_limits,
+                    false,
+                    "vs_main",
+                    "fs_main",
+                    false,
+                ));
+            }
+            built += 2;
+            if inputs.batch_limits.storage {
+                drop(create_mesh_shape_pipeline(
+                    device,
+                    cache,
+                    inputs.surface_format,
+                    &inputs.uniform_layout,
+                    &inputs.shape_layout,
+                    inputs.batch_limits,
+                    false,
+                ));
+                built += 1;
+            }
+            drop(create_glyph_atlas_pipeline(
+                device,
+                cache,
+                inputs.surface_format,
+                &inputs.uniform_layout,
+                &inputs.image_layout,
+                false,
+            ));
+            built += 1;
+            log::info!(
+                "[pipeline-prewarm] {built} pipelines in {:.1} ms",
+                instant_ms(started, Instant::now())
+            );
+        });
+    if let Err(error) = spawned {
+        log::warn!("[pipeline-prewarm] thread failed to spawn: {error}");
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn create_shape_pipeline(
     device: &wgpu::Device,
+    cache: Option<&wgpu::PipelineCache>,
     surface_format: wgpu::TextureFormat,
     uniform_layout: &wgpu::BindGroupLayout,
     shape_layout: &wgpu::BindGroupLayout,
@@ -1499,8 +1641,9 @@ fn create_shape_pipeline(
 
     create_render_pipeline_logged(
         device,
+        cache,
         &format!("shape entry={fragment_entry} blend={blend_mode:?} depth={depth}"),
-        &wgpu::RenderPipelineDescriptor {
+        wgpu::RenderPipelineDescriptor {
             label: Some("Render Pipeline"),
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
@@ -1547,6 +1690,7 @@ fn create_shape_pipeline(
 #[cfg(not(target_arch = "wasm32"))]
 fn create_mesh_shape_pipeline(
     device: &wgpu::Device,
+    cache: Option<&wgpu::PipelineCache>,
     surface_format: wgpu::TextureFormat,
     uniform_layout: &wgpu::BindGroupLayout,
     shape_layout: &wgpu::BindGroupLayout,
@@ -1571,8 +1715,9 @@ fn create_mesh_shape_pipeline(
 
     create_render_pipeline_logged(
         device,
+        cache,
         &format!("mesh depth={depth}"),
-        &wgpu::RenderPipelineDescriptor {
+        wgpu::RenderPipelineDescriptor {
             label: Some("Retained Mesh Pipeline"),
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
@@ -1619,6 +1764,7 @@ fn create_mesh_shape_pipeline(
 #[allow(clippy::too_many_arguments)]
 fn create_instanced_shape_pipeline(
     device: &wgpu::Device,
+    cache: Option<&wgpu::PipelineCache>,
     surface_format: wgpu::TextureFormat,
     uniform_layout: &wgpu::BindGroupLayout,
     shape_layout: &wgpu::BindGroupLayout,
@@ -1645,8 +1791,9 @@ fn create_instanced_shape_pipeline(
 
     create_render_pipeline_logged(
         device,
+        cache,
         &format!("instanced entry={fragment_entry} blend={blend_mode:?} depth={depth}"),
-        &wgpu::RenderPipelineDescriptor {
+        wgpu::RenderPipelineDescriptor {
             label: Some("Instanced Render Pipeline"),
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
@@ -1687,6 +1834,7 @@ fn create_instanced_shape_pipeline(
 
 fn create_image_pipeline(
     device: &wgpu::Device,
+    cache: Option<&wgpu::PipelineCache>,
     surface_format: wgpu::TextureFormat,
     uniform_layout: &wgpu::BindGroupLayout,
     image_layout: &wgpu::BindGroupLayout,
@@ -1709,8 +1857,9 @@ fn create_image_pipeline(
 
     create_render_pipeline_logged(
         device,
+        cache,
         &format!("image blend={blend_mode:?} depth={depth}"),
-        &wgpu::RenderPipelineDescriptor {
+        wgpu::RenderPipelineDescriptor {
             label: Some("Image Pipeline"),
             layout: Some(&image_pipeline_layout),
             vertex: wgpu::VertexState {
@@ -1748,6 +1897,7 @@ fn create_image_pipeline(
 
 fn create_glyph_atlas_pipeline(
     device: &wgpu::Device,
+    cache: Option<&wgpu::PipelineCache>,
     surface_format: wgpu::TextureFormat,
     uniform_layout: &wgpu::BindGroupLayout,
     image_layout: &wgpu::BindGroupLayout,
@@ -1769,8 +1919,9 @@ fn create_glyph_atlas_pipeline(
 
     create_render_pipeline_logged(
         device,
+        cache,
         &format!("glyph-atlas depth={depth}"),
-        &wgpu::RenderPipelineDescriptor {
+        wgpu::RenderPipelineDescriptor {
             label: Some("Glyph Atlas Pipeline"),
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
@@ -1816,6 +1967,7 @@ fn create_glyph_atlas_pipeline(
 #[cfg(not(target_arch = "wasm32"))]
 fn create_display_clip_occluder_pipeline(
     device: &wgpu::Device,
+    cache: Option<&wgpu::PipelineCache>,
     surface_format: wgpu::TextureFormat,
 ) -> wgpu::RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
@@ -1829,8 +1981,9 @@ fn create_display_clip_occluder_pipeline(
     });
     create_render_pipeline_logged(
         device,
+        cache,
         "occluder",
-        &wgpu::RenderPipelineDescriptor {
+        wgpu::RenderPipelineDescriptor {
             label: Some("Display Clip Occluder Pipeline"),
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
@@ -5611,6 +5764,12 @@ pub struct GpuRenderer {
     surface_format: wgpu::TextureFormat,
     adapter_backend: wgpu::Backend,
     shape_batch_limits: ShapeBatchLimits,
+    /// `Some` exactly when the device granted [`wgpu::Features::PIPELINE_CACHE`]
+    /// (Vulkan; the platform layer requests it where the adapter offers it).
+    /// Every pipeline creation in this renderer passes it so the driver can
+    /// reuse compiled code across creates — and across launches once
+    /// [`crate::pipeline_disk_cache`] persists the blob.
+    pipeline_cache: Option<wgpu::PipelineCache>,
     pipeline: PassPipeline,
     pipeline_dst_out: PassPipeline,
     /// `fs_solid` twin of `pipeline` (SrcOver only), for gradient-free draws.
@@ -6349,8 +6508,38 @@ impl GpuRenderer {
                 }],
             });
 
+        // The cache handle costs nothing to create and pays on every device:
+        // in-process, the shape family's permutations share most of their
+        // compiled code; across launches, the persisted blob turns first-use
+        // compiles (2.0 s of render thread inside the first six seconds on a
+        // Pixel Watch 3) into cache hits. `None` where the device lacks the
+        // feature — every creation site then behaves exactly as before.
+        #[cfg(not(target_arch = "wasm32"))]
+        let pipeline_cache = crate::pipeline_disk_cache::load(&device);
+        #[cfg(target_arch = "wasm32")]
+        let pipeline_cache: Option<wgpu::PipelineCache> = None;
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(cache) = pipeline_cache.clone() {
+            crate::pipeline_disk_cache::spawn_persist_schedule(cache);
+            spawn_pipeline_prewarm(PipelinePrewarmInputs {
+                device: Arc::clone(&device),
+                cache: pipeline_cache.clone(),
+                surface_format,
+                uniform_layout: uniform_bind_group_layout.clone(),
+                shape_layout: shape_bind_group_layout.clone(),
+                image_layout: image_bind_group_layout.clone(),
+                batch_limits: shape_batch_limits,
+                instanced: instanced_quads.is_some(),
+            });
+        }
+
         let effects_started = Instant::now();
-        let effect_renderer = EffectRenderer::new(&device, surface_format, adapter_backend);
+        let effect_renderer = EffectRenderer::new(
+            &device,
+            pipeline_cache.clone(),
+            surface_format,
+            adapter_backend,
+        );
         let effects_ms = instant_ms(effects_started, Instant::now());
 
         let renderer = Self {
@@ -6363,6 +6552,7 @@ impl GpuRenderer {
             surface_format,
             adapter_backend,
             shape_batch_limits,
+            pipeline_cache,
             pipeline,
             pipeline_dst_out,
             pipeline_solid,
@@ -6650,12 +6840,16 @@ impl GpuRenderer {
             return;
         };
         debug_assert_eq!((*size_w, *size_h), (width, height));
-        let pipeline = self
-            .display_clip
-            .occluder_pipeline
-            .get_or_init(self.adapter_backend, || {
-                create_display_clip_occluder_pipeline(&self.device, self.surface_format)
-            });
+        let pipeline =
+            self.display_clip
+                .occluder_pipeline
+                .get_or_init(self.adapter_backend, || {
+                    create_display_clip_occluder_pipeline(
+                        &self.device,
+                        self.pipeline_cache.as_ref(),
+                        self.surface_format,
+                    )
+                });
         render_pass.set_scissor_rect(0, 0, width, height);
         render_pass.set_pipeline(pipeline);
         render_pass.set_vertex_buffer(0, resources.occluder_vertex_buffer.slice(..));
@@ -6671,6 +6865,7 @@ impl GpuRenderer {
         resource.get_or_init(self.adapter_backend, self.pass_depth(), |depth| {
             create_shape_pipeline(
                 &self.device,
+                self.pipeline_cache.as_ref(),
                 self.surface_format,
                 &self.uniform_bind_group_layout,
                 &self.shape_bind_group_layout,
@@ -6703,6 +6898,7 @@ impl GpuRenderer {
                 };
                 create_shape_pipeline(
                     &self.device,
+                    self.pipeline_cache.as_ref(),
                     self.surface_format,
                     &self.uniform_bind_group_layout,
                     &self.shape_bind_group_layout,
@@ -6722,6 +6918,7 @@ impl GpuRenderer {
             .get_or_init(self.adapter_backend, self.pass_depth(), |depth| {
                 create_mesh_shape_pipeline(
                     &self.device,
+                    self.pipeline_cache.as_ref(),
                     self.surface_format,
                     &self.uniform_bind_group_layout,
                     &self.shape_bind_group_layout,
@@ -6744,6 +6941,7 @@ impl GpuRenderer {
         resource.get_or_init(self.adapter_backend, self.pass_depth(), |depth| {
             create_instanced_shape_pipeline(
                 &self.device,
+                self.pipeline_cache.as_ref(),
                 self.surface_format,
                 &self.uniform_bind_group_layout,
                 &self.shape_bind_group_layout,
@@ -6776,6 +6974,7 @@ impl GpuRenderer {
                 };
                 create_instanced_shape_pipeline(
                     &self.device,
+                    self.pipeline_cache.as_ref(),
                     self.surface_format,
                     &self.uniform_bind_group_layout,
                     &self.shape_bind_group_layout,
@@ -6797,6 +6996,7 @@ impl GpuRenderer {
         resource.get_or_init(self.adapter_backend, self.pass_depth(), |depth| {
             create_image_pipeline(
                 &self.device,
+                self.pipeline_cache.as_ref(),
                 self.surface_format,
                 &self.uniform_bind_group_layout,
                 &self.image_bind_group_layout,
@@ -6811,6 +7011,7 @@ impl GpuRenderer {
             .get_or_init(self.adapter_backend, self.pass_depth(), |depth| {
                 create_glyph_atlas_pipeline(
                     &self.device,
+                    self.pipeline_cache.as_ref(),
                     self.surface_format,
                     &self.uniform_bind_group_layout,
                     &self.image_bind_group_layout,
@@ -6827,6 +7028,7 @@ impl GpuRenderer {
             |depth| {
                 create_glyph_atlas_pipeline(
                     &self.device,
+                    self.pipeline_cache.as_ref(),
                     self.surface_format,
                     &self.retained_glyph_uniform_bind_group_layout,
                     &self.image_bind_group_layout,

--- a/crates/cranpose-render/wgpu/src/shader_cache.rs
+++ b/crates/cranpose-render/wgpu/src/shader_cache.rs
@@ -86,37 +86,41 @@ impl ShaderPipelineCache {
                 immediate_size: 0,
             });
 
-            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("RuntimeShader Effect Pipeline"),
-                layout: Some(&pipeline_layout),
-                vertex: wgpu::VertexState {
-                    module: &shader_module,
-                    entry_point: Some("fullscreen_vs"),
-                    buffers: &[], // Fullscreen quad from vertex_index
-                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+            crate::render::create_render_pipeline_logged(
+                device,
+                &format!("runtime-shader mode={mode:?} depth={depth}"),
+                &wgpu::RenderPipelineDescriptor {
+                    label: Some("RuntimeShader Effect Pipeline"),
+                    layout: Some(&pipeline_layout),
+                    vertex: wgpu::VertexState {
+                        module: &shader_module,
+                        entry_point: Some("fullscreen_vs"),
+                        buffers: &[], // Fullscreen quad from vertex_index
+                        compilation_options: wgpu::PipelineCompilationOptions::default(),
+                    },
+                    fragment: Some(wgpu::FragmentState {
+                        module: &shader_module,
+                        entry_point: Some("effect_fs"),
+                        targets: &[Some(wgpu::ColorTargetState {
+                            format,
+                            blend: Some(mode.blend_state()),
+                            write_mask: wgpu::ColorWrites::ALL,
+                        })],
+                        compilation_options: wgpu::PipelineCompilationOptions::default(),
+                    }),
+                    primitive: wgpu::PrimitiveState {
+                        topology: wgpu::PrimitiveTopology::TriangleStrip,
+                        strip_index_format: None,
+                        front_face: wgpu::FrontFace::Ccw,
+                        cull_mode: None,
+                        ..Default::default()
+                    },
+                    depth_stencil: crate::display_clip::content_depth_state(depth),
+                    multisample: wgpu::MultisampleState::default(),
+                    multiview_mask: None,
+                    cache: None,
                 },
-                fragment: Some(wgpu::FragmentState {
-                    module: &shader_module,
-                    entry_point: Some("effect_fs"),
-                    targets: &[Some(wgpu::ColorTargetState {
-                        format,
-                        blend: Some(mode.blend_state()),
-                        write_mask: wgpu::ColorWrites::ALL,
-                    })],
-                    compilation_options: wgpu::PipelineCompilationOptions::default(),
-                }),
-                primitive: wgpu::PrimitiveState {
-                    topology: wgpu::PrimitiveTopology::TriangleStrip,
-                    strip_index_format: None,
-                    front_face: wgpu::FrontFace::Ccw,
-                    cull_mode: None,
-                    ..Default::default()
-                },
-                depth_stencil: crate::display_clip::content_depth_state(depth),
-                multisample: wgpu::MultisampleState::default(),
-                multiview_mask: None,
-                cache: None,
-            })
+            )
         };
 
         self.cache.insert(cache_key, pipeline);

--- a/crates/cranpose-render/wgpu/src/shader_cache.rs
+++ b/crates/cranpose-render/wgpu/src/shader_cache.rs
@@ -27,14 +27,18 @@ pub(crate) struct ShaderPipelineCache {
     backend: wgpu::Backend,
     cache: HashMap<(u64, RuntimeShaderPipelineMode, bool), wgpu::RenderPipeline>,
     disabled: HashSet<u64>,
+    /// The device's shared pipeline cache (see `GpuRenderer`); runtime
+    /// shader pipelines pass it like every built-in pipeline does.
+    pipeline_cache: Option<wgpu::PipelineCache>,
 }
 
 impl ShaderPipelineCache {
-    pub fn new(backend: wgpu::Backend) -> Self {
+    pub fn new(backend: wgpu::Backend, pipeline_cache: Option<wgpu::PipelineCache>) -> Self {
         Self {
             backend,
             cache: HashMap::new(),
             disabled: HashSet::new(),
+            pipeline_cache,
         }
     }
 
@@ -88,8 +92,9 @@ impl ShaderPipelineCache {
 
             crate::render::create_render_pipeline_logged(
                 device,
+                self.pipeline_cache.as_ref(),
                 &format!("runtime-shader mode={mode:?} depth={depth}"),
-                &wgpu::RenderPipelineDescriptor {
+                wgpu::RenderPipelineDescriptor {
                     label: Some("RuntimeShader Effect Pipeline"),
                     layout: Some(&pipeline_layout),
                     vertex: wgpu::VertexState {

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -1370,9 +1370,38 @@ fn create_android_gpu_resources(
     log::info!("Found adapter: {:?}", adapter_info.backend);
     let adapter = Arc::new(adapter);
 
+    // Name the pipeline disk cache's blob now that the adapter is known: the
+    // file is keyed by adapter identity (vendor, device, driver strings), so
+    // a driver update or a different GPU starts cold instead of feeding wgpu
+    // a stale blob. `run` decided the directory; a pre-set full path wins.
+    if std::env::var_os("CRANPOSE_PIPELINE_CACHE_FILE").is_none() {
+        if let Some(cache_dir) = std::env::var_os("CRANPOSE_PIPELINE_CACHE_DIR") {
+            let mut driver_hash: u64 = 0xcbf2_9ce4_8422_2325;
+            for byte in adapter_info
+                .driver
+                .bytes()
+                .chain(adapter_info.driver_info.bytes())
+            {
+                driver_hash ^= u64::from(byte);
+                driver_hash = driver_hash.wrapping_mul(0x0000_0100_0000_01b3);
+            }
+            let file_name = format!(
+                "pipeline_cache_v1_{:04x}_{:04x}_{driver_hash:016x}.bin",
+                adapter_info.vendor, adapter_info.device,
+            );
+            std::env::set_var(
+                "CRANPOSE_PIPELINE_CACHE_FILE",
+                std::path::Path::new(&cache_dir).join(file_name),
+            );
+        }
+    }
+
     let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
         label: Some("Android Device"),
-        required_features: wgpu::Features::empty(),
+        // The pipeline cache feature where the driver offers it (Vulkan) —
+        // see `pipeline_disk_cache` in the renderer. The intersection stays
+        // empty on adapters without it, so nothing else changes.
+        required_features: adapter.features() & wgpu::Features::PIPELINE_CACHE,
         required_limits: crate::gpu_limits::mobile_device_limits(adapter.limits()),
         experimental_features: wgpu::ExperimentalFeatures::disabled(),
         memory_hints: crate::gpu_limits::mobile_memory_hints(),
@@ -1717,6 +1746,21 @@ pub fn run(
     // before anything reads it, so the renderer's and app shell's existing
     // environment-gated telemetry is reachable on device.
     crate::android_frame_telemetry::seed_env_from_system_properties();
+
+    // Give the renderer's pipeline disk cache a writable home. Only the
+    // directory is decided here — the blob's file name is keyed by adapter
+    // identity, which is not known until device setup composes
+    // `CRANPOSE_PIPELINE_CACHE_FILE` from this directory. Seeded properties
+    // (above) and pre-set environments win, so tests and debugging can
+    // redirect or disable it.
+    if std::env::var_os("CRANPOSE_PIPELINE_CACHE_DIR").is_none() {
+        if let Some(data_path) = app.internal_data_path() {
+            std::env::set_var(
+                "CRANPOSE_PIPELINE_CACHE_DIR",
+                data_path.join("cranpose_gpu"),
+            );
+        }
+    }
 
     // Threaded present runtime (pipeline step 7b), default OFF: the frame
     // is split at the packet boundary and acquire/encode/submit/present

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -73,7 +73,7 @@ fn property_flag(name: &str) -> bool {
 /// any length — so a name may run right up to or past that pre-O limit, as
 /// `debug.cranpose.retained_mesh_px2` does; every deployment target is far
 /// past O.)
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 31] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 33] = [
     ("debug.cranpose.gpu_stats", "CRANPOSE_GPU_STATS"),
     ("debug.cranpose.present_thread", "CRANPOSE_PRESENT_THREAD"),
     ("debug.cranpose.command_feed", "CRANPOSE_COMMAND_FEED"),
@@ -144,6 +144,14 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 31] = [
     (
         "debug.cranpose.segment_surface_waiver",
         "CRANPOSE_SEGMENT_SURFACE_WAIVER_RATIO",
+    ),
+    (
+        "debug.cranpose.pipeline_disk_cache",
+        "CRANPOSE_PIPELINE_DISK_CACHE",
+    ),
+    (
+        "debug.cranpose.pipeline_prewarm",
+        "CRANPOSE_PIPELINE_PREWARM",
     ),
     ("debug.cranpose.solid_trim", "CRANPOSE_SOLID_TRIM_VARYINGS"),
     (

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -1500,6 +1500,11 @@ fn workspace_ffi_boundaries_are_explicit() {
         // whose invariants the pool's completion barrier enforces; the crate
         // root denies unsafe code and opts this one module back in by name.
         "crates/cranpose-render/wgpu/src/worker_pool.rs",
+        // The pipeline disk cache: one wgpu create_pipeline_cache call,
+        // unsafe because seeding data is trusted; the module writes that
+        // data itself from get_data, keys the file by adapter identity,
+        // and asks wgpu to validate the header besides (fallback: true).
+        "crates/cranpose-render/wgpu/src/pipeline_disk_cache.rs",
         // The shape-run entry borrows its DrawPrimitive, whose TYPE is !Sync
         // (the Text variant holds Rc) even though the constructor only ever
         // admits the Sync-payload shape variants. The module is kept tiny so
@@ -1560,6 +1565,7 @@ fn unsafe_blocks_have_nearby_safety_invariants() {
         "crates/cranpose/src/ios_accessibility.rs",
         "crates/cranpose-audio/src/ring.rs",
         "crates/cranpose-audio/src/backend/aaudio.rs",
+        "crates/cranpose-render/wgpu/src/pipeline_disk_cache.rs",
         "apps/desktop-demo-platform/src/android_entry.rs",
         "apps/isolated-demo/src/native_entry.rs",
     ];


### PR DESCRIPTION
## What

A fresh launch on a Pixel Watch 3 spends **2.0 s of its first six seconds compiling pipelines on the render thread** — measured by the new `[pipeline-create]` telemetry (first commit): instanced fs_solid 661 ms, fs_main 496 ms, mesh 552 ms, blit 144, projective 107, glyph 41, each swallowed as one silent sub-second frame behind `get_or_init`. A from-launch simpleperf put ~1.3 s of libllvm-qgl (the Adreno backend compiler) on android_main across t=2-5 s, exactly where the fps curve reads zero.

Three pieces (second commit):
- every `create_render_pipeline` passes one shared `wgpu::PipelineCache` when the device grants `Features::PIPELINE_CACHE`;
- `pipeline_disk_cache` persists the blob (adapter-keyed file, write-tmp-rename, content-compared, two sweeps at +8 s/+28 s) and seeds the next launch from disk;
- a prewarm thread builds the base pipeline family off the render thread at renderer construction.

Kill switches: `debug.cranpose.pipeline_disk_cache` / `debug.cranpose.pipeline_prewarm`. Devices without the feature and platforms that never name a cache file keep exactly the old behavior.

The third commit fixes mains red CI (the #421 merge push failed `wasm_framework_sources_use_browser_safe_time`): #418s stopwatch used `std::time::Instant`; it now uses the crate clock (web_time), which is the same type on native.

## Measured (Pixel Watch 3, cool + unplugged, md5-verified installs, fresh install before every arm)

Frames in the first 5 s of a fresh MEGA arena, treatment vs telemetry-only control, alternating pairs:

| arm | frames t1-5 |
|---|---|
| warm (blob on disk) | **74 / 90** |
| control | 36 / 29 |
| cold (prewarm only) | 44 |

Warm launches: every create collapses to 2-33 ms (661 -> 32 worst case), first frame at t=3 instead of t=5, blob 67 KB. Huawei Mate 20 X (Mali-G76) smoke: same mechanism, warm creates <= 6 ms, prewarm 16 ms, no crashes, host suites all green (the cache is feature-gated so desktop/CI devices are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2