### PR TITLE
Record what a macOS codesign chain error actually means

### DIFF
--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -954,7 +954,7 @@ project's build competes with the robot suite, and it carries services of its
 own. During the failure it had 20GB paged out with 55GB of RAM free, and the
 suite's one memory-bound test degraded twice as much as the suite average.
 
-## macOS codesign fails with a chain error that is not a chain problem (2026-08-24)
+## macOS codesign "unable to build chain" means the intermediate is missing (2026-08-24)
 
 `codesign` on a self-hosted macOS runner failing with
 
@@ -963,34 +963,36 @@ Warning: unable to build chain to self-signed root for signer "Developer ID Appl
 Cranamp.app: errSecInternalComponent
 ```
 
-names the certificate chain, and the chain is fine. The cause is the
-**keychain search list**, which is user-level state that outlives the job. A
-signing step that does
+means what it says, and the fastest way to lose an hour is to decide it does
+not. A `.p12` exported from Keychain Access carries the **leaf and its private
+key**, not the intermediate that links the leaf to Apple Root CA. codesign
+builds the chain from the keychains it searches, so on a host with no Apple CA
+in any of them there is nothing to build it from.
 
-```bash
-security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
-```
+- **Check for the intermediate before theorising.** One command, over ssh, no
+  build:
+  `security find-certificate -c "Developer ID Certification Authority" ~/Library/Keychains/login.keychain-db`
+  Finding it *only* in `/System/Library/Keychains/SystemRootCertificates.keychain`
+  is the failure: that is the anchor store, not a searched keychain.
+- **`security find-identity -v` is not evidence the chain works.** It listed
+  the identity as valid on the host that could not sign, so a guard built on
+  it passes and the failure lands later, inside codesign, looking like a bad
+  key.
+- **Fix it in the job, not on the host.** Fetch
+  `https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer` and
+  `security import` it into the ephemeral signing keychain, pinned by SHA-256 —
+  this installs a CA into the keychain used for signing, so an unpinned
+  download is a real hole. A host fixed by hand regresses the next time the
+  machine is rebuilt.
 
-adds its ephemeral keychain to that list and never removes it. `RUNNER_TEMP`
-is a fixed directory for a given runner, so `$KEYCHAIN` is always the same
-path, and the runner wipes `_temp` between jobs — the entry survives as a
-dangling path, and appending the current list next run re-adds it. `codesign`
-walks the search list to build the chain, hits the dead entry, and dies.
-
-- **Check the search list before reading anything into the error text.**
-  `for k in $(security list-keychains | tr -d '"'); do [ -e "$k" ] || echo "DANGLING $k"; done`
-  answers it in one command, over ssh, without a build.
-- **A pass/fail alternation across releases is the signature.** v0.1.37 ✅,
-  .38 ❌, .39 ✅, .40 ❌, .41 ✅, .42 ❌ — a run starting from a clean list
-  leaves a dirty one and vice versa. Anything alternating that cleanly is
-  leaked state between runs, never a flake and never a code change.
-- **Compare against the sibling workflow that works.** cranscan signs on the
-  same host and never fails, because it deletes its keychain and never touches
-  the search list. Two workflows on one machine, one failing, is a diff to
-  read rather than a mystery to theorise about.
-- **Restore under `always()`.** The job that fails is precisely the one that
-  must not poison the next release, so cleanup belongs in a step that runs on
-  failure too.
+**A pass/fail alternation across releases is not automatically leaked state.**
+This one alternated cleanly — v0.1.37 passed, .38 failed, .39 passed, .40
+failed, .41 passed, .42 failed — and that pattern sent an hour into a leaked
+keychain search-list entry, which was genuinely present and genuinely worth
+cleaning up but was not the cause. Rerunning the identical commit from a clean
+search list failed identically, which is the check that should have come
+first: **confirm a suspected cause by removing it and re-running, before
+writing the fix.**
 
 **`ssh <host> '...'` runs the remote user's login shell, which on macOS is
 zsh, and zsh does not word-split unquoted expansions.** `security

