### PR TITLE
Hold the clock at the frame deadline with an ADPF hint session

### DIFF
--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -1845,6 +1845,11 @@ pub fn run(
 
     let android_frame_driver = AndroidFrameDriver::new(app.create_waker());
     let mut frame_rate_voter = crate::android_frame_rate::FrameRateVoter::default();
+    // The ADPF hint session opens lazily on the first presented frame — the
+    // vsync period is a live estimate by then, and `open` must run on this
+    // loop thread (the session names the calling thread). `Some(None)`
+    // remembers an absent/refused ADPF so it is probed exactly once.
+    let mut perf_hint: Option<Option<crate::android_perf_hint::PerfHintSession>> = None;
     // How long after the last input event the Auto frame-rate vote keeps the
     // panel's fast rate. SurfaceFlinger's own touch boost holds for seconds,
     // and a shorter hold-off measurably hurts: at 1 s the display mode
@@ -2738,11 +2743,14 @@ pub fn run(
         // the expensive update/lowering work, and the present thread's
         // completion wakes the looper through the frame waker. In sync mode
         // `has_frame_credit` is constant `true` and this is today's block.
+        let mut adpf_work_started: Option<web_time::Instant> = None;
+        let mut adpf_sync_presented = false;
         if let (Some(resources), Some(shell)) = (&mut gpu_resources, &mut app_shell) {
             if resources.has_surface()
                 && shell.needs_update()
                 && shell.renderer().has_frame_credit()
             {
+                adpf_work_started = Some(web_time::Instant::now());
                 let update_result = android_host_window::with_android_host_window_registry(
                     &host_window_registry,
                     || shell.update(),
@@ -2794,6 +2802,12 @@ pub fn run(
                         &mut frame_timings,
                     ) {
                         break; // Out of memory, exit
+                    } else {
+                        // Presented exactly when the render arm cleared the
+                        // dirty flag — Reconfigure and Skip both re-set it.
+                        // The telemetry stamps cannot carry this signal:
+                        // they are property-gated zeros in production.
+                        adpf_sync_presented = !resources.surface_dirty;
                     }
                 } else {
                     frame_telemetry.note_idle_iteration();
@@ -2818,6 +2832,26 @@ pub fn run(
         } else {
             drained_present_at
         };
+        // The frame's declared work for the ADPF session: update through
+        // present returning, measured with the loop's own clock — the
+        // telemetry stamps are property-gated and read zero in production.
+        // Threaded-present frames complete elsewhere and report nothing
+        // rather than a made-up number.
+        if adpf_sync_presented {
+            if let Some(started) = adpf_work_started {
+                let reported = crate::android_frame_telemetry::vsync_period_ns();
+                let period = if reported > 0 {
+                    reported
+                } else {
+                    crate::android_vsync::observed_vsync_period_ns().unwrap_or(16_666_667)
+                };
+                let session = perf_hint
+                    .get_or_insert_with(|| crate::android_perf_hint::PerfHintSession::open(period));
+                if let Some(session) = session.as_mut() {
+                    session.report(started.elapsed().as_nanos() as i64, period);
+                }
+            }
+        }
         if let Some(now) = presented_at {
             behind_deadline = catchup_pacing
                 && last_present_at.is_some_and(|previous| {

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -73,11 +73,12 @@ fn property_flag(name: &str) -> bool {
 /// any length — so a name may run right up to or past that pre-O limit, as
 /// `debug.cranpose.retained_mesh_px2` does; every deployment target is far
 /// past O.)
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 34] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 35] = [
     ("debug.cranpose.gpu_stats", "CRANPOSE_GPU_STATS"),
     ("debug.cranpose.present_thread", "CRANPOSE_PRESENT_THREAD"),
     ("debug.cranpose.command_feed", "CRANPOSE_COMMAND_FEED"),
     ("debug.cranpose.arc_mesh", "CRANPOSE_ARC_MESH"),
+    ("debug.cranpose.adpf", "CRANPOSE_ADPF"),
     ("debug.cranpose.rim_mesh", "CRANPOSE_RIM_MESH"),
     ("debug.cranpose.round_cull", "CRANPOSE_ROUND_CULL"),
     (

--- a/crates/cranpose/src/android_perf_hint.rs
+++ b/crates/cranpose/src/android_perf_hint.rs
@@ -1,0 +1,157 @@
+//! ADPF performance-hint session for the Android frame loop.
+//!
+//! On a small watch the cpufreq governor samples the frame loop into a lower
+//! OPP whenever a few frames finish early, and the next heavy frame then
+//! misses its deadline before the clock climbs back — measured on a Pixel
+//! Watch 3 as uniform double-vsync presents every few seconds with no other
+//! system activity, the difference between 59.7 fps and a locked 60. The
+//! platform's answer is the performance-hint session: the loop declares its
+//! target work duration (one vsync) and reports the actual duration every
+//! presented frame, and the kernel holds the clock exactly where the
+//! deadline needs it — the sanctioned, vendor-neutral form of the priority
+//! and DVFS pinning an unprivileged app cannot do itself.
+//!
+//! `APerformanceHint_*` lives in `libandroid.so` from API 33; every symbol
+//! is `dlsym`-resolved so a minSdk 29 build loads everywhere and quietly
+//! does nothing where the API (or a vendor implementation) is absent.
+//! `CRANPOSE_ADPF=0` (property `debug.cranpose.adpf`) is the kill switch.
+
+#![allow(unsafe_code)]
+
+use std::ffi::c_void;
+
+type GetManagerFn = unsafe extern "C" fn() -> *mut c_void;
+type CreateSessionFn = unsafe extern "C" fn(*mut c_void, *const i32, usize, i64) -> *mut c_void;
+type UpdateTargetFn = unsafe extern "C" fn(*mut c_void, i64) -> i32;
+type ReportActualFn = unsafe extern "C" fn(*mut c_void, i64) -> i32;
+type CloseSessionFn = unsafe extern "C" fn(*mut c_void);
+
+struct HintApi {
+    update_target: UpdateTargetFn,
+    report_actual: ReportActualFn,
+    close_session: CloseSessionFn,
+}
+
+/// One hint session for the calling thread. Created on the frame-loop
+/// thread so the session's thread list is exactly the loop itself; the
+/// worker pool's threads earn their cycles through the loop's reports (the
+/// governor scales the cluster, not a core).
+pub(crate) struct PerfHintSession {
+    session: *mut c_void,
+    api: HintApi,
+    target_ns: i64,
+}
+
+// SAFETY: the session pointer is used and closed only from the frame-loop
+// thread that owns this value; the NDK object itself is thread-safe.
+unsafe impl Send for PerfHintSession {}
+
+fn enabled() -> bool {
+    std::env::var("CRANPOSE_ADPF").as_deref() != Ok("0")
+}
+
+unsafe fn resolve(name: &std::ffi::CStr) -> *mut c_void {
+    // SAFETY: dlsym/dlopen with a static NUL-terminated name; libandroid.so
+    // is always loadable by an app process and never closed here.
+    unsafe {
+        let direct = libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr());
+        if !direct.is_null() {
+            return direct;
+        }
+        let library = libc::dlopen(c"libandroid.so".as_ptr(), libc::RTLD_LAZY);
+        if library.is_null() {
+            return std::ptr::null_mut();
+        }
+        libc::dlsym(library, name.as_ptr())
+    }
+}
+
+impl PerfHintSession {
+    /// Opens the session with `target_ns` as the declared work budget.
+    /// `None` where ADPF is absent, disabled, or refuses the session —
+    /// callers keep exactly the pre-ADPF behavior.
+    pub(crate) fn open(target_ns: i64) -> Option<Self> {
+        if !enabled() || target_ns <= 0 {
+            return None;
+        }
+        // SAFETY: symbols come from libandroid.so and the transmutes target
+        // the NDK-documented APerformanceHint signatures; null checks gate
+        // every call; gettid names the calling thread, which is the thread
+        // the session is created for.
+        unsafe {
+            let get_manager = resolve(c"APerformanceHint_getManager");
+            let create_session = resolve(c"APerformanceHint_createSession");
+            let update_target = resolve(c"APerformanceHint_updateTargetWorkDuration");
+            let report_actual = resolve(c"APerformanceHint_reportActualWorkDuration");
+            let close_session = resolve(c"APerformanceHint_closeSession");
+            if get_manager.is_null()
+                || create_session.is_null()
+                || update_target.is_null()
+                || report_actual.is_null()
+                || close_session.is_null()
+            {
+                log::info!("[perf-hint] APerformanceHint unavailable; running without");
+                return None;
+            }
+            let get_manager = std::mem::transmute::<*mut c_void, GetManagerFn>(get_manager);
+            let create_session =
+                std::mem::transmute::<*mut c_void, CreateSessionFn>(create_session);
+            let manager = get_manager();
+            if manager.is_null() {
+                log::info!("[perf-hint] no hint manager on this device");
+                return None;
+            }
+            let tid = libc::gettid();
+            let session = create_session(manager, &tid, 1, target_ns);
+            if session.is_null() {
+                log::info!("[perf-hint] session refused");
+                return None;
+            }
+            log::info!(
+                "[perf-hint] session open, target {:.2} ms",
+                target_ns as f64 / 1e6
+            );
+            Some(Self {
+                session,
+                api: HintApi {
+                    update_target: std::mem::transmute::<*mut c_void, UpdateTargetFn>(
+                        update_target,
+                    ),
+                    report_actual: std::mem::transmute::<*mut c_void, ReportActualFn>(
+                        report_actual,
+                    ),
+                    close_session: std::mem::transmute::<*mut c_void, CloseSessionFn>(
+                        close_session,
+                    ),
+                },
+                target_ns,
+            })
+        }
+    }
+
+    /// Reports one presented frame's work duration, refreshing the target
+    /// first when the display period moved (mode switch); tiny jitter in
+    /// the period estimate is not a new target.
+    pub(crate) fn report(&mut self, actual_ns: i64, target_ns: i64) {
+        if actual_ns <= 0 {
+            return;
+        }
+        // SAFETY: session is the live pointer `open` created on this thread.
+        unsafe {
+            if target_ns > 0 && (target_ns - self.target_ns).abs() > self.target_ns / 64 {
+                if (self.api.update_target)(self.session, target_ns) == 0 {
+                    self.target_ns = target_ns;
+                }
+            }
+            (self.api.report_actual)(self.session, actual_ns);
+        }
+    }
+}
+
+impl Drop for PerfHintSession {
+    fn drop(&mut self) {
+        // SAFETY: closes the pointer `open` created; dropped on the same
+        // thread, after which it is never touched.
+        unsafe { (self.api.close_session)(self.session) }
+    }
+}

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -57,6 +57,8 @@ mod android_keyboard;
 mod android_launch_args;
 #[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
 mod android_overlay_window;
+#[cfg(all(feature = "android", target_os = "android"))]
+mod android_perf_hint;
 /// The Play Billing wire format behind `cranpose_services::purchases`. Built on
 /// the host as well so its decoding tests run everywhere.
 #[cfg(any(

--- a/crates/cranpose/tests/platform_scheduling_static.rs
+++ b/crates/cranpose/tests/platform_scheduling_static.rs
@@ -1256,6 +1256,9 @@ fn unsafe_code_stays_in_reviewed_platform_boundary_modules() {
         // `ANativeWindow_setFrameRate*` NDK symbols and the calls through
         // them, mirroring how HWUI votes the panel's frame rate.
         "android_frame_rate.rs",
+        // The ADPF hint session: dlsym-resolved APerformanceHint_* calls and
+        // the sessions they manage; absent symbols degrade to a no-op.
+        "android_perf_hint.rs",
         "android_frame_telemetry.rs",
         "android_jni.rs",
         "android_accessibility.rs",
@@ -1454,6 +1457,7 @@ fn workspace_ffi_boundaries_are_explicit() {
         // `ANativeWindow_setFrameRate*` NDK symbols and the calls through
         // them, mirroring how HWUI votes the panel's frame rate.
         "crates/cranpose/src/android_frame_rate.rs",
+        "crates/cranpose/src/android_perf_hint.rs",
         "crates/cranpose/src/android_frame_telemetry.rs",
         "crates/cranpose/src/android_jni.rs",
         "crates/cranpose/src/android_accessibility.rs",


### PR DESCRIPTION
Observer-clean SurfaceFlinger latency rings on a Pixel Watch 3 show the gap between 59.7 fps and a locked 60 is uniform double-vsync presents — no periodic co-tenant, no big stalls, just marginal frames missing the deadline while the cpufreq governor samples the loop into a lower OPP between them. The platform's answer is the performance hint session: the frame loop declares one vsync as its target work duration and reports each presented frame's actual duration, and the kernel holds the clock where the deadline needs it. This is the sanctioned, vendor-neutral form of the DVFS pinning an unprivileged app cannot do itself.

`APerformanceHint_*` is `dlsym`-resolved from `libandroid.so` (API 33+), so a minSdk 29 build loads everywhere and quietly runs without a session where the API — or a vendor implementation — is missing. The session opens lazily on the first presented frame, on the loop thread it names, and probes exactly once.

The reported duration is measured with the loop's own clock (update through present returning), **not** the frame-telemetry stamps: those are property-gated and read zero in production builds. Threaded-present frames complete elsewhere and report nothing rather than a made-up number.

Kill switch `CRANPOSE_ADPF=0` (property `debug.cranpose.adpf`).

## Device status, honestly

The campaign device cannot exercise this: the Pixel Watch 3's PowerHAL reports `Hint Session Support: false` / `HintSessionPreferredRate: -1`, and `createSession` returns null there — the implementation was verified end-to-end by its own probe logging (`[perf-hint] session refused` after a live manager), which is exactly the no-op-and-continue path. It lands as a zero-risk fleet feature for the many Android devices whose HAL does support sessions; measurement on such a device is future work.

Verified: Android armv7 build (the only build that compiles the `target_os = "android"` telemetry module), host workspace tests, clippy `-D warnings`, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJBDkLjfXHRBJeM6bZp6b2
