### PR TITLE
ci: second Linux runner on samarch-1 + host-level robot-suite lock

### DIFF
--- a/.github/workflows/heavy-selfhosted.yml
+++ b/.github/workflows/heavy-selfhosted.yml
@@ -36,7 +36,14 @@ jobs:
         env:
           RUNNER_NAME: ${{ runner.name }}
         run: |
-          if [[ "$RUNNER_NAME" == "samarch-1-cranpose" ]]; then
+          if [[ "$RUNNER_NAME" == samarch-1-cranpose* ]]; then
+            # Every runner registered on this host shares its name prefix
+            # (samarch-1-cranpose, samarch-1-cranpose-2, ...) — match the
+            # prefix, not one runner's exact name, so a second runner on
+            # the same physical box still gets the host's real knobs
+            # instead of silently falling back to defaults that lie about
+            # this machine.
+            #
             # This host idles near 91-93C ambient; the suite's thermal
             # governor needs both knobs raised or the resume wait arms
             # against an unreachable temperature.
@@ -59,7 +66,14 @@ jobs:
         # below: a GPU swapchain under Xvfb never lands pixels in the X
         # server's buffer, so they can only read their screenshots on
         # software present.
+        #
+        # This and robot-capture-software both drive the same GPU and X
+        # server. Two Linux runners can now pick either job up, so a
+        # host-level lock serialises the two robot jobs against each other
+        # without serialising anything else in the fleet — see
+        # scripts/ci/with_robot_host_lock.sh.
         run: >
+          scripts/ci/with_robot_host_lock.sh
           xvfb-run -a -s "-screen 0 1280x800x24" ./run_robot_test.sh
           --sequential
           --skip robot_underline_screenshot
@@ -89,7 +103,9 @@ jobs:
         env:
           RUNNER_NAME: ${{ runner.name }}
         run: |
-          if [[ "$RUNNER_NAME" == "samarch-1-cranpose" ]]; then
+          if [[ "$RUNNER_NAME" == samarch-1-cranpose* ]]; then
+            # See robot-e2e-gpu above: match the host's runner-name prefix,
+            # not one runner's exact name.
             echo "CRANPOSE_HOST_MAX_TEMP_C=97" >> "$GITHUB_ENV"
             echo "CRANPOSE_HOST_RESUME_TEMP_C=93" >> "$GITHUB_ENV"
             echo "SCCACHE_DIR=/home/s/ci-cache/cranpose/sccache" >> "$GITHUB_ENV"
@@ -102,10 +118,13 @@ jobs:
           sccache --start-server || true
 
       - name: Run the external capture trio on software present
+        # See robot-e2e-gpu above: this suite and that one share a
+        # host-level lock so they never run at once on the same box.
         env:
           WGPU_BACKEND: gl
           LIBGL_ALWAYS_SOFTWARE: "1"
         run: >
+          scripts/ci/with_robot_host_lock.sh
           xvfb-run -a -s "-screen 0 1600x1200x24" ./run_robot_test.sh
           --sequential
           --example robot_underline_screenshot
@@ -174,7 +193,10 @@ jobs:
           RUNNER_NAME: ${{ runner.name }}
           RUNNER_OS: ${{ runner.os }}
         run: |
-          if [[ "$RUNNER_OS" == "Linux" && "$RUNNER_NAME" == "samarch-1-cranpose" ]]; then
+          # Match the host's runner-name prefix, not one runner's exact
+          # name: every runner registered on samarch-1 shares it
+          # (samarch-1-cranpose, samarch-1-cranpose-2, ...).
+          if [[ "$RUNNER_OS" == "Linux" && "$RUNNER_NAME" == samarch-1-cranpose* ]]; then
             sdk_root="${ANDROID_SDK_ROOT:-/home/s/develop/sdk}"
             cache_root=/home/s/ci-cache/cranpose
           elif [[ "$RUNNER_OS" == "macOS" && -d /Volumes/files/sdk ]]; then

