### PR TITLE
Read the density from the composition, not from the shell

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -60,6 +60,24 @@ Fixing it means requiring `K: PartialEq + 'static` and storing the key itself,
 which costs keys that are `Hash` but not `Eq`. That trade is the open question;
 the divergence is not in doubt.
 
+### A provided density does not reach measurement
+
+`local_density()` scopes a grid to a subtree and composables read it, but the
+layout pass does not: `LayoutNode` captures no density, so measurement reads
+whatever the host installed on the shell. A `ProvideDensity` around a subtree
+therefore changes what its composables compute and not what its children are
+measured against.
+
+Compose captures density onto the layout node at composition time, which is what
+makes `MeasureScope` able to carry one into `MeasurePolicy.measure`. Here
+`MeasurePolicy::measure` receives no scope at all, and `MeasureScope` — which
+has exactly one implementor, the subcompose scope — still declares `density()`
+and `font_scale()` with `1.0` defaults that would silently lie for the next one.
+
+Closing it means deciding where the value is captured before threading anything:
+give `LayoutNode` the grid it was composed with, source the scope from that, and
+drop the defaults.
+
 ### The Android panic hook overwrites the application's
 
 `crates/cranpose/src/android.rs` installs a panic hook unconditionally, and it

--- a/crates/cranpose-ui/src/density.rs
+++ b/crates/cranpose-ui/src/density.rs
@@ -8,34 +8,52 @@
 //!
 //! That difference is not cosmetic. Half a pixel of drift moves a line of
 //! text's antialiasing onto the next row, and it puts a soft edge everywhere
-//! the Compose build draws a crisp one. Every Wear widget in this module
-//! therefore rounds its own sizes and offsets through [`WearDensity`] rather
-//! than trusting the ambient float arithmetic.
+//! the Compose build draws a crisp one. A widget that must draw a crisp edge
+//! therefore rounds its own sizes and offsets through [`Density`] rather than
+//! trusting the ambient float arithmetic. The Wear widgets do this throughout;
+//! the rest of the library does not, which is where a soft edge still comes
+//! from.
 //!
 //! One length unit runs through all of it: a Cranpose layout point is a dp.
-//! `WearDensity` converts to and from device pixels and does the rounding on
+//! `Density` converts to and from device pixels and does the rounding on
 //! the pixel side, which is the only side where rounding means anything.
+
+use cranpose_core::{compositionLocalOf, CompositionLocal, CompositionLocalProvider};
 
 use crate::font_scale::FontScaleCurve;
 use crate::render_state::{current_density, current_font_scale_curve};
 use crate::round_scaling_list::round_to_px;
 
-/// The device pixel grid a Wear widget measures against.
+/// The device pixel grid a layout measures against: how many device pixels
+/// a layout point is worth, and how the platform converts a text size.
 ///
-/// A measure policy has no scope parameter and so cannot be handed a density;
-/// [`WearDensity::current`] reads the ambient one the host installed. Tests and
-/// goldens construct one directly so a measurement does not depend on the
-/// machine it runs on.
+/// This is Compose's `Density`, and [`local_density`] is its `LocalDensity`.
+///
+/// Read it in a composable through [`density`], which subscribes to the
+/// composition local rather than to process-wide state, so a subtree given its
+/// own density recomposes only what read it. Tests and goldens construct one
+/// directly so a measurement does not depend on the machine it runs on.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct WearDensity {
+pub struct Density {
     density: f32,
     font_scale: FontScaleCurve,
 }
 
