### PR TITLE
Probe the layer cache with the key the render path actually stores

### DIFF
--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -1040,3 +1040,13 @@ parse failure stops the runner starting at all. Put the explanation in a file
 next to the runners instead — `/Volumes/files/actions-runners/README-caches.md`
 does this for the sccache and Gradle redirects.
 
+
+## `~/develop/projects/Cranpose` on samarch-1 is a synced mirror, not a repo
+
+Its `.git` is a worktree pointer file naming a macOS path
+(`/Users/s/develop/projects/Cranpose/.git/worktrees/Cranpose-wear`), so every
+git command there dies with `fatal: not a git repository: (null)`. To run
+anything from a branch on that host, rsync the tree into a scratch directory
+(exclude `target/` and `.git`) instead of trying to fetch or checkout there.
+`just` lives in `~/.cargo/bin`, which a non-interactive ssh PATH does not
+include.

--- a/crates/cranpose-render/common/src/raster_cache.rs
+++ b/crates/cranpose-render/common/src/raster_cache.rs
@@ -165,6 +165,10 @@ impl LayerRasterCacheKey {
         self.kind == LayerRasterCacheKind::SceneRange
     }
 
+    pub fn is_source_content(self) -> bool {
+        self.kind == LayerRasterCacheKind::SourceContent
+    }
+
     pub fn identity(self) -> Option<LayerRasterCacheIdentity> {
         Some(LayerRasterCacheIdentity {
             stable_id: self.stable_id?,

--- a/crates/cranpose-render/wgpu/src/gpu_stats.rs
+++ b/crates/cranpose-render/wgpu/src/gpu_stats.rs
@@ -6,6 +6,7 @@
 use std::cell::{Cell, RefCell};
 
 use cranpose_core::NodeId;
+use cranpose_render_common::raster_cache::LayerRasterCacheKey;
 use cranpose_ui_graphics::Rect;
 
 use crate::{
@@ -398,6 +399,16 @@ pub(crate) struct FrameStats {
     top_isolated_layers: RefCell<[Option<IsolatedLayerStat>; TOP_ISOLATED_LAYER_LIMIT]>,
     top_isolated_layer_count: Cell<usize>,
     shadow_shape_cache_miss_log_count: Cell<u32>,
+    /// Keys the layer cache was probed for and did not hold, this frame.
+    ///
+    /// A miss is only ever worth paying once: the render that follows it
+    /// stores the surface under the key that missed, so the next frame hits.
+    /// A miss on a key the render path never stores under is a miss that
+    /// repeats forever, and the counters alone cannot tell the two apart --
+    /// which is how issue #478 survived. `LayerSurfaceCache::finish_frame`
+    /// checks this list against what it actually stored.
+    #[cfg(debug_assertions)]
+    missed_layer_cache_keys: RefCell<Vec<LayerRasterCacheKey>>,
 }
 
 impl FrameStats {
@@ -495,7 +506,13 @@ impl FrameStats {
         );
     }
 
-    pub fn record_layer_cache_miss(&self, width: u32, height: u32) {
+    #[cfg_attr(
+        not(debug_assertions),
+        expect(unused_variables, reason = "the key is only tracked in debug builds")
+    )]
+    pub fn record_layer_cache_miss(&self, key: &LayerRasterCacheKey, width: u32, height: u32) {
+        #[cfg(debug_assertions)]
+        self.missed_layer_cache_keys.borrow_mut().push(*key);
         self.layer_cache_misses
             .set(self.layer_cache_misses.get().saturating_add(1));
         self.layer_cache_miss_pixels.set(
@@ -503,6 +520,15 @@ impl FrameStats {
                 .get()
                 .saturating_add((width as u64) * (height as u64)),
         );
+    }
+
+    /// Hands over the keys that missed this frame, leaving the list empty.
+    ///
+    /// Only [`crate::layer_surface_cache::LayerSurfaceCache`] can judge them:
+    /// it is the side that knows which keys were stored against those misses.
+    #[cfg(debug_assertions)]
+    pub fn take_missed_layer_cache_keys(&self) -> Vec<LayerRasterCacheKey> {
+        self.missed_layer_cache_keys.take()
     }
 
     pub fn record_layer_cache_eviction(&self) {
@@ -853,6 +879,21 @@ fn shadow_cache_diagnostics_enabled() -> bool {
 mod tests {
     use super::*;
 
+    fn test_layer_cache_key() -> LayerRasterCacheKey {
+        LayerRasterCacheKey::source_content(
+            None,
+            0,
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 5.0,
+                height: 6.0,
+            },
+            (5, 6),
+            cranpose_render_common::raster_cache::ScaleBucket::from_scale(1.0),
+        )
+    }
+
     #[test]
     fn layer_cache_counters_accumulate_and_reset() {
         let stats = FrameStats::default();
@@ -871,7 +912,7 @@ mod tests {
         stats.offscreen_pool_bytes.set(2048);
         stats.record_layer_cache_hit(10, 20);
         stats.record_layer_cache_hit(3, 4);
-        stats.record_layer_cache_miss(5, 6);
+        stats.record_layer_cache_miss(&test_layer_cache_key(), 5, 6);
         stats.record_layer_cache_eviction();
         stats.record_shadow_shape_cache_hit(8, 9);
         stats.record_shadow_shape_cache_miss(10, 11);

--- a/crates/cranpose-render/wgpu/src/layer_surface_cache.rs
+++ b/crates/cranpose-render/wgpu/src/layer_surface_cache.rs
@@ -64,6 +64,10 @@ pub(crate) struct LayerSurfaceCache {
     /// of twenty-six unused targets. The sizes repeat exactly, so the pool
     /// serves every one of them once the surfaces come back.
     recycled: Vec<Rc<OffscreenTarget>>,
+    /// Keys stored this frame, checked at `finish_frame` against the keys the
+    /// render paths were probed for and missed.
+    #[cfg(debug_assertions)]
+    inserted_this_frame: HashSet<LayerRasterCacheKey>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -90,6 +94,8 @@ impl LayerSurfaceCache {
             scene_range_bytes: 0,
             seen_this_frame: HashSet::new(),
             recycled: Vec::new(),
+            #[cfg(debug_assertions)]
+            inserted_this_frame: HashSet::new(),
         }
     }
 
@@ -130,6 +136,9 @@ impl LayerSurfaceCache {
         logical_rect: Rect,
         frame_stats: &FrameStats,
     ) -> Rc<OffscreenTarget> {
+        #[cfg(debug_assertions)]
+        self.inserted_this_frame.insert(key);
+
         if key.is_scene_range() {
             return self.insert_scene_range(key, target, logical_rect, frame_stats);
         }
@@ -182,12 +191,47 @@ impl LayerSurfaceCache {
         cached_handle
     }
 
+    /// Fails the frame if the render paths were probed for a key that nothing
+    /// went on to store.
+    ///
+    /// A miss is a one-off cost by design: whatever missed gets rendered and
+    /// stored under the key that missed, so the next frame hits it. A miss on
+    /// a key no path ever stores under is a miss that repeats every frame for
+    /// the life of the layer, and in the counters it is indistinguishable from
+    /// honest eviction pressure. Issue #478 was exactly that -- the retained
+    /// lookup probed a full-surface key for every backdrop-carrying layer,
+    /// which is stored under a source-content key and never under the one
+    /// probed -- and it hid behind a plausible-looking hit rate for as long as
+    /// nothing compared the two sets. Every scene any test renders now does.
+    #[cfg(debug_assertions)]
+    fn assert_every_miss_was_stored(&self, frame_stats: &FrameStats) {
+        let missed = frame_stats.take_missed_layer_cache_keys();
+        let Some(unstored) = missed
+            .iter()
+            .find(|key| !self.inserted_this_frame.contains(key))
+        else {
+            return;
+        };
+        panic!(
+            "layer cache was probed for a key nothing stored: {unstored:?}\n\
+             a miss must be paid once, not every frame -- the probing path and \
+             the storing path have to name the surface the same way. Run with \
+             CRANPOSE_LAYER_CACHE_DIAG=1 to see which path probed it."
+        );
+    }
+
     pub(crate) fn finish_frame(&mut self, frame_stats: &FrameStats) {
+        #[cfg(debug_assertions)]
+        self.assert_every_miss_was_stored(frame_stats);
+
         self.seen_this_frame.clear();
         if self.seen_this_frame.capacity() > RETAINED_LAYER_SEEN_THIS_FRAME_CAPACITY {
             self.seen_this_frame
                 .shrink_to(RETAINED_LAYER_SEEN_THIS_FRAME_CAPACITY);
         }
+
+        #[cfg(debug_assertions)]
+        self.inserted_this_frame.clear();
 
         self.identity.retain(|_, key| self.entries.contains(key));
         frame_stats

--- a/crates/cranpose-render/wgpu/src/layer_surface_cache.rs
+++ b/crates/cranpose-render/wgpu/src/layer_surface_cache.rs
@@ -22,6 +22,15 @@ pub(crate) const MAX_SCENE_RANGE_CACHE_ENTRY_BYTES: u64 = 16 * 1024 * 1024;
 pub(crate) const MAX_SCENE_RANGE_CACHE_BYTES: u64 = 64 * 1024 * 1024;
 const RETAINED_LAYER_SEEN_THIS_FRAME_CAPACITY: usize = 256;
 
+/// Env-gated cache-key diagnostics (`CRANPOSE_LAYER_CACHE_DIAG=1`): logs every
+/// miss with the key that missed, and every insert with the key it landed
+/// under, so a cache that misses without eviction pressure names the field
+/// that varied — or shows that the two key spaces never met.
+pub(crate) fn cache_diag_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("CRANPOSE_LAYER_CACHE_DIAG").is_some())
+}
+
 /// Takes out the values no other holder still references, and keeps the rest
 /// for a later call.
 fn take_unshared<T>(pending: &mut Vec<Rc<T>>) -> Vec<T> {
@@ -131,9 +140,18 @@ impl LayerSurfaceCache {
             let identity = key.identity().expect("stable cache key must have identity");
             if let Some(previous_key) = self.identity.insert(identity, key) {
                 if previous_key != key {
+                    if cache_diag_enabled() {
+                        log::warn!(
+                            "[layer-cache-diag] rekey {identity:?} prev={previous_key:?} new={key:?}"
+                        );
+                    }
                     self.remove(&previous_key);
                 }
+            } else if cache_diag_enabled() {
+                log::warn!("[layer-cache-diag] insert {identity:?} key={key:?}");
             }
+        } else if cache_diag_enabled() {
+            log::warn!("[layer-cache-diag] insert anonymous key={key:?}");
         }
 
         while self.bytes + byte_size > MAX_LAYER_SURFACE_CACHE_BYTES {

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -8967,10 +8967,10 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
         self.renderer.warning_state.warn_unsupported_effect_once();
     }
 
-    fn record_layer_cache_miss(&self, width: u32, height: u32) {
+    fn record_layer_cache_miss(&self, key: &LayerRasterCacheKey, width: u32, height: u32) {
         self.renderer
             .frame_stats
-            .record_layer_cache_miss(width, height);
+            .record_layer_cache_miss(key, width, height);
     }
 
     fn record_isolated_layer_render(

--- a/crates/cranpose-render/wgpu/src/surface_executor/backend.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/backend.rs
@@ -337,7 +337,7 @@ pub(crate) trait SurfaceExecutionBackend {
     ) -> Result<(), String>;
     fn is_render_effect_supported(&self, effect: &RenderEffect) -> bool;
     fn warn_unsupported_effect_once(&self);
-    fn record_layer_cache_miss(&self, width: u32, height: u32);
+    fn record_layer_cache_miss(&self, key: &LayerRasterCacheKey, width: u32, height: u32);
     fn record_isolated_layer_render(
         &self,
         width: u32,

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -58,6 +58,25 @@ fn layer_render_diag_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("CRANPOSE_LAYER_RENDER_DIAG").is_some())
 }
 
+/// Counts a layer-cache miss, and under `CRANPOSE_LAYER_CACHE_DIAG` names the
+/// key that missed and the path that probed it.
+///
+/// A miss on a key nothing ever stores is indistinguishable from a miss under
+/// eviction pressure in the counters alone, which is how issue #478 stayed
+/// hidden. Every miss goes through here so the key is always recoverable.
+fn record_layer_cache_miss<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    site: &str,
+    key: &LayerRasterCacheKey,
+    width: u32,
+    height: u32,
+) {
+    if crate::layer_surface_cache::cache_diag_enabled() {
+        log::warn!("[layer-cache-diag] miss site={site} key={key:?}");
+    }
+    backend.record_layer_cache_miss(width, height);
+}
+
 fn direct_scene_range_cache_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| std::env::var_os("CRANPOSE_DISABLE_DIRECT_SCENE_RANGE_CACHE").is_none())
@@ -2618,9 +2637,16 @@ pub(crate) fn render_layer_surface<B: SurfaceExecutionBackend>(
         activates_nested_capture
             && effective_requirements.contains(SurfaceRequirement::MotionStableCapture),
     );
+    let supported_isolation_effect = child
+        .isolation
+        .as_ref()
+        .and_then(|params| params.effect.as_ref())
+        .filter(|effect| backend.is_render_effect_supported(effect));
     let cache_candidate = child_layer_raster_cache_candidate(
         child,
         target_scale,
+        effective_requirements,
+        supported_isolation_effect,
         backdrop_underlay.is_some(),
         backdrop_underlay_color,
         allow_runtime_cache,
@@ -2647,7 +2673,7 @@ pub(crate) fn render_layer_surface<B: SurfaceExecutionBackend>(
             });
         }
         let (width, height) = cache_key.pixel_size();
-        backend.record_layer_cache_miss(width, height);
+        record_layer_cache_miss(backend, "child-candidate", &cache_key, width, height);
         return render_layer_surface_uncached(
             backend,
             child,
@@ -2692,6 +2718,8 @@ pub(crate) fn render_layer_surface<B: SurfaceExecutionBackend>(
 fn child_layer_raster_cache_candidate(
     child: &ChildLayerComposite,
     root_scale: f32,
+    effective_requirements: SurfaceRequirementSet,
+    supported_isolation_effect: Option<&RenderEffect>,
     has_backdrop_underlay: bool,
     backdrop_underlay_color: Option<u32>,
     allow_runtime_cache: bool,
@@ -2699,6 +2727,55 @@ fn child_layer_raster_cache_candidate(
     max_texture_dim: u32,
 ) -> Option<(LayerRasterCacheKey, Rect)> {
     let surface_requirements = child.surface_requirements;
+    // A RuntimeShader produces different output every frame from uniforms no
+    // content hash carries, so nothing can invalidate a texture it was
+    // rastered into. Caching the shader's own layer would only fill the LRU
+    // with stale entries; caching an ANCESTOR of one freezes the effect
+    // outright, because the ancestor stays a hit forever and replays whatever
+    // frame it first rastered. The whole subtree is therefore uncacheable.
+    if surface_requirements.contains_runtime_shader {
+        return None;
+    }
+
+    // The candidate must be the key the render path will STORE, or the lookup
+    // mints a miss every frame against a key that never exists. A layer the
+    // render path serves out of the source-content cache never stores a
+    // full-surface entry, so its candidate has to be that same source-content
+    // key — or nothing, where no key is nameable from here.
+    if let Some(source) = layer_source_cache_entry(
+        child,
+        effective_requirements,
+        has_backdrop_underlay,
+        allow_runtime_cache,
+    ) {
+        match supported_isolation_effect {
+            None => {
+                // No collected hash means only the render path can name the
+                // key, so there is nothing here worth probing for.
+                let content_hash = source.collected_content_hash?;
+                let logical_rect = logical_rect_override.unwrap_or(child.logical_rect);
+                let pixel_size = surface_target_size(logical_rect, root_scale, max_texture_dim);
+                if offscreen_byte_size(pixel_size.0, pixel_size.1) > MAX_LAYER_SURFACE_CACHE_BYTES {
+                    return None;
+                }
+                return Some((
+                    source.key(content_hash, logical_rect, pixel_size, root_scale),
+                    logical_rect,
+                ));
+            }
+            Some(effect) if can_materialize_cached_effect(effect, child.backdrop.as_ref()) => {
+                // The render path materializes the effect over the cached
+                // source and stores the result under the full-surface key:
+                // fall through to the full-surface candidate.
+            }
+            Some(_) => {
+                // The effect re-applies over the cached source every frame,
+                // so no post-effect surface is ever stored under any key.
+                return None;
+            }
+        }
+    }
+
     let runtime_cache_is_safe = allow_runtime_cache
         && surface_requirements
             .surface_requirements
@@ -2714,18 +2791,12 @@ fn child_layer_raster_cache_candidate(
     if external_backdrop_input && backdrop_underlay_color.is_none() {
         return None;
     }
-    // A RuntimeShader produces different output every frame from uniforms no
-    // content hash carries, so nothing can invalidate a texture it was
-    // rastered into. Caching the shader's own layer would only fill the LRU
-    // with stale entries; caching an ANCESTOR of one freezes the effect
-    // outright, because the ancestor stays a hit forever and replays whatever
-    // frame it first rastered. The whole subtree is therefore uncacheable.
-    if surface_requirements.contains_runtime_shader {
-        return None;
-    }
 
     let logical_rect = logical_rect_override.unwrap_or(child.logical_rect);
     let pixel_size = surface_target_size(logical_rect, root_scale, max_texture_dim);
+    if offscreen_byte_size(pixel_size.0, pixel_size.1) > MAX_LAYER_SURFACE_CACHE_BYTES {
+        return None;
+    }
     let content_hash = if external_backdrop_input {
         let mut hasher = FxHasher::default();
         0xF1A7_C010u64.hash(&mut hasher);
@@ -2819,16 +2890,50 @@ fn materialize_render_effect_to_target<B: SurfaceExecutionBackend>(
     )
 }
 
-#[allow(clippy::too_many_arguments)]
-fn layer_source_cache_key(
+/// What the source-content cache holds for a layer, if anything.
+///
+/// The retained lookup and the render path have to answer this identically:
+/// the key one probes is the key the other stores under, and a probe against a
+/// key nothing ever writes mints a miss every frame forever. Both read the
+/// answer from [`layer_source_cache_entry`] so the two cannot drift apart.
+struct LayerSourceCacheEntry {
+    stable_id: Option<NodeId>,
+    /// The content hash the key carries, when collection already settled it.
+    ///
+    /// `None` for a motion-stable capture. Collection snapshots that hash into
+    /// `motion_source_content_hash` only when its own recomputation of the
+    /// effective requirements agrees with the render body's, and the retained
+    /// lookup recomputes them from a context that legitimately differs. The
+    /// render path resolves the hash there, alongside the capture rect it
+    /// resolves for the same reason; a caller working from a collection-time
+    /// estimate cannot name the resulting key at all.
+    collected_content_hash: Option<u64>,
+}
+
+impl LayerSourceCacheEntry {
+    fn key(
+        &self,
+        content_hash: u64,
+        rect: Rect,
+        pixel_size: (u32, u32),
+        scale: f32,
+    ) -> LayerRasterCacheKey {
+        LayerRasterCacheKey::source_content(
+            self.stable_id,
+            content_hash,
+            rect,
+            pixel_size,
+            ScaleBucket::from_scale(scale),
+        )
+    }
+}
+
+fn layer_source_cache_entry(
     child: &ChildLayerComposite,
     effective_requirements: SurfaceRequirementSet,
-    surface_rect: Rect,
-    pixel_size: (u32, u32),
-    target_scale: f32,
     has_backdrop_underlay: bool,
     allow_runtime_cache: bool,
-) -> Option<LayerRasterCacheKey> {
+) -> Option<LayerSourceCacheEntry> {
     let runtime_shader_source = child.effect_contains_runtime_shader;
     let motion_stable_source =
         effective_requirements.contains(SurfaceRequirement::MotionStableCapture);
@@ -2845,21 +2950,34 @@ fn layer_source_cache_key(
         return None;
     }
 
-    let content_hash = if motion_stable_source {
+    Some(LayerSourceCacheEntry {
+        stable_id: child.node_id,
+        collected_content_hash: (!motion_stable_source).then_some(child.target_content_hash),
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn layer_source_cache_key(
+    child: &ChildLayerComposite,
+    effective_requirements: SurfaceRequirementSet,
+    surface_rect: Rect,
+    pixel_size: (u32, u32),
+    target_scale: f32,
+    has_backdrop_underlay: bool,
+    allow_runtime_cache: bool,
+) -> Option<LayerRasterCacheKey> {
+    let source = layer_source_cache_entry(
+        child,
+        effective_requirements,
+        has_backdrop_underlay,
+        allow_runtime_cache,
+    )?;
+    let content_hash = source.collected_content_hash.unwrap_or_else(|| {
         child
             .motion_source_content_hash
             .expect("motion-stable source snapshots its motion content hash at collection")
-    } else {
-        child.target_content_hash
-    };
-
-    Some(LayerRasterCacheKey::source_content(
-        child.node_id,
-        content_hash,
-        surface_rect,
-        pixel_size,
-        ScaleBucket::from_scale(target_scale),
-    ))
+    });
+    Some(source.key(content_hash, surface_rect, pixel_size, target_scale))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4029,7 +4147,13 @@ fn cached_direct_scene_range_surface<B: SurfaceExecutionBackend>(
                 target_height,
             );
         }
-        backend.record_layer_cache_miss(target_width, target_height);
+        record_layer_cache_miss(
+            backend,
+            "scene-range",
+            &cache_key,
+            target_width,
+            target_height,
+        );
         let target = backend.acquire_retained_surface(target_width, target_height);
         let window_scene = build_scene_window(
             SceneWindowSource {
@@ -4931,15 +5055,26 @@ fn render_layer_surface_uncached<B: SurfaceExecutionBackend>(
             &child_layers,
             backdrop_underlay.is_some(),
         );
-        let source_cache_key = layer_source_cache_key(
-            child,
-            effective_requirements,
-            surface_rect,
-            (width, height),
-            target_scale,
-            source_uses_external_backdrop,
-            allow_runtime_cache,
-        );
+        // A source-kind candidate arrives from the retained lookup that just
+        // missed on it. It is authoritative: the entry has to be stored under
+        // the key the next frame's lookup probes, not under a recomputed key
+        // whose rect or scale the deep path may have adjusted since. Probing
+        // it again here could only repeat the miss it arrived from.
+        let candidate_source_key = cache_candidate
+            .take_if(|(key, _)| key.is_source_content())
+            .map(|(key, _)| key);
+        let source_probe_missed_upstream = candidate_source_key.is_some();
+        let source_cache_key = candidate_source_key.or_else(|| {
+            layer_source_cache_key(
+                child,
+                effective_requirements,
+                surface_rect,
+                (width, height),
+                target_scale,
+                source_uses_external_backdrop,
+                allow_runtime_cache,
+            )
+        });
         if layer_render_diag_enabled() {
             log::warn!(
                 "[layer-render-diag] node={:?} size={}x{} scale={:.3} rect=({:.1},{:.1},{:.1},{:.1}) requirements={:?} cache_candidate={} backdrop_underlay={} external_backdrop_input={}",
@@ -4958,10 +5093,17 @@ fn render_layer_surface_uncached<B: SurfaceExecutionBackend>(
             );
         }
         let mut target = if let Some(cache_key) = source_cache_key {
-            if let Some((cached_target, _)) = backend.cached_layer_surface(&cache_key) {
+            let cached = if source_probe_missed_upstream {
+                None
+            } else {
+                backend.cached_layer_surface(&cache_key)
+            };
+            if let Some((cached_target, _)) = cached {
                 LayerSurfaceTexture::Cached(cached_target)
             } else {
-                backend.record_layer_cache_miss(width, height);
+                if !source_probe_missed_upstream {
+                    record_layer_cache_miss(backend, "source-content", &cache_key, width, height);
+                }
                 let rendered = render_layer_source_uncached(
                     backend,
                     &local_scene,
@@ -5485,7 +5627,13 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
     {
         LayerSurfaceTexture::Cached(cached_target)
     } else {
-        backend.record_layer_cache_miss(backdrop_width, backdrop_height);
+        record_layer_cache_miss(
+            backend,
+            "backdrop",
+            &cache_key,
+            backdrop_width,
+            backdrop_height,
+        );
         let snapshot = backend.acquire_frame_surface(backdrop_width, backdrop_height);
         let copied_snapshot = copy_plan.is_some_and(|plan| {
             backend.copy_texture_region_to_target(target, plan.source_origin, &snapshot, plan.size)

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -74,7 +74,7 @@ fn record_layer_cache_miss<B: SurfaceExecutionBackend>(
     if crate::layer_surface_cache::cache_diag_enabled() {
         log::warn!("[layer-cache-diag] miss site={site} key={key:?}");
     }
-    backend.record_layer_cache_miss(width, height);
+    backend.record_layer_cache_miss(key, width, height);
 }
 
 fn direct_scene_range_cache_enabled() -> bool {

--- a/crates/cranpose-render/wgpu/tests/effect_semantics.rs
+++ b/crates/cranpose-render/wgpu/tests/effect_semantics.rs
@@ -1564,8 +1564,12 @@ fn translated_backdrop_capture_preserves_local_picture_under_rigid_motion() {
         "translated backdrop base frame should isolate only the backdrop child under the readable composition root: {base_stats:?}"
     );
     assert!(
-        (1..=2).contains(&moved_stats.isolated_layer_renders),
+        moved_stats.isolated_layer_renders <= 2,
         "translated backdrop moved frame should reuse cached rigid content without adding extra isolated layers: {moved_stats:?}"
+    );
+    assert!(
+        moved_stats.layer_cache_hits >= 1,
+        "translated backdrop moved frame should serve the rigid content from the layer cache: {moved_stats:?}"
     );
 
     let base_normalized = normalize_translated_backdrop_region(&base_frame, base_translation);

--- a/crates/cranpose-render/wgpu/tests/glass_layer_cache.rs
+++ b/crates/cranpose-render/wgpu/tests/glass_layer_cache.rs
@@ -1,0 +1,292 @@
+//! Render-layer cache behaviour for the glass scenario: a lazy list of
+//! backdrop-blur rows under an animated glass overlay, the shape of the
+//! `glass_lazy_scroll` perf scenario.
+
+mod support;
+
+use std::{cell::RefCell, rc::Rc};
+
+use cranpose_app_shell::AppShell;
+use cranpose_core::{location_key, MutableState};
+use cranpose_foundation::lazy::{rememberLazyListState, LazyItems, LazyListScope, LazyListState};
+use cranpose_ui::{
+    composable,
+    widgets::{Box, BoxSpec, Column, ColumnSpec, LazyColumn, LazyColumnSpec, Text},
+    Color, LinearArrangement, Modifier, RenderEffect, TextStyle,
+};
+
+const FRAME_WIDTH: u32 = 640;
+const FRAME_HEIGHT: u32 = 640;
+
+#[composable]
+#[allow(non_snake_case)]
+fn GlassRow(index: usize) {
+    let tint = match index % 4 {
+        0 => Color(0.20, 0.26, 0.36, 0.55),
+        1 => Color(0.28, 0.20, 0.34, 0.55),
+        2 => Color(0.18, 0.32, 0.30, 0.55),
+        _ => Color(0.32, 0.26, 0.20, 0.55),
+    };
+    Box(
+        Modifier::empty()
+            .fill_max_width()
+            .height(96.0)
+            .backdrop_effect(RenderEffect::blur(12.0))
+            .background(tint)
+            .rounded_corners(18.0)
+            .padding(14.0),
+        BoxSpec::new(),
+        move || {
+            Text(
+                format!("Glass row {index}"),
+                Modifier::empty(),
+                TextStyle::default(),
+            );
+        },
+    );
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn GlassOverlay(pulse: MutableState<f32>, drift: MutableState<f32>) {
+    let pulse_value = pulse.get();
+    let drift_value = drift.get();
+    Box(
+        Modifier::empty()
+            .offset(48.0 + drift_value * 180.0, 72.0 + drift_value * 96.0)
+            .width(300.0)
+            .height(164.0)
+            .backdrop_effect(RenderEffect::blur(10.0 + pulse_value * 14.0))
+            .background(Color(0.80, 0.88, 0.98, 0.20 + pulse_value * 0.12))
+            .rounded_corners(22.0)
+            .padding(18.0),
+        BoxSpec::new(),
+        move || {
+            Column(
+                Modifier::empty(),
+                ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
+                move || {
+                    Text(
+                        "Animated glass".to_string(),
+                        Modifier::empty(),
+                        TextStyle::default(),
+                    );
+                },
+            );
+        },
+    );
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn GlassScene(list_state: LazyListState, pulse: MutableState<f32>, drift: MutableState<f32>) {
+    Box(
+        Modifier::empty()
+            .size_points(FRAME_WIDTH as f32, FRAME_HEIGHT as f32)
+            .background(Color(0.03, 0.04, 0.06, 1.0))
+            .rounded_corners(18.0),
+        BoxSpec::new(),
+        move || {
+            Box(
+                Modifier::empty().fill_max_size().padding(12.0),
+                BoxSpec::new(),
+                move || {
+                    LazyColumn(
+                        Modifier::empty().fill_max_size(),
+                        list_state,
+                        LazyColumnSpec::new()
+                            .vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
+                        move |scope| {
+                            scope.items(LazyItems::new(40).key(|i: usize| i as u64), GlassRow);
+                        },
+                    );
+                    GlassOverlay(pulse, drift);
+                },
+            );
+        },
+    );
+}
+
+struct GlassHarness {
+    shell: AppShell<cranpose_render_wgpu::WgpuRenderer>,
+    list_state: Rc<RefCell<Option<LazyListState>>>,
+    pulse: Rc<RefCell<Option<MutableState<f32>>>>,
+    drift: Rc<RefCell<Option<MutableState<f32>>>>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+struct FrameCacheStats {
+    hits: u32,
+    misses: u32,
+    blur_passes: u32,
+    isolated_layer_renders: u32,
+}
+
+impl GlassHarness {
+    fn new(renderer: cranpose_render_wgpu::WgpuRenderer) -> Self {
+        let root_key = location_key(file!(), line!(), column!());
+        let list_state: Rc<RefCell<Option<LazyListState>>> = Rc::new(RefCell::new(None));
+        let pulse: Rc<RefCell<Option<MutableState<f32>>>> = Rc::new(RefCell::new(None));
+        let drift: Rc<RefCell<Option<MutableState<f32>>>> = Rc::new(RefCell::new(None));
+        let list_state_for_app = Rc::clone(&list_state);
+        let pulse_for_app = Rc::clone(&pulse);
+        let drift_for_app = Rc::clone(&drift);
+        let mut shell = AppShell::new(renderer, root_key, move || {
+            let state = rememberLazyListState();
+            let pulse_state = cranpose_core::rememberMutableStateOf(|| 0.0f32);
+            let drift_state = cranpose_core::rememberMutableStateOf(|| 0.0f32);
+            *list_state_for_app.borrow_mut() = Some(state);
+            *pulse_for_app.borrow_mut() = Some(pulse_state);
+            *drift_for_app.borrow_mut() = Some(drift_state);
+            GlassScene(state, pulse_state, drift_state);
+        });
+        shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
+        shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+        shell.update();
+        Self {
+            shell,
+            list_state,
+            pulse,
+            drift,
+        }
+    }
+
+    /// Advances one frame: applies the given scroll delta and animation
+    /// values, recomposes, renders, and returns that frame's cache counters.
+    fn frame(&mut self, scroll_delta: f32, pulse: f32, drift: f32) -> FrameCacheStats {
+        if scroll_delta != 0.0 {
+            let state = self
+                .list_state
+                .borrow()
+                .as_ref()
+                .cloned()
+                .expect("list state captured");
+            self.shell
+                .debug_enter_app_context(|| state.dispatch_scroll_delta(scroll_delta));
+        }
+        let pulse_state = self
+            .pulse
+            .borrow()
+            .as_ref()
+            .cloned()
+            .expect("pulse state captured");
+        let drift_state = self
+            .drift
+            .borrow()
+            .as_ref()
+            .cloned()
+            .expect("drift state captured");
+        self.shell.debug_enter_app_context(|| {
+            pulse_state.set(pulse);
+            drift_state.set(drift);
+        });
+        self.shell.update();
+        self.shell
+            .renderer()
+            .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+            .expect("frame capture should succeed");
+        let stats = self
+            .shell
+            .renderer()
+            .last_frame_stats()
+            .expect("frame stats");
+        FrameCacheStats {
+            hits: stats.layer_cache_hits,
+            misses: stats.layer_cache_misses,
+            blur_passes: stats.blur_passes,
+            isolated_layer_renders: stats.isolated_layer_renders,
+        }
+    }
+}
+
+const WARMUP_FRAMES: usize = 4;
+const MEASURED_FRAMES: usize = 8;
+
+/// A still glass scene must serve every layer from the cache: zero misses,
+/// zero re-blurs, zero isolated re-renders.
+///
+/// Regression for issue #478. The retained lookup probed a full-surface key
+/// for every backdrop-carrying layer, while the render path stores those
+/// surfaces under a source-content key and never under the full-surface one.
+/// The probe therefore missed every frame forever — `cache_evictions=0` with
+/// a sub-30% hit rate in `glass_lazy_scroll` — and the phantom misses kept a
+/// still scene redrawing through the cache-miss warmup machinery.
+#[test]
+fn a_still_glass_scene_leaves_no_layer_cache_misses() {
+    let (_lock, renderer) = match support::headless_renderer_parts() {
+        Ok(parts) => parts,
+        Err(err) => {
+            eprintln!("skipping (headless WGPU init failed): {err}");
+            return;
+        }
+    };
+    let mut harness = GlassHarness::new(renderer);
+
+    for _ in 0..WARMUP_FRAMES {
+        harness.frame(0.0, 0.0, 0.0);
+    }
+    for frame_index in 0..MEASURED_FRAMES {
+        let stats = harness.frame(0.0, 0.0, 0.0);
+        assert_eq!(
+            stats.misses, 0,
+            "a still glass frame must not miss the layer cache (frame {frame_index}): {stats:?}"
+        );
+        assert!(
+            stats.hits > 0,
+            "a still glass frame must serve its layers from the cache (frame {frame_index}): {stats:?}"
+        );
+        assert_eq!(
+            stats.blur_passes, 0,
+            "a still glass frame must not re-run any blur (frame {frame_index}): {stats:?}"
+        );
+        assert_eq!(
+            stats.isolated_layer_renders, 0,
+            "a still glass frame must not re-render any isolated layer (frame {frame_index}): {stats:?}"
+        );
+    }
+}
+
+/// An overlay animating its blur radius and offset re-renders only itself:
+/// its own content (the pulse tints its fill) and its own backdrop blur.
+/// The still glass rows underneath must keep hitting their cached surfaces
+/// and cached backdrops.
+#[test]
+fn an_animated_overlay_leaves_still_glass_rows_fully_cached() {
+    let (_lock, renderer) = match support::headless_renderer_parts() {
+        Ok(parts) => parts,
+        Err(err) => {
+            eprintln!("skipping (headless WGPU init failed): {err}");
+            return;
+        }
+    };
+    let mut harness = GlassHarness::new(renderer);
+
+    let animation = |frame_index: usize| {
+        let t = (frame_index + 1) as f32 / 16.0;
+        (t, t)
+    };
+    for frame_index in 0..WARMUP_FRAMES {
+        let (pulse, drift) = animation(frame_index);
+        harness.frame(0.0, pulse, drift);
+    }
+    for frame_index in 0..MEASURED_FRAMES {
+        let (pulse, drift) = animation(WARMUP_FRAMES + frame_index);
+        let stats = harness.frame(0.0, pulse, drift);
+        assert_eq!(
+            stats.misses, 2,
+            "an animated overlay re-renders exactly its own content and its own \
+             backdrop blur; anything more means a still row lost its cache \
+             (frame {frame_index}): {stats:?}"
+        );
+        assert!(
+            stats.hits >= 12,
+            "the still rows' surfaces and backdrops must keep hitting while the \
+             overlay animates (frame {frame_index}): {stats:?}"
+        );
+        assert_eq!(
+            stats.blur_passes, 1,
+            "only the overlay's backdrop re-blurs while the rows hold still \
+             (frame {frame_index}): {stats:?}"
+        );
+    }
+}


### PR DESCRIPTION
A layer carrying a local backdrop has its surface stored under a
source-content key, but the retained fast path built a full-surface key and
probed for that. The two key spaces never meet, so every glass layer recorded
a miss on every frame and re-entered the deep render path.

Measured on the `glass_lazy_scroll` scene, pre-fix, with nothing moving at all:

| mode | hits/frame | misses/frame | blur/frame | offscreen MB/frame |
|---|---|---|---|---|
| **static** | 14 | **7** | 0 | 0 |
| pulse-only | 12 | 9 | 1 | 0.9 |
| drift-only | 13 | 8 | 1 | 0.45 |
| scroll-only | 7.75 | 15.75 | 7.83 | 3.82 |

Seven misses per frame in a still scene with zero blur passes and zero bytes
acquired: phantom misses, on keys nothing ever writes. `cache_evictions=0`
because nothing was ever displaced. Each one also re-entered the full uncached
path -- scene lowering, translation, isolated-layer bookkeeping -- and re-armed
the cache-miss warmup, so a still glass scene never settled.

The animated blur radius, the original suspicion in #478, was not the cause. It
costs exactly one legitimate re-blur per frame, because the overlay's output
genuinely changes.

## Probe the key that gets stored

Both sides now read one answer. `layer_source_cache_entry` decides whether the
source-content cache holds a layer and with which content hash, and owns the
key construction; the retained lookup and the render path both call it, so the
probe key and the stored key cannot drift apart. Where the lookup cannot name
the stored key it returns no candidate rather than minting a miss:

- a motion-stable capture resolves its rect *and* its content hash inside the
  render path, from a recomputation of the effective requirements that
  legitimately differs from the lookup's;
- an effect that re-applies over the cached source every frame is never stored
  under any key at all.

The render path treats an arriving source-kind candidate as authoritative and
stores it verbatim, so estimate-vs-exact rect drift cannot split the key space
back apart.

## Make the whole class loud

Fixing the instance leaves the next divergence just as silent, because a miss
on a key nothing stores is indistinguishable in the counters from a miss under
eviction pressure. Only the ratio between them ever said otherwise, and a
plausible-looking hit rate hid this for as long as nothing compared the sets.

A miss is a one-off cost by design: whatever missed is rendered and stored
under the key that missed, so the following frame hits it. That makes the
invariant checkable. `FrameStats` collects the keys that missed,
`LayerSurfaceCache` knows what it stored, and `finish_frame` compares them and
panics naming the key. Debug builds only -- `native-release` inherits
`release`, so nothing is paid in the perf harness or in shipped binaries, while
`profile.robot` and `profile.ci` inherit `dev` and get the check for free.

Every scene the suite renders is now a check. Reintroducing the bug fails
**twelve tests in `effect_semantics`** that have nothing to do with glass:

```
layer cache was probed for a key nothing stored:
  LayerRasterCacheKey { kind: FullSurface, stable_id: None, ... }
a miss must be paid once, not every frame -- the probing path and the storing
path have to name the surface the same way. Run with
CRANPOSE_LAYER_CACHE_DIAG=1 to see which path probed it.
```

## Tests

`crates/cranpose-render/wgpu/tests/glass_layer_cache.rs` runs the scene through
the full composition pipeline and asserts per-frame counters. Verified failing
on the pre-fix source with the test in place:

```
a_still_glass_scene_leaves_no_layer_cache_misses
  FrameCacheStats { hits: 14, misses: 7, blur_passes: 0, isolated_layer_renders: 7 }
an_animated_overlay_leaves_still_glass_rows_fully_cached
  FrameCacheStats { hits: 12, misses: 9, blur_passes: 1, isolated_layer_renders: 7 }
```

Both are `misses: 0` / `misses: 2` after the fix. `just test`: 4644 passed, 0
failed, with the frame-level guard live.

One existing assertion in `effect_semantics.rs` had its lower bound beaten --
the moved frame now needs zero isolated re-renders where it asserted one to
two. Upper bound kept, cache-hit assertion added.

## Result

`glass_lazy_scroll`, 20s, samarch-1 on a real display (`DISPLAY=:0`, not xvfb,
which measures software presentation):

| | hit rate | isolated layers/frame | isolated pixels/frame | evictions | fps |
|---|---|---|---|---|---|
| before | 29.92% | 7 | 1,106,754 | 0 | 67.0 |
| after | **44.23%** | **1** | **120,322** | 0 | 64.6 |

Isolated repaint work per scrolling frame drops 9.2x. FPS is unchanged within
noise -- run-to-run spread of the same binary on that shared GPU is wider than
the effect. The win the drag-only metric does not reward is that a still glass
scene now costs no render work at all; it previously never settled, because
every phantom miss re-armed the warmup.

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)