### PR TITLE
Compile the web runtime against the bindings applications compile against

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,7 +16,6 @@ xtask = "run -p xtask --"
 
 [target.wasm32-unknown-unknown]
 rustflags = [
-    "--cfg", "web_sys_unstable_apis",
     "--cfg", "getrandom_backend=\"wasm_js\"",
     "--remap-path-prefix", "/root/.cargo/registry/src/=",
     "--remap-path-prefix", "/home/user/cranpose/=",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -466,7 +466,12 @@ jobs:
           git diff --stat -- apps/isolated-demo
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add apps/isolated-demo/Cargo.toml apps/isolated-demo/Cargo.lock
+          # sync_isolated_demo.py rewrites the Android settings script as well as
+          # the manifest. Staging only the manifest left the Gradle plugin naming
+          # the previous release, which fails check_cranpose_versions.py on the
+          # default branch and points the canary's Android build at the plugin
+          # before the one being released.
+          git add apps/isolated-demo
           git commit -m "chore: point isolated demo at ${TAG_NAME}"
           # Pushes made with GITHUB_TOKEN do not retrigger workflows, so this
           # cannot recurse into another Publish run.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -485,6 +485,19 @@ jobs:
           cargo build --manifest-path apps/isolated-demo/Cargo.toml \
             --features desktop --release
 
+      # The web is the one target whose build can differ from this
+      # repository's own: `apps/desktop-demo` compiles under the cargo
+      # configuration checked in here, and an application compiles under its
+      # own. apps/isolated-demo carries no cargo configuration, so this is the
+      # only place a release is proven to build for the browser the way an
+      # application builds it.
+      - name: Build the isolated demo for the web
+        run: |
+          set -euo pipefail
+          rustup target add --toolchain stable wasm32-unknown-unknown
+          command -v wasm-pack >/dev/null || cargo install wasm-pack --version 0.13.1 --locked
+          apps/isolated-demo/build-web.sh
+
       # The Android distribution is not on a remote repository yet, so the
       # plugin and its libraries reach the demo through mavenLocal, exactly as
       # they reach a developer following apps/isolated-demo/README.md.

--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -879,3 +879,46 @@ unpublished crate that caused the resolution failure in the first place.
   one failure that asserts on pixels with no external input at all — a
   screenshot with the same SHA-256 and an empty `ImageChops.difference` bbox.
   Byte-identical output from two revisions is the end of the question.
+
+## A green wasm CI that ships an unbuildable crate (2026-08-22)
+
+`v0.1.96` was published with four `error[E0308]` in `crates/cranpose/src/web.rs`:
+`pointer_position(x: f64, y: f64)` called with the `i32` that `event.offset_x()`
+returns. Every consumer's web build failed. This repository's own
+`wasm build (linux)` job was green on the same source, and so was a local
+`cargo check --target wasm32-unknown-unknown`.
+
+The cause is `--cfg web_sys_unstable_apis`, which was set in `.cargo/config.toml`
+and `apps/desktop-demo/.cargo/config.toml`. It is not an additive opt-in: in
+`web-sys`, `MouseEvent::offset_x`/`offset_y` are declared twice, `-> i32` under
+`#[cfg(not(web_sys_unstable_apis))]` and `-> f64` under `#[cfg(web_sys_unstable_apis)]`.
+So the framework compiled against one signature here and applications compiled
+against the other. Clippy made it worse rather than catching it: running under
+the same flag, it saw `offset_x() as f64` as an `unnecessary_cast` and the cast
+was removed, which is precisely what broke every consumer.
+
+What to check when a build is green here and red for an application:
+
+- Diff the rustflags, not the source. `cargo` config in this repository applies
+  to builds started here and to nothing a consumer runs. Reproduce with
+  `RUSTFLAGS= cargo check --target wasm32-unknown-unknown` from a directory that
+  carries no `.cargo/config.toml`, or from a copy of `apps/isolated-demo` with a
+  `[patch.crates-io]` pointing at the local crates.
+- Do not trust a clippy suggestion about a cast or a conversion in `cfg`-divergent
+  code until the same clippy runs without the repository's flags.
+- `apps/isolated-demo` is the only tree shaped like a consumer. Before this, the
+  release canary built it for desktop and Android but never for the web, so the
+  one thing that could have caught this was not run.
+
+`no_cargo_config_enables_unstable_web_sys_bindings` in
+`apps/desktop-demo/tests/source_hygiene_aliases.rs` now fails if the flag comes
+back, and the publish canary builds the isolated demo for the web.
+
+## crates.io and the GitHub API answer 403 without a User-Agent (2026-08-21)
+
+Both refuse a request that sends no `User-Agent`, and the failure reads as
+"crate absent" or "release missing" rather than as a rejected request. A release
+monitor reported `cranpose = ABSENT` for crates that were published and served
+correctly. Send a `User-Agent` from every script that queries either API, and
+when a registry lookup says something is missing, re-check with `curl -A` before
+believing it.

--- a/apps/desktop-demo/.cargo/config.toml
+++ b/apps/desktop-demo/.cargo/config.toml
@@ -1,5 +1,4 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
-    "--cfg", "web_sys_unstable_apis",
     "--cfg", "getrandom_backend=\"wasm_js\"",
 ]

