### PR TITLE
Scope a lazy-list scroll to its subtree instead of rebuilding the whole scene

### DIFF
--- a/crates/cranpose-app-shell/src/shell_frame.rs
+++ b/crates/cranpose-app-shell/src/shell_frame.rs
@@ -188,11 +188,25 @@ where
         // (re-sizing, e.g. a collapsing swipe-dismissed row) drive a layout pass.
         let has_scoped_repasses = cranpose_ui::has_pending_layout_repasses()
             || cranpose_ui::has_pending_measure_repasses();
-        let scoped_layout_nodes = if cranpose_ui::has_pending_layout_repasses() {
+        // Both kinds carry the node they were scheduled for, and the scene
+        // phase scopes its graph update to exactly those nodes. Collecting only
+        // the layout ids silently dropped the measure ones, which is the path a
+        // scrolling `LazyColumn` takes: the scene phase then saw an empty dirty
+        // set with the scene marked dirty, read that as "everything changed",
+        // and rebuilt the graph from the composition root on every scrolled
+        // frame.
+        let mut scoped_layout_nodes = if cranpose_ui::has_pending_layout_repasses() {
             cranpose_ui::pending_layout_repass_nodes_snapshot()
         } else {
             Vec::new()
         };
+        if cranpose_ui::has_pending_measure_repasses() {
+            for node in cranpose_ui::pending_measure_repass_nodes_snapshot() {
+                if !scoped_layout_nodes.contains(&node) {
+                    scoped_layout_nodes.push(node);
+                }
+            }
+        }
 
         // Global layout invalidation is reserved for app-wide inputs such as
         // viewport, density, font-scale, or debug layout changes. Normal node
@@ -281,14 +295,22 @@ where
                     if self.semantics_enabled {
                         self.semantics_tree = None;
                     }
-                    if has_scoped_repasses
-                        && !global_layout_invalidation
-                        && !force_layout_pass
-                        && !scoped_layout_nodes.is_empty()
-                    {
-                        self.scoped_layout_scene_nodes = scoped_layout_nodes;
-                    } else {
+                    // A frame runs this phase more than once — the initial pass
+                    // and again after post-layout recomposition — and the scene
+                    // phase consumes the ids once, at the end. Assigning here
+                    // let a later pass with nothing pending wipe the ids an
+                    // earlier one recorded, which is how a scrolling
+                    // `LazyColumn` reached the scene phase with an empty dirty
+                    // set and got a full rebuild. Accumulate instead; only an
+                    // app-wide relayout, where scoping means nothing, clears.
+                    if global_layout_invalidation || force_layout_pass {
                         self.scoped_layout_scene_nodes.clear();
+                    } else if has_scoped_repasses {
+                        for node in scoped_layout_nodes {
+                            if !self.scoped_layout_scene_nodes.contains(&node) {
+                                self.scoped_layout_scene_nodes.push(node);
+                            }
+                        }
                     }
                     self.scene_dirty = true;
                 }

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -4319,6 +4319,75 @@ fn lazy_column_scroll_repass_uses_scoped_renderer_update_without_stale_rows() {
     );
 }
 
