### PR TITLE
The camera says which lenses it has, and what the flash does

### DIFF
--- a/crates/cranpose-services/src/camera.rs
+++ b/crates/cranpose-services/src/camera.rs
@@ -35,6 +35,31 @@ pub struct CameraStill {
     pub jpeg: Vec<u8>,
 }
 
+/// One capture device the app may pick, as reported by [`Camera::lenses`].
+///
+/// `id` is the platform's own handle for the device (an `AVCaptureDevice`
+/// uniqueID on iOS, a camera2 id on Android); pass it back to
+/// [`Camera::use_lens`]. `name` is for a button label: "Ultra wide", "Wide",
+/// "Tele".
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CameraLens {
+    pub id: String,
+    pub name: String,
+}
+
+/// What the light does when a still is captured.
+///
+/// `Auto` leaves the choice to the device's exposure metering. A backend with
+/// no flash reports `false` from [`Camera::set_flash`] and the app hides the
+/// control.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FlashMode {
+    #[default]
+    Off,
+    Auto,
+    On,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum CameraError {
     /// No live camera backend on this platform.
@@ -72,6 +97,38 @@ pub trait Camera: Send + Sync {
     fn set_torch(&self, _on: bool) -> bool {
         false
     }
+    /// The capture devices the app may pick between, back cameras first and in
+    /// field-of-view order (widest first). An empty list means the app shows no
+    /// lens control: either the platform has one camera or the backend does not
+    /// list them.
+    fn lenses(&self) -> Vec<CameraLens> {
+        Vec::new()
+    }
+
+    /// The id of the device the session uses, or `None` when nothing is open
+    /// and the backend has no stored choice.
+    fn lens(&self) -> Option<String> {
+        None
+    }
+
+    /// Open `id` instead of the current device, keeping the session running.
+    /// Returns `false` when the id is unknown or the backend cannot switch.
+    fn use_lens(&self, _id: &str) -> bool {
+        false
+    }
+
+    /// Whether the current device has a flash for stills.
+    fn has_flash(&self) -> bool {
+        false
+    }
+
+    /// What the flash does on the next [`capture_still`](Self::capture_still).
+    /// Returns `false` where the device has no flash or the backend has none
+    /// wired; the mode dies with the session.
+    fn set_flash(&self, _mode: FlashMode) -> bool {
+        false
+    }
+
     /// Stop the session and release the device.
     fn stop(&self);
 }
@@ -128,6 +185,71 @@ mod tests {
         let cam = camera().expect("registered");
         assert_eq!(cam.start().unwrap(), "fake");
         assert_eq!(cam.latest_frame().unwrap().width, 1);
+        clear_platform_camera();
+    }
+
+    #[test]
+    fn a_backend_that_lists_no_lens_and_no_flash_says_so() {
+        clear_platform_camera();
+        struct Bare;
+        impl Camera for Bare {
+            fn start(&self) -> Result<String, CameraError> {
+                Ok("bare".into())
+            }
+            fn latest_frame(&self) -> Option<CameraFrame> {
+                None
+            }
+            fn stop(&self) {}
+        }
+        set_platform_camera(Arc::new(Bare));
+        let cam = camera().expect("registered");
+        assert!(cam.lenses().is_empty());
+        assert_eq!(cam.lens(), None);
+        assert!(!cam.use_lens("0"));
+        assert!(!cam.has_flash());
+        assert!(!cam.set_flash(FlashMode::On));
+        clear_platform_camera();
+    }
+
+    #[test]
+    fn a_backend_that_lists_two_lenses_hands_them_over_in_order() {
+        clear_platform_camera();
+        struct Two;
+        impl Camera for Two {
+            fn start(&self) -> Result<String, CameraError> {
+                Ok("two".into())
+            }
+            fn latest_frame(&self) -> Option<CameraFrame> {
+                None
+            }
+            fn lenses(&self) -> Vec<CameraLens> {
+                vec![
+                    CameraLens {
+                        id: "u".into(),
+                        name: "Ultra wide".into(),
+                    },
+                    CameraLens {
+                        id: "w".into(),
+                        name: "Wide".into(),
+                    },
+                ]
+            }
+            fn lens(&self) -> Option<String> {
+                Some("w".into())
+            }
+            fn use_lens(&self, id: &str) -> bool {
+                id == "u" || id == "w"
+            }
+            fn stop(&self) {}
+        }
+        set_platform_camera(Arc::new(Two));
+        let cam = camera().expect("registered");
+        let lenses = cam.lenses();
+        assert_eq!(lenses.len(), 2);
+        assert_eq!(lenses[0].name, "Ultra wide");
+        assert_eq!(cam.lens().as_deref(), Some("w"));
+        assert!(cam.use_lens("u"));
+        assert!(!cam.use_lens("tele"));
         clear_platform_camera();
     }
 }

