### PR TITLE
Fix robot suite capability gating and mislabeled retry knob

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -122,12 +122,14 @@ shared pair.
   else, so they are only ever exercised on Linux.
 - **`robot_leetcodedaily_code_scroll_pixel_drift` needs Python Pillow** for its
   pixel comparison and is skipped on hosts without it.
-- **`robot_shader_rect` and `robot_shader_backdrop_drag` need a compositing
-  display.** Both call `.with_headless(false)` because they verify real GPU
-  presentation, but the suite's capability skips gate on X11 plus `xdotool`,
-  which these two do not need — so they run wherever the suite runs and fail
-  wherever nothing can present a frame. A sleeping panel is enough to fail them,
-  and the failure says nothing about why.
+- **`robot_shader_rect` and `robot_shader_backdrop_drag` need a display that
+  can present a frame.** Both call `.with_headless(false)` because they verify
+  real GPU presentation. They are skipped, with that reason printed, when
+  `DISPLAY`/`WAYLAND_DISPLAY` is unset or `xset q` reports the X11 monitor
+  asleep (Off/Standby/Suspend) — the condition that otherwise surfaces as an
+  opaque "window ... refused N consecutive frames" failure. `xvfb-run`, which
+  is what CI runs the suite under, has no DPMS extension, so this gate is a
+  no-op there and the pair runs as before.
 
 ## Infrastructure
 

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -20,6 +20,12 @@
 #                   Number of staged artifact shards (default: 16)
 #   CRANPOSE_ROBOT_KEEP_FAILURE_RESULTS=0
 #                   Remove per-example result artifacts even when the suite fails
+#   CRANPOSE_ROBOT_TIMEOUT_RETRY_ATTEMPTS=N
+#                   Attempts allowed per example when a run is killed by the
+#                   timeout guard (exit 124/137), default 2. A failure the
+#                   example itself reports (nonzero exit, panic, FAIL/FATAL in
+#                   its output) is never retried — it gets exactly one attempt,
+#                   because retrying it would hide a genuine failure as flake.
 #   --help          Show this help message
 
 LOG_FILE="${CRANPOSE_ROBOT_LOG_FILE:-robot_test.log}"
@@ -43,7 +49,7 @@ else
     PARALLEL_JOBS=1
 fi
 ROBOT_TEST_TIMEOUT_CAP_SECS="${CRANPOSE_ROBOT_TEST_TIMEOUT_CAP_SECS:-900}"
-ROBOT_TEST_ATTEMPTS="${CRANPOSE_ROBOT_TEST_ATTEMPTS:-2}"
+ROBOT_TIMEOUT_RETRY_ATTEMPTS="${CRANPOSE_ROBOT_TIMEOUT_RETRY_ATTEMPTS:-2}"
 ROBOT_FAILURE_LOG_LINES="${CRANPOSE_ROBOT_FAILURE_LOG_LINES:-220}"
 ROBOT_KEEP_FAILURE_RESULTS="${CRANPOSE_ROBOT_KEEP_FAILURE_RESULTS:-1}"
 SELECTED_EXAMPLES=()
