### PR TITLE
A gesture belongs to the call that declared it

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -26,6 +26,51 @@ matched names as substrings so `with_timeout` read as covered because
 `exit_with_timeout` exists, and it excluded the robot suite. A proxy metric that
 is quietly wrong sends work to the wrong places for as long as nobody reads it.
 
+### Conditional branches share one composition slot
+
+Compose's compiler plugin gives every `if`/`else` and `match` branch a group of
+its own, so a branch that leaves takes its nodes with it. Cranpose has no
+plugin, and a `#[composable]` opens one group keyed on where it is *defined*,
+not where it is called. Two branches emitting the same widget are therefore one
+slot: the arriving branch is handed the node the departing one was using,
+together with whatever that node was carrying.
+
+What it cost, on a Pixel Watch 3: starting CranOrbit's Daily run from the title
+ring left the ball parked on the paddle through any number of taps. The taps
+arrived and the simulation ran — the run ended `TIME UP` at score 0 while it
+was being tapped — but the ring's gesture loop was still the one reading them,
+because `pointer_input` restarts only when its key changes and both branches
+passed `()`. Campaign works only because it stops at a screen of a different
+shape on the way to the arena. Two earlier fixes missed it by reasoning about
+`AppState`, which was never at fault.
+
+`a_branch_switch_hands_the_gesture_to_the_branch_that_is_on_screen` in
+`cranpose-app-shell` is the reproduction: before the fix it reported
+`(menu, arena) = (2, 0)`, the departed branch having eaten the arriving one's
+tap.
+
+Gestures are closed: a handler's identity is now the declaration — this call,
+with these keys — so a node handed to a different `pointer_input` call
+restarts. **The general case is open.** A reused node still carries the
+departed branch's `remember`ed state, its animations and its scroll offsets,
+and nothing warns the author. The same shape already produced a second
+reported bug in the same application, where every list screen shared one
+scroll position because one call site is one slot.
+
+Applications can state the identity themselves with `cranpose_core::with_key`,
+Compose's `key(…) { }`, and CranOrbit's router now does. That is the framework
+asking every author to remember what Compose's compiler never makes them think
+about, and the failure is quiet: a stale gesture or a wrong scroll offset reads
+as a rendering glitch, not as shared state.
+
+Closing it means what the plugin does — a group per branch. The macro parses
+the function with `syn` and could wrap branch bodies, but the group API is
+closure-shaped (`Composer::with_group_seed`), and wrapping an arbitrary branch
+in a closure breaks `return`, `?`, `break` and `continue` inside it. So this
+wants an RAII group guard on the composer first, then the macro transform,
+then a sweep of the repo's own conditionals. It is a slot-table change and
+deserves its own validation pass rather than riding along with a bug fix.
+
 ## Limits that are correct, and surprising
 
 These are deliberate. They are here so nobody rediscovers them as bugs.
@@ -68,35 +113,11 @@ content off screen after firing `on_dismiss`, right for a dismissed row whose
 host removes it and wrong for a navigation gesture whose host stays composed.
 Both are verified on the watch against `v1.3.3`. What is left:
 
-### A level does not begin play when it is started
-
-Reported from the watch: after the framework-ownership work, tapping to start a
-level does not get the game playing.
-
-Partly reproduced against `v1.3.3`, and the part that did not reproduce matters
-as much as the part that did. Tapping `START` on the level intro **does** open
-the arena, and it animates: five screenshots two seconds apart were all
-different, so the render loop and some simulation are running. What is visible
-in those frames is the ball still sitting on the paddle, unlaunched, with the
-bricks untouched — a level that is loaded and idling rather than one that never
-opened.
-
-Whether the ball fails to launch, or is waiting for an input that is no longer
-delivered, is **not** established. `robot_*` coverage does not reach this: the
-arena is a real GPU surface and the launch is an input gesture.
-
-What the next attempt needs to know, because it cost time here: **a dozing
-watch freezes the picture and reads exactly like a frozen game.** Two
-consecutive screenshots came back byte-identical after a tap and a drag, which
-looked like input being ignored, and `dumpsys power` said `mWakefulness=Dozing`.
-Check wakefulness before concluding anything from a still frame, and drive the
-test faster than the display's idle timeout.
-
-The discriminator to reach for first is whether the simulation is advancing at
-all -- `AppState::needs_frames`/`simulation_runs` on a state driven headlessly
-through `start_selected_level` -- because that separates "the ball is waiting
-for input that no longer arrives" from "the session never started". A headless
-test can settle it without a watch, and none exists.
+A Daily run that would not launch the ball on a tap is fixed in `v1.3.6`, by
+CranOrbit naming its three gesture surfaces and keying the router on them. The
+cause was not in this application, though: see *Conditional branches share one
+composition slot* above, which is what let the ring go on reading the arena's
+taps. What is left:
 
 ### Leaving a run is crown-only, and the back gesture cannot do it
 
