### PR TITLE
Drop the accessibility policy's dead enabled() accessor

### DIFF
--- a/crates/cranpose/src/accessibility_publish_policy.rs
+++ b/crates/cranpose/src/accessibility_publish_policy.rs
@@ -62,10 +62,6 @@ impl AccessibilityPublishPolicy {
         became_enabled
     }
 
-    pub(crate) fn enabled(&self) -> bool {
-        self.enabled
-    }
-
     /// Whether the bridge may probe-and-publish right now. `false` either
     /// means no assistive technology is listening, or the throttle window is
     /// still closed — in the latter case a wake deadline is armed so the
@@ -112,7 +108,6 @@ mod tests {
     fn disabled_policy_never_publishes_and_arms_no_wake() {
         let mut policy = AccessibilityPublishPolicy::new();
         let now = Instant::now();
-        assert!(!policy.enabled());
         assert!(!policy.try_begin_publish(now));
         assert_eq!(policy.wake_deadline(), None);
     }


### PR DESCRIPTION
## Problem

`cargo ndk --platform 26 -t arm64-v8a check -p cranscan --lib --features android,renderer-wgpu,ai-inprocess --no-default-features` reports:

    warning: method `enabled` is never used
      crates/cranpose/src/accessibility_publish_policy.rs:65

This is mine, from #497, and it is holding the v0.1.103 cut. AGENTS.md is explicit that zero warnings is not negotiable.

`git grep '\.enabled()' -- crates/cranpose/src` finds exactly one caller: the test one line below its own assertion. On a real Android build nothing outside the test reads it.

## Fix

The accessor goes. It was redundant as well as dead — `try_begin_publish` already refuses when the policy is disabled, so a production caller consulting `enabled()` first would ask the same question twice.

The **field** stays: `update_enabled` and `try_begin_publish` both read it, and the struct is live on the Android path (`android.rs`, `android_accessibility.rs`).

The test loses nothing. `disabled_policy_never_publishes_and_arms_no_wake` still pins the property through behaviour — a disabled policy refuses to publish and arms no wake deadline — which is what callers actually depend on. All 10 policy tests pass.

## Why it escaped

Android is the one shipped target with **no zero-warning gate**. The justfile has `clippy` (host), `clippy-wasm` and `clippy-ios`, all `-D warnings`; `android` only runs `./gradlew :app:assembleRelease`, which does not deny warnings, and no workflow sets `-D warnings` for an Android target. Anything behind an `android`-only `cfg` reaches main unlinted.

I have a `clippy-android` recipe working locally, but it surfaces **33+ pre-existing Android-only lints** across `cranpose`, `cranpose-services` and `cranpose-core`. That cleanup is real and I am doing it, but it should not hold a release behind it — so it ships separately and this PR is only the warning that blocks the cut.

Credit to cranscan-da for catching it on a real Android build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)