@@ -166,6 +172,10 @@ while [[ $# -gt 0 ]]; do
             echo "                  Number of staged artifact shards (default: 16)"
             echo "  CRANPOSE_ROBOT_KEEP_FAILURE_RESULTS=0"
             echo "                  Remove per-example result artifacts even when the suite fails"
+            echo "  CRANPOSE_ROBOT_TIMEOUT_RETRY_ATTEMPTS=N"
+            echo "                  Attempts allowed per example when a run is killed by the"
+            echo "                  timeout guard (exit 124/137), default 2. Failures the example"
+            echo "                  itself reports are never retried."
             echo "  --help          Show this help message"
             exit 0
             ;;
@@ -243,6 +253,35 @@ robot_source_path() {
     return 1
 }
 
+# Whether the host can currently present a frame to a real, awake display.
+#
+# A DPMS-blanked panel leaves DISPLAY set and the X connection alive while
+# every present silently stalls: the app is the one that eventually times out
+# and reports "the window is occluded, off-screen, or on a display that is
+# not compositing" (see TIME_WASTERS.md), which names the symptom, not the
+# cause. `xset q` reads the DPMS monitor state directly, so this probe skips
+# the affected tests before they pay for a build and a multi-second present
+# timeout only to fail with that opaque message.
+#
+# Xvfb (what CI's `xvfb-run` gives every robot example) has no DPMS
+# extension, so `xset q` there prints no "Monitor is ..." line at all and
+# this probe reports presentable — CI behavior is unchanged by this check.
+robot_display_can_present() {
+    if [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ]; then
+        return 1
+    fi
+    if [ -n "${DISPLAY:-}" ] && command -v xset >/dev/null 2>&1; then
+        local dpms_state
+        dpms_state=$(xset q 2>/dev/null) || return 1
+        case "$dpms_state" in
+            *"Monitor is Off"*|*"Monitor is Standby"*|*"Monitor is Suspend"*)
+                return 1
+                ;;
+        esac
+    fi
+    return 0
+}
+
 robot_capability_skip_reason() {
     local example="$1"
     local source
@@ -252,6 +291,15 @@ robot_capability_skip_reason() {
         case "$example" in
             robot_counter_button_release_external_visual|robot_hacker_news_scroll_exact_external_contract|robot_leetcodedaily_full_layout_scroll_stability|robot_liquid_scroll_exact_external_contract|robot_liquid_*_cheatsheet|robot_markdown_default_visual_contract|robot_markdown_full_demo_code_block_visual_contract|robot_markdown_scroll_exact_external_contract|robot_presented_window_geometry|robot_presented_window_hidpi_geometry|robot_presented_window_redraw|robot_regression_hn_markdown_visual_contract|robot_regression_layout_jitter_contract|robot_regression_shader_visual_contract|robot_renderer_micro_contract|robot_shader_external_x11_drag|robot_shader_full_demo_external_perf|robot_shader_rect_external_animation|robot_tab_walk_text_visual_contract|robot_text_indent_scroll_stability|robot_text_scroll_exact_external_contract|robot_text_strikeout_presented|robot_underline_screenshot|robot_winamp_native_window_geometry)
                 echo "requires an X11 session and xdotool"
+                return 0
+                ;;
+        esac
+    fi
+
+    if ! robot_display_can_present; then
+        case "$example" in
+            robot_shader_backdrop_drag|robot_shader_rect)
+                echo "requires a display that can present a frame (no DISPLAY/WAYLAND_DISPLAY, or the panel is asleep)"
                 return 0
                 ;;
         esac
@@ -644,9 +692,9 @@ run_test() {
         timeout_secs="$ROBOT_TEST_TIMEOUT_CAP_SECS"
     fi
 
-    local max_attempts="$ROBOT_TEST_ATTEMPTS"
-    if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
-        max_attempts=1
+    local max_timeout_retry_attempts="$ROBOT_TIMEOUT_RETRY_ATTEMPTS"
+    if ! [[ "$max_timeout_retry_attempts" =~ ^[1-9][0-9]*$ ]]; then
+        max_timeout_retry_attempts=1
     fi
 
     local headless_env="CRANPOSE_HEADLESS=1"
@@ -669,10 +717,10 @@ run_test() {
     : > "$output_file"
 
     local attempt=1
-    while [ "$attempt" -le "$max_attempts" ]; do
+    while [ "$attempt" -le "$max_timeout_retry_attempts" ]; do
         local attempt_output="$RESULTS_DIR/$example.attempt.$attempt.output"
         {
-            echo "Attempt $attempt/$max_attempts for $example (timeout=${timeout_secs}s)"
+            echo "Attempt $attempt/$max_timeout_retry_attempts for $example (timeout=${timeout_secs}s)"
             echo "Host before attempt: $(host_state_summary)"
         } >> "$output_file"
 
@@ -722,7 +770,7 @@ run_test() {
                 echo "Attempt $attempt timed out or was killed."
                 echo "Host after timeout: $(host_state_summary)"
             } >> "$output_file"
-            if [ "$attempt" -lt "$max_attempts" ]; then
+            if [ "$attempt" -lt "$max_timeout_retry_attempts" ]; then
                 attempt=$((attempt + 1))
                 continue
             fi
@@ -730,6 +778,10 @@ run_test() {
             return 75
         fi
 
+        # Any other failure (nonzero exit, panic, FAIL/FATAL in the log) is
+        # the example reporting its own result, not the timeout guard cutting
+        # it off — retrying it would risk turning a genuine failure into a
+        # flake-shaped pass. It gets exactly one attempt.
         echo "FAIL:$reason" > "$result_file"
         return 0
     done
@@ -744,7 +796,7 @@ robot_process_env() {
 
     while IFS='=' read -r name value; do
         case "$name" in
-            BASH_FUNC_*|RESULTS_DIR|EXAMPLE_BIN_DIR|ROBOT_TEST_TIMEOUT_CAP_SECS|ROBOT_TEST_ATTEMPTS)
+            BASH_FUNC_*|RESULTS_DIR|EXAMPLE_BIN_DIR|ROBOT_TEST_TIMEOUT_CAP_SECS|ROBOT_TIMEOUT_RETRY_ATTEMPTS)
                 ;;
             PATH|HOME|USER|LOGNAME|SHELL|DISPLAY|XAUTHORITY|WAYLAND_DISPLAY|XDG_RUNTIME_DIR|LD_LIBRARY_PATH|LIBGL_ALWAYS_SOFTWARE|LIBGL_DRIVERS_PATH|VK_ICD_FILENAMES|VK_LAYER_PATH|MESA_LOADER_DRIVER_OVERRIDE|MESA_VK_DEVICE_SELECT|RUST_BACKTRACE|RUST_LOG|ROBOT_SHOT_DIR|WINIT_*|WGPU_*|CRANPOSE_*|TMPDIR)
                 env_args+=("$name=$value")
@@ -770,7 +822,7 @@ export -f wait_for_host_capacity
 export RESULTS_DIR
 export EXAMPLE_BIN_DIR
 export ROBOT_TEST_TIMEOUT_CAP_SECS
-export ROBOT_TEST_ATTEMPTS
+export ROBOT_TIMEOUT_RETRY_ATTEMPTS
 
 print_failure_excerpt() {
     local example="$1"


### PR DESCRIPTION
## Summary

Two defects in `run_robot_test.sh`, both found by reading a real CI failure and documented in PLAN.md's "Robot suite corner cases" section.

**1. `robot_shader_rect` / `robot_shader_backdrop_drag` were gated on the wrong capability.** Both call `.with_headless(false)` to verify real GPU presentation, which needs nothing from X11/`xdotool` — but the suite's only capability gate checked for X11+`xdotool`. They ran unconditionally and failed with an opaque "window ... refused N consecutive frames ... occluded, off-screen, or on a display that is not compositing" message whenever the display couldn't actually present a frame.

Added `robot_display_can_present()`, wired into the *same* `robot_capability_skip_reason()` case-statement mechanism the existing `xdotool` and Pillow checks already use (no second parallel mechanism). It reports "cannot present" when `DISPLAY`/`WAYLAND_DISPLAY` is unset, or when X11 `xset q` reports the monitor DPMS state as Off/Standby/Suspended (a "sleeping panel", per PLAN.md's own wording and TIME_WASTERS.md's prior investigation of this exact failure mode).

**2. `ROBOT_TEST_ATTEMPTS` didn't do what its name said.** The retry loop only re-runs an example when the external `timeout` guard kills it (exit 124/137) — every other failure (panic, assertion, nonzero exit, `FAIL`/`FATAL` in the log) gets exactly one attempt no matter what the knob is set to. A real CI failure showed `Attempt 1/2` printed once with no second attempt, because the failure wasn't a timeout.

Per AGENTS.md, broadening this into a blanket retry-on-any-failure would hide genuine failures as flakes, which is the wrong fix. Instead the knob (`CRANPOSE_ROBOT_TEST_ATTEMPTS` → `CRANPOSE_ROBOT_TIMEOUT_RETRY_ATTEMPTS`, and the internal `max_attempts` → `max_timeout_retry_attempts`) is renamed to say precisely what it does, and documented in both usage blocks at the top of the script (the `#` header and the `--help` output).

PLAN.md's "Robot suite corner cases" section is updated: the shader-pair bullet now describes the fixed gating behavior instead of the bug (per PLAN.md's own rule that an item leaves the file when the behaviour changes).

## What I verified

- `bash -n run_robot_test.sh` passes.
- `shellcheck run_robot_test.sh` reports the exact same 3 pre-existing informational/style findings as `origin/main` (SC2086, SC2329, SC2129) — zero new findings from this change.
- `cargo test --test source_hygiene_aliases` (in `apps/desktop-demo`) passes all 15 tests, including the ones that assert on `run_robot_test.sh` content (`robot_runner_enforces_timeouts_without_gnu_coreutils`, the `CRANPOSE_HEADLESS=0` case-statement substrings) — nothing I touched broke those invariants.
- **Direct evidence on samarch-1** (the only Linux+X11 host, reachable via `ssh`, without launching the full suite): extracted just the new/changed shell functions and ran them there.
  - Under the real X session (`DISPLAY=:0`), `xset q` currently reports `Monitor is Off` on that machine right now — reproducing the exact condition the bug describes. With the fix, `robot_capability_skip_reason` correctly reports `SKIP (requires a display that can present a frame ...)` for both `robot_shader_rect` and `robot_shader_backdrop_drag`.
  - Under `xvfb-run -a bash -c ...` — the same wrapper `.github/workflows/heavy-selfhosted.yml` uses for every robot-suite job — `xset q` reports `Server does not have the DPMS Extension` (no "Monitor is ..." line), so the new gate is a no-op and both examples report `RUN`, unchanged from current CI behavior.
  - Confirmed via the workflow file that neither CI job (`robot-e2e-gpu`, `robot-capture-software`) skips or excludes these two examples today, and both jobs use `xvfb-run`, so this fix does not change what CI builds/runs — it only changes behavior on a host that cannot present.

## What I could NOT verify

- I did **not** run the actual robot binaries (`robot_shader_rect`, `robot_shader_backdrop_drag`) end-to-end, on samarch-1 or anywhere else — the host is saturated with CI per the task constraints, and I was told not to launch a full robot run. Verification above is of the shell capability-gating logic in isolation, not the example binaries themselves.
- I did not exercise the renamed `CRANPOSE_ROBOT_TIMEOUT_RETRY_ATTEMPTS` knob against a real timing-out example (would require a real robot run); the change there is a straightforward rename/re-document of existing, unchanged control flow, confirmed by reading the retry loop.
- CI (`heavy (self-hosted)` workflow) has not run against this branch yet — this PR targets `main` per the repo's trigger configuration so it will run automatically once opened.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>