--- a/scripts/ci/with_robot_host_lock.sh
+++ b/scripts/ci/with_robot_host_lock.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Serialises robot-suite invocations against each other on the physical
+# machine that runs them, without serialising anything else.
+#
+# `robot e2e (self-hosted GPU)` and `robot external captures (software
+# present)` in heavy-selfhosted.yml both drive the same GPU and X server.
+# Two Linux runners on one host can now pick either job up independently,
+# so nothing about runner assignment stops them from landing on the same
+# box at the same time -- which starves both of CPU and produces flaky
+# robot failures that are host contention, not code (see PLAN.md's
+# Infrastructure section). GitHub's `concurrency:` key cannot express "not
+# while a job on this host is doing something else": it only supersedes
+# older runs of the *same* workflow ref. A host-level file lock can.
+#
+# flock is the right primitive because the kernel -- not this script --
+# owns releasing it: the lock lives on an open file descriptor, and closing
+# that descriptor (script exits, errors out, or is killed by a cancelled
+# job) releases it immediately. There is no PID file to go stale and no
+# cleanup step that a crash can skip.
+#
+# Only the robot-suite steps should ever call this. Everything else in the
+# fleet (architecture budgets, wasm build, Android/iOS builds) must keep
+# scheduling independently of robot-suite activity.
+
+readonly lock_file="/tmp/cranpose-robot-suite.lock"
+
+if [[ "$#" -eq 0 ]]; then
+  echo "usage: $0 <command> [args...]" >&2
+  exit 64
+fi
+
+exec 9>"$lock_file"
+
+if flock -n 9; then
+  echo "with_robot_host_lock: acquired $lock_file immediately"
+else
+  echo "with_robot_host_lock: $lock_file is held by another robot job on this host -- waiting..."
+  wait_started_at=$(date +%s)
+  flock 9
+  waited_seconds=$(( $(date +%s) - wait_started_at ))
+  echo "with_robot_host_lock: acquired $lock_file after waiting ${waited_seconds}s"
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary

- Registers a second Linux GitHub Actions runner (`samarch-1-cranpose-2`) on `samarch-1`, doubling `cranpose-heavy` capacity on the one machine that serves the X11 robot suite and the binary-size budget.
- Adds `scripts/ci/with_robot_host_lock.sh`, a `flock`-based host lock that serialises `robot e2e (self-hosted GPU)` against `robot external captures (software present)` so the two robot jobs never run concurrently on the same physical box, however runner assignment lands — without serialising anything else in the fleet.
- Fixes three `RUNNER_NAME == "samarch-1-cranpose"` exact-match checks (thermal knobs, shared sccache dir, shared Android SDK/cache root) that would have silently missed the second runner and left it running with wrong/default host config. Matched by prefix instead.

## Why

PLAN.md's Infrastructure section: one Linux machine serves every `cranpose-heavy` job, two of those jobs genuinely can't move (the X11 robot suite needs a real X server; the binary-size budget is pinned to Linux codegen), and if queueing keeps hurting, "the remaining lever is a second Linux runner, not more relabelling." That's what this PR adds.

It also matters for correctness, not just speed: two robot failures were host contention, not code, on the day this was written — `robot_memory_leak` timed out on one PR (15% slower than three passing runs) and `robot_winamp_native_window_geometry` failed with `exit=134` on a PLAN.md-only diff, then passed on re-run. Doubling capacity naively (same labels, no coordination) would let both robot jobs run on that host's 12 cores at once, which is exactly that contention. `flock` fixes it at the one layer that can see "this host," which GitHub's `concurrency:` key cannot (`concurrency:` only supersedes older runs of the *same workflow ref*).

## Runner registration (machine state — not in this diff)

Done directly on `samarch-1` by inspecting `~/actions-runner-cranpose/` first and matching its layout exactly:

- Directory: `~/actions-runner-cranpose-2/`, GitHub Actions Runner v2.336.0 (tarball sha256 verified against the `actions/runner` v2.336.0 release notes — matches the version already running as the sibling runner).
- Registered via `./config.sh --url https://github.com/samoylenkodmitry/Cranpose --token <one-time registration token> --name samarch-1-cranpose-2 --labels samarch1,heavy,cranpose-heavy --work _work --unattended`.
- `.env` matches the sibling: `ANDROID_SDK_ROOT=/home/s/develop/sdk`.
- Labels verified via `gh api /repos/samoylenkodmitry/Cranpose/actions/runners` to match the sibling exactly: `self-hosted, Linux, X64, samarch1, heavy, cranpose-heavy` (the sibling actually carries `heavy` in addition to `cranpose-heavy`; matched both).

**Blocked on privilege, not worked around:** the sibling runs as a system-wide systemd service, installed via `sudo ./svc.sh install <user>` writing `/etc/systemd/system/actions.runner.*.service`. The `s` account on `samarch-1` does not have passwordless sudo (`sudo -n systemctl daemon-reload` → `sudo: a password is required`), so that one step could not be completed from this session. Per the task's own instruction, I stopped there rather than substituting something that only looks equivalent (e.g. a user-level `systemd --user` unit under the account's enabled linger, which *would* survive a reboot but is not "exactly like its sibling").