@@ -127,40 +148,6 @@ wrong twice over. Injected gestures deliver exactly one `on_back` per swipe,
 and the alternation they were invoked to explain is the intended behaviour.
 Both handlers do reach `on_back`, and that is worth knowing, but nothing
 observed needs it as an explanation.
-
-### CranOrbit's list screens share one scroll position
-
-Open Settings, scroll to the bottom, open Credits from the last row: Credits
-opens already scrolled to its end. The scroll position is not per screen.
-
-`WearListScreen` remembers exactly one list state, at
-`app/src/ui/composed.rs:342`:
-
-```rust
-let list = rememberWearScalingListState(CentreAnchor {
-    index: CENTRED_ITEM,
-    offset: 0.0,
-});
-```
-
-and `OrbitApp` calls `WearListScreen` from a single site, passing the screen as
-an argument. One call site is one composition slot, so Settings, Credits,
-Volume and Haptics all read and write the same remembered state, and switching
-screens carries the offset across. `remember` is doing exactly what it
-promises — the slot did not change, so the value does not — and the identity
-the state should hang off, which screen is being shown, is never stated.
-
-The framework already has what states it: `cranpose_core::with_key`, Compose's
-`key(…) { }`. Keying the list screen by its screen gives each one its own slot
-and its own scroll position, and drops the stale one when a screen goes away.
-Resetting the anchor on a screen change would look similar and is not the same
-thing: it would return to Credits from a sub-screen having forgotten where the
-reader was, which is the bug in the other direction.
-
-This is a hazard for any screen-switching composable that remembers scroll
-state at one call site, not a quirk of this application. Nothing in the widget
-or its documentation points at it, and the failure is quiet — a wrong starting
-offset reads as a rendering glitch rather than as shared state.
 
 ## CranAmp's network library: fixed, and what it cost
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -111,7 +111,7 @@ scrolling list is restored, and the blank screen on backing out of the pause
 overlay is fixed in Cranpose `0.1.99` -- `SwipeToDismissBox` was holding its
 content off screen after firing `on_dismiss`, right for a dismissed row whose
 host removes it and wrong for a navigation gesture whose host stays composed.
-Both are verified on the watch against `v1.3.3`. What is left:
+Both are verified on the watch against `v1.3.3`.
 
 A Daily run that would not launch the ball on a tap is fixed in `v1.3.6`, by
 CranOrbit naming its three gesture surfaces and keying the router on them. The

--- a/_typos.toml
+++ b/_typos.toml
@@ -33,3 +33,6 @@ PN = "PN"
 # Deliberate near-miss fixtures: a short string and bytes that are not "abc".
 Helo = "Helo"
 abd = "abd"
+# Apple's Core Audio Format container, one of the audio extensions CranAmp
+# lists.
+caf = "caf"

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -7678,6 +7678,140 @@ fn pointer_input_scope_reports_node_size_in_running_shell() {
     APP_SHELL_POINTER_SCOPE_EVENTS.with(|slot| slot.borrow_mut().clear());
 }
 
