### PR TITLE
Time each pass on the GPU, and run the fused blur's vertical axis at scratch size

### DIFF
--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -7,7 +7,7 @@ use crate::frame_graph::{
     FrameCommandRecorder, FrameCommandStats, FrameTextureDescriptor, UploadAllocatorId,
     UploadAllocatorSpec,
 };
-use crate::gpu_timing::GpuSpanKind;
+use crate::gpu_timing::{GpuSpanKind, PassTimestamps};
 use crate::offscreen::{OffscreenPool, OffscreenTarget};
 use crate::shader_cache::{RuntimeShaderPipelineMode, ShaderPipelineCache};
 use crate::shaders;
@@ -1028,7 +1028,7 @@ impl EffectRenderer {
             &self.debug_upload_bytes,
         );
         self.note_offscreen_fill(scissor, None, dest_size);
-        let span = recorder.begin_gpu_span(
+        let timestamps = recorder.pass_timestamps(
             if horizontal {
                 GpuSpanKind::BlurHorizontal
             } else {
@@ -1045,6 +1045,7 @@ impl EffectRenderer {
                 } else {
                     "Blur Vertical Pass"
                 }),
+                timestamp_writes: timestamps.as_ref().map(PassTimestamps::writes),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: dest_view,
                     resolve_target: None,
@@ -1064,8 +1065,6 @@ impl EffectRenderer {
             pass.set_scissor_rect(x, y, w, h);
         }
         pass.draw(0..4, 0..1);
-        drop(pass);
-        recorder.end_gpu_span(span);
     }
 
     fn blur_uniforms(
@@ -1256,7 +1255,7 @@ impl EffectRenderer {
             &self.debug_upload_bytes,
         );
         self.note_composite_fill(scissor, Some(dest_viewport), (source.width, source.height));
-        let span = recorder.begin_gpu_span(
+        let timestamps = recorder.pass_timestamps(
             GpuSpanKind::BlurRoundedMask,
             dest_viewport.2.max(0.0) as u32,
             dest_viewport.3.max(0.0) as u32,
@@ -1265,6 +1264,7 @@ impl EffectRenderer {
             .encoder()
             .begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("Blur Rounded Mask Pass"),
+                timestamp_writes: timestamps.as_ref().map(PassTimestamps::writes),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: dest_view,
                     resolve_target: None,
@@ -1286,8 +1286,6 @@ impl EffectRenderer {
             pass.set_scissor_rect(x, y, w, h);
         }
         pass.draw(0..4, 0..1);
-        drop(pass);
-        recorder.end_gpu_span(span);
         true
     }
 
@@ -1836,7 +1834,7 @@ impl EffectRenderer {
             (source.width, source.height),
         );
 
-        let span = recorder.begin_gpu_span(
+        let timestamps = recorder.pass_timestamps(
             GpuSpanKind::Composite,
             options
                 .dest_viewport
@@ -1849,6 +1847,7 @@ impl EffectRenderer {
             .encoder()
             .begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("Blit Composite Pass"),
+                timestamp_writes: timestamps.as_ref().map(PassTimestamps::writes),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: dest_view,
                     resolve_target: None,
@@ -1869,8 +1868,6 @@ impl EffectRenderer {
             pass.set_scissor_rect(x, y, w, h);
         }
         pass.draw(0..4, 0..1);
-        drop(pass);
-        recorder.end_gpu_span(span);
     }
 
     pub(crate) fn encode_composite_batch_to_view_pass<C: FrameCommandRecorder>(
@@ -1888,11 +1885,12 @@ impl EffectRenderer {
 
         let prepared = self.prepare_composite_batch_draws(recorder, device, load_op, items);
 
-        let span = recorder.begin_gpu_span(GpuSpanKind::Composite, viewport.0, viewport.1);
+        let timestamps = recorder.pass_timestamps(GpuSpanKind::Composite, viewport.0, viewport.1);
         let mut pass = recorder
             .encoder()
             .begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("Batched Blit Composite Pass"),
+                timestamp_writes: timestamps.as_ref().map(PassTimestamps::writes),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: dest_view,
                     resolve_target: None,
@@ -1909,8 +1907,6 @@ impl EffectRenderer {
         for draw in &prepared {
             self.draw_prepared_composite(&mut pass, viewport, draw);
         }
-        drop(pass);
-        recorder.end_gpu_span(span);
     }
 
     pub(crate) fn prepare_composite_batch_draws<'a, C: FrameCommandRecorder>(

--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -1193,7 +1193,6 @@ impl EffectRenderer {
         device: &wgpu::Device,
         source: &OffscreenTarget,
         scratch: &OffscreenTarget,
-        vertical_scratch: Option<&OffscreenTarget>,
         dest_view: &wgpu::TextureView,
         radius_x: f32,
         radius_y: f32,
@@ -1209,13 +1208,6 @@ impl EffectRenderer {
         }
         let scale_x = source.width as f32 / scratch.width.max(1) as f32;
         let scale_y = source.height as f32 / scratch.height.max(1) as f32;
-        let vertical_scratch = vertical_scratch
-            .filter(|target| target.width == scratch.width && target.height == scratch.height);
-        let mask_radius_y = if vertical_scratch.is_some() {
-            0.0
-        } else {
-            radius_y / scale_y
-        };
         let Some(mask_uniforms) = Self::rounded_mask_uniforms(
             shader,
             layer_pixel_rect,
@@ -1224,7 +1216,7 @@ impl EffectRenderer {
             scratch.width,
             scratch.height,
             radius_x / scale_x,
-            mask_radius_y,
+            radius_y / scale_y,
             tile_mode,
         ) else {
             return false;
@@ -1249,32 +1241,7 @@ impl EffectRenderer {
             (scratch.width, scratch.height),
         );
 
-        let masked_source = match vertical_scratch {
-            Some(vertical) => {
-                self.encode_blur_axis_pass(
-                    recorder,
-                    device,
-                    scratch,
-                    &vertical.view,
-                    Self::blur_uniforms(
-                        false,
-                        scratch.width,
-                        scratch.height,
-                        radius_x / scale_x,
-                        radius_y / scale_y,
-                        tile_mode,
-                    ),
-                    false,
-                    wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                    None,
-                    (scratch.width, scratch.height),
-                );
-                vertical
-            }
-            None => scratch,
-        };
-
-        let scratch_bind_group = masked_source.get_or_create_bind_group(
+        let scratch_bind_group = scratch.get_or_create_bind_group(
             device,
             &self.effect_texture_bind_group_layout,
             &self.effect_linear_sampler,
@@ -2211,42 +2178,6 @@ fn composite_sampling_mode_value(sample_mode: CompositeSampleMode) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::{projective_dest_bounds_rect, BlurUniforms};
-
-    #[test]
-    fn a_vertical_blur_at_the_scratch_size_leaves_the_mask_pass_one_sample() {
-        use cranpose_ui_graphics::{rounded_alpha_mask_effect, RenderEffect, TileMode};
-        let RenderEffect::Shader { shader } = rounded_alpha_mask_effect(120.0, 40.0, 8.0, 1.0)
-        else {
-            panic!("the rounded alpha mask is a runtime shader effect");
-        };
-        let with_scratch = super::EffectRenderer::rounded_mask_uniforms(
-            &shader,
-            [0.0, 0.0, 120.0, 40.0],
-            480,
-            160,
-            120,
-            40,
-            2.5,
-            0.0,
-            TileMode::Clamp,
-        )
-        .expect("the rounded alpha mask shader carries mask uniforms");
-        assert_eq!(with_scratch.direction_and_radius[3], 0.0);
-
-        let without_scratch = super::EffectRenderer::rounded_mask_uniforms(
-            &shader,
-            [0.0, 0.0, 120.0, 40.0],
-            480,
-            160,
-            120,
-            40,
-            2.5,
-            2.5,
-            TileMode::Clamp,
-        )
-        .expect("the rounded alpha mask shader carries mask uniforms");
-        assert_eq!(without_scratch.direction_and_radius[3], 2.5);
-    }
 
     #[test]
     fn blur_uniforms_use_vec4_packing_for_gl_backends() {

--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -7,6 +7,7 @@ use crate::frame_graph::{
     FrameCommandRecorder, FrameCommandStats, FrameTextureDescriptor, UploadAllocatorId,
     UploadAllocatorSpec,
 };
+use crate::gpu_timing::GpuSpanKind;
 use crate::offscreen::{OffscreenPool, OffscreenTarget};
 use crate::shader_cache::{RuntimeShaderPipelineMode, ShaderPipelineCache};
 use crate::shaders;
@@ -1027,6 +1028,15 @@ impl EffectRenderer {
             &self.debug_upload_bytes,
         );
         self.note_offscreen_fill(scissor, None, dest_size);
+        let span = recorder.begin_gpu_span(
+            if horizontal {
+                GpuSpanKind::BlurHorizontal
+            } else {
+                GpuSpanKind::BlurVertical
+            },
+            dest_size.0,
+            dest_size.1,
+        );
         let mut pass = recorder
             .encoder()
             .begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -1054,6 +1064,8 @@ impl EffectRenderer {
             pass.set_scissor_rect(x, y, w, h);
         }
         pass.draw(0..4, 0..1);
+        drop(pass);
+        recorder.end_gpu_span(span);
     }
 
     fn blur_uniforms(
@@ -1244,6 +1256,11 @@ impl EffectRenderer {
             &self.debug_upload_bytes,
         );
         self.note_composite_fill(scissor, Some(dest_viewport), (source.width, source.height));
+        let span = recorder.begin_gpu_span(
+            GpuSpanKind::BlurRoundedMask,
+            dest_viewport.2.max(0.0) as u32,
+            dest_viewport.3.max(0.0) as u32,
+        );
         let mut pass = recorder
             .encoder()
             .begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -1269,6 +1286,8 @@ impl EffectRenderer {
             pass.set_scissor_rect(x, y, w, h);
         }
         pass.draw(0..4, 0..1);
+        drop(pass);
+        recorder.end_gpu_span(span);
         true
     }
 
@@ -1817,6 +1836,15 @@ impl EffectRenderer {
             (source.width, source.height),
         );
 
+        let span = recorder.begin_gpu_span(
+            GpuSpanKind::Composite,
+            options
+                .dest_viewport
+                .map_or(source.width, |viewport| viewport.2.max(0.0) as u32),
+            options
+                .dest_viewport
+                .map_or(source.height, |viewport| viewport.3.max(0.0) as u32),
+        );
         let mut pass = recorder
             .encoder()
             .begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -1841,6 +1869,8 @@ impl EffectRenderer {
             pass.set_scissor_rect(x, y, w, h);
         }
         pass.draw(0..4, 0..1);
+        drop(pass);
+        recorder.end_gpu_span(span);
     }
 
     pub(crate) fn encode_composite_batch_to_view_pass<C: FrameCommandRecorder>(
@@ -1858,6 +1888,7 @@ impl EffectRenderer {
 
         let prepared = self.prepare_composite_batch_draws(recorder, device, load_op, items);
 
+        let span = recorder.begin_gpu_span(GpuSpanKind::Composite, viewport.0, viewport.1);
         let mut pass = recorder
             .encoder()
             .begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -1878,6 +1909,8 @@ impl EffectRenderer {
         for draw in &prepared {
             self.draw_prepared_composite(&mut pass, viewport, draw);
         }
+        drop(pass);
+        recorder.end_gpu_span(span);
     }
 
     pub(crate) fn prepare_composite_batch_draws<'a, C: FrameCommandRecorder>(

--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -1193,6 +1193,7 @@ impl EffectRenderer {
         device: &wgpu::Device,
         source: &OffscreenTarget,
         scratch: &OffscreenTarget,
+        vertical_scratch: Option<&OffscreenTarget>,
         dest_view: &wgpu::TextureView,
         radius_x: f32,
         radius_y: f32,
@@ -1208,6 +1209,13 @@ impl EffectRenderer {
         }
         let scale_x = source.width as f32 / scratch.width.max(1) as f32;
         let scale_y = source.height as f32 / scratch.height.max(1) as f32;
+        let vertical_scratch = vertical_scratch
+            .filter(|target| target.width == scratch.width && target.height == scratch.height);
+        let mask_radius_y = if vertical_scratch.is_some() {
+            0.0
+        } else {
+            radius_y / scale_y
+        };
         let Some(mask_uniforms) = Self::rounded_mask_uniforms(
             shader,
             layer_pixel_rect,
@@ -1216,7 +1224,7 @@ impl EffectRenderer {
             scratch.width,
             scratch.height,
             radius_x / scale_x,
-            radius_y / scale_y,
+            mask_radius_y,
             tile_mode,
         ) else {
             return false;
@@ -1241,7 +1249,32 @@ impl EffectRenderer {
             (scratch.width, scratch.height),
         );
 
-        let scratch_bind_group = scratch.get_or_create_bind_group(
+        let masked_source = match vertical_scratch {
+            Some(vertical) => {
+                self.encode_blur_axis_pass(
+                    recorder,
+                    device,
+                    scratch,
+                    &vertical.view,
+                    Self::blur_uniforms(
+                        false,
+                        scratch.width,
+                        scratch.height,
+                        radius_x / scale_x,
+                        radius_y / scale_y,
+                        tile_mode,
+                    ),
+                    false,
+                    wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    None,
+                    (scratch.width, scratch.height),
+                );
+                vertical
+            }
+            None => scratch,
+        };
+
+        let scratch_bind_group = masked_source.get_or_create_bind_group(
             device,
             &self.effect_texture_bind_group_layout,
             &self.effect_linear_sampler,
@@ -2178,6 +2211,42 @@ fn composite_sampling_mode_value(sample_mode: CompositeSampleMode) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::{projective_dest_bounds_rect, BlurUniforms};
+
+    #[test]
+    fn a_vertical_blur_at_the_scratch_size_leaves_the_mask_pass_one_sample() {
+        use cranpose_ui_graphics::{rounded_alpha_mask_effect, RenderEffect, TileMode};
+        let RenderEffect::Shader { shader } = rounded_alpha_mask_effect(120.0, 40.0, 8.0, 1.0)
+        else {
+            panic!("the rounded alpha mask is a runtime shader effect");
+        };
+        let with_scratch = super::EffectRenderer::rounded_mask_uniforms(
+            &shader,
+            [0.0, 0.0, 120.0, 40.0],
+            480,
+            160,
+            120,
+            40,
+            2.5,
+            0.0,
+            TileMode::Clamp,
+        )
+        .expect("the rounded alpha mask shader carries mask uniforms");
+        assert_eq!(with_scratch.direction_and_radius[3], 0.0);
+
+        let without_scratch = super::EffectRenderer::rounded_mask_uniforms(
+            &shader,
+            [0.0, 0.0, 120.0, 40.0],
+            480,
+            160,
+            120,
+            40,
+            2.5,
+            2.5,
+            TileMode::Clamp,
+        )
+        .expect("the rounded alpha mask shader carries mask uniforms");
+        assert_eq!(without_scratch.direction_and_radius[3], 2.5);
+    }
 
     #[test]
     fn blur_uniforms_use_vec4_packing_for_gl_backends() {

--- a/crates/cranpose-render/wgpu/src/frame_graph.rs
+++ b/crates/cranpose-render/wgpu/src/frame_graph.rs
@@ -1,4 +1,4 @@
-use crate::gpu_timing::{GpuFrameTimer, GpuSpanId, GpuSpanKind};
+use crate::gpu_timing::{GpuFrameTimer, GpuSpanKind, PassTimestamps};
 use crate::offscreen::OffscreenTarget;
 use std::cell::{Cell, OnceCell};
 use std::fmt;
@@ -680,14 +680,12 @@ pub(crate) trait FrameCommandRecorder {
 
     fn recorded_pass_count(&self) -> u32;
 
-    fn begin_gpu_span(
+    fn pass_timestamps(
         &mut self,
         kind: GpuSpanKind,
         width: u32,
         height: u32,
-    ) -> Option<GpuSpanId>;
-
-    fn end_gpu_span(&mut self, span: Option<GpuSpanId>);
+    ) -> Option<PassTimestamps>;
 }
 
 impl FrameCommandRecorder for PassContext<'_> {
@@ -759,12 +757,13 @@ impl FrameCommandRecorder for PassContext<'_> {
         self.pass_count
     }
 
-    fn begin_gpu_span(&mut self, kind: GpuSpanKind, width: u32, height: u32) -> Option<GpuSpanId> {
-        self.gpu_timer.begin_span(self.encoder, kind, width, height)
-    }
-
-    fn end_gpu_span(&mut self, span: Option<GpuSpanId>) {
-        self.gpu_timer.end_span(self.encoder, span);
+    fn pass_timestamps(
+        &mut self,
+        kind: GpuSpanKind,
+        width: u32,
+        height: u32,
+    ) -> Option<PassTimestamps> {
+        self.gpu_timer.pass_timestamps(kind, width, height)
     }
 }
 
@@ -920,13 +919,13 @@ impl FrameCommandRecorder for WgpuFrameEncoder<'_> {
         Self::recorded_pass_count(self)
     }
 
-    fn begin_gpu_span(&mut self, kind: GpuSpanKind, width: u32, height: u32) -> Option<GpuSpanId> {
-        self.gpu_timer
-            .begin_span(&mut self.encoder, kind, width, height)
-    }
-
-    fn end_gpu_span(&mut self, span: Option<GpuSpanId>) {
-        self.gpu_timer.end_span(&mut self.encoder, span);
+    fn pass_timestamps(
+        &mut self,
+        kind: GpuSpanKind,
+        width: u32,
+        height: u32,
+    ) -> Option<PassTimestamps> {
+        self.gpu_timer.pass_timestamps(kind, width, height)
     }
 }
 

--- a/crates/cranpose-render/wgpu/src/frame_graph.rs
+++ b/crates/cranpose-render/wgpu/src/frame_graph.rs
@@ -1,3 +1,4 @@
+use crate::gpu_timing::{GpuFrameTimer, GpuSpanId, GpuSpanKind};
 use crate::offscreen::OffscreenTarget;
 use std::cell::{Cell, OnceCell};
 use std::fmt;
@@ -7,6 +8,7 @@ use web_time::Instant;
 pub(crate) struct WgpuFrameGraphExecutor {
     transient_textures: TransientTexturePool,
     upload_allocators: FrameUploadAllocators,
+    gpu_timer: GpuFrameTimer,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -332,6 +334,7 @@ pub(crate) struct PassContext<'pass> {
     transient_texture_bytes: &'pass mut u64,
     staged_upload_cursor: &'pass mut u64,
     pass_count: u32,
+    gpu_timer: &'pass mut GpuFrameTimer,
 }
 
 fn texture_format_bytes_per_pixel(format: wgpu::TextureFormat) -> u64 {
@@ -449,6 +452,7 @@ impl WgpuFrameGraphExecutor {
             transient_releases: PendingTransientReleases::new(&mut self.transient_textures),
             transient_texture_bytes: 0,
             pass_count: 0,
+            gpu_timer: &mut self.gpu_timer,
         }
     }
 
@@ -466,6 +470,7 @@ impl WgpuFrameGraphExecutor {
         let mut staged_upload_cursor = 0u64;
         let mut pending_transient_releases = Vec::new();
         let mut encoder = Self::create_command_encoder(device, graph.label);
+        self.gpu_timer.begin_frame(device, queue, &mut encoder);
 
         if graph.passes.len() == 1 {
             let pass = graph
@@ -526,7 +531,9 @@ impl WgpuFrameGraphExecutor {
             release_pending_transients(&mut self.transient_textures, pending_transient_releases);
             return Err(FrameGraphError::NoDeclaredPasses);
         }
+        self.gpu_timer.end_frame(&mut encoder);
         let submission = Self::submit_with_timing(queue, encoder);
+        self.gpu_timer.after_submit(device);
         release_pending_transients(&mut self.transient_textures, pending_transient_releases);
         let retained_texture_bytes = self.retained_texture_bytes();
         Ok(FrameGraphExecution {
@@ -564,6 +571,7 @@ impl WgpuFrameGraphExecutor {
             transient_texture_bytes,
             staged_upload_cursor,
             pass_count: 0,
+            gpu_timer: &mut self.gpu_timer,
         };
         let recorded_pass_count = pass.encode(pass_index, &mut context)?;
         log_frame_graph_pass_timing(pass_start, pass_label, pass_index);
@@ -671,6 +679,15 @@ pub(crate) trait FrameCommandRecorder {
     }
 
     fn recorded_pass_count(&self) -> u32;
+
+    fn begin_gpu_span(
+        &mut self,
+        kind: GpuSpanKind,
+        width: u32,
+        height: u32,
+    ) -> Option<GpuSpanId>;
+
+    fn end_gpu_span(&mut self, span: Option<GpuSpanId>);
 }
 
 impl FrameCommandRecorder for PassContext<'_> {
@@ -741,6 +758,14 @@ impl FrameCommandRecorder for PassContext<'_> {
     fn recorded_pass_count(&self) -> u32 {
         self.pass_count
     }
+
+    fn begin_gpu_span(&mut self, kind: GpuSpanKind, width: u32, height: u32) -> Option<GpuSpanId> {
+        self.gpu_timer.begin_span(self.encoder, kind, width, height)
+    }
+
+    fn end_gpu_span(&mut self, span: Option<GpuSpanId>) {
+        self.gpu_timer.end_span(self.encoder, span);
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -749,6 +774,7 @@ pub(crate) struct WgpuFrameEncoder<'a> {
     encoder: wgpu::CommandEncoder,
     uploads: &'a mut FrameUploadAllocators,
     transient_releases: PendingTransientReleases<'a>,
+    gpu_timer: &'a mut GpuFrameTimer,
     transient_texture_bytes: u64,
     pass_count: u32,
 }
@@ -892,6 +918,15 @@ impl FrameCommandRecorder for WgpuFrameEncoder<'_> {
 
     fn recorded_pass_count(&self) -> u32 {
         Self::recorded_pass_count(self)
+    }
+
+    fn begin_gpu_span(&mut self, kind: GpuSpanKind, width: u32, height: u32) -> Option<GpuSpanId> {
+        self.gpu_timer
+            .begin_span(&mut self.encoder, kind, width, height)
+    }
+
+    fn end_gpu_span(&mut self, span: Option<GpuSpanId>) {
+        self.gpu_timer.end_span(&mut self.encoder, span);
     }
 }
 

--- a/crates/cranpose-render/wgpu/src/gpu_timing.rs
+++ b/crates/cranpose-render/wgpu/src/gpu_timing.rs
@@ -155,7 +155,76 @@ pub(crate) fn decode_spans(spans: &[SpanRecord], ticks: &[u64], period_ns: f32) 
 #[derive(Default)]
 pub(crate) struct GpuFrameTimer {
     state: Option<TimerState>,
+    sizes: Option<SizeReport>,
     refused: bool,
+}
+
+#[derive(Default)]
+pub(crate) struct SizeReport {
+    window: u32,
+    frames: u32,
+    buckets: BTreeMap<(GpuSpanKind, u32, u32), u32>,
+    frame: Vec<(GpuSpanKind, u32, u32)>,
+    last_frame: Vec<(GpuSpanKind, u32, u32)>,
+}
+
+impl SizeReport {
+    pub(crate) fn new(window: u32) -> Self {
+        Self {
+            window,
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn record(&mut self, kind: GpuSpanKind, width: u32, height: u32) {
+        if self.frame.len() < MAX_LISTED_PASSES {
+            self.frame.push((kind, width, height));
+        }
+    }
+
+    pub(crate) fn end_frame(&mut self) {
+        self.frames += 1;
+        for entry in &self.frame {
+            *self.buckets.entry(*entry).or_default() += 1;
+        }
+        std::mem::swap(&mut self.last_frame, &mut self.frame);
+        self.frame.clear();
+        if self.frames >= self.window {
+            self.print();
+            let window = self.window;
+            *self = Self::new(window);
+        }
+    }
+
+    fn print(&self) {
+        if self.frames == 0 {
+            return;
+        }
+        let frames = f64::from(self.frames);
+        log::warn!(
+            "[gpu-pass] sizes only, frames={}, the adapter carries no timestamp query",
+            self.frames
+        );
+        for ((kind, width, height), count) in &self.buckets {
+            log::warn!(
+                "[gpu-pass]   {} {}x{} per_frame_n={:.2}",
+                kind.label(),
+                width,
+                height,
+                f64::from(*count) / frames,
+            );
+        }
+        let mut line = String::new();
+        for (kind, width, height) in &self.last_frame {
+            if !line.is_empty() {
+                line.push_str("; ");
+            }
+            line.push_str(&format!("{} {width}x{height}", kind.label()));
+        }
+        if !line.is_empty() {
+            log::warn!("[gpu-pass]   one frame: {line}");
+        }
+    }
 }
 
 struct TimerState {
@@ -186,10 +255,6 @@ struct Pending {
 }
 
 impl GpuFrameTimer {
-    pub(crate) fn is_on(&self) -> bool {
-        self.state.is_some()
-    }
-
     pub(crate) fn begin_frame(
         &mut self,
         device: &wgpu::Device,
@@ -205,8 +270,12 @@ impl GpuFrameTimer {
         };
         if self.state.is_none() {
             if !device.features().contains(wgpu::Features::TIMESTAMP_QUERY) {
-                self.refused = true;
-                log::warn!("[gpu-pass] the device has no timestamp queries, timing stays off");
+                if self.sizes.is_none() {
+                    log::warn!(
+                        "[gpu-pass] the device has no timestamp query, the report carries pass sizes alone"
+                    );
+                    self.sizes = Some(SizeReport::new(window));
+                }
                 return;
             }
             let inside_encoders = device
@@ -237,10 +306,18 @@ impl GpuFrameTimer {
         width: u32,
         height: u32,
     ) -> Option<PassTimestamps> {
+        if let Some(sizes) = self.sizes.as_mut() {
+            sizes.record(kind, width, height);
+            return None;
+        }
         self.state.as_mut()?.open_pass(kind, width, height)
     }
 
     pub(crate) fn end_frame(&mut self, encoder: &mut wgpu::CommandEncoder) {
+        if let Some(sizes) = self.sizes.as_mut() {
+            sizes.end_frame();
+            return;
+        }
         let Some(state) = self.state.as_mut() else {
             return;
         };
@@ -629,6 +706,26 @@ mod tests {
         assert!((report.blur_ms() - 3.0).abs() < 1e-9);
         assert!((report.composite_ms() - 3.0).abs() < 1e-9);
         assert!((report.frame_ms - report.spans_ms() - 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn the_size_report_counts_passes_per_frame() {
+        let mut report = SizeReport::new(2);
+        report.record(GpuSpanKind::BlurHorizontal, 270, 100);
+        report.record(GpuSpanKind::BlurHorizontal, 270, 100);
+        report.record(GpuSpanKind::Composite, 1080, 420);
+        report.end_frame();
+        assert_eq!(report.frames, 1);
+        assert_eq!(
+            report.buckets.get(&(GpuSpanKind::BlurHorizontal, 270, 100)),
+            Some(&2)
+        );
+        assert_eq!(report.last_frame.len(), 3);
+        assert!(report.frame.is_empty());
+        report.record(GpuSpanKind::Composite, 1080, 420);
+        report.end_frame();
+        assert_eq!(report.frames, 0);
+        assert!(report.buckets.is_empty());
     }
 
     #[test]

--- a/crates/cranpose-render/wgpu/src/gpu_timing.rs
+++ b/crates/cranpose-render/wgpu/src/gpu_timing.rs
@@ -22,15 +22,23 @@ pub fn timing_window_frames() -> Option<u32> {
 }
 
 pub fn requested_features(adapter_features: wgpu::Features) -> wgpu::Features {
-    if timing_window_frames().is_none() {
+    let Some(window) = timing_window_frames() else {
+        return wgpu::Features::empty();
+    };
+    log::warn!(
+        "[gpu-pass] window={window} adapter timestamp_query={} inside_encoders={} inside_passes={}",
+        adapter_features.contains(wgpu::Features::TIMESTAMP_QUERY),
+        adapter_features.contains(wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS),
+        adapter_features.contains(wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES),
+    );
+    if !adapter_features.contains(wgpu::Features::TIMESTAMP_QUERY) {
         return wgpu::Features::empty();
     }
-    let wanted = wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS;
-    if adapter_features.contains(wanted) {
-        wanted
-    } else {
-        wgpu::Features::empty()
+    let mut asked = wgpu::Features::TIMESTAMP_QUERY;
+    if adapter_features.contains(wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS) {
+        asked |= wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS;
     }
+    asked
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
@@ -65,6 +73,22 @@ impl GpuSpanKind {
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct GpuSpanId(usize);
+
+pub(crate) struct PassTimestamps {
+    query_set: wgpu::QuerySet,
+    begin: u32,
+    end: u32,
+}
+
+impl PassTimestamps {
+    pub(crate) fn writes(&self) -> wgpu::RenderPassTimestampWrites<'_> {
+        wgpu::RenderPassTimestampWrites {
+            query_set: &self.query_set,
+            beginning_of_pass_write_index: Some(self.begin),
+            end_of_pass_write_index: Some(self.end),
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct SpanRecord {
@@ -145,6 +169,7 @@ struct TimerState {
     dropped_spans: u32,
     period_ns: f32,
     window: u32,
+    inside_encoders: bool,
     report: Report,
 }
 
@@ -179,15 +204,18 @@ impl GpuFrameTimer {
             return;
         };
         if self.state.is_none() {
-            let wanted =
-                wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS;
-            if !device.features().contains(wanted) {
+            if !device.features().contains(wgpu::Features::TIMESTAMP_QUERY) {
                 self.refused = true;
                 log::warn!("[gpu-pass] the device has no timestamp queries, timing stays off");
                 return;
             }
-            self.state = Some(TimerState::new(device, queue, window));
-            log::warn!("[gpu-pass] per pass timing on, window={window} frames");
+            let inside_encoders = device
+                .features()
+                .contains(wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS);
+            self.state = Some(TimerState::new(device, queue, window, inside_encoders));
+            log::warn!(
+                "[gpu-pass] per pass timing on, window={window} frames, frame span={inside_encoders}"
+            );
         }
         let Some(state) = self.state.as_mut() else {
             return;
@@ -196,24 +224,20 @@ impl GpuFrameTimer {
         state.spans.clear();
         state.dropped_spans = 0;
         state.filled_slot = None;
-        state.frame_span = state.open(encoder, GpuSpanKind::Frame, 0, 0);
+        state.frame_span = None;
+        if state.inside_encoders {
+            let frame_span = state.open_encoder_span(encoder, GpuSpanKind::Frame, 0, 0);
+            state.frame_span = frame_span;
+        }
     }
 
-    pub(crate) fn begin_span(
+    pub(crate) fn pass_timestamps(
         &mut self,
-        encoder: &mut wgpu::CommandEncoder,
         kind: GpuSpanKind,
         width: u32,
         height: u32,
-    ) -> Option<GpuSpanId> {
-        self.state.as_mut()?.open(encoder, kind, width, height)
-    }
-
-    pub(crate) fn end_span(&mut self, encoder: &mut wgpu::CommandEncoder, span: Option<GpuSpanId>) {
-        let (Some(state), Some(span)) = (self.state.as_mut(), span) else {
-            return;
-        };
-        state.close(encoder, span);
+    ) -> Option<PassTimestamps> {
+        self.state.as_mut()?.open_pass(kind, width, height)
     }
 
     pub(crate) fn end_frame(&mut self, encoder: &mut wgpu::CommandEncoder) {
@@ -237,7 +261,12 @@ impl GpuFrameTimer {
 }
 
 impl TimerState {
-    fn new(device: &wgpu::Device, queue: &wgpu::Queue, window: u32) -> Self {
+    fn new(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        window: u32,
+        inside_encoders: bool,
+    ) -> Self {
         let query_set = device.create_query_set(&wgpu::QuerySetDescriptor {
             label: Some("Gpu Pass Timing Query Set"),
             ty: wgpu::QueryType::Timestamp,
@@ -272,11 +301,34 @@ impl TimerState {
             dropped_spans: 0,
             period_ns: queue.get_timestamp_period(),
             window,
+            inside_encoders,
             report: Report::default(),
         }
     }
 
-    fn open(
+    fn open_pass(&mut self, kind: GpuSpanKind, width: u32, height: u32) -> Option<PassTimestamps> {
+        if self.next_query + 2 > MAX_QUERIES {
+            self.dropped_spans += 1;
+            return None;
+        }
+        let begin = self.next_query;
+        let end = begin + 1;
+        self.next_query += 2;
+        self.spans.push(SpanRecord {
+            kind,
+            width,
+            height,
+            begin,
+            end: Some(end),
+        });
+        Some(PassTimestamps {
+            query_set: self.query_set.clone(),
+            begin,
+            end,
+        })
+    }
+
+    fn open_encoder_span(
         &mut self,
         encoder: &mut wgpu::CommandEncoder,
         kind: GpuSpanKind,

--- a/crates/cranpose-render/wgpu/src/gpu_timing.rs
+++ b/crates/cranpose-render/wgpu/src/gpu_timing.rs
@@ -1,0 +1,600 @@
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+const MAX_QUERIES: u32 = 512;
+const READBACK_SLOTS: usize = 3;
+const QUERY_BYTES: u64 = 8;
+const MAX_REPORTED_BUCKETS: usize = 24;
+const MAX_LISTED_PASSES: usize = 40;
+
+pub fn timing_window_frames() -> Option<u32> {
+    static WINDOW: OnceLock<Option<u32>> = OnceLock::new();
+    *WINDOW.get_or_init(|| {
+        let raw = std::env::var("CRANPOSE_GPU_PASS_TIMING").ok()?;
+        let raw = raw.trim().to_owned();
+        if raw.is_empty() || raw == "0" || raw == "off" || raw == "false" {
+            return None;
+        }
+        Some(raw.parse::<u32>().unwrap_or(120).clamp(1, 10_000))
+    })
+}
+
+pub fn requested_features(adapter_features: wgpu::Features) -> wgpu::Features {
+    if timing_window_frames().is_none() {
+        return wgpu::Features::empty();
+    }
+    let wanted = wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS;
+    if adapter_features.contains(wanted) {
+        wanted
+    } else {
+        wgpu::Features::empty()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub(crate) enum GpuSpanKind {
+    Frame,
+    BlurHorizontal,
+    BlurVertical,
+    BlurRoundedMask,
+    Composite,
+    Content,
+}
+
+impl GpuSpanKind {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            GpuSpanKind::Frame => "frame",
+            GpuSpanKind::BlurHorizontal => "blur_h",
+            GpuSpanKind::BlurVertical => "blur_v",
+            GpuSpanKind::BlurRoundedMask => "blur_mask",
+            GpuSpanKind::Composite => "composite",
+            GpuSpanKind::Content => "content",
+        }
+    }
+
+    pub(crate) fn is_blur(self) -> bool {
+        matches!(
+            self,
+            GpuSpanKind::BlurHorizontal | GpuSpanKind::BlurVertical | GpuSpanKind::BlurRoundedMask
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct GpuSpanId(usize);
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SpanRecord {
+    kind: GpuSpanKind,
+    width: u32,
+    height: u32,
+    begin: u32,
+    end: Option<u32>,
+}
+
+impl SpanRecord {
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        kind: GpuSpanKind,
+        width: u32,
+        height: u32,
+        begin: u32,
+        end: Option<u32>,
+    ) -> Self {
+        Self {
+            kind,
+            width,
+            height,
+            begin,
+            end,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct SpanTime {
+    pub(crate) kind: GpuSpanKind,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) ms: f64,
+}
+
+pub(crate) fn decode_spans(spans: &[SpanRecord], ticks: &[u64], period_ns: f32) -> Vec<SpanTime> {
+    let mut out = Vec::with_capacity(spans.len());
+    for span in spans {
+        let Some(end) = span.end else {
+            continue;
+        };
+        let (Some(begin_tick), Some(end_tick)) = (
+            ticks.get(span.begin as usize).copied(),
+            ticks.get(end as usize).copied(),
+        ) else {
+            continue;
+        };
+        if end_tick < begin_tick {
+            continue;
+        }
+        let ms = (end_tick - begin_tick) as f64 * f64::from(period_ns) / 1_000_000.0;
+        out.push(SpanTime {
+            kind: span.kind,
+            width: span.width,
+            height: span.height,
+            ms,
+        });
+    }
+    out
+}
+
+#[derive(Default)]
+pub(crate) struct GpuFrameTimer {
+    state: Option<TimerState>,
+    refused: bool,
+}
+
+struct TimerState {
+    query_set: wgpu::QuerySet,
+    resolve: wgpu::Buffer,
+    slots: Vec<Slot>,
+    filled_slot: Option<usize>,
+    next_query: u32,
+    spans: Vec<SpanRecord>,
+    frame_span: Option<GpuSpanId>,
+    dropped_spans: u32,
+    period_ns: f32,
+    window: u32,
+    report: Report,
+}
+
+struct Slot {
+    buffer: wgpu::Buffer,
+    ready: Arc<AtomicBool>,
+    pending: Option<Pending>,
+}
+
+struct Pending {
+    spans: Vec<SpanRecord>,
+    queries: u32,
+    mapped: bool,
+}
+
+impl GpuFrameTimer {
+    pub(crate) fn is_on(&self) -> bool {
+        self.state.is_some()
+    }
+
+    pub(crate) fn begin_frame(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+    ) {
+        if self.refused {
+            return;
+        }
+        let Some(window) = timing_window_frames() else {
+            self.refused = true;
+            return;
+        };
+        if self.state.is_none() {
+            let wanted =
+                wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS;
+            if !device.features().contains(wanted) {
+                self.refused = true;
+                log::warn!("[gpu-pass] the device has no timestamp queries, timing stays off");
+                return;
+            }
+            self.state = Some(TimerState::new(device, queue, window));
+            log::warn!("[gpu-pass] per pass timing on, window={window} frames");
+        }
+        let Some(state) = self.state.as_mut() else {
+            return;
+        };
+        state.next_query = 0;
+        state.spans.clear();
+        state.dropped_spans = 0;
+        state.filled_slot = None;
+        state.frame_span = state.open(encoder, GpuSpanKind::Frame, 0, 0);
+    }
+
+    pub(crate) fn begin_span(
+        &mut self,
+        encoder: &mut wgpu::CommandEncoder,
+        kind: GpuSpanKind,
+        width: u32,
+        height: u32,
+    ) -> Option<GpuSpanId> {
+        self.state.as_mut()?.open(encoder, kind, width, height)
+    }
+
+    pub(crate) fn end_span(&mut self, encoder: &mut wgpu::CommandEncoder, span: Option<GpuSpanId>) {
+        let (Some(state), Some(span)) = (self.state.as_mut(), span) else {
+            return;
+        };
+        state.close(encoder, span);
+    }
+
+    pub(crate) fn end_frame(&mut self, encoder: &mut wgpu::CommandEncoder) {
+        let Some(state) = self.state.as_mut() else {
+            return;
+        };
+        if let Some(frame_span) = state.frame_span.take() {
+            state.close(encoder, frame_span);
+        }
+        state.resolve_into_slot(encoder);
+    }
+
+    pub(crate) fn after_submit(&mut self, device: &wgpu::Device) {
+        let Some(state) = self.state.as_mut() else {
+            return;
+        };
+        state.map_filled_slot();
+        let _ = device.poll(wgpu::PollType::Poll);
+        state.drain_ready_slots();
+    }
+}
+
+impl TimerState {
+    fn new(device: &wgpu::Device, queue: &wgpu::Queue, window: u32) -> Self {
+        let query_set = device.create_query_set(&wgpu::QuerySetDescriptor {
+            label: Some("Gpu Pass Timing Query Set"),
+            ty: wgpu::QueryType::Timestamp,
+            count: MAX_QUERIES,
+        });
+        let resolve = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Gpu Pass Timing Resolve Buffer"),
+            size: u64::from(MAX_QUERIES) * QUERY_BYTES,
+            usage: wgpu::BufferUsages::QUERY_RESOLVE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let slots = (0..READBACK_SLOTS)
+            .map(|_| Slot {
+                buffer: device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("Gpu Pass Timing Readback Buffer"),
+                    size: u64::from(MAX_QUERIES) * QUERY_BYTES,
+                    usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+                    mapped_at_creation: false,
+                }),
+                ready: Arc::new(AtomicBool::new(false)),
+                pending: None,
+            })
+            .collect::<Vec<_>>();
+        Self {
+            query_set,
+            resolve,
+            slots,
+            filled_slot: None,
+            next_query: 0,
+            spans: Vec::with_capacity(64),
+            frame_span: None,
+            dropped_spans: 0,
+            period_ns: queue.get_timestamp_period(),
+            window,
+            report: Report::default(),
+        }
+    }
+
+    fn open(
+        &mut self,
+        encoder: &mut wgpu::CommandEncoder,
+        kind: GpuSpanKind,
+        width: u32,
+        height: u32,
+    ) -> Option<GpuSpanId> {
+        if self.next_query + 2 > MAX_QUERIES {
+            self.dropped_spans += 1;
+            return None;
+        }
+        let begin = self.next_query;
+        self.next_query += 1;
+        encoder.write_timestamp(&self.query_set, begin);
+        let id = GpuSpanId(self.spans.len());
+        self.spans.push(SpanRecord {
+            kind,
+            width,
+            height,
+            begin,
+            end: None,
+        });
+        Some(id)
+    }
+
+    fn close(&mut self, encoder: &mut wgpu::CommandEncoder, span: GpuSpanId) {
+        if self.next_query >= MAX_QUERIES {
+            return;
+        }
+        let end = self.next_query;
+        self.next_query += 1;
+        encoder.write_timestamp(&self.query_set, end);
+        if let Some(record) = self.spans.get_mut(span.0) {
+            record.end = Some(end);
+        }
+    }
+
+    fn resolve_into_slot(&mut self, encoder: &mut wgpu::CommandEncoder) {
+        let queries = self.next_query;
+        if queries == 0 {
+            return;
+        }
+        let Some(slot_index) = self.slots.iter().position(|slot| slot.pending.is_none()) else {
+            return;
+        };
+        let bytes = u64::from(queries) * QUERY_BYTES;
+        encoder.resolve_query_set(&self.query_set, 0..queries, &self.resolve, 0);
+        encoder.copy_buffer_to_buffer(&self.resolve, 0, &self.slots[slot_index].buffer, 0, bytes);
+        self.slots[slot_index].ready.store(false, Ordering::Release);
+        self.slots[slot_index].pending = Some(Pending {
+            spans: self.spans.clone(),
+            queries,
+            mapped: false,
+        });
+        self.filled_slot = Some(slot_index);
+    }
+
+    fn map_filled_slot(&mut self) {
+        let Some(index) = self.filled_slot.take() else {
+            return;
+        };
+        let Some(slot) = self.slots.get_mut(index) else {
+            return;
+        };
+        let Some(pending) = slot.pending.as_mut() else {
+            return;
+        };
+        if pending.mapped {
+            return;
+        }
+        pending.mapped = true;
+        let bytes = u64::from(pending.queries) * QUERY_BYTES;
+        let ready = Arc::clone(&slot.ready);
+        slot.buffer
+            .slice(0..bytes)
+            .map_async(wgpu::MapMode::Read, move |result| {
+                if result.is_ok() {
+                    ready.store(true, Ordering::Release);
+                }
+            });
+    }
+
+    fn drain_ready_slots(&mut self) {
+        for index in 0..self.slots.len() {
+            if !self.slots[index].ready.load(Ordering::Acquire) {
+                continue;
+            }
+            let Some(pending) = self.slots[index].pending.take() else {
+                self.slots[index].ready.store(false, Ordering::Release);
+                continue;
+            };
+            let bytes = u64::from(pending.queries) * QUERY_BYTES;
+            let ticks = {
+                let view = self.slots[index].buffer.slice(0..bytes).get_mapped_range();
+                view.chunks_exact(8)
+                    .map(|chunk| {
+                        u64::from_le_bytes([
+                            chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6],
+                            chunk[7],
+                        ])
+                    })
+                    .collect::<Vec<_>>()
+            };
+            self.slots[index].buffer.unmap();
+            self.slots[index].ready.store(false, Ordering::Release);
+            let times = decode_spans(&pending.spans, &ticks, self.period_ns);
+            self.report.add_frame(&times);
+            if self.report.frames >= self.window {
+                self.report.print(self.dropped_spans);
+                self.report = Report::default();
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct Report {
+    frames: u32,
+    frame_ms: f64,
+    buckets: BTreeMap<(GpuSpanKind, u32, u32), Bucket>,
+    last_frame: Vec<SpanTime>,
+}
+
+#[derive(Default, Clone, Copy)]
+struct Bucket {
+    count: u32,
+    ms: f64,
+}
+
+impl Report {
+    pub(crate) fn add_frame(&mut self, times: &[SpanTime]) {
+        self.frames += 1;
+        self.last_frame.clear();
+        for time in times {
+            if time.kind == GpuSpanKind::Frame {
+                self.frame_ms += time.ms;
+                continue;
+            }
+            let bucket = self
+                .buckets
+                .entry((time.kind, time.width, time.height))
+                .or_default();
+            bucket.count += 1;
+            bucket.ms += time.ms;
+            if self.last_frame.len() < MAX_LISTED_PASSES {
+                self.last_frame.push(*time);
+            }
+        }
+    }
+
+    fn spans_ms(&self) -> f64 {
+        self.buckets.values().map(|bucket| bucket.ms).sum()
+    }
+
+    fn blur_ms(&self) -> f64 {
+        self.buckets
+            .iter()
+            .filter(|((kind, _, _), _)| kind.is_blur())
+            .map(|(_, bucket)| bucket.ms)
+            .sum()
+    }
+
+    fn composite_ms(&self) -> f64 {
+        self.buckets
+            .iter()
+            .filter(|((kind, _, _), _)| *kind == GpuSpanKind::Composite)
+            .map(|(_, bucket)| bucket.ms)
+            .sum()
+    }
+
+    pub(crate) fn print(&self, dropped_spans: u32) {
+        if self.frames == 0 {
+            return;
+        }
+        let frames = f64::from(self.frames);
+        let frame_ms = self.frame_ms / frames;
+        let spans_ms = self.spans_ms() / frames;
+        log::warn!(
+            "[gpu-pass] frames={} frame_ms={frame_ms:.3} spans_ms={spans_ms:.3} blur_ms={:.3} composite_ms={:.3} rest_ms={:.3} dropped={dropped_spans}",
+            self.frames,
+            self.blur_ms() / frames,
+            self.composite_ms() / frames,
+            (self.frame_ms - self.spans_ms()).max(0.0) / frames,
+        );
+        for (index, ((kind, width, height), bucket)) in self.buckets.iter().enumerate() {
+            if index >= MAX_REPORTED_BUCKETS {
+                log::warn!("[gpu-pass]   and {} more sizes", self.buckets.len() - index);
+                break;
+            }
+            log::warn!(
+                "[gpu-pass]   {} {}x{} per_frame_n={:.2} per_frame_ms={:.3} per_pass_ms={:.3}",
+                kind.label(),
+                width,
+                height,
+                f64::from(bucket.count) / frames,
+                bucket.ms / frames,
+                bucket.ms / f64::from(bucket.count.max(1)),
+            );
+        }
+        let mut line = String::new();
+        for time in &self.last_frame {
+            if !line.is_empty() {
+                line.push_str("; ");
+            }
+            line.push_str(&format!(
+                "{} {}x{} {:.3}",
+                time.kind.label(),
+                time.width,
+                time.height,
+                time.ms
+            ));
+        }
+        if !line.is_empty() {
+            log::warn!("[gpu-pass]   one frame: {line}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_span_pair_becomes_milliseconds() {
+        let spans = vec![SpanRecord::for_test(
+            GpuSpanKind::BlurHorizontal,
+            270,
+            100,
+            0,
+            Some(1),
+        )];
+        let times = decode_spans(&spans, &[1_000, 2_000_000], 1.0);
+        assert_eq!(times.len(), 1);
+        assert_eq!(times[0].kind, GpuSpanKind::BlurHorizontal);
+        assert_eq!(times[0].width, 270);
+        assert!((times[0].ms - 1.999).abs() < 0.001, "{}", times[0].ms);
+    }
+
+    #[test]
+    fn a_span_without_an_end_is_left_out() {
+        let spans = vec![SpanRecord::for_test(GpuSpanKind::Composite, 8, 8, 0, None)];
+        assert!(decode_spans(&spans, &[10, 20], 1.0).is_empty());
+    }
+
+    #[test]
+    fn a_backward_pair_is_left_out() {
+        let spans = vec![SpanRecord::for_test(
+            GpuSpanKind::Composite,
+            8,
+            8,
+            0,
+            Some(1),
+        )];
+        assert!(decode_spans(&spans, &[20, 10], 1.0).is_empty());
+    }
+
+    #[test]
+    fn a_missing_tick_is_left_out() {
+        let spans = vec![SpanRecord::for_test(
+            GpuSpanKind::Composite,
+            8,
+            8,
+            0,
+            Some(5),
+        )];
+        assert!(decode_spans(&spans, &[20, 30], 1.0).is_empty());
+    }
+
+    #[test]
+    fn the_report_splits_blur_composite_and_rest() {
+        let mut report = Report::default();
+        report.add_frame(&[
+            SpanTime {
+                kind: GpuSpanKind::Frame,
+                width: 0,
+                height: 0,
+                ms: 10.0,
+            },
+            SpanTime {
+                kind: GpuSpanKind::BlurHorizontal,
+                width: 270,
+                height: 100,
+                ms: 1.0,
+            },
+            SpanTime {
+                kind: GpuSpanKind::BlurVertical,
+                width: 1080,
+                height: 400,
+                ms: 2.0,
+            },
+            SpanTime {
+                kind: GpuSpanKind::Composite,
+                width: 1080,
+                height: 400,
+                ms: 3.0,
+            },
+        ]);
+        assert_eq!(report.frames, 1);
+        assert!((report.blur_ms() - 3.0).abs() < 1e-9);
+        assert!((report.composite_ms() - 3.0).abs() < 1e-9);
+        assert!((report.frame_ms - report.spans_ms() - 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn two_passes_of_one_size_share_a_bucket() {
+        let mut report = Report::default();
+        let time = SpanTime {
+            kind: GpuSpanKind::BlurHorizontal,
+            width: 270,
+            height: 100,
+            ms: 1.5,
+        };
+        report.add_frame(&[time, time]);
+        let bucket = report
+            .buckets
+            .get(&(GpuSpanKind::BlurHorizontal, 270, 100))
+            .copied()
+            .expect("the bucket holds both passes");
+        assert_eq!(bucket.count, 2);
+        assert!((bucket.ms - 3.0).abs() < 1e-9);
+    }
+}

--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -12,6 +12,7 @@ mod frame_graph;
 mod frame_packet;
 mod frontend;
 pub(crate) mod gpu_stats;
+pub mod gpu_timing;
 mod layer_events;
 mod layer_surface_cache;
 mod lazy_resource;

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -9080,8 +9080,8 @@ impl GpuRenderer {
 
             let use_retained_bundles = retained_bundles_enabled();
             let mut retained_encode_ms = 0.0_f64;
-            let content_span =
-                frame_encoder.begin_gpu_span(GpuSpanKind::Content, width, height);
+            let content_timestamps =
+                frame_encoder.pass_timestamps(GpuSpanKind::Content, width, height);
             {
                 let mut render_pass =
                     frame_encoder
@@ -9098,7 +9098,9 @@ impl GpuRenderer {
                                 },
                             })],
                             depth_stencil_attachment: None,
-                            timestamp_writes: None,
+                            timestamp_writes: content_timestamps
+                                .as_ref()
+                                .map(crate::gpu_timing::PassTimestamps::writes),
                             occlusion_query_set: None,
                             multiview_mask: None,
                         });
@@ -9220,7 +9222,6 @@ impl GpuRenderer {
                     }
                 }
             }
-            frame_encoder.end_gpu_span(content_span);
             // Span capture (miss frames whose leading run proved stable):
             // re-render JUST the span shapes into the pooled offscreen,
             // through the IDENTICAL pipelines at identical device

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -6772,6 +6772,14 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
                     let scratch = self
                         .recorder
                         .acquire_transient_offscreen(&device, scratch_descriptor);
+                    let vertical_descriptor = self.renderer.transient_offscreen_descriptor(
+                        "Blur Rounded Mask Vertical Scratch",
+                        scratch_width,
+                        scratch_height,
+                    );
+                    let vertical = self
+                        .recorder
+                        .acquire_transient_offscreen(&device, vertical_descriptor);
                     let fused = self
                         .renderer
                         .effect_renderer
@@ -6780,6 +6788,7 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
                             &device,
                             source,
                             &scratch,
+                            Some(&vertical),
                             dest_view,
                             *radius_x,
                             *radius_y,
@@ -6791,7 +6800,7 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
                             viewport,
                         );
                     if fused {
-                        self.recorder.record_passes(2);
+                        self.recorder.record_passes(3);
                         self.renderer.effect_renderer.record_blur_pass();
                         self.renderer
                             .effect_renderer
@@ -6799,9 +6808,13 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
                             .set(self.renderer.effect_renderer.debug_effects.get() + 1);
                         self.renderer.effect_renderer.record_composite_pass();
                         self.recorder
+                            .release_transient_offscreen(vertical_descriptor, vertical);
+                        self.recorder
                             .release_transient_offscreen(scratch_descriptor, scratch);
                         return Ok(());
                     }
+                    self.recorder
+                        .release_transient_offscreen(vertical_descriptor, vertical);
                     self.recorder
                         .release_transient_offscreen(scratch_descriptor, scratch);
                 }

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -101,6 +101,7 @@ use web_time::Instant;
 
 use crate::gpu_stats;
 use crate::gpu_stats::gpu_stats_enabled;
+use crate::gpu_timing::GpuSpanKind;
 use crate::pipeline::push_layer_shadow;
 
 /// Must equal the `array<ShapeData, N>` literal in `shape.wgsl`: on wasm the
@@ -9079,6 +9080,8 @@ impl GpuRenderer {
 
             let use_retained_bundles = retained_bundles_enabled();
             let mut retained_encode_ms = 0.0_f64;
+            let content_span =
+                frame_encoder.begin_gpu_span(GpuSpanKind::Content, width, height);
             {
                 let mut render_pass =
                     frame_encoder
@@ -9217,6 +9220,7 @@ impl GpuRenderer {
                     }
                 }
             }
+            frame_encoder.end_gpu_span(content_span);
             // Span capture (miss frames whose leading run proved stable):
             // re-render JUST the span shapes into the pooled offscreen,
             // through the IDENTICAL pipelines at identical device

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -6772,14 +6772,6 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
                     let scratch = self
                         .recorder
                         .acquire_transient_offscreen(&device, scratch_descriptor);
-                    let vertical_descriptor = self.renderer.transient_offscreen_descriptor(
-                        "Blur Rounded Mask Vertical Scratch",
-                        scratch_width,
-                        scratch_height,
-                    );
-                    let vertical = self
-                        .recorder
-                        .acquire_transient_offscreen(&device, vertical_descriptor);
                     let fused = self
                         .renderer
                         .effect_renderer
@@ -6788,7 +6780,6 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
                             &device,
                             source,
                             &scratch,
-                            Some(&vertical),
                             dest_view,
                             *radius_x,
                             *radius_y,
@@ -6800,7 +6791,7 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
                             viewport,
                         );
                     if fused {
-                        self.recorder.record_passes(3);
+                        self.recorder.record_passes(2);
                         self.renderer.effect_renderer.record_blur_pass();
                         self.renderer
                             .effect_renderer
@@ -6808,13 +6799,9 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
                             .set(self.renderer.effect_renderer.debug_effects.get() + 1);
                         self.renderer.effect_renderer.record_composite_pass();
                         self.recorder
-                            .release_transient_offscreen(vertical_descriptor, vertical);
-                        self.recorder
                             .release_transient_offscreen(scratch_descriptor, scratch);
                         return Ok(());
                     }
-                    self.recorder
-                        .release_transient_offscreen(vertical_descriptor, vertical);
                     self.recorder
                         .release_transient_offscreen(scratch_descriptor, scratch);
                 }

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -1131,9 +1131,14 @@ fn create_android_gpu_resources(
     log::info!("Found adapter: {:?}", adapter_info.backend);
     let adapter = Arc::new(adapter);
 
+    let timing_features =
+        cranpose_render_wgpu::gpu_timing::requested_features(adapter.features());
+    if !timing_features.is_empty() {
+        log::info!("[gpu-pass] the android device asks for timestamp queries");
+    }
     let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
         label: Some("Android Device"),
-        required_features: wgpu::Features::empty(),
+        required_features: timing_features,
         required_limits: crate::gpu_limits::mobile_device_limits(adapter.limits()),
         experimental_features: wgpu::ExperimentalFeatures::disabled(),
         memory_hints: crate::gpu_limits::mobile_memory_hints(),

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -69,7 +69,7 @@ fn property_flag(name: &str) -> bool {
 ///
 /// Property names are capped at 32 bytes by `PROP_NAME_MAX`, which is why they
 /// are abbreviations rather than the full variable name.
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 29] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 30] = [
     ("debug.cranpose.no_backdrop", "CRANPOSE_NO_BACKDROP"),
     ("debug.cranpose.blur_scale", "CRANPOSE_BLUR_SCALE"),
     ("debug.cranpose.root_direct", "CRANPOSE_ROOT_DIRECT_DIAG"),
@@ -135,6 +135,7 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 29] = [
     ("debug.cranpose.async_haptics", "CRANPOSE_ASYNC_HAPTICS"),
     ("debug.cranpose.fill_diag", "CRANPOSE_FILL_DIAG"),
     ("debug.cranpose.static_span", "CRANPOSE_STATIC_SPAN"),
+    ("debug.cranpose.gpu_pass", "CRANPOSE_GPU_PASS_TIMING"),
 ];
 
 /// Copies the [`PROPERTY_BACKED_ENV_VARS`] properties that are set into the

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -4149,7 +4149,9 @@ impl ApplicationHandler for App {
         let (device, queue) =
             match pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
                 label: Some("Main Device"),
-                required_features: wgpu::Features::empty(),
+                required_features: cranpose_render_wgpu::gpu_timing::requested_features(
+                    adapter.features(),
+                ),
                 required_limits: wgpu::Limits::default(),
                 experimental_features: wgpu::ExperimentalFeatures::disabled(),
                 memory_hints: wgpu::MemoryHints::default(),


### PR DESCRIPTION
Five commits found unpushed in a local worktree. Publishing so the work is upstream rather than on one disk.

- The renderer times each pass on the GPU and prints the split.
- The timing writes its pair into the render pass descriptor.
- The pass report names the sizes where the adapter has no timer, rather than reporting a silent zero.
- The fused blur runs its vertical axis at the scratch size.
- Takes back the vertical scratch; the numbers name another term.

## Provenance

I did not write this and have not verified it. It was sitting in a worktree with no copy on any remote, and `git cherry` says all five commits are absent from `main`. CI on this PR is the first check it has had — review it as new work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)