### PR TITLE
Reopen an audio device the platform took back

### DIFF
--- a/crates/cranpose-audio/src/backend.rs
+++ b/crates/cranpose-audio/src/backend.rs
@@ -24,6 +24,17 @@ pub trait AudioSink {
     /// Starts the stream again: after [`suspend`](AudioSink::suspend), and
     /// after the mixer gave the device up for want of anything to play.
     fn resume(&self) {}
+    /// Whether the stream is actually running right now.
+    ///
+    /// NOT a cached flag: ask the platform. `streaming` is set by the engine
+    /// and cleared only by the mixer's own data callback, so a stream the
+    /// platform reclaims WITHOUT running that callback leaves every liveness
+    /// signal the engine owns stuck at "fine" -- and cues are then written into
+    /// a dead stream for the life of the process. Observed on a Pixel Watch 3.
+    fn is_running(&self) -> bool {
+        true
+    }
+
     /// Releases the device after the mixer reported itself idle.
     ///
     /// This is the half of stopping that a real-time callback cannot do for

--- a/crates/cranpose-audio/src/backend/aaudio.rs
+++ b/crates/cranpose-audio/src/backend/aaudio.rs
@@ -78,7 +78,6 @@ pub(crate) fn open(seed: MixerSeed) -> Result<Box<dyn AudioSink>, AudioError> {
             // Runs on an AAudio worker thread, not the real-time one, so this
             // may log. A disconnect ends the stream; the engine reopens the
             // device the next time it is asked to play.
-            log::warn!("AAudio stream error: {error:?}");
         }))
         .open_stream()
         .map_err(backend_error("failed to open the AAudio output stream"))?;
@@ -114,9 +113,7 @@ struct AAudioSink {
 
 impl AudioSink for AAudioSink {
     fn suspend(&self) {
-        if let Err(error) = self.stream.request_pause() {
-            log::debug!("failed to pause the AAudio stream: {error}");
-        }
+        if let Err(error) = self.stream.request_pause() {}
     }
 
     fn resume(&self) {
@@ -132,9 +129,17 @@ impl AudioSink for AAudioSink {
                 log::debug!("failed to settle the AAudio stream before starting it: {error}");
             }
         }
-        if let Err(error) = self.stream.request_start() {
-            log::debug!("failed to restart the AAudio stream: {error}");
-        }
+        match self.stream.request_start() {}
+    }
+
+    fn is_running(&self) -> bool {
+        let state = self.stream.state();
+        let alive = matches!(
+            state,
+            AudioStreamState::Started | AudioStreamState::Starting
+        );
+        if !alive {}
+        alive
     }
 
     fn park(&self) {
@@ -143,9 +148,7 @@ impl AudioSink for AAudioSink {
         // stopped stream is a no-op in AAudio, so this stays correct on the
         // releases where returning `Stop` from the callback already tore the
         // stream down.
-        if let Err(error) = self.stream.request_stop() {
-            log::debug!("failed to release the idle AAudio stream: {error}");
-        }
+        if let Err(error) = self.stream.request_stop() {}
     }
 }
 

--- a/crates/cranpose-audio/src/backend/aaudio.rs
+++ b/crates/cranpose-audio/src/backend/aaudio.rs
@@ -78,6 +78,7 @@ pub(crate) fn open(seed: MixerSeed) -> Result<Box<dyn AudioSink>, AudioError> {
             // Runs on an AAudio worker thread, not the real-time one, so this
             // may log. A disconnect ends the stream; the engine reopens the
             // device the next time it is asked to play.
+            log::warn!("AAudio stream error: {error:?}");
         }))
         .open_stream()
         .map_err(backend_error("failed to open the AAudio output stream"))?;
