### PR TITLE
docs: refresh PLAN.md public API coverage figures

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -9,10 +9,10 @@ is acceptable.
 
 ## Gaps in the framework
 
-### Public API test coverage: 365 of 3396 functions
+### Public API test coverage: 364 of 3400 functions
 
-`python3 scripts/public_api_test_coverage.py` reports **3031/3396 (89.3%)**.
-Treat the 365 as a map of where a change is unguarded, not as a backlog of 365
+`python3 scripts/public_api_test_coverage.py` reports **3036/3400 (89.3%)**.
+Treat the 364 as a map of where a change is unguarded, not as a backlog of 364
 tests to write — a test written to raise the number tests the implementation it
 was written against. Tests here are added the other way round: each pins a
 defect found first, or covers a new module's own decisions, which is where a


### PR DESCRIPTION
## Summary
- `python3 scripts/public_api_test_coverage.py`, run from a clean `git worktree add --detach` checkout of `origin/main` (a1156621), reports `3036/3400 (89.3%)`, 364 not covered — not the `3031/3396` / 365 the file previously stated. Updated both figures and the two inline repetitions of the "not covered" count; the surrounding prose about the measure having been wrong three times is untouched.

## The other requested change was not made, and here is why

I was also asked to add a new "Gaps in the framework" subsection about `SubcomposeMeasureScopeImpl` reaching density through the ambient `composer_context::with_composer`, contrasted with a `DensityMeasureScope` in `crates/cranpose-ui/src/density.rs` that the plain `LayoutNode` path was supposedly migrated onto. Verifying against this branch's base (`origin/main`, a1156621) rather than the density PRs:

- `crates/cranpose-ui/src/density.rs` does not exist on `main`. There is no `DensityMeasureScope` anywhere in the tree (`find` confirms the only `density.rs` is `widgets/wear/density.rs`).
- On `main`, `SubcomposeMeasureScopeImpl::density()`/`font_scale()` (`crates/cranpose-ui/src/subcompose_layout.rs:447-456`) call `crate::current_density()`/`crate::current_font_scale()`, which read a thread-local `AppContext` in `render_state.rs`, not `composer_context::with_composer`. That panics with `"render state access requires an active AppContext"` (`render_state.rs`), a different mechanism than the `.expect("with_composer: no active composer")` in `crates/cranpose-core/src/composer_context.rs:37-42`.
- `composer_context::with_composer` only becomes reachable from this call site, and `DensityMeasureScope`/`density.rs` only come into existence, once open PRs #450 (`feat/density-composition-local`) and #454 (`feat/measure-scope-carries-density`, stacked on #450) land — neither is merged.
- Checking `gh pr diff 454`: it does *not* fully migrate `SubcomposeMeasureScopeImpl` even in that branch. It only repoints `density()`/`font_scale()` from `crate::current_density()` to `crate::density::density()` (still an ambient read via `composer_context::with_composer`, still ignoring the struct's own `self.composer` field) — unlike the plain `LayoutNode` path, which is changed to build a `DensityMeasureScope` from a captured value and thread it explicitly through `measure_into`/`CoordinatorFrame`. So the pattern described is real, but only inside an unmerged, stacked branch pair, not in `main`.

Every existing PLAN.md item I spot-checked (e.g. the effect-keys hash comparison) describes code that is verifiably present on `main` today. Writing a subsection naming a file, function and panic message that don't exist in this repository yet would misdocument the framework rather than describe it, so per the task's own instruction ("if anything you were told above turns out to be false, say so rather than writing it into the file") I left `PLAN.md`'s other content untouched instead of inventing it. This gap belongs in whichever of #450/#454 lands last, describing what that PR's own diff leaves undone.

## Test plan
- `git diff` confirms only `PLAN.md` changed, and only the coverage subsection.
- Coverage script output attached above, reproduced from a disposable `git worktree add --detach` off `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)