### PR TITLE
One live activity takes every incoming share

### DIFF
--- a/crates/cranpose-core/src/concurrency.rs
+++ b/crates/cranpose-core/src/concurrency.rs
@@ -549,6 +549,7 @@ fn deliver_bridged<T: Send + 'static>(bridge: u64, event: T) {
     let Some(channel) = channel else {
         // The composition that asked for these events is gone; dropping the
         // event here is the whole point of scoping the stream to it.
+        log::debug!("event bridge {bridge} is gone, one event dropped");
         return;
     };
     if let Ok(channel) = channel.downcast::<EventChannel<T>>() {

--- a/crates/cranpose-services/src/incoming_share.rs
+++ b/crates/cranpose-services/src/incoming_share.rs
@@ -193,6 +193,10 @@ pub fn observe_incoming_content(
         };
         inbox.observe(id, Arc::clone(&observer))
     };
+    log::info!(
+        "incoming share: observer {id} registered, replays {} item(s)",
+        replay.len()
+    );
     for item in replay {
         observer(item);
     }
@@ -208,8 +212,17 @@ pub fn publish_incoming_content(content: IncomingContent) {
         };
         inbox.publish(content.clone())
     }) else {
+        log::info!(
+            "incoming share: no observer yet, item {} waits in the backlog",
+            content.display_name()
+        );
         return;
     };
+    log::info!(
+        "incoming share: item {} goes to {} observer(s)",
+        content.display_name(),
+        observers.len()
+    );
     // Every observer sees every item: two screens can each react to a share.
     for observer in observers {
         observer(content.clone());

--- a/crates/cranpose-services/tests/incoming_share_delivery.rs
+++ b/crates/cranpose-services/tests/incoming_share_delivery.rs
@@ -1,0 +1,155 @@
+//! A share must reach the application's collector no matter when it arrives:
+//! before the first composition, during one, or between two of them.
+//!
+//! These tests walk the same road the Android host walks:
+//! `publish_incoming_content` from a platform thread, and an application
+//! composition that collects `rememberIncomingContent()` with `CollectEvents`.
+//! They live in one file on purpose: the inbox is process-global, and this
+//! binary runs its tests one at a time via a shared lock so two tests never
+//! interleave their publishes.
+
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    sync::{Mutex, MutexGuard, OnceLock},
+    time::{Duration, Instant},
+};
+
+use cranpose_core::{CollectEvents, Composition, MemoryApplier, location_key};
+use cranpose_services::{
+    IncomingContent, clear_incoming_content, publish_incoming_content, rememberIncomingContent,
+};
+
+fn serial() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+}
+
+fn pump_until(composition: &mut Composition<MemoryApplier>, done: impl Fn() -> bool) -> bool {
+    let runtime = composition.runtime_handle();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        runtime.drain_ui();
+        if done() {
+            return true;
+        }
+        std::thread::yield_now();
+    }
+    done()
+}
+
+fn item(name: &str) -> IncomingContent {
+    IncomingContent::from_bytes(vec![1, 2, 3]).with_name(name)
+}
+
+fn render_collector(
+    composition: &mut Composition<MemoryApplier>,
+    key: cranpose_core::Key,
+    seen: &Rc<RefCell<Vec<String>>>,
+) {
+    let sink = Rc::clone(seen);
+    composition
+        .render(key, move || {
+            let shared = rememberIncomingContent();
+            let sink = Rc::clone(&sink);
+            CollectEvents(shared, (), move |item: IncomingContent| {
+                sink.borrow_mut().push(item.display_name());
+            });
+        })
+        .expect("render succeeds");
+}
+
+#[test]
+fn a_share_published_before_the_first_composition_is_imported() {
+    let _guard = serial();
+    clear_incoming_content();
+
+    publish_incoming_content(item("early.png"));
+
+    let mut composition = Composition::new(MemoryApplier::new());
+    let key = location_key(file!(), line!(), column!());
+    let seen = Rc::new(RefCell::new(Vec::new()));
+    render_collector(&mut composition, key, &seen);
+
+    assert!(
+        pump_until(&mut composition, || !seen.borrow().is_empty()),
+        "the share from before the first composition never reached the collector"
+    );
+    assert_eq!(*seen.borrow(), vec!["early.png".to_string()]);
+}
+
+#[test]
+fn a_share_published_while_the_composition_lives_is_imported() {
+    let _guard = serial();
+    clear_incoming_content();
+
+    let mut composition = Composition::new(MemoryApplier::new());
+    let key = location_key(file!(), line!(), column!());
+    let seen = Rc::new(RefCell::new(Vec::new()));
+    render_collector(&mut composition, key, &seen);
+    assert!(pump_until(&mut composition, || true));
+
+    let publisher = std::thread::spawn(|| publish_incoming_content(item("warm.png")));
+    publisher.join().expect("publisher thread finishes");
+
+    assert!(
+        pump_until(&mut composition, || !seen.borrow().is_empty()),
+        "the share published into the live composition never reached the collector"
+    );
+    assert_eq!(*seen.borrow(), vec!["warm.png".to_string()]);
+}
+
+#[test]
+fn a_share_published_between_two_compositions_is_imported_by_the_second() {
+    let _guard = serial();
+    clear_incoming_content();
+
+    let key = location_key(file!(), line!(), column!());
+    {
+        let mut first = Composition::new(MemoryApplier::new());
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        render_collector(&mut first, key, &seen);
+        assert!(pump_until(&mut first, || true));
+    }
+
+    publish_incoming_content(item("between.png"));
+
+    let mut second = Composition::new(MemoryApplier::new());
+    let seen = Rc::new(RefCell::new(Vec::new()));
+    render_collector(&mut second, key, &seen);
+
+    assert!(
+        pump_until(&mut second, || !seen.borrow().is_empty()),
+        "the share published between two compositions never reached the second collector"
+    );
+    assert_eq!(*seen.borrow(), vec!["between.png".to_string()]);
+}
+
+#[test]
+fn a_share_published_during_first_render_before_effects_is_imported() {
+    let _guard = serial();
+    clear_incoming_content();
+
+    let mut composition = Composition::new(MemoryApplier::new());
+    let key = location_key(file!(), line!(), column!());
+    let seen = Rc::new(RefCell::new(Vec::new()));
+    let sink = Rc::clone(&seen);
+    composition
+        .render(key, move || {
+            let shared = rememberIncomingContent();
+            publish_incoming_content(item("mid-render.png"));
+            let sink = Rc::clone(&sink);
+            CollectEvents(shared, (), move |item: IncomingContent| {
+                sink.borrow_mut().push(item.display_name());
+            });
+        })
+        .expect("render succeeds");
+
+    assert!(
+        pump_until(&mut composition, || !seen.borrow().is_empty()),
+        "the share published during the first render never reached the collector"
+    );
+    assert_eq!(*seen.borrow(), vec!["mid-render.png".to_string()]);
+}

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
@@ -1927,20 +1927,27 @@ public class CranposeActivity extends NativeActivity {
             }
         }
         String mimeType = intent.getType() == null ? "" : intent.getType();