Everything short of that step is done and verified working: the runner is registered, its config matches the sibling, and it was brought online with a plain `./run.sh` (no elevated privilege needed) to prove it end-to-end — it went `online`/idle, then picked up real queued work from the existing backlog (`robot external captures (software present)`, which **succeeded**, then `architecture budgets (linux)`), confirming both the registration and the label match are correct. It is currently running as that unsupervised foreground process (not systemd-supervised, will not survive a reboot) because killing it mid-job to hand off to the privileged install would fail whatever real job it's holding.

**To finish, someone with sudo on `samarch-1` needs to run, once the runner is idle** (check with `pgrep -fa 'actions-runner-cranpose-2.*Runner.Listener'`; nothing else about this runner needs to change):
```sh
pkill -f 'actions-runner-cranpose-2/bin/Runner.Listener'   # stop the temporary foreground process
cd ~/actions-runner-cranpose-2
sudo ./svc.sh install s
sudo ./svc.sh start
```

## Verification

**Second runner online, correct labels** (`gh api /repos/samoylenkodmitry/Cranpose/actions/runners`):
```
id=21 samarch-1-cranpose    online busy=true  [self-hosted, Linux, X64, samarch1, heavy, cranpose-heavy]
id=25 samarch-1-cranpose-2  online busy=true  [self-hosted, Linux, X64, samarch1, heavy, cranpose-heavy]
```

**Real jobs occupy both runners at once** — while bringing the second runner up, it picked up real queued work and ran concurrently with the first:
```
robot e2e (self-hosted GPU)      -> runner samarch-1-cranpose    (run 32644027402)
architecture budgets (linux)     -> runner samarch-1-cranpose-2  (run 32644027430)
```
(the intervening job on the new runner, `robot external captures (software present)`, completed `Succeeded` before that.)

**Lock waits, logs, and serialises** — shell demonstration over ssh (two concurrent invocations of the committed script against a real host, not simulated):
```
=== Job A: starting at 17:12:05.832 ===
=== Job B: starting at 17:12:06.833 (1s after A) ===
=== A log ===
with_robot_host_lock: acquired /tmp/cranpose-robot-suite.lock immediately
[A] doing robot-suite work for 8s starting 17:12:05.835
[A] done at 17:12:13.836
=== B log ===
with_robot_host_lock: /tmp/cranpose-robot-suite.lock is held by another robot job on this host -- waiting...
with_robot_host_lock: acquired /tmp/cranpose-robot-suite.lock after waiting 7s
[B] doing robot-suite work starting 17:12:13.838
```

**A crashed holder cannot wedge the lock** — SIGKILLed a holder mid-hold; a fresh invocation acquired immediately with no wait:
```
PID=3168313, killing with SIGKILL now at 17:12:23.467
with_robot_host_lock: acquired /tmp/cranpose-robot-suite.lock immediately
[D] acquired at 17:12:23.971 after crash of C
```

**Static checks:**
```
$ bash -n scripts/ci/with_robot_host_lock.sh   # OK
$ shellcheck scripts/ci/with_robot_host_lock.sh  # OK, no findings
$ actionlint .github/workflows/heavy-selfhosted.yml
# identical finding set before and after this change (pre-existing: actionlint
# doesn't know the cranpose-heavy custom label with no actionlint.yaml config,
# plus two pre-existing SC2129/SC1007 style nits in code this PR didn't touch)
```

**Scope check** — only `robot-e2e-gpu` and `robot-capture-software` invoke the lock; `architecture-budget`, `wasm-build`, `android-release`, and the iOS job are untouched and keep scheduling independently, which the "two real jobs on both runners at once" run above already demonstrates directly (`architecture budgets (linux)` ran while a robot job held the other runner).

## Constraints honored

- Did not touch the other 16 repos' runners on `samarch-1`, did not restart the host, did not touch swap/system settings.
- No host paths hardcoded into the workflow — the lock file lives at a fixed, generic `/tmp/cranpose-robot-suite.lock`, not under any per-host directory.
- No `rm -rf`; test artifacts on the host (`/tmp/with_robot_host_lock_test.sh`, test lock file, test logs) were cleaned up after the demonstration.