--- a/crates/cranpose-services/src/lib.rs
+++ b/crates/cranpose-services/src/lib.rs
@@ -42,7 +42,7 @@ pub use background::{
 };
 pub use camera::{
     camera, clear_platform_camera, set_platform_camera, Camera, CameraError, CameraFrame,
-    CameraRef, CameraStill,
+    CameraLens, CameraRef, CameraStill, FlashMode,
 };
 pub use device_info::{
     clear_platform_device_info, device_info, set_platform_device_info, DeviceInfo, DeviceInfoRef,

--- a/crates/cranpose/src/ios_camera.rs
+++ b/crates/cranpose/src/ios_camera.rs
@@ -385,7 +385,7 @@ fn capture_photo() -> Option<CameraStill> {
         };
         let supported = unsafe { holder.photo_output.supportedFlashModes() }
             .iter()
-            .any(|mode| mode.as_i64() == wanted.0);
+            .any(|mode| mode.as_i64() == wanted.0 as i64);
         if supported {
             unsafe { settings.setFlashMode(wanted) };
         }

--- a/crates/cranpose/src/ios_camera.rs
+++ b/crates/cranpose/src/ios_camera.rs
@@ -237,7 +237,7 @@ fn back_lenses() -> Vec<Retained<AVCaptureDevice>> {
         )
     };
     let mut found: Vec<Retained<AVCaptureDevice>> = unsafe { session.devices() }.to_vec();
-    found.sort_by(|a, b| lens_order(a).cmp(&lens_order(b)));
+    found.sort_by_key(lens_order);
     found
 }
 

--- a/crates/cranpose/src/ios_camera.rs
+++ b/crates/cranpose/src/ios_camera.rs
@@ -8,15 +8,20 @@
 #![allow(unsafe_code)]
 
 use block2::RcBlock;
-use cranpose_services::{set_platform_camera, Camera, CameraError, CameraFrame, CameraStill};
+use cranpose_services::{
+    set_platform_camera, Camera, CameraError, CameraFrame, CameraLens, CameraStill, FlashMode,
+};
 use dispatch2::{DispatchQueue, DispatchRetained};
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, Bool, ProtocolObject};
 use objc2::{define_class, msg_send, AllocAnyThread};
 use objc2_av_foundation::{
-    AVCaptureAutoFocusRangeRestriction, AVCaptureConnection, AVCaptureDevice, AVCaptureDeviceInput,
-    AVCaptureDevicePosition, AVCaptureDeviceType, AVCaptureDeviceTypeBuiltInDualWideCamera,
-    AVCaptureDeviceTypeBuiltInTripleCamera, AVCaptureFocusMode, AVCaptureOutput, AVCapturePhoto,
+    AVCaptureAutoFocusRangeRestriction, AVCaptureConnection, AVCaptureDevice,
+    AVCaptureDeviceDiscoverySession, AVCaptureDeviceInput, AVCaptureDevicePosition,
+    AVCaptureDeviceType, AVCaptureDeviceTypeBuiltInDualWideCamera,
+    AVCaptureDeviceTypeBuiltInTelephotoCamera, AVCaptureDeviceTypeBuiltInTripleCamera,
+    AVCaptureDeviceTypeBuiltInUltraWideCamera, AVCaptureDeviceTypeBuiltInWideAngleCamera,
+    AVCaptureFlashMode, AVCaptureFocusMode, AVCaptureOutput, AVCapturePhoto,
     AVCapturePhotoCaptureDelegate, AVCapturePhotoOutput, AVCapturePhotoSettings,
     AVCapturePrimaryConstituentDeviceRestrictedSwitchingBehaviorConditions,
     AVCapturePrimaryConstituentDeviceSwitchingBehavior, AVCaptureSession,
@@ -30,7 +35,9 @@ use objc2_core_video::{
     CVPixelBufferGetBytesPerRow, CVPixelBufferGetHeight, CVPixelBufferGetWidth,
     CVPixelBufferLockBaseAddress, CVPixelBufferLockFlags, CVPixelBufferUnlockBaseAddress,
 };
-use objc2_foundation::{NSDictionary, NSError, NSNumber, NSObject, NSObjectProtocol, NSString};
+use objc2_foundation::{
+    NSArray, NSDictionary, NSError, NSNumber, NSObject, NSObjectProtocol, NSString,
+};
 use std::sync::mpsc;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -73,6 +80,18 @@ unsafe impl Send for SessionHolder {}
 
 fn session_slot() -> &'static Mutex<Option<SessionHolder>> {
     static SLOT: OnceLock<Mutex<Option<SessionHolder>>> = OnceLock::new();
+    SLOT.get_or_init(|| Mutex::new(None))
+}
+
+/// What the flash does on the next still, kept across a lens switch.
+fn flash_slot() -> &'static Mutex<FlashMode> {
+    static SLOT: OnceLock<Mutex<FlashMode>> = OnceLock::new();
+    SLOT.get_or_init(|| Mutex::new(FlashMode::Off))
+}
+
+/// The lens the app picked, or `None` while the default device is in use.
+fn lens_slot() -> &'static Mutex<Option<String>> {
+    static SLOT: OnceLock<Mutex<Option<String>>> = OnceLock::new();
     SLOT.get_or_init(|| Mutex::new(None))
 }
 
