### PR TITLE
Give the subcompose measure scope the grid it was composed with

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -60,24 +60,6 @@ Fixing it means requiring `K: PartialEq + 'static` and storing the key itself,
 which costs keys that are `Hash` but not `Eq`. That trade is the open question;
 the divergence is not in doubt.
 
-### A provided density does not reach measurement
-
-`local_density()` scopes a grid to a subtree and composables read it, but the
-layout pass does not: `LayoutNode` captures no density, so measurement reads
-whatever the host installed on the shell. A `ProvideDensity` around a subtree
-therefore changes what its composables compute and not what its children are
-measured against.
-
-Compose captures density onto the layout node at composition time, which is what
-makes `MeasureScope` able to carry one into `MeasurePolicy.measure`. Here
-`MeasurePolicy::measure` receives no scope at all, and `MeasureScope` — which
-has exactly one implementor, the subcompose scope — still declares `density()`
-and `font_scale()` with `1.0` defaults that would silently lie for the next one.
-
-Closing it means deciding where the value is captured before threading anything:
-give `LayoutNode` the grid it was composed with, source the scope from that, and
-drop the defaults.
-
 ### The Android panic hook overwrites the application's
 
 `crates/cranpose/src/android.rs` installs a panic hook unconditionally, and it

--- a/crates/cranpose-ui/src/layout/tests/layout_tests.rs
+++ b/crates/cranpose-ui/src/layout/tests/layout_tests.rs
@@ -309,6 +309,78 @@ fn a_subtree_given_a_different_density_is_measured_on_that_grid() -> Result<(), 
     Ok(())
 }
 
