### PR TITLE
fix: rename recranpose -> recompose across the codebase

### DIFF
--- a/apps/desktop-demo/src/app/hacker_news.rs
+++ b/apps/desktop-demo/src/app/hacker_news.rs
@@ -980,7 +980,7 @@ thread_local! {
 #[composable]
 fn DebugScopeTag(name: &'static str) {
     cranpose_core::with_current_composer(|composer| {
-        if let Some(scope) = composer.current_recranpose_scope() {
+        if let Some(scope) = composer.current_recompose_scope() {
             DEBUG_SCOPE_TAGS.with(|tags| {
                 tags.borrow_mut().insert(scope.id(), name);
             });

--- a/crates/cranpose-animation/src/tests/animation_tests.rs
+++ b/crates/cranpose-animation/src/tests/animation_tests.rs
@@ -114,7 +114,7 @@ fn animate_float_as_state_invalidates_composition_time_readers() {
     ) {
         {
             let rendered_values = Rc::clone(&rendered_values);
-            composer.set_recranpose_callback(move |composer| {
+            composer.set_recompose_callback(move |composer| {
                 render_animation_reader(composer, target, Rc::clone(&rendered_values));
             });
         }

--- a/crates/cranpose-core/src/composer.rs
+++ b/crates/cranpose-core/src/composer.rs
@@ -473,7 +473,7 @@ pub(crate) struct ComposerCore {
     pub(crate) pending_scope_options: RefCell<Option<RecomposeOptions>>,
     pub(crate) phase: Cell<crate::Phase>,
     pub(crate) last_node_reused: Cell<Option<bool>>,
-    pub(crate) recranpose_parent_hint: Cell<Option<NodeId>>,
+    pub(crate) recompose_parent_hint: Cell<Option<NodeId>>,
     pub(crate) root_render_requested: Cell<bool>,
     pub(crate) _not_send: PhantomData<*const ()>,
 }
@@ -538,7 +538,7 @@ impl ComposerCore {
             pending_scope_options: RefCell::new(None),
             phase: Cell::new(crate::Phase::Compose),
             last_node_reused: Cell::new(None),
-            recranpose_parent_hint: Cell::new(None),
+            recompose_parent_hint: Cell::new(None),
             root_render_requested: Cell::new(false),
             _not_send: PhantomData,
         }
@@ -755,7 +755,7 @@ impl Composer {
         let stack_hint = stack
             .last()
             .and_then(|frame| (!frame.synthetic_root).then_some(frame.id));
-        stack_hint.or_else(|| self.core.recranpose_parent_hint.get())
+        stack_hint.or_else(|| self.core.recompose_parent_hint.get())
     }
 
     pub(crate) fn subcompose_stack(&self) -> RefMut<'_, Vec<SubcomposeFrame>> {
@@ -986,7 +986,7 @@ impl Composer {
             }
         }
 
-        let parent_scope = self.current_recranpose_scope();
+        let parent_scope = self.current_recompose_scope();
         let options = self.pending_scope_options().take().unwrap_or_default();
         let parent_scope_id = parent_scope.as_ref().map(RecomposeScope::id);
         let reserved_key = self.with_slot_session_mut(|slots| slots.preview_group_key(key));
@@ -1334,7 +1334,7 @@ impl Composer {
 
     #[doc(hidden)]
     pub fn __invalidate_return_consumer_scope(&self) {
-        let Some(scope) = self.current_recranpose_scope() else {
+        let Some(scope) = self.current_recompose_scope() else {
             self.request_root_render();
             return;
         };
@@ -1424,7 +1424,7 @@ impl Composer {
         local.default_value()
     }
 
-    pub fn current_recranpose_scope(&self) -> Option<RecomposeScope> {
+    pub fn current_recompose_scope(&self) -> Option<RecomposeScope> {
         self.core.scope_stack.borrow().last().cloned()
     }
 
@@ -1579,7 +1579,7 @@ impl Composer {
         CapturedCompositionContext {
             locals: self.current_local_stack(),
             owner_scope: self
-                .current_recranpose_scope()
+                .current_recompose_scope()
                 .map(|scope| scope.downgrade()),
         }
     }
@@ -1703,19 +1703,19 @@ impl Composer {
         self.core.runtime.clone()
     }
 
-    pub fn set_recranpose_callback<F>(&self, callback: F)
+    pub fn set_recompose_callback<F>(&self, callback: F)
     where
         F: FnMut(&Composer) + 'static,
     {
-        self.set_recranpose_callback_boxed(Box::new(callback));
+        self.set_recompose_callback_boxed(Box::new(callback));
     }
 
     /// Monomorphic core (`inline(never)` so fat LTO keeps one copy). The
     /// generic entry point above would otherwise re-instantiate this observer
     /// wiring for every composable call site.
     #[inline(never)]
-    fn set_recranpose_callback_boxed(&self, mut callback: Box<dyn FnMut(&Composer)>) {
-        if let Some(scope) = self.current_recranpose_scope() {
+    fn set_recompose_callback_boxed(&self, mut callback: Box<dyn FnMut(&Composer)>) {
+        if let Some(scope) = self.current_recompose_scope() {
             let observer = self.observer();
             let scope_weak = scope.downgrade();
             scope.set_recompose(Box::new(move |composer: &Composer| {
@@ -1733,8 +1733,8 @@ impl Composer {
         }
     }
 
-    pub fn set_recranpose_fn(&self, callback: fn(&Composer)) {
-        if let Some(scope) = self.current_recranpose_scope() {
+    pub fn set_recompose_fn(&self, callback: fn(&Composer)) {
+        if let Some(scope) = self.current_recompose_scope() {
             scope.set_recompose_fn(callback);
         }
     }

--- a/crates/cranpose-core/src/composition.rs
+++ b/crates/cranpose-core/src/composition.rs
@@ -24,7 +24,7 @@ pub struct Composition<A: Applier + 'static> {
 ///
 /// Each root render clears `root_render_requested` but may re-raise it if a
 /// recompose pass inside `render()` promotes a scope callback to the root
-/// (see `Composer::recranpose_group` in recompose.rs — callbacks that cannot
+/// (see `Composer::recompose_group` in recompose.rs — callbacks that cannot
 /// run invalidate their `callback_promotion_target`, and if no ancestor can
 /// absorb the callback, `request_root_render()` is called). Each promotion
 /// walks up one parent scope, so natural convergence is bounded by the
@@ -470,7 +470,7 @@ impl<A: Applier + 'static> Composition<A> {
                                     for scope in scopes {
                                         if let Some(threshold_ms) = scope_telemetry_threshold_ms {
                                             let start = Instant::now();
-                                            composer.recranpose_group(scope);
+                                            composer.recompose_group(scope);
                                             let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
                                             if elapsed_ms >= threshold_ms {
                                                 eprintln!(
@@ -481,7 +481,7 @@ impl<A: Applier + 'static> Composition<A> {
                                                 );
                                             }
                                         } else {
-                                            composer.recranpose_group(scope);
+                                            composer.recompose_group(scope);
                                         }
                                     }
                                 },

--- a/crates/cranpose-core/src/debug_trace.rs
+++ b/crates/cranpose-core/src/debug_trace.rs
@@ -30,7 +30,7 @@ pub fn debug_label_current_scope(name: &'static str) {
     }
     #[cfg(debug_assertions)]
     with_current_composer(|composer| {
-        if let Some(scope) = composer.current_recranpose_scope() {
+        if let Some(scope) = composer.current_recompose_scope() {
             DEBUG_SCOPE_LABELS.with(|labels| {
                 labels.borrow_mut().insert(scope.id(), name);
             });

--- a/crates/cranpose-core/src/emit.rs
+++ b/crates/cranpose-core/src/emit.rs
@@ -62,7 +62,7 @@ impl Composer {
         if let (Some(id), Some(slot_gen)) = (existing_id, existing_generation) {
             if type_matches && gen_matches {
                 let scope_debug = self
-                    .current_recranpose_scope()
+                    .current_recompose_scope()
                     .map(|scope| (scope.id(), debug_scope_label(scope.id())))
                     .unwrap_or((0, None));
                 log::trace!(
@@ -132,7 +132,7 @@ impl Composer {
             (id, gen)
         };
         let scope_debug = self
-            .current_recranpose_scope()
+            .current_recompose_scope()
             .map(|scope| (scope.id(), debug_scope_label(scope.id())))
             .unwrap_or((0, None));
         log::trace!(
@@ -318,7 +318,7 @@ impl Composer {
         }
 
         // During recomposition, preserve the original parent when possible.
-        if let Some(parent_hint) = self.core.recranpose_parent_hint.get() {
+        if let Some(parent_hint) = self.core.recompose_parent_hint.get() {
             if parent_hint == id {
                 debug_assert_ne!(
                     parent_hint, id,

--- a/crates/cranpose-core/src/hooks.rs
+++ b/crates/cranpose-core/src/hooks.rs
@@ -256,7 +256,7 @@ pub fn derivedStateOf<T: 'static + Clone>(compute: impl Fn() -> T + 'static) -> 
         let key = location_key(file!(), line!(), column!());
         composer.with_group(key, |composer| {
             let should_recompute = composer
-                .current_recranpose_scope()
+                .current_recompose_scope()
                 .map(|scope| scope.should_recompose())
                 .unwrap_or(true);
             let runtime = composer.runtime_handle();

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -949,7 +949,7 @@ pub fn current_recompose_scope_invalidated_only_by(
 ) -> Option<bool> {
     with_current_composer_opt(|composer| {
         let allowed_sources = allowed_sources.into_iter().collect();
-        let mut scope = composer.current_recranpose_scope();
+        let mut scope = composer.current_recompose_scope();
         let mut saw_unknown_source = false;
         while let Some(current) = scope {
             if current.has_unknown_invalidation_source() {

--- a/crates/cranpose-core/src/recompose.rs
+++ b/crates/cranpose-core/src/recompose.rs
@@ -5,7 +5,7 @@ use crate::{
 use std::rc::Rc;
 
 impl Composer {
-    pub(crate) fn recranpose_group(&self, scope: &RecomposeScope) {
+    pub(crate) fn recompose_group(&self, scope: &RecomposeScope) {
         struct RecomposeGuard {
             composer: Composer,
             scope: RecomposeScope,
@@ -56,17 +56,14 @@ impl Composer {
             debug_scope_invalidation_sources(scope.id()),
         );
         if started.is_some() {
-            let previous_hint = self
-                .core
-                .recranpose_parent_hint
-                .replace(scope.parent_hint());
+            let previous_hint = self.core.recompose_parent_hint.replace(scope.parent_hint());
             struct HintGuard {
                 core: Rc<ComposerCore>,
                 previous: Option<NodeId>,
             }
             impl Drop for HintGuard {
                 fn drop(&mut self) {
-                    self.core.recranpose_parent_hint.set(self.previous);
+                    self.core.recompose_parent_hint.set(self.previous);
                 }
             }
             let _hint_guard = HintGuard {

--- a/crates/cranpose-core/src/tests/composition_and_recompose_scope_tests.rs
+++ b/crates/cranpose-core/src/tests/composition_and_recompose_scope_tests.rs
@@ -545,9 +545,7 @@ fn cranpose_with_reuse_skips_then_recomposes() {
                 let local_state = state_clone;
                 with_current_composer(|composer| {
                     composer.cranpose_with_reuse(slot_key, options, |composer| {
-                        let scope = composer
-                            .current_recranpose_scope()
-                            .expect("scope available");
+                        let scope = composer.current_recompose_scope().expect("scope available");
                         let changed = scope.should_recompose();
                         let has_previous = composer.remember(|| false);
                         if !changed && has_previous.with(|value| *value) {
@@ -596,9 +594,7 @@ fn cranpose_with_reuse_forces_recomposition_when_requested() {
                 let local_state = state_clone;
                 with_current_composer(|composer| {
                     composer.cranpose_with_reuse(slot_key, options, |composer| {
-                        let scope = composer
-                            .current_recranpose_scope()
-                            .expect("scope available");
+                        let scope = composer.current_recompose_scope().expect("scope available");
                         let changed = scope.should_recompose();
                         let has_previous = composer.remember(|| false);
                         if !changed && has_previous.with(|value| *value) {
@@ -642,9 +638,7 @@ fn inactive_scopes_delay_invalidation_until_reactivated() {
     fn capture_scope(state: MutableState<i32>) {
         INVOCATIONS.with(|count| count.set(count.get() + 1));
         with_current_composer(|composer| {
-            let scope = composer
-                .current_recranpose_scope()
-                .expect("scope available");
+            let scope = composer.current_recompose_scope().expect("scope available");
             CAPTURED_SCOPE.with(|slot| slot.replace(Some(scope)));
         });
         let _ = state.value();
@@ -721,7 +715,7 @@ fn scope_deactivated_during_invalidation_batch_waits_for_reactivation() {
             CHILD_SCOPE.with(|slot| {
                 slot.replace(Some(
                     composer
-                        .current_recranpose_scope()
+                        .current_recompose_scope()
                         .expect("child scope available"),
                 ));
             });
@@ -789,7 +783,7 @@ fn scope_beneath_inactive_ancestor_waits_for_tree_reactivation() {
             CHILD_SCOPE.with(|slot| {
                 slot.replace(Some(
                     composer
-                        .current_recranpose_scope()
+                        .current_recompose_scope()
                         .expect("child scope available"),
                 ));
             });
@@ -802,7 +796,7 @@ fn scope_beneath_inactive_ancestor_waits_for_tree_reactivation() {
             PARENT_SCOPE.with(|slot| {
                 slot.replace(Some(
                     composer
-                        .current_recranpose_scope()
+                        .current_recompose_scope()
                         .expect("parent scope available"),
                 ));
             });
@@ -878,7 +872,7 @@ fn subcomposition_scope_inherits_source_owner_lifetime() {
             CHILD_SCOPE.with(|slot| {
                 slot.replace(Some(
                     composer
-                        .current_recranpose_scope()
+                        .current_recompose_scope()
                         .expect("secondary child scope available"),
                 ));
             });
@@ -893,7 +887,7 @@ fn subcomposition_scope_inherits_source_owner_lifetime() {
             OWNER_SCOPE.with(|slot| {
                 slot.replace(Some(
                     composer
-                        .current_recranpose_scope()
+                        .current_recompose_scope()
                         .expect("source owner scope available"),
                 ));
             });
@@ -911,7 +905,7 @@ fn subcomposition_scope_inherits_source_owner_lifetime() {
                     SECONDARY_ROOT_SCOPE.with(|slot| {
                         slot.replace(Some(
                             secondary_composer
-                                .current_recranpose_scope()
+                                .current_recompose_scope()
                                 .expect("secondary root scope available"),
                         ));
                     });
@@ -1007,9 +1001,7 @@ fn invalidating_active_scope_recomposes_that_scope() {
     fn capture_scope() {
         INVOCATIONS.with(|count| count.set(count.get() + 1));
         with_current_composer(|composer| {
-            let scope = composer
-                .current_recranpose_scope()
-                .expect("scope available");
+            let scope = composer.current_recompose_scope().expect("scope available");
             CAPTURED_SCOPE.with(|slot| slot.replace(Some(scope)));
         });
     }
@@ -1063,7 +1055,7 @@ fn callbackless_scope_promotes_via_parent_scope_metadata() {
         PARENT_INVOCATIONS.with(|count| count.set(count.get() + 1));
         with_current_composer(|composer| {
             let scope = composer
-                .current_recranpose_scope()
+                .current_recompose_scope()
                 .expect("parent scope available");
             PARENT_SCOPE.with(|slot| slot.replace(Some(scope.clone())));
             PARENT_SCOPE_ID.with(|slot| slot.set(Some(scope.id())));
@@ -1072,7 +1064,7 @@ fn callbackless_scope_promotes_via_parent_scope_metadata() {
         cranpose_core::with_key(&"callbackless-child", || {
             with_current_composer(|composer| {
                 let scope = composer
-                    .current_recranpose_scope()
+                    .current_recompose_scope()
                     .expect("child scope available");
                 CHILD_SCOPE.with(|slot| slot.replace(Some(scope)));
             });
@@ -1157,7 +1149,7 @@ fn render_stable_reaches_fixpoint_when_internal_invalid_scope_processing_request
         cranpose_core::with_key(&"root-callbackless", || {
             with_current_composer(|composer| {
                 let scope = composer
-                    .current_recranpose_scope()
+                    .current_recompose_scope()
                     .expect("callbackless root scope available");
                 ROOT_CALLBACKLESS_SCOPE.with(|slot| slot.replace(Some(scope)));
             });
@@ -1251,7 +1243,7 @@ fn reconcile_clears_scope_flags_during_root_replay() {
         TRACKED_RENDERS.with(|count| count.set(count.get() + 1));
         with_current_composer(|composer| {
             let scope = composer
-                .current_recranpose_scope()
+                .current_recompose_scope()
                 .expect("tracked scope available");
             TRACKED_SCOPE.with(|slot| slot.replace(Some(scope)));
         });
@@ -1261,7 +1253,7 @@ fn reconcile_clears_scope_flags_during_root_replay() {
     fn parent_scope_host() {
         with_current_composer(|composer| {
             let scope = composer
-                .current_recranpose_scope()
+                .current_recompose_scope()
                 .expect("parent scope available");
             PARENT_SCOPE.with(|slot| slot.replace(Some(scope)));
         });
@@ -1283,7 +1275,7 @@ fn reconcile_clears_scope_flags_during_root_replay() {
         cranpose_core::with_key(&"root-callbackless", || {
             with_current_composer(|composer| {
                 let scope = composer
-                    .current_recranpose_scope()
+                    .current_recompose_scope()
                     .expect("callbackless root scope available");
                 CALLBACKLESS_SCOPE.with(|slot| slot.replace(Some(scope)));
             });
@@ -1347,9 +1339,7 @@ fn process_invalid_scopes_preserves_later_fresh_subtree_when_earlier_scope_runs_
     fn earlier_sibling() {
         EARLY_INVOCATIONS.with(|count| count.set(count.get() + 1));
         with_current_composer(|composer| {
-            let scope = composer
-                .current_recranpose_scope()
-                .expect("scope available");
+            let scope = composer.current_recompose_scope().expect("scope available");
             EARLY_SCOPE.with(|slot| slot.replace(Some(scope)));
         });
     }
@@ -1453,9 +1443,7 @@ fn retained_scope_stays_inactive_until_restored() {
             with_current_composer(|composer| {
                 composer.cranpose_with_reuse(branch_key, RecomposeOptions::default(), |composer| {
                     INVOCATIONS.with(|count| count.set(count.get() + 1));
-                    let scope = composer
-                        .current_recranpose_scope()
-                        .expect("scope available");
+                    let scope = composer.current_recompose_scope().expect("scope available");
                     CAPTURED_SCOPE.with(|slot| slot.replace(Some(scope)));
                     OBSERVED_VALUES.with(|values| values.borrow_mut().push(observed.value()));
                 });
@@ -1637,7 +1625,7 @@ fn restored_retained_scope_processes_forced_recompose() {
                 composer.cranpose_with_reuse(BRANCH_KEY, RecomposeOptions::default(), |composer| {
                     INVOCATIONS.with(|count| count.set(count.get() + 1));
                     let scope = composer
-                        .current_recranpose_scope()
+                        .current_recompose_scope()
                         .expect("retained branch scope available");
                     CAPTURED_SCOPE.with(|slot| slot.replace(Some(scope)));
                 });

--- a/crates/cranpose-core/src/tests/recompose_and_diff_tests.rs
+++ b/crates/cranpose-core/src/tests/recompose_and_diff_tests.rs
@@ -110,7 +110,7 @@ fn returned_composable_state_change_recomposes_parent_consumer() {
 }
 
 #[test]
-fn recranpose_does_not_use_stale_indices_when_prior_scope_changes_length() {
+fn recompose_does_not_use_stale_indices_when_prior_scope_changes_length() {
     thread_local! {
         static STABLE_RECOMPOSE_A: Cell<usize> = const { Cell::new(0) };
         static STABLE_RECOMPOSE_B: Cell<usize> = const { Cell::new(0) };
@@ -180,7 +180,7 @@ fn recranpose_does_not_use_stale_indices_when_prior_scope_changes_length() {
 }
 
 #[test]
-fn recranpose_handles_removed_scopes_gracefully() {
+fn recompose_handles_removed_scopes_gracefully() {
     thread_local! {
         static REMOVED_SCOPE_LOG: RefCell<Vec<&'static str>> = const { RefCell::new(Vec::new()) };
     }
@@ -194,7 +194,7 @@ fn recranpose_handles_removed_scopes_gracefully() {
             let state_clone = *state_a;
             composer.with_group(21, |composer| {
                 let state_capture = state_clone;
-                composer.set_recranpose_callback({
+                composer.set_recompose_callback({
                     move |composer| {
                         let _ = state_capture.value();
                         composer.register_side_effect(|| {

--- a/crates/cranpose-macros/src/lib.rs
+++ b/crates/cranpose-macros/src/lib.rs
@@ -303,7 +303,7 @@ pub fn composable(attr: TokenStream, item: TokenStream) -> TokenStream {
     let scope_label_ident = func.sig.ident.clone();
     let original_block = func.block.clone();
     let helper_block = original_block.clone();
-    let recranpose_block = original_block.clone();
+    let recompose_block = original_block.clone();
     let key_expr = quote! { #core_path::location_key(file!(), line!(), column!()) };
 
     // Rebinds will be generated later in the helper_body context where we have access to slots
@@ -622,17 +622,17 @@ pub fn composable(attr: TokenStream, item: TokenStream) -> TokenStream {
             })
             .collect();
 
-        let recranpose_fn_ident = Ident::new(
-            &format!("__cranpose_recranpose_{}", func.sig.ident),
+        let recompose_fn_ident = Ident::new(
+            &format!("__cranpose_recompose_{}", func.sig.ident),
             Span::call_site(),
         );
 
-        let recranpose_setter = quote! {
+        let recompose_setter = quote! {
             {
-                __composer.set_recranpose_callback(move |
+                __composer.set_recompose_callback(move |
                     __composer: &#core_path::Composer|
                 {
-                    #recranpose_fn_ident #ty_generics_turbofish (
+                    #recompose_fn_ident #ty_generics_turbofish (
                         __composer
                     );
                 });
@@ -643,11 +643,11 @@ pub fn composable(attr: TokenStream, item: TokenStream) -> TokenStream {
             quote! {
                 #core_path::debug_label_current_scope(stringify!(#scope_label_ident));
                 let __current_scope = __composer
-                    .current_recranpose_scope()
+                    .current_recompose_scope()
                     .expect("missing recompose scope");
                 let mut __changed = __current_scope.should_recompose();
                 #(#param_setup)*
-                #recranpose_setter
+                #recompose_setter
                 if !__changed && __current_scope.has_composed_once() {
                     __composer.skip_current_group();
                     return;
@@ -659,11 +659,11 @@ pub fn composable(attr: TokenStream, item: TokenStream) -> TokenStream {
             quote! {
                 #core_path::debug_label_current_scope(stringify!(#scope_label_ident));
                 let __current_scope = __composer
-                    .current_recranpose_scope()
+                    .current_recompose_scope()
                     .expect("missing recompose scope");
                 let mut __changed = __current_scope.should_recompose();
                 #(#param_setup)*
-                #recranpose_setter
+                #recompose_setter
                 let __result_slot_index = __composer
                     .__use_return_slot(|| #core_path::ReturnSlot::<#return_ty>::default());
                 let __has_previous = __composer
@@ -697,12 +697,12 @@ pub fn composable(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         };
 
-        let recranpose_fn_body = if returns_unit {
+        let recompose_fn_body = if returns_unit {
             quote! {
                 #(#param_setup_recompose)*
                 #(#rebinds_for_recompose)*
-                #recranpose_block
-                #recranpose_setter
+                #recompose_block
+                #recompose_setter
             }
         } else {
             quote! {
@@ -711,7 +711,7 @@ pub fn composable(attr: TokenStream, item: TokenStream) -> TokenStream {
                     .__use_return_slot(|| #core_path::ReturnSlot::<#return_ty>::default());
                 #(#rebinds_for_recompose)*
                 let __value: #return_ty = {
-                    #recranpose_block
+                    #recompose_block
                 };
                 __composer.with_slot_value_mut::<#core_path::ReturnSlot<#return_ty>, _>(
                     __result_slot_index,
@@ -719,18 +719,18 @@ pub fn composable(attr: TokenStream, item: TokenStream) -> TokenStream {
                         slot.store(__value.clone());
                     },
                 );
-                #recranpose_setter
+                #recompose_setter
                 #invalidate_return_consumer
                 __value
             }
         };
 
-        let recranpose_fn = quote! {
+        let recompose_fn = quote! {
             #[allow(non_snake_case)]
-            fn #recranpose_fn_ident #impl_generics (
+            fn #recompose_fn_ident #impl_generics (
                 __composer: &#core_path::Composer
             ) -> #return_ty #where_clause {
-                #recranpose_fn_body
+                #recompose_fn_body
             }
         };
 
@@ -772,7 +772,7 @@ pub fn composable(attr: TokenStream, item: TokenStream) -> TokenStream {
         });
         *func.block = syn::parse2(wrapped).expect("failed to build block");
         TokenStream::from(quote! {
-            #recranpose_fn
+            #recompose_fn
             #helper_fn
             #func
         })

--- a/crates/cranpose-runtime-std/src/tests/std_runtime_tests.rs
+++ b/crates/cranpose-runtime-std/src/tests/std_runtime_tests.rs
@@ -34,7 +34,7 @@ fn std_runtime_requests_frame_and_recomposes_on_state_change() {
             cranpose_core::with_current_composer(|composer| {
                 let recompositions_cb = recompositions.clone();
                 let state_slot_cb = state_slot.clone();
-                composer.set_recranpose_callback(move |_composer| {
+                composer.set_recompose_callback(move |_composer| {
                     cranpose_counter_body(&recompositions_cb, &state_slot_cb);
                 });
             });

--- a/crates/cranpose-ui/src/subcompose_layout.rs
+++ b/crates/cranpose-ui/src/subcompose_layout.rs
@@ -648,7 +648,7 @@ impl<'a> SubcomposeMeasureScopeImpl<'a> {
 fn compose_subcompose_slot_content(holder: cranpose_core::CallbackHolder) {
     cranpose_core::with_current_composer(|composer| {
         let holder_for_recompose = holder.clone();
-        composer.set_recranpose_callback(move |_composer| {
+        composer.set_recompose_callback(move |_composer| {
             compose_subcompose_slot_content(holder_for_recompose.clone());
         });
     });

--- a/docs/SNAPSHOTS_AND_SLOTS.md
+++ b/docs/SNAPSHOTS_AND_SLOTS.md
@@ -903,7 +903,7 @@ let invalid_scopes = observer.notify_changed_objects(&changed_objects);
 
 // 3. Recompose each scope
 for scope in invalid_scopes {
-    composer.recranpose_group(scope);
+    composer.recompose_group(scope);
 }
 ```
 

--- a/docs/binary_size.md
+++ b/docs/binary_size.md
@@ -52,7 +52,7 @@ closure that only ever gets erased anyway":
    monomorphic cores (`with_group_in_active_pass_dyn` over
    `&mut dyn FnMut(&Composer)`, `value_slot_with_kind_dyn` over a
    `PayloadInit` type-id + boxed factory) behind thin generic shims.
-2. `Composer::set_recranpose_callback` duplicated its observer wiring per
+2. `Composer::set_recompose_callback` duplicated its observer wiring per
    call site (393 copies, 703 KiB). Fixed by boxing at the entry point into
    an `#[inline(never)]` monomorphic core.
 3. The `#[composable]` macro made every generated helper/recompose fn

--- a/docs/cranpose_slot_table_v2_design.md
+++ b/docs/cranpose_slot_table_v2_design.md
@@ -79,7 +79,7 @@ Historical source-level observations:
 - `trim_to_cursor` marks unreachable slots as gaps and intentionally keeps group length as physical extent rather than active subtree size.
 - `SlotStorage::begin_group` returned a gap-restoration boolean; `Composer::with_group` checked that flag and forced recomposition.
 - `SlotStorage` exposed cursor-repair methods such as `step_back` and `advance_after_node_read`.
-- `begin_recranpose_at_scope` starts from a `ScopeId`; the current slot table finds a group by scanning slots for a matching scope.
+- `begin_recompose_at_scope` starts from a `ScopeId`; the current slot table finds a group by scanning slots for a matching scope.
 - `SubcomposeState` already shows a cleaner lifecycle pattern: it owns active slots, reusable pools, slot compositions, precomposed nodes, and a reuse policy outside the main slot table.
 
 ---
@@ -725,7 +725,7 @@ impl Default for RecomposeOptions {
 
 ```rust
 pub fn with_group_seed<R>(&self, key: GroupKeySeed, f: impl FnOnce(&Composer) -> R) -> R {
-    let parent_scope = self.current_recranpose_scope();
+    let parent_scope = self.current_recompose_scope();
     let options = self.pending_scope_options().take().unwrap_or_default();
     let parent_scope_id = parent_scope.as_ref().map(RecomposeScope::id);
     let host = self.active_slots_host();


### PR DESCRIPTION
## Summary

An early project-wide find-and-replace of `compose` -> `cranpose` (the crate
prefix) incorrectly matched inside the word "recompose", producing
`recranpose` in ~69 places across the tree. Recomposition is core framework
vocabulary — it names the process the composer runs when tracked state
changes — so the typo reached the public API:

```rust
// crates/cranpose-core/src/composer.rs
pub fn current_recranpose_scope(&self) -> Option<RecomposeScope>
```

The function name disagreed with its own correctly-spelled return type
(`RecomposeScope`).

- Renamed every `recranpose` / `Recranpose` / `RECRANPOSE` occurrence to
  `recompose` / `Recompose` / `RECOMPOSE`, including the public
  `Composer::current_recompose_scope`, `set_recompose_callback`, internal
  fields, tests, and docs.
- Left every legitimate use of `cranpose` untouched (crate names, the
  `__cranpose_` generated-function prefix in the `#[composable]` macro, doc
  filenames).
- Updated the `#[composable]` proc-macro's generated identifier
  (`recompose_fn_ident`, previously `recranpose_fn_ident`) and every site
  that constructs or references it, so macro expansion stays internally
  consistent.
- `cargo fmt` reflowed a handful of call sites whose line length changed
  with the shorter identifier.

## Test plan

Run on the `macm3` build host (workspace build/test exceeds local time budget):

- [x] `grep -rni "recranpose" .` (excluding `.git`) returns nothing
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test --workspace` — all suites pass, including
      `cranpose-core` (694 unit tests) which owns the renamed public API,
      and every crate whose `#[composable]` functions exercise the
      renamed macro-generated identifier (`cranpose-ui`: 482 tests,
      `cranpose-animation`, `cranpose-app-shell`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)