### PR TITLE
Ask the iOS picker for a directory, not a folder

### DIFF
--- a/crates/cranpose/src/ios_file_picker.rs
+++ b/crates/cranpose/src/ios_file_picker.rs
@@ -37,7 +37,7 @@ use objc2_ui_kit::{
     UIApplication, UIDocumentPickerDelegate, UIDocumentPickerViewController, UIViewController,
     UIWindowScene,
 };
-use objc2_uniform_type_identifiers::{UTType, UTTypeFolder, UTTypeItem};
+use objc2_uniform_type_identifiers::{UTType, UTTypeDirectory, UTTypeItem};
 
 /// Installs the iOS chooser as the platform file picker.
 pub(crate) fn register() {
@@ -245,10 +245,26 @@ fn present(
 
 fn present_open(kind: Kind, multiple: bool) -> PickerFuture<PickResult> {
     present(move |mtm| {
-        // SAFETY: `UTTypeItem`/`UTTypeFolder` are immutable framework constants.
+        // `public.directory`, not `public.folder`. The picker enables a
+        // provider only if it can vend something conforming to the type asked
+        // for, and Apple defines these as
+        //
+        //     public.folder     a user-browsable directory (i.e. not a
+        //                       package); conforms to public.directory
+        //     public.directory  a file system directory (includes packages
+        //                       AND folders); conforms to public.item
+        //
+        // so `public.folder` is the narrow one, and asking for it disables
+        // every provider whose directories are not typed as that exact kind.
+        // What this picker is for is a directory to walk, which is what
+        // `public.directory` means; a folder conforms to it, so nothing that
+        // matched before stops matching.
+        //
+        // SAFETY: `UTTypeItem`/`UTTypeDirectory` are immutable framework
+        // constants.
         let ty: &UTType = match kind {
             Kind::File => unsafe { UTTypeItem },
-            Kind::Folder => unsafe { UTTypeFolder },
+            Kind::Folder => unsafe { UTTypeDirectory },
         };
         let picker = UIDocumentPickerViewController::initForOpeningContentTypes(
             UIDocumentPickerViewController::alloc(mtm),


### PR DESCRIPTION
Reported from an iPhone: CranAmp can pick a single file through a Tailscale-provided location, and the same row is **greyed out** when the folder picker opens.

`UIDocumentPickerViewController` enables a provider only if it can vend something conforming to the type it was asked for, and `present_open` asked for the narrower of the two directory types. Apple's own definitions:

| type | meaning | conforms to |
|---|---|---|
| `public.folder` | a user-browsable directory (i.e. **not** a package) | `public.directory` |
| `public.directory` | a file system directory (includes packages **and** folders) | `public.item` |

So `public.folder` is the narrow one, and asking for it disables every provider whose directories are not typed as that exact kind. It was never the type this picker wanted: what a caller of `pick_folder` needs is *a directory to walk*, which is precisely `public.directory`. A folder conforms to it, so nothing that matched before stops matching — this only widens the set.

## What this does not claim

Whether it is what greys out that particular row is **not settled**. A provider that vends no directories at all stays disabled either way, and confirming which it is takes eyes on the dialog — which I could not get: the device is paired to Xcode over the network rather than USB, so libimobiledevice cannot see it and there is no screenshot path.

The narrowing is a defect regardless of how that question resolves.

## Verification

`cargo check -p cranpose --target aarch64-apple-ios --no-default-features --features ios,renderer-wgpu` — clean, zero warnings. (That is the feature set the apps ship: `cranamp`'s `ios = ["cranpose/ios", "renderer-wgpu"]`, and `platform/ios/build-app.sh` passes `--no-default-features --features ios`.)

No test. The choice is a framework constant handed to a UIKit view controller; there is nothing headless to observe about which providers a picker enables, and the app builds do not run iOS tests. The comment in the source carries the reasoning instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)