### PR TITLE
Install the spell-checker the gate needs instead of assuming it

### DIFF
--- a/justfile
+++ b/justfile
@@ -135,7 +135,14 @@ size-budget:
 # domain-term allowlist is in _typos.toml.
 
 # Spell-check the repository.
+#
+# Installed on demand, the way the workflow provisions sccache and just. A
+# gate that assumes a tool is already on the machine is a gate that passes or
+# fails on which machine ran it: this one failed on a self-hosted mac with
+# `typos: command not found` while passing everywhere the tool happened to be
+# installed.
 typos:
+    @command -v typos >/dev/null || cargo install typos-cli --locked
     typos
 
 # Workspace, lockfile and isolated-demo versions must agree.


### PR DESCRIPTION
`just typos` invokes `typos` and nothing installs it, so the gate fails on a self-hosted mac with:

```
sh: typos: command not found
error: recipe `typos` failed on line 139 with exit code 127
```

while passing on every machine that happens to have the tool. **A gate that depends on what is already on the box passes or fails on which box ran it** — the same fault the `rust-toolchain.toml` pin fixed for rustfmt in cranorbit today.

Installed on demand, the way the workflow already provisions `sccache` and `just`.

I checked the rest rather than fixing only the one that bit: `typos` is the **only** recipe reaching for a tool outside the baseline. The others use `cargo`, `rustup`, `python3`, repo scripts, or `xvfb-run` inside the Linux-only robot job.

Context: this surfaced only after repairing the same host's `rustup`, whose binary had vanished leaving all 11 shims in `~/.cargo/bin` as dangling symlinks — `cargo` resolved to nothing while appearing installed. With cargo working again, CI advanced to the next missing tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)