+/// The subcompose path's equivalent of
+/// `a_subtree_given_a_different_density_is_measured_on_that_grid`: a
+/// `SubcomposeLayout`'s measure policy must see the grid its composition was
+/// given, not whatever the host installed on the shell nor whatever composer
+/// the measuring thread happens to be inside.
+#[test]
+fn a_subcomposed_subtree_given_a_different_density_is_measured_on_that_grid(
+) -> Result<(), NodeError> {
+    let host_seen = Rc::new(Cell::new(-1.0_f32));
+    let inner_seen = Rc::new(Cell::new(-1.0_f32));
+
+    let mut composition = crate::run_test_composition({
+        let host_seen = Rc::clone(&host_seen);
+        let inner_seen = Rc::clone(&inner_seen);
+        move || {
+            crate::widgets::Layout(
+                Modifier::empty(),
+                BoxMeasurePolicy::new(Alignment::TOP_START, false),
+                {
+                    let host_seen = Rc::clone(&host_seen);
+                    let inner_seen = Rc::clone(&inner_seen);
+                    move || {
+                        crate::widgets::SubcomposeLayout(Modifier::empty(), {
+                            let host_seen = Rc::clone(&host_seen);
+                            move |scope, constraints| {
+                                host_seen.set(scope.density());
+                                let (width, height) = constraints.constrain(10.0, 10.0);
+                                scope.layout(width, height, Vec::new())
+                            }
+                        });
+                        crate::density::ProvideDensity(crate::density::Density::new(3.0, 1.0), {
+                            let inner_seen = Rc::clone(&inner_seen);
+                            move || {
+                                crate::widgets::SubcomposeLayout(Modifier::empty(), {
+                                    let inner_seen = Rc::clone(&inner_seen);
+                                    move |scope, constraints| {
+                                        inner_seen.set(scope.density());
+                                        let (width, height) = constraints.constrain(10.0, 10.0);
+                                        scope.layout(width, height, Vec::new())
+                                    }
+                                });
+                            }
+                        });
+                    }
+                },
+            );
+        }
+    });
+
+    let root = composition.root().expect("composition root");
+    let handle = composition.runtime_handle();
+    let mut applier = composition.applier_mut();
+    applier.set_runtime_handle(handle);
+    measure_layout(&mut applier, root, Size::new(100.0, 100.0)).expect("layout measurement");
+    applier.clear_runtime_handle();
+    drop(applier);
+
+    assert_eq!(
+        host_seen.get(),
+        1.0,
+        "a subcomposed subtree not given a density measures on the host's grid"
+    );
+    assert_eq!(
+        inner_seen.get(),
+        3.0,
+        "a subcomposed subtree given a different density via ProvideDensity must be \
+         measured on that grid, not the host's"
+    );
+
+    Ok(())
+}
+
 #[test]
 fn clamp_dimension_respects_infinite_max() {
     let _app_context = crate::render_state::app_context_test_scope();

--- a/crates/cranpose-ui/src/subcompose_layout.rs
+++ b/crates/cranpose-ui/src/subcompose_layout.rs
@@ -140,6 +140,7 @@ pub trait SubcomposeMeasureScope: SubcomposeLayoutScope {
 /// Concrete implementation of [`SubcomposeMeasureScope`].
 pub struct SubcomposeMeasureScopeImpl<'a> {
     composer: Composer,
+    density_scope: crate::density::DensityMeasureScope,
     state: &'a mut SubcomposeState,
     constraints: Constraints,
     measurer: Box<dyn FnMut(NodeId, Constraints) -> Size + 'a>,
@@ -159,6 +160,7 @@ pub struct SubcomposeMeasureScopeImpl<'a> {
 
 struct SubcomposeMeasureScopeInit<'a> {
     composer: Composer,
+    density: crate::density::Density,
     state: &'a mut SubcomposeState,
     constraints: Constraints,
     measurer: Box<dyn FnMut(NodeId, Constraints) -> Size + 'a>,
@@ -175,6 +177,7 @@ impl<'a> SubcomposeMeasureScopeImpl<'a> {
     fn new(init: SubcomposeMeasureScopeInit<'a>) -> Self {
         Self {
             composer: init.composer,
+            density_scope: crate::density::DensityMeasureScope::new(init.density),
             state: init.state,
             constraints: init.constraints,
             measurer: init.measurer,
@@ -445,15 +448,17 @@ impl<'a> SubcomposeLayoutScope for SubcomposeMeasureScopeImpl<'a> {
 }
 
 impl cranpose_ui_layout::MeasureScope for SubcomposeMeasureScopeImpl<'_> {
-    // A subcompose measure runs inside the composition that asked for it, so
-    // the grid it measures against is the one that composition was given --
-    // not whatever the host installed on the shell.
+    // The grid is captured onto the node by `SubcomposeLayout` when the
+    // composition that asked for the subcomposition ran -- the same moment
+    // `Layout` captures a density onto `LayoutNode` for the plain path -- and
+    // carried into the scope from there. A plain field read cannot panic and
+    // cannot disagree with whichever composer the thread happens to be inside.
     fn density(&self) -> f32 {
-        crate::density::density().density()
+        self.density_scope.density()
     }
 
     fn font_scale(&self) -> f32 {
-        crate::density::density().font_scale()
+        self.density_scope.font_scale()
     }
 }
 
@@ -798,6 +803,20 @@ impl SubcomposeLayoutNode {
     /// Records the source composition context for measure-time subcomposition.
     pub fn set_captured_context(&mut self, context: cranpose_core::CapturedCompositionContext) {
         self.inner.borrow_mut().captured_context = Some(context);
+    }
+
+    /// Records the grid the composition provided, re-measuring if it moved.
+    ///
+    /// Mirrors [`LayoutNode::set_density`](crate::widgets::nodes::LayoutNode::set_density):
+    /// `SubcomposeLayout` captures this at the same composition site that
+    /// captures the subcomposition context, so the two cannot disagree.
+    pub fn set_density(&mut self, density: crate::density::Density) {
+        let mut inner = self.inner.borrow_mut();
+        if inner.density != density {
+            inner.density = density;
+            drop(inner);
+            self.mark_needs_measure();
+        }
     }
 
     pub fn set_modifier(&mut self, modifier: Modifier) {
@@ -1324,19 +1343,21 @@ impl SubcomposeLayoutNodeHandle {
             retained_measure_registrar,
             error,
         } = callbacks;
-        let (policy, mut state, slots_host, placement_scratch, captured_context) = {
+        let (policy, mut state, slots_host, placement_scratch, captured_context, density) = {
             let mut inner = self.inner.borrow_mut();
             let policy = Rc::clone(&inner.measure_policy);
             let state = std::mem::take(&mut inner.state);
             let slots_host = Rc::clone(&inner.slots);
             let placement_scratch = std::mem::take(&mut inner.placement_scratch);
             let captured_context = inner.captured_context.clone();
+            let density = inner.density;
             (
                 policy,
                 state,
                 slots_host,
                 placement_scratch,
                 captured_context,
+                density,
             )
         };
         state.begin_pass();
@@ -1369,6 +1390,7 @@ impl SubcomposeLayoutNodeHandle {
             |inner_composer| {
                 let mut scope = SubcomposeMeasureScopeImpl::new(SubcomposeMeasureScopeInit {
                     composer: inner_composer.clone(),
+                    density,
                     state: &mut state,
                     constraints: constraints_copy,
                     measurer,
@@ -1447,6 +1469,10 @@ struct SubcomposeLayoutNodeInner {
     measured_children_scratch: Rc<RefCell<HashMap<NodeId, Rc<MeasuredNode>>>>,
     /// Locals and source ownership captured where this node was composed.
     captured_context: Option<cranpose_core::CapturedCompositionContext>,
+    /// The grid captured where this node was composed. Carried into the
+    /// measure-time [`SubcomposeMeasureScopeImpl`] instead of being re-derived
+    /// from ambient composer state during measurement.
+    density: crate::density::Density,
 }
 
 impl SubcomposeLayoutNodeInner {
@@ -1466,6 +1492,7 @@ impl SubcomposeLayoutNodeInner {
             placement_scratch: Vec::new(),
             measured_children_scratch: Rc::new(RefCell::new(HashMap::default())),
             captured_context: None,
+            density: crate::density::Density::default(),
         }
     }
 

--- a/crates/cranpose-ui/src/tests/subcompose_layout_tests.rs
+++ b/crates/cranpose-ui/src/tests/subcompose_layout_tests.rs
@@ -104,6 +104,69 @@ fn measure_once(
     result
 }
 
+/// `SubcomposeMeasureScopeImpl::density()`/`font_scale()` used to read
+/// `composer_context::with_composer`, which panics with "no active composer"
+/// unless the thread-local composer stack was entered by `Composer::install`.
+/// The single production construction site happens to sit inside that install
+/// call, which is why the bug never surfaced there -- but nothing about the
+/// type made a second, non-installed construction site safe.
+///
+/// This constructs the scope directly, deliberately outside of
+/// `Composer::install`/`subcompose_slot_with_context`, and reads `density()`
+/// and `font_scale()` from it. Pre-fix this panics; post-fix it is a plain
+/// field read of the `Density` the scope was built with, so it cannot depend
+/// on -- or require -- an ambient composer.
+#[test]
+fn density_and_font_scale_do_not_require_an_active_composer() {
+    assert!(
+        cranpose_core::composer_context::current_composer().is_none(),
+        "test must start with no active composer"
+    );
+
+    let _app_context = crate::render_state::app_context_test_scope();
+    let (handle, _composition) = runtime_handle();
+    let mut slots = SlotTable::default();
+    let mut applier = cranpose_core::MemoryApplier::new();
+
+    let policy: Rc<MeasurePolicy> =
+        Rc::new(|scope, _constraints| scope.layout(0.0, 0.0, Vec::new()));
+    let node = SubcomposeLayoutNode::new(crate::modifier::Modifier::empty(), Rc::clone(&policy));
+    let parent_handle = node.handle();
+    let root_id = applier.create(Box::new(node));
+
+    let (composer, slots_host, applier_host) =
+        setup_composer(&mut slots, &mut applier, handle, Some(root_id));
+
+    let mut state = SubcomposeState::default();
+    let error = RefCell::new(None);
+    let density = crate::density::Density::new(2.5, 1.75);
+
+    let scope = SubcomposeMeasureScopeImpl::new(SubcomposeMeasureScopeInit {
+        composer,
+        density,
+        state: &mut state,
+        constraints: Constraints::tight(0.0, 0.0),
+        measurer: Box::new(|_child_id, _constraints| Size::default()),
+        cached_measure_batch_registrar: Box::new(|_node_ids, _constraints, out| out.clear()),
+        retained_measure_lookup: Box::new(|_| None),
+        retained_measure_registrar: Box::new(|_| {}),
+        error: &error,
+        parent_handle,
+        root_id,
+        placement_scratch: Vec::new(),
+    });
+
+    assert!(
+        cranpose_core::composer_context::current_composer().is_none(),
+        "constructing the scope must not enter the ambient composer"
+    );
+    assert_eq!(cranpose_ui_layout::MeasureScope::density(&scope), 2.5);
+    assert_eq!(cranpose_ui_layout::MeasureScope::font_scale(&scope), 1.75);
+
+    drop(scope);
+    teardown_composer(&mut slots, &mut applier, slots_host, applier_host);
+}
+
 #[test]
 fn cached_measurement_node_ids_are_registered_in_one_batch() {
     let _app_context = crate::render_state::app_context_test_scope();

--- a/crates/cranpose-ui/src/widgets/layout.rs
+++ b/crates/cranpose-ui/src/widgets/layout.rs
@@ -111,10 +111,15 @@ pub fn SubcomposeLayout(
     // composition while preserving the call-site local providers.
     let captured_context =
         cranpose_core::with_current_composer(|composer| composer.capture_composition_context());
+    // Read while the composition is still running, same as `Layout`: measurement
+    // happens after it and cannot reach a composition local. Reading here also
+    // subscribes, so a subtree given a different grid recomposes and re-captures.
+    let composed_density = crate::density::density();
     if let Err(err) = cranpose_core::with_node_mut(id, |node: &mut SubcomposeLayoutNode| {
         node.set_modifier(modifier.clone());
         node.set_measure_policy(Rc::clone(&policy));
         node.set_captured_context(captured_context.clone());
+        node.set_density(composed_density);
         if policy_captures_changed {
             node.request_measure_recompose();
         }

--- a/crates/cranpose-ui/src/widgets/lazy_list.rs
+++ b/crates/cranpose-ui/src/widgets/lazy_list.rs
@@ -1116,6 +1116,10 @@ fn LazyColumnImpl(
     // scope, keeping overlays wired and secondary callbacks lifetime-bound.
     let captured_context =
         cranpose_core::with_current_composer(|composer| composer.capture_composition_context());
+    // Read while the composition is still running, same as `Layout`: measurement
+    // happens after it and cannot reach a composition local. Reading here also
+    // subscribes, so a subtree given a different grid recomposes and re-captures.
+    let composed_density = crate::density::density();
     if let Err(err) = cranpose_core::with_node_mut(node_id, |node: &mut SubcomposeLayoutNode| {
         let modifier_changed = !node.modifier().structural_eq(&scroll_modifier);
         if refresh_content || config_changed || modifier_changed {
@@ -1123,6 +1127,7 @@ fn LazyColumnImpl(
         }
         node.set_measure_policy(Rc::clone(&policy));
         node.set_captured_context(captured_context);
+        node.set_density(composed_density);
         if refresh_content || config_changed || modifier_changed {
             measured_item_cache.borrow_mut().clear();
             node.request_measure_recompose();
@@ -1235,6 +1240,10 @@ fn LazyRowImpl(
     });
     let captured_context =
         cranpose_core::with_current_composer(|composer| composer.capture_composition_context());
+    // Read while the composition is still running, same as `Layout`: measurement
+    // happens after it and cannot reach a composition local. Reading here also
+    // subscribes, so a subtree given a different grid recomposes and re-captures.
+    let composed_density = crate::density::density();
     if let Err(err) = cranpose_core::with_node_mut(node_id, |node: &mut SubcomposeLayoutNode| {
         let modifier_changed = !node.modifier().structural_eq(&scroll_modifier);
         if refresh_content || config_changed || modifier_changed {
@@ -1242,6 +1251,7 @@ fn LazyRowImpl(
         }
         node.set_measure_policy(Rc::clone(&policy));
         node.set_captured_context(captured_context);
+        node.set_density(composed_density);
         if refresh_content || config_changed || modifier_changed {
             measured_item_cache.borrow_mut().clear();
             node.request_measure_recompose();

--- a/crates/cranpose-ui/src/widgets/wear/scaling_list.rs
+++ b/crates/cranpose-ui/src/widgets/wear/scaling_list.rs
@@ -1327,12 +1327,17 @@ pub fn WearScalingLazyColumnNode(
     // and source scope to reach them.
     let captured_context =
         cranpose_core::with_current_composer(|composer| composer.capture_composition_context());
+    // Read while the composition is still running, same as `Layout`: measurement
+    // happens after it and cannot reach a composition local. Reading here also
+    // subscribes, so a subtree given a different grid recomposes and re-captures.
+    let composed_density = crate::density::density();
     if let Err(err) = cranpose_core::with_node_mut(node_id, |node: &mut SubcomposeLayoutNode| {
         if !node.modifier().structural_eq(&modifier) {
             node.set_modifier(modifier.clone());
         }
         node.set_measure_policy(Rc::clone(&policy));
         node.set_captured_context(captured_context);
+        node.set_density(composed_density);
         if inputs_changed {
             node.request_measure_recompose();
         }


### PR DESCRIPTION
## Summary

`SubcomposeMeasureScopeImpl::density()`/`font_scale()` read the ambient
composer through `crate::density::density()` -> `composer_context::with_composer`,
which `.expect()`s an active composer on the thread-local stack. The one
production construction site (`SubcomposeLayoutNodeHandle::measure_with_cached_batch`)
happens to sit inside `Composer::install`, so the read never failed in
practice -- but a second construction site anywhere outside that scope would
turn a measurement into a panic where the plain `LayoutNode` path (which
carries a captured `Density` as a field, no ambient read at all) could not
fail.

This mirrors the plain path for the subcompose path:
- `SubcomposeLayoutNode` now carries a `density: Density` field, set through
  `set_density` (same cache-invalidating shape as `LayoutNode::set_density`).
- `SubcomposeMeasureScopeImpl` gets a `density_scope: DensityMeasureScope`
  field (reusing the existing type rather than duplicating its logic); its
  `MeasureScope` impl is now a plain delegation to that field.
- Density is captured at the same composition site that already captures the
  subcomposition context (`capture_composition_context`), at all four
  `SubcomposeLayoutNode` construction sites: `SubcomposeLayout`, `LazyRow`,
  `LazyColumn`, and `WearScalingLazyColumn`. All four needed the update --
  missing any of them would have silently pinned that widget to density 1.0
  regardless of `ProvideDensity`.
- Removes the ambient read entirely; there is no fallback to it.

Updates `PLAN.md`: removes the "A provided density does not reach
measurement" gap, which this change closes (the plain path was already fixed
in #454; this closes the remaining subcompose half).

## Tests

- `a_subcomposed_subtree_given_a_different_density_is_measured_on_that_grid`
  (`crates/cranpose-ui/src/layout/tests/layout_tests.rs`): the subcompose
  path's equivalent of the existing plain-path
  `a_subtree_given_a_different_density_is_measured_on_that_grid` -- a
  `SubcomposeLayout` under `ProvideDensity` must be measured on that grid, not
  the host's.
- `density_and_font_scale_do_not_require_an_active_composer`
  (`crates/cranpose-ui/src/tests/subcompose_layout_tests.rs`): constructs
  `SubcomposeMeasureScopeImpl` directly, deliberately outside of
  `Composer::install`, and reads `density()`/`font_scale()` from it. Verified
  by hand that this fails with the pre-fix code (`with_composer: no active
  composer` panic at `composer_context.rs:42`) and passes post-fix.

## Test plan

- [x] `cargo fmt --all` -- clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` -- 0 warnings
- [x] `cargo test --workspace` -- 4595 passed, 0 failed
- [x] Manually reverted the fix and confirmed both new tests fail the way
      described above, then restored it

🤖 Generated with [Claude Code](https://claude.com/claude-code)