### PR TITLE
Give robot wait_for_idle convergence-based timeout semantics

### DIFF
--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -43,8 +43,30 @@ const NATIVE_WINDOW_POSITION_POLL_INTERVAL: Duration = Duration::from_millis(16)
 const NATIVE_WINDOW_POSITION_SETTLE_TIMEOUT: Duration = Duration::from_millis(36);
 const NATIVE_WINDOW_POSITION_SETTLE_POLL: Duration = Duration::from_millis(1);
 const NATIVE_WINDOW_PLACEMENT_MARGIN: f32 = 32.0;
+/// Soft wall-clock budget for `wait_for_idle`. Elapsing this alone is not
+/// proof the *application* failed to converge -- see
+/// `ROBOT_IDLE_MIN_ITERATIONS` below for why.
 #[cfg(feature = "robot")]
 const ROBOT_IDLE_TIMEOUT: Duration = Duration::from_secs(10);
+/// Minimum number of `about_to_wait` turns the idle-wait loop must actually
+/// have executed before `ROBOT_IDLE_TIMEOUT` elapsing is trusted to mean the
+/// application stopped converging. While a wait is outstanding the loop runs
+/// at `ControlFlow::Poll` (see `awaiting_progress`), so on a host that is
+/// scheduling this process at all, a genuinely non-converging app races
+/// through far more than this many iterations inside the soft budget above.
+/// A starved host can instead let the whole budget elapse in wall-clock time
+/// while the OS schedules this thread for only one or two of those turns --
+/// observed on CI as "timed out after 1 iterations" with 17 self-hosted
+/// runners sharing a host at load average 14. That is host starvation, not
+/// an application defect, and must not fail the same way.
+#[cfg(feature = "robot")]
+const ROBOT_IDLE_MIN_ITERATIONS: u32 = 100;
+/// Absolute ceiling on `wait_for_idle`, independent of iteration count. Even
+/// a host so overloaded that the loop can barely execute must not hang the
+/// robot driver forever; past this point the wait is abandoned and reported
+/// as host starvation rather than blamed on the application.
+#[cfg(feature = "robot")]
+const ROBOT_IDLE_STARVATION_CEILING: Duration = Duration::from_secs(60);
 #[cfg(feature = "robot")]
 const ROBOT_PUMP_FRAME_INTERVAL: Duration = Duration::from_nanos(16_666_667);
 /// A present wait is a wait on the compositor, and a compositor is allowed to
@@ -160,6 +182,22 @@ struct RobotScrollSequence {
     remaining: u32,
 }
 
