### PR TITLE
Build on samarch-1 or the mac over ssh where possible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,7 @@
 # Agent Notes for cranpose
 
 - no unsafe
-- cargo test > 1.tmp 2>& # then read and fix all
-- cargo clippy > 2.tmp 2>& # then read and fix all
-- cargo fmt
+- just test, just clippy, just fmt # `just` lists every gate; CI runs these same recipes
 - KISS, DRY, SOLID. don't copy-paste lazily
 - Use `cargo add <crate>` to add dependencies.
 - Use `cargo upgrade` to upgrade dependencies.
@@ -17,25 +15,28 @@
 - Use `async`/`await` for asynchronous code; prefer `tokio` as the async runtime.
 - do proper review mitigation; don't short-cut and do a honest professional work; be very strict to your code & architecture decisions; keep repo clean and don't put unfinished parts here; fix everything
 - do not create a half-migrated state of the repo; don't "deprecate"; always change the existing code
-- cargo clippy
-- cargo test
-- make sure android compiles [:app:assembleRelease] in project /home/s/develop/projects/compose-rs-proposal/apps/android-demo/android
-- make sure wasm compiles apps/desktop-demo/build-web.sh
+- just android # :app:assembleRelease in apps/android-demo/android
+- just web # always --release; the fast path skips the wasm size budget
 - (+robot tests)
 - instead of accepting the shortcut always choose to fix the underlying architecture issue
 - do not avoid and do not defer the big architecture refactoring when necessary
 - if there is a bug start with writing a failing test that will catch it so we never regress to it again in the future
-- do a code review; look for any shortcuts, lazyness, taking the easy path instead of doing the hard necessary work, poor architectural choices, everything that will shoot in the foot, poorly written code like it was a deadline 1 minute before end of the work day; but not invent the problems if there arent any- don't fear the significant arch change; everything is still pre-alpha; this is the right time for a big change
+- do a code review; look for any shortcuts, laziness, taking the easy path instead of doing the hard necessary work, poor architectural choices, everything that will shoot in the foot, poorly written code like it was a deadline 1 minute before end of the work day; but not invent the problems if there arent any- don't fear the significant arch change; everything is still pre-alpha; this is the right time for a big change
 - do not ever git reset, always stash if needed
 - do not ever rm -rf, prefer mv to some _old name
 - all tests should pass, its never *not yours*
 - zero warnings on all build/clippy/test commands, never *was pre-existing*
 - the #[cfg(feature = "robot-app")] is forbidden
 - reference JC kt repo /media/huge/composerepo/
+- use samarch-1 or the mac by ssh for builds where possible: `ssh samarch-1`
+  (Linux, Android SDK at /home/s/develop/sdk, X11 for the robot suite) and
+  `ssh macm3` (macOS, Apple toolchains). They are faster than this machine and
+  keep long compiles off it. Note macOS logs in over ssh with zsh, which does
+  not word-split unquoted expansions, so wrap remote scripts in `bash -lc "..."`.
 - perf scripts are perf*.sh at project root
-- e2e robot headless tests is ./run_robot_test.sh --sequential (should all pass)
+- e2e robot headless tests is `just robot` (should all pass)
 - do not use big models as subagents (opus, codex xhigh thinking, etc), only small fast & cheap to not waste tokens
-- no 'backwards compatability' is allowed; we in a pre-alpha
+- no 'backwards compatibility' is allowed; we in a pre-alpha
 - no comments in style "now it is like that" - we are not writing history
 - duplicated code (10+ lines) without architecture is forbidden
 - 'legacy'/'old way' etc not allowed. we are in a pre-alpha, everything is fresh, clean, single instance


### PR DESCRIPTION
Both hosts are faster than the machine an agent usually runs on and already carry the toolchains a build needs — `samarch-1` has the Android SDK at `/home/s/develop/sdk` and the X11 session the robot suite wants, `macm3` has the Apple ones. Long compiles belong there rather than on this machine.

The zsh caveat is included because it cost an hour today: macOS logs in over ssh with **zsh**, which does not word-split unquoted expansions, so a remote `cmd $list` passes one argument instead of several. It silently corrupted a keychain search list that way — the repair looked like it worked and made things worse. `bash -lc "..."` avoids it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)