--- a/apps/desktop-demo/tests/source_hygiene_aliases.rs
+++ b/apps/desktop-demo/tests/source_hygiene_aliases.rs
@@ -751,3 +751,72 @@ fn assert_shell_entrypoint_guarded(
         "{relative_path} must limit local cargo jobs before heavy work marker {heavy_marker:?}"
     );
 }
+
+/// The wasm build must see the same `web_sys` bindings an application sees.
+///
+/// `--cfg web_sys_unstable_apis` is not a neutral opt-in: it swaps whole method
+/// signatures. `MouseEvent::offset_x`/`offset_y` return `i32` without it and
+/// `f64` with it, so framework source written -- or clippy-corrected -- under
+/// the flag compiles here and fails in every project that consumes the
+/// published crates, which carry none of this repository's cargo configuration.
+/// A release built that way is broken for the web and nothing upstream of the
+/// consumer notices. `web_media` states the rule this guards: an application
+/// should not have to set a rustc flag to get a lock screen, so the framework
+/// reaches unstable browser APIs by name through `js_sys::Reflect` instead.
+#[test]
+fn no_cargo_config_enables_unstable_web_sys_bindings() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("desktop demo should live under workspace/apps")
+        .to_path_buf();
+
+    let mut offenders = Vec::new();
+    collect_cargo_configs(&workspace_root, &mut |path| {
+        let source =
+            fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path:?}: {err}"));
+        for (line_number, line) in source.lines().enumerate() {
+            if line.contains("web_sys_unstable_apis") {
+                offenders.push(format!(
+                    "{}:{}: {}",
+                    path.strip_prefix(&workspace_root).unwrap_or(path).display(),
+                    line_number + 1,
+                    line.trim()
+                ));
+            }
+        }
+    });
+
+    assert!(
+        offenders.is_empty(),
+        "cargo configuration must not enable unstable web-sys bindings; it changes \
+         published API signatures so the wasm build stops matching what applications \
+         compile:\n{}",
+        offenders.join("\n")
+    );
+}
+
+/// Walks every `.cargo/config.toml` the workspace carries, skipping build
+/// output and version-control directories.
+fn collect_cargo_configs(root: &std::path::Path, visit: &mut impl FnMut(&std::path::Path)) {
+    let config = root.join(".cargo/config.toml");
+    if config.is_file() {
+        visit(&config);
+    }
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if matches!(name.as_ref(), "target" | ".git" | "node_modules" | ".cargo") {
+            continue;
+        }
+        collect_cargo_configs(&path, visit);
+    }
+}

--- a/apps/isolated-demo/android/settings.gradle.kts
+++ b/apps/isolated-demo/android/settings.gradle.kts
@@ -15,7 +15,7 @@ pluginManagement {
     }
     plugins {
         id("com.android.application") version "9.2.1"
-        id("dev.cranpose.android") version "0.1.95"
+        id("dev.cranpose.android") version "0.1.96"
     }
 }
 

--- a/apps/isolated-demo/build-web.sh
+++ b/apps/isolated-demo/build-web.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Without this a failed step still reaches the success footer, which matters
+# now that the release canary uses this script to prove a published release
+# builds for the browser.
+set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
@@ -45,6 +49,7 @@ if [ $BUILD_RESULT -ne 0 ]; then
     echo "This might be due to wasm-opt issues. Retrying without wasm-opt..."
     echo ""
 
+    set +e
     "$WASM_PACK" build \
         --target web \
         --out-dir pkg \
@@ -52,6 +57,7 @@ if [ $BUILD_RESULT -ne 0 ]; then
         --no-default-features \
         --no-opt
     BUILD_RESULT=$?
+    set -e
 
     if [ $BUILD_RESULT -ne 0 ]; then
         echo "Build failed even without wasm-opt"

