### PR TITLE
Replay transition groundwork: buffer reuse and the restore-patch hole

### DIFF
--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -5895,6 +5895,16 @@ pub struct GpuRenderer {
     /// high-water capacity across frames. Always empty between drains.
     #[cfg(not(target_arch = "wasm32"))]
     color_patch_scratch: Vec<crate::scene::ColorPatch>,
+    /// Capture staging scratch for `capture_replay_slot`: the converted
+    /// `ShapeData` records and gradient stops are built here, copied into
+    /// the slot's fresh GPU buffers, and the allocations survive to the
+    /// next capture — a re-partition frame captures one slot per segment
+    /// and used to allocate both vectors per slot.
+    #[cfg(not(target_arch = "wasm32"))]
+    replay_capture_shape_scratch: Vec<ShapeData>,
+    /// The gradient-stop half of the capture staging scratch.
+    #[cfg(not(target_arch = "wasm32"))]
+    replay_capture_gradient_scratch: Vec<GradientStop>,
     /// Recycled confirmations buffer for the next [`crate::frame_packet::ReplayAck`]:
     /// `consume_replay_ops` fills it, the planner drains it in `apply_ack`,
     /// and the render loop hands the emptied vec (capacity intact) back
@@ -6668,6 +6678,10 @@ impl GpuRenderer {
             replay_color_patches: Vec::new(),
             #[cfg(not(target_arch = "wasm32"))]
             color_patch_scratch: Vec::new(),
+            #[cfg(not(target_arch = "wasm32"))]
+            replay_capture_shape_scratch: Vec::new(),
+            #[cfg(not(target_arch = "wasm32"))]
+            replay_capture_gradient_scratch: Vec::new(),
             #[cfg(not(target_arch = "wasm32"))]
             replay_ack_confirmations: Vec::new(),
             #[cfg(not(target_arch = "wasm32"))]
@@ -12374,6 +12388,10 @@ impl GpuRenderer {
         // loop restores the vec after the planner drains the ack.
         let mut confirmations = std::mem::take(&mut self.replay_ack_confirmations);
         debug_assert!(confirmations.is_empty());
+        // One refs buffer for the whole batch: a re-partition frame carries
+        // one capture per segment, and `shapes` outlives the loop, so each
+        // capture's collect reuses a single allocation.
+        let mut refs: Vec<&DrawShape> = Vec::new();
         for capture in ops.captures.drain(..) {
             if capture.frame != ops.frame {
                 // Defensive: a capture that outlived its frame references
@@ -12396,7 +12414,8 @@ impl GpuRenderer {
             let Some(slice) = shapes.get(capture.shape_start..end) else {
                 continue;
             };
-            let refs: Vec<&DrawShape> = slice.iter().collect();
+            refs.clear();
+            refs.extend(slice.iter());
             let Some(gpu_slot) = self.capture_replay_slot(&refs, brushes, root_scale) else {
                 continue;
             };
@@ -12573,8 +12592,17 @@ impl GpuRenderer {
             gradient_offsets.push(total_gradient_stops);
         }
 
-        let mut shape_data = vec![ShapeData::zeroed(); shape_count];
-        let mut gradients = vec![GradientStop::zeroed(); (total_gradient_stops as usize).max(1)];
+        // Staging scratch, not fresh vectors: cleared and re-zeroed to this
+        // capture's exact sizes, capacity kept across captures.
+        let mut shape_data = std::mem::take(&mut self.replay_capture_shape_scratch);
+        shape_data.clear();
+        shape_data.resize(shape_count, ShapeData::zeroed());
+        let mut gradients = std::mem::take(&mut self.replay_capture_gradient_scratch);
+        gradients.clear();
+        gradients.resize(
+            (total_gradient_stops as usize).max(1),
+            GradientStop::zeroed(),
+        );
         convert_shapes_into_outputs(
             shape_refs,
             brushes,
@@ -12836,6 +12864,10 @@ impl GpuRenderer {
                 submitted_area_scale,
             },
         );
+        // The staging buffers return to their scratch slots, contents
+        // spent, capacity kept for the next capture.
+        self.replay_capture_shape_scratch = shape_data;
+        self.replay_capture_gradient_scratch = gradients;
         Some(id)
     }
 

--- a/crates/cranpose-render/wgpu/tests/command_feed_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/command_feed_parity.rs
@@ -24,7 +24,14 @@ use cranpose_ui_graphics::{
 
 const SIZE: u32 = 408;
 const CENTER: f32 = 204.0;
-const FRAMES: usize = 8;
+/// Enough frames for the twinkle alpha cycle (period 11, `record_frame`'s
+/// `% 11`) to wrap past the frame-1 capture: at frame 12 every twinkle
+/// returns EXACTLY to its captured color, which must reach the GPU as an
+/// explicit restore patch — a recorder that emits recolors only as
+/// diff-vs-snapshot emits nothing there, the slot's paint mirror keeps
+/// frame 11's colors, and the whole twinkle field renders stale. Eight
+/// frames never wrapped the cycle, which is how that defect hid.
+const FRAMES: usize = 13;
 
 /// One frame of the synthetic boss through the RECORDING path: rings
 /// rotating at distinct speeds under a breathing scale, churning sparks,
@@ -206,6 +213,12 @@ fn command_feed_matches_the_full_pipeline_pixel_for_pixel() {
     // adds its own interpolation noise, measured in arc_mesh_parity).
     std::env::set_var("CRANPOSE_ARC_MESH", "0");
     std::env::set_var("CRANPOSE_SIMILARITY_REPLAY", "0");
+    // The feed has defaulted ON since its parity was proven, so the
+    // baseline must say "0" explicitly: with the variable merely unset the
+    // baseline renders through the very retention path under test, and any
+    // stale-slot defect cancels out of the comparison — which is exactly
+    // how the mod-11 stale-recolor defect stayed invisible here.
+    std::env::set_var("CRANPOSE_COMMAND_FEED", "0");
     let baseline = render_sequence(&mut renderer, &graphs);
 
     std::env::set_var("CRANPOSE_SIMILARITY_REPLAY", "1");
@@ -308,10 +321,12 @@ fn command_feed_matches_the_full_pipeline_pixel_for_pixel() {
             // capture quad crops the AA falloff slightly differently than a
             // freshly computed tight quad. This is the envelope the flat
             // detector has always shipped — the feed measures IDENTICAL
-            // per-frame counts on this scene (253..1195 channels of 666k,
-            // growing with accumulated rotation until a recapture resets
-            // it). Wider divergence means a real defect, like the shifted
-            // self-similar anchor pairing this test once caught.
+            // per-frame counts on this scene (260..1815 channels of 666k
+            // across the 13 frames, growing with accumulated rotation until
+            // a recapture resets it). Wider divergence means a real defect:
+            // the shifted self-similar anchor pairing this test once
+            // caught, or the stale twinkle recolors at the frame-12 alpha
+            // wrap (11398 channels) that the restore patches now reset.
             assert!(
                 differing < 2500 && worst < 160,
                 "frame {frame}: {differing} channels diverged (worst {worst}) — beyond the\n                 flat detector's edge-AA envelope"

--- a/crates/cranpose-ui-graphics/src/geometry.rs
+++ b/crates/cranpose-ui-graphics/src/geometry.rs
@@ -1035,6 +1035,19 @@ impl CommandRecording {
         self.arcs.clear();
         self.others.clear();
     }
+
+    /// A buffer-reusing deep copy: `clone_from` on every store, so
+    /// refreshing a long-lived recording (the replay snapshot, twice per
+    /// convergence cycle on a heavy scene's ~17k-record tape) truncates and
+    /// copies into the existing allocations instead of cloning five fresh
+    /// buffers. Semantically identical to `*self = source.clone()`.
+    pub(crate) fn clone_records_from(&mut self, source: &Self) {
+        self.tape.clone_from(&source.tape);
+        self.rects.clone_from(&source.rects);
+        self.round_rects.clone_from(&source.round_rects);
+        self.arcs.clone_from(&source.arcs);
+        self.others.clone_from(&source.others);
+    }
 }
 
 /// What [`DrawScopeDefault::finish`] hands back: the materialized primitives,

--- a/crates/cranpose-ui-graphics/src/record_replay.rs
+++ b/crates/cranpose-ui-graphics/src/record_replay.rs
@@ -524,14 +524,21 @@ fn views_compatible(
 /// insertions and deletions (entity churn between frames). Pairing is
 /// structural only; transform-consistency during verification decides
 /// whether a pair actually moved together, so a wrong pairing costs a
-/// segment, never a wrong capture.
-fn align_recordings(current: &CommandRecording, retained: &CommandRecording) -> Vec<Option<usize>> {
+/// segment, never a wrong capture. Fills `aligned` (cleared, then resized
+/// to the current tape length): an out-param, so the caller owns a
+/// reusable buffer instead of allocating ~tape-length per call.
+fn align_recordings(
+    current: &CommandRecording,
+    retained: &CommandRecording,
+    aligned: &mut Vec<Option<usize>>,
+) {
     let pair = |i: usize, j: usize| -> bool {
         views_compatible(current, view_at(current, i), retained, view_at(retained, j))
     };
     let current_len = current.tape.len();
     let retained_len = retained.tape.len();
-    let mut aligned = vec![None; current_len];
+    aligned.clear();
+    aligned.resize(current_len, None);
     let (mut i, mut j) = (0usize, 0usize);
     let mut events = 0usize;
     while i < current_len && j < retained_len {
@@ -545,7 +552,8 @@ fn align_recordings(current: &CommandRecording, retained: &CommandRecording) -> 
         if events > MAX_RESYNC_EVENTS {
             // Not churn — the structure is gone. An empty alignment makes
             // the caller restart from a fresh snapshot.
-            return vec![None; current_len];
+            aligned.fill(None);
+            return;
         }
         let mut resynced = false;
         'search: for total in 1..=RESYNC_SPAN {
@@ -564,7 +572,6 @@ fn align_recordings(current: &CommandRecording, retained: &CommandRecording) -> 
             j += 1;
         }
     }
-    aligned
 }
 
 /// Derives the pair's implied transform, with pinnedness.
@@ -855,6 +862,10 @@ pub struct CommandReplayState {
     /// high-water capacity; refilled per verified frame.
     verify_pending: std::collections::VecDeque<CommandSegment>,
     verify_survivors: Vec<CommandSegment>,
+    /// [`align_recordings`]' alignment buffer, persistent so the partition
+    /// after every collapse reuses one ~tape-length allocation instead of
+    /// growing a fresh one per convergence cycle.
+    align_scratch: Vec<Option<usize>>,
 }
 
 impl Default for CommandReplayState {
@@ -876,6 +887,7 @@ impl Default for CommandReplayState {
             best_recolor_scratch: Vec::new(),
             verify_pending: std::collections::VecDeque::new(),
             verify_survivors: Vec::new(),
+            align_scratch: Vec::new(),
         }
     }
 }
@@ -958,7 +970,10 @@ impl CommandReplayState {
     }
 
     fn take_snapshot(&mut self, current: &CommandRecording, center: Point) {
-        self.snapshot = current.clone();
+        // `clone_from` semantics: the previous snapshot's buffers are
+        // reused, not reallocated — this runs twice per convergence cycle
+        // on the heavy scenes' ~17k-record tapes.
+        self.snapshot.clone_records_from(current);
         self.center = center;
         self.segments.clear();
         self.phase = CommandReplayPhase::Snapshotted;
@@ -972,13 +987,13 @@ impl CommandReplayState {
     /// IS this frame, so what the renderer retains equals what later
     /// transforms move.
     fn partition(&mut self, current: &CommandRecording, center: Point) -> ReplayOutcome {
-        let aligned = align_recordings(current, &self.snapshot);
+        align_recordings(current, &self.snapshot, &mut self.align_scratch);
         let mut chains: Vec<(usize, usize)> = Vec::new();
         let mut i = 0;
         while i < current.tape.len() {
             let (Some(view), Some(snapshot_view)) = (
                 view_at(current, i),
-                aligned[i].and_then(|j| view_at(&self.snapshot, j)),
+                self.align_scratch[i].and_then(|j| view_at(&self.snapshot, j)),
             ) else {
                 i += 1;
                 continue;
@@ -1001,7 +1016,7 @@ impl CommandReplayState {
             while end < current.tape.len() {
                 let (Some(view), Some(snapshot_view)) = (
                     view_at(current, end),
-                    aligned[end].and_then(|j| view_at(&self.snapshot, j)),
+                    self.align_scratch[end].and_then(|j| view_at(&self.snapshot, j)),
                 ) else {
                     break;
                 };

--- a/crates/cranpose-ui-graphics/src/record_replay.rs
+++ b/crates/cranpose-ui-graphics/src/record_replay.rs
@@ -682,13 +682,23 @@ pub struct CommandSegment {
     pub tape_end: usize,
     /// Loose logical bounds at capture.
     pub bounds: Rect,
+    /// Span-relative record offsets (ascending) this segment's span
+    /// recolored on the PREVIOUS verified frame. The renderer's slot paint
+    /// is a patched mirror, never rebuilt, so a record whose color returns
+    /// EXACTLY to its capture value needs an explicit restore patch — pure
+    /// diff-vs-snapshot emission would leave the mirror stale forever
+    /// (see [`merge_color_restores`]).
+    pub prev_recolors: Vec<u32>,
 }
 
 /// One span of this frame's recording, in tape order.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ReplaySpan {
     /// The retained segment moved by `transform`; `recolors` are
-    /// (span-relative record offset, new color) patches.
+    /// (span-relative record offset, new color) patches — including
+    /// explicit restores to the capture color for records recolored on the
+    /// previous frame and clean again on this one, because the renderer's
+    /// slot paint is a patched mirror that never resets on its own.
     Retained {
         /// The capture identity ([`CommandSegment::slot`]).
         slot: u32,
@@ -1066,6 +1076,8 @@ impl CommandReplayState {
                     tape_start: range.0,
                     tape_end: range.1,
                     bounds: range_bounds(&self.snapshot, range),
+                    // A fresh capture IS the snapshot: nothing recolored.
+                    prev_recolors: Vec::new(),
                 }
             })
             .collect();
@@ -1246,7 +1258,7 @@ impl CommandReplayState {
             // out of the owning scratch — the buffer walks into the graph
             // and the scratch re-grows on the next attempt (accepted:
             // emitting spans do real work).
-            let (span_start, t, recolors, span_len) = match located {
+            let (span_start, t, mut recolors, span_len) = match located {
                 Some((start, t)) => (start, t, std::mem::take(&mut self.recolor_scratch), len),
                 None => {
                     let split = best_prefix_len >= MIN_SEGMENT_RECORDS;
@@ -1259,13 +1271,23 @@ impl CommandReplayState {
                         && segment.tape_end - suffix_start >= MIN_SEGMENT_RECORDS
                     {
                         // The suffix addresses the SAME captured content,
-                        // just deeper in: no recapture, only an offset.
+                        // just deeper in: no recapture, only an offset. It
+                        // inherits its share of the previous frame's
+                        // recolor memory re-based to its own start; the
+                        // split record itself leaves retained drawing, so
+                        // its offset needs no restore anywhere.
+                        let rebase = (best_prefix_len + 1) as u32;
+                        let cut = segment.prev_recolors.partition_point(|&p| p < rebase);
                         self.verify_pending.push_front(CommandSegment {
                             slot: segment.slot,
                             slot_offset: segment.slot_offset + (suffix_start - segment.tape_start),
                             tape_start: suffix_start,
                             tape_end: segment.tape_end,
                             bounds: range_bounds(&self.snapshot, (suffix_start, segment.tape_end)),
+                            prev_recolors: segment.prev_recolors[cut..]
+                                .iter()
+                                .map(|&p| p - rebase)
+                                .collect(),
                         });
                     }
                     self.lifetime_splits += 1;
@@ -1277,11 +1299,13 @@ impl CommandReplayState {
                     )
                 }
             };
-            let survivor = if span_len == len {
+            let mut survivor = if span_len == len {
                 segment
             } else {
                 // The prefix keeps its capture identity — it addresses the
-                // same slot content from the same offset, just shorter.
+                // same slot content from the same offset, just shorter. It
+                // carries the whole recolor memory: offsets past the span
+                // are skipped by the merge and cleared by its roll-forward.
                 CommandSegment {
                     slot: segment.slot,
                     slot_offset: segment.slot_offset,
@@ -1291,8 +1315,16 @@ impl CommandReplayState {
                         &self.snapshot,
                         (segment.tape_start, segment.tape_start + span_len),
                     ),
+                    prev_recolors: segment.prev_recolors,
                 }
             };
+            merge_color_restores(
+                &self.snapshot,
+                survivor.tape_start,
+                span_len,
+                &mut survivor.prev_recolors,
+                &mut recolors,
+            );
             if span_start > cursor {
                 spans.push(ReplaySpan::Dynamic {
                     tape_start: cursor,
@@ -1477,15 +1509,25 @@ impl CommandReplayState {
         let mut cursor = 0usize;
         for (segment, (job, result)) in self
             .segments
-            .iter()
+            .iter_mut()
             .zip(jobs.iter().zip(&self.verify_results))
             .take(committed)
         {
             // Committing: each emitted span takes its slot's buffer — the
             // capacity walks into the graph and the slot re-grows next
             // frame (accepted: emitting spans do real work).
-            let recolors =
+            let mut recolors =
                 std::mem::take(&mut result.lock().expect("verify span job lock").recolors);
+            // A committed body matched WHOLE, so this is the same restore
+            // merge the serial walk performs for a whole-span commit —
+            // equality by construction extends to the restore patches.
+            merge_color_restores(
+                &self.snapshot,
+                segment.tape_start,
+                job.len,
+                &mut segment.prev_recolors,
+                &mut recolors,
+            );
             if job.start > cursor {
                 spans.push(ReplaySpan::Dynamic {
                     tape_start: cursor,
@@ -1535,6 +1577,56 @@ struct PooledCommit {
     committed: usize,
     /// Current-tape position after the last committed span.
     cursor: usize,
+}
+
+/// The snapshot's color for one retained record — the value the renderer's
+/// slot paint was seeded with at capture (the snapshot IS the capture
+/// content for as long as the segment lives; splits only re-address it).
+fn snapshot_record_color(snapshot: &CommandRecording, i: usize) -> Option<Color> {
+    match view_at(snapshot, i)? {
+        ReplayView::Arc(index) => Some(snapshot.arcs[index].color),
+        ReplayView::RoundRect(index) => Some(snapshot.round_rects[index].color),
+    }
+}
+
+/// Rolls one emitted span's recolor memory a frame forward and emits the
+/// restore patches the renderer needs: for every span-relative offset in
+/// `prev` (last frame's recolors, ascending) that this frame's `recolors`
+/// (ascending) do NOT patch, appends `(offset, snapshot color)`, then
+/// replaces `prev` with this frame's patched offsets. The renderer's slot
+/// paint is a patched mirror, never rebuilt, so a record whose color
+/// returns EXACTLY to its capture value would otherwise keep the previous
+/// frame's patch indefinitely — pure diff-vs-snapshot emission goes silent
+/// on exactly that frame (the parity scene's mod-11 twinkle wrap). Restores
+/// append after the ordinary patches; every patched offset is distinct and
+/// patches write disjoint records, so order across the two groups cannot
+/// matter. Offsets at or past `span_len` (a split's suffix share) are the
+/// caller's to hand to the suffix segment.
+fn merge_color_restores(
+    snapshot: &CommandRecording,
+    seg_tape_start: usize,
+    span_len: usize,
+    prev: &mut Vec<u32>,
+    recolors: &mut Vec<(u32, Color)>,
+) {
+    let patched = recolors.len();
+    let mut cursor = 0usize;
+    for &offset in prev.iter() {
+        if offset as usize >= span_len {
+            break;
+        }
+        while cursor < patched && recolors[cursor].0 < offset {
+            cursor += 1;
+        }
+        if cursor < patched && recolors[cursor].0 == offset {
+            continue;
+        }
+        if let Some(color) = snapshot_record_color(snapshot, seg_tape_start + offset as usize) {
+            recolors.push((offset, color));
+        }
+    }
+    prev.clear();
+    prev.extend(recolors[..patched].iter().map(|&(offset, _)| offset));
 }
 
 /// The cheap anchor test shared by the serial walk and the pooled fast


### PR DESCRIPTION
First two slices of the convergence-resilience plan (phase transitions currently cost 22-75 ms frames re-encoding the whole ~17k-record tape; full plan archived with the campaign notes).

**Slice 1 — allocation hygiene, zero semantic change.** take_snapshot clones a ~17k-record recording twice per convergence cycle; it now reuses the snapshot's buffers (clone_records_from). align_recordings' per-call alignment vector became persistent scratch on CommandReplayState; capture_replay_slot's ShapeData/GradientStop staging became renderer-owned scratch, and the per-capture shape-ref vector is one buffer per ops batch.

**Slice 2 — correctness: restore a record's capture color when a recolor stops applying.** match_span emits recolors as diff-vs-snapshot only and the GPU paint mirror never resets, so a record whose color returns exactly to its capture value kept the stale color indefinitely. Per-segment prev_recolors now emit explicit (offset, snapshot_color) restore patches; serial and pooled paths share the merge; splits hand the suffix its share.

**The test that pins it had to be fixed to be a test at all**: command_feed_parity's FRAMES=8 never wrapped its mod-11 alpha cycle, and its "feed-free" baseline never actually disabled the feed (CRANPOSE_COMMAND_FEED defaults on), so both runs went stale identically and the defect cancelled out. The baseline now sets CRANPOSE_COMMAND_FEED=0 and FRAMES=13 wraps the cycle — verified red-first: 11398 diverged channels at frame 12 against the unfixed recorder, 1815 (normal AA trend) after the fix.

Full workspace suite green, clippy -D warnings clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2
