### PR TITLE
Correct the back entry: the alternation is the design, not a fault

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -123,6 +123,23 @@ delivered twice plays its cue twice. Whether input beyond back is doubled is
 unverified and is the first thing to measure, because it decides whether this
 is one fault or two.
 
+**Injected gestures do not reproduce it, so the double dispatch is not
+confirmed.** Driving `adb shell input swipe` from the leading edge on a Pixel
+Watch 3 against `v1.3.3`: from the title screen one swipe leaves the
+application, focus moving to `com.google.android.wearable.sysui`; from
+gameplay one swipe pauses and one more resumes, which is one `on_back` each.
+Two dispatches per gesture would pause and resume in a single swipe and land
+back on gameplay, and that is not what happens. So either the platform
+delivers a real finger down both paths in a way the injected event does not,
+or the cause is something else entirely and the two handlers are a latent
+hazard rather than this bug.
+
+Do not "fix" this by deleting a handler on the reading alone. Both paths reach
+`on_back`, so removing the wrong one removes back everywhere, and the reading
+is exactly what the injected test contradicts. The next real-finger occurrence
+is worth more than more code review: `adb logcat` while it happens, or a
+counter on `on_back` surfaced on screen, settles it in one go.
+
 **This was hidden until `0.1.99` fixed something else.** Before that,
 `SwipeToDismissBox` left its content off screen after firing, so the second
 `on_back` resumed a game nobody could see and the symptom was a blank screen.

--- a/PLAN.md
+++ b/PLAN.md
@@ -98,62 +98,35 @@ through `start_selected_level` -- because that separates "the ball is waiting
 for input that no longer arrives" from "the session never started". A headless
 test can settle it without a watch, and none exists.
 
-### Back is handled twice, and it looks like back doing nothing
+### Leaving a run is crown-only, and the back gesture cannot do it
 
-Reported from the watch: the back gesture does not leave the application, it
-lands on the same screen — or one that looks the same. Reported alongside it,
-and probably the same fault: sounds sometimes echo, as though played twice.
+Back from play pauses, and back from the pause overlay resumes. So the gesture
+alternates and never leaves: five swipes on a Pixel Watch 3 against `v1.3.4`
+went paused, playing, paused, playing, paused, with the application still in
+front the whole time. On a watch, where the swipe is the only back there is,
+that reads as the application refusing to close.
 
-`OrbitApp` wires **two** independent paths to `AppState::on_back`:
+**This is deliberate.** The way out of a run is the rotary crown, and
+`back_while_paused_resumes` pins the resume behaviour as a contract. A change
+to `on_back` here is a change to the design, not a bug fix — one was written
+and reverted precisely because that test caught it.
 
-- `BackHandler(back_enabled.get(), …)` at `app/src/ui/mod.rs:106`, and
-- `SwipeToDismissBox`'s `on_dismiss` at `app/src/ui/mod.rs:153`, which calls
-  `on_back` when `back_intercepted()` and `cranpose::request_exit()` otherwise.
+What is worth revisiting is the design: the only way out of a run is an
+affordance nothing on screen names, on a device where the swipe is what a user
+reaches for first. The pause overlay already offers an explicit exit item, so
+the gap is between what the gesture does and what a user expects it to do,
+not a missing capability.
 
-On Wear the back gesture *is* the leading-edge swipe, and the system dispatches
-a back event for the same motion, so one gesture can drive both. `on_back`
-running twice from `Playing` is `pause_game` then `resume_game`: the
-application returns exactly where it started, which is what "it exits to the
-same screen" describes. It also explains back never leaving — the second call
-re-enters a screen that intercepts, so `request_exit()` is never the branch
-taken.
+Two things reported alongside this are still unexplained and are NOT this
+entry: sounds sometimes echoing as though played twice, and a level not
+beginning play on the first tap. Neither reproduces through injected input.
 
-An echo on a sound fits the same cause without needing a second one: a tap
-delivered twice plays its cue twice. Whether input beyond back is doubled is
-unverified and is the first thing to measure, because it decides whether this
-is one fault or two.
-
-**Injected gestures do not reproduce it, so the double dispatch is not
-confirmed.** Driving `adb shell input swipe` from the leading edge on a Pixel
-Watch 3 against `v1.3.3`: from the title screen one swipe leaves the
-application, focus moving to `com.google.android.wearable.sysui`; from
-gameplay one swipe pauses and one more resumes, which is one `on_back` each.
-Two dispatches per gesture would pause and resume in a single swipe and land
-back on gameplay, and that is not what happens. So either the platform
-delivers a real finger down both paths in a way the injected event does not,
-or the cause is something else entirely and the two handlers are a latent
-hazard rather than this bug.
-
-Do not "fix" this by deleting a handler on the reading alone. Both paths reach
-`on_back`, so removing the wrong one removes back everywhere, and the reading
-is exactly what the injected test contradicts. The next real-finger occurrence
-is worth more than more code review: `adb logcat` while it happens, or a
-counter on `on_back` surfaced on screen, settles it in one go.
-
-**This was hidden until `0.1.99` fixed something else.** Before that,
-`SwipeToDismissBox` left its content off screen after firing, so the second
-`on_back` resumed a game nobody could see and the symptom was a blank screen.
-Fixing the widget did not change the double dispatch; it changed what the
-double dispatch looks like. A fix that makes a fault legible rather than
-removing it is worth saying out loud, because the blank screen is gone and the
-underlying wiring is not.
-
-The application owns this one: two handlers for one gesture is CranOrbit's
-wiring, not the framework's. What the framework should answer is whether a
-composition that installs a `BackHandler` *and* a `SwipeToDismissBox` is
-supposed to see one dispatch or two — nothing states it, and both widgets are
-framework API, so an application cannot get this right by reading either in
-isolation.
+The earlier reading of this section -- that `BackHandler` and
+`SwipeToDismissBox` both reach `on_back` and one gesture fires both -- was
+wrong twice over. Injected gestures deliver exactly one `on_back` per swipe,
+and the alternation they were invoked to explain is the intended behaviour.
+Both handlers do reach `on_back`, and that is worth knowing, but nothing
+observed needs it as an explanation.
 
 ### CranOrbit's list screens share one scroll position
 


### PR DESCRIPTION
The entry claimed back was being handled twice. **It isn't, and the behaviour it described is intended.**

Back from play pauses; back from the pause overlay resumes. So the gesture alternates and never leaves a run — five swipes on a Pixel Watch 3 against `v1.3.4` went paused, playing, paused, playing, paused with the app still in front throughout. That looks exactly like "back won't close the app", which is what was reported.

But the way out of a run is the **rotary crown**, and `back_while_paused_resumes` pins the resume behaviour as a contract. I wrote a change to `on_back` to "fix" it and that test failed — the repo caught the regression before CI did. Reverted.

So the entry now records the design honestly, and points at what is actually worth revisiting: the only way out of a run is an affordance nothing on screen names, on a device where the swipe is what a user reaches for first.

The previous reading — `BackHandler` and `SwipeToDismissBox` both reaching `on_back`, one gesture firing both — was wrong **twice over**: injected gestures deliver exactly one `on_back` per swipe, *and* the alternation it was invoked to explain is intended. Both handlers do reach `on_back` and that's worth knowing, but nothing observed needs it as an explanation.

The echoing sound and the level not starting on first tap are separated out as still unexplained, so they aren't carried along by a diagnosis that didn't survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)