--- a/crates/cranpose/src/web.rs
+++ b/crates/cranpose/src/web.rs
@@ -420,8 +420,8 @@ pub async fn run(
         let wheel_canvas = canvas.clone();
         let request_frame = request_frame.clone();
         let closure = Closure::wrap(Box::new(move |event: WheelEvent| {
-            let x = event.offset_x();
-            let y = event.offset_y();
+            let x = event.offset_x() as f64;
+            let y = event.offset_y() as f64;
             let logical = platform.borrow().pointer_position(x, y);
 
             // What the sample means -- zoom, rotary, axis-swapped scroll, or
@@ -458,8 +458,8 @@ pub async fn run(
         let request_frame = request_frame.clone();
         let closure = Closure::wrap(Box::new(move |event: PointerEvent| {
             event.prevent_default();
-            let x = event.offset_x();
-            let y = event.offset_y();
+            let x = event.offset_x() as f64;
+            let y = event.offset_y() as f64;
             let logical = platform.borrow().pointer_position(x, y);
             if let Ok(mut app_mut) = app.try_borrow_mut() {
                 app_mut.set_pointer_source(web_pointer_source(&event));
@@ -479,8 +479,8 @@ pub async fn run(
         let closure = Closure::wrap(Box::new(move |event: PointerEvent| {
             event.prevent_default();
             let _ = pointer_canvas.set_pointer_capture(event.pointer_id());
-            let x = event.offset_x();
-            let y = event.offset_y();
+            let x = event.offset_x() as f64;
+            let y = event.offset_y() as f64;
             let logical = platform.borrow().pointer_position(x, y);
             if let Ok(mut app_mut) = app.try_borrow_mut() {
                 app_mut.set_pointer_source(web_pointer_source(&event));
@@ -501,8 +501,8 @@ pub async fn run(
         let request_frame = request_frame.clone();
         let closure = Closure::wrap(Box::new(move |event: PointerEvent| {
             event.prevent_default();
-            let x = event.offset_x();
-            let y = event.offset_y();
+            let x = event.offset_x() as f64;
+            let y = event.offset_y() as f64;
             let logical = platform.borrow().pointer_position(x, y);
             if let Ok(mut app_mut) = app.try_borrow_mut() {
                 app_mut.set_pointer_source(web_pointer_source(&event));


### PR DESCRIPTION
## What was broken

`v0.1.96` is published and **does not compile for the web**. Four `error[E0308]` in `crates/cranpose/src/web.rs`: `pointer_position(x: f64, y: f64)` called with the `i32` that `event.offset_x()` returns. Every consumer's web build fails on it — cranamp's `Rust` and `Web Build` jobs are red on exactly this.

## Why our own wasm CI was green on the same source

`--cfg web_sys_unstable_apis`, set in `.cargo/config.toml` and `apps/desktop-demo/.cargo/config.toml`.

It is not an additive opt-in. `web-sys` declares `MouseEvent::offset_x`/`offset_y` **twice**:

- `-> i32` under `#[cfg(not(web_sys_unstable_apis))]` (`gen_MouseEvent.rs:74`)
- `-> f64` under `#[cfg(web_sys_unstable_apis)]` (`gen_MouseEvent.rs:224`)

That configuration applies to builds started in this repository and to nothing an application runs. So the framework compiled against one signature and every consumer against the other. Clippy ran under the flag too, saw `offset_x() as f64` as an `unnecessary_cast`, and the cast was removed — which is precisely what broke the published crate.

## Evidence, not inference

- published `cranpose-0.1.96/src/web.rs` is byte-identical to `origin/main` (`diff` reports 0 lines)
- `mod web` **is** compiled in our wasm build — a planted `compile_error!` under the same cfg fires
- a planted `let _: () = x;` makes rustc report `x` as **`f64`** in our build
- removing the flag from a clean `origin/main` clone reproduces **exactly those four errors and no others**, so nothing else in the tree needed it

## The fix

1. Flag removed from both cargo configurations; `as f64` restored at the four sites.
2. `no_cargo_config_enables_unstable_web_sys_bindings` fails if any `.cargo/config.toml` enables it again.
3. The release canary now builds `apps/isolated-demo` for the web. That tree carries no cargo configuration, so it is the only place a release is compiled the way an application compiles it. The canary already built it for desktop and Android — the web, the one target whose configuration can differ, was the one it skipped.

## Verification

On a copy of the isolated demo with no cargo configuration, resolving the framework through `[patch.crates-io]`:

- with the casts: `cargo check --target wasm32-unknown-unknown --no-default-features --features web,renderer-wgpu` → clean
- without them: the same four `error[E0308]` — so the new canary genuinely catches this class

Also green: `apps/desktop-demo/build-web.sh --release` with the flag gone (11M wasm, `Build complete`), host clippy `-D warnings`, `cargo fmt --check`.

## Known, and deliberately not in this PR

`cargo clippy --target wasm32-unknown-unknown -- -D warnings` fails on `arc_with_non_send_sync` at `crates/cranpose-core/src/runtime.rs:455`. Verified **pre-existing on pristine `origin/main` with the flag intact** — CI has never run clippy for wasm, only `build-web.sh`. On wasm `RuntimeScheduler` deliberately drops `Send + Sync`, so `Arc<dyn RuntimeScheduler>` trips the lint. Fixing it changes a public constructor signature on the wasm target, which should not ride on the patch that unbreaks the wasm target. It follows separately, with a wasm clippy CI job.