### PR TITLE
Re-serve the previous emission when replay convergence collapses

### DIFF
--- a/crates/cranpose-render/common/src/scene_builder.rs
+++ b/crates/cranpose-render/common/src/scene_builder.rs
@@ -761,6 +761,158 @@ struct RecorderSlot {
     /// The feed epoch `replay` was built under; `None` before the first
     /// verified recording. See [`set_retained_feed_epoch`].
     replay_epoch: Option<u64>,
+    /// The previous build's emission in re-emittable form, for the
+    /// stale-transition serve (see [`SavedReplayEmission`]). `None` unless
+    /// the flag is on and the last build emitted a replay frame.
+    saved_emission: Option<SavedReplayEmission>,
+}
+
+/// One command's emitted frame, saved so the NEXT build can re-emit it
+/// byte-for-byte if its verification collapses — the stale-transition
+/// serve. A collapse frame otherwise re-materializes and re-encodes the
+/// whole tape at once (22-75 ms against a ~17k-record scene on a
+/// watch-class core); re-emitting the previous frame's output costs one
+/// frame of lag on the collapsing command instead. Valid only when exactly
+/// one build has passed since the save (`generation`) under the same
+/// renderer slot universe (`epoch`); the serve TAKES the emission, so two
+/// consecutive stale frames are unconstructible — the one-frame cap is
+/// structural, not a counter.
+///
+/// In the steady state the `Rc`s alias the registry's live handles, so a
+/// save is two refcount bumps plus one small sanitized span vector — never
+/// a copy of the primitives or the tape.
+struct SavedReplayEmission {
+    /// The frame's primitive-space spans, sanitized for re-emission by
+    /// [`sanitized_replay_spans`]: recolors emptied, capture spans
+    /// downgraded to dynamic draws.
+    spans: Vec<cranpose_ui_graphics::FrameSpan>,
+    /// The similarity pivot the spans' transforms rotate and scale about.
+    center: cranpose_ui_graphics::Point,
+    /// The emission's materialized primitives — the exact vector the
+    /// spans' `range`s address.
+    primitives: Rc<Vec<cranpose_ui_graphics::DrawPrimitive>>,
+    /// The emission's published recording — the exact tape the spans'
+    /// `tape_range`s address, re-attached as the re-emitted frame's
+    /// `fallback` so bypassed spans keep their rematerialization source.
+    recording: Rc<cranpose_ui_graphics::CommandRecording>,
+    /// Retained feed epoch at save: a different epoch means the renderer's
+    /// slot universe died, and the spans' slot references with it.
+    epoch: u64,
+    /// [`RECORDING_GENERATION`] at save. Serving requires
+    /// `generation + 1 == current`: only the immediately following build
+    /// may re-emit, so a served frame is never more than one frame stale.
+    generation: u64,
+}
+
+/// Kill switch for the stale-transition serve, default OFF: set
+/// `CRANPOSE_STALE_TRANSITION` (to anything but `0` or empty) to let a
+/// command's replay collapse frame re-emit the previous build's emission
+/// instead of re-materializing its whole tape. Gates BOTH the save and the
+/// serve, so OFF is today's behavior byte-for-byte with zero saved-state
+/// cost. Read fresh (not cached) so an A/B comparison can flip it
+/// mid-process, exactly like the renderer's `CRANPOSE_COMMAND_FEED`; one
+/// environment lookup per build is noise against the multi-vsync frame
+/// this exists to remove.
+fn stale_transition_enabled() -> bool {
+    matches!(
+        std::env::var("CRANPOSE_STALE_TRANSITION").as_deref(),
+        Ok(value) if !value.is_empty() && value != "0"
+    )
+}
+
+/// Frame spans prepared for re-emission on a later build. Two rewrites,
+/// both required for the re-emitted frame to redraw the previous frame's
+/// pixels exactly:
+///
+/// - Recolors are emptied. The renderer's slot paint is a patched mirror
+///   of absolute color writes, so the previous frame's recolors still
+///   stand; re-sending them would be redundant patch traffic, and a
+///   re-emission with them emptied redraws the same colors by
+///   construction.
+/// - Capture spans (`capture: true`) become plain dynamic draws over the
+///   same materialized range. Their content was already offered for
+///   capture when the frame first rendered; a re-emission must draw the
+///   same pixels — capture frames render their content ordinarily, so a
+///   dynamic draw of the same primitives is byte-identical — without
+///   re-queuing a capture under a recorder state that has since moved on.
+fn sanitized_replay_spans(
+    spans: &[cranpose_ui_graphics::FrameSpan],
+) -> Vec<cranpose_ui_graphics::FrameSpan> {
+    use cranpose_ui_graphics::FrameSpan;
+    spans
+        .iter()
+        .map(|span| match span {
+            FrameSpan::Retained {
+                capture: true,
+                range,
+                ..
+            } => FrameSpan::Dynamic { range: *range },
+            FrameSpan::Retained {
+                slot,
+                capture: false,
+                slot_offset,
+                range,
+                tape_range,
+                transform,
+                recolors: _,
+                bounds,
+            } => FrameSpan::Retained {
+                slot: *slot,
+                capture: false,
+                slot_offset: *slot_offset,
+                range: *range,
+                tape_range: *tape_range,
+                transform: *transform,
+                recolors: Vec::new(),
+                bounds: *bounds,
+            },
+            FrameSpan::Dynamic { range } => FrameSpan::Dynamic { range: *range },
+        })
+        .collect()
+}
+
+/// Whether `id` holds a saved emission the CURRENT build may serve: saved
+/// exactly one recording generation ago, under the currently declared feed
+/// epoch. Anything else — older, consumed by a previous serve, from a dead
+/// slot universe, or no feed at all — is not servable, which is what caps
+/// staleness at one frame structurally.
+fn saved_emission_available(id: DrawCommandId) -> bool {
+    let Some(epoch) = RETAINED_FEED_EPOCH.with(std::cell::Cell::get) else {
+        return false;
+    };
+    let generation = RECORDING_GENERATION.with(std::cell::Cell::get);
+    COMMAND_RECORDINGS.with(|map| {
+        map.borrow()
+            .get(&id)
+            .and_then(|slot| slot.saved_emission.as_ref())
+            .is_some_and(|saved| {
+                saved.generation.wrapping_add(1) == generation && saved.epoch == epoch
+            })
+    })
+}
+
+/// Takes `id`'s saved emission for serving. Consuming it (rather than
+/// cloning) is deliberate: with the emission gone, a second collapse on
+/// the very next build finds nothing to serve and pays the ordinary
+/// collapse — the one-frame staleness cap needs no counter.
+fn take_saved_emission(id: DrawCommandId) -> Option<SavedReplayEmission> {
+    COMMAND_RECORDINGS.with(|map| {
+        map.borrow_mut()
+            .get_mut(&id)
+            .and_then(|slot| slot.saved_emission.take())
+    })
+}
+
+/// Stores (or clears, with `None`) `id`'s saved emission. Clearing on
+/// frame-less builds matters: without it a command that stops emitting
+/// replay frames would pin its last emission's primitives and tape
+/// indefinitely.
+fn store_saved_emission(id: DrawCommandId, saved: Option<SavedReplayEmission>) {
+    COMMAND_RECORDINGS.with(|map| {
+        if let Some(slot) = map.borrow_mut().get_mut(&id) {
+            slot.saved_emission = saved;
+        }
+    });
 }
 
 thread_local! {
@@ -961,6 +1113,7 @@ fn publish_recording(
             recordings: [None, None],
             replay: cranpose_ui_graphics::CommandReplayState::default(),
             replay_epoch: None,
+            saved_emission: None,
         });
         slot.generation = generation;
         if let Some(replay) = replay {
@@ -985,6 +1138,7 @@ fn draw_nodes(
     phase: PrimitivePhase,
 ) -> Vec<RenderNode> {
     let mut nodes = Vec::new();
+    let stale_transition = stale_transition_enabled();
     for (command_index, command) in commands.iter().enumerate() {
         let id = DrawCommandId {
             node_id,
@@ -992,16 +1146,54 @@ fn draw_nodes(
             placement,
         };
         let (recording, storage, mut replay) = acquire_recording(id);
-        let mut replay_ref = replay.as_mut();
+        let stale_available = stale_transition && replay.is_some() && saved_emission_available(id);
+        let mut ctx = replay
+            .as_mut()
+            .map(|state| crate::style_shared::CommandReplayContext {
+                state,
+                stale_available,
+                serve_stale: false,
+            });
         let (primitives, recording, frame) = primitives_for_placement_verified(
             command,
             placement,
             size,
             recording,
             storage,
-            &mut replay_ref,
+            &mut ctx,
             Some(id),
         );
+        if ctx.is_some_and(|ctx| ctx.serve_stale) {
+            // The stale-transition serve: verification collapsed out of its
+            // capture, nothing was materialized, and the node re-emits the
+            // PREVIOUS build's emission byte-for-byte — same primitives,
+            // same sanitized spans, same fallback recording. Publishing
+            // still happens first: the (empty) recording and storage
+            // buffers return to the registry for the command's steady-state
+            // ping-pong, and the advanced replay state is stored back so
+            // re-convergence proceeds on the next builds.
+            publish_recording(id, recording, primitives, replay);
+            if let Some(saved) = take_saved_emission(id) {
+                let frame = cranpose_ui_graphics::CommandReplayFrame {
+                    center: saved.center,
+                    spans: saved.spans,
+                    fallback: Some(saved.recording),
+                };
+                nodes.push(RenderNode::DrawRun(DrawRunNode::for_command_replayed(
+                    phase,
+                    Some(id),
+                    saved.primitives,
+                    Some(Box::new(frame)),
+                )));
+            } else {
+                // Unreachable: `stale_available` was read from this same
+                // thread-local slot within this build and nothing between
+                // consumes it. Fail soft — one frame without this command —
+                // rather than panic in a renderer.
+                debug_assert!(false, "serve_stale without a saved emission");
+            }
+            continue;
+        }
         // A bypassed span leaves no primitives behind, so emptiness alone no
         // longer means the command drew nothing in this placement.
         let has_replay_spans = frame.as_ref().is_some_and(|frame| !frame.spans.is_empty());
@@ -1014,6 +1206,28 @@ fn draw_nodes(
             continue;
         }
         let (shared, published_recording) = publish_recording(id, recording, primitives, replay);
+        if stale_transition {
+            // Save this build's emission in re-emittable form — or clear a
+            // previous save when this build emitted no replay frame, so a
+            // command that stops emitting does not pin its last frame's
+            // buffers. The save is what the NEXT build's collapse frame
+            // may serve; a build where the emission was itself served
+            // stale never reaches this point, which is the other half of
+            // the one-frame staleness cap.
+            let saved = frame.as_ref().and_then(|frame| {
+                RETAINED_FEED_EPOCH
+                    .with(std::cell::Cell::get)
+                    .map(|epoch| SavedReplayEmission {
+                        spans: sanitized_replay_spans(&frame.spans),
+                        center: frame.center,
+                        primitives: shared.clone(),
+                        recording: published_recording.clone(),
+                        epoch,
+                        generation: RECORDING_GENERATION.with(std::cell::Cell::get),
+                    })
+            });
+            store_saved_emission(id, saved);
+        }
         if shared.is_empty() && !has_replay_spans {
             continue;
         }
@@ -1036,6 +1250,23 @@ fn draw_nodes(
         )));
     }
     nodes
+}
+
+/// The real [`draw_nodes`] path — acquire, record, verify, publish, and
+/// the stale-transition save/serve — exposed so integration tests can
+/// drive a command through the production seam build by build. Each call
+/// is one build: the recording generation advances exactly as
+/// [`build_graph_from_layout_tree`] and friends advance it.
+#[doc(hidden)]
+pub fn draw_command_nodes_for_tests(
+    node_id: NodeId,
+    commands: &[DrawCommand],
+    placement: DrawPlacement,
+    size: Size,
+    phase: PrimitivePhase,
+) -> Vec<RenderNode> {
+    bump_recording_generation();
+    draw_nodes(node_id, commands, placement, size, phase)
 }
 
 struct TextNodeParts<'a> {
