### PR TITLE
Carry keyboard modifiers on PointerEvent

### DIFF
--- a/crates/cranpose-app-shell/src/lib.rs
+++ b/crates/cranpose-app-shell/src/lib.rs
@@ -43,9 +43,12 @@ use hit_path_tracker::{HitPathTracker, PointerId};
 use std::collections::HashSet;
 
 // Re-export key event types for use by cranpose
-pub use cranpose_ui::{KeyCode, KeyEvent, KeyEventType, Modifiers};
-// Re-export the pointer device source so platform backends can stamp it.
-pub use cranpose_foundation::PointerSource;
+pub use cranpose_ui::{KeyCode, KeyEvent, KeyEventType};
+// Re-export the pointer device source and the keyboard-modifiers type so
+// platform backends can stamp them. `Modifiers` lives in cranpose-foundation
+// (not cranpose-ui, which merely re-exports it) because `PointerEvent` needs
+// it too; re-exported from here directly rather than via cranpose-ui.
+pub use cranpose_foundation::{Modifiers, PointerSource};
 // Re-export the rotary (Wear OS crown / rotating bezel) event so platform
 // backends can build one and apps can type their window-level handler.
 pub use cranpose_foundation::{
@@ -216,6 +219,17 @@ where
     /// (`set_cursor` then `pointer_pressed`), so a single per-shell cell mirrors
     /// the existing cursor/buttons state without churning every method signature.
     pointer_source: PointerSource,
+    /// Keyboard modifiers held during the most recent sample, set by the
+    /// platform and stamped onto every `PointerEvent` the shell constructs.
+    /// Mirrors `pointer_source` above: a single per-shell cell instead of
+    /// threading the value through every pointer method signature.
+    ///
+    /// `None` until a platform calls [`set_modifiers`](Self::set_modifiers) at
+    /// least once, which is honest for Android/iOS touch input: neither
+    /// platform's JNI/UIKit bridge currently reports keyboard modifier state
+    /// for a touch sample, so their pointer events keep reporting "unknown"
+    /// rather than a silently wrong "nothing held".
+    modifiers: Option<Modifiers>,
     /// Tracks which nodes were hit on PointerDown (by stable NodeId).
     ///
     /// This follows Jetpack Compose's HitPathTracker pattern:
@@ -573,6 +587,7 @@ where
             is_dirty: true,
             buttons_pressed: PointerButtons::NONE,
             pointer_source: PointerSource::Unknown,
+            modifiers: None,
             hit_path_tracker: HitPathTracker::new(),
             hovered_nodes: Vec::new(),
             on_rotary_scroll: None,

--- a/crates/cranpose-app-shell/src/shell_input.rs
+++ b/crates/cranpose-app-shell/src/shell_input.rs
@@ -12,9 +12,16 @@ where
         global_position: Point,
         event_time: PointerEventTime,
     ) -> PointerEvent {
-        PointerEvent::new(kind, position, global_position)
+        let mut event = PointerEvent::new(kind, position, global_position)
             .with_time_ms(event_time.platform_time_ms)
-            .with_animation_time_nanos(event_time.animation_time_nanos)
+            .with_animation_time_nanos(event_time.animation_time_nanos);
+        // Unlike `source` (stamped per call site because it varies per
+        // event -- a touch vs. a mouse sample), modifiers track continuously
+        // and every PointerEvent the shell builds goes through this one
+        // constructor, so this is the single choke point to stamp it from:
+        // no call site below can forget it, including ones added later.
+        event.modifiers = self.modifiers;
+        event
     }
 
     fn resolve_gesture_targets(
@@ -86,6 +93,25 @@ where
     /// The device source of the most recent pointer sample.
     pub fn pointer_source(&self) -> PointerSource {
         self.pointer_source
+    }
+
+    /// Sets the keyboard modifiers held right now, so the platform's live
+    /// modifier state (winit's `ModifiersChanged`, a DOM event's
+    /// `shiftKey`/`ctrlKey`/`altKey`/`metaKey`) reaches every `PointerEvent`
+    /// the shell dispatches from here on -- the same state the wheel path
+    /// already carries via [`WheelScroll::with_modifiers`](crate::WheelScroll::with_modifiers).
+    /// A platform that never calls this leaves pointer events reporting
+    /// `None` (see [`PointerEvent::modifiers`]) rather than a silently wrong
+    /// "nothing held".
+    pub fn set_modifiers(&mut self, modifiers: Modifiers) {
+        self.modifiers = Some(modifiers);
+    }
+
+    /// The keyboard modifiers most recently set via
+    /// [`set_modifiers`](Self::set_modifiers), or `None` if the platform has
+    /// never reported them.
+    pub fn modifiers(&self) -> Option<Modifiers> {
+        self.modifiers
     }
 
     pub fn set_cursor(&mut self, x: f32, y: f32) -> bool {
@@ -813,8 +839,9 @@ where
                 .rev()
                 .filter_map(|&node_id| self.renderer.scene().find_target(node_id))
                 .collect::<Vec<_>>();
-            let capture_event =
+            let mut capture_event =
                 PointerEvent::rotary(PointerEventKind::RotaryScrollPre, rotary, position);
+            capture_event.modifiers = self.modifiers;
             self.dispatch_targets(capture_targets, capture_event.clone(), true);
             if capture_event.is_consumed() {
                 return true;
@@ -825,8 +852,9 @@ where
                 .iter()
                 .filter_map(|&node_id| self.renderer.scene().find_target(node_id))
                 .collect::<Vec<_>>();
-            let bubble_event =
+            let mut bubble_event =
                 PointerEvent::rotary(PointerEventKind::RotaryScroll, rotary, position);
+            bubble_event.modifiers = self.modifiers;
             self.dispatch_targets(bubble_targets, bubble_event.clone(), true);
             if bubble_event.is_consumed() {
                 return true;

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -4,7 +4,7 @@ use cranpose_core::{
     rememberMutableStateOf, CompositionLocal, CompositionLocalProvider, MutableState, TaskSite,
 };
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope, LazyListState};
-use cranpose_foundation::{PointerEvent, PointerEventKind, PointerSource};
+use cranpose_foundation::{Modifiers, PointerEvent, PointerEventKind, PointerSource};
 use cranpose_macros::composable;
 use cranpose_ui::{
     Alignment, BlendMode, Box, BoxSpec, Brush, Button, ButtonSpec, Color, Column, ColumnSpec,
@@ -8138,6 +8138,11 @@ thread_local! {
         const { RefCell::new(None) };
 }
 
+thread_local! {
+    static POINTER_MODIFIERS_PROBE: RefCell<Option<Rc<Cell<Option<Modifiers>>>>> =
+        const { RefCell::new(None) };
+}
+
 type PointerTimeSample = (PointerEventKind, Option<i64>, Option<u64>);
 
 thread_local! {
@@ -8165,6 +8170,39 @@ fn app_shell_pointer_source_probe() {
                                 let event = await_scope.await_pointer_event().await;
                                 if event.kind == PointerEventKind::Down {
                                     captured.set(event.source);
+                                    event.consume();
+                                }
+                            }
+                        })
+                        .await;
+                }
+            }),
+        BoxSpec::default(),
+        || {},
+    );
+}
+
+/// A probe that records the `Modifiers` of every pointer-down it receives via
+/// `Modifier::pointer_input` -- the surface an app reads to implement
+/// shift/ctrl-click multi-select without touching a platform API.
+fn app_shell_pointer_modifiers_probe() {
+    let captured = Rc::new(Cell::new(None::<Modifiers>));
+    POINTER_MODIFIERS_PROBE.with(|slot| *slot.borrow_mut() = Some(Rc::clone(&captured)));
+    Box(
+        Modifier::empty()
+            .size(Size {
+                width: 200.0,
+                height: 200.0,
+            })
+            .pointer_input((), move |scope: PointerInputScope| {
+                let captured = Rc::clone(&captured);
+                async move {
+                    scope
+                        .await_pointer_event_scope(|await_scope| async move {
+                            loop {
+                                let event = await_scope.await_pointer_event().await;
+                                if event.kind == PointerEventKind::Down {
+                                    captured.set(event.modifiers);
                                     event.consume();
                                 }
                             }
@@ -8290,6 +8328,84 @@ fn shell_stamps_pointer_source_on_dispatched_events() {
         captured.get(),
         PointerSource::Mouse,
         "shell must stamp the mouse source onto the dispatched pointer event"
+    );
+}
+
+#[test]
+fn shift_click_reaches_the_pointer_input_handler_through_the_shell() {
+    // Pins the bug: PointerEvent carried no keyboard-modifier state, so an app
+    // implementing shift/ctrl-click multi-select had to read the keyboard
+    // itself through a platform API. This proves the whole path instead: the
+    // platform tells the shell what is held via `set_modifiers` (the same
+    // per-shell cell the wheel path's `WheelScroll::with_modifiers` already
+    // threads through), and a plain `Modifier::pointer_input` handler -- the
+    // surface every app already reads pointer events from -- sees it on the
+    // dispatched event with no platform-specific code of its own.
+    let _guard = test_guard();
+    POINTER_MODIFIERS_PROBE.with(|slot| slot.borrow_mut().take());
+
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(
+        HitGraphRenderer::default(),
+        root_key,
+        app_shell_pointer_modifiers_probe,
+    );
+    shell.set_buffer_size(200, 200);
+    shell.set_viewport(200.0, 200.0);
+    shell.update();
+
+    let captured = POINTER_MODIFIERS_PROBE
+        .with(|slot| slot.borrow().as_ref().map(Rc::clone))
+        .expect("probe should install its capture cell");
+
+    // Before any platform ever reports modifiers, a press must arrive with
+    // `None` -- honestly "unreported", never a silently wrong "none held".
+    assert_eq!(shell.modifiers(), None);
+    assert!(shell.set_cursor(50.0, 50.0));
+    assert!(shell.pointer_pressed(), "down should hit the probe");
+    assert_eq!(
+        captured.get(),
+        None,
+        "a press before set_modifiers must reach the handler as unreported, not as Modifiers::NONE"
+    );
+    shell.pointer_released();
+
+    // A shift-held press must reach the handler with shift set.
+    shell.set_modifiers(Modifiers {
+        shift: true,
+        ..Modifiers::NONE
+    });
+    assert_eq!(
+        shell.modifiers(),
+        Some(Modifiers {
+            shift: true,
+            ..Modifiers::NONE
+        })
+    );
+    assert!(shell.set_cursor(50.0, 50.0));
+    assert!(shell.pointer_pressed());
+    let modifiers = captured
+        .get()
+        .expect("a press after set_modifiers must report Some(Modifiers)");
+    assert!(
+        modifiers.shift,
+        "shift held at the platform must reach the pointer_input handler on the dispatched event"
+    );
+    assert!(!modifiers.ctrl);
+    shell.pointer_released();
+
+    // Releasing shift and holding ctrl instead must update what the handler sees.
+    shell.set_modifiers(Modifiers {
+        ctrl: true,
+        ..Modifiers::NONE
+    });
+    assert!(shell.set_cursor(50.0, 50.0));
+    assert!(shell.pointer_pressed());
+    let modifiers = captured.get().expect("ctrl press must report Some");
+    assert!(modifiers.ctrl);
+    assert!(
+        !modifiers.shift,
+        "stale shift must not survive a modifier change"
     );
 }
 

--- a/crates/cranpose-app-shell/src/wheel.rs
+++ b/crates/cranpose-app-shell/src/wheel.rs
@@ -18,7 +18,7 @@
 //! wheel is turned *down*, so the browser host negates on the way in. Getting
 //! this wrong does not fail loudly — it scrolls backwards.
 
-use cranpose_ui::Modifiers;
+use cranpose_foundation::Modifiers;
 use cranpose_ui_graphics::Point;
 
 /// Logical pixels one wheel notch scrolls, and the notch the ctrl+wheel zoom

--- a/crates/cranpose-foundation/src/lib.rs
+++ b/crates/cranpose-foundation/src/lib.rs
@@ -19,7 +19,7 @@ pub use modifier::*;
 #[allow(unused_imports)]
 pub use modifier_helpers::*;
 pub use nodes::input::{
-    rotary_scroll_pixels_from_detents, PointerButton, PointerButtons, PointerEvent,
+    rotary_scroll_pixels_from_detents, Modifiers, PointerButton, PointerButtons, PointerEvent,
     PointerEventKind, PointerId, PointerPhase, PointerSource, RotaryScrollEvent,
     RotaryStepAccumulator, DEFAULT_ROTARY_SCROLL_FACTOR_DP,
 };

--- a/crates/cranpose-foundation/src/nodes/input/mod.rs
+++ b/crates/cranpose-foundation/src/nodes/input/mod.rs
@@ -8,8 +8,8 @@ pub use rotary::{
     DEFAULT_ROTARY_SCROLL_FACTOR_DP,
 };
 pub use types::{
-    PointerButton, PointerButtons, PointerEvent, PointerEventKind, PointerId, PointerPhase,
-    PointerSource,
+    Modifiers, PointerButton, PointerButtons, PointerEvent, PointerEventKind, PointerId,
+    PointerPhase, PointerSource,
 };
 
 pub mod prelude {
@@ -19,7 +19,7 @@ pub mod prelude {
     };
     pub use super::rotary::{RotaryScrollEvent, RotaryStepAccumulator};
     pub use super::types::{
-        PointerButton, PointerButtons, PointerEvent, PointerEventKind, PointerId, PointerPhase,
-        PointerSource,
+        Modifiers, PointerButton, PointerButtons, PointerEvent, PointerEventKind, PointerId,
+        PointerPhase, PointerSource,
     };
 }

--- a/crates/cranpose-foundation/src/nodes/input/types.rs
+++ b/crates/cranpose-foundation/src/nodes/input/types.rs
@@ -134,6 +134,53 @@ impl Default for PointerButtons {
     }
 }
 
+/// Keyboard modifier keys held during an input sample.
+///
+/// Lives here (rather than up in `cranpose-ui`, where the keyboard `KeyEvent`
+/// type lives) because [`PointerEvent`] needs it too and `cranpose-foundation`
+/// sits below `cranpose-ui` in the dependency graph — this is the one crate
+/// both a key event and a pointer event can share it from. `cranpose-ui`
+/// re-exports this type rather than defining its own, so there is exactly one
+/// `Modifiers` in the framework.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Modifiers {
+    /// Shift key is pressed.
+    pub shift: bool,
+    /// Control key is pressed (Cmd on macOS).
+    pub ctrl: bool,
+    /// Alt key is pressed (Option on macOS).
+    pub alt: bool,
+    /// Meta/Super key is pressed (Windows key, Cmd on macOS).
+    pub meta: bool,
+}
+
+impl Modifiers {
+    /// No modifiers pressed.
+    pub const NONE: Modifiers = Modifiers {
+        shift: false,
+        ctrl: false,
+        alt: false,
+        meta: false,
+    };
+
+    /// Returns true if any modifier is pressed.
+    pub fn any(&self) -> bool {
+        self.shift || self.ctrl || self.alt || self.meta
+    }
+
+    /// Returns true if Ctrl (or Cmd on macOS) is pressed.
+    pub fn command_or_ctrl(&self) -> bool {
+        #[cfg(target_os = "macos")]
+        {
+            self.meta
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            self.ctrl
+        }
+    }
+}
+
 /// Pointer event with consumption tracking for gesture disambiguation.
 ///
 /// Events can be consumed by handlers (e.g., scroll) to prevent other handlers
@@ -171,6 +218,17 @@ pub struct PointerEvent {
     /// The kind of device that produced this event (touch, mouse, stylus), when
     /// the platform reports it. Defaults to [`PointerSource::Unknown`].
     pub source: PointerSource,
+    /// Keyboard modifiers held at the time of this sample, when the platform
+    /// can report them.
+    ///
+    /// `None` means the platform never told the shell what the keyboard state
+    /// was — touch-only Android/iOS input has no channel for it today — and is
+    /// deliberately distinct from `Some(Modifiers::NONE)`, which means the
+    /// platform looked and nothing was held. An app that wants shift/ctrl-click
+    /// multi-select reads this field directly; it must not treat `None` as
+    /// "nothing held" or it silently drops the gesture on the platforms that
+    /// cannot yet report it instead of visibly doing nothing.
+    pub modifiers: Option<Modifiers>,
     /// Tracks whether this event has been consumed by a handler.
     /// Shared via Rc<Cell> so consumption can be tracked across copies.
     consumed: Rc<Cell<bool>>,
@@ -202,6 +260,7 @@ impl PointerEvent {
             animation_time_nanos: None,
             zoom_delta: 1.0,
             source: PointerSource::Unknown,
+            modifiers: None,
             consumed: Rc::new(Cell::new(false)),
             deferred_post_dispatch: DeferredPostDispatch {
                 action: Rc::new(RefCell::new(None)),
@@ -248,6 +307,16 @@ impl PointerEvent {
     /// Set the device source (touch/mouse/stylus) for this event.
     pub fn with_source(mut self, source: PointerSource) -> Self {
         self.source = source;
+        self
+    }
+
+    /// Set the keyboard modifiers held during this event, when the platform
+    /// can report them. See the [`modifiers`](Self::modifiers) field docs for
+    /// why this takes a concrete [`Modifiers`] rather than an `Option`: the
+    /// `None` case is the *absence* of a call to this builder, not a value it
+    /// produces.
+    pub fn with_modifiers(mut self, modifiers: Modifiers) -> Self {
+        self.modifiers = Some(modifiers);
         self
     }
 
@@ -336,6 +405,7 @@ impl PointerEvent {
             animation_time_nanos: self.animation_time_nanos,
             zoom_delta: self.zoom_delta,
             source: self.source,
+            modifiers: self.modifiers,
             consumed: self.consumed.clone(),
             deferred_post_dispatch: self.deferred_post_dispatch.clone(),
         }
@@ -378,6 +448,66 @@ mod tests {
         // Local-position copies (used during hit-test dispatch) keep the source.
         let local = touch.copy_with_local_position(point(5.0, 5.0));
         assert_eq!(local.source, PointerSource::Touch);
+    }
+
+    #[test]
+    fn modifiers_any_is_true_when_any_field_is_set() {
+        assert!(!Modifiers::NONE.any());
+        assert!(!Modifiers::default().any());
+        assert!(Modifiers {
+            shift: true,
+            ..Modifiers::NONE
+        }
+        .any());
+    }
+
+    #[test]
+    fn modifiers_command_or_ctrl_reads_the_platform_appropriate_key() {
+        let ctrl_only = Modifiers {
+            ctrl: true,
+            ..Modifiers::NONE
+        };
+        let meta_only = Modifiers {
+            meta: true,
+            ..Modifiers::NONE
+        };
+
+        #[cfg(target_os = "macos")]
+        {
+            assert!(!ctrl_only.command_or_ctrl());
+            assert!(meta_only.command_or_ctrl());
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            assert!(ctrl_only.command_or_ctrl());
+            assert!(!meta_only.command_or_ctrl());
+        }
+        assert!(!Modifiers::NONE.command_or_ctrl());
+    }
+
+    #[test]
+    fn pointer_event_modifiers_default_to_unreported_and_thread_through_copy() {
+        let event = PointerEvent::new(PointerEventKind::Down, point(1.0, 1.0), point(1.0, 1.0));
+        // Unreported (None) must stay visibly distinct from "reported, none
+        // held" (Some(Modifiers::NONE)) -- see the field doc on why.
+        assert_eq!(event.modifiers, None);
+
+        let shift = event.with_modifiers(Modifiers {
+            shift: true,
+            ..Modifiers::NONE
+        });
+        assert_eq!(
+            shift.modifiers,
+            Some(Modifiers {
+                shift: true,
+                ..Modifiers::NONE
+            })
+        );
+
+        // Local-position copies (used during hit-test dispatch) keep the
+        // modifiers, exactly like they keep the source.
+        let local = shift.copy_with_local_position(point(5.0, 5.0));
+        assert_eq!(local.modifiers, shift.modifiers);
     }
 
     #[test]

--- a/crates/cranpose-ui/src/key_event.rs
+++ b/crates/cranpose-ui/src/key_event.rs
@@ -5,6 +5,12 @@
 
 use std::fmt;
 
+// `Modifiers` lives in `cranpose-foundation` because `PointerEvent` there
+// needs it too and this crate sits above foundation in the dependency graph;
+// re-exported here so keyboard call sites keep importing it from
+// `cranpose_ui`/`cranpose_ui::key_event`.
+pub use cranpose_foundation::Modifiers;
+
 /// Type of keyboard event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyEventType {
@@ -12,46 +18,6 @@ pub enum KeyEventType {
     KeyDown,
     /// Key was released.
     KeyUp,
-}
-
-/// Modifier keys state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct Modifiers {
-    /// Shift key is pressed.
-    pub shift: bool,
-    /// Control key is pressed (Cmd on macOS).
-    pub ctrl: bool,
-    /// Alt key is pressed (Option on macOS).
-    pub alt: bool,
-    /// Meta/Super key is pressed (Windows key, Cmd on macOS).
-    pub meta: bool,
-}
-
-impl Modifiers {
-    /// No modifiers pressed.
-    pub const NONE: Modifiers = Modifiers {
-        shift: false,
-        ctrl: false,
-        alt: false,
-        meta: false,
-    };
-
-    /// Returns true if any modifier is pressed.
-    pub fn any(&self) -> bool {
-        self.shift || self.ctrl || self.alt || self.meta
-    }
-
-    /// Returns true if Ctrl (or Cmd on macOS) is pressed.
-    pub fn command_or_ctrl(&self) -> bool {
-        #[cfg(target_os = "macos")]
-        {
-            self.meta
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            self.ctrl
-        }
-    }
 }
 
 /// Physical key codes for keyboard input.
@@ -257,15 +223,5 @@ mod tests {
     fn backspace_has_no_text() {
         let event = KeyEvent::key_down(KeyCode::Backspace, "");
         assert!(!event.has_text());
-    }
-
-    #[test]
-    fn modifiers_any() {
-        assert!(!Modifiers::NONE.any());
-        assert!(Modifiers {
-            shift: true,
-            ..Modifiers::NONE
-        }
-        .any());
     }
 }

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -3,7 +3,7 @@
 //! This module provides the desktop event loop implementation using winit.
 
 use crate::app_launcher::{AppSettings, LaunchError};
-use crate::desktop_input::dispatch_keyboard_input;
+use crate::desktop_input::{app_modifiers, dispatch_keyboard_input};
 use crate::native_window::{
     self, NativeWindowEvents, NativeWindowKey, NativeWindowOptions, NativeWindowPositionOrigin,
     NativeWindowRequest, WindowGraphMove, WindowGraphNodeSnapshot, WindowGraphPeerSnapshot,
@@ -2454,6 +2454,13 @@ impl App {
             }
             WindowEvent::ModifiersChanged(modifiers) => {
                 self.current_modifiers = modifiers.state();
+                // Same conversion the wheel path already uses (see
+                // `dispatch_mouse_wheel` below); pointer events need it too so
+                // apps can implement shift/ctrl-click without an X11/Win32
+                // escape hatch of their own.
+                native
+                    .app
+                    .set_modifiers(app_modifiers(self.current_modifiers));
             }
             WindowEvent::MouseWheel { delta, .. } => {
                 if native.last_cursor_position.is_none() {
@@ -4571,6 +4578,11 @@ impl ApplicationHandler for App {
             WindowEvent::ModifiersChanged(modifiers) => {
                 // Track current keyboard modifiers for key events
                 self.current_modifiers = modifiers.state();
+                // Same conversion the wheel path already uses (see
+                // `dispatch_mouse_wheel` below); pointer events need it too so
+                // apps can implement shift/ctrl-click without an X11/Win32
+                // escape hatch of their own.
+                app.set_modifiers(app_modifiers(self.current_modifiers));
             }
             WindowEvent::MouseWheel { delta, .. } => {
                 if self.last_cursor_position.is_none()

--- a/crates/cranpose/src/web.rs
+++ b/crates/cranpose/src/web.rs
@@ -463,6 +463,7 @@ pub async fn run(
             let logical = platform.borrow().pointer_position(x, y);
             if let Ok(mut app_mut) = app.try_borrow_mut() {
                 app_mut.set_pointer_source(web_pointer_source(&event));
+                app_mut.set_modifiers(web_modifiers(&event));
                 app_mut.set_cursor(logical.x, logical.y);
                 request_frame();
             }
@@ -484,6 +485,7 @@ pub async fn run(
             let logical = platform.borrow().pointer_position(x, y);
             if let Ok(mut app_mut) = app.try_borrow_mut() {
                 app_mut.set_pointer_source(web_pointer_source(&event));
+                app_mut.set_modifiers(web_modifiers(&event));
                 let event_time = app_mut.realtime_pointer_event_time(None);
                 app_mut.set_cursor_at_event_time(logical.x, logical.y, event_time);
                 app_mut.pointer_pressed_at_event_time(event_time);
@@ -506,6 +508,7 @@ pub async fn run(
             let logical = platform.borrow().pointer_position(x, y);
             if let Ok(mut app_mut) = app.try_borrow_mut() {
                 app_mut.set_pointer_source(web_pointer_source(&event));
+                app_mut.set_modifiers(web_modifiers(&event));
                 // Touch lift-off positions must not become velocity samples
                 // (see AppShell::pointer_released_at_position).
                 let event_time = app_mut.realtime_pointer_event_time(None);


### PR DESCRIPTION
## Summary

`PointerEvent` carried no keyboard-modifier state. An app implementing shift/ctrl-click multi-select had to read the keyboard itself through a platform API — the motivating case is CranAmp, which does this via raw `x11rb` (`native_playlist_click_modifiers`), so `x11rb::connect` fails silently on macOS/Windows and the interaction falls back to "no modifiers held" with no error.

The framework already had both halves of the fix and simply never joined them: the desktop shell tracks `current_modifiers: winit::keyboard::ModifiersState`, and `winit_wheel.rs` already converted it into a `Modifiers` value — but only for wheel-scroll events, never for pointer events.

### What was mapped first (before any edit)

- Every platform funnels pointer construction through **one** place: `AppShell::pointer_event` in `crates/cranpose-app-shell/src/shell_input.rs`. Desktop (winit), web, android and ios all call `AppShell` methods (`set_cursor`, `pointer_pressed`, ...); none constructs `PointerEvent` directly.
- There was exactly **one** `Modifiers` shape in the codebase already, not two: `cranpose_app_shell::Modifiers` was a re-export of `cranpose_ui::key_event::Modifiers`. But `PointerEvent` lives in `cranpose-foundation`, which sits *below* `cranpose-ui` in the dependency graph, so foundation couldn't reuse ui's type without a cycle. Fixed by moving the single `Modifiers` definition down into `cranpose-foundation` (alongside `PointerButtons`/`PointerSource`, the types it already shares this role with) and making `cranpose-ui` re-export it instead of defining its own copy.

### What changed

- `PointerEvent::modifiers: Option<Modifiers>`. **`Option`, not a bare `Modifiers` defaulting to `NONE`** — Android/iOS touch input has no channel for keyboard modifiers today (neither the JNI nor the UIKit bridge reports it for a touch sample), and collapsing "unreported" into `Modifiers::NONE` would silently recreate the exact bug this fixes: an indistinguishable "nothing held" on a platform that simply never looked. `None` = the platform didn't say; `Some(Modifiers::NONE)` = it looked and nothing was held.
- `AppShell` gets a `modifiers: Option<Modifiers>` cell with `set_modifiers`/`modifiers()`, mirroring the existing `pointer_source` cell (its doc comment already explains why: a single per-shell cell instead of threading a new parameter through every pointer method signature). The shared `pointer_event()` constructor stamps it onto every event from one place, so no call site — present or future — can forget it. Rotary events pick it up too.
- **Desktop (winit)**: pushed from the same `current_modifiers` → `app_modifiers()` conversion the wheel path already used, at both `ModifiersChanged` sites (primary window and native sub-windows).
- **Web**: read directly off each DOM event (`shiftKey`/`ctrlKey`/`altKey`/`metaKey`) via the `web_modifiers` helper already used for wheel events, now also called from `pointermove`/`pointerdown`/`pointerup`.
- **Android/iOS**: left honestly unreported (`None`) — wiring real hardware-keyboard modifier state into their touch path would mean extending the JNI/UIKit event schema itself, a separate feature beyond connecting plumbing that already exists.
- `Modifier::pointer_input`'s `AwaitPointerEventScope` already hands the whole `PointerEvent` to the app's handler, so no extra propagation code was needed to reach the app — adding the field and stamping it in `AppShell` is the entire fix. An app's handler can now read `event.modifiers` directly.

### Test

`crates/cranpose-app-shell/src/tests/app_shell_tests.rs::shift_click_reaches_the_pointer_input_handler_through_the_shell` pins the bug end-to-end: builds a real `Modifier::pointer_input` handler, drives it through `AppShell::set_modifiers` + `set_cursor`/`pointer_pressed`, and asserts the dispatched event carries `shift`/`ctrl` correctly — and that a press *before* `set_modifiers` is ever called arrives as `None`, not a silently wrong `Some(Modifiers::NONE)`. Unit tests for `PointerEvent`'s new field and for `Modifiers::any()`/`command_or_ctrl()` were added next to their definitions in `cranpose-foundation`.

## Test plan

Verified on `macm3` (`CARGO_TARGET_DIR=/Volumes/files/pointermods-target`):
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 149 test binaries, all passing, zero failures
- [x] `cargo clippy --target wasm32-unknown-unknown -p desktop-app-platform --no-default-features --features web,renderer-wgpu -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)