### PR TITLE
Report memory pressure and guard the background service ask

### DIFF
--- a/crates/cranpose-services/src/lib.rs
+++ b/crates/cranpose-services/src/lib.rs
@@ -168,8 +168,8 @@ pub use media::{
     uri_for_path,
 };
 pub use memory_pressure::{
-    observe_memory_pressure, publish_memory_pressure, rememberMemoryPressure, MemoryPressure,
-    MemoryPressureObserver,
+    MemoryPressure, MemoryPressureObserver, observe_memory_pressure, publish_memory_pressure,
+    rememberMemoryPressure,
 };
 pub use navigation::{
     BackRequestObserver, back_interception_enabled, exit_requested, observe_back_requests,

--- a/crates/cranpose-services/src/lib.rs
+++ b/crates/cranpose-services/src/lib.rs
@@ -24,6 +24,7 @@ pub mod incoming_share;
 pub mod launch_args;
 pub mod launcher;
 pub mod media;
+pub mod memory_pressure;
 pub mod navigation;
 pub mod network_status;
 pub mod notifier;
@@ -165,6 +166,10 @@ pub use media::{
     set_media_looping, set_media_metadata, set_media_speed, set_media_volume,
     set_platform_media_player, set_platform_media_source_opener, stop_media, toggle_media,
     uri_for_path,
+};
+pub use memory_pressure::{
+    observe_memory_pressure, publish_memory_pressure, rememberMemoryPressure, MemoryPressure,
+    MemoryPressureObserver,
 };
 pub use navigation::{
     BackRequestObserver, back_interception_enabled, exit_requested, observe_back_requests,

--- a/crates/cranpose-services/src/memory_pressure.rs
+++ b/crates/cranpose-services/src/memory_pressure.rs
@@ -7,11 +7,11 @@
 //! pools.
 
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
     Arc, Mutex, OnceLock,
+    atomic::{AtomicU64, Ordering},
 };
 
-use cranpose_core::{rememberEventStream, EventStream};
+use cranpose_core::{EventStream, rememberEventStream};
 
 /// How hard the platform asks for memory back.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/cranpose-services/src/memory_pressure.rs
+++ b/crates/cranpose-services/src/memory_pressure.rs
@@ -1,0 +1,228 @@
+//! Memory pressure the platform reports for this process.
+//!
+//! Android delivers it through `onTrimMemory`; other hosts publish their own
+//! signal. There is no backlog: pressure describes a moment, so an observer
+//! that registers later waits for the next report. Applications collect the
+//! stream and give back what they can rebuild — caches, warm model sessions,
+//! pools.
+
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Mutex, OnceLock,
+};
+
+use cranpose_core::{rememberEventStream, EventStream};
+
+/// How hard the platform asks for memory back.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MemoryPressure {
+    /// The UI left the screen. Anything held only to draw the next frame fast
+    /// can go.
+    UiHidden,
+    /// The process should give back what it can rebuild.
+    Low,
+    /// The system reclaims by force next. Free everything that can go.
+    Critical,
+}
+
+impl MemoryPressure {
+    /// Maps an Android `ComponentCallbacks2` trim level.
+    pub fn from_android_trim_level(level: i32) -> Self {
+        match level {
+            20 => Self::UiHidden,
+            level if level >= 60 || level == 15 => Self::Critical,
+            _ => Self::Low,
+        }
+    }
+}
+
+type Observer = Arc<dyn Fn(MemoryPressure) + Send + Sync>;
+
+struct Registry {
+    observers: Vec<(u64, Observer)>,
+}
+
+impl Registry {
+    fn new() -> Self {
+        Self {
+            observers: Vec::new(),
+        }
+    }
+
+    fn observe(&mut self, id: u64, observer: Observer) {
+        self.observers.push((id, observer));
+    }
+
+    /// The observers a report should reach. Handed back rather than run here
+    /// so the caller can leave the lock before running application code.
+    fn publish(&self) -> Vec<Observer> {
+        self.observers
+            .iter()
+            .map(|(_, observer)| Arc::clone(observer))
+            .collect()
+    }
+
+    fn remove_observer(&mut self, id: u64) {
+        self.observers.retain(|(existing, _)| *existing != id);
+    }
+}
+
+fn registry() -> &'static Mutex<Registry> {
+    static REGISTRY: OnceLock<Mutex<Registry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(Registry::new()))
+}
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Keeps an observer registered until it is dropped.
+pub struct MemoryPressureObserver {
+    id: u64,
+}
+
+impl Drop for MemoryPressureObserver {
+    fn drop(&mut self) {
+        if let Ok(mut registry) = registry().lock() {
+            registry.remove_observer(self.id);
+        }
+    }
+}
+
+/// Registers `observer` for pressure reports.
+///
+/// Applications collect the stream from [`rememberMemoryPressure`] instead of
+/// calling this.
+pub fn observe_memory_pressure(
+    observer: impl Fn(MemoryPressure) + Send + Sync + 'static,
+) -> MemoryPressureObserver {
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    if let Ok(mut registry) = registry().lock() {
+        registry.observe(id, Arc::new(observer));
+    }
+    MemoryPressureObserver { id }
+}
+
+/// Publishes a pressure report. Callable from any thread; the framework moves
+/// each report onto the UI thread before a composition sees it.
+pub fn publish_memory_pressure(pressure: MemoryPressure) {
+    let observers = {
+        let Ok(registry) = registry().lock() else {
+            return;
+        };
+        registry.publish()
+    };
+    for observer in observers {
+        observer(pressure);
+    }
+}
+
+/// Collects pressure reports for as long as this call stays in the
+/// composition.
+///
+/// ```rust,no_run
+/// use cranpose_macros::composable;
+/// use cranpose_services::rememberMemoryPressure;
+///
+/// #[composable]
+/// fn Caches() {
+///     let pressure = rememberMemoryPressure();
+///     cranpose_core::CollectEvents(pressure, (), |report| {
+///         log::info!("memory pressure: {report:?}");
+///     });
+/// }
+/// ```
+#[allow(non_snake_case)]
+pub fn rememberMemoryPressure() -> EventStream<MemoryPressure> {
+    rememberEventStream((), |sender| {
+        observe_memory_pressure(move |pressure| sender.send(pressure))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn recording_observer() -> (Observer, Arc<Mutex<Vec<MemoryPressure>>>) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let recorder = Arc::clone(&seen);
+        let observer: Observer = Arc::new(move |pressure| {
+            recorder
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push(pressure)
+        });
+        (observer, seen)
+    }
+
+    /// These exercise `Registry` directly rather than the process-global one,
+    /// for the same reason the incoming-share tests do: the global is shared
+    /// by every test in this binary and the harness runs them on parallel
+    /// threads.
+    #[test]
+    fn trim_levels_map_to_the_three_kinds() {
+        assert_eq!(
+            MemoryPressure::from_android_trim_level(20),
+            MemoryPressure::UiHidden
+        );
+        for level in [5, 10, 40] {
+            assert_eq!(
+                MemoryPressure::from_android_trim_level(level),
+                MemoryPressure::Low
+            );
+        }
+        for level in [15, 60, 80] {
+            assert_eq!(
+                MemoryPressure::from_android_trim_level(level),
+                MemoryPressure::Critical
+            );
+        }
+    }
+
+    #[test]
+    fn publish_reaches_every_observer() {
+        let mut registry = Registry::new();
+        let (first, first_seen) = recording_observer();
+        let (second, second_seen) = recording_observer();
+        registry.observe(1, first);
+        registry.observe(2, second);
+
+        for observer in registry.publish() {
+            observer(MemoryPressure::Critical);
+        }
+
+        for seen in [first_seen, second_seen] {
+            assert_eq!(
+                seen.lock().unwrap_or_else(|e| e.into_inner()).as_slice(),
+                [MemoryPressure::Critical]
+            );
+        }
+    }
+
+    #[test]
+    fn a_removed_observer_stops_seeing_reports() {
+        let mut registry = Registry::new();
+        let (observer, seen) = recording_observer();
+        registry.observe(7, observer);
+
+        for observer in registry.publish() {
+            observer(MemoryPressure::Low);
+        }
+        registry.remove_observer(7);
+        for observer in registry.publish() {
+            observer(MemoryPressure::Low);
+        }
+
+        assert_eq!(
+            seen.lock().unwrap_or_else(|e| e.into_inner()).as_slice(),
+            [MemoryPressure::Low]
+        );
+    }
+
+    #[test]
+    fn a_report_with_no_observers_goes_nowhere() {
+        let registry = Registry::new();
+        assert!(
+            registry.publish().is_empty(),
+            "pressure describes a moment; nothing is kept for late observers"
+        );
+    }
+}

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
@@ -17,6 +17,8 @@ import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.os.VibratorManager;
@@ -516,28 +518,60 @@ public class CranposeActivity extends NativeActivity {
     private CranposeAccessibilityProvider cranposeAccessibilityProvider;
     private CranposeCamera cranposeCamera;
     private volatile CranposeMedia cranposeMedia;
+    /** How long a pause must last before the foreground service is asked for.
+     * Launch-shaped pauses — a screen-off start that pauses without ever
+     * resuming, an EMUI start that pauses and resumes together — get
+     * {@code startForegroundService} accepted but the service never created,
+     * and the framework then ends the process for the missing
+     * {@code startForeground}. A real backgrounding outlives this delay, and
+     * the delayed ask still lands inside the grace window Android grants an
+     * app that just left the foreground. */
+    private static final long BACKGROUND_SERVICE_ASK_DELAY_MS = 700;
+
+    /** Background-service state, all of it confined to the UI thread: JNI
+     * callers cross over in {@link #cranposeSetBackgroundActive}, and
+     * {@link #onPause} reads on the UI thread, so an off-thread write would be
+     * a data race. */
     private boolean cranposeBackgroundActive;
     private boolean cranposePaused;
-    // A launch with the screen off pauses without ever resuming. Asking for a
-    // foreground service from that state is a background start: the system
-    // accepts the request, never creates the service, and ends the process for
-    // the missing startForeground. Only an activity the user has actually seen
-    // may ask.
     private boolean cranposeEverResumed;
+    private final Handler cranposeBackgroundServiceHandler = new Handler(Looper.getMainLooper());
+    private final Runnable cranposeBackgroundServiceAsk = this::startCranposeBackgroundService;
 
     public void cranposeSetBackgroundActive(boolean active) {
-        cranposeBackgroundActive = active;
         runOnUiThread(() -> {
-            if (active && cranposePaused && cranposeEverResumed) {
-                startCranposeBackgroundService();
+            cranposeBackgroundActive = active;
+            if (active && cranposePaused) {
+                askForCranposeBackgroundService();
             } else if (!active) {
-                stopService(new Intent(this, CranposeBackgroundService.class));
+                cranposeBackgroundServiceHandler.removeCallbacks(cranposeBackgroundServiceAsk);
+                CranposeBackgroundService.stop(this);
             }
         });
     }
 
+    private void askForCranposeBackgroundService() {
+        if (!cranposeEverResumed) {
+            // A lifetime that never reached the foreground must not ask:
+            // Android accepts the call, defers creating the service while the
+            // screen is off, and ends the process when nothing calls
+            // startForeground.
+            return;
+        }
+        cranposeBackgroundServiceHandler.removeCallbacks(cranposeBackgroundServiceAsk);
+        cranposeBackgroundServiceHandler.postDelayed(
+                cranposeBackgroundServiceAsk, BACKGROUND_SERVICE_ASK_DELAY_MS);
+    }
+
     private void startCranposeBackgroundService() {
+        if (!cranposeBackgroundActive || !cranposePaused) {
+            // The world moved while the ask waited: the work finished, or the
+            // activity resumed. Starting now would leave a foreground service
+            // with nothing to protect.
+            return;
+        }
         Intent service = new Intent(this, CranposeBackgroundService.class);
+        CranposeBackgroundService.noteStartRequested();
         try {
             if (Build.VERSION.SDK_INT >= 26) {
                 startForegroundService(service);
@@ -1961,8 +1995,8 @@ public class CranposeActivity extends NativeActivity {
     @Override
     protected void onPause() {
         cranposePaused = true;
-        if (cranposeBackgroundActive && cranposeEverResumed) {
-            startCranposeBackgroundService();
+        if (cranposeBackgroundActive) {
+            askForCranposeBackgroundService();
         }
         if (cranposeCamera != null) {
             cranposeCamera.stop();
@@ -1975,7 +2009,8 @@ public class CranposeActivity extends NativeActivity {
         super.onResume();
         cranposePaused = false;
         cranposeEverResumed = true;
-        stopService(new Intent(this, CranposeBackgroundService.class));
+        cranposeBackgroundServiceHandler.removeCallbacks(cranposeBackgroundServiceAsk);
+        CranposeBackgroundService.stop(this);
     }
 
     private static final java.util.concurrent.atomic.AtomicBoolean cranposeTrimHookInstalled =
@@ -2017,7 +2052,8 @@ public class CranposeActivity extends NativeActivity {
 
     @Override
     protected void onDestroy() {
-        stopService(new Intent(this, CranposeBackgroundService.class));
+        cranposeBackgroundServiceHandler.removeCallbacks(cranposeBackgroundServiceAsk);
+        CranposeBackgroundService.stop(this);
         try {
             unregisterReceiver(cranposeUpdateInstallReceiver);
         } catch (IllegalArgumentException ignored) {

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
@@ -518,11 +518,17 @@ public class CranposeActivity extends NativeActivity {
     private volatile CranposeMedia cranposeMedia;
     private boolean cranposeBackgroundActive;
     private boolean cranposePaused;
+    // A launch with the screen off pauses without ever resuming. Asking for a
+    // foreground service from that state is a background start: the system
+    // accepts the request, never creates the service, and ends the process for
+    // the missing startForeground. Only an activity the user has actually seen
+    // may ask.
+    private boolean cranposeEverResumed;
 
     public void cranposeSetBackgroundActive(boolean active) {
         cranposeBackgroundActive = active;
         runOnUiThread(() -> {
-            if (active && cranposePaused) {
+            if (active && cranposePaused && cranposeEverResumed) {
                 startCranposeBackgroundService();
             } else if (!active) {
                 stopService(new Intent(this, CranposeBackgroundService.class));
@@ -1954,7 +1960,7 @@ public class CranposeActivity extends NativeActivity {
     @Override
     protected void onPause() {
         cranposePaused = true;
-        if (cranposeBackgroundActive) {
+        if (cranposeBackgroundActive && cranposeEverResumed) {
             startCranposeBackgroundService();
         }
         if (cranposeCamera != null) {
@@ -1967,6 +1973,7 @@ public class CranposeActivity extends NativeActivity {
     protected void onResume() {
         super.onResume();
         cranposePaused = false;
+        cranposeEverResumed = true;
         stopService(new Intent(this, CranposeBackgroundService.class));
     }
 

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
@@ -1869,6 +1869,7 @@ public class CranposeActivity extends NativeActivity {
     protected void onCreate(Bundle savedInstanceState) {
         loadCranposeNativeLibrary();
         super.onCreate(savedInstanceState);
+        installTrimMemoryHook();
         focusNativeContentView();
         installInsetsListener();
         registerNetworkCallback();
@@ -1977,10 +1978,31 @@ public class CranposeActivity extends NativeActivity {
         stopService(new Intent(this, CranposeBackgroundService.class));
     }
 
-    @Override
-    public void onTrimMemory(int level) {
-        super.onTrimMemory(level);
-        nativeOnTrimMemory(level);
+    private static final java.util.concurrent.atomic.AtomicBoolean cranposeTrimHookInstalled =
+            new java.util.concurrent.atomic.AtomicBoolean();
+
+    // Registered on the application context rather than overriding the
+    // activity's onTrimMemory: activity dispatch does not fire on every
+    // OEM build (seen absent on an EMUI Android 10 phone), while registered
+    // callbacks receive every trim on every version.
+    private void installTrimMemoryHook() {
+        if (!cranposeTrimHookInstalled.compareAndSet(false, true)) {
+            return;
+        }
+        getApplicationContext().registerComponentCallbacks(new android.content.ComponentCallbacks2() {
+            @Override
+            public void onTrimMemory(int level) {
+                nativeOnTrimMemory(level);
+            }
+
+            @Override
+            public void onConfigurationChanged(android.content.res.Configuration configuration) {}
+
+            @Override
+            public void onLowMemory() {
+                nativeOnTrimMemory(TRIM_MEMORY_COMPLETE);
+            }
+        });
     }
 
     @Override

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeActivity.java
@@ -80,6 +80,7 @@ import org.json.JSONObject;
 public class CranposeActivity extends NativeActivity {
     private static native boolean nativeOnBackInvoked();
     private static native void nativeOnIncomingContent(String name, String mimeType, String uri);
+    private static native void nativeOnTrimMemory(int level);
     private static native void nativeOnAppUpdateStatus(int kind, String version,
             String downloadUrl, long downloaded, long total, String message, String digest);
     private static native void nativeOnCameraFrame(byte[] nv12, int width, int height,
@@ -1967,6 +1968,12 @@ public class CranposeActivity extends NativeActivity {
         super.onResume();
         cranposePaused = false;
         stopService(new Intent(this, CranposeBackgroundService.class));
+    }
+
+    @Override
+    public void onTrimMemory(int level) {
+        super.onTrimMemory(level);
+        nativeOnTrimMemory(level);
     }
 
     @Override

--- a/crates/cranpose/android/java/dev/cranpose/android/CranposeBackgroundService.java
+++ b/crates/cranpose/android/java/dev/cranpose/android/CranposeBackgroundService.java
@@ -4,6 +4,7 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.ServiceInfo;
@@ -14,6 +15,35 @@ import android.os.IBinder;
 public final class CranposeBackgroundService extends Service {
     private static final int NOTIFICATION_ID = 0x4352414e;
     private static final String CHANNEL = "cranpose.background";
+
+    /** Main-thread handshake with {@link CranposeActivity}. Stopping a started
+     * foreground service before its {@code startForeground} has run is a
+     * deliberate framework kill ("Bringing down service while still waiting
+     * for start foreground"), and the caller cannot see from outside whether
+     * that obligation is still open — a background-work lease that closes
+     * moments after it opened lands the stop inside the window. The activity
+     * arms the record before every start, {@link #enterForeground} clears it,
+     * and a stop that arrives while it is armed waits for the service to
+     * honour it itself. */
+    private static boolean obligationArmed;
+    private static boolean stopRequested;
+
+    /** Called by {@link CranposeActivity} immediately before every
+     * {@code startForegroundService}, so a stale stop from the previous cycle
+     * cannot end the service the moment it comes up. */
+    static void noteStartRequested() {
+        obligationArmed = true;
+        stopRequested = false;
+    }
+
+    /** The one way the activity stops this service. */
+    static void stop(Context context) {
+        if (obligationArmed) {
+            stopRequested = true;
+            return;
+        }
+        context.stopService(new Intent(context, CranposeBackgroundService.class));
+    }
 
     @Override
     public void onCreate() {
@@ -53,6 +83,12 @@ public final class CranposeBackgroundService extends Service {
             }
         } catch (RuntimeException error) {
             android.util.Log.w("cranpose", "foreground background-work service failed", error);
+            stopSelf();
+            return;
+        }
+        obligationArmed = false;
+        if (stopRequested) {
+            stopRequested = false;
             stopSelf();
         }
     }

--- a/crates/cranpose/src/android_services.rs
+++ b/crates/cranpose/src/android_services.rs
@@ -23,12 +23,13 @@ use cranpose_services::{
     AppUpdateCapabilities, AppUpdateError, AppUpdateStatus, AppUpdater, BackgroundActivity,
     BatteryStatus, BundledAssetError, BundledAssetReader, BundledAssets, GitHubReleaseUpdate,
     HapticEffect, HapticFeedback, HapticPattern, Haptics, IncomingContent, LaunchArgs,
-    NetworkMonitor, NetworkStatus, Notifier, NotifyRequest, PackageDigest, PowerCapabilities,
-    PowerMonitor, PowerReading, ShareContent, ShareError, ShareSheet, StreamingAssetReader,
-    ThermalState, UpdatePackage, publish_incoming_content, push_notification_deeplink,
-    set_platform_app_updater, set_platform_background_activity, set_platform_bundled_assets,
-    set_platform_haptics, set_platform_launch_args, set_platform_network_monitor,
-    set_platform_notifier, set_platform_power_monitor, set_platform_share_sheet,
+    MemoryPressure, NetworkMonitor, NetworkStatus, Notifier, NotifyRequest, PackageDigest,
+    PowerCapabilities, PowerMonitor, PowerReading, ShareContent, ShareError, ShareSheet,
+    StreamingAssetReader, ThermalState, UpdatePackage, publish_incoming_content,
+    publish_memory_pressure, push_notification_deeplink, set_platform_app_updater,
+    set_platform_background_activity, set_platform_bundled_assets, set_platform_haptics,
+    set_platform_launch_args, set_platform_network_monitor, set_platform_notifier,
+    set_platform_power_monitor, set_platform_share_sheet,
 };
 use jni::{
     EnvUnowned, Outcome, jni_sig, jni_str,
@@ -1100,6 +1101,17 @@ pub extern "system" fn Java_dev_cranpose_android_CranposeActivity_nativeOnIncomi
         publish_incoming_content(shared);
         wake_native_loop();
     }
+}
+
+#[doc(hidden)]
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_cranpose_android_CranposeActivity_nativeOnTrimMemory(
+    _env: EnvUnowned<'_>,
+    _class: JClass<'_>,
+    level: jint,
+) {
+    publish_memory_pressure(MemoryPressure::from_android_trim_level(level));
+    wake_native_loop();
 }
 
 #[doc(hidden)]

--- a/crates/cranpose/src/android_services.rs
+++ b/crates/cranpose/src/android_services.rs
@@ -290,7 +290,7 @@ struct AndroidBackgroundActivity {
 
 impl BackgroundActivity for AndroidBackgroundActivity {
     fn set_active(&self, active: bool) {
-        let _ = with_android_activity_env(&self.app, |env, activity| {
+        let result = with_android_activity_env(&self.app, |env, activity| {
             env.call_method(
                 &activity,
                 jni_str!("cranposeSetBackgroundActive"),
@@ -303,6 +303,11 @@ impl BackgroundActivity for AndroidBackgroundActivity {
                 error.to_string()
             })
         });
+        if let Err(error) = result {
+            // Swallowed, this failure reads as "the app never asked" when a
+            // backgrounded import later runs with no foreground service.
+            log::warn!("Android background activity set_active({active}) failed: {error}");
+        }
     }
 }
 


### PR DESCRIPTION
## Why

Google Play sets memory limits from February 2027, judged as the 90th percentile of Anonymous RSS + Swap per app state. The tightest state is a foreground service with the app off screen: 1 GB on 4 GB phones, 2 GB even on 16 GB phones. The framework had no road to hand trim reports to an application, and two service-ask defects ended the process on real phones.

## What

- `rememberMemoryPressure()`: Android's `onTrimMemory` reaches applications as a collected event stream (UiHidden, Low, Critical), plus `observe_memory_pressure` for work that must run while the composition loop sleeps. Unit tests cover the registry and the level mapping.
- The trim hook registers a `ComponentCallbacks2` on the application context. The activity override never fired on an EMUI Android 10 phone; the registered callback fires everywhere.
- The activity asks for the foreground service only after a first resume, and 700 ms after a pause with a resume that cancels the ask. A screen-off start used to end the process with ForegroundServiceDidNotStartInTimeException, reproduced twice on a Pixel 9 Pro on Android 16.
- The service tracks its startForeground obligation, so a stop inside that window waits for the service to honour it first. A refused `set_active` logs instead of passing quietly.

## Checked

- Screen-off cold start on the Pixel 9 Pro (Android 16) and the Huawei EVR-AL00 (Android 10): process alive, no crash, no service asked.
- Trim delivery on both the arm64 emulator (Android 15) and the Huawei: one report per event, from the system's own UI_HIDDEN too.
- In the consuming app: the system hid the UI and the app freed its models 12 ms later, 1.36 GB anon down to 0.70 GB.
- fmt, clippy and the service tests pass; the consuming app's 14-step robot suite passes against this branch.

cranscan consumes this branch through `[patch.crates-io]` until a release carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)