@@ -3994,5 +4225,135 @@ mod tests {
             ptrs[6], ptrs[7],
             "a recording a live frame still shares must never be recorded into"
         );
+    }
+
+    #[test]
+    fn sanitized_spans_drop_recolors_and_downgrade_captures() {
+        use cranpose_ui_graphics::{FrameSpan, RecordTransform};
+        let bounds = Rect {
+            x: 1.0,
+            y: 2.0,
+            width: 3.0,
+            height: 4.0,
+        };
+        let spans = vec![
+            FrameSpan::Dynamic { range: (0, 5) },
+            FrameSpan::Retained {
+                slot: 7,
+                capture: true,
+                slot_offset: 0,
+                range: (5, 105),
+                tape_range: (5, 105),
+                transform: RecordTransform::IDENTITY,
+                recolors: Vec::new(),
+                bounds,
+            },
+            FrameSpan::Retained {
+                slot: 8,
+                capture: false,
+                slot_offset: 3,
+                range: (105, 205),
+                tape_range: (110, 210),
+                transform: RecordTransform {
+                    scale: 0.999,
+                    angle: 0.05,
+                },
+                recolors: vec![(4, cranpose_ui_graphics::Color(1.0, 0.5, 0.2, 1.0))],
+                bounds,
+            },
+        ];
+        let sanitized = sanitized_replay_spans(&spans);
+        // The dynamic span passes through untouched.
+        assert_eq!(sanitized[0], FrameSpan::Dynamic { range: (0, 5) });
+        // The capture span becomes a plain dynamic draw of the SAME
+        // materialized range: re-emitting it must redraw its pixels
+        // without re-queuing a capture.
+        assert_eq!(sanitized[1], FrameSpan::Dynamic { range: (5, 105) });
+        // The retained span keeps its identity and transform but sheds its
+        // recolors: the renderer's slot paint is persistent, so the
+        // previous frame's absolute writes already show them.
+        match &sanitized[2] {
+            FrameSpan::Retained {
+                slot,
+                capture,
+                slot_offset,
+                range,
+                tape_range,
+                transform,
+                recolors,
+                bounds: sanitized_bounds,
+            } => {
+                assert_eq!((*slot, *capture, *slot_offset), (8, false, 3));
+                assert_eq!((*range, *tape_range), ((105, 205), (110, 210)));
+                assert_eq!(transform.angle, 0.05);
+                assert!(recolors.is_empty(), "recolors must be emptied");
+                assert_eq!(*sanitized_bounds, bounds);
+            }
+            other => panic!("expected a retained span, got {other:?}"),
+        }
+    }
+
+    /// The one-frame staleness cap, at the registry seam it lives on: a
+    /// saved emission serves on the IMMEDIATELY following build only, and
+    /// serving consumes it — so two consecutive collapses can produce at
+    /// most one stale frame, with no counter anywhere.
+    #[test]
+    fn a_saved_emission_serves_the_next_build_once() {
+        let command = DrawCommandId {
+            node_id: 990_303,
+            command_index: 0,
+            placement: DrawPlacement::Behind,
+        };
+        set_retained_feed_epoch(Some(77));
+        // Materialize the slot the save writes into.
+        publish_recording(
+            command,
+            cranpose_ui_graphics::CommandRecording::default(),
+            Vec::new(),
+            None,
+        );
+        let saved = || SavedReplayEmission {
+            spans: vec![cranpose_ui_graphics::FrameSpan::Dynamic { range: (0, 3) }],
+            center: cranpose_ui_graphics::Point::new(204.0, 204.0),
+            primitives: Rc::new(Vec::new()),
+            recording: Rc::new(cranpose_ui_graphics::CommandRecording::default()),
+            epoch: 77,
+            generation: RECORDING_GENERATION.with(std::cell::Cell::get),
+        };
+
+        // Saved this build: not servable within the SAME build...
+        store_saved_emission(command, Some(saved()));
+        assert!(!saved_emission_available(command));
+        // ...servable on the next...
+        bump_recording_generation();
+        assert!(saved_emission_available(command));
+        // ...and expired one build later: only the immediately following
+        // build may re-emit, so a served frame is never more than one
+        // frame stale.
+        bump_recording_generation();
+        assert!(!saved_emission_available(command));
+
+        // A fresh save served on time is CONSUMED by the take: the second
+        // of two consecutive collapse builds finds nothing to serve.
+        store_saved_emission(command, Some(saved()));
+        bump_recording_generation();
+        assert!(saved_emission_available(command));
+        assert!(take_saved_emission(command).is_some());
+        assert!(
+            !saved_emission_available(command),
+            "a second serve of one emission must be unconstructible"
+        );
+        assert!(take_saved_emission(command).is_none());
+
+        // A dead slot universe invalidates the save wholesale.
+        store_saved_emission(command, Some(saved()));
+        bump_recording_generation();
+        set_retained_feed_epoch(Some(78));
+        assert!(!saved_emission_available(command));
+        set_retained_feed_epoch(None);
+        assert!(!saved_emission_available(command));
+        set_retained_feed_epoch(Some(77));
+        assert!(saved_emission_available(command));
+        set_retained_feed_epoch(None);
     }
 }