@@ -113,7 +114,9 @@ struct AAudioSink {
 
 impl AudioSink for AAudioSink {
     fn suspend(&self) {
-        if let Err(error) = self.stream.request_pause() {}
+        if let Err(error) = self.stream.request_pause() {
+            log::debug!("failed to pause the AAudio stream: {error}");
+        }
     }
 
     fn resume(&self) {
@@ -129,17 +132,20 @@ impl AudioSink for AAudioSink {
                 log::debug!("failed to settle the AAudio stream before starting it: {error}");
             }
         }
-        match self.stream.request_start() {}
+        if let Err(error) = self.stream.request_start() {
+            log::warn!("failed to restart the AAudio stream: {error}");
+        }
     }
 
     fn is_running(&self) -> bool {
         let state = self.stream.state();
-        let alive = matches!(
+        !matches!(
             state,
-            AudioStreamState::Started | AudioStreamState::Starting
-        );
-        if !alive {}
-        alive
+            AudioStreamState::Uninitialized
+                | AudioStreamState::Closing
+                | AudioStreamState::Closed
+                | AudioStreamState::Disconnected
+        )
     }
 
     fn park(&self) {
@@ -148,7 +154,9 @@ impl AudioSink for AAudioSink {
         // stopped stream is a no-op in AAudio, so this stays correct on the
         // releases where returning `Stop` from the callback already tore the
         // stream down.
-        if let Err(error) = self.stream.request_stop() {}
+        if let Err(error) = self.stream.request_stop() {
+            log::debug!("failed to release the idle AAudio stream: {error}");
+        }
     }
 }
 

--- a/crates/cranpose-audio/src/engine.rs
+++ b/crates/cranpose-audio/src/engine.rs
@@ -43,6 +43,13 @@ pub struct AudioEngine {
     commands: RefCell<ring::Producer<Command>>,
     retired: RefCell<ring::Consumer<ClipData>>,
     seed: RefCell<Option<MixerSeed>>,
+    /// Every clip currently loaded, by slot, so a REOPENED device can be
+    /// refilled. `ClipData` holds `Arc<[f32]>`, so this is a handle each, not
+    /// a second copy of the audio.
+    ///
+    /// Without it a reopen produces a working stream with an empty bank --
+    /// silence again, from a device that now looks healthy.
+    loaded: RefCell<Vec<Option<ClipData>>>,
     sink: RefCell<Option<Box<dyn AudioSink>>>,
     open_sink: SinkOpener,
     free_slots: RefCell<Vec<u32>>,
@@ -89,6 +96,7 @@ impl AudioEngine {
                 underruns: Arc::clone(&underruns),
                 streaming: Arc::clone(&streaming),
             })),
+            loaded: RefCell::new(vec![None; MAX_CLIPS]),
             sink: RefCell::new(None),
             open_sink,
             free_slots: RefCell::new((0..MAX_CLIPS as u32).rev().collect()),
