### PR TITLE
Update project and standalone demo docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ them.
 
 [`apps/isolated-demo`](apps/isolated-demo) is a complete starter project that
 depends only on published crates — copy it rather than starting from scratch.
+It targets desktop, Android, and the web. The workspace's comprehensive demo
+(`apps/desktop-demo`) also contains the iOS entry point.
 
 ```bash
 git clone https://github.com/samoylenkodmitry/cranpose.git
@@ -33,7 +35,7 @@ Or add the framework to an existing project:
 
 ```toml
 [dependencies]
-cranpose = { version = "0.1.88", features = ["desktop", "renderer-wgpu"] }
+cranpose = { version = "0.1.95", features = ["desktop", "renderer-wgpu"] }
 ```
 
 ## Example
@@ -152,6 +154,9 @@ gap-table notes elsewhere are historical rationale only.
 Release binaries for the desktop platforms are attached to each
 [release](https://github.com/samoylenkodmitry/Cranpose/releases).
 
+The iOS implementation is built from `apps/desktop-demo`; the standalone
+`apps/isolated-demo` template does not include an iOS target.
+
 ## Building
 
 ### Desktop (Linux/macOS/Windows)
@@ -197,11 +202,14 @@ cd apps/ios-demo
 ### Web (WASM)
 
 ```bash
-# Prerequisites: cargo install wasm-pack
+# Prerequisites: rustup target add wasm32-unknown-unknown && cargo install wasm-pack
 cd apps/isolated-demo
 ./build-web.sh
 python3 -m http.server 8080
 ```
+
+Open `http://localhost:8080`. WebGL2 is the default backend; append
+`?backend=webgpu` to the URL to force WebGPU when the browser supports it.
 
 ## Binary size
 
@@ -238,7 +246,7 @@ out-of-the-box behaviour over size:
 
 ```toml
 [dependencies]
-cranpose = { version = "0.1.88", default-features = false, features = [
+cranpose = { version = "0.1.95", default-features = false, features = [
     "desktop",        # or just "desktop-wayland" / "desktop-x11"
     "renderer-wgpu",
 ] }

--- a/apps/isolated-demo/Cargo.lock
+++ b/apps/isolated-demo/Cargo.lock
@@ -1253,9 +1253,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1554,9 +1556,11 @@ dependencies = [
  "cranpose",
  "cranpose-core",
  "env_logger",
+ "getrandom 0.3.4",
  "js-sys",
  "log",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-logger",
  "web-sys",
 ]

--- a/apps/isolated-demo/Cargo.toml
+++ b/apps/isolated-demo/Cargo.toml
@@ -68,6 +68,10 @@ web-sys = { version = "0.3", features = [
     "DataTransfer",
 ] }
 
+[target.wasm32-unknown-unknown.dependencies]
+getrandom = { version = "0.3.4", features = ["wasm_js"] }
+wasm-bindgen-futures = "0.4.71"
+
 [workspace]
 
 [profile.release-small]

--- a/apps/isolated-demo/README.md
+++ b/apps/isolated-demo/README.md
@@ -1,36 +1,87 @@
 # Cranpose Isolated Demo
 
-This demo is intentionally **isolated** from the repository workspace and depends only on
-published crates from crates.io. It serves as the starter project template showing how to
-build a Cranpose app for supported platforms.
+This is the standalone Cranpose starter project. It is a separate Cargo
+workspace and depends on the published `cranpose` and `cranpose-core` crates
+from crates.io, so it can be copied out of this repository without path
+dependencies.
 
-## Desktop (Linux/macOS/Windows)
+The demo shows a counter, state-driven accent-color changes, layout, buttons,
+and the framework's embedded fallback font. Its supported targets are desktop,
+Android, and web. iOS is intentionally not part of this template; the
+repository's iOS reference is [`../ios-demo`](../ios-demo/README.md).
+
+## Requirements
+
+- Rust stable with the target needed for the platform you are building.
+- A working native graphics environment for desktop builds.
+- `cargo-ndk` and the Android SDK/NDK for Android builds.
+- `wasm-pack` for web builds.
+
+## Desktop
+
+From this directory, run the demo with the default wgpu renderer:
 
 ```bash
