### PR TITLE
Record how to tell a robot host flake from a regression

### DIFF
--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -922,3 +922,33 @@ monitor reported `cranpose = ABSENT` for crates that were published and served
 correctly. Send a `User-Agent` from every script that queries either API, and
 when a registry lookup says something is missing, re-check with `curl -A` before
 believing it.
+
+## A robot suite failure that is the host, not the branch (2026-08-23)
+
+`robot_memory_leak` failed on one pull request with `wait_for_idle: timed out
+after 1 iterations` and passed on three others the same morning. Two hours went
+into hunting a cause in the branch's own diff that was never there.
+
+Three things tell a host flake from a regression, and none of them need access
+to the machine or a re-run.
+
+- **Read the iteration count in the message before forming any theory.** `timed
+  out after 1 iterations` means a single event-loop turn consumed the whole
+  budget: the process was not scheduled. An application that genuinely never
+  converges races through thousands of iterations in the same wall-clock time.
+  The two are opposite readings of the same message.
+- **Derive a load index from the run's own log.** Sum the gaps between
+  `Running robot_<name>...` timestamps, excluding the test under suspicion, and
+  compare runs. Three passing runs came to 843s, 843s and 844s across the same
+  150 tests; the failing run came to 970s, 15% slower on identical work. The
+  suite is reproducible to within a second, so an outlier is unmistakable. Short
+  tests dominated by fixed startup stay flat while long ones stretch, which is
+  what host contention looks like and what a hot code path does not.
+- **Confirm with one dispatch instead of a day of inference.**
+  `gh workflow run heavy-selfhosted.yml --ref <branch>` re-runs the identical
+  commit. Do this first, not last.
+
+The host is shared: samarch-1 serves a runner per repository, so another
+project's build competes with the robot suite, and it carries services of its
+own. During the failure it had 20GB paged out with 55GB of RAM free, and the
+suite's one memory-bound test degraded twice as much as the suite average.


### PR DESCRIPTION
`robot_memory_leak` failed on #450 with `wait_for_idle: timed out after 1 iterations` and passed on #451, #452 and #453 the same morning. It was host contention, not a regression, and finding that out took hours it should not have.

**Confirmed, not inferred.** The identical commit (`67a65a27`) was re-run twice and passed both times — once via `gh workflow run heavy-selfhosted.yml --ref feat/density-composition-local` ([run 32630842463](https://github.com/samoylenkodmitry/Cranpose/actions/runs/32630842463)), and once directly on samarch-1 against that exact SHA.

**The load index, derived from each run's own log** by summing the gaps between `Running robot_<name>...` timestamps with `robot_memory_leak` excluded:

| run | 150 tests | mean | memory_leak | result |
|---|---|---|---|---|
| #451 | 844s | 5.63s | 15s | pass |
| #452 | 843s | 5.62s | 15s | pass |
| #453 | 843s | 5.62s | 15s | pass |
| #450 | 970s | 6.47s | 40s | fail |

The three passing runs agree to within a second across 150 tests, so the failing run is unmistakably an outlier. Short tests stayed flat and long ones stretched 27–35%, which is host contention rather than a hot code path — and the one memory-bound test degraded twice the suite average on a host with 20GB paged out and 55GB of RAM free.

The iteration count was the discriminator and it was in the very first log read: one iteration means the process was not scheduled, thousands mean an application that will not converge.

Docs only — no code changes.