### PR TITLE
Let any heavy runner serve the wasm job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -168,10 +168,14 @@ jobs:
         run: cargo bench --package cranpose-ui --bench slot_table_v2 -- --test
 
   wasm-build:
-    name: wasm build (linux)
+    name: wasm build
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    # binaryen + wasm-pack are provisioned on the Linux runner.
-    runs-on: [self-hosted, Linux, cranpose-heavy]
+    # A wasm32 build and lint do not depend on the host, and the step below
+    # provisions what they need, so any cranpose-heavy runner can serve them.
+    # Pinning to Linux put every wasm result behind the one Linux machine, which
+    # also carries the X11 robot suite and the binary-size budget -- the work
+    # that genuinely cannot move.
+    runs-on: [self-hosted, cranpose-heavy]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
@@ -183,7 +187,9 @@ jobs:
           sccache --start-server || true
           rustup target add --toolchain stable wasm32-unknown-unknown
           command -v wasm-pack >/dev/null || cargo install wasm-pack --version 0.13.1 --locked
-          wasm-opt --version
+          # wasm-pack fetches its own binaryen when the host has none, so a
+          # missing system wasm-opt is reported rather than treated as fatal.
+          wasm-opt --version || echo "no system binaryen; wasm-pack supplies its own"
 
       - name: Run wasm clippy
         # A build alone (below) does not lint: `Arc<dyn Trait>` values that are


### PR DESCRIPTION
## What this changes

`wasm build (linux)` → `wasm build`, and `runs-on: [self-hosted, Linux, cranpose-heavy]` → `[self-hosted, cranpose-heavy]`.

## Why the Linux pin was not real

The stated reason was *"binaryen + wasm-pack are provisioned on the Linux runner."* That is no longer what gates the job:

- the setup step already runs `rustup target add wasm32-unknown-unknown` and installs wasm-pack if missing, so it self-provisions;
- wasm-pack fetches its own binaryen when the host has none. macm3 has **no** system `wasm-opt`, and `build-web.sh --release` there still produced an optimized module.

So the only thing actually blocking a mac was the `wasm-opt --version` line asserting a system binaryen the job does not need. That is now reported instead of fatal.

## Evidence it is host-independent

Same tree, both hosts:

| host | bytes |
|---|---|
| macm3 | 11,233,945 |
| CI Linux | 11,220,923 |

0.12% apart, against a ceiling of 14,680,064 that `build-web.sh` tests with `-gt`, not equality — 3.4 MB of headroom.

## Why it matters

One Linux machine serves *every* `[self-hosted, Linux, cranpose-heavy]` job. Two of the four genuinely cannot move — the X11 robot suite needs a real X server, and the binary-size budget is pinned against Linux codegen, so `architecture budgets` stays Linux. But the wasm job queued behind them for no reason, and if that machine is offline the wasm job has **nowhere to run at all** — the failure mode where a check sits queued indefinitely rather than failing.

The mac runners already carry `cranpose-heavy`, so this widens the pool without introducing a label to maintain.

Verified there are no required status checks configured on `main`, so renaming the check is safe.