### PR TITLE
Fix Android panic hook clobbering + add LazyRow composition tests

### DIFF
--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -378,5 +378,9 @@ mod swipe_to_dismiss_render_tests;
 mod lazy_list_recompose_tests;
 
 #[cfg(test)]
+#[path = "tests/lazy_row_tests.rs"]
+mod lazy_row_tests;
+
+#[cfg(test)]
 #[path = "tests/wear_widget_tests.rs"]
 mod wear_widget_tests;

--- a/crates/cranpose-ui/src/tests/lazy_row_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_row_tests.rs
@@ -1,0 +1,366 @@
+//! Composition tests for `LazyRow`, mirroring the coverage
+//! `lazy_list_viewport_tests.rs`/`lazy_list_recompose_tests.rs` give
+//! `LazyColumn`: items composed and measured against the viewport, item
+//! count driving scroll bounds through recomposition, and — the behavior
+//! unique to the horizontal orientation — rendered items actually moving
+//! along the x axis (not y) when the list is scrolled.
+
+use super::*;
+use cranpose_core::{location_key, Composition, MemoryApplier, MutableState, NodeId};
+use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope, LazyListState};
+use cranpose_ui_graphics::Size as ViewportSize;
+use std::cell::RefCell;
+
+thread_local! {
+    static LAST_LAZY_ROW_STATE: RefCell<Option<LazyListState>> = const { RefCell::new(None) };
+    static GROWING_LAZY_ROW_CALL_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[test]
+fn lazy_row_unbounded_width_matches_effective_viewport() {
+    let mut composition = run_test_composition(|| {
+        let list_state = rememberLazyListState();
+        LAST_LAZY_ROW_STATE.with(|cell| {
+            *cell.borrow_mut() = Some(list_state);
+        });
+
+        LazyRow(
+            Modifier::empty(),
+            list_state,
+            LazyRowSpec::default(),
+            |scope| {
+                scope.items(100, |_| {
+                    Spacer(Size {
+                        width: 100.0,
+                        height: 0.0,
+                    });
+                });
+            },
+        );
+    });
+
+    let root = composition.root().expect("lazy row root");
+    let handle = composition.runtime_handle();
+    let measurements = {
+        let mut applier = composition.applier_mut();
+        applier.set_runtime_handle(handle);
+        let result = measure_layout(
+            &mut applier,
+            root,
+            ViewportSize {
+                width: f32::INFINITY,
+                height: 320.0,
+            },
+        )
+        .expect("layout measurement");
+        applier.clear_runtime_handle();
+        result
+    };
+
+    let list_state = LAST_LAZY_ROW_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let expected_width = list_state.layout_info().viewport_size;
+    let actual_width = measurements.root_size().width;
+
+    assert!(actual_width.is_finite());
+    assert!(
+        (actual_width - expected_width).abs() < 0.01,
+        "expected lazy row width to match effective viewport {expected_width}, got {actual_width}"
+    );
+
+    LAST_LAZY_ROW_STATE.with(|cell| {
+        *cell.borrow_mut() = None;
+    });
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn GrowingLazyRow(item_count: MutableState<usize>) {
+    let list_state = rememberLazyListState();
+    LAST_LAZY_ROW_STATE.with(|cell| {
+        *cell.borrow_mut() = Some(list_state);
+    });
+    let count = item_count.value();
+    GROWING_LAZY_ROW_CALL_COUNT.with(|call_count| {
+        call_count.set(call_count.get() + 1);
+    });
+
+    Column(Modifier::empty(), ColumnSpec::default(), move || {
+        Text(
+            format!("Count {count}"),
+            Modifier::empty(),
+            TextStyle::default(),
+        );
+        LazyRow(
+            Modifier::empty().height(120.0),
+            list_state,
+            LazyRowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
+            |scope| {
+                scope.items(count, |index| {
+                    Row(
+                        Modifier::empty().height(48.0).width(96.0),
+                        RowSpec::default(),
+                        move || {
+                            Text(
+                                format!("Item {}", index),
+                                Modifier::empty(),
+                                TextStyle::default(),
+                            );
+                        },
+                    );
+                });
+            },
+        );
+    });
+}
+
+#[test]
+fn lazy_row_updates_scroll_bounds_when_item_count_grows_without_scrolling() {
+    let _app_context = crate::render_state::app_context_test_scope();
+    let mut composition = Composition::new(MemoryApplier::new());
+    let runtime = composition.runtime_handle();
+    let item_count = MutableState::with_runtime(2usize, runtime.clone());
+
+    GROWING_LAZY_ROW_CALL_COUNT.with(|call_count| call_count.set(0));
+    let key = location_key(file!(), line!(), column!());
+    composition
+        .render(key, || {
+            GrowingLazyRow(item_count);
+        })
+        .expect("initial render");
+
+    let root = composition.root().expect("lazy row root");
+    let viewport = Size {
+        width: 260.0,
+        height: 320.0,
+    };
+    measure_root(&mut composition, root, viewport);
+
+    let list_state = LAST_LAZY_ROW_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    assert_eq!(list_state.layout_info().total_items_count, 2);
+    assert!(
+        !list_state.can_scroll_forward(),
+        "initial short row should not scroll"
+    );
+
+    item_count.set(24);
+    let mut recomposed = false;
+    while composition
+        .process_invalid_scopes()
+        .expect("recompose after item count growth")
+    {
+        recomposed = true;
+    }
+    assert!(
+        recomposed,
+        "expected composition to re-run after item count growth"
+    );
+    GROWING_LAZY_ROW_CALL_COUNT.with(|call_count| {
+        assert!(
+            call_count.get() >= 2,
+            "expected LazyRow parent composable to execute again after item count growth"
+        );
+    });
+    measure_root(&mut composition, root, viewport);
+
+    assert_eq!(list_state.layout_info().total_items_count, 24);
+    assert!(
+        list_state.can_scroll_forward(),
+        "lazy row should become scrollable when item count grows beyond viewport"
+    );
+    let texts = render_texts(&mut composition, root);
+    assert!(
+        texts.iter().any(|text| text == "Count 24"),
+        "expected parent composition to observe the grown item count"
+    );
+
+    LAST_LAZY_ROW_STATE.with(|cell| {
+        *cell.borrow_mut() = None;
+    });
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn HorizontalScrollIndicatorLazyRow() {
+    let list_state = rememberLazyListState();
+    LAST_LAZY_ROW_STATE.with(|cell| {
+        *cell.borrow_mut() = Some(list_state);
+    });
+
+    Column(Modifier::empty(), ColumnSpec::default(), move || {
+        Text(
+            format!("First visible {}", list_state.first_visible_item_index()),
+            Modifier::empty(),
+            TextStyle::default(),
+        );
+        Text(
+            format!("Can scroll back {}", list_state.can_scroll_backward()),
+            Modifier::empty(),
+            TextStyle::default(),
+        );
+        LazyRow(
+            Modifier::empty().fill_max_height().width(240.0),
+            list_state,
+            LazyRowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
+            |scope| {
+                scope.items(80, |index| {
+                    Text(
+                        format!("Item {}", index),
+                        Modifier::empty().width(48.0),
+                        TextStyle::default(),
+                    );
+                });
+            },
+        );
+    });
+}
+
+#[test]
+fn lazy_row_gesture_scroll_moves_rendered_items_along_the_horizontal_axis() {
+    let _app_context = crate::render_state::app_context_test_scope();
+    let mut composition = Composition::new(MemoryApplier::new());
+    LAST_LAZY_ROW_STATE.with(|cell| {
+        *cell.borrow_mut() = None;
+    });
+
+    composition
+        .render(location_key(file!(), line!(), column!()), || {
+            HorizontalScrollIndicatorLazyRow();
+        })
+        .expect("initial render");
+
+    let root = composition.root().expect("lazy row root");
+    let viewport = Size {
+        width: 320.0,
+        height: 320.0,
+    };
+    measure_root(&mut composition, root, viewport);
+    let initial_texts = render_texts(&mut composition, root);
+    assert!(
+        initial_texts.iter().any(|text| text == "First visible 0"),
+        "test must subscribe a composition scope to the scroll position"
+    );
+    assert!(
+        initial_texts
+            .iter()
+            .any(|text| text == "Can scroll back false"),
+        "test must subscribe a composition scope to lazy scroll bounds"
+    );
+    let initial_records = render_text_records(&mut composition, root);
+    let initial_item_0_x = text_x(&initial_records, "Item 0");
+    let initial_item_0_y = text_y(&initial_records, "Item 0");
+
+    // A delta smaller than one item's span (48px width + 8px spacing) keeps
+    // item 0 within the retained/composed window, so the assertion below
+    // exercises axis-correctness rather than virtualization edge cases.
+    let list_state = LAST_LAZY_ROW_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    list_state.dispatch_scroll_delta(-40.0);
+    measure_root(&mut composition, root, viewport);
+
+    assert!(
+        list_state.can_scroll_backward_non_reactive(),
+        "gesture scroll should update retained lazy scroll bounds"
+    );
+    assert!(
+        composition
+            .process_invalid_scopes()
+            .expect("gesture scroll invalidation processing"),
+        "gesture scroll must recompose scopes that observe public scroll position"
+    );
+    measure_root(&mut composition, root, viewport);
+    let scrolled_texts = render_texts(&mut composition, root);
+    assert!(
+        scrolled_texts
+            .iter()
+            .any(|text| text == "Can scroll back true"),
+        "scroll observer text did not track gesture-updated backward capability; got {scrolled_texts:?}"
+    );
+
+    let scrolled_records = render_text_records(&mut composition, root);
+    let scrolled_item_0_x = text_x(&scrolled_records, "Item 0");
+    let scrolled_item_0_y = text_y(&scrolled_records, "Item 0");
+    assert!(
+        (initial_item_0_x - scrolled_item_0_x - 40.0).abs() < 0.5,
+        "scrolling a lazy row should move its rendered items along x by the scroll delta: \
+         initial_x={initial_item_0_x}, scrolled_x={scrolled_item_0_x}"
+    );
+    assert!(
+        (initial_item_0_y - scrolled_item_0_y).abs() < 0.01,
+        "scrolling a lazy row must not move its rendered items along y: \
+         initial_y={initial_item_0_y}, scrolled_y={scrolled_item_0_y}"
+    );
+
+    LAST_LAZY_ROW_STATE.with(|cell| {
+        *cell.borrow_mut() = None;
+    });
+}
+
+#[derive(Debug)]
+struct RenderedText {
+    value: String,
+    x: f32,
+    y: f32,
+}
+
+fn render_texts(composition: &mut Composition<MemoryApplier>, root: NodeId) -> Vec<String> {
+    render_text_records(composition, root)
+        .into_iter()
+        .map(|record| record.value)
+        .collect()
+}
+
+fn render_text_records(
+    composition: &mut Composition<MemoryApplier>,
+    root: NodeId,
+) -> Vec<RenderedText> {
+    let handle = composition.runtime_handle();
+    let mut applier = composition.applier_mut();
+    applier.set_runtime_handle(handle);
+    let layout = applier
+        .compute_layout(
+            root,
+            Size {
+                width: 320.0,
+                height: 320.0,
+            },
+        )
+        .expect("layout");
+    applier.clear_runtime_handle();
+    let renderer = HeadlessRenderer::new();
+    let scene = renderer.render(&layout);
+    scene
+        .operations()
+        .iter()
+        .filter_map(|op| match op {
+            RenderOp::Text { rect, value, .. } => Some(RenderedText {
+                value: value.clone(),
+                x: rect.x,
+                y: rect.y,
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+fn text_x(records: &[RenderedText], value: &str) -> f32 {
+    records
+        .iter()
+        .find(|record| record.value == value)
+        .unwrap_or_else(|| panic!("expected rendered text {value:?}, got {records:?}"))
+        .x
+}
+
+fn text_y(records: &[RenderedText], value: &str) -> f32 {
+    records
+        .iter()
+        .find(|record| record.value == value)
+        .unwrap_or_else(|| panic!("expected rendered text {value:?}, got {records:?}"))
+        .y
+}
+
+fn measure_root(composition: &mut Composition<MemoryApplier>, root: NodeId, size: Size) {
+    let handle = composition.runtime_handle();
+    let mut applier = composition.applier_mut();
+    applier.set_runtime_handle(handle);
+    let _ = applier.compute_layout(root, size).expect("layout");
+    applier.clear_runtime_handle();
+}

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -1841,25 +1841,34 @@ pub fn run(
     // packaged identity of a running process does not change.
     crate::android_app_info::install_app_info(&app);
 
-    // Install panic hook for better crash logging in Logcat
-    std::panic::set_hook(Box::new(|panic_info| {
-        let location = panic_info
-            .location()
-            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
-            .unwrap_or_else(|| "unknown location".to_string());
-        let message = panic_info
-            .payload()
-            .downcast_ref::<&str>()
-            .map(|s| *s)
-            .or_else(|| {
-                panic_info
-                    .payload()
-                    .downcast_ref::<String>()
-                    .map(|s| s.as_str())
-            })
-            .unwrap_or("Box<dyn Any>");
-        log::error!("PANIC at {}: {}", location, message);
-    }));
+    // Install a panic hook for crash logging in Logcat. `take_hook()` grabs
+    // whatever hook the application installed before handing control to
+    // `AppLauncher::run_android()` (e.g. its own crash reporter), and
+    // `chained_panic_hook` wraps the framework's hook around it so both run
+    // instead of the framework's silently winning.
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(crate::android_panic_hook::chained_panic_hook(
+        |panic_info| {
+            let location = panic_info
+                .location()
+                .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+                .unwrap_or_else(|| "unknown location".to_string());
+            let message = panic_info
+                .payload()
+                .downcast_ref::<&str>()
+                .copied()
+                .or_else(|| {
+                    panic_info
+                        .payload()
+                        .downcast_ref::<String>()
+                        .map(String::as_str)
+                })
+                .unwrap_or("Box<dyn Any>");
+            let backtrace = std::backtrace::Backtrace::force_capture();
+            log::error!("PANIC at {location}: {message}\n{backtrace}");
+        },
+        previous_hook,
+    ));
 
     // Wrap content in Rc<RefCell> for reuse across window recreations
     let content = std::rc::Rc::new(std::cell::RefCell::new(content));

--- a/crates/cranpose/src/android_panic_hook.rs
+++ b/crates/cranpose/src/android_panic_hook.rs
@@ -1,0 +1,94 @@
+//! Panic-hook chaining for the Android runtime.
+//!
+//! An application installs its own panic hook — for crash reporting, say —
+//! before handing control to `AppLauncher::run_android()`. `android.rs`'s
+//! `run()` used to call `std::panic::set_hook()` unconditionally, silently
+//! replacing whatever the application had installed. [`chained_panic_hook`]
+//! fixes that: it wraps the framework's own diagnostic hook around the hook
+//! that was already installed (captured via `std::panic::take_hook()`
+//! before the framework installs its own), so both run.
+//!
+//! `android.rs` is gated to `target_os = "android"` and cannot be unit
+//! tested on the host. The chaining itself is plain `std::panic`, nothing
+//! Android-specific, so it lives here instead, where it is also built on
+//! the host under `cfg(test)`.
+
+use std::panic::PanicHookInfo;
+
+/// Wraps `own_hook` so it runs, then `previous_hook` runs — the hook
+/// returned by `std::panic::take_hook()` right before the framework installs
+/// its own — producing a single hook that runs both instead of one
+/// replacing the other.
+///
+/// `own_hook` must not panic. A panic raised while a panic hook is already
+/// running for the panic it was called for is an unrecoverable nested panic:
+/// the process aborts immediately, before unwinding starts, so not even
+/// `catch_unwind` around `own_hook` can stop it from also taking
+/// `previous_hook` — and with it, the application's own crash reporting —
+/// down. Keep `own_hook` to operations that cannot panic (plain getters,
+/// `downcast_ref`, `format!`, `std::backtrace::Backtrace::force_capture()`,
+/// logging), the same way `own_hook` in `android.rs` does.
+pub(crate) fn chained_panic_hook(
+    own_hook: impl Fn(&PanicHookInfo<'_>) + Sync + Send + 'static,
+    previous_hook: Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send>,
+) -> Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send> {
+    Box::new(move |info| {
+        own_hook(info);
+        previous_hook(info);
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    };
+
+    // `std::panic::set_hook`/`take_hook` mutate process-global state, so
+    // tests that install a hook must not run concurrently with each other.
+    static HOOK_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn chained_hook_runs_both_the_framework_hook_and_the_previously_installed_one() {
+        let _guard = HOOK_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let saved_hook = std::panic::take_hook();
+
+        // Stand in for an application's own hook, installed before the
+        // framework runs and captured here exactly as `android.rs` captures
+        // it: via `take_hook()`.
+        let marker_fired = Arc::new(AtomicBool::new(false));
+        let marker_for_previous = Arc::clone(&marker_fired);
+        std::panic::set_hook(Box::new(move |_| {
+            marker_for_previous.store(true, Ordering::SeqCst)
+        }));
+        let previous_hook = std::panic::take_hook();
+
+        let own_fired = Arc::new(AtomicBool::new(false));
+        let own_for_hook = Arc::clone(&own_fired);
+        std::panic::set_hook(chained_panic_hook(
+            move |_| own_for_hook.store(true, Ordering::SeqCst),
+            previous_hook,
+        ));
+
+        let panicked = std::panic::catch_unwind(|| panic!("chained_panic_hook test panic"));
+
+        std::panic::set_hook(saved_hook);
+
+        assert!(
+            panicked.is_err(),
+            "the panic should have unwound and been caught"
+        );
+        assert!(
+            own_fired.load(Ordering::SeqCst),
+            "framework's own hook did not run"
+        );
+        assert!(
+            marker_fired.load(Ordering::SeqCst),
+            "previously installed hook was replaced instead of chained onto"
+        );
+    }
+}

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -67,6 +67,10 @@ mod android_keyboard;
 mod android_launch_args;
 #[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
 mod android_overlay_window;
+/// Panic-hook chaining behind `android.rs`'s `run()`. Built on the host as
+/// well so the chaining logic's test runs everywhere.
+#[cfg(any(test, all(feature = "android", target_os = "android")))]
+mod android_panic_hook;
 #[cfg(all(feature = "android", target_os = "android"))]
 mod android_perf_hint;
 /// The Play Billing wire format behind `cranpose_services::purchases`. Built on


### PR DESCRIPTION
## Summary

Two independent, unrelated fixes bundled per instruction, one commit each.

### Fix 1: the Android panic hook no longer destroys an application's own hook

`crates/cranpose/src/android.rs`'s `run()` called `std::panic::set_hook(...)` unconditionally, *after* an application's own launcher had already installed its hook. The framework silently won, so the application's crash reporting never fired.

**Evidence this bites a real app:** CranScan installs a richer hook (backtrace + thread name + a `"CRANSCAN_PANIC"` tag) at `app/src/panic_log.rs`, invoked from `android_launcher()` in `app/src/native_entry.rs` before the launcher value reaches `cranpose::android_main!`. The framework's own hook logged only file, line, column and message — no backtrace, no thread name — and always replaced the app's.

**Fix:** `run()` now takes the previously-installed hook via `std::panic::take_hook()` and passes it to a new `chained_panic_hook()` helper (`crates/cranpose/src/android_panic_hook.rs`), which wraps the framework's own hook (now also capturing a `std::backtrace::Backtrace`) around it, so both fire. No feature flag, no opt-out — one correct behavior.

Because `android.rs` is gated to `target_os = "android"` and can't be unit tested on the host, the chaining logic itself was extracted into its own module, gated the same way the existing `android_launch_args` module is (`#[cfg(any(test, all(feature = "android", target_os = "android")))]`), so it also builds — and is unit tested — on the host.

A quick host experiment (see the module doc comment) confirmed `catch_unwind` around a panic hook's own logic **cannot** protect against a panic raised while a panic is already being processed — the process aborts immediately, before any unwind starts. So rather than wrap the hook in a no-op safety net, `own_hook` is documented as must-not-panic and kept to infallible operations (plain getters, `downcast_ref`, `format!`, `Backtrace::force_capture()`, logging).

### Fix 2: LazyRow now has composition test coverage

`LazyRow` is exported from `cranpose-ui` but had no composition test anywhere. `LazyColumn` is exercised through a real composition in `tests/lazy_list_viewport_tests.rs` and `tests/lazy_list_recompose_tests.rs`. I checked every "lazy_row"-named test that already existed in the suite (`lazy_recycle_effect_tests`) and confirmed they all actually build on `LazyColumn` — the name just described row-shaped item *content*, not the `LazyRow` composable itself. The only test that literally touches `LazyRow` (`widgets/lazy_list.rs::test_lazy_row_spec_default`) only checks `LazyRowSpec::default()` field values, never composing anything.

Added `crates/cranpose-ui/src/tests/lazy_row_tests.rs`, mirroring the shape/assertions of the LazyColumn suite:
- `lazy_row_unbounded_width_matches_effective_viewport` — items composed and measured against an unbounded main axis (mirrors `lazy_column_unbounded_height_matches_effective_viewport`).
- `lazy_row_updates_scroll_bounds_when_item_count_grows_without_scrolling` — item count driving `total_items_count`/`can_scroll_forward` through recomposition (mirrors the `GrowingLazyList` test).
- `lazy_row_gesture_scroll_moves_rendered_items_along_the_horizontal_axis` — a gesture scroll moves rendered items along x (not y) by the scroll delta; this is the one assertion with no faithful LazyColumn analog, since it specifically pins the horizontal orientation being wired correctly end to end.

## Verification (paste of real output, run on macm3 per machine policy)

```
=== cargo fmt --all --check ===
FMT_EXIT=0

=== cargo clippy --workspace --all-targets -- -D warnings ===
CLIPPY_EXIT=0

=== cargo test --workspace ===
TEST_EXIT=0
(all `test result: ok` across every crate, 0 failed)
test android_panic_hook::tests::chained_hook_runs_both_the_framework_hook_and_the_previously_installed_one ... ok
test lazy_row_tests::lazy_row_unbounded_width_matches_effective_viewport ... ok
test lazy_row_tests::lazy_row_updates_scroll_bounds_when_item_count_grows_without_scrolling ... ok
test lazy_row_tests::lazy_row_gesture_scroll_moves_rendered_items_along_the_horizontal_axis ... ok

=== cargo check --target aarch64-linux-android -p cranpose --no-default-features --features android,renderer-wgpu ===
ANDROID_CHECK_EXIT=0
```

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo check --target aarch64-linux-android -p cranpose --no-default-features --features android,renderer-wgpu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)