### PR TITLE
Bill a slow present to the compositor, not to the app

### DIFF
--- a/apps/desktop-demo/tests/mineswapper_lazy_list_regression.rs
+++ b/apps/desktop-demo/tests/mineswapper_lazy_list_regression.rs
@@ -10,9 +10,7 @@ use cranpose_ui_graphics::DrawPrimitive;
 use desktop_app::app::{
     combined_app, DemoTab, TEST_ACTIVE_TAB_STATE, TEST_COMPOSITION_LOCAL_COUNTER,
 };
-use tab_switch_regression_support::{
-    pump_robot_until_stable, set_active_tab, wait_for_active_tab_registration_robot,
-};
+use tab_switch_regression_support::{set_active_tab, wait_for_active_tab_registration_robot};
 
 fn drain_all(composition: &mut Composition<MemoryApplier>) -> Result<(), NodeError> {
     loop {
@@ -446,7 +444,7 @@ fn animations_to_other_tabs_preserve_tab_content_markers() {
     wait_for_active_tab_registration_robot(&mut robot);
 
     set_active_tab(DemoTab::Animations);
-    pump_robot_until_stable(&mut robot, 40);
+    robot.wait_for_idle();
     assert_animations_tab_visible(&mut robot, "before leaving Animations");
 
     let tab_markers = [
@@ -474,7 +472,7 @@ fn animations_to_other_tabs_preserve_tab_content_markers() {
 
     for (tab, marker) in tab_markers {
         set_active_tab(tab);
-        pump_robot_until_stable(&mut robot, 60);
+        robot.wait_for_idle();
         assert_layout_contains_text(
             &mut robot,
             marker,

--- a/apps/desktop-demo/tests/tab_switch_regression_support.rs
+++ b/apps/desktop-demo/tests/tab_switch_regression_support.rs
@@ -70,15 +70,6 @@ pub fn wait_for_recursive_depth_registration(rule: &mut ComposeTestRule) {
     );
 }
 
-pub fn pump_robot_until_stable(robot: &mut RobotTestRule<TestRenderer>, max_steps: usize) {
-    for _ in 0..max_steps {
-        robot.shell_mut().update();
-        if !robot.shell_mut().needs_redraw() {
-            break;
-        }
-    }
-}
-
 pub fn pump_shell_until_stable<R>(shell: &mut AppShell<R>)
 where
     R: Renderer,

--- a/crates/cranpose-testing/src/robot.rs
+++ b/crates/cranpose-testing/src/robot.rs
@@ -31,6 +31,28 @@ use cranpose_render_common::{HitTestTarget, RenderScene, Renderer};
 use cranpose_ui::{LayoutTree, TextMeasurer};
 use cranpose_ui_graphics::{Point, Rect, Size};
 
+/// How many `AppShell::update` turns a headless robot pump gives the shell
+/// before it treats the composition as wedged.
+///
+/// This budget is an iteration count rather than a wall clock on purpose, and
+/// it is the opposite call from the desktop robot's `wait_for_idle`. There the
+/// wait is on a compositor in another process, so loop turns say nothing about
+/// whether the frame is coming and only elapsed time can bound it. Here
+/// `AppShell::update` is synchronous work against an in-memory renderer --
+/// no compositor, no surface to acquire, nothing to block on -- so the number
+/// of turns a healthy app needs is a property of the app and is the same on
+/// every host. Timing it instead would hand a loaded machine fewer turns than
+/// a quiet one and decide headless results by host load, which is exactly the
+/// flakiness the desktop side had to remove.
+///
+/// The limit matches `ROOT_RENDER_REPLAY_LIMIT` and has room to spare: the
+/// loop condition is `AppShell::needs_redraw`, which reports stale pixels and
+/// renderer warm-up rather than pending composition work, and against the
+/// in-memory renderer one update clears it -- every call in the suite settles
+/// on the first turn. What the budget guards is a shell that stays dirty
+/// however many turns it is given.
+const HEADLESS_IDLE_UPDATE_LIMIT: u32 = 100;
+
 /// Main robot testing rule that provides programmatic control over a real app.
 ///
 /// This is similar to Jetpack Compose's `ComposeTestRule` but for full app testing
@@ -87,17 +109,33 @@ where
         self.frame_time_nanos
     }
 
-    /// Pump the app until it's idle (no pending updates).
+    /// Pump the shell until it stops asking to be redrawn.
     ///
-    /// This ensures all compositions, layouts, and renders have completed.
+    /// The condition is `AppShell::needs_redraw` -- stale pixels and renderer
+    /// warm-up. That is a weaker question than "has every pending composition,
+    /// layout and render drained", which is what `FrameSchedule` answers, so a
+    /// caller that needs the composition itself settled has to say so.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the shell still wants a redraw after
+    /// `HEADLESS_IDLE_UPDATE_LIMIT` turns. Returning quietly instead would
+    /// hand back a half-settled tree and move the failure to whichever
+    /// assertion read it next, which is the harder bug to find.
     pub fn wait_for_idle(&mut self) {
-        // Update multiple times to ensure everything settles
-        for _ in 0..10 {
+        for _ in 0..HEADLESS_IDLE_UPDATE_LIMIT {
             self.shell.update();
             if !self.shell.needs_redraw() {
-                break;
+                return;
             }
         }
+        panic!(
+            "wait_for_idle: the shell still wants a redraw after \
+             {HEADLESS_IDLE_UPDATE_LIMIT} update turns (animations={}, \
+             transient frame callbacks={})",
+            self.shell.has_active_animations(),
+            self.shell.has_transient_frame_callbacks(),
+        );
     }
 
     /// Perform a click at the given coordinates.
@@ -561,5 +599,80 @@ mod tests {
 
         robot.advance_time(8_000_000);
         assert_eq!(robot.frame_time_nanos(), 24_000_000);
+    }
+
+    #[test]
+    fn robot_idle_pump_settles_a_healthy_app_far_inside_its_budget() {
+        // The budget is an iteration count because every turn here is
+        // synchronous work with nothing to block on, so what a healthy app
+        // needs does not move with host load. Pin that it is a budget with
+        // room rather than one the suite runs up against: an app that settles
+        // must not depend on where in the budget it lands.
+        let mut robot = create_headless_robot_test(800, 600, || {});
+
+        for _ in 0..HEADLESS_IDLE_UPDATE_LIMIT {
+            robot.wait_for_idle();
+            assert!(!robot.shell_mut().needs_redraw());
+        }
+    }
+
+    /// A renderer that never finishes warming up, so `needs_redraw` stays true
+    /// however many turns it is given. `needs_frame_warmup` is the hook a real
+    /// renderer uses to demand initial frames, which makes this the shape a
+    /// wedged shell actually takes.
+    #[derive(Default)]
+    struct NeverWarmRenderer {
+        inner: TestRenderer,
+    }
+
+    impl Renderer for NeverWarmRenderer {
+        type Scene = TestScene;
+        type Error = ();
+
+        fn attach_app_context_services(&mut self, app_context: &cranpose_ui::AppContext) {
+            self.inner.attach_app_context_services(app_context);
+        }
+
+        fn scene(&self) -> &Self::Scene {
+            self.inner.scene()
+        }
+
+        fn scene_mut(&mut self) -> &mut Self::Scene {
+            self.inner.scene_mut()
+        }
+
+        fn rebuild_scene(
+            &mut self,
+            layout_tree: &LayoutTree,
+            viewport: Size,
+        ) -> Result<(), Self::Error> {
+            self.inner.rebuild_scene(layout_tree, viewport)
+        }
+
+        fn rebuild_scene_from_applier(
+            &mut self,
+            applier: &mut cranpose_core::MemoryApplier,
+            root: cranpose_core::NodeId,
+            viewport: Size,
+        ) -> Result<(), Self::Error> {
+            self.inner
+                .rebuild_scene_from_applier(applier, root, viewport)
+        }
+
+        fn needs_frame_warmup(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "still wants a redraw after")]
+    fn robot_idle_pump_fails_loudly_when_the_shell_never_settles() {
+        // Exhausting the budget used to `break` and return, handing the caller
+        // a tree that had not settled and moving the failure to whichever
+        // assertion read it next -- which is the harder bug to find. It has to
+        // fail here instead, where the diagnostic can say what is still dirty.
+        let mut robot = RobotTestRule::new(800, 600, NeverWarmRenderer::default(), || {});
+
+        robot.wait_for_idle();
     }
 }

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -48,9 +48,13 @@ const NATIVE_WINDOW_POSITION_POLL_INTERVAL: Duration = Duration::from_millis(16)
 const NATIVE_WINDOW_POSITION_SETTLE_TIMEOUT: Duration = Duration::from_millis(36);
 const NATIVE_WINDOW_POSITION_SETTLE_POLL: Duration = Duration::from_millis(1);
 const NATIVE_WINDOW_PLACEMENT_MARGIN: f32 = 32.0;
-/// Soft wall-clock budget for `wait_for_idle`. Elapsing this alone is not
-/// proof the *application* failed to converge -- see
-/// `ROBOT_IDLE_MIN_ITERATIONS` below for why.
+/// Soft wall-clock budget for `wait_for_idle`, and the only budget that can
+/// name the application at fault. Elapsing it is not on its own proof the
+/// *application* failed to converge: it must also be the application that the
+/// wait is blocked on (composition still producing work, rather than a frame
+/// the compositor has not shown -- see `IdleWaitTimeout::SurfaceNotPresenting`)
+/// and the loop must have turned enough times for the elapsed time to mean
+/// anything at all -- see `ROBOT_IDLE_MIN_ITERATIONS` below.
 #[cfg(feature = "robot")]
 const ROBOT_IDLE_TIMEOUT: Duration = Duration::from_secs(10);
 /// Minimum number of `about_to_wait` turns the idle-wait loop must actually
@@ -66,10 +70,23 @@ const ROBOT_IDLE_TIMEOUT: Duration = Duration::from_secs(10);
 /// an application defect, and must not fail the same way.
 #[cfg(feature = "robot")]
 const ROBOT_IDLE_MIN_ITERATIONS: u32 = 100;
+/// How long `wait_for_idle` waits for a frame the compositor has not handed
+/// back yet, measured from the turn composition settled rather than from the
+/// start of the wait. A present is a wait on another process, so it gets a
+/// budget of its own: under load a compositor can take many seconds to turn a
+/// frame around, and the budget above exists to catch an application that
+/// will not stop producing work, which is a different question with a
+/// different answer. It stays under `run_robot_test.sh`'s own per-example
+/// timeout so a surface that never presents is reported with the diagnostic
+/// the message below carries, rather than killed as an opaque exit 124.
+#[cfg(feature = "robot")]
+const ROBOT_IDLE_PRESENT_TIMEOUT: Duration = Duration::from_secs(30);
 /// Absolute ceiling on `wait_for_idle`, independent of iteration count. Even
 /// a host so overloaded that the loop can barely execute must not hang the
 /// robot driver forever; past this point the wait is abandoned and reported
-/// as host starvation rather than blamed on the application.
+/// as host starvation rather than blamed on the application. A wait blocked
+/// on the compositor never reaches this: `ROBOT_IDLE_PRESENT_TIMEOUT` above
+/// bounds that one, and bounds it sooner.
 #[cfg(feature = "robot")]
 const ROBOT_IDLE_STARVATION_CEILING: Duration = Duration::from_secs(60);
 #[cfg(feature = "robot")]
@@ -172,6 +189,7 @@ struct RobotController {
     idle_started_at: Option<Instant>,
     idle_iterations: u32,
     idle_structure_clean_frames: u32,
+    idle_present_blocked_since: Option<Instant>,
     waiting_for_present_generation: Option<u64>,
     waiting_for_pump_present_generation: Option<u64>,
     pump_present_started_at: Option<Instant>,
@@ -187,16 +205,21 @@ struct RobotScrollSequence {
     remaining: u32,
 }
 
-/// Why `wait_for_idle` gave up. The two causes need different messages and
-/// different remediation: one names a broken application, the other names a
-/// host that never let the application run.
+/// Why `wait_for_idle` gave up. Each cause names a different owner and needs
+/// a different message and remediation: a broken application, a compositor
+/// that never showed the frame, or a host that never let the application run.
 #[cfg(feature = "robot")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum IdleWaitTimeout {
-    /// The soft budget elapsed AND the loop actually turned enough times for
-    /// that elapsed time to mean something: the application kept producing
-    /// work instead of converging.
+    /// The soft budget elapsed while the application was the outstanding
+    /// work, AND the loop actually turned enough times for that elapsed time
+    /// to mean something: the application kept producing work instead of
+    /// converging.
     AppNotConverging,
+    /// `ROBOT_IDLE_PRESENT_TIMEOUT` elapsed with the only outstanding work a
+    /// frame the compositor had not handed back: composition converged and
+    /// the surface never presented.
+    SurfaceNotPresenting,
     /// The absolute ceiling elapsed without the loop ever reaching the
     /// iteration floor: the host did not schedule this process enough to
     /// tell whether the application was converging at all.
@@ -217,6 +240,7 @@ impl RobotController {
             idle_started_at: None,
             idle_iterations: 0,
             idle_structure_clean_frames: 0,
+            idle_present_blocked_since: None,
             waiting_for_present_generation: None,
             waiting_for_pump_present_generation: None,
             pump_present_started_at: None,
@@ -248,13 +272,39 @@ impl RobotController {
         self.idle_started_at = Some(started_at);
         self.idle_iterations = 0;
         self.idle_structure_clean_frames = 0;
+        self.idle_present_blocked_since = None;
+    }
+
+    /// Record whether this turn found composition settled with only a frame
+    /// the compositor has not handed back still outstanding. The clock runs
+    /// from the turn that became true, so a wait that spends time on the
+    /// application first does not spend the surface's budget doing it, and an
+    /// application that goes back to producing work returns the wait to the
+    /// convergence budget.
+    fn observe_idle_present_block(&mut self, present_is_sole_blocker: bool, now: Instant) {
+        if !present_is_sole_blocker {
+            self.idle_present_blocked_since = None;
+        } else if self.idle_present_blocked_since.is_none() {
+            self.idle_present_blocked_since = Some(now);
+        }
     }
 
     /// Convergence-based timeout check: see the constants above for why
     /// elapsed time alone cannot tell a livelocked application from a
     /// starved host. Returns `None` while the wait should keep running.
+    ///
+    /// The two budgets belong to different owners and never apply at once.
+    /// While composition is settled and a frame is outstanding, the wait is on
+    /// the compositor: an application in that state has converged, so the
+    /// budget that exists to catch one which will not stop producing work has
+    /// nothing to say about it and must not fail it.
     fn idle_wait_timeout(&self, now: Instant) -> Option<IdleWaitTimeout> {
         let started_at = self.idle_started_at?;
+        if let Some(blocked_since) = self.idle_present_blocked_since {
+            let blocked_for = now.saturating_duration_since(blocked_since);
+            return (blocked_for >= ROBOT_IDLE_PRESENT_TIMEOUT)
+                .then_some(IdleWaitTimeout::SurfaceNotPresenting);
+        }
         let elapsed = now.saturating_duration_since(started_at);
         if elapsed >= ROBOT_IDLE_TIMEOUT && self.idle_iterations >= ROBOT_IDLE_MIN_ITERATIONS {
             return Some(IdleWaitTimeout::AppNotConverging);
@@ -306,6 +356,7 @@ impl RobotController {
         self.idle_started_at = None;
         self.waiting_for_present_generation = None;
         self.idle_structure_clean_frames = 0;
+        self.idle_present_blocked_since = None;
     }
 
     /// Whether the driver is waiting on something the loop has to turn to give.
@@ -5637,12 +5688,31 @@ impl ApplicationHandler for App {
                         );
                     }
 
-                    if let Some(timeout) = controller.idle_wait_timeout(Instant::now()) {
+                    // Composition has settled and the only thing left is a
+                    // frame the compositor has not handed back. That wait is
+                    // on the surface, not on the application, and belongs to
+                    // the surface's budget.
+                    let present_is_sole_blocker = waiting_for_present
+                        && !needs_update
+                        && !has_active_animations
+                        && !has_transient_frame_callbacks;
+                    let timeout_check_at = Instant::now();
+                    controller
+                        .observe_idle_present_block(present_is_sole_blocker, timeout_check_at);
+                    if let Some(timeout) = controller.idle_wait_timeout(timeout_check_at) {
                         let iterations = controller.idle_iterations;
+                        let target_generation = controller.waiting_for_present_generation;
                         controller.finish_idle_wait();
                         let message = match timeout {
                             IdleWaitTimeout::AppNotConverging => format!(
-                                "wait_for_idle: timed out after {iterations} iterations; needs_update={needs_update}, needs_redraw={}, has_animations={has_active_animations}, waiting_for_present={waiting_for_present}",
+                                "wait_for_idle: timed out after {ROBOT_IDLE_TIMEOUT:?} ({iterations} iterations); needs_update={needs_update}, needs_redraw={}, has_animations={has_active_animations}, waiting_for_present={waiting_for_present}",
+                                app.needs_redraw(),
+                            ),
+                            IdleWaitTimeout::SurfaceNotPresenting => format!(
+                                "wait_for_idle: the window surface refused {} consecutive frames over {:?} and never reached generation {target_generation:?} (currently {}); composition had already settled, so this is the compositor and not the application -- the window is occluded, off-screen, or on a display that is not compositing; needs_update={needs_update}, needs_redraw={}, has_animations={has_active_animations}, waiting_for_present={waiting_for_present}",
+                                self.unpresentable_frames_since_present,
+                                ROBOT_IDLE_PRESENT_TIMEOUT,
+                                self.presented_frame_generation,
                                 app.needs_redraw(),
                             ),
                             IdleWaitTimeout::HostStarved => format!(
@@ -6126,9 +6196,9 @@ mod tests {
     };
     #[cfg(feature = "robot")]
     use super::{
-        ControlFlow, IdleWaitTimeout, ROBOT_IDLE_MIN_ITERATIONS, ROBOT_IDLE_STARVATION_CEILING,
-        ROBOT_IDLE_TIMEOUT, ROBOT_PARKED_COMMAND_POLL_INTERVAL, ROBOT_PRESENT_WAIT_TIMEOUT,
-        bound_park_for_robot,
+        ControlFlow, IdleWaitTimeout, ROBOT_IDLE_MIN_ITERATIONS, ROBOT_IDLE_PRESENT_TIMEOUT,
+        ROBOT_IDLE_STARVATION_CEILING, ROBOT_IDLE_TIMEOUT, ROBOT_PARKED_COMMAND_POLL_INTERVAL,
+        ROBOT_PRESENT_WAIT_TIMEOUT, bound_park_for_robot,
     };
     #[cfg(feature = "robot")]
     use super::{
@@ -6487,6 +6557,85 @@ mod tests {
         assert_eq!(
             controller.idle_wait_timeout(started_at + ROBOT_IDLE_STARVATION_CEILING),
             Some(IdleWaitTimeout::HostStarved)
+        );
+    }
+
+    #[cfg(feature = "robot")]
+    #[test]
+    fn robot_idle_wait_does_not_blame_the_app_for_a_slow_present() {
+        // Regression test for a real failure on a loaded host: "timed out
+        // after 1280577 iterations; needs_update=false, needs_redraw=true,
+        // has_animations=false, waiting_for_present=true" on a 10-core
+        // machine at load average 24, which then passed in isolation and
+        // passed again in a full suite run on the same commit.
+        //
+        // 1.28M turns inside the soft budget is a loop with all the CPU it
+        // asked for, so the starvation floor does not apply and the failure
+        // was reported as an application defect. But the diagnostics it
+        // printed say composition had already converged -- no pending update,
+        // no animation -- and the only outstanding work was a frame the
+        // compositor had not handed back. An application that has settled
+        // cannot be failed for not converging, however long the surface
+        // takes.
+        let (mut controller, _robot) = RobotController::new(|| {});
+        let started_at = Instant::now();
+
+        controller.start_idle_wait_at(started_at);
+        controller.idle_iterations = 1_280_577;
+        controller.observe_idle_present_block(true, started_at);
+
+        assert_eq!(
+            controller.idle_wait_timeout(started_at + ROBOT_IDLE_TIMEOUT),
+            None
+        );
+        assert_eq!(
+            controller.idle_wait_timeout(
+                started_at + ROBOT_IDLE_PRESENT_TIMEOUT - std::time::Duration::from_millis(1)
+            ),
+            None
+        );
+    }
+
+    #[cfg(feature = "robot")]
+    #[test]
+    fn robot_idle_wait_blames_the_surface_when_a_present_never_lands() {
+        // Patience for a slow present cannot be unconditional, or a window the
+        // compositor refuses to show parks the driver forever. Past the
+        // absolute ceiling the wait is abandoned -- and because composition
+        // had settled, it is the surface that is named, distinctly from both
+        // an application defect and a starved host.
+        let (mut controller, _robot) = RobotController::new(|| {});
+        let started_at = Instant::now();
+
+        controller.start_idle_wait_at(started_at);
+        controller.idle_iterations = 1_280_577;
+        controller.observe_idle_present_block(true, started_at);
+
+        assert_eq!(
+            controller.idle_wait_timeout(started_at + ROBOT_IDLE_PRESENT_TIMEOUT),
+            Some(IdleWaitTimeout::SurfaceNotPresenting)
+        );
+    }
+
+    #[cfg(feature = "robot")]
+    #[test]
+    fn robot_idle_wait_still_blames_an_app_that_churns_while_a_present_is_outstanding() {
+        // The exemption is for a *settled* composition waiting on a frame, not
+        // for any wait that happens to have a present outstanding. An
+        // application still producing work owns the wait even while the
+        // surface has a frame in flight, and must keep failing on the soft
+        // budget.
+        let (mut controller, _robot) = RobotController::new(|| {});
+        let started_at = Instant::now();
+
+        controller.start_idle_wait_at(started_at);
+        controller.idle_iterations = ROBOT_IDLE_MIN_ITERATIONS;
+        controller.observe_idle_present_block(true, started_at);
+        controller.observe_idle_present_block(false, started_at);
+
+        assert_eq!(
+            controller.idle_wait_timeout(started_at + ROBOT_IDLE_TIMEOUT),
+            Some(IdleWaitTimeout::AppNotConverging)
         );
     }
 


### PR DESCRIPTION
`robot_idle_fps_after_tab_walk` failed on a loaded host (load_1m 24 on a 10-core machine) with:

```
wait_for_idle: timed out after 1280577 iterations; needs_update=false,
needs_redraw=true, has_animations=false, waiting_for_present=true
```

then passed in isolation and passed again in a full 121-test suite run on the same commit (a1f64e59).

## The defect

The budget was already wall-clock (`ROBOT_IDLE_TIMEOUT = 10s`); `iterations` is a diagnostic, and enters the decision only as a floor that *delays* failure on a starved host. 1.28M turns inside that budget is a loop with all the CPU it asked for — an outstanding idle wait pins the event loop at `ControlFlow::Poll` — so the floor did not apply and the wait was reported as `AppNotConverging`.

But its own diagnostics say composition **had** converged: `needs_update=false`, `has_animations=false`. The only outstanding work was `waiting_for_present` — a frame the compositor had not handed back. The application was failed for a wait it does not own. The codebase already models compositor refusal separately (`ROBOT_PRESENT_WAIT_TIMEOUT`, `unpresentable_frames_since_present`); the idle path never consulted it.

## The fix

The two waits have different owners and now have different budgets. A settled composition waiting on a present gets its own clock, armed on the turn it becomes the sole blocker, bounded by `ROBOT_IDLE_PRESENT_TIMEOUT = 30s` and reported as `SurfaceNotPresenting` against the surface — naming refused frames, target generation and current one, as the standalone present wait already does.

30s keeps that under `run_robot_test.sh`'s generic 60s per-example timeout, so a window that truly never presents still reports a diagnostic instead of dying as an opaque exit 124; the 60s starvation ceiling would have collided with it. `AppNotConverging` keeps the soft budget and every diagnostic field it carried. Headless runs are unaffected — they never arm a present target.

Three tests. Verified against the unfixed code: the two new ones fail with exactly the reported misattribution (`AppNotConverging` where `SurfaceNotPresenting`/`None` belongs). The third pins that an app *still churning* with a present outstanding keeps being blamed, so the exemption cannot over-correct.

## cranpose-testing

The headless `wait_for_idle` deliberately does **not** get the same treatment. That pump is synchronous work against an in-memory renderer with nothing to block on, so what a healthy app needs does not move with host load; timing it would decide headless results by host load — the flakiness this PR removes from the desktop side.

Its defect was the opposite: exhausting the budget returned quietly and handed back a half-settled tree. It now has a named budget, the reason it is counted in turns, and a loud failure with a diagnostic. `pump_robot_until_stable` was a copy of the same loop with per-call-site bounds of 40 and 60; instrumented measurement says every call settles on turn 1, so it goes and its callers use `wait_for_idle`.

## Also

`debug_toggles`' non-UTF-8 fixture spelled a tmpfs path, which the workspace tmpfs hygiene gate reads as a test writing to `/tmp` — `just test` was red on main before this branch (introduced by #495). The fixture is about byte preservation; the directory is arbitrary.

## Known, not addressed here

- While parked on a present the loop spins at `Poll`, competing with the compositor it waits for. That is the mechanism behind the failure, but polling across "asking for a frame and being handed it" is documented as required or measured FPS clamps to vsync — changing it would break the frame-rate contracts this test family exists to check.
- `RobotTestRule::wait_for_idle` loops on `needs_redraw()` (stale pixels + renderer warm-up), not pending work, so it is effectively "update once and return" — all 35 calls measured settle at turn 1. Fixing that means switching to `frame_schedule()` plus a shared animation-loop exit, and changes what every headless test observes. Filed separately; the misleading doc is corrected here.

Local gates: `just fmt-check`, `just test`, `just clippy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)