### PR TITLE
Stop the source toggle displacing every tab, and anchor the underline check

### DIFF
--- a/apps/desktop-demo/robot-runners/robot_regression_fused_viewport_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_regression_fused_viewport_contract.rs
@@ -15,11 +15,30 @@ use std::{
 
 use cranpose::AppLauncher;
 use cranpose_testing::find_text_in_semantics;
-use desktop_app::app::{self, TEST_ACTIVE_TAB_STATE};
+use desktop_app::app::{self, DEMO_TABS, TEST_ACTIVE_TAB_STATE};
 use image::RgbaImage;
 
 const WINDOW_WIDTH: u32 = 900;
 const WINDOW_HEIGHT: u32 = 800;
+
+/// The bottom edge of the tab strip, measured rather than assumed.
+///
+/// Anything above this line is behind the chrome and cannot be expected to
+/// have rendered, whatever the chrome happens to contain. A literal here
+/// silently becomes wrong the moment the strip changes height -- which is
+/// what a source-view toggle above the tab content did to five robot tests.
+fn chrome_bottom(robot: &cranpose::Robot) -> f32 {
+    let measured = DEMO_TABS
+        .iter()
+        .filter_map(|tab| find_text_in_semantics(robot, tab.label()))
+        .map(|(_, y, _, h)| y + h)
+        .fold(0.0f32, f32::max);
+    assert!(
+        measured > 0.0,
+        "no tab label found in semantics: the chrome probe cannot measure what it is guarding against"
+    );
+    measured
+}
 
 fn main() {
     let _ = env_logger::try_init();
@@ -48,6 +67,8 @@ fn main() {
                 .invoke_app_hook("set-tab", "shaderrect")
                 .expect("select shaderrect tab");
             settle(&robot, 800);
+            let chrome_bottom = chrome_bottom(&robot);
+            println!("chrome bottom measured at y={chrome_bottom:.1}");
             let texts = [
                 "Fire Shader — Animated Flame Border",
                 "SDF Halo Border",
@@ -60,7 +81,8 @@ fn main() {
                     if let Some((x, y, w, h)) = find_text_in_semantics(&robot, label) {
                         let ink = count_ink(&shot, x, y, w, h);
                         println!("initial '{label}' at ({x:.0},{y:.0}) ink={ink}");
-                        let fully_visible = y > 100.0 && y + h < WINDOW_HEIGHT as f32 - 10.0;
+                        let fully_visible =
+                            y > chrome_bottom && y + h < WINDOW_HEIGHT as f32 - 10.0;
                         if fully_visible && ink < 40 {
                             fail(
                                 &robot,
@@ -80,7 +102,8 @@ fn main() {
                 let mut line = format!("step={step}");
                 for label in texts {
                     if let Some((x, y, w, h)) = find_text_in_semantics(&robot, label) {
-                        let visible = y + h > 100.0 && y < WINDOW_HEIGHT as f32 - 10.0;
+                        let visible =
+                            y + h > chrome_bottom && y < WINDOW_HEIGHT as f32 - 10.0;
                         if visible {
                             let ink = count_ink(&shot, x, y, w, h);
                             line.push_str(&format!(" | {label}: y={y:.0} ink={ink}"));

--- a/apps/desktop-demo/robot-runners/robot_scroll_decoration_invariance.rs
+++ b/apps/desktop-demo/robot-runners/robot_scroll_decoration_invariance.rs
@@ -25,7 +25,13 @@ const TARGET_TEXT: &str =
 const CAPTURE_SCALE: f32 = 2.0;
 const UNDERLINE_TRACK_STEPS: usize = 12;
 const UNDERLINE_TRACK_SCROLL_DELTA_Y: f32 = -0.7;
-const UNDERLINE_LOCAL_Y_TOLERANCE: f32 = 0.35;
+/// The underline is rasterised onto the pixel grid while the semantic bounds
+/// it is measured against stay unsnapped, so their difference must swing by up
+/// to one snap step as a fractional scroll sweeps the phase. That swing is
+/// correct rendering. What must not happen is the swing widening, or the row
+/// walking away from the text.
+const UNDERLINE_LOCAL_Y_SPREAD: f32 = 0.5;
+const UNDERLINE_LOCAL_Y_TREND: f32 = 0.25;
 const MIN_NORMALIZED_TEXT_INK_PIXELS: usize = 500;
 
 fn main() {
@@ -91,14 +97,31 @@ fn verify_underline_row_tracks_fractional_scroll(robot: &cranpose::Robot) {
         }
     }
 
-    let baseline = samples[0];
-    for (step, local_y) in samples.iter().copied().enumerate().skip(1) {
-        let drift = (local_y - baseline).abs();
-        assert!(
-            drift <= UNDERLINE_LOCAL_Y_TOLERANCE,
-            "underlined span decoration row drifted relative to text bounds at step {step}: baseline={baseline:.3} local_y={local_y:.3} drift={drift:.3}"
-        );
-    }
+    // Anchoring on samples[0] would make this test pass or fail on where the
+    // first sample happened to land in that swing: with a 0.40-wide swing and
+    // a 0.35 tolerance, a run starting at the floor of the swing failed while
+    // the identical rendering starting mid-swing passed. Both bounds below are
+    // independent of where the sweep starts.
+    let min = samples.iter().copied().fold(f32::INFINITY, f32::min);
+    let max = samples.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let spread = max - min;
+    assert!(
+        spread <= UNDERLINE_LOCAL_Y_SPREAD,
+        "underlined span decoration row swings wider than one snap step: min={min:.3} max={max:.3} spread={spread:.3} samples={samples:?}"
+    );
+
+    // A row that is slowly walking away from its text stays inside the spread
+    // bound for as long as the walk is smaller than a snap step per sweep, so
+    // compare where the sweep starts against where it ends.
+    let half = samples.len() / 2;
+    let mean = |values: &[f32]| values.iter().sum::<f32>() / values.len() as f32;
+    let first_half = mean(&samples[..half]);
+    let second_half = mean(&samples[half..]);
+    let trend = (second_half - first_half).abs();
+    assert!(
+        trend <= UNDERLINE_LOCAL_Y_TREND,
+        "underlined span decoration row is walking away from its text: first_half={first_half:.3} second_half={second_half:.3} trend={trend:.3} samples={samples:?}"
+    );
 }
 
 fn find_presented_underline_row(

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -409,7 +409,10 @@ fn TabButton(tab: DemoTab, active_tab: cranpose_core::MutableState<DemoTab>, pad
 
 #[allow(non_snake_case)]
 #[composable]
-fn TabBarHorizontal(active_tab: cranpose_core::MutableState<DemoTab>) {
+fn TabBarHorizontal(
+    active_tab: cranpose_core::MutableState<DemoTab>,
+    showing_source: cranpose_core::MutableState<bool>,
+) {
     let tabs_scroll_state =
         cranpose_core::remember(|| cranpose_ui::ScrollState::new(0.0)).with(|state| *state);
     Row(
@@ -431,6 +434,10 @@ fn TabBarHorizontal(active_tab: cranpose_core::MutableState<DemoTab>) {
                     for tab in DEMO_TABS {
                         TabButton(tab, active_tab, 10.0);
                     }
+                    // Last in the strip: the tabs keep their positions, the
+                    // content below keeps its height, and nothing is drawn
+                    // over a tab that has to stay clickable.
+                    source_view::SourceToggleButton(showing_source, Modifier::empty());
                 },
             );
         },
@@ -443,31 +450,26 @@ fn TabContent(
     active_tab: cranpose_core::MutableState<DemoTab>,
     startup: StartupSelection,
     winamp_tab_state: WinampTabState,
+    showing_source: cranpose_core::MutableState<bool>,
     modifier: Modifier,
 ) {
     let active = active_tab.get();
-    let showing_source = cranpose_core::rememberMutableStateOf(|| false);
+    // The source panel replaces the tab's content rather than sitting above it.
+    // A control that pushes every tab down costs each one a row of height for
+    // a button they are not using, and moves content the renderer's e2e suite
+    // measures against the window.
     cranpose_ui::Box(modifier.clip_to_bounds(), BoxSpec::default(), move || {
-        Column(
-            Modifier::empty().fill_max_size(),
-            ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(6.0)),
-            move || {
-                source_view::SourceToggleButton(showing_source);
-                if showing_source.get() {
-                    source_view::SourcePanel(active);
+        if showing_source.get() {
+            source_view::SourcePanel(active);
+        } else {
+            cranpose_core::with_key(&active, || {
+                if tab_requires_scroll(active) {
+                    ScrollableTab(move || render_active_tab(active, startup, winamp_tab_state));
                 } else {
-                    cranpose_core::with_key(&active, || {
-                        if tab_requires_scroll(active) {
-                            ScrollableTab(move || {
-                                render_active_tab(active, startup, winamp_tab_state)
-                            });
-                        } else {
-                            render_active_tab(active, startup, winamp_tab_state);
-                        }
-                    });
+                    render_active_tab(active, startup, winamp_tab_state);
                 }
-            },
-        );
+            });
+        }
     });
 }
 
@@ -499,11 +501,13 @@ pub fn combined_app_with_startup(startup: StartupSelection) {
         *cell.borrow_mut() = Some(active_tab);
     });
 
+    let showing_source = cranpose_core::rememberMutableStateOf(|| false);
+
     Column(
         Modifier::empty().fill_max_size(),
         ColumnSpec::default(),
         move || {
-            TabBarHorizontal(active_tab);
+            TabBarHorizontal(active_tab, showing_source);
 
             Spacer(Size {
                 width: 0.0,
@@ -514,6 +518,7 @@ pub fn combined_app_with_startup(startup: StartupSelection) {
                 active_tab,
                 startup,
                 winamp_tab_state,
+                showing_source,
                 Modifier::empty().fill_max_width().weight(1.0).padding_each(
                     DEMO_PAGE_PADDING,
                     0.0,

--- a/apps/desktop-demo/src/app/source_view.rs
+++ b/apps/desktop-demo/src/app/source_view.rs
@@ -92,14 +92,14 @@ enum SourceState {
 /// Toggles the source panel for the active tab.
 #[allow(non_snake_case)]
 #[composable]
-pub(crate) fn SourceToggleButton(showing: MutableState<bool>) {
+pub(crate) fn SourceToggleButton(showing: MutableState<bool>, modifier: Modifier) {
     let label = if showing.get() {
         "Hide source"
     } else {
         "Show source"
     };
     Button(
-        Modifier::empty().padding(8.0),
+        modifier.rounded_corners(12.0).padding(10.0),
         ButtonSpec::default(),
         move || showing.set(!showing.get()),
         move || {


### PR DESCRIPTION
`main`'s robot suite has been red since `21401f67`, on five tests. This is that
regression, and it is mine: the source toggle shipped in a **new row above the
tab content**, pushing every tab down 41.6px.

It also blocks both other open PRs -- #484 and #485 each fail exactly one
check, `robot e2e`, with six passing, purely by being branched off red `main`.

## What it was not

Each of these was a suspect I argued for and then killed by experiment rather
than by reasoning:

| suspect | how it died |
|---|---|
| host contention (`cpu_mhz=800`) | the five tests **pass** on the last-green commit under today's conditions |
| `opt-level = 3` on nine crates | removing the block from `main` gave **byte-identical** output and the same failure |
| the `rust-toolchain.toml` pin | `stable` **is** 1.98.0 on that host, same commit hash |

## What it was

`da4bf847` and `main` render the underline **identically** -- same 0.40-wide
band, same 866 red pixels, same 433-pixel run. Only the starting phase moved:

| | content top | sample[0] | max deviation | tolerance |
|---|---|---|---|---|
| before the toggle | 599.40 | 26.350 (mid-swing) | 0.30 | 0.35 |
| with the toggle | 641.00 | 26.250 (swing floor) | **0.40** | 0.35 |

## The placement

The toggle now rides at the end of the tab strip, styled as the tab button it
sits beside, and the source panel replaces the tab's content rather than
sitting above it. Two placements were wrong before this one, and the suite
caught both rather than review doing so:

| | content height | strip width | tab clicks |
|---|---|---|---|
| new row above content (shipped) | ✗ shifted 41.6px | ✓ | ✓ |
| a share of the row's width | ✓ | ✗ `Shaders` stopped being laid out | ✓ |
| overlaying the strip's end | ✓ | ✓ | ✗ swallowed clicks meant for tabs |
| last item in the strip | ✓ | ✓ | ✓ |

Content is back at `semantic_y=599.40`, the value it had before the toggle
existed -- a restoration, not a tolerance tuned until it stopped complaining.

## Two tests that were complicit

**`robot_scroll_decoration_invariance` only ever passed by luck.** The
underline is rasterised onto the pixel grid while the semantic bounds it is
measured against stay unsnapped, so their difference must swing by one snap
step as a fractional scroll sweeps the phase. Comparing every sample against
`samples[0]` with a tolerance *narrower than that swing* cannot hold for every
phase. It now bounds the **spread**, which is what "does not drift" means when
one end of the measurement is snapped, and separately compares the first half
of the sweep against the second -- a row walking away from its text slower than
a snap step per sweep would sit inside a spread bound alone. Against the real
captures: trend 0.002 before, 0.062 after, both well inside 0.25.

**`robot_regression_fused_viewport_contract` hard-coded the chrome height** as
`y + h > 100.0`. That literal is how it became complicit: a taller chrome turns
occluded content into a reported culling bug, and the number gives no hint that
it is the thing that went stale. It now measures the tab strip's bottom from
semantics, and asserts it found a tab to measure so it cannot decay into
guarding nothing. Measured: **y=65.6** against the assumed 100.0 -- so the probe
now checks a 34px band it used to skip. Stricter than the literal it replaces.

## Gates

`just test` 4644 passed / 0 failed, `just robot-gpu` **152 passed / 0 failed**,
`just clippy`, `just clippy-wasm`, `just fmt-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)