@@ -123,6 +142,64 @@ impl Camera for IosCamera {
         true
     }
 
+    fn lenses(&self) -> Vec<CameraLens> {
+        back_lenses()
+            .into_iter()
+            .map(|device| CameraLens {
+                id: unsafe { device.uniqueID() }.to_string(),
+                name: lens_name(&device),
+            })
+            .collect()
+    }
+
+    fn lens(&self) -> Option<String> {
+        if let Ok(slot) = session_slot().lock() {
+            if let Some(holder) = slot.as_ref() {
+                return Some(unsafe { holder.device.uniqueID() }.to_string());
+            }
+        }
+        lens_slot().lock().ok().and_then(|slot| slot.clone())
+    }
+
+    fn use_lens(&self, id: &str) -> bool {
+        if !back_lenses()
+            .iter()
+            .any(|device| unsafe { device.uniqueID() }.to_string() == id)
+        {
+            return false;
+        }
+        let running = session_slot().lock().map(|s| s.is_some()).unwrap_or(false);
+        match lens_slot().lock() {
+            Ok(mut slot) => *slot = Some(id.to_string()),
+            Err(_) => return false,
+        }
+        if !running {
+            return true;
+        }
+        self.stop();
+        start_session().is_ok()
+    }
+
+    fn has_flash(&self) -> bool {
+        if let Ok(slot) = session_slot().lock() {
+            if let Some(holder) = slot.as_ref() {
+                return unsafe { holder.device.hasFlash() };
+            }
+        }
+        back_lenses()
+            .first()
+            .map(|device| unsafe { device.hasFlash() })
+            .unwrap_or(false)
+    }
+
+    fn set_flash(&self, mode: FlashMode) -> bool {
+        match flash_slot().lock() {
+            Ok(mut slot) => *slot = mode,
+            Err(_) => return false,
+        }
+        self.has_flash()
+    }
+
     fn stop(&self) {
         if let Ok(mut slot) = session_slot().lock() {
             if let Some(holder) = slot.take() {
@@ -132,6 +209,56 @@ impl Camera for IosCamera {
         if let Ok(mut f) = latest().lock() {
             *f = None;
         }
+    }
+}
+
+/// The back cameras a phone carries, widest field of view first.
+///
+/// The virtual triple/dual devices are left out: they are what
+/// [`select_camera_device`] opens when the app picks no lens, and listing them
+/// beside their own constituents would offer the same picture twice.
+fn back_lenses() -> Vec<Retained<AVCaptureDevice>> {
+    let Some(media_type) = (unsafe { AVMediaTypeVideo }) else {
+        return Vec::new();
+    };
+    let types: [&AVCaptureDeviceType; 3] = unsafe {
+        [
+            AVCaptureDeviceTypeBuiltInUltraWideCamera,
+            AVCaptureDeviceTypeBuiltInWideAngleCamera,
+            AVCaptureDeviceTypeBuiltInTelephotoCamera,
+        ]
+    };
+    let wanted = NSArray::from_slice(&types);
+    let session = unsafe {
+        AVCaptureDeviceDiscoverySession::discoverySessionWithDeviceTypes_mediaType_position(
+            &wanted,
+            Some(media_type),
+            AVCaptureDevicePosition::Back,
+        )
+    };
+    let mut found: Vec<Retained<AVCaptureDevice>> = unsafe { session.devices() }.to_vec();
+    found.sort_by(|a, b| lens_order(a).cmp(&lens_order(b)));
+    found
+}
+
+fn lens_order(device: &AVCaptureDevice) -> u8 {
+    let kind = unsafe { device.deviceType() };
+    let ultra = unsafe { AVCaptureDeviceTypeBuiltInUltraWideCamera };
+    let wide = unsafe { AVCaptureDeviceTypeBuiltInWideAngleCamera };
+    if &*kind == ultra {
+        0
+    } else if &*kind == wide {
+        1
+    } else {
+        2
+    }
+}
+
+fn lens_name(device: &AVCaptureDevice) -> String {
+    match lens_order(device) {
+        0 => "Ultra wide".into(),
+        1 => "Wide".into(),
+        _ => "Tele".into(),
     }
 }
 
@@ -251,6 +378,17 @@ fn capture_photo() -> Option<CameraStill> {
         unsafe {
             settings.setHighResolutionPhotoEnabled(true);
         }
+        let wanted = match *flash_slot().lock().ok()? {
+            FlashMode::Off => AVCaptureFlashMode::Off,
+            FlashMode::Auto => AVCaptureFlashMode::Auto,
+            FlashMode::On => AVCaptureFlashMode::On,
+        };
+        let supported = unsafe { holder.photo_output.supportedFlashModes() }
+            .iter()
+            .any(|mode| mode.as_i64() == wanted.0);
+        if supported {
+            unsafe { settings.setFlashMode(wanted) };
+        }
         unsafe {
             holder
                 .photo_output
@@ -329,6 +467,12 @@ fn frame_from_sample(sample: &CMSampleBuffer) -> Option<CameraFrame> {
 /// for macro (close-up receipts, below the wide lens's minimum focus distance).
 /// Falls back to the plain wide-angle camera on devices without a virtual one.
 fn select_camera_device(media_type: &AVMediaType) -> Option<Retained<AVCaptureDevice>> {
+    if let Some(id) = lens_slot().lock().ok().and_then(|slot| slot.clone()) {
+        let wanted = NSString::from_str(&id);
+        if let Some(device) = unsafe { AVCaptureDevice::deviceWithUniqueID(&wanted) } {
+            return Some(device);
+        }
+    }
     let virtual_types: [&AVCaptureDeviceType; 2] = unsafe {
         [
             AVCaptureDeviceTypeBuiltInTripleCamera,


### PR DESCRIPTION
A scanner app wants two presses on its camera screen: pick the lens, and set the light. The `Camera` trait carried neither, only a torch switch.

## The trait

`Camera` gains five methods, each with a default:

- `lenses() -> Vec<CameraLens>` — the capture devices the app may pick between, widest field of view first. Empty means the app shows no lens control.
- `lens() -> Option<String>` — the id of the device in use.
- `use_lens(&str) -> bool` — open that device instead, keep the session running.
- `has_flash() -> bool`
- `set_flash(FlashMode) -> bool` — `Off`, `Auto` or `On` for the next still.

A backend that answers none of them keeps working: the app sees an empty list and no flash, and hides both controls.

## iOS

`AVCaptureDeviceDiscoverySession` lists the back ultra wide, wide and tele devices. They are sorted widest first and named `Ultra wide`, `Wide`, `Tele` for the button. `use_lens` stores the `uniqueID` and restarts the session on it, and `select_camera_device` reads that id before it falls back to the virtual triple or dual camera, so the auto switching behaviour is what an app gets until it picks a lens.

The flash mode rides on `AVCapturePhotoSettings` for the still, and only when `AVCapturePhotoOutput::supportedFlashModes` lists it.

## Checks

- `cargo test -p cranpose-services --lib camera` — 4 pass, two of them new: a backend that lists nothing reports nothing, and a backend that lists two lenses hands them over in order.
- `cargo check -p cranpose --lib --target aarch64-apple-ios --no-default-features --features ios` on a Mac: clean.
- `rustfmt --check` on both changed files: clean.

Wanted by CranScan, whose camera screen now offers a flash choice on Android and a torch on iOS; the iPhone lens switch waits on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