+/// A steady-state lazy-list scroll must reach the renderer as a *scoped*
+/// update, never a full-tree rebuild.
+///
+/// `LazyColumn` invalidates through `schedule_measure_repass`, and the scene
+/// phase only ever learns node ids from *layout* repasses. When the measure
+/// repass ids are dropped the scene phase sees no dirty nodes at all, decides
+/// the whole scene is dirty, and rebuilds the graph from the composition root
+/// on every scrolled frame — O(whole app) where the work is O(visible rows).
+/// The sibling `graphics_layer` repass tests below already assert this bound;
+/// the lazy list is the path that lost it, and it is the path every scrolling
+/// screen in a real app takes.
+#[test]
+fn lazy_column_scroll_never_rebuilds_the_whole_scene() {
+    let _guard = test_guard();
+    APP_SHELL_LAZY_LIST_STATE.with(|slot| slot.borrow_mut().take());
+    let root_key = location_key(file!(), line!(), column!());
+    let rebuilds = Rc::new(Cell::new(0));
+    let updates = Rc::new(Cell::new(0));
+    let visual_updates = Rc::new(Cell::new(0));
+    let last_dirty_nodes = Rc::new(RefCell::new(Vec::new()));
+
+    let mut shell = AppShell::new(
+        ScopedUpdateCountingRenderer::with_visual_updates(
+            Rc::clone(&rebuilds),
+            Rc::clone(&updates),
+            Rc::clone(&visual_updates),
+            Rc::clone(&last_dirty_nodes),
+        ),
+        root_key,
+        AppShellScrollIndicatorLazyList,
+    );
+    shell.set_buffer_size(320, 240);
+    shell.set_viewport(320.0, 240.0);
+    shell.update();
+
+    let list_state = APP_SHELL_LAZY_LIST_STATE
+        .with(|slot| *slot.borrow())
+        .expect("lazy scroll probe should expose its list state");
+
+    // Several steady-state scroll frames, so this cannot pass on a first-frame
+    // special case: every one of them must stay scoped.
+    for step in 0..3 {
+        rebuilds.set(0);
+        updates.set(0);
+        last_dirty_nodes.borrow_mut().clear();
+
+        assert!(
+            list_state.dispatch_scroll_delta(-40.0).abs() > 0.0,
+            "lazy scroll state should consume scroll delta on step {step}"
+        );
+        shell.update();
+
+        assert_eq!(
+            rebuilds.get(),
+            0,
+            "lazy-list scroll step {step} must not rebuild the scene from the root"
+        );
+        assert_eq!(
+            updates.get(),
+            1,
+            "lazy-list scroll step {step} should perform exactly one scoped scene update"
+        );
+        assert!(
+            !last_dirty_nodes.borrow().is_empty(),
+            "scoped lazy-list update on step {step} must carry the dirty node ids"
+        );
+    }
+}
+
 #[test]
 fn graphics_layer_state_repass_does_not_recompose() {
     let _guard = test_guard();

--- a/crates/cranpose-foundation/src/lazy/lazy_list_state.rs
+++ b/crates/cranpose-foundation/src/lazy/lazy_list_state.rs
@@ -646,9 +646,12 @@ impl LazyListState {
     ///
     /// Returns the amount of scroll actually consumed.
     ///
-    /// This triggers layout invalidation via registered callbacks. The callbacks are
-    /// registered by LazyColumnImpl/LazyRowImpl with schedule_layout_repass(node_id),
-    /// which provides O(subtree) performance instead of O(entire app).
+    /// This triggers layout invalidation via registered callbacks. The callbacks
+    /// are registered by LazyColumnImpl/LazyRowImpl with
+    /// `schedule_measure_repass(node_id)` — the list's own item sizes are what
+    /// changes, so the repass has to bubble measure dirtiness, not just
+    /// placement. The node id carries through to the scene phase, which scopes
+    /// its graph update to that subtree: O(subtree) instead of O(entire app).
     pub fn dispatch_scroll_delta(&self, delta: f32) -> f32 {
         // Guard against stale handles: fling animation frame callbacks can fire
         // after a tab switch disposes the composition group that owns this state.

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -183,12 +183,12 @@ pub use render_state::{
     debug_reset_last_fling_velocity, has_current_app_context, has_pending_draw_repasses,
     has_pending_layout_repasses, has_pending_measure_repasses, peek_focus_invalidation,
     peek_layout_invalidation, peek_pointer_invalidation, peek_render_invalidation,
-    pending_layout_repass_nodes_snapshot, prune_draw_observations_to_nodes,
-    request_focus_invalidation, request_layout_invalidation, request_pointer_invalidation,
-    request_render_invalidation, schedule_draw_repass, schedule_layout_repass,
-    schedule_measure_repass, take_draw_repass_nodes, take_focus_invalidation,
-    take_layout_invalidation, take_layout_repass_nodes, take_measure_repass_nodes,
-    take_pointer_invalidation, take_render_invalidation,
+    pending_layout_repass_nodes_snapshot, pending_measure_repass_nodes_snapshot,
+    prune_draw_observations_to_nodes, request_focus_invalidation, request_layout_invalidation,
+    request_pointer_invalidation, request_render_invalidation, schedule_draw_repass,
+    schedule_layout_repass, schedule_measure_repass, take_draw_repass_nodes,
+    take_focus_invalidation, take_layout_invalidation, take_layout_repass_nodes,
+    take_measure_repass_nodes, take_pointer_invalidation, take_render_invalidation,
 };
 pub use renderer::{HeadlessRenderer, PaintLayer, RecordedRenderScene, RenderOp};
 pub use safe_area::{WindowInsets, local_ime_insets, local_safe_area_insets, window_insets};

--- a/crates/cranpose-ui/src/render_state.rs
+++ b/crates/cranpose-ui/src/render_state.rs
@@ -786,6 +786,18 @@ pub fn has_pending_measure_repasses() -> bool {
     with_render_state(|state| lock_repass_manager(&state.measure_repasses).has_pending_repass())
 }
 
+/// Returns a stable snapshot of pending measure repass node IDs without
+/// consuming them.
+///
+/// The layout pass takes these ids to bubble measure dirtiness; the scene phase
+/// needs the same ids *before* that happens, to scope its graph update to the
+/// subtree that moved. Without the snapshot a measure repass reaches the scene
+/// phase as "something changed, but nothing says where", which is
+/// indistinguishable from a full invalidation.
+pub fn pending_measure_repass_nodes_snapshot() -> Vec<NodeId> {
+    with_render_state(|state| lock_repass_manager(&state.measure_repasses).dirty_nodes_snapshot())
+}
+
 /// Takes all pending measure repass node IDs.
 ///
 /// The caller should iterate over these and call `bubble_measure_dirty` for each.


### PR DESCRIPTION
Part of #500 (cause 1 of 3). Independent of #497 — different subsystem, no shared commits.

## Problem

A scrolling `LazyColumn` rebuilt the render graph **from the composition root on every frame** — `rebuild_scene_from_applier` rather than the scoped `update_scene_from_applier` the path was designed to take. The work is O(whole app) where it should be O(visible rows).

Two independent gaps stacked, and both had to close:

1. **The measure-repass node ids were dropped.** The list invalidates through `schedule_measure_repass` — its *item sizes* are what change, so placement-only dirtiness is not enough — but `run_layout_phase_in_context` only ever collected ids from **layout** repasses. The scene phase then saw `scene_dirty = true` with an empty dirty set, which is indistinguishable from "everything changed", and fell through to the full rebuild.

2. **The scoped ids were assigned, not accumulated.** A frame runs the layout phase twice — once initially, once after post-layout recomposition — and the second pass, with nothing pending, cleared what the first had recorded. Whichever pass ran last won, so scoping survived or vanished depending on which pass the scroll landed in. (Closing gap 1 alone fixed the first scroll step and not the second; that asymmetry is what exposed this.)

The phase now accumulates across passes and only an app-wide relayout — where scoping means nothing — clears them. The scene phase already takes them once per frame via `std::mem::take`.

Also corrects the doc on `LazyListState::dispatch_scroll_delta`, which claimed `schedule_layout_repass` and "O(subtree) performance instead of O(entire app)". The code had drifted from its own stated contract; that stale comment is part of why this went unnoticed.

## Why no test caught it

`lazy_column_scroll_repass_uses_scoped_renderer_update_without_stale_rows` asserts `updates + rebuilds == 1` — it accepts **either** path. The sibling `graphics_layer` repass tests in the same file assert `rebuilds == 0`. The lazy path is the one that lost that bound, and it is the path every scrolling screen in a real app takes.

New test `lazy_column_scroll_never_rebuilds_the_whole_scene` asserts zero rebuilds and exactly one scoped update carrying dirty ids, held across three steady-state scroll steps so it cannot pass on a first-frame special case. It fails on the parent commit (`rebuilds: 1`) and passes here.

## Measurements (Huawei EVR-AL00, Kirin 980)

Same scene, same gesture, same branch, A/B against the parent commit — demo Lazy List tab, `debug.cranpose.frame_stage_ms`:

| | before | after |
|---|---|---|
| `scene_ms` typical | ~1.5 ms | ~0.8 ms |
| `scene_ms` worst | 3.11 ms | 2.06 ms |

Please read that as a *lower bound on the win, not the headline*: the demo's whole composition tree is small, and the bug's cost is proportional to total app size, so a real app pays more than the demo does. I have not yet measured a real app against this build — that verification is still outstanding.

Explicitly **not** fixed by this change: the demo's Liquid tab does not take this path and is unchanged (its heavy frames still show `scene_ms` 6-13 ms, because the scoped update itself rebuilds the whole dirty subtree with no offset-only fast path). Causes 2 and 3 from #500 — render-pass count and backdrop cache thrash — are untouched here; both are traced to exact mechanisms in the issue thread.

## Testing

`cargo test` green for the changed crates (`cranpose-app-shell`, `cranpose-ui`, `cranpose-foundation` — 1400+ tests). `just fmt` and `clippy` clean on the changed crates. The full `just test` workspace gate was still running when this PR was opened; I will report the result on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)