--- a/crates/cranpose-render/common/src/style_shared.rs
+++ b/crates/cranpose-render/common/src/style_shared.rs
@@ -365,6 +365,26 @@ pub fn primitives_for_placement_retained(
     (primitives, recording)
 }
 
+/// The replay half of [`primitives_for_placement_verified`]'s contract: the
+/// command's verification state plus the stale-transition seam. The caller
+/// (the scene builder, which owns the per-command registry) says whether a
+/// valid previous-frame emission is on hand; verification answers whether
+/// this frame collapsed out of its capture and was therefore NOT emitted —
+/// nothing materialized, the caller must re-emit its saved emission.
+pub struct CommandReplayContext<'a> {
+    pub state: &'a mut cranpose_ui_graphics::CommandReplayState,
+    /// In: the previous build emitted a replay frame the caller saved,
+    /// still valid under the current recording generation and retained
+    /// feed epoch, and the stale-transition flag is on.
+    pub stale_available: bool,
+    /// Out: verification collapsed out of an established capture while
+    /// `stale_available` held, so the recording was finished via
+    /// [`cranpose_ui_graphics::DrawScopeDefault::finish_recording_only`]
+    /// — no primitives, no frame — and the caller re-emits its saved
+    /// emission in place of this frame's.
+    pub serve_stale: bool,
+}
+
 /// [`primitives_for_placement_retained`] with per-command similarity
 /// verification: when `replay` carries the command's state, the freshly
 /// recorded compact form advances it BEFORE materialization, yielding the