--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -953,3 +953,48 @@ The host is shared: samarch-1 serves a runner per repository, so another
 project's build competes with the robot suite, and it carries services of its
 own. During the failure it had 20GB paged out with 55GB of RAM free, and the
 suite's one memory-bound test degraded twice as much as the suite average.
+
+## macOS codesign fails with a chain error that is not a chain problem (2026-08-24)
+
+`codesign` on a self-hosted macOS runner failing with
+
+```
+Warning: unable to build chain to self-signed root for signer "Developer ID Application: ..."
+Cranamp.app: errSecInternalComponent
+```
+
+names the certificate chain, and the chain is fine. The cause is the
+**keychain search list**, which is user-level state that outlives the job. A
+signing step that does
+
+```bash
+security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+```
+
+adds its ephemeral keychain to that list and never removes it. `RUNNER_TEMP`
+is a fixed directory for a given runner, so `$KEYCHAIN` is always the same
+path, and the runner wipes `_temp` between jobs — the entry survives as a
+dangling path, and appending the current list next run re-adds it. `codesign`
+walks the search list to build the chain, hits the dead entry, and dies.
+
+- **Check the search list before reading anything into the error text.**
+  `for k in $(security list-keychains | tr -d '"'); do [ -e "$k" ] || echo "DANGLING $k"; done`
+  answers it in one command, over ssh, without a build.
+- **A pass/fail alternation across releases is the signature.** v0.1.37 ✅,
+  .38 ❌, .39 ✅, .40 ❌, .41 ✅, .42 ❌ — a run starting from a clean list
+  leaves a dirty one and vice versa. Anything alternating that cleanly is
+  leaked state between runs, never a flake and never a code change.
+- **Compare against the sibling workflow that works.** cranscan signs on the
+  same host and never fails, because it deletes its keychain and never touches
+  the search list. Two workflows on one machine, one failing, is a diff to
+  read rather than a mystery to theorise about.
+- **Restore under `always()`.** The job that fails is precisely the one that
+  must not poison the next release, so cleanup belongs in a step that runs on
+  failure too.
+
+**`ssh <host> '...'` runs the remote user's login shell, which on macOS is
+zsh, and zsh does not word-split unquoted expansions.** `security
+list-keychains -s $keep` there passes one argument with a leading space
+instead of a list, and `security` resolves it as a relative path — which
+corrupts the search list you were trying to repair. Wrap remote scripts in
+`bash -lc "..."`, or pass each path as its own quoted argument.


### PR DESCRIPTION
cranamp's macOS release job failed on:

```
Warning: unable to build chain to self-signed root for signer "Developer ID Application: ..."
Cranamp.app: errSecInternalComponent
```

The warning means what it says. A `.p12` carries the **leaf and its private key**, not the intermediate that links the leaf to Apple Root CA, and `codesign` builds the chain from the keychains it searches. On that host the login keychain held 7 certificates and none was Apple's; `Developer ID Certification Authority` existed only in `SystemRootCertificates.keychain`, which is the *anchor* store and not searched for intermediates.

What this adds to TIME_WASTERS.md:

- the one-command check for the intermediate, runnable over ssh with no build;
- that **`security find-identity -v` is not evidence the chain works** — it listed the identity as valid on the host that could not sign, so a guard built on it passes and the failure lands later inside codesign, looking like a bad key;
- that the fix belongs in the job (fetch + `security import`, pinned by SHA-256, since this installs a CA into the keychain used for signing) rather than by hand on the host, which regresses on rebuild;
- and the lesson this cost an hour to learn: **a clean pass/fail alternation is not automatically leaked state.** The history alternated perfectly (`.37 ✅ .38 ❌ .39 ✅ .40 ❌ .41 ✅ .42 ❌`), which sent me into a leaked keychain search-list entry that was genuinely present and genuinely worth cleaning up — and was not the cause. **Confirm a suspected cause by removing it and re-running, before writing the fix.** I wrote the fix first; the rerun from a clean list failed identically.

The real fix is samoylenkodmitry/cranamp#43; the search-list cleanup (samoylenkodmitry/cranamp#42) stays as hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)