+        android.util.Log.i("cranpose", "incoming share: " + uris.size()
+                + " uri(s), type " + mimeType);
         // The URI is published, not the bytes: the framework opens it through the
         // content resolver when the application actually reads it, so sharing a
         // multi-gigabyte video costs nothing until it is used.
         new Thread(() -> {
             for (Uri uri : uris) {
                 if (!"content".equalsIgnoreCase(uri.getScheme())) {
+                    android.util.Log.i("cranpose",
+                            "incoming share: skipped, scheme " + uri.getScheme());
                     continue;
                 }
                 try {
                     android.content.pm.ProviderInfo provider =
                             getPackageManager().resolveContentProvider(uri.getAuthority(), 0);
                     if (provider != null && getPackageName().equals(provider.packageName)) {
+                        android.util.Log.i("cranpose",
+                                "incoming share: skipped, own provider " + uri.getAuthority());
                         continue;
                     }
+                    android.util.Log.i("cranpose", "incoming share: to native, " + uri);
                     nativeOnIncomingContent(
                             sanitize(displayName(uri, "shared")), mimeType, uri.toString());
                 } catch (Exception error) {

--- a/crates/cranpose/android/manifests/base.xml
+++ b/crates/cranpose/android/manifests/base.xml
@@ -17,6 +17,7 @@
         <activity
             android:name="dev.cranpose.android.CranposeActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:label="${cranposeLabel}"
             android:theme="${cranposeTheme}"
             android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout|uiMode|layoutDirection|fontScale|density">

--- a/crates/cranpose/src/android_services.rs
+++ b/crates/cranpose/src/android_services.rs
@@ -1096,9 +1096,14 @@ pub extern "system" fn Java_dev_cranpose_android_CranposeActivity_nativeOnIncomi
         }
         Ok(shared)
     });
-    if let Outcome::Ok(shared) = shared.into_outcome() {
-        publish_incoming_content(shared);
-        wake_native_loop();
+    match shared.into_outcome() {
+        Outcome::Ok(shared) => {
+            publish_incoming_content(shared);
+            wake_native_loop();
+        }
+        Outcome::Err(_) | Outcome::Panic(_) => {
+            log::warn!("incoming share: the strings did not decode");
+        }
     }
 }
 


### PR DESCRIPTION
The library manifest gave CranposeActivity no launch mode. A share picked in the system sheet then made a second activity in a new task, and that second activity started a second native loop in the same process: the loop waker and the platform service handles are process statics, so the second register overwrote the first. The shared item went to the collector of the hidden first instance, and the visible second instance showed an empty application. Reproduced with CranScan 1.0.19 on a Pixel 9 Pro and on an emulator.

The activity now declares launchMode singleTask, so every cranpose application keeps one live instance: a share goes to it over onNewIntent, or starts it cold, and the inbox backlog holds items published before the first collector registers. An application manifest can still override the attribute in its own activity entry.

Four integration tests in crates/cranpose-services/tests/incoming_share_delivery.rs pin delivery on the cold, warm, mid-render, and between-compositions roads. The share road also leaves a short trail now: the Java side logs the uri count and the skip reasons, the inbox logs backlog and delivery, and a JNI string that does not decode logs a warning instead of returning in silence.

Verified end to end with CranScan on a Pixel 9 Pro through the Photos share sheet: one activity record, the image imports, the document shows with the parsed sum. cargo test, fmt, and clippy are clean for the touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)