### PR TITLE
Drop the /tmp literal from the toggle byte-fidelity test

### DIFF
--- a/crates/cranpose-render/common/src/debug_toggles.rs
+++ b/crates/cranpose-render/common/src/debug_toggles.rs
@@ -61,7 +61,7 @@ mod tests {
 
     #[test]
     fn a_non_utf8_path_override_survives_byte_for_byte() {
-        let raw = OsStr::from_bytes(b"/tmp/\xff\xfe/cache.bin");
+        let raw = OsStr::from_bytes(b"cache-\xff\xfe.bin");
         set_debug_toggle_os("CRANPOSE_TOGGLE_OS_TEST", Some(raw));
         assert_eq!(
             debug_toggle_os("CRANPOSE_TOGGLE_OS_TEST").as_deref(),


### PR DESCRIPTION
`main` is red on `workspace_tests_do_not_default_to_tmpfs_paths`.

The byte-fidelity test in `debug_toggles.rs` round-trips non-UTF-8 bytes through the override map and never touches the filesystem, so the `/tmp/` prefix in its literal was decoration — but the hygiene guard scans sources for `/tmp/` and rightly flagged it. Removing the prefix rather than allowlisting the file: the guard is correct, the test was wrong.

Verified: `cargo test -p desktop-app --test source_hygiene_aliases` → 15/15 pass with this change.

Process note: this slipped through because the per-round gate set ran targeted `-p <crate>` tests and never the full `just test`, so the guard in `apps/desktop-demo/tests/` was never exercised locally; the blind review's own `just test` runs always died at sandboxed socket tests before reaching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)