### PR TITLE
Put cargo on PATH inside the step that uses it, not only after it

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,12 @@ jobs:
 
       - name: Provision PATH and sccache
         run: |
+          # Both, and in this order. `GITHUB_PATH` only reaches LATER steps,
+          # and the `cargo install` on the next line runs in THIS one -- so on
+          # a self-hosted runner whose service PATH does not already carry
+          # `~/.cargo/bin` the step dies with `cargo: command not found` and
+          # exit 127, having "provisioned" a PATH it never used itself.
+          export PATH="$HOME/.cargo/bin:$PATH"
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           command -v sccache >/dev/null || RUSTC_WRAPPER= cargo install sccache --locked
           sccache --start-server || true
@@ -63,6 +69,12 @@ jobs:
 
       - name: Provision PATH and sccache
         run: |
+          # Both, and in this order. `GITHUB_PATH` only reaches LATER steps,
+          # and the `cargo install` on the next line runs in THIS one -- so on
+          # a self-hosted runner whose service PATH does not already carry
+          # `~/.cargo/bin` the step dies with `cargo: command not found` and
+          # exit 127, having "provisioned" a PATH it never used itself.
+          export PATH="$HOME/.cargo/bin:$PATH"
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           command -v sccache >/dev/null || RUSTC_WRAPPER= cargo install sccache --locked
           sccache --start-server || true
@@ -123,6 +135,12 @@ jobs:
 
       - name: Provision PATH and sccache
         run: |
+          # Both, and in this order. `GITHUB_PATH` only reaches LATER steps,
+          # and the `cargo install` on the next line runs in THIS one -- so on
+          # a self-hosted runner whose service PATH does not already carry
+          # `~/.cargo/bin` the step dies with `cargo: command not found` and
+          # exit 127, having "provisioned" a PATH it never used itself.
+          export PATH="$HOME/.cargo/bin:$PATH"
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           command -v sccache >/dev/null || RUSTC_WRAPPER= cargo install sccache --locked
           sccache --start-server || true
@@ -140,6 +158,12 @@ jobs:
 
       - name: Provision PATH and sccache
         run: |
+          # Both, and in this order. `GITHUB_PATH` only reaches LATER steps,
+          # and the `cargo install` on the next line runs in THIS one -- so on
+          # a self-hosted runner whose service PATH does not already carry
+          # `~/.cargo/bin` the step dies with `cargo: command not found` and
+          # exit 127, having "provisioned" a PATH it never used itself.
+          export PATH="$HOME/.cargo/bin:$PATH"
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           command -v sccache >/dev/null || RUSTC_WRAPPER= cargo install sccache --locked
           sccache --start-server || true
@@ -160,6 +184,12 @@ jobs:
 
       - name: Provision PATH and sccache
         run: |
+          # Both, and in this order. `GITHUB_PATH` only reaches LATER steps,
+          # and the `cargo install` on the next line runs in THIS one -- so on
+          # a self-hosted runner whose service PATH does not already carry
+          # `~/.cargo/bin` the step dies with `cargo: command not found` and
+          # exit 127, having "provisioned" a PATH it never used itself.
+          export PATH="$HOME/.cargo/bin:$PATH"
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           command -v sccache >/dev/null || RUSTC_WRAPPER= cargo install sccache --locked
           sccache --start-server || true
@@ -182,6 +212,12 @@ jobs:
 
       - name: Provision PATH and sccache
         run: |
+          # Both, and in this order. `GITHUB_PATH` only reaches LATER steps,
+          # and the `cargo install` on the next line runs in THIS one -- so on
+          # a self-hosted runner whose service PATH does not already carry
+          # `~/.cargo/bin` the step dies with `cargo: command not found` and
+          # exit 127, having "provisioned" a PATH it never used itself.
+          export PATH="$HOME/.cargo/bin:$PATH"
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           command -v sccache >/dev/null || RUSTC_WRAPPER= cargo install sccache --locked
           sccache --start-server || true


### PR DESCRIPTION
`Provision PATH and sccache` wrote `~/.cargo/bin` to `GITHUB_PATH` and then, on the very next line **of the same step**, ran `cargo install sccache`:

```bash
echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
command -v sccache >/dev/null || RUSTC_WRAPPER= cargo install sccache --locked
```

`GITHUB_PATH` only takes effect for *later* steps. That `cargo` therefore had to come from whatever PATH the runner service happened to be launched with — so the step worked by inheritance, not by anything it did. On a self-hosted mac whose service does not carry `~/.cargo/bin`:

```
cargo: command not found
##[error]Process completed with exit code 127
```

It reads as a missing toolchain and is not one — rustup is installed at `~/.cargo/bin`, the step just cannot see it. Caught on `dmitriis-mac-Cranpose` while a docs-only PR failed `fmt + tests + clippy (mac)`.

Fixed by exporting PATH in the step as well, which is the idiom the iOS job in `heavy-selfhosted.yml` already uses. Six jobs in `rust.yml` shared the broken copy; `heavy-selfhosted.yml` needed no change — its `GITHUB_PATH` writes end their step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)