+/// Why `wait_for_idle` gave up. The two causes need different messages and
+/// different remediation: one names a broken application, the other names a
+/// host that never let the application run.
+#[cfg(feature = "robot")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum IdleWaitTimeout {
+    /// The soft budget elapsed AND the loop actually turned enough times for
+    /// that elapsed time to mean something: the application kept producing
+    /// work instead of converging.
+    AppNotConverging,
+    /// The absolute ceiling elapsed without the loop ever reaching the
+    /// iteration floor: the host did not schedule this process enough to
+    /// tell whether the application was converging at all.
+    HostStarved,
+}
+
 #[cfg(feature = "robot")]
 impl RobotController {
     fn new(wake_event_loop: impl Fn() + Send + Sync + 'static) -> (Self, Robot) {
@@ -207,10 +245,19 @@ impl RobotController {
         self.idle_structure_clean_frames = 0;
     }
 
-    fn idle_wait_timed_out(&self, now: Instant) -> bool {
-        self.idle_started_at.is_some_and(|started_at| {
-            now.saturating_duration_since(started_at) >= ROBOT_IDLE_TIMEOUT
-        })
+    /// Convergence-based timeout check: see the constants above for why
+    /// elapsed time alone cannot tell a livelocked application from a
+    /// starved host. Returns `None` while the wait should keep running.
+    fn idle_wait_timeout(&self, now: Instant) -> Option<IdleWaitTimeout> {
+        let started_at = self.idle_started_at?;
+        let elapsed = now.saturating_duration_since(started_at);
+        if elapsed >= ROBOT_IDLE_TIMEOUT && self.idle_iterations >= ROBOT_IDLE_MIN_ITERATIONS {
+            return Some(IdleWaitTimeout::AppNotConverging);
+        }
+        if elapsed >= ROBOT_IDLE_STARVATION_CEILING {
+            return Some(IdleWaitTimeout::HostStarved);
+        }
+        None
     }
 
     fn begin_pump_present_wait(&mut self, target_generation: u64) {
@@ -5580,16 +5627,21 @@ impl ApplicationHandler for App {
                         );
                     }
 
-                    if controller.idle_wait_timed_out(Instant::now()) {
+                    if let Some(timeout) = controller.idle_wait_timeout(Instant::now()) {
+                        let iterations = controller.idle_iterations;
                         controller.finish_idle_wait();
-                        let _ = controller.tx.send(RobotResponse::Error(format!(
-                            "wait_for_idle: timed out after {} iterations; needs_update={}, needs_redraw={}, has_animations={}, waiting_for_present={}",
-                            controller.idle_iterations,
-                            needs_update,
-                            app.needs_redraw(),
-                            has_active_animations,
-                            waiting_for_present
-                        )));
+                        let message = match timeout {
+                            IdleWaitTimeout::AppNotConverging => format!(
+                                "wait_for_idle: timed out after {iterations} iterations; needs_update={needs_update}, needs_redraw={}, has_animations={has_active_animations}, waiting_for_present={waiting_for_present}",
+                                app.needs_redraw(),
+                            ),
+                            IdleWaitTimeout::HostStarved => format!(
+                                "wait_for_idle: host starvation -- only {iterations} iterations ran in {:?} (need {ROBOT_IDLE_MIN_ITERATIONS} to trust the elapsed budget); the process was not scheduled enough to tell whether the application is converging, not an application defect; needs_update={needs_update}, needs_redraw={}, has_animations={has_active_animations}, waiting_for_present={waiting_for_present}",
+                                ROBOT_IDLE_STARVATION_CEILING,
+                                app.needs_redraw(),
+                            ),
+                        };
+                        let _ = controller.tx.send(RobotResponse::Error(message));
                     }
                 }
             }
@@ -6043,7 +6095,8 @@ fn resolve_robot_screenshot_params_with_scale(
 mod tests {
     #[cfg(feature = "robot")]
     use super::{
-        bound_park_for_robot, ControlFlow, ROBOT_IDLE_TIMEOUT, ROBOT_PARKED_COMMAND_POLL_INTERVAL,
+        bound_park_for_robot, ControlFlow, IdleWaitTimeout, ROBOT_IDLE_MIN_ITERATIONS,
+        ROBOT_IDLE_STARVATION_CEILING, ROBOT_IDLE_TIMEOUT, ROBOT_PARKED_COMMAND_POLL_INTERVAL,
         ROBOT_PRESENT_WAIT_TIMEOUT,
     };
     use super::{
@@ -6353,17 +6406,79 @@ mod tests {
 
     #[cfg(feature = "robot")]
     #[test]
-    fn robot_idle_timeout_tracks_elapsed_time_instead_of_loop_iterations() {
+    fn robot_idle_wait_times_out_once_the_app_keeps_the_loop_busy() {
+        // A livelocked application keeps producing work every turn, so the
+        // loop races through iterations far faster than
+        // `ROBOT_IDLE_MIN_ITERATIONS` inside the soft budget. That
+        // combination -- budget elapsed AND enough turns to prove the loop
+        // was actually running -- is what must fail, and must fail as an
+        // application defect.
         let (mut controller, _robot) = RobotController::new(|| {});
         let started_at = Instant::now();
 
         controller.start_idle_wait_at(started_at);
-        controller.idle_iterations = u32::MAX;
+        controller.idle_iterations = ROBOT_IDLE_MIN_ITERATIONS;
 
-        assert!(!controller.idle_wait_timed_out(started_at + ROBOT_IDLE_TIMEOUT / 2));
-        assert!(controller.idle_wait_timed_out(started_at + ROBOT_IDLE_TIMEOUT));
+        assert_eq!(
+            controller.idle_wait_timeout(started_at + ROBOT_IDLE_TIMEOUT / 2),
+            None
+        );
+        assert_eq!(
+            controller.idle_wait_timeout(started_at + ROBOT_IDLE_TIMEOUT),
+            Some(IdleWaitTimeout::AppNotConverging)
+        );
         controller.finish_idle_wait();
-        assert!(!controller.idle_wait_timed_out(started_at + ROBOT_IDLE_TIMEOUT * 2));
+        assert_eq!(
+            controller.idle_wait_timeout(started_at + ROBOT_IDLE_TIMEOUT * 2),
+            None
+        );
+    }
+
+    #[cfg(feature = "robot")]
+    #[test]
+    fn robot_idle_wait_does_not_blame_the_app_for_a_starved_host() {
+        // Regression test for a real CI failure: 17 self-hosted runners
+        // sharing one host at load average 14 let the wall clock run past
+        // `ROBOT_IDLE_TIMEOUT` while scheduling the event-loop thread for a
+        // single turn ("timed out after 1 iterations"). Elapsed time alone
+        // used to fail this as an application defect; the loop must instead
+        // keep waiting past the soft budget when it has not accumulated
+        // enough iterations to prove it was ever given the chance to run.
+        let (mut controller, _robot) = RobotController::new(|| {});
+        let started_at = Instant::now();
+
+        controller.start_idle_wait_at(started_at);
+        controller.idle_iterations = 1;
+
+        assert_eq!(
+            controller.idle_wait_timeout(started_at + ROBOT_IDLE_TIMEOUT),
+            None
+        );
+        assert_eq!(
+            controller.idle_wait_timeout(
+                started_at + ROBOT_IDLE_STARVATION_CEILING - std::time::Duration::from_millis(1)
+            ),
+            None
+        );
+    }
+
+    #[cfg(feature = "robot")]
+    #[test]
+    fn robot_idle_wait_still_gives_up_on_a_permanently_wedged_host() {
+        // The starvation exemption above cannot be unconditional, or a host
+        // that never schedules this process again hangs the driver forever.
+        // Past the absolute ceiling the wait is abandoned and reported as
+        // host starvation, distinctly from an application defect.
+        let (mut controller, _robot) = RobotController::new(|| {});
+        let started_at = Instant::now();
+
+        controller.start_idle_wait_at(started_at);
+        controller.idle_iterations = 1;
+
+        assert_eq!(
+            controller.idle_wait_timeout(started_at + ROBOT_IDLE_STARVATION_CEILING),
+            Some(IdleWaitTimeout::HostStarved)
+        );
     }
 
     #[cfg(feature = "robot")]


### PR DESCRIPTION
## Summary

- `wait_for_idle` timed out purely on elapsed wall-clock time
  (`ROBOT_IDLE_TIMEOUT`), which cannot distinguish an application that
  genuinely never converges from a host that never scheduled the
  driver thread. This produced a real, reproducible CI failure:
  `wait_for_idle: timed out after 1 iterations; ...` — the "1
  iterations" is the tell that the host (17 self-hosted runners
  sharing one machine, load average 14) starved the process for the
  whole 10s budget rather than the app actually being stuck.
- `RobotController::idle_wait_timeout` now returns
  `Option<IdleWaitTimeout>` instead of a bool:
  - `AppNotConverging` — the soft budget (`ROBOT_IDLE_TIMEOUT`, 10s)
    elapsed **and** `idle_iterations` reached `ROBOT_IDLE_MIN_ITERATIONS`
    (100), i.e. proof the loop actually turned enough times for the
    elapsed time to mean the app kept producing work instead of going
    idle.
  - `HostStarved` — the absolute ceiling (`ROBOT_IDLE_STARVATION_CEILING`,
    60s) elapsed regardless of iteration count, so a permanently wedged
    host still fails rather than hanging the driver forever, reported
    with a distinct message that names the host, not the app.
  - Below the soft budget, or above it without enough iterations to
    trust the elapsed time, the wait keeps running.
- This mirrors the convergence convention `begin_pump_present_wait_at`
  already established for the present-wait timeout (re-arm on
  progress instead of trusting a flat wall-clock budget).
- No magic-number bump: the fix replaces a single time-only check with
  a two-signal (time + iterations) check plus a distinct absolute
  ceiling, per the "don't just raise the constant" constraint.

## Test plan

Extended the existing idle-timeout unit tests in
`crates/cranpose/src/desktop.rs` (previously named
`robot_idle_timeout_tracks_elapsed_time_instead_of_loop_iterations`
and pinned exactly the buggy time-only behavior) into three tests
pinning both directions:

- `robot_idle_wait_times_out_once_the_app_keeps_the_loop_busy` — many
  iterations + elapsed budget ⇒ `AppNotConverging`.
- `robot_idle_wait_does_not_blame_the_app_for_a_starved_host` —
  regression test for the CI failure above: 1 iteration, elapsed past
  the soft budget (even up to just under the absolute ceiling) ⇒ no
  timeout.
- `robot_idle_wait_still_gives_up_on_a_permanently_wedged_host` — 1
  iteration, elapsed past the absolute ceiling ⇒ `HostStarved`.

Verified on the `macm3` remote build box (working tree rsynced there;
no local build was performed) against this exact diff:

```
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy --workspace --all-targets -- -D warnings
... (workspace crates checking) ...
Finished `dev` profile [unoptimized + debuginfo] target(s) in 28.22s
(exit code 0, zero warnings)

$ cargo test --workspace
test desktop::tests::robot_idle_wait_does_not_blame_the_app_for_a_starved_host ... ok
test desktop::tests::robot_idle_wait_still_gives_up_on_a_permanently_wedged_host ... ok
test desktop::tests::robot_idle_wait_times_out_once_the_app_keeps_the_loop_busy ... ok
...
149 test binaries, all "test result: ok", 0 failed, 0 warnings
(exit code 0)
```

Also re-ran `cargo fmt --all` (not just `--check`) on the remote copy
and compared `sha256sum` of `crates/cranpose/src/desktop.rs` before
and after — identical, confirming fmt made zero changes.

Not run: `./run_robot_test.sh` (explicitly out of scope — a parallel
agent owns that file) and the Android/wasm build gates (out of scope
for this change, which only touches `crates/cranpose/src/desktop.rs`
behind `#[cfg(feature = "robot")]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
