### PR TITLE
Give wasm its own scheduler and HTTP-body handles instead of a fake-Sync Arc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -185,5 +185,12 @@ jobs:
           command -v wasm-pack >/dev/null || cargo install wasm-pack --version 0.13.1 --locked
           wasm-opt --version
 
+      - name: Run wasm clippy
+        # A build alone (below) does not lint: `Arc<dyn Trait>` values that are
+        # not `Send + Sync` on the single-threaded wasm target compile fine but
+        # pay for synchronisation the target cannot use. Only clippy catches
+        # that, and only for the exact package/feature set the web demo ships.
+        run: cargo clippy --target wasm32-unknown-unknown -p desktop-app-platform --no-default-features --features web,renderer-wgpu -- -D warnings
+
       - name: Build web demo
         run: apps/desktop-demo/build-web.sh --release

--- a/crates/cranpose-core/src/composition.rs
+++ b/crates/cranpose-core/src/composition.rs
@@ -1,12 +1,11 @@
 use crate::{
     collections::map::HashMap, debug_scope_invalidation_sources, debug_scope_label, runtime,
-    snapshot_state_observer, Applier, ApplierGuard, ApplierHost, CommandQueue, Composer,
-    CompositionPassDebugStats, ConcreteApplierHost, DefaultScheduler, Key, NodeError, NodeId,
-    RecomposeScope, RetentionPolicy, Runtime, RuntimeHandle, ScopeId, SlotDebugSnapshot, SlotTable,
-    SlotTableDebugStats, SlotsHost, SnapshotStateObserver,
+    scheduler_ref, snapshot_state_observer, Applier, ApplierGuard, ApplierHost, CommandQueue,
+    Composer, CompositionPassDebugStats, ConcreteApplierHost, DefaultScheduler, Key, NodeError,
+    NodeId, RecomposeScope, RetentionPolicy, Runtime, RuntimeHandle, ScopeId, SlotDebugSnapshot,
+    SlotTable, SlotTableDebugStats, SlotsHost, SnapshotStateObserver,
 };
 use std::rc::Rc;
-use std::sync::Arc;
 use web_time::Instant;
 
 pub struct Composition<A: Applier + 'static> {