+thread_local! {
+    static APP_SHELL_ROUTER_ARENA: RefCell<Option<MutableState<bool>>> = const { RefCell::new(None) };
+    static APP_SHELL_ROUTER_MENU_DOWNS: Cell<u32> = const { Cell::new(0) };
+    static APP_SHELL_ROUTER_ARENA_DOWNS: Cell<u32> = const { Cell::new(0) };
+}
+
+/// A screen router: one full-screen gesture surface for a ring menu and
+/// another for a game arena, picked by a plain `if`/`else`, each asking for
+/// gestures with `pointer_input((), ..)` — the key that means "this gesture
+/// outlives recomposition". Compose's compiler plugin gives each branch its
+/// own group, so switching branches is a new node and a new gesture.
+#[composable]
+fn app_shell_router_branch_probe() {
+    let arena = rememberMutableStateOf(|| false);
+    APP_SHELL_ROUTER_ARENA.with(|slot| *slot.borrow_mut() = Some(arena));
+    // Each branch is its own call site, the way an app writes two different
+    // screen composables — the only thing they share is the slot position.
+    if arena.get() {
+        Box(
+            Modifier::empty().fill_max_size().pointer_input(
+                (),
+                move |scope: PointerInputScope| async move {
+                    scope
+                        .await_pointer_event_scope(|await_scope| async move {
+                            loop {
+                                let event = await_scope.await_pointer_event().await;
+                                if event.kind == PointerEventKind::Down {
+                                    APP_SHELL_ROUTER_ARENA_DOWNS
+                                        .with(|count| count.set(count.get() + 1));
+                                }
+                            }
+                        })
+                        .await;
+                },
+            ),
+            BoxSpec::default(),
+            || {},
+        );
+    } else {
+        Box(
+            Modifier::empty().fill_max_size().pointer_input(
+                (),
+                move |scope: PointerInputScope| async move {
+                    scope
+                        .await_pointer_event_scope(|await_scope| async move {
+                            loop {
+                                let event = await_scope.await_pointer_event().await;
+                                if event.kind == PointerEventKind::Down {
+                                    APP_SHELL_ROUTER_MENU_DOWNS
+                                        .with(|count| count.set(count.get() + 1));
+                                }
+                            }
+                        })
+                        .await;
+                },
+            ),
+            BoxSpec::default(),
+            || {},
+        );
+    }
+}
+
+/// Reported from a Pixel Watch 3: starting the Daily run from cranorbit's
+/// title ring left the ball parked on the paddle, and no number of taps
+/// launched it, while the same tap worked in Campaign. Campaign reaches the
+/// arena through an intervening screen; Daily goes straight from the ring to
+/// the arena, and that is the branch switch below.
+///
+/// `pointer_input` restarts its handler only when the key changes, which is
+/// Compose's contract. It holds only because Compose gives each conditional
+/// branch its own group, so the branch that leaves takes its node with it.
+/// Reuse the node across the switch and the departed branch's gesture loop is
+/// still the one reading the events.
+#[test]
+fn a_branch_switch_hands_the_gesture_to_the_branch_that_is_on_screen() {
+    let _guard = test_guard();
+    APP_SHELL_ROUTER_ARENA.with(|slot| {
+        slot.borrow_mut().take();
+    });
+    APP_SHELL_ROUTER_MENU_DOWNS.with(|count| count.set(0));
+    APP_SHELL_ROUTER_ARENA_DOWNS.with(|count| count.set(0));
+
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(
+        HitGraphRenderer::default(),
+        root_key,
+        app_shell_router_branch_probe,
+    );
+    shell.set_viewport(408.0, 408.0);
+    shell.update();
+
+    let tap = |shell: &mut AppShell<HitGraphRenderer>| {
+        shell.set_cursor(10.0, 10.0);
+        shell.update();
+        shell.set_cursor(204.0, 204.0);
+        shell.update();
+        assert!(shell.pointer_pressed(), "the surface must take the press");
+        shell.update();
+        assert!(
+            shell.pointer_released(),
+            "the surface must take the release"
+        );
+        shell.update();
+    };
+
+    tap(&mut shell);
+    assert_eq!(
+        APP_SHELL_ROUTER_MENU_DOWNS.with(|count| count.get()),
+        1,
+        "the menu owns the gesture while the menu is what is on screen"
+    );
+
+    // The menu's own tap is what moves to the arena.
+    APP_SHELL_ROUTER_ARENA
+        .with(|slot| *slot.borrow())
+        .expect("the probe publishes its route")
+        .set(true);
+    shell.update();
+
+    tap(&mut shell);
+    let menu = APP_SHELL_ROUTER_MENU_DOWNS.with(|count| count.get());
+    let arena = APP_SHELL_ROUTER_ARENA_DOWNS.with(|count| count.get());
+    assert_eq!(
+        (menu, arena),
+        (1, 1),
+        "the arena must read the tap once the arena is what is on screen, and the \
+         menu must stop reading gestures after it has left it (menu, arena)"
+    );
+
+    APP_SHELL_ROUTER_ARENA.with(|slot| {
+        slot.borrow_mut().take();
+    });
+}
+
 #[test]
 fn headless_shell_render_graph_survives_restored_draw_state() {
     let _guard = test_guard();

--- a/crates/cranpose-ui/src/modifier/pointer_input.rs
+++ b/crates/cranpose-ui/src/modifier/pointer_input.rs
@@ -22,14 +22,28 @@ use futures_task::{waker, ArcWake};
 use super::{inspector_metadata, Modifier, PointerEvent};
 
 impl Modifier {
+    /// A suspending gesture handler. It restarts when `key` changes and
+    /// otherwise runs on across recomposition, which is what makes a drag
+    /// survive the frames it spans.
+    ///
+    /// Its identity is the declaration — this call, with these keys — not the
+    /// node it happens to land on. Two branches of an `if` are two different
+    /// gestures even when both pass `()`, and if the slot table hands the
+    /// second branch the first one's node, the arriving gesture is the one
+    /// that has to run: keeping the departed branch's handler would deliver
+    /// its events to code that is no longer on screen.
+    #[track_caller]
     pub fn pointer_input<K, F, Fut>(self, key: K, handler: F) -> Self
     where
         K: Hash + 'static,
         F: Fn(PointerInputScope) -> Fut + 'static,
         Fut: Future<Output = ()> + 'static,
     {
-        let element =
-            PointerInputElement::new(vec![KeyToken::new(&key)], pointer_input_handler(handler));
+        let element = PointerInputElement::new(
+            KeyToken::declaration_site(std::panic::Location::caller()),
+            vec![KeyToken::new(&key)],
+            pointer_input_handler(handler),
+        );
         let key_count = element.key_count();
         let handler_id = element.handler_id();
         self.then(
@@ -88,15 +102,19 @@ impl PointerInputTaskRegistry {
 
 #[derive(Clone)]
 struct PointerInputElement {
+    /// Where the gesture was declared. Part of its identity, and not one of
+    /// the `keys` the caller passed, which are what `keyCount` reports.
+    site: KeyToken,
     keys: Vec<KeyToken>,
     handler: PointerInputHandler,
     handler_id: u64,
 }
 
 impl PointerInputElement {
-    fn new(keys: Vec<KeyToken>, handler: PointerInputHandler) -> Self {
+    fn new(site: KeyToken, keys: Vec<KeyToken>, handler: PointerInputHandler) -> Self {
         let handler_id = pointer_handler_identity(&handler);
         Self {
+            site,
             keys,
             handler,
             handler_id,
@@ -119,6 +137,7 @@ fn pointer_handler_identity(handler: &PointerInputHandler) -> u64 {
 impl fmt::Debug for PointerInputElement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PointerInputElement")
+            .field("site", &self.site)
             .field("keys", &self.keys)
             .field("handler", &Rc::as_ptr(&self.handler))
             .field("handler_id", &self.handler_id)
@@ -131,7 +150,7 @@ impl PartialEq for PointerInputElement {
         // Only compare keys, not handler_id. In Compose, elements are equal if their
         // keys match, even if the handler closure is recreated on recomposition.
         // This ensures nodes are reused instead of being dropped and recreated.
-        self.keys == other.keys
+        self.site == other.site && self.keys == other.keys
     }
 }
 
@@ -141,6 +160,7 @@ impl Hash for PointerInputElement {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Only hash keys, not handler_id. This ensures stable hashing across
         // recompositions when the closure is recreated but keys remain the same.
+        self.site.hash(state);
         self.keys.hash(state);
     }
 }
@@ -149,11 +169,11 @@ impl ModifierNodeElement for PointerInputElement {
     type Node = SuspendingPointerInputNode;
 
     fn create(&self) -> Self::Node {
-        SuspendingPointerInputNode::new(self.keys.clone(), self.handler.clone())
+        SuspendingPointerInputNode::new(self.site, self.keys.clone(), self.handler.clone())
     }
 
     fn update(&self, node: &mut Self::Node) {
-        node.update(self.keys.clone(), self.handler.clone());
+        node.update(self.site, self.keys.clone(), self.handler.clone());
     }
 
     fn capabilities(&self) -> NodeCapabilities {
@@ -387,6 +407,9 @@ impl ArcWake for PointerInputTaskWaker {
 }
 
 pub struct SuspendingPointerInputNode {
+    /// Which `pointer_input` call the running gesture belongs to. A node that
+    /// is handed to a different declaration is running the wrong gesture.
+    site: KeyToken,
     keys: Vec<KeyToken>,
     handler: PointerInputHandler,
     dispatcher: PointerEventDispatcher,
@@ -400,8 +423,9 @@ pub struct SuspendingPointerInputNode {
 }
 
 impl SuspendingPointerInputNode {
-    fn new(keys: Vec<KeyToken>, handler: PointerInputHandler) -> Self {
+    fn new(site: KeyToken, keys: Vec<KeyToken>, handler: PointerInputHandler) -> Self {
         Self {
+            site,
             keys,
             handler,
             dispatcher: PointerEventDispatcher::new(),
@@ -414,12 +438,17 @@ impl SuspendingPointerInputNode {
         }
     }
 
-    fn update(&mut self, keys: Vec<KeyToken>, handler: PointerInputHandler) {
+    fn update(&mut self, site: KeyToken, keys: Vec<KeyToken>, handler: PointerInputHandler) {
         // Only restart if keys changed - not if handler Rc pointer changed.
         // In Compose, closures are recreated every composition but the task should
         // continue running as long as the keys are the same. This matches Jetpack
         // Compose behavior where rememberUpdatedState keeps the task alive.
-        let should_restart = self.keys != keys;
+        //
+        // A different declaration site is a different gesture, whatever its
+        // keys say: the node has been handed from one `pointer_input` call to
+        // another, and the arriving one is the gesture that is on screen.
+        let should_restart = self.site != site || self.keys != keys;
+        self.site = site;
         self.keys = keys;
         self.handler = handler; // Update handler even if not restarting
         if should_restart {
@@ -498,6 +527,10 @@ struct KeyToken {
 }
 
 impl KeyToken {
+    fn declaration_site(site: &'static std::panic::Location<'static>) -> Self {
+        Self::new(&(site.file(), site.line(), site.column()))
+    }
+
     fn new<T: Hash + 'static>(value: &T) -> Self {
         let mut hasher = default::new();
         value.hash(&mut hasher);


### PR DESCRIPTION
## The bug this came from

Reported from a Pixel Watch 3: starting cranorbit's **Daily** run from the title ring left the ball parked on the paddle, and no number of taps launched it — while the same tap worked in Campaign.

The taps were reaching the app. The simulation was running (the run even ended `TIME UP — SCORE 0` while I tapped). They were being read by the **title ring's gesture loop**, which was still running on the node the arena had inherited.

## Cause

`pointer_input` restarts its handler only when its key changes. That is Compose's contract, and it is what lets a drag survive the frames it spans.

It holds in Compose because the compiler plugin gives every conditional branch its own group, so a branch that leaves takes its node with it. Cranpose has no such plugin: two branches of an `if` share a slot, the arriving branch is handed the node the departing one was using, and the keys — `()` in both — say nothing changed. So the handler that goes on running belongs to content that is no longer on screen.

Campaign works only because it stops at a screen of a different shape on the way to the arena.

## Fix

A handler's identity is the **declaration** — this call, with these keys — not the node it happens to land on. The element now carries its declaration site, and a node handed to a different `pointer_input` call restarts. Two branches are two gestures even when both pass `()`.

The site is identity rather than one of the caller's keys, so `keyCount` still reports what was passed.

## Test

`a_branch_switch_hands_the_gesture_to_the_branch_that_is_on_screen` drives a router of two full-screen gesture surfaces through the shell, taps each, and asserts the arriving branch reads the tap. Before the fix it reported `(menu, arena) = (2, 0)` — the departed menu had eaten the arena's tap.

## Note

This closes the gesture-shaped hole, not the general one: a reused node still carries the departed branch's `remember`ed state and animations. Auto-keying conditional branches is the compiler-plugin-equivalent work and belongs in its own change.

4640 tests, clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)