-impl WearDensity {
-    /// The grid the running app is on.
-    pub fn current() -> Self {
-        Self::with_curve(current_density(), current_font_scale_curve())
+impl Density {
+    /// The grid the host installed on this shell.
+    ///
+    /// This is the composition local's default, not the way a composable should
+    /// read the density -- use [`density`] for that, so a subtree provided its
+    /// own grid is honoured.
+    pub fn from_host() -> Self {
+        // A composition can run without a shell -- a test, a golden, a headless
+        // measurement -- and asking the render state for a grid there panics.
+        // The unit grid is the honest answer when no host has stated one.
+        if crate::render_state::has_current_app_context() {
+            Self::with_curve(current_density(), current_font_scale_curve())
+        } else {
+            Self::default()
+        }
     }
 
     /// A grid stated outright, for a test or a golden. The setting is taken as
@@ -87,7 +105,7 @@ impl WearDensity {
     /// A text size in scale-independent pixels, snapped the same way.
     ///
     /// Anything that must not move when the user changes their text size is
-    /// measured with [`WearDensity::dp`] instead — that is the whole difference
+    /// measured with [`Density::dp`] instead — that is the whole difference
     /// between the two.
     pub fn sp(self, value: f32) -> f32 {
         self.dp(self.font_scale.sp_to_dp(value))
@@ -136,19 +154,90 @@ impl WearDensity {
     }
 }
 
-impl Default for WearDensity {
+impl Default for Density {
     fn default() -> Self {
         Self::new(1.0, 1.0)
     }
+}
+
+/// The [`CompositionLocal`] carrying the device pixel grid.
+///
+/// Compose's `LocalDensity`. Its default is whatever grid the host installed on
+/// this shell, so an application that never provides one still measures against
+/// the real screen; providing one scopes a different grid to a subtree, which
+/// is what a preview, a scaled container or a density-specific golden needs.
+pub fn local_density() -> CompositionLocal<Density> {
+    thread_local! {
+        static LOCAL: std::cell::RefCell<Option<CompositionLocal<Density>>> =
+            const { std::cell::RefCell::new(None) };
+    }
+    LOCAL.with(|cell| {
+        cell.borrow_mut()
+            .get_or_insert_with(|| compositionLocalOf(Density::from_host))
+            .clone()
+    })
+}
+
+/// The device pixel grid in force here.
+pub fn density() -> Density {
+    local_density().current()
+}
+
+/// Runs `content` on `density`.
+///
+/// Compose's `CompositionLocalProvider(LocalDensity provides ...)`. A preview, a
+/// scaled container or a golden that must not depend on the machine it runs on
+/// states its grid here instead of moving the whole shell onto it.
+#[allow(non_snake_case)]
+pub fn ProvideDensity(density: Density, content: impl FnOnce()) {
+    CompositionLocalProvider(vec![local_density().provides(density)], content);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Density was a value read from the shell, so a subtree could not be
+    /// measured on a different grid. Reading it through the local is what lets a
+    /// preview or a golden state its own grid without moving the whole shell.
+    #[test]
+    fn a_provided_density_reaches_the_content_and_ends_with_it() {
+        use cranpose_core::{location_key, Composition, MemoryApplier};
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let mut composition = Composition::new(MemoryApplier::new());
+        let outer = Rc::new(Cell::new(0.0_f32));
+        let inside = Rc::new(Cell::new(0.0_f32));
+        let after = Rc::new(Cell::new(0.0_f32));
+
+        let key = location_key(file!(), line!(), column!());
+        {
+            let (outer, inside, after) = (Rc::clone(&outer), Rc::clone(&inside), Rc::clone(&after));
+            let mut render = move || {
+                outer.set(density().density());
+                ProvideDensity(Density::new(3.0, 1.0), || inside.set(density().density()));
+                after.set(density().density());
+            };
+            composition.render(key, &mut render).expect("render");
+        }
+
+        assert_eq!(inside.get(), 3.0, "the subtree reads the grid it was given");
+        assert_ne!(
+            outer.get(),
+            3.0,
+            "the provision does not escape upwards out of its content"
+        );
+        assert_eq!(
+            after.get(),
+            outer.get(),
+            "nor does it leak into what follows it"
+        );
+    }
+
     #[test]
     fn a_dp_length_lands_on_a_whole_device_pixel() {
-        let density = WearDensity::new(2.0, 1.0);
+        let density = Density::new(2.0, 1.0);
         assert_eq!(density.dp(13.3), 13.5);
         assert_eq!(density.to_px(density.dp(13.3)), 27.0);
         // An exact half goes up, as Kotlin's `roundToInt` does.
@@ -157,7 +246,7 @@ mod tests {
 
     #[test]
     fn a_text_size_moves_with_the_font_scale_and_a_dp_length_does_not() {
-        let density = WearDensity::new(2.0, 1.24);
+        let density = Density::new(2.0, 1.24);
         assert_eq!(density.dp(15.0), 15.0);
         // 15sp at 1.24 is 18.6dp = 37.2px, which is 37px.
         assert_eq!(density.to_px(density.sp(15.0)), 37.0);
@@ -165,7 +254,7 @@ mod tests {
 
     #[test]
     fn centring_puts_the_leading_gap_on_a_pixel_boundary() {
-        let density = WearDensity::new(2.0, 1.0);
+        let density = Density::new(2.0, 1.0);
         // 104px of room, 93px of content: 5.5px above, which rounds up to a
         // whole 6px rather than landing across a pixel boundary.
         let leading = density.centre(52.0, 46.5);
@@ -174,7 +263,7 @@ mod tests {
 
     #[test]
     fn floor_and_ceil_move_whole_pixels_only() {
-        let density = WearDensity::new(2.0, 1.0);
+        let density = Density::new(2.0, 1.0);
         assert_eq!(density.floor(13.3), 13.0);
         assert_eq!(density.ceil(13.3), 13.5);
         assert_eq!(density.ceil(13.5), 13.5);
@@ -182,7 +271,7 @@ mod tests {
 
     #[test]
     fn a_nonsense_grid_falls_back_to_one_rather_than_dividing_by_zero() {
-        let density = WearDensity::new(0.0, f32::NAN);
+        let density = Density::new(0.0, f32::NAN);
         assert_eq!(density.density(), 1.0);
         assert_eq!(density.font_scale(), 1.0);
         assert_eq!(density.dp(3.7), 4.0);

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -12,6 +12,7 @@ pub mod bring_into_view;
 pub mod clipboard_session;
 mod cursor_animation;
 mod debug;
+pub mod density;
 pub mod draggable;
 mod draw;
 pub mod fling_animation;
@@ -144,6 +145,7 @@ pub use primitives::{
 pub use cranpose_foundation::lazy::{
     LazyItems, LazyListItemInfo, LazyListLayoutInfo, LazyListScope, LazyListState,
 };
+pub use density::{density, local_density, Density};
 pub use draggable::{rememberDraggableState, DragDeltaHandler, DraggableState};
 pub use font_scale::{FontScaleCurve, MAX_FONT_SCALE_KNOTS};
 pub use key_event::{KeyCode, KeyEvent, KeyEventType, Modifiers};

--- a/crates/cranpose-ui/src/subcompose_layout.rs
+++ b/crates/cranpose-ui/src/subcompose_layout.rs
@@ -445,12 +445,15 @@ impl<'a> SubcomposeLayoutScope for SubcomposeMeasureScopeImpl<'a> {
 }
 
 impl cranpose_ui_layout::MeasureScope for SubcomposeMeasureScopeImpl<'_> {
+    // A subcompose measure runs inside the composition that asked for it, so
+    // the grid it measures against is the one that composition was given --
+    // not whatever the host installed on the shell.
     fn density(&self) -> f32 {
-        crate::current_density()
+        crate::density::density().density()
     }
 
     fn font_scale(&self) -> f32 {
-        crate::current_font_scale()
+        crate::density::density().font_scale()
     }
 }
 

--- a/crates/cranpose-ui/src/widgets/wear/button.rs
+++ b/crates/cranpose-ui/src/widgets/wear/button.rs
@@ -20,8 +20,8 @@
 #![allow(non_snake_case)]
 
 use crate::composable;
+use crate::density::Density;
 use crate::modifier::{Brush, Color, CornerRadii, Modifier, SemanticsConfiguration};
-use crate::widgets::wear::density::WearDensity;
 use crate::widgets::wear::theme::{WearColors, WearTextStyle};
 use crate::widgets::{Layout, Text};
 use crate::SemanticsWidgetRole;
@@ -82,7 +82,7 @@ pub fn WearButton<F>(
 where
     F: FnMut() + 'static,
 {
-    let density = WearDensity::current();
+    let density = crate::density::density();
     let container = spec.colors.primary;
     let radius = density.dp(spec.corner_radius);
     let description = match &secondary_label {
@@ -148,7 +148,7 @@ impl MeasurePolicy for WearButtonMeasurePolicy {
         placements: &mut Vec<Placement>,
     ) -> Size {
         placements.clear();
-        let density = WearDensity::new(self.density, 1.0);
+        let density = Density::new(self.density, 1.0);
         let horizontal = density.dp(self.spec.padding_horizontal) * 2.0;
         let vertical = density.dp(self.spec.padding_vertical) * 2.0;
         let width = if constraints.max_width.is_finite() {
@@ -197,7 +197,7 @@ impl MeasurePolicy for WearButtonMeasurePolicy {
     }
 
     fn min_intrinsic_width(&self, measurables: &[Box<dyn Measurable>], height: f32) -> f32 {
-        let density = WearDensity::new(self.density, 1.0);
+        let density = Density::new(self.density, 1.0);
         measurables
             .iter()
             .map(|m| m.min_intrinsic_width(height))
@@ -206,7 +206,7 @@ impl MeasurePolicy for WearButtonMeasurePolicy {
     }
 
     fn max_intrinsic_width(&self, measurables: &[Box<dyn Measurable>], height: f32) -> f32 {
-        let density = WearDensity::new(self.density, 1.0);
+        let density = Density::new(self.density, 1.0);
         measurables
             .iter()
             .map(|m| m.max_intrinsic_width(height))
@@ -215,7 +215,7 @@ impl MeasurePolicy for WearButtonMeasurePolicy {
     }
 
     fn min_intrinsic_height(&self, measurables: &[Box<dyn Measurable>], width: f32) -> f32 {
-        let density = WearDensity::new(self.density, 1.0);
+        let density = Density::new(self.density, 1.0);
         let spacing =
             density.dp(self.spec.label_spacing) * measurables.len().saturating_sub(1) as f32;
         let column = measurables

--- a/crates/cranpose-ui/src/widgets/wear/list_header.rs
+++ b/crates/cranpose-ui/src/widgets/wear/list_header.rs
@@ -24,9 +24,9 @@
 #![allow(non_snake_case)]
 
 use crate::composable;
+use crate::density::Density;
 use crate::modifier::Modifier;
 use crate::text::paragraph::TextAlign;
-use crate::widgets::wear::density::WearDensity;
 use crate::widgets::wear::theme::{WearColors, WearTextStyle};
 use crate::widgets::{Layout, Text};
 use cranpose_core::NodeId;
@@ -89,7 +89,7 @@ where
         modifier,
         ListHeaderMeasurePolicy {
             spec,
-            density: WearDensity::current().density(),
+            density: crate::density::density().density(),
         },
         move || {
             Text(label.clone(), Modifier::empty(), style.clone());
@@ -104,11 +104,11 @@ struct ListHeaderMeasurePolicy {
 }
 
 impl ListHeaderMeasurePolicy {
-    fn horizontal(&self, density: WearDensity) -> f32 {
+    fn horizontal(&self, density: Density) -> f32 {
         density.dp(self.spec.padding_start) + density.dp(self.spec.padding_end)
     }
 
-    fn vertical(&self, density: WearDensity) -> f32 {
+    fn vertical(&self, density: Density) -> f32 {
         density.dp(self.spec.padding_top) + density.dp(self.spec.padding_bottom)
     }
 }
@@ -131,7 +131,7 @@ impl MeasurePolicy for ListHeaderMeasurePolicy {
         placements: &mut Vec<Placement>,
     ) -> Size {
         placements.clear();
-        let density = WearDensity::new(self.density, 1.0);
+        let density = Density::new(self.density, 1.0);
         let horizontal = self.horizontal(density);
         let available = (constraints.max_width - horizontal).max(0.0);
         let child_constraints = Constraints {
@@ -175,7 +175,7 @@ impl MeasurePolicy for ListHeaderMeasurePolicy {
     }
 
     fn min_intrinsic_width(&self, measurables: &[Box<dyn Measurable>], height: f32) -> f32 {
-        let density = WearDensity::new(self.density, 1.0);
+        let density = Density::new(self.density, 1.0);
         measurables
             .iter()
             .map(|m| m.min_intrinsic_width(height))
@@ -184,7 +184,7 @@ impl MeasurePolicy for ListHeaderMeasurePolicy {
     }
 
     fn max_intrinsic_width(&self, measurables: &[Box<dyn Measurable>], height: f32) -> f32 {
-        let density = WearDensity::new(self.density, 1.0);
+        let density = Density::new(self.density, 1.0);
         measurables
             .iter()
             .map(|m| m.max_intrinsic_width(height))
@@ -193,7 +193,7 @@ impl MeasurePolicy for ListHeaderMeasurePolicy {
     }
 
     fn min_intrinsic_height(&self, measurables: &[Box<dyn Measurable>], width: f32) -> f32 {
-        let density = WearDensity::new(self.density, 1.0);
+        let density = Density::new(self.density, 1.0);
         let content = measurables
             .iter()
             .map(|m| m.min_intrinsic_height(width))

--- a/crates/cranpose-ui/src/widgets/wear/mod.rs
+++ b/crates/cranpose-ui/src/widgets/wear/mod.rs
@@ -9,7 +9,7 @@
 //! These are built against Cranpose's own text and colour model, not against
 //! any app's. There is no theme system here and no ambient lookup: every widget
 //! takes its colours in its spec (see [`theme::WearColors`]) and its geometry
-//! from [`density::WearDensity`].
+//! from [`crate::density::Density`].
 //!
 //! The pieces, in dependency order:
 //!
@@ -25,7 +25,6 @@
 
 pub mod button;
 pub mod color_appearance;
-pub mod density;
 pub mod list_header;
 pub mod scaffold;
 pub mod scaling_list;
@@ -35,7 +34,6 @@ pub mod theme;
 
 pub use button::*;
 pub use color_appearance::*;
-pub use density::*;
 pub use list_header::*;
 pub use scaffold::*;
 pub use scaling_list::*;

--- a/crates/cranpose-ui/src/widgets/wear/scaling_list.rs
+++ b/crates/cranpose-ui/src/widgets/wear/scaling_list.rs
@@ -50,7 +50,7 @@
 //! read like they need every height in the list.
 //!
 //! Neither does, because of one arithmetic fact. Every slot height is
-//! `WearDensity::ceil`ed and the gap is `WearDensity::dp`ed, so **a slot top is
+//! `Density::ceil`ed and the gap is `Density::dp`ed, so **a slot top is
 //! always a whole number of device pixels**; and `round_to_px` is
 //! `floor(v * d + 0.5) / d`, which commutes with subtracting a whole pixel:
 //!
@@ -92,6 +92,7 @@
 #![allow(non_snake_case)]
 
 use crate::composable;
+use crate::density::Density;
 use crate::fling_animation::FlingAnimation;
 use crate::modifier::{
     GraphicsLayer, Modifier, PointerEventKind, PointerInputScope, TransformOrigin,
@@ -107,7 +108,6 @@ use crate::subcompose_layout::{
     MeasurePolicy as SubcomposeMeasurePolicy, SubcomposeChild, SubcomposeLayoutNode,
     SubcomposeMeasureScope, SubcomposeMeasureScopeImpl,
 };
-use crate::widgets::wear::density::WearDensity;
 use crate::widgets::Layout;
 use cranpose_core::internal::FrameCallbackRegistration;
 use cranpose_core::{remember, rememberMutableStateOf, MutableState, NodeId, SlotId};
@@ -317,7 +317,7 @@ impl IndicatorState {
         spec: &WearScalingLazyColumnSpec,
         known: &ItemHeights,
         viewport: f32,
-        density: WearDensity,
+        density: Density,
     ) {
         let count = known.len();
         if count == 0 {
@@ -1401,8 +1401,8 @@ fn measure_wear_scaling_list(
     } = outputs;
     let spec = inputs.spec;
     let top_aligned = spec.auto_centering.is_none();
-    let scale = WearDensity::current().density();
-    let density = WearDensity::new(scale, 1.0);
+    let scale = Density::from_host().density();
+    let density = Density::new(scale, 1.0);
     let width = if constraints.max_width.is_finite() {
         constraints.max_width
     } else {
@@ -1682,7 +1682,7 @@ fn compose_and_measure_item(
     inputs: &WearScalingListInputs,
     transforms: &Rc<RefCell<Vec<WearItemTransform>>>,
     heights: &Rc<RefCell<ItemHeights>>,
-    density: &WearDensity,
+    density: &Density,
     child_constraints: Constraints,
 ) -> MeasuredItem {
     let transform = transforms

--- a/crates/cranpose-ui/src/widgets/wear/switch_button.rs
+++ b/crates/cranpose-ui/src/widgets/wear/switch_button.rs
@@ -18,8 +18,8 @@
 #![allow(non_snake_case)]
 
 use crate::composable;
+use crate::density::Density;
 use crate::modifier::{Brush, Color, CornerRadii, Modifier, Point, Rect};
-use crate::widgets::wear::density::WearDensity;
 use crate::widgets::wear::theme::{WearColors, WearTextStyle};
 use crate::widgets::{Layout, Text};
 use cranpose_core::NodeId;
@@ -334,7 +334,7 @@ pub fn SwitchButtonNode<F>(
 where
     F: FnMut() + 'static,
 {
-    let density = WearDensity::current();
+    let density = crate::density::density();
     let colors = SwitchColors::of(spec.colors, checked);
     let radius = density.dp(spec.corner_radius);
     let container = colors.container;
@@ -409,7 +409,7 @@ impl MeasurePolicy for SwitchButtonMeasurePolicy {
         placements: &mut Vec<Placement>,
     ) -> Size {
         placements.clear();
-        let density = WearDensity::new(self.density, 1.0);
+        let density = Density::new(self.density, 1.0);
         let horizontal = density.dp(self.spec.padding_horizontal) * 2.0;
         let vertical = density.dp(self.spec.padding_vertical) * 2.0;
         let width = if constraints.max_width.is_finite() {
@@ -480,7 +480,7 @@ impl MeasurePolicy for SwitchButtonMeasurePolicy {
     }
 
     fn min_intrinsic_width(&self, measurables: &[Box<dyn Measurable>], height: f32) -> f32 {
-        let density = WearDensity::new(self.density, 1.0);
+        let density = Density::new(self.density, 1.0);
         measurables
             .iter()
             .map(|m| m.min_intrinsic_width(height))
@@ -495,7 +495,7 @@ impl MeasurePolicy for SwitchButtonMeasurePolicy {
     }
 
     fn min_intrinsic_height(&self, measurables: &[Box<dyn Measurable>], width: f32) -> f32 {
-        let density = WearDensity::new(self.density, 1.0);
+        let density = Density::new(self.density, 1.0);
         let label_count = if self.has_secondary { 2 } else { 1 };
         let column: f32 = measurables
             .iter()

--- a/crates/cranpose-ui/tests/geometry_and_modifiers.rs
+++ b/crates/cranpose-ui/tests/geometry_and_modifiers.rs
@@ -6,11 +6,11 @@
 //! the point: a spacer that is half a pixel out, or a modifier that quietly
 //! drops what it was handed, is invisible in a screenshot and obvious here.
 
+use cranpose_ui::density::Density;
 use cranpose_ui::round_scaling_list::{
     leading_auto_centring_spacer, trailing_auto_centring_spacer,
 };
 use cranpose_ui::widgets::wear::color_appearance::hct_solve;
-use cranpose_ui::widgets::wear::density::WearDensity;
 use cranpose_ui::{font_scale::FontScaleCurve, run_test_composition, Modifier};
 
 #[test]
@@ -51,18 +51,18 @@ fn an_odd_viewport_floors_its_centre_line_the_same_way_for_both_spacers() {
 fn a_wear_grid_rejects_a_density_that_cannot_be_drawn_at() {
     for bad in [0.0, -2.0, f32::NAN, f32::INFINITY] {
         assert_eq!(
-            WearDensity::new(bad, 1.0).density(),
+            Density::new(bad, 1.0).density(),
             1.0,
             "a density of {bad} was accepted"
         );
     }
-    assert_eq!(WearDensity::new(2.0, 1.0).density(), 2.0);
+    assert_eq!(Density::new(2.0, 1.0).density(), 2.0);
 }
 
 #[test]
 fn a_wear_grid_takes_a_font_scale_curve_rather_than_a_bare_multiplier() {
-    let linear = WearDensity::with_curve(2.0, FontScaleCurve::linear(1.5));
-    let plain = WearDensity::new(2.0, 1.5);
+    let linear = Density::with_curve(2.0, FontScaleCurve::linear(1.5));
+    let plain = Density::new(2.0, 1.5);
     assert_eq!(
         linear.density(),
         plain.density(),


### PR DESCRIPTION
## What was wrong

Density was a value the host installed on a shell, read back everywhere through `current_density()`. Compose makes it `LocalDensity` — a composition local — and the difference costs real capability:

1. **No per-subtree density.** A preview, a scaled container or a density-specific golden could not be measured on a grid of its own.
2. **A read established no dependency.** `current_density()` is an atomic load outside the snapshot system, so correctness came from `set_density` invalidating the *entire* layout rather than recomposing what actually read it.
3. **Tests had to move the whole shell** to exercise a different grid.

There was already a guard rail admitting the shape was awkward: a static test, `platform_drivers_set_density_through_app_shell`, forbidding platform drivers from calling `cranpose_ui::set_density` directly.

## The type already existed

`WearDensity` was exactly Compose's `Density` — a scale plus a font-scale curve, with `dp`/`sp`/`round`/`floor`/`ceil`/`centre` — but lived under `widgets/wear/`. Its own doc comment said why it read globals:

> *"A measure policy has no scope parameter and so cannot be handed a density."*

It is `Density` now, at the top of `cranpose-ui`, with `local_density()` and `density()` beside it in the shape the other **65** composition locals already use, plus `ProvideDensity` to scope one to a subtree.

## One source of truth, not two

The local's default is the grid the host installed, and it is **evaluated per read** rather than captured — verified in `read_composition_local`, which falls through to `default_value()` on every read. So an application that provides nothing still measures against the real screen, and a host that changes density still reaches every reader. No root provision needed.

## Call sites, classified rather than swept

- `WearButton`, `SwitchButtonNode`, `ListHeader` are composables → read the local
- `measure_wear_scaling_list` is a **measure policy** and cannot → reads the host outright, which is what it was already doing via the ambient call, now said plainly
- `SubcomposeMeasureScopeImpl` → reads the local, because a subcompose runs inside the composition that asked for it

## A panic the test found

Reading density in a composition with **no shell** used to panic — the render state refuses access without an `AppContext`, which a test, a golden or a headless measurement does not have. The unit grid is the honest answer there.

## What this does NOT do

A provided density **does not reach measurement**. `LayoutNode` captures no density, so the layout pass still reads the host — a `ProvideDensity` changes what a subtree's composables compute, not what its children are measured against.

Compose captures density onto the layout node at composition time, which is what makes `MeasureScope` able to carry one. Closing that means deciding where the value is captured *before* threading anything, so it is not folded in here. PLAN.md records it as the gap it is, including that `MeasureScope` still declares `density()`/`font_scale()` with `1.0` defaults that would silently lie for its next implementor.

## Verification

Full gate on macm3: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, wasm clippy, and `cargo test --workspace` — **4576 tests passed, 0 failed**. A new test proves a provided density reaches its content, does not escape upward, and does not leak into what follows.