@@ -147,16 +155,70 @@ impl AudioEngine {
 
     /// Opens the output device if it is not open yet. Returns whether a device
     /// is running afterwards.
+    /// Builds a seed for a device that is being opened AGAIN.
+    ///
+    /// The seed carries one half of each ring, moved into the mixer, so the
+    /// original is single-use and `ensure_running` used to fail forever once a
+    /// sink was dropped -- the engine had no reopen path at all. New rings are
+    /// made here and the engine's own ends swapped to match; commands still
+    /// queued for the dead mixer are dropped with it, which is correct, because
+    /// nothing was ever going to drain them.
+    fn rebuild_seed(&self) -> MixerSeed {
+        let (command_tx, command_rx) = ring::channel::<Command>(COMMAND_CAPACITY);
+        let (retired_tx, retired_rx) = ring::channel::<ClipData>(RETIRE_CAPACITY);
+        *self.commands.borrow_mut() = command_tx;
+        *self.retired.borrow_mut() = retired_rx;
+        MixerSeed {
+            commands: command_rx,
+            retired: retired_tx,
+            leaked_clips: Arc::clone(&self.leaked_clips),
+            underruns: Arc::clone(&self.underruns),
+            streaming: Arc::clone(&self.streaming),
+        }
+    }
+
+    /// Re-sends every retained clip to a freshly opened mixer.
+    fn refill_clips(&self) {
+        let clips: Vec<(u32, ClipData)> = self
+            .loaded
+            .borrow()
+            .iter()
+            .enumerate()
+            .filter_map(|(slot, entry)| entry.clone().map(|data| (slot as u32, data)))
+            .collect();
+        if clips.is_empty() {
+            return;
+        }
+        for (slot, clip) in clips {
+            self.send(Command::LoadClip { slot, clip });
+        }
+    }
+
     fn ensure_running(&self) -> bool {
-        if self.sink.borrow().is_some() {
+        // A sink that is PRESENT is not a sink that is RUNNING. The platform
+        // can reclaim a stream without ever running the data callback that
+        // clears `streaming`, so presence is the one thing that stays true no
+        // matter what happened to the device. Ask the sink itself.
+        if self
+            .sink
+            .borrow()
+            .as_ref()
+            .is_some_and(|sink| sink.is_running())
+        {
             return true;
+        }
+        if self.sink.borrow().is_some() {
+            *self.sink.borrow_mut() = None;
+            self.streaming.store(false, Ordering::SeqCst);
+            self.parked.set(false);
         }
         if self.device_unavailable.get() {
             return false;
         }
-        let Some(seed) = self.seed.borrow_mut().take() else {
-            self.device_unavailable.set(true);
-            return false;
+        let seed = match self.seed.borrow_mut().take() {
+            Some(seed) => seed,
+            // Not a failure any more: this is a REOPEN.
+            None => self.rebuild_seed(),
         };
         // Set before the opener runs, not after: the backend starts the stream
         // inside it, and the first callback can land before it returns.
@@ -165,10 +227,10 @@ impl AudioEngine {
             Ok(sink) => {
                 *self.sink.borrow_mut() = Some(sink);
                 self.publish_settings();
+                self.refill_clips();
                 true
             }
             Err(error) => {
-                log::warn!("cranpose audio device unavailable: {error}");
                 self.streaming.store(false, Ordering::SeqCst);
                 *self.last_error.borrow_mut() = Some(error);
                 self.device_unavailable.set(true);
@@ -220,6 +282,7 @@ impl AudioEngine {
         self.publish_settings();
         if let Some(sink) = self.sink.borrow().as_ref() {
             sink.resume();
+        } else {
         }
     }
 
@@ -247,8 +310,33 @@ impl AudioEngine {
     /// What every entry point does first: drop clips the mixer handed back, and
     /// release a device the mixer has reported idle.
     fn housekeeping(&self) {
+        self.drop_dead_sink();
         self.drain_retired();
         self.park_if_idle();
+    }
+
+    /// Throws away a sink whose stream the platform has taken back.
+    ///
+    /// This has to run BEFORE anything reads `streaming` or `sink.is_some()`,
+    /// because those are the two signals a silently reclaimed device leaves
+    /// stale: the mixer's data callback is what clears `streaming`, and a
+    /// stream that dies without running it never clears anything. `play` then
+    /// short-circuits in `wake_stream` (the flag is still true) and never
+    /// reaches `ensure_running` at all -- which is why checking liveness only
+    /// there fixes nothing.
+    fn drop_dead_sink(&self) {
+        let dead = self
+            .sink
+            .borrow()
+            .as_ref()
+            .is_some_and(|sink| !sink.is_running());
+        if !dead {
+            return;
+        }
+        *self.sink.borrow_mut() = None;
+        self.streaming.store(false, Ordering::SeqCst);
+        self.parked.set(false);
+        self.suspended.set(false);
     }
 
     /// Drops clips the mixer handed back. Called from every engine entry point,
@@ -370,14 +458,15 @@ impl AudioPlayer for AudioEngine {
             .ok_or(AudioError::ClipTableFull {
                 capacity: MAX_CLIPS,
             })?;
-        self.send(Command::LoadClip {
-            slot,
-            clip: ClipData {
-                samples: clip.shared_samples(),
-                channels: clip.channels().min(2) as u8,
-                sample_rate: clip.sample_rate(),
-            },
-        });
+        let data = ClipData {
+            samples: clip.shared_samples(),
+            channels: clip.channels().min(2) as u8,
+            sample_rate: clip.sample_rate(),
+        };
+        if let Some(entry) = self.loaded.borrow_mut().get_mut(slot as usize) {
+            *entry = Some(data.clone());
+        }
+        self.send(Command::LoadClip { slot, clip: data });
         Ok(SoundId::from_raw(slot + 1))
     }
 
@@ -386,6 +475,9 @@ impl AudioPlayer for AudioEngine {
             return;
         };
         self.send(Command::UnloadClip { slot });
+        if let Some(entry) = self.loaded.borrow_mut().get_mut(slot as usize) {
+            *entry = None;
+        }
         let mut free = self.free_slots.borrow_mut();
         if !free.contains(&slot) {
             free.push(slot);
@@ -520,6 +612,9 @@ mod tests {
     /// "released and started again".
     #[derive(Default)]
     struct SinkLog {
+        /// Set when the platform has taken the stream back WITHOUT running the
+        /// data callback -- the state that leaves `streaming` stuck true.
+        dead: Cell<bool>,
         suspended: Cell<bool>,
         parks: Cell<u32>,
         resumes: Cell<u32>,
@@ -531,6 +626,9 @@ mod tests {
     }
 
     impl AudioSink for TestSink {
+        fn is_running(&self) -> bool {
+            !self.log.dead.get()
+        }
         fn suspend(&self) {
             self.log.suspended.set(true);
         }
@@ -544,6 +642,7 @@ mod tests {
     }
 
     struct Rig {
+        opens: Rc<Cell<u32>>,
         engine: AudioEngine,
         mixer: Rc<RefCell<Option<Mixer>>>,
         sink: Rc<SinkLog>,
@@ -559,16 +658,21 @@ mod tests {
             let sink = Rc::new(SinkLog::default());
             let mixer_for_opener = Rc::clone(&mixer);
             let sink_for_opener = Rc::clone(&sink);
+            let opens = Rc::new(Cell::new(0u32));
+            let opens_for_opener = Rc::clone(&opens);
             let engine = AudioEngine::with_sink_opener(Box::new(move |seed| {
                 if fail {
                     return Err(AudioError::Backend("no device in this test".into()));
                 }
+                opens_for_opener.set(opens_for_opener.get() + 1);
+                sink_for_opener.dead.set(false);
                 *mixer_for_opener.borrow_mut() = Some(Mixer::new(seed, RIG_SAMPLE_RATE, 2));
                 Ok(Box::new(TestSink {
                     log: Rc::clone(&sink_for_opener),
                 }))
             }));
             Rig {
+                opens,
                 engine,
                 mixer,
                 sink,
@@ -657,6 +761,51 @@ mod tests {
         let out = rig.render(16);
         assert!(out[0] > 0.0, "the load queued before the mixer existed ran");
         assert_eq!(rig.active_voices(), 1);
+    }
+
+    /// REGRESSION: a stream the platform reclaims silently must be reopened.
+    ///
+    /// Captured on a Pixel Watch 3, process alive 1h50m, game in front, no
+    /// sound: cues dispatched and counted, `available=true`, `recoveries=0`,
+    /// and ZERO AAudio activity for the process. No park, no resume, no error
+    /// callback -- the stream was simply gone.
+    ///
+    /// `streaming` is set by the engine and cleared only by the mixer's own
+    /// data callback (`Mixer::settle`). A device reclaimed WITHOUT that
+    /// callback running leaves it stuck true, and every recovery is gated on
+    /// it: `park_if_idle` returns early, `wake_stream` early-returns on the
+    /// swap, and `ensure_running` returns on `sink.is_some()`. Presence is the
+    /// one signal that survives the device dying, so it was the one thing being
+    /// trusted.
+    #[test]
+    fn a_stream_reclaimed_without_a_callback_is_reopened() {
+        let rig = Rig::new();
+        let id = rig.engine.load_clip(tone(4096)).expect("loads");
+        rig.engine.play(id, PlaybackParams::new());
+        assert!(
+            rig.render(16)[0] > 0.0,
+            "audible before the device is taken"
+        );
+        assert_eq!(rig.opens.get(), 1);
+
+        // The platform takes the stream back. No callback runs, so `streaming`
+        // is never cleared and the sink stays Some.
+        rig.sink.dead.set(true);
+        assert!(
+            rig.engine.is_streaming(),
+            "the flag is exactly as stale as on the watch"
+        );
+
+        rig.engine.play(id, PlaybackParams::new());
+        assert_eq!(
+            rig.opens.get(),
+            2,
+            "a dead stream must be dropped and reopened; presence is not liveness"
+        );
+        assert!(
+            rig.render(16)[0] > 0.0,
+            "and the reopened device must be audible"
+        );
     }
 
     #[test]

--- a/crates/cranpose-audio/src/engine.rs
+++ b/crates/cranpose-audio/src/engine.rs
@@ -231,6 +231,7 @@ impl AudioEngine {
                 true
             }
             Err(error) => {
+                log::warn!("cranpose audio device unavailable: {error}");
                 self.streaming.store(false, Ordering::SeqCst);
                 *self.last_error.borrow_mut() = Some(error);
                 self.device_unavailable.set(true);
@@ -282,7 +283,6 @@ impl AudioEngine {
         self.publish_settings();
         if let Some(sink) = self.sink.borrow().as_ref() {
             sink.resume();
-        } else {
         }
     }
 
@@ -1084,6 +1084,7 @@ mod tests {
 
         rig.engine.play(id, PlaybackParams::new());
         assert!(rig.engine.is_streaming());
+        assert_eq!(rig.opens.get(), 1, "an idle stream is resumed in place");
         assert_eq!(rig.sink.resumes.get(), resumes + 1, "the stream restarted");
 
         let out = rig.render(16);


### PR DESCRIPTION
Reproduced on a Pixel Watch 3 — process alive 1h50m, app in front, no sound. Cues dispatched and counted, `available=true`, `recoveries=0`, and **zero AAudio activity for the process**. No park, no resume, no error callback: the stream was gone and nothing in the engine could tell.

## Three faults, each independently enough to make the silence permanent

1. **`ensure_running` returned early on `sink.is_some()`.** Presence is the one signal that survives the device dying, so it was the one thing being trusted.
2. **`streaming` is cleared only by the mixer's own data callback.** A stream reclaimed *without* that callback running leaves it stuck `true`, and both `wake_stream` (swap) and `park_if_idle` short-circuit on it — which is precisely why the captured log contained no park and no resume.
3. **`MixerSeed` was `take()`n on first open and never rebuilt**, so even a detected death was unrecoverable: there was no reopen path in the design at all.

## The fix

- `AudioSink::is_running()` — ask the platform, not a flag. AAudio answers from `stream.state()`.
- `housekeeping()` calls `drop_dead_sink()` first, so the stale `streaming` flag cannot gate recovery.
- `rebuild_seed()` makes fresh rings and swaps the engine's ends, so reopening is possible.
- Loaded clips are retained as `Arc` handles and re-sent on reopen — otherwise the reopened device has an empty bank and is silent again, but harder to diagnose.
- The AAudio restart failure moves `debug` → `warn`. At `debug` logcat drops it by default, which is why this presented as *no audio logging whatsoever* instead of as an error. That one line would have made this a ten-minute diagnosis.

## Test

`a_stream_reclaimed_without_a_callback_is_reopened` models the state observed on hardware: the sink is killed without the callback running, so `streaming` stays true. It fails against the previous behaviour (`opens 1, expected 2`) and passes with the fix. 58/58 green.

## Note on scope

This fixes detection and recovery, **not** the cause of death — what actually stopped the stream was never established. The app now survives it, which is what matters to a player, but the underlying event is still unexplained and worth investigating with the new `warn` as the marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)