-cd apps/isolated-demo
 cargo run --features desktop,renderer-wgpu,logging
 ```
 
+The `desktop` and `renderer-wgpu` features are enabled by default; they are
+shown explicitly here so the feature choices are clear.
+
 ## Android
 
+Install the native build bridge once:
+
 ```bash
-# Prerequisites: cargo install cargo-ndk
-cd apps/isolated-demo/android
+cargo install cargo-ndk
+```
+
+Then build from the Android project directory:
+
+```bash
+cd android
+./gradlew :app:assembleDebug
+```
+
+The debug build produces the x86_64 library used by the emulator. Build the
+release APK to package all configured ABIs:
+
+```bash
 ./gradlew :app:assembleRelease
 ```
 
-## iOS
-
-iOS is unavailable until Cranpose has a real iOS platform crate with a CAMetalLayer
-surface, CADisplayLink frame driver, UIKit lifecycle bridge, touch/keyboard bridge,
-and safe-area/density updates.
-
 ## Web (WASM)
 
+Install the WebAssembly target and build tool:
+
 ```bash
-cd apps/isolated-demo
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack
+```
+
+Build and serve the demo from this directory:
+
+```bash
 ./build-web.sh
 python3 -m http.server 8080
 ```
 
-Open http://localhost:8080
+Open <http://localhost:8080>. The default browser backend is WebGL2. To force
+WebGPU, open <http://localhost:8080/?backend=webgpu>; to force WebGL2, use
+`?backend=gl`. Install Binaryen (`wasm-opt`) if you want the size optimizer
+used by the web build to be available.
+
+## Project layout
+
+```text
+apps/isolated-demo/
+├── src/                 # Shared Cranpose app and platform entry points
+├── android/             # Minimal Gradle host for the NativeActivity APK
+├── build-web.sh         # wasm-pack build for the browser
+├── index.html           # Canvas host page
+├── Cargo.toml           # Standalone package and published dependencies
+└── Cargo.lock
+```
+
+To start a new app from this template, copy this directory and change the
+package metadata and the `cranpose` dependency in `Cargo.toml` as needed.

--- a/apps/isolated-demo/build-web.sh
+++ b/apps/isolated-demo/build-web.sh
@@ -45,13 +45,13 @@ if [ $BUILD_RESULT -ne 0 ]; then
     echo "This might be due to wasm-opt issues. Retrying without wasm-opt..."
     echo ""
 
-    cp Cargo.toml Cargo.toml.backup
-    sed -i 's/wasm-opt = \[.*\]/wasm-opt = false/' Cargo.toml
-
-    "$WASM_PACK" build --target web --out-dir pkg --features web,renderer-wgpu --no-default-features
+    "$WASM_PACK" build \
+        --target web \
+        --out-dir pkg \
+        --features web,renderer-wgpu \
+        --no-default-features \
+        --no-opt
     BUILD_RESULT=$?
-
-    mv Cargo.toml.backup Cargo.toml
 
     if [ $BUILD_RESULT -ne 0 ]; then
         echo "Build failed even without wasm-opt"
@@ -76,4 +76,4 @@ echo "   npx serve ."
 echo ""
 echo "2. Open http://localhost:8080 in your browser"
 echo ""
-echo "Note: WebGPU support is required. Use Chrome 113+, Edge 113+, or Safari 18+"
+echo "Note: WebGL2 is the default browser backend. Add ?backend=webgpu to the URL to force WebGPU."


### PR DESCRIPTION
## What changed

- Refresh the project README for the current 0.1.95 release and platform/demo boundaries.
- Replace the standalone demo README with current desktop, Android, and WASM setup instructions.
- Document WebGL2 as the default browser backend with WebGPU opt-in.
- Add the standalone WASM dependencies required by the published-crate template.
- Make the web build retry use wasm-pack's portable --no-opt flag.

## Why

The documentation had stale release versions and incorrectly described the standalone demo's iOS and web support. Exercising the documented web command also exposed missing WASM dependency wiring in the standalone template.

## Validation

- cargo fmt --check
- cargo test and cargo clippy --workspace
- standalone cargo test and cargo clippy
- standalone Android :app:assembleRelease
- standalone ./build-web.sh
- git diff --check