@@ -380,7 +400,7 @@ pub fn primitives_for_placement_verified(
     size: Size,
     recording: CommandRecording,
     storage: Vec<DrawPrimitive>,
-    replay: &mut Option<&mut cranpose_ui_graphics::CommandReplayState>,
+    replay: &mut Option<CommandReplayContext<'_>>,
     command_id: Option<crate::graph::DrawCommandId>,
 ) -> (
     Vec<DrawPrimitive>,
@@ -454,7 +474,7 @@ pub fn primitives_for_placement_verified(
         size: Size,
         recording: CommandRecording,
         storage: Vec<DrawPrimitive>,
-        replay: &mut Option<&mut cranpose_ui_graphics::CommandReplayState>,
+        replay: &mut Option<CommandReplayContext<'_>>,
         command: Option<crate::graph::DrawCommandId>,
     ) -> (
         FinishedRecording,
@@ -462,9 +482,10 @@ pub fn primitives_for_placement_verified(
     ) {
         let mut scope = cranpose_ui::command_draw_scope_retained(size, recording, storage);
         func(&mut scope);
-        let Some(state) = replay.as_mut() else {
+        let Some(ctx) = replay.as_mut() else {
             return (scope.finish(), None);
         };
+        let state = &mut *ctx.state;
         let outcome =
             state.advance_pooled(scope.recorded(), crate::scene_builder::verify_executor());
         // Span counts are taken before `finish_replay` consumes the outcome
@@ -530,6 +551,28 @@ pub fn primitives_for_placement_verified(
         // for this frame's ordinary path. A marker-bearing recording drops
         // its frame after the split, so it must materialize whole.
         let markers = scope.content_marker_count();
+        if ctx.stale_available && markers == 0 && state.collapsed_from_captured() {
+            // The transition frame: verification collapsed out of an
+            // established capture, so emitting `outcome` would materialize
+            // and re-encode the ENTIRE tape in one frame — 22-75 ms on a
+            // watch-class core against a ~17k-record scene, two to four
+            // missed vsyncs. The caller holds the previous frame's
+            // emission; serve that instead. Nothing materializes here, and
+            // the advance above already re-snapshotted, so re-convergence
+            // proceeds on the next frames exactly as if this frame had
+            // emitted its collapse. A marker-bearing recording never
+            // qualifies: its frame would have been dropped anyway, so
+            // there is no saved emission shape that matches it.
+            ctx.serve_stale = true;
+            if cranpose_core::env_flag!("CRANPOSE_COMMAND_REPLAY_DIAG") {
+                log::warn!(
+                    "[command-replay] stale transition: collapse frame of {} records \
+                     re-serves the previous emission",
+                    scope.recorded().len(),
+                );
+            }
+            return (scope.finish_recording_only(), None);
+        }
         let mut bypass = |slot: u32| {
             markers == 0
                 && command.is_some_and(|id| crate::scene_builder::retained_slot_confirmed(id, slot))

--- a/crates/cranpose-render/wgpu/tests/stale_transition_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/stale_transition_parity.rs
@@ -1,0 +1,458 @@
+//! The stale-transition serve, end to end through the production seam.
+//!
+//! A mid-sequence content flip collapses a command's replay verification,
+//! and the collapse frame otherwise re-materializes and re-encodes the
+//! whole tape at once — the 22-75 ms transition stall on a watch-class
+//! core. With `CRANPOSE_STALE_TRANSITION` set, the collapse frame instead
+//! re-emits the PREVIOUS build's emission, byte-for-byte, and only that
+//! one frame; everything else must render exactly as the flag-off build
+//! does, and re-convergence must proceed on the frames after the flip.
+//!
+//! Sequences are built through `draw_command_nodes_for_tests` — the real
+//! `draw_nodes` path (acquire, record, verify, publish, save/serve) —
+//! so the graphs carry exactly what production would ship, then rendered
+//! on the same headless harness as `command_feed_parity`.
+//!
+//! ENV HYGIENE: this file deliberately holds a single test. It toggles
+//! process-global `CRANPOSE_*` variables between runs (the flag is read
+//! fresh per build, like `CRANPOSE_COMMAND_FEED`, precisely so one
+//! process can A/B it), and `cargo test` threads share the environment —
+//! a second test in this binary could race the toggles. Integration test
+//! binaries are separate processes, so other test files are unaffected.
+
+mod support;
+
+use std::rc::Rc;
+
+use cranpose_render_common::graph::{
+    CachePolicy, DrawRunNode, IsolationReasons, LayerNode, PrimitivePhase, ProjectiveTransform,
+    RenderGraph, RenderNode,
+};
+use cranpose_render_common::raster_cache::LayerRasterCacheHashes;
+use cranpose_render_common::scene_builder::{
+    draw_command_nodes_for_tests, set_retained_feed_epoch,
+};
+use cranpose_render_common::style_shared::DrawPlacement;
+use cranpose_render_common::Renderer;
+use cranpose_ui::DrawCommand;
+use cranpose_ui_graphics::{
+    Brush, Color, DrawScope, DrawScopeDefault, FrameSpan, GraphicsLayer, Point, Rect, Size,
+};
+
+const SIZE: u32 = 408;
+const CENTER: f32 = 204.0;
+const FRAMES: usize = 13;
+/// The content flip: every generator constant changes, so nothing
+/// survives verification and the frame collapses to `AllDynamic`.
+const FLIP: usize = 8;
+
+/// One frame of ring-plus-twinkle content. `variant` selects a disjoint
+/// constant set — radii, bands, sweeps, counts, twinkle orbits — so a
+/// capture of one variant dies whole against another, while frames within
+/// a variant move by per-ring rotations and per-frame recolors exactly
+/// like the game scene the recorder was built for.
+fn record_content(scope: &mut DrawScopeDefault, frame: usize, variant: usize) {
+    scope.draw_rect_at(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: SIZE as f32,
+            height: SIZE as f32,
+        },
+        Brush::solid(Color(0.02, 0.02, 0.05, 1.0)),
+    );
+    let rings: &[(f32, f32, f32, usize)] = match variant {
+        0 => &[
+            (150.0, 10.0, 0.013, 420),
+            (120.0, 9.0, -0.008, 420),
+            (90.0, 8.0, 0.019, 420),
+        ],
+        1 => &[
+            (165.0, 12.0, -0.011, 350),
+            (135.0, 7.0, 0.017, 350),
+            (105.0, 9.0, -0.013, 350),
+            (75.0, 6.0, 0.021, 350),
+        ],
+        _ => &[(140.0, 14.0, 0.009, 520), (80.0, 11.0, -0.018, 520)],
+    };
+    for &(radius, band, speed, count) in rings {
+        let sweep = std::f32::consts::TAU / count as f32 * 0.8;
+        for i in 0..count {
+            let start = i as f32 * (std::f32::consts::TAU / count as f32) + speed * frame as f32;
+            scope.draw_annular_sector(
+                Brush::solid(Color(0.3, 0.5 + (i % 5) as f32 * 0.08, 0.8, 1.0)),
+                Point::new(CENTER, CENTER),
+                radius - band,
+                radius,
+                start,
+                sweep,
+            );
+        }
+    }
+    let (orbit_base, angle_step) = match variant {
+        0 => (55.0f32, 0.285f32),
+        1 => (49.0, 0.301),
+        _ => (63.0, 0.267),
+    };
+    for d in 0..220 {
+        let angle = d as f32 * angle_step;
+        let orbit = orbit_base + (d % 7) as f32 * 3.0;
+        let alpha = 0.25 + 0.7 * (((d + frame * 3) % 11) as f32 / 10.0);
+        scope.draw_annular_sector(
+            Brush::solid(Color(0.9, 0.85, 0.4, alpha)),
+            Point::new(CENTER, CENTER),
+            orbit - 3.0,
+            orbit + 3.0,
+            angle - 0.02,
+            0.04,
+        );
+    }
+}
+
+/// Builds one sequence through the production `draw_nodes` seam. Each
+/// frame is one build: the recording generation advances, the command
+/// re-records under its stable identity, verification runs, and the
+/// stale-transition save/serve engages exactly as it would in an app.
+/// `flips` lists the frames at which the content variant advances.
+fn build_graphs(node_id: usize, flips: &[usize]) -> Vec<RenderGraph> {
+    (0..FRAMES)
+        .map(|frame| {
+            let variant = flips.iter().filter(|&&flip| frame >= flip).count();
+            let command = DrawCommand::Behind(Rc::new(move |scope: &mut DrawScopeDefault| {
+                record_content(scope, frame, variant);
+            }));
+            let children = draw_command_nodes_for_tests(
+                node_id,
+                std::slice::from_ref(&command),
+                DrawPlacement::Behind,
+                Size::new(SIZE as f32, SIZE as f32),
+                PrimitivePhase::BeforeChildren,
+            );
+            assert!(
+                !children.is_empty(),
+                "frame {frame}: the command must emit a node"
+            );
+            let bounds = Rect {
+                x: 0.0,
+                y: 0.0,
+                width: SIZE as f32,
+                height: SIZE as f32,
+            };
+            RenderGraph::new(LayerNode {
+                node_id: None,
+                local_bounds: bounds,
+                transform_to_parent: ProjectiveTransform::identity(),
+                content_offset: Point::default(),
+                motion_context_animated: false,
+                translated_content_context: false,
+                translated_content_offset: Point::default(),
+                scene_children_origin: Point::default(),
+                scene_children_layer_translation: Point::default(),
+                graphics_layer: GraphicsLayer::default(),
+                clip_to_bounds: false,
+                shadow_clip: None,
+                hit_test: None,
+                has_hit_targets: false,
+                isolation: IsolationReasons::default(),
+                cache_policy: CachePolicy::None,
+                cache_hashes: LayerRasterCacheHashes::default(),
+                cache_hashes_valid: false,
+                children,
+            })
+        })
+        .collect()
+}
+
+fn run_of(graph: &RenderGraph) -> &DrawRunNode {
+    match &graph.root.children[0] {
+        RenderNode::DrawRun(run) => run,
+        _ => panic!("expected a draw run"),
+    }
+}
+
+/// What one frame's render moved in the renderer's lifetime feed stats:
+/// live slot count, recolor patches, remat misses.
+struct FeedStatsDelta {
+    slots: i64,
+    patches: i64,
+    remat: i64,
+}
+
+/// Renders the sequence, returning per-frame pixels and the feed-stats
+/// delta each frame's render produced.
+fn render_sequence(
+    renderer: &mut support::LockedRenderer,
+    graphs: &[RenderGraph],
+) -> (Vec<Vec<u8>>, Vec<FeedStatsDelta>) {
+    let mut frames = Vec::with_capacity(graphs.len());
+    let mut deltas = Vec::with_capacity(graphs.len());
+    for (frame, graph) in graphs.iter().enumerate() {
+        let (slots0, patches0, remat0) = cranpose_render_wgpu::command_feed_live_stats();
+        renderer.scene_mut().graph = Some(graph.clone());
+        let captured = renderer
+            .capture_frame(SIZE, SIZE)
+            .unwrap_or_else(|err| panic!("frame {frame} capture failed: {err:?}"));
+        assert_eq!((captured.width, captured.height), (SIZE, SIZE));
+        let (slots1, patches1, remat1) = cranpose_render_wgpu::command_feed_live_stats();
+        frames.push(captured.pixels);
+        deltas.push(FeedStatsDelta {
+            slots: slots1 as i64 - slots0 as i64,
+            patches: patches1 as i64 - patches0 as i64,
+            remat: remat1 as i64 - remat0 as i64,
+        });
+    }
+    (frames, deltas)
+}
+
+fn differing(a: &[u8], b: &[u8]) -> usize {
+    assert_eq!(a.len(), b.len());
+    a.iter().zip(b).filter(|(a, b)| a.abs_diff(**b) > 0).count()
+}
+
+fn worst_diff(a: &[u8], b: &[u8]) -> u8 {
+    a.iter()
+        .zip(b)
+        .map(|(a, b)| a.abs_diff(*b))
+        .max()
+        .unwrap_or(0)
+}
+
+#[test]
+fn a_collapse_frame_re_serves_the_previous_emission_exactly_once() {
+    // Plain quad expansion, as in command_feed_parity: this test documents
+    // the serve's byte-level contract, not the arc mesh's interpolation.
+    std::env::set_var("CRANPOSE_ARC_MESH", "0");
+    std::env::remove_var("CRANPOSE_STALE_TRANSITION");
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!("skipping stale transition parity: headless WGPU init failed: {err}");
+            return;
+        }
+    };
+
+    // Feed-free baseline graphs: no declared epoch means no verification
+    // at all; rendered later (warm) with CRANPOSE_COMMAND_FEED=0 so the
+    // renderer stays on the full pipeline.
+    std::env::set_var("CRANPOSE_COMMAND_FEED", "0");
+    set_retained_feed_epoch(None);
+    let baseline_graphs = build_graphs(11, &[FLIP]);
+
+    // Everything below is the fed configuration production ships.
+    std::env::set_var("CRANPOSE_COMMAND_FEED", "1");
+    set_retained_feed_epoch(Some(cranpose_render_wgpu::retained_feed_generation()));
+
+    // Flag OFF, twice: pins current behavior and the determinism floor.
+    let off_graphs = build_graphs(12, &[FLIP]);
+    let off2_graphs = build_graphs(13, &[FLIP]);
+    let off3_graphs = build_graphs(15, &[FLIP, FLIP + 1]);
+
+    // Flag ON: the single-flip sequence and the consecutive-collapse one.
+    std::env::set_var("CRANPOSE_STALE_TRANSITION", "1");
+    let on_graphs = build_graphs(14, &[FLIP]);
+    let on2_graphs = build_graphs(16, &[FLIP, FLIP + 1]);
+    std::env::set_var("CRANPOSE_STALE_TRANSITION", "0");
+
+    // Scenario validity before believing any pixel number: flag off, the
+    // flip frame collapsed to AllDynamic (no replay frame rides the run);
+    // the frames around it verified or recaptured (replay frames present).
+    assert!(
+        run_of(&off_graphs[FLIP - 1]).replay.is_some(),
+        "the frame before the flip must be verified"
+    );
+    assert!(
+        run_of(&off_graphs[FLIP]).replay.is_none(),
+        "the flip frame must collapse to AllDynamic under today's behavior"
+    );
+    assert!(
+        run_of(&off_graphs[FLIP + 1]).replay.is_some(),
+        "the frame after the flip must re-partition"
+    );
+    // Flag on, the flip frame carries the SERVED frame instead: the
+    // previous build's primitives handle (aliased, not copied) and its
+    // sanitized spans — no capture re-queues, no recolor patches.
+    let served = run_of(&on_graphs[FLIP]);
+    let served_frame = served
+        .replay
+        .as_ref()
+        .expect("the flip frame must re-serve the previous emission");
+    assert!(
+        Rc::ptr_eq(&served.primitives, &run_of(&on_graphs[FLIP - 1]).primitives),
+        "the served frame must alias the previous build's primitives"
+    );
+    assert!(!served_frame.spans.is_empty());
+    for span in &served_frame.spans {
+        match span {
+            FrameSpan::Retained {
+                capture, recolors, ..
+            } => {
+                assert!(!capture, "served spans must not re-queue captures");
+                assert!(recolors.is_empty(), "served spans must carry no recolors");
+            }
+            FrameSpan::Dynamic { .. } => {}
+        }
+    }
+    // Re-convergence in the graphs: the capture right after the flip, and
+    // retained (non-capture) spans within three frames of it.
+    let recaptured = run_of(&on_graphs[FLIP + 1])
+        .replay
+        .as_ref()
+        .is_some_and(|frame| {
+            frame
+                .spans
+                .iter()
+                .any(|span| matches!(span, FrameSpan::Retained { capture: true, .. }))
+        });
+    assert!(recaptured, "the frame after the served flip must recapture");
+    let reconverged = (FLIP + 1..=FLIP + 3).any(|frame| {
+        run_of(&on_graphs[frame])
+            .replay
+            .as_ref()
+            .is_some_and(|frame| {
+                frame
+                    .spans
+                    .iter()
+                    .any(|span| matches!(span, FrameSpan::Retained { capture: false, .. }))
+            })
+    });
+    assert!(
+        reconverged,
+        "retained spans must reappear within 3 frames of the flip"
+    );
+
+    // Two discarded warmup passes: the renderer's first passes over a
+    // scene render its heavy ordinary frames up to 2/255 differently from
+    // every later pass — the same pass-position artifact
+    // command_feed_parity documents (it compares against its `fed2`
+    // control, not its first fed run; measured here, the artifact settles
+    // from the third pass on). Every compared run below starts from the
+    // settled state.
+    let _ = render_sequence(&mut renderer, &off_graphs);
+    let _ = render_sequence(&mut renderer, &off_graphs);
+    std::env::set_var("CRANPOSE_COMMAND_FEED", "0");
+    let (baseline, _) = render_sequence(&mut renderer, &baseline_graphs);
+    std::env::set_var("CRANPOSE_COMMAND_FEED", "1");
+    let (off, _) = render_sequence(&mut renderer, &off_graphs);
+    let (off2, _) = render_sequence(&mut renderer, &off2_graphs);
+    let (on, on_deltas) = render_sequence(&mut renderer, &on_graphs);
+    let (off3, _) = render_sequence(&mut renderer, &off3_graphs);
+    let (on2, _) = render_sequence(&mut renderer, &on2_graphs);
+    std::env::remove_var("CRANPOSE_STALE_TRANSITION");
+    std::env::remove_var("CRANPOSE_COMMAND_FEED");
+    std::env::remove_var("CRANPOSE_ARC_MESH");
+    set_retained_feed_epoch(None);
+
+    for frame in 0..FRAMES {
+        eprintln!(
+            "frame {frame}: off-vs-off2 {} off-vs-on {} off-vs-baseline {} (worst {})",
+            differing(&off[frame], &off2[frame]),
+            differing(&off[frame], &on[frame]),
+            differing(&off[frame], &baseline[frame]),
+            worst_diff(&off[frame], &baseline[frame]),
+        );
+    }
+
+    // Determinism floor: two flag-off runs of the same sequence must be
+    // byte-identical, or nothing below can be read as a measurement.
+    for (frame, (a, b)) in off.iter().zip(&off2).enumerate() {
+        assert_eq!(
+            differing(a, b),
+            0,
+            "frame {frame}: two flag-off runs must render identically"
+        );
+    }
+    // The content genuinely moved at the flip — the stale assertion below
+    // cannot pass vacuously.
+    assert!(
+        differing(&off[FLIP], &off[FLIP - 1]) > 0,
+        "the flip must change the rendered frame"
+    );
+
+    // THE assertion: flag on, the flip frame is byte-identical to the
+    // PREVIOUS frame's fed render — the emission was re-served, not
+    // rebuilt — and genuinely differs from what a fresh emission draws.
+    assert_eq!(
+        differing(&on[FLIP], &on[FLIP - 1]),
+        0,
+        "the served flip frame must re-render the previous frame exactly"
+    );
+    assert!(
+        differing(&on[FLIP], &off[FLIP]) > 0,
+        "the served frame must differ from the fresh collapse frame"
+    );
+    // Every other frame is untouched by the flag: byte-identical to the
+    // flag-off run, including the re-convergence frames after the flip.
+    for frame in (0..FRAMES).filter(|&frame| frame != FLIP) {
+        assert_eq!(
+            differing(&on[frame], &off[frame]),
+            0,
+            "frame {frame}: the flag must only touch the collapse frame"
+        );
+    }
+    // The serve queues nothing into the frame's ops: zero recolor patches,
+    // zero new feed slots, zero remat misses — while an ordinary verified
+    // frame right before it does push recolor patches.
+    let serve = &on_deltas[FLIP];
+    assert_eq!(serve.patches, 0, "a served frame must patch no colors");
+    assert_eq!(serve.slots, 0, "a served frame must confirm no new slots");
+    assert_eq!(serve.remat, 0, "a served frame must not hit the remat path");
+    assert!(
+        on_deltas[FLIP - 1].patches > 0,
+        "the twinkle recolors must flow as patches on ordinary frames"
+    );
+
+    // Kill-switch pin: flag off, the collapse frame IS today's behavior —
+    // the whole tape re-materializes through the full pipeline. Against
+    // the feed-free baseline only the ≤2/255 pass-position artifact may
+    // remain (command_feed_parity documents the same artifact on its
+    // pre-retention frames): a frame that had regressed to serving
+    // retained content instead would sit at the fed envelope, two orders
+    // of magnitude above (worst ~150), and its graph would carry a replay
+    // frame — asserted None above.
+    assert!(
+        worst_diff(&off[FLIP], &baseline[FLIP]) <= 2,
+        "flag off, the collapse frame must render the full fresh pipeline \
+         (worst {} channels {})",
+        worst_diff(&off[FLIP], &baseline[FLIP]),
+        differing(&off[FLIP], &baseline[FLIP]),
+    );
+
+    // The one-frame cap, end to end: consecutive collapses (content flips
+    // at FLIP and FLIP+1) serve stale exactly once. The second collapse
+    // finds the saved emission consumed and renders fresh — structurally
+    // (no replay frame rides the run, where a serve always carries one)
+    // and on pixels, where only the ≤2/255 pass-position artifact remains
+    // (the frame BEFORE it renders differently in the two runs — served
+    // vs fresh — which is exactly the state the artifact tracks).
+    assert!(
+        run_of(&on2_graphs[FLIP]).replay.is_some(),
+        "the first of two consecutive collapses must serve"
+    );
+    assert!(
+        run_of(&on2_graphs[FLIP + 1]).replay.is_none(),
+        "the second consecutive collapse must not serve — nothing is saved"
+    );
+    assert_eq!(
+        differing(&on2[FLIP], &on2[FLIP - 1]),
+        0,
+        "the first of two consecutive collapses serves stale"
+    );
+    assert!(
+        differing(&on2[FLIP + 1], &on2[FLIP]) > 0,
+        "the second consecutive collapse must NOT serve stale"
+    );
+    assert!(
+        worst_diff(&on2[FLIP + 1], &off3[FLIP + 1]) <= 2,
+        "the second collapse frame must render fresh, as flag-off does \
+         (worst {} channels {})",
+        worst_diff(&on2[FLIP + 1], &off3[FLIP + 1]),
+        differing(&on2[FLIP + 1], &off3[FLIP + 1]),
+    );
+    let stale_frames = (1..FRAMES)
+        .filter(|&frame| differing(&on2[frame], &on2[frame - 1]) == 0)
+        .count();
+    assert_eq!(
+        stale_frames, 1,
+        "two forced consecutive collapses must produce exactly one stale frame"
+    );
+}

--- a/crates/cranpose-ui-graphics/src/geometry.rs
+++ b/crates/cranpose-ui-graphics/src/geometry.rs
@@ -1271,6 +1271,27 @@ impl DrawScopeDefault {
         }
     }
 
+    /// Like [`Self::finish`], but materializing nothing: the consumer is
+    /// about to re-emit a PREVIOUS frame's saved emission in place of this
+    /// recording (the stale-transition serve on a replay collapse frame),
+    /// so building this frame's primitives — the very cost the serve
+    /// exists to skip — would be pure waste. The recording and
+    /// materialization buffers still return, cleared exactly as
+    /// [`Self::finish`] leaves them, so the command's steady-state
+    /// ping-pong keeps its earned capacity.
+    pub fn finish_recording_only(mut self) -> FinishedRecording {
+        let mut out = std::mem::take(&mut self.out);
+        out.clear();
+        note_recorded_primitive_count(self.size, self.rec.tape.len());
+        self.rec.clear();
+        FinishedRecording {
+            primitives: out,
+            content_markers: self.content_markers,
+            recording: self.rec,
+            dropped: Vec::new(),
+        }
+    }
+
     /// Like [`Self::finish`], but for a verified command: a retained span
     /// whose slot `bypass` approves is NOT materialized — its records cease
     /// to exist as per-frame primitives, which is the entire point of

--- a/crates/cranpose-ui-graphics/src/record_replay.rs
+++ b/crates/cranpose-ui-graphics/src/record_replay.rs
@@ -876,6 +876,15 @@ pub struct CommandReplayState {
     /// after every collapse reuses one ~tape-length allocation instead of
     /// growing a fresh one per convergence cycle.
     align_scratch: Vec<Option<usize>>,
+    /// Whether the LAST advance collapsed out of an established capture —
+    /// the `Captured`-phase coverage collapse in [`Self::finish_verify`].
+    /// That is the frame whose emission re-materializes and re-encodes the
+    /// whole tape at once, and therefore the only frame the
+    /// stale-transition serve (scene builder) may replace. Bootstrap
+    /// `AllDynamic` frames (idle snapshot, short tape, retirement) never
+    /// set it: they are not transitions out of retention, so there is
+    /// nothing cheaper to substitute. Cleared at every advance.
+    collapsed_from_captured: bool,
 }
 
 impl Default for CommandReplayState {
@@ -898,6 +907,7 @@ impl Default for CommandReplayState {
             verify_pending: std::collections::VecDeque::new(),
             verify_survivors: Vec::new(),
             align_scratch: Vec::new(),
+            collapsed_from_captured: false,
         }
     }
 }
@@ -930,6 +940,16 @@ impl CommandReplayState {
         self.center
     }
 
+    /// Whether the last [`Self::advance_pooled`] collapsed out of an
+    /// established capture (the `Captured`-phase coverage collapse) — the
+    /// expensive full-rematerialization frame the stale-transition serve
+    /// can replace with the previous frame's emission. False on every
+    /// bootstrap `AllDynamic` frame: an idle snapshot, a short tape, or a
+    /// retirement never had a capture to collapse out of.
+    pub fn collapsed_from_captured(&self) -> bool {
+        self.collapsed_from_captured
+    }
+
     /// Advances the state machine with this frame's recording and returns
     /// what the frame can retain. Phases mirror the flat-list detector:
     /// snapshot on the first sighting, partition into
@@ -955,6 +975,7 @@ impl CommandReplayState {
         current: &CommandRecording,
         pool: Option<&dyn VerifyExecutor>,
     ) -> ReplayOutcome {
+        self.collapsed_from_captured = false;
         if current.tape.len() < MIN_REPLAY_COMMAND_RECORDS {
             self.retire();
             return ReplayOutcome::AllDynamic;
@@ -1376,6 +1397,10 @@ impl CommandReplayState {
         let collapsed = retained_records == 0 || coverage < MIN_COVERAGE_FRACTION;
         let eroded = coverage + RECAPTURE_EROSION < self.capture_coverage
             && self.frames_since_capture >= RECAPTURE_COOLDOWN_FRAMES;
+        // Only the collapse marks the frame as servable-stale: an eroded
+        // frame still emits high-coverage spans and costs an ordinary
+        // frame, so replacing it would trade nothing for a frame of lag.
+        self.collapsed_from_captured = collapsed;
         if collapsed || eroded {
             // Re-snapshot so the next two frames re-partition. Collapse pays
             // immediately; mere erosion waits out the capture cooldown.
@@ -2299,6 +2324,71 @@ mod tests {
             })
             .collect();
         assert!(transforms.windows(2).any(|w| w[0].angle != w[1].angle));
+    }
+
+    /// A ring scene sharing nothing with [`ring_frame`] — different radii,
+    /// band ratio, sweep, counts — so a state captured on one collapses
+    /// whole when fed the other.
+    fn flipped_ring_frame(frame: usize) -> CommandRecording {
+        let mut scope = DrawScopeDefault::new(Size::new(408.0, 408.0));
+        for ring in 0..4 {
+            let rotation = (0.02 + ring as f32 * 0.007) * frame as f32;
+            let radius = 75.0 + ring as f32 * 27.0;
+            for slot in 0..260 {
+                let start = slot as f32 * (std::f32::consts::TAU / 260.0) + rotation;
+                scope.draw_annular_sector(
+                    Brush::solid(Color::WHITE),
+                    CENTER,
+                    radius * 0.75,
+                    radius,
+                    start,
+                    0.015,
+                );
+            }
+        }
+        scope.recorded().clone()
+    }
+
+    #[test]
+    fn only_a_collapse_out_of_capture_sets_the_transition_flag() {
+        let mut state = CommandReplayState::default();
+        // Bootstrap frames never flag: the idle snapshot...
+        assert!(matches!(
+            state.advance(&ring_frame(3, 300, 0, 10)),
+            ReplayOutcome::AllDynamic
+        ));
+        assert!(!state.collapsed_from_captured());
+        // ...the partition/capture frame...
+        assert!(matches!(
+            state.advance(&ring_frame(3, 300, 1, 10)),
+            ReplayOutcome::Spans(_)
+        ));
+        assert!(!state.collapsed_from_captured());
+        // ...and an ordinary verified frame.
+        assert!(matches!(
+            state.advance(&ring_frame(3, 300, 2, 10)),
+            ReplayOutcome::Spans(_)
+        ));
+        assert!(!state.collapsed_from_captured());
+        // The content flip: nothing survives verification, the frame
+        // collapses out of the established capture — the flag's one
+        // trigger, and the frame whose emission would re-materialize the
+        // whole tape.
+        assert!(matches!(
+            state.advance(&flipped_ring_frame(3)),
+            ReplayOutcome::AllDynamic
+        ));
+        assert!(state.collapsed_from_captured());
+        // The next advance clears it: re-convergence frames are ordinary.
+        let _ = state.advance(&flipped_ring_frame(4));
+        assert!(!state.collapsed_from_captured());
+        // A short tape retires the state — a bootstrap path, never a
+        // collapse, even straight after retention.
+        let _ = state.advance(&flipped_ring_frame(5));
+        let short = ring_frame(1, 40, 0, 0);
+        assert!(short.len() < MIN_REPLAY_COMMAND_RECORDS);
+        assert!(matches!(state.advance(&short), ReplayOutcome::AllDynamic));
+        assert!(!state.collapsed_from_captured());
     }
 
     #[test]

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -73,7 +73,7 @@ fn property_flag(name: &str) -> bool {
 /// any length — so a name may run right up to or past that pre-O limit, as
 /// `debug.cranpose.retained_mesh_px2` does; every deployment target is far
 /// past O.)
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 33] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 34] = [
     ("debug.cranpose.gpu_stats", "CRANPOSE_GPU_STATS"),
     ("debug.cranpose.present_thread", "CRANPOSE_PRESENT_THREAD"),
     ("debug.cranpose.command_feed", "CRANPOSE_COMMAND_FEED"),
@@ -97,6 +97,10 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 33] = [
     (
         "debug.cranpose.similarity_replay",
         "CRANPOSE_SIMILARITY_REPLAY",
+    ),
+    (
+        "debug.cranpose.stale_transition",
+        "CRANPOSE_STALE_TRANSITION",
     ),
     (
         "debug.cranpose.update_stage_ms",


### PR DESCRIPTION
Slice 3 of the convergence-resilience plan, landing as a **no-op behind a default-OFF flag**.

## The problem, measured

On a Pixel Watch 3, a content phase transition collapses a command's converged replay spans. The collapse frame then re-materializes and re-encodes the entire ~17k-record tape dynamically — `[slow-chunk]` telemetry caught it as `batches=1 shapes=16874 stops=2 passes=1` taking **74.5 ms**, with 22-32 ms siblings. That is two to four missed vsyncs, once per transition, and it is the dominant cause of missed frames in the heavy phase (~80% of misses are render-stage).

## Why re-serving is sound

Three properties of the existing design make the previous frame's emission a byte-exact substitute:

- Collapse does **not** evict GPU slots — only the 120-frame idle aging and the retire paths (scale change, unsupported frame, rejected collection, renderer replacement) release them.
- `RecorderSlot` already double-buffers the primitives and recording handles, so the previous frame's materialized primitives are still alive.
- Slot paint is a mirror of **absolute** color writes, so re-emitting with recolors emptied redraws the previous frame's colors exactly, with zero patch traffic.

Per-span stale serving would be unsound (a dead segment has no current tape range to suppress, so it would double-draw or mis-order); the whole command's frame is the smallest coherent unit, and that is what this serves.

## Staleness bound is structural

Serving requires the save to be exactly one build old (`generation + 1 == current`) and to match the retained feed epoch. A served frame does not refresh the save. Two consecutive stale frames are therefore unconstructible — no counter, no cap to tune.

## Renderer untouched

The re-emitted spans flow through the existing serve path, which revalidates the context fingerprint and capture clip every frame and falls back to drawing the saved recording on any mismatch. Every hard invalidator (root-scale change, unsupported frame, rejected collect, device loss) already clears confirmations and bumps the epoch, which the save refuses to serve across.

## Flag

`CRANPOSE_STALE_TRANSITION` (property `debug.cranpose.stale_transition`) gates **both** the save and the serve, default OFF: OFF is today's behavior byte-for-byte with zero saved-state cost. Property table 34 → 35. The device A/B flips it; a follow-up one-line PR flips the default after soak.

## Tests

New `stale_transition_parity` integration test drives a mid-sequence content flip that collapses coverage and pins, with the flag on, that the collapse frame re-serves the previous emission exactly once — and that convergence rebuilds afterward. Full workspace suite green, clippy `-D warnings` clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2