@@ -47,7 +46,7 @@ fn recompose_scope_telemetry_threshold_ms() -> Option<f64> {
 
 impl<A: Applier + 'static> Composition<A> {
     pub fn new(applier: A) -> Self {
-        Self::with_runtime(applier, Runtime::new(Arc::new(DefaultScheduler)))
+        Self::with_runtime(applier, Runtime::new(scheduler_ref(DefaultScheduler)))
     }
 
     pub fn with_runtime(applier: A, runtime: Runtime) -> Self {

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -68,7 +68,7 @@ pub use launched_effect::{
     TaskSite,
 };
 pub use owned::Owned;
-pub use platform::{Clock, RuntimeScheduler};
+pub use platform::{scheduler_ref, Clock, RuntimeScheduler, SchedulerRef};
 pub use retention::{RetentionBudget, RetentionEvictionPolicy, RetentionMode, RetentionPolicy};
 #[doc(hidden)]
 pub use runtime::{

--- a/crates/cranpose-core/src/platform.rs
+++ b/crates/cranpose-core/src/platform.rs
@@ -21,6 +21,41 @@ pub trait RuntimeScheduler {
     fn schedule_frame(&self);
 }
 
+/// Shared handle to a [`RuntimeScheduler`].
+///
+/// A native host wakes the runtime from other threads (a background task
+/// finishing, a timer firing), so the handle has to be an atomically
+/// reference-counted pointer to a `Send + Sync` scheduler. A wasm host runs
+/// everything on a single thread and its scheduler holds JS values that can
+/// only ever live on that thread, so it cannot be `Send + Sync`; wrapping it
+/// in `Arc` there would buy synchronisation the target has no use for, so a
+/// plain `Rc` is used instead.
+#[cfg(not(target_arch = "wasm32"))]
+pub type SchedulerRef = std::sync::Arc<dyn RuntimeScheduler>;
+
+/// Shared handle to a [`RuntimeScheduler`]. See the native definition for why
+/// this is `Rc` on wasm instead of `Arc`.
+#[cfg(target_arch = "wasm32")]
+pub type SchedulerRef = std::rc::Rc<dyn RuntimeScheduler>;
+
+/// Wraps `scheduler` in a [`SchedulerRef`].
+///
+/// A trait-object alias cannot expose its own `new` the way a concrete type
+/// can (`Arc<dyn Trait>::new` has no `Sized` value to accept), so this is the
+/// one place that picks `Arc` on native and `Rc` on wasm; callers that need a
+/// [`SchedulerRef`] from a concrete scheduler go through this instead of
+/// repeating that choice.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn scheduler_ref<S: RuntimeScheduler + 'static>(scheduler: S) -> SchedulerRef {
+    std::sync::Arc::new(scheduler)
+}
+
+/// See the native definition of [`scheduler_ref`] for why this is `Rc` on wasm.
+#[cfg(target_arch = "wasm32")]
+pub fn scheduler_ref<S: RuntimeScheduler + 'static>(scheduler: S) -> SchedulerRef {
+    std::rc::Rc::new(scheduler)
+}
+
 /// Provides timing information for the runtime.
 pub trait Clock: Send + Sync {
     /// Instant type produced by this clock implementation.

--- a/crates/cranpose-core/src/runtime.rs
+++ b/crates/cranpose-core/src/runtime.rs
@@ -16,7 +16,7 @@ use std::thread_local;
 
 #[cfg(any(feature = "internal", test))]
 use crate::frame_clock::FrameClock;
-use crate::platform::RuntimeScheduler;
+use crate::platform::{RuntimeScheduler, SchedulerRef};
 use crate::{Applier, Command, FrameCallbackId, NodeError, RecomposeScopeInner, ScopeId};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -305,13 +305,29 @@ impl RuntimeId {
 }
 
 struct UiDispatcherInner {
-    scheduler: Arc<dyn RuntimeScheduler>,
+    scheduler: SchedulerRef,
     tx: mpsc::Sender<UiMessage>,
     pending: AtomicUsize,
 }
 
+/// Shared handle to a [`UiDispatcherInner`].
+///
+/// `UiDispatcherInner` holds a [`SchedulerRef`], so it inherits the same
+/// per-target split: native code posts work onto the UI dispatcher from other
+/// threads (see `EventSender` and `launchBlocking` in `concurrency.rs`), so
+/// the handle has to be an atomically reference-counted `Send + Sync` pointer
+/// there; on wasm the dispatcher is only ever touched from the one thread it
+/// was created on, and its scheduler cannot be `Send + Sync`, so `Rc` is used
+/// instead of paying for synchronisation the target cannot use.
+#[cfg(not(target_arch = "wasm32"))]
+type UiDispatcherRef = Arc<UiDispatcherInner>;
+
+/// See the native definition of [`UiDispatcherRef`] for why this is `Rc` on wasm.
+#[cfg(target_arch = "wasm32")]
+type UiDispatcherRef = Rc<UiDispatcherInner>;
+
 impl UiDispatcherInner {
-    fn new(scheduler: Arc<dyn RuntimeScheduler>, tx: mpsc::Sender<UiMessage>) -> Self {
+    fn new(scheduler: SchedulerRef, tx: mpsc::Sender<UiMessage>) -> Self {
         Self {
             scheduler,
             tx,
@@ -374,11 +390,11 @@ impl<'a> Drop for PendingGuard<'a> {
 
 #[derive(Clone)]
 pub struct UiDispatcher {
-    inner: Arc<UiDispatcherInner>,
+    inner: UiDispatcherRef,
 }
 
 impl UiDispatcher {
-    fn new(inner: Arc<UiDispatcherInner>) -> Self {
+    fn new(inner: UiDispatcherRef) -> Self {
         Self { inner }
     }
 
@@ -399,7 +415,7 @@ impl UiDispatcher {
 }
 
 struct RuntimeInner {
-    scheduler: Arc<dyn RuntimeScheduler>,
+    scheduler: SchedulerRef,
     needs_frame: RefCell<bool>,
     node_updates: RefCell<Vec<Command>>,
     invalid_scopes: RefCell<HashSet<ScopeId>>,
@@ -407,7 +423,7 @@ struct RuntimeInner {
     frame_callbacks: RefCell<VecDeque<FrameCallbackEntry>>,
     next_frame_callback_id: Cell<u64>,
     last_frame_time_nanos: Cell<Option<u64>>,
-    ui_dispatcher: Arc<UiDispatcherInner>,
+    ui_dispatcher: UiDispatcherRef,
     ui_rx: RefCell<mpsc::Receiver<UiMessage>>,
     local_tasks: RefCell<VecDeque<Box<dyn FnOnce() + 'static>>>,
     ui_conts: RefCell<UiContinuationMap>,
@@ -450,9 +466,9 @@ pub fn label_next_ui_task(label: impl Into<String>) {
 }
 
 impl RuntimeInner {
-    fn new(scheduler: Arc<dyn RuntimeScheduler>) -> Self {
+    fn new(scheduler: SchedulerRef) -> Self {
         let (tx, rx) = mpsc::channel();
-        let dispatcher = Arc::new(UiDispatcherInner::new(scheduler.clone(), tx));
+        let dispatcher = UiDispatcherRef::new(UiDispatcherInner::new(scheduler.clone(), tx));
         Self {
             scheduler,
             needs_frame: RefCell::new(false),
@@ -869,7 +885,7 @@ pub struct Runtime {
 }
 
 impl Runtime {
-    pub fn new(scheduler: Arc<dyn RuntimeScheduler>) -> Self {
+    pub fn new(scheduler: SchedulerRef) -> Self {
         let inner = Rc::new(RuntimeInner::new(scheduler));
         let runtime = Self { inner };
         let handle = runtime.handle();
@@ -1388,7 +1404,7 @@ pub(crate) struct FrameCallbackEntry {
 /// finishing, a platform service replying.
 #[cfg(not(target_arch = "wasm32"))]
 struct RuntimeTaskWaker {
-    scheduler: Arc<dyn RuntimeScheduler>,
+    scheduler: SchedulerRef,
     runnable: Arc<AtomicBool>,
 }
 

--- a/crates/cranpose-render/wgpu/src/frontend.rs
+++ b/crates/cranpose-render/wgpu/src/frontend.rs
@@ -253,7 +253,7 @@ impl RendererFrontend {
                         .take_frame_ops(crate::pipeline::retained_feed_generation())
                 });
                 #[cfg(target_arch = "wasm32")]
-                let replay = ReplayFrameOps::default();
+                let replay = ReplayFrameOps;
                 (PacketRoot::Direct(Box::new(root)), replay)
             }
             None => {
@@ -274,10 +274,11 @@ impl RendererFrontend {
                     height,
                     root_scale,
                 );
-                (
-                    PacketRoot::Surface(Box::new(surface)),
-                    ReplayFrameOps::default(),
-                )
+                #[cfg(not(target_arch = "wasm32"))]
+                let replay = ReplayFrameOps::default();
+                #[cfg(target_arch = "wasm32")]
+                let replay = ReplayFrameOps;
+                (PacketRoot::Surface(Box::new(surface)), replay)
             }
         };
         let after_root_collect = Instant::now();

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -11675,7 +11675,6 @@ impl GpuRenderer {
                 staged_uploads.is_empty(),
                 "wasm draw uploads use retained per-batch resource slots"
             );
-            return;
         }
 
         #[cfg(not(target_arch = "wasm32"))]

--- a/crates/cranpose-runtime-std/src/lib.rs
+++ b/crates/cranpose-runtime-std/src/lib.rs
@@ -138,6 +138,21 @@ impl RuntimeScheduler for StdScheduler {
     }
 }
 
+/// Shared handle to a [`StdScheduler`].
+///
+/// Mirrors [`cranpose_core::SchedulerRef`]: native code wakes the runtime
+/// from other threads, so the handle needs to be an atomically
+/// reference-counted `Arc`. On wasm `StdScheduler` keeps its frame waker in a
+/// `RefCell` because the host is single-threaded, so the type is not
+/// `Send + Sync` there and an `Rc` handle is used instead of paying for
+/// synchronisation the target has no use for.
+#[cfg(not(target_arch = "wasm32"))]
+pub type StdSchedulerRef = Arc<StdScheduler>;
+
+/// See the native definition of [`StdSchedulerRef`] for why this is `Rc` on wasm.
+#[cfg(target_arch = "wasm32")]
+pub type StdSchedulerRef = std::rc::Rc<StdScheduler>;
+
 /// Clock implementation backed by a cross-platform monotonic timer.
 #[derive(Debug, Default, Clone)]
 pub struct StdClock;
@@ -164,7 +179,7 @@ impl StdClock {
 /// Convenience container bundling the standard scheduler and clock.
 #[derive(Clone)]
 pub struct StdRuntime {
-    scheduler: Arc<StdScheduler>,
+    scheduler: StdSchedulerRef,
     clock: Arc<StdClock>,
     runtime: Runtime,
 }
@@ -172,7 +187,7 @@ pub struct StdRuntime {
 impl StdRuntime {
     /// Creates a new standard runtime instance.
     pub fn new() -> Self {
-        let scheduler = Arc::new(StdScheduler::default());
+        let scheduler = StdSchedulerRef::new(StdScheduler::default());
         let runtime = Runtime::new(scheduler.clone());
         Self {
             scheduler,
@@ -198,8 +213,8 @@ impl StdRuntime {
     }
 
     /// Returns the scheduler implementation.
-    pub fn scheduler(&self) -> Arc<StdScheduler> {
-        Arc::clone(&self.scheduler)
+    pub fn scheduler(&self) -> StdSchedulerRef {
+        StdSchedulerRef::clone(&self.scheduler)
     }
 
     /// Returns the clock implementation.

--- a/crates/cranpose-services/src/http.rs
+++ b/crates/cranpose-services/src/http.rs
@@ -221,8 +221,29 @@ pub trait HttpBody {
 pub type HttpBodyRef = Arc<dyn HttpBody + Send + Sync>;
 
 /// Shared handle to a response body.
+///
+/// A browser's body is a `ReadableStream` reader that belongs to the one
+/// thread a page has and cannot claim otherwise, so it is never `Send + Sync`
+/// there; `Rc` avoids paying for synchronisation the target cannot use.
 #[cfg(target_arch = "wasm32")]
-pub type HttpBodyRef = Arc<dyn HttpBody>;
+pub type HttpBodyRef = std::rc::Rc<dyn HttpBody>;
+
+/// Wraps `body` in an [`HttpBodyRef`].
+///
+/// A trait-object alias cannot expose its own `new`, so this is the one place
+/// that picks `Arc` on native and `Rc` on wasm; callers that need an
+/// [`HttpBodyRef`] from a concrete body go through this instead of repeating
+/// that choice.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn http_body_ref<B: HttpBody + Send + Sync + 'static>(body: B) -> HttpBodyRef {
+    Arc::new(body)
+}
+
+/// See the native definition of [`http_body_ref`] for why this is `Rc` on wasm.
+#[cfg(target_arch = "wasm32")]
+pub fn http_body_ref<B: HttpBody + 'static>(body: B) -> HttpBodyRef {
+    std::rc::Rc::new(body)
+}
 
 /// A body with nothing in it, which is what a `HEAD` answers with.
 struct EmptyBody;
@@ -321,7 +342,7 @@ impl HttpResponse {
 
     /// A response with no body, which is what a `HEAD` answers with.
     pub fn empty(url: impl Into<String>, status: u16) -> Self {
-        Self::new(url, status, Arc::new(EmptyBody))
+        Self::new(url, status, http_body_ref(EmptyBody))
     }
 
     pub fn with_headers(mut self, headers: Vec<(String, String)>) -> Self {
@@ -638,7 +659,7 @@ impl StubHttpClient {
             Ok(HttpResponse::new(
                 request.url.clone(),
                 200,
-                Arc::new(BytesBody::new(body.clone())),
+                http_body_ref(BytesBody::new(body.clone())),
             ))
         })
     }
@@ -652,7 +673,7 @@ impl StubHttpClient {
             Ok(HttpResponse::new(
                 request.url.clone(),
                 200,
-                Arc::new(BytesBody::new(body)),
+                http_body_ref(BytesBody::new(body)),
             ))
         })
     }
@@ -767,12 +788,14 @@ async fn send_native(
             message: "the transfer ended before a response arrived".to_string(),
         })??;
 
-    Ok(
-        HttpResponse::new(url, head.status, Arc::new(ChannelBody { chunks: stream }))
-            .with_headers(head.headers)
-            .with_content_length(head.content_length)
-            .with_resumed(head.resumed),
+    Ok(HttpResponse::new(
+        url,
+        head.status,
+        http_body_ref(ChannelBody { chunks: stream }),
     )
+    .with_headers(head.headers)
+    .with_content_length(head.content_length)
+    .with_resumed(head.resumed))
 }
 
 /// The worker body of [`send_native`]: sends the request, publishes the head,
@@ -1102,7 +1125,7 @@ async fn send_web(request: &HttpRequest, control: HttpControl) -> Result<HttpRes
     Ok(HttpResponse::new(
         request.url.clone(),
         status,
-        Arc::new(FetchBody {
+        http_body_ref(FetchBody {
             url: request.url.clone(),
             reader,
             control,


### PR DESCRIPTION
## Summary

`cargo clippy --target wasm32-unknown-unknown -p desktop-app-platform --no-default-features --features web,renderer-wgpu -- -D warnings` has never run in CI — the wasm CI job only builds the demo, it does not lint. That let two independent `Arc`-on-a-non-`Send`/`Sync`-type bugs slip in: the wasm host is single-threaded and several of its trait objects (a JS-backed `RuntimeScheduler`, a `ReadableStream`-backed `HttpBody`) can never be `Send + Sync`, so wrapping them in `Arc` compiles but pays for synchronisation the target cannot use. `clippy::arc_with_non_send_sync` is right to flag it once it actually runs.

- **`cranpose-core`**: added `platform::SchedulerRef`, a handle that's `Arc<dyn RuntimeScheduler>` on native and `Rc<dyn RuntimeScheduler>` on wasm (mirroring the existing per-target split on the `RuntimeScheduler` trait itself), plus `scheduler_ref()` to build one from a concrete scheduler (a trait-object alias has no `::new` of its own). Replaces the 6 `Arc<dyn RuntimeScheduler>` sites in `runtime.rs`. `UiDispatcherInner` picked up the identical bug one level up once its scheduler field became `Rc` on wasm — wrapping it in `Arc` unconditionally would fail the same lint — so it gets its own private `UiDispatcherRef` with the same split.
- **`cranpose-runtime-std`**: added `StdSchedulerRef`, mirroring `SchedulerRef` for the concrete `StdScheduler`, whose wasm half already used a `RefCell` for exactly this reason.
- **`cranpose-services`**: `http::HttpBodyRef` was `Arc<dyn HttpBody>` on wasm with *no* `Send + Sync` bound at all — a separate, pre-existing bug that surfaced once clippy could get past the scheduler fix. Now `Rc` on wasm, with `http_body_ref()` playing the same role as `scheduler_ref()`.
- **`cranpose-render-wgpu`**: two unrelated, previously-uncaught lints the same clippy run surfaced next (`default_constructed_unit_structs`, `needless_return`) — fixed directly, no `#[allow]`.
- **CI**: added a "Run wasm clippy" step to the existing `wasm-build` job in `.github/workflows/rust.yml`, running the exact command above. Added as a step in the existing job rather than a new job: it reuses that job's runner provisioning (PATH, sccache, the `wasm32-unknown-unknown` target already added for `wasm-pack`) instead of paying for a second Linux GPU-heavy runner allocation, and it needs the identical package/feature set as the build step it sits next to. It runs before the release build so a lint regression fails fast.

No public API is unaffected on native (all these aliases resolve to the exact same `Arc<...>` types they were before there). On wasm they are a real, if currently unused-by-any-external-crate, breaking change:
- `cranpose_core::Runtime::new(scheduler: SchedulerRef)` — was `Arc<dyn RuntimeScheduler>` unconditionally; wasm callers now need `Rc`.
- `cranpose_runtime_std::StdRuntime::scheduler(&self) -> StdSchedulerRef` — was `Arc<StdScheduler>` unconditionally; wasm callers now get `Rc<StdScheduler>`.
- New public items: `cranpose_core::{SchedulerRef, scheduler_ref}`, `cranpose_runtime_std::StdSchedulerRef`.

## Verification

All run against the final commit.

1. `cargo fmt --all` then `cargo fmt --all --check` — clean, exit 0.
2. `cargo clippy --workspace --all-targets -- -D warnings` (host) — `Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 5.12s`, zero errors.
3. `cargo clippy --target wasm32-unknown-unknown -p desktop-app-platform --no-default-features --features web,renderer-wgpu -- -D warnings` — `Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 1.70s`, zero errors.
4. `cargo test --workspace` — 149 test binaries, all `test result: ok`, zero failures.
5. `apps/desktop-demo/build-web.sh --release` — `Finished \`release\` profile [optimized] target(s) in 1m 38s`; `WASM binary size: 11M`; `WASM release size budget: 11233945 / 14680064 bytes`; `Build complete!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)