### PR TITLE
Record what cost the most time this session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,4 +47,24 @@
 - if you spot you wasted too much time on something, please put the discovered info into TIME_WASTERS.md so save future time for everyone
 - not "if you want to"; should be "the proper fix for production-grade ui-framework"; not "I WANT"; should be "this is wrong, this is right, this is the cause, this has to be re-architectured and be rewritten"
 - for non-trivial bugs: explore → document findings → rank suspicions with evidence → propose re-architecture options → implement → diagnostic verify → iterate until confirmed fixed. no one-shot guessing.
+- confirm a suspected cause by REMOVING it and re-running, before writing the
+  fix. three wrong fixes for one macOS signing failure came from reasoning
+  about an error message instead of testing what it claimed.
+- for a UI bug that reproduces on a device, write the state-machine test FIRST.
+  If it passes, the fault is above `AppState` and reading more of `AppState` is
+  wasted time. That test passed twice for bugs that turned out to live in the
+  layer above -- a widget holding content off screen, and a pointer claim
+  surviving a screen change.
+- an existing test is a design decision. If a "fix" makes one fail, the
+  behaviour was deliberate: read the test before changing the code.
+- device testing on the Pixel Watch over adb: the watch dozes between commands
+  and silently drops injected input, and a dozing screen captures as a ~1.6KB
+  black PNG that looks exactly like a frozen app. Send `input keyevent
+  KEYCODE_WAKEUP` before every step and check `dumpsys power | grep
+  mWakefulness` before believing a screenshot. The rotary crown is
+  `adb shell input rotaryencoder scroll --axis SCROLL,<n>`, and ring menus also
+  take taps on the screen edge.
+- `gh` has more than one account here and the active one flips. When a repo
+  starts 404ing or a rerun says "must have admin rights", run
+  `gh auth switch --user samoylenkodmitry` rather than believing the error.
 - should never workaround bugs instead of fixing the root issue


### PR DESCRIPTION
Five additions, each earned the expensive way today.

**Confirm a cause by removing it and re-running, before writing the fix.** One macOS signing failure took *three* wrong fixes — a leaked keychain search-list entry, a "missing" intermediate, a keychain locking mid-build — because the error named the certificate chain and the chain was provably fine (`verify-cert -p codeSign` succeeded on the same keychain). Only added diagnostics produced real evidence.

**For a device-reproduced UI bug, write the state-machine test first.** It *passed* twice for bugs that lived above `AppState` — `SwipeToDismissBox` holding content off screen after `on_dismiss`, and a pointer claim surviving a screen change. Each time, that pass is what redirected the search upward instead of deeper into `AppState`.

**An existing test is a design decision.** `back_while_paused_resumes` caught a "fix" that changed deliberate behaviour (back alternating pause/resume is intended; the crown is the way out of a run).

**Watch testing over adb.** It dozes between commands and silently drops injected input, and a dozing screen captures as a ~1.6KB black PNG indistinguishable from a frozen app — I nearly filed that as a bug. Also records the non-obvious rotary injection: `adb shell input rotaryencoder scroll --axis SCROLL,<n>`. I told the user this was impossible before finding it.

**`gh` flips between accounts here**, and the resulting 404s read as deleted repositories; a rerun fails with "must have admin rights".

🤖 Generated with [Claude Code](https://claude.com/claude-code)