### PR TITLE
Give the non-UTF8 toggle fixture a path the tmpfs gate allows

### DIFF
--- a/crates/cranpose-render/common/src/debug_toggles.rs
+++ b/crates/cranpose-render/common/src/debug_toggles.rs
@@ -61,7 +61,7 @@ mod tests {
 
     #[test]
     fn a_non_utf8_path_override_survives_byte_for_byte() {
-        let raw = OsStr::from_bytes(b"/tmp/\xff\xfe/cache.bin");
+        let raw = OsStr::from_bytes(b"/cranpose/\xff\xfe/cache.bin");
         set_debug_toggle_os("CRANPOSE_TOGGLE_OS_TEST", Some(raw));
         assert_eq!(
             debug_toggle_os("CRANPOSE_TOGGLE_OS_TEST").as_deref(),


### PR DESCRIPTION
**main is red right now** — `cargo test --profile ci --workspace` fails on `a1f64e59` (#495) before any of this branch's changes, so every open PR inherits the failure:

```
---- workspace_tests_do_not_default_to_tmpfs_paths stdout ----
tests and diagnostics must write under workspace target/test-output, ...:
crates/cranpose-render/common/src/debug_toggles.rs:64: let raw = OsStr::from_bytes(b"/tmp/\xff\xfe/cache.bin");
```

Verified by running that one test in a clean worktree checked out at `origin/main` — it fails there with no other changes present.

## The fix

`a_non_utf8_path_override_survives_byte_for_byte` touches no filesystem: it asserts that `\xff\xfe` survives the toggle store byte for byte. The `/tmp/` prefix is arbitrary to what it proves, so it becomes `/cranpose/` and carries exactly the same non-UTF8 bytes.

The scanner it trips is deliberately absolute — a plain line scan over `crates/`, `robot-runners`, `tests` and `xtask` with no allowlist — so the honest move is to fix the literal rather than cut an exemption into the gate.

## Verification

- `cargo test --profile ci -p desktop-app --test source_hygiene_aliases` → 15 passed (was 14 passed / 1 failed)
- `cargo test --profile ci -p cranpose-render-common --lib debug_toggles` → the round-trip test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)