### PR TITLE
Gate every shipped Android ABI on clippy, and fix the 33 warnings that finds

### DIFF
--- a/.github/workflows/heavy-selfhosted.yml
+++ b/.github/workflows/heavy-selfhosted.yml
@@ -225,6 +225,12 @@ jobs:
           sccache --start-server || true
           sccache --zero-stats || true
 
+      - name: Clippy Android ABIs
+        # Gradle does not deny warnings, so the APK build below cannot be the
+        # zero-warning gate for this target. Runs first: a lint failure should
+        # not wait behind a full release APK.
+        run: just clippy-android
+
       - name: Build Android release APK
         # --no-daemon: never attach to a shared/foreign Gradle daemon on this
         # self-hosted box. Reused daemons started by other builds on the runner

--- a/crates/cranpose-services/src/http.rs
+++ b/crates/cranpose-services/src/http.rs
@@ -948,7 +948,7 @@ fn configure_native_client_builder(
 ) -> Result<reqwest::blocking::ClientBuilder, HttpError> {
     #[cfg(target_os = "android")]
     {
-        return Ok(builder.tls_certs_only(android_root_certificates()?));
+        Ok(builder.tls_certs_only(android_root_certificates()?))
     }
 
     #[cfg(not(target_os = "android"))]

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -350,7 +350,7 @@ fn push_pending_inputs_from_android_event(
     let event_source = motion_event.source();
     let logical_of = |x: f32, y: f32| {
         let logical = android_platform.pointer_position(x as f64, y as f64);
-        (logical.x as f32, logical.y as f32)
+        (logical.x, logical.y)
     };
 
     match motion_event.action() {
@@ -935,10 +935,8 @@ fn drain_present_returns_into_loop(
                 }
             }
         });
-    if presented {
-        if let Some(resources) = gpu_resources.as_mut() {
-            resources.surface_dirty = false;
-        }
+    if presented && let Some(resources) = gpu_resources.as_mut() {
+        resources.surface_dirty = false;
     }
     if refused {
         if let Some(resources) = gpu_resources.as_mut() {
@@ -1394,29 +1392,28 @@ fn create_android_gpu_resources(
     // file is keyed by adapter identity (vendor, device, driver strings), so
     // a driver update or a different GPU starts cold instead of feeding wgpu
     // a stale blob. `run` decided the directory; a pre-set full path wins.
-    if cranpose_render_wgpu::debug_toggle_os("CRANPOSE_PIPELINE_CACHE_FILE").is_none() {
-        if let Some(cache_dir) =
+    if cranpose_render_wgpu::debug_toggle_os("CRANPOSE_PIPELINE_CACHE_FILE").is_none()
+        && let Some(cache_dir) =
             cranpose_render_wgpu::debug_toggle_os("CRANPOSE_PIPELINE_CACHE_DIR")
+    {
+        let mut driver_hash: u64 = 0xcbf2_9ce4_8422_2325;
+        for byte in adapter_info
+            .driver
+            .bytes()
+            .chain(adapter_info.driver_info.bytes())
         {
-            let mut driver_hash: u64 = 0xcbf2_9ce4_8422_2325;
-            for byte in adapter_info
-                .driver
-                .bytes()
-                .chain(adapter_info.driver_info.bytes())
-            {
-                driver_hash ^= u64::from(byte);
-                driver_hash = driver_hash.wrapping_mul(0x0000_0100_0000_01b3);
-            }
-            let file_name = format!(
-                "pipeline_cache_v1_{:04x}_{:04x}_{driver_hash:016x}.bin",
-                adapter_info.vendor, adapter_info.device,
-            );
-            let file_path = std::path::Path::new(&cache_dir).join(file_name);
-            cranpose_render_wgpu::set_debug_toggle_os(
-                "CRANPOSE_PIPELINE_CACHE_FILE",
-                Some(file_path.as_os_str()),
-            );
+            driver_hash ^= u64::from(byte);
+            driver_hash = driver_hash.wrapping_mul(0x0000_0100_0000_01b3);
         }
+        let file_name = format!(
+            "pipeline_cache_v1_{:04x}_{:04x}_{driver_hash:016x}.bin",
+            adapter_info.vendor, adapter_info.device,
+        );
+        let file_path = std::path::Path::new(&cache_dir).join(file_name);
+        cranpose_render_wgpu::set_debug_toggle_os(
+            "CRANPOSE_PIPELINE_CACHE_FILE",
+            Some(file_path.as_os_str()),
+        );
     }
 
     let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -1496,7 +1493,7 @@ fn create_android_surface_config(
     width: u32,
     height: u32,
 ) -> Result<wgpu::SurfaceConfiguration, AndroidSurfaceError> {
-    let surface_caps = surface.get_capabilities(&adapter);
+    let surface_caps = surface.get_capabilities(adapter);
     let surface_format =
         crate::surface_format::select_display_surface_format(&surface_caps.formats)
             .ok_or(AndroidSurfaceError::NoSurfaceFormat)?;
@@ -1781,14 +1778,14 @@ pub fn run(
     // `CRANPOSE_PIPELINE_CACHE_FILE` from this directory. Seeded properties
     // (above) and pre-set environments win, so tests and debugging can
     // redirect or disable it.
-    if cranpose_render_wgpu::debug_toggle_os("CRANPOSE_PIPELINE_CACHE_DIR").is_none() {
-        if let Some(data_path) = app.internal_data_path() {
-            let cache_dir = data_path.join("cranpose_gpu");
-            cranpose_render_wgpu::set_debug_toggle_os(
-                "CRANPOSE_PIPELINE_CACHE_DIR",
-                Some(cache_dir.as_os_str()),
-            );
-        }
+    if cranpose_render_wgpu::debug_toggle_os("CRANPOSE_PIPELINE_CACHE_DIR").is_none()
+        && let Some(data_path) = app.internal_data_path()
+    {
+        let cache_dir = data_path.join("cranpose_gpu");
+        cranpose_render_wgpu::set_debug_toggle_os(
+            "CRANPOSE_PIPELINE_CACHE_DIR",
+            Some(cache_dir.as_os_str()),
+        );
     }
 
     // Threaded present runtime (pipeline step 7b), default OFF: the frame
@@ -2149,8 +2146,8 @@ pub fn run(
                             }
                         }
 
-                        if overlay_window_options.is_none() {
-                            if let Some(native_window) = app.native_window() {
+                        if overlay_window_options.is_none()
+                            && let Some(native_window) = app.native_window() {
                                 let width = native_window.width() as u32;
                                 let height = native_window.height() as u32;
                                 let density =
@@ -2247,7 +2244,6 @@ pub fn run(
                                     }
                                 }
                             }
-                        }
                     }
                     MainEvent::TerminateWindow { .. } => {
                         log::info!("Window terminated");
@@ -2260,8 +2256,8 @@ pub fn run(
                         }
                     }
                     MainEvent::WindowResized { .. } => {
-                        if overlay_window_options.is_none() {
-                            if let Some(native_window) = app.native_window() {
+                        if overlay_window_options.is_none()
+                            && let Some(native_window) = app.native_window() {
                                 let width = native_window.width() as u32;
                                 let height = native_window.height() as u32;
 
@@ -2280,8 +2276,7 @@ pub fn run(
 
                                 if let (Some(resources), Some(shell)) =
                                     (&mut gpu_resources, &mut app_shell)
-                                {
-                                    if width > 0 && height > 0 {
+                                    && width > 0 && height > 0 {
                                         resources.config.width = width;
                                         resources.config.height = height;
                                         if present_thread {
@@ -2311,9 +2306,7 @@ pub fn run(
                                             current_host_window_size = actual_size;
                                         }
                                     }
-                                }
                             }
-                        }
                     }
                     MainEvent::ContentRectChanged { .. } => {
                         let density = update_android_platform_geometry(&app, &mut android_platform);
@@ -2329,13 +2322,12 @@ pub fn run(
                             density
                         );
 
-                        if let Some(shell) = &mut app_shell {
-                            if let Some(actual_size) =
+                        if let Some(shell) = &mut app_shell
+                            && let Some(actual_size) =
                                 update_android_shell_geometry(shell, density, &host_window_registry)
                             {
                                 current_host_window_size = actual_size;
                             }
-                        }
                     }
                     MainEvent::RedrawNeeded { .. } => {
                         if let Some(shell) = &mut app_shell {
@@ -2413,22 +2405,20 @@ pub fn run(
                         // Follow OS light/dark switches live (uiMode arrives as
                         // a configuration change).
                         let theme = system_theme_from_android(app.config().ui_mode_night());
-                        if android_platform_env().set_system_theme(theme) {
-                            if let Some(shell) = &mut app_shell {
+                        if android_platform_env().set_system_theme(theme)
+                            && let Some(shell) = &mut app_shell {
                                 shell.request_root_render();
                             }
-                        }
                         // So does the font-size setting: the platform changes
                         // the configuration rather than restarting the process,
                         // so an app that never re-read it would keep laying
                         // text out at the size the user just moved away from.
-                        if crate::android_font_scale::refresh_font_scale(&app) {
-                            if let Some(shell) = &mut app_shell {
+                        if crate::android_font_scale::refresh_font_scale(&app)
+                            && let Some(shell) = &mut app_shell {
                                 shell.set_font_scale_curve(
                                     crate::android_font_scale::font_scale_curve(),
                                 );
                             }
-                        }
                         // Multi-window transitions arrive as configuration
                         // changes too, and they gate the renderer's
                         // round-display corner cull: re-read the platform
@@ -2553,8 +2543,8 @@ pub fn run(
                     match action {
                         android_overlay_window::AndroidOverlayPointerAction::Down => {
                             pending_inputs.push(PendingInput::PointerDown(
-                                logical.x as f32,
-                                logical.y as f32,
+                                logical.x,
+                                logical.y,
                                 None,
                                 // The overlay JNI bridge does not forward tool
                                 // type; overlay surfaces are touch in practice.
@@ -2563,8 +2553,8 @@ pub fn run(
                         }
                         android_overlay_window::AndroidOverlayPointerAction::Up => {
                             pending_inputs.push(PendingInput::PointerUp(
-                                logical.x as f32,
-                                logical.y as f32,
+                                logical.x,
+                                logical.y,
                                 None,
                                 PointerSource::Touch,
                             ));
@@ -2574,8 +2564,8 @@ pub fn run(
                         }
                         android_overlay_window::AndroidOverlayPointerAction::Move => {
                             pending_inputs.push(PendingInput::PointerMove(
-                                logical.x as f32,
-                                logical.y as f32,
+                                logical.x,
+                                logical.y,
                                 None,
                                 PointerSource::Touch,
                             ));
@@ -2587,33 +2577,31 @@ pub fn run(
 
         // Install the soft-keyboard focus hook as soon as the shell exists so
         // the first tap on a text field already opens the keyboard.
-        if !soft_keyboard_installed {
-            if let Some(shell) = &mut app_shell {
-                shell.set_platform_text_input(Rc::new(AndroidSoftKeyboard::new(Rc::clone(
-                    &ime_session,
-                ))));
-                soft_keyboard_installed = true;
-                log::info!("Android soft keyboard focus hook installed");
+        if !soft_keyboard_installed && let Some(shell) = &mut app_shell {
+            shell.set_platform_text_input(Rc::new(AndroidSoftKeyboard::new(Rc::clone(
+                &ime_session,
+            ))));
+            soft_keyboard_installed = true;
+            log::info!("Android soft keyboard focus hook installed");
 
-                // The system clipboard is per-AppContext (it backs the text
-                // selection menu), so it registers once the shell exists.
-                let clipboard_app = app.clone();
-                shell.app_context().enter(move || {
-                    cranpose_ui::clipboard_session::set_platform_clipboard(Rc::new(
-                        crate::android_services::AndroidClipboard { app: clipboard_app },
-                    ));
-                });
+            // The system clipboard is per-AppContext (it backs the text
+            // selection menu), so it registers once the shell exists.
+            let clipboard_app = app.clone();
+            shell.app_context().enter(move || {
+                cranpose_ui::clipboard_session::set_platform_clipboard(Rc::new(
+                    crate::android_services::AndroidClipboard { app: clipboard_app },
+                ));
+            });
 
-                // Cold-start guard (bug 5): on a fresh launch the OS can restore
-                // the soft keyboard left over from the previous process — even on
-                // a screen with no text field. Re-request it only if a field is
-                // genuinely focused this launch; otherwise force it hidden so the
-                // keyboard does not resurrect on relaunch. `notify_app_resumed`
-                // returns whether a focused field re-opened it.
-                if !shell.notify_app_resumed() {
-                    ime_session.ensure_hidden();
-                    log::info!("No focused field at launch; ensured soft keyboard hidden");
-                }
+            // Cold-start guard (bug 5): on a fresh launch the OS can restore
+            // the soft keyboard left over from the previous process — even on
+            // a screen with no text field. Re-request it only if a field is
+            // genuinely focused this launch; otherwise force it hidden so the
+            // keyboard does not resurrect on relaunch. `notify_app_resumed`
+            // returns whether a focused field re-opened it.
+            if !shell.notify_app_resumed() {
+                ime_session.ensure_hidden();
+                log::info!("No focused field at launch; ensured soft keyboard hidden");
             }
         }
 
@@ -2716,17 +2704,17 @@ pub fn run(
         // input handling: refreshes the IME's selection view and restarts
         // the input session when the field content diverged from the mirror
         // (e.g. the app transformed or rejected input).
-        if ime_session.is_active() {
-            if let Some(shell) = &mut app_shell {
-                ime_session.sync_editor_state(shell.ime_editor_state());
-            }
+        if ime_session.is_active()
+            && let Some(shell) = &mut app_shell
+        {
+            ime_session.sync_editor_state(shell.ime_editor_state());
         }
 
         // Check if app side requested a frame (animations, state changes)
-        if android_frame_driver.take_frame_request() {
-            if let Some(shell) = &mut app_shell {
-                shell.mark_dirty();
-            }
+        if android_frame_driver.take_frame_request()
+            && let Some(shell) = &mut app_shell
+        {
+            shell.mark_dirty();
         }
 
         confirm_android_host_window_request(
@@ -2775,13 +2763,13 @@ pub fn run(
         // recomposition that work asked for still runs.
         let offscreen_due = next_offscreen_update.is_some_and(|at| at <= web_time::Instant::now());
         if offscreen && (offscreen_pending_ui || offscreen_due) {
-            if let Some(shell) = &mut app_shell {
-                if shell.needs_update() {
-                    android_host_window::with_android_host_window_registry(
-                        &host_window_registry,
-                        || shell.update(),
-                    );
-                }
+            if let Some(shell) = &mut app_shell
+                && shell.needs_update()
+            {
+                android_host_window::with_android_host_window_registry(
+                    &host_window_registry,
+                    || shell.update(),
+                );
             }
             next_offscreen_update = match offscreen_pending_ui {
                 true => Some(web_time::Instant::now() + OFFSCREEN_UPDATE_PERIOD),
@@ -2812,7 +2800,7 @@ pub fn run(
                 if let Err(error) = crate::android_accessibility::sync(
                     &app,
                     shell,
-                    android_platform.scale_factor() as f32,
+                    android_platform.scale_factor(),
                     &mut accessibility_elements,
                     &mut accessibility_revision,
                     &mut accessibility_policy,
@@ -2874,17 +2862,16 @@ pub fn run(
                 if accessibility_policy
                     .wake_deadline()
                     .is_some_and(|deadline| deadline <= std::time::Instant::now())
-                {
-                    if let Err(error) = crate::android_accessibility::sync(
+                    && let Err(error) = crate::android_accessibility::sync(
                         &app,
                         shell,
-                        android_platform.scale_factor() as f32,
+                        android_platform.scale_factor(),
                         &mut accessibility_elements,
                         &mut accessibility_revision,
                         &mut accessibility_policy,
-                    ) {
-                        log::warn!("{error}");
-                    }
+                    )
+                {
+                    log::warn!("{error}");
                 }
             }
         } else {
@@ -2909,19 +2896,17 @@ pub fn run(
         // telemetry stamps are property-gated and read zero in production.
         // Threaded-present frames complete elsewhere and report nothing
         // rather than a made-up number.
-        if adpf_sync_presented {
-            if let Some(started) = adpf_work_started {
-                let reported = crate::android_frame_telemetry::vsync_period_ns();
-                let period = if reported > 0 {
-                    reported
-                } else {
-                    crate::android_vsync::observed_vsync_period_ns().unwrap_or(16_666_667)
-                };
-                let session = perf_hint
-                    .get_or_insert_with(|| crate::android_perf_hint::PerfHintSession::open(period));
-                if let Some(session) = session.as_mut() {
-                    session.report(started.elapsed().as_nanos() as i64, period);
-                }
+        if adpf_sync_presented && let Some(started) = adpf_work_started {
+            let reported = crate::android_frame_telemetry::vsync_period_ns();
+            let period = if reported > 0 {
+                reported
+            } else {
+                crate::android_vsync::observed_vsync_period_ns().unwrap_or(16_666_667)
+            };
+            let session = perf_hint
+                .get_or_insert_with(|| crate::android_perf_hint::PerfHintSession::open(period));
+            if let Some(session) = session.as_mut() {
+                session.report(started.elapsed().as_nanos() as i64, period);
             }
         }
         if let Some(now) = presented_at {

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -195,6 +195,17 @@ pub(crate) fn seed_env_from_system_properties() {
 
 /// `CLOCK_MONOTONIC` in nanoseconds — the same clock `AChoreographer` frame
 /// times use, so the two can be subtracted directly.
+// `timespec` fields are `i64` on the 64-bit ABIs and `i32` on armeabi-v7a and
+// x86. The widening is mandatory on 32-bit and is a no-op on 64-bit, and there
+// is no spelling that satisfies both: `as i64` trips `unnecessary_cast` on
+// 64-bit, `i64::from` trips `useless_conversion` there instead. Keeping
+// `i64::from` and allowing the 64-bit complaint is the honest resolution — it
+// states the widening intent, and dropping it to silence the lint would make
+// this a type error on the two 32-bit ABIs that CI ships.
+#[allow(
+    clippy::useless_conversion,
+    reason = "identity on 64-bit ABIs, required widening on armeabi-v7a and x86"
+)]
 pub(crate) fn monotonic_nanos() -> i64 {
     let mut now = libc::timespec {
         tv_sec: 0,
@@ -204,7 +215,11 @@ pub(crate) fn monotonic_nanos() -> i64 {
     unsafe {
         libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut now);
     }
-    now.tv_sec as i64 * 1_000_000_000 + now.tv_nsec as i64
+    // `timespec` fields are `i64` on 64-bit ABIs and `i32` on armeabi-v7a and
+    // x86, so this has to widen on 32-bit and must not look like a redundant
+    // cast on 64-bit. `i64::from` is both: infallible widening where the types
+    // differ, identity where they do not, and no `unnecessary_cast` either way.
+    i64::from(now.tv_sec) * 1_000_000_000 + i64::from(now.tv_nsec)
 }
 
 static VSYNC_LAST_NS: AtomicI64 = AtomicI64::new(0);

--- a/crates/cranpose/src/android_host.rs
+++ b/crates/cranpose/src/android_host.rs
@@ -102,12 +102,10 @@ pub(crate) fn install(app: android_activity::AndroidApp) {
             std::env::set_var("XDG_DATA_HOME", path);
         }
     }
-    if let Some(package) = package_name(&app) {
-        if let Err(error) = set_application_id(&package) {
-            log::warn!(
-                "cranpose: the Android package name is not a usable application id: {error}"
-            );
-        }
+    if let Some(package) = package_name(&app)
+        && let Err(error) = set_application_id(&package)
+    {
+        log::warn!("cranpose: the Android package name is not a usable application id: {error}");
     }
     set_host_controller(Arc::new(AndroidHost { app }));
 }

--- a/crates/cranpose/src/android_perf_hint.rs
+++ b/crates/cranpose/src/android_perf_hint.rs
@@ -138,10 +138,11 @@ impl PerfHintSession {
         }
         // SAFETY: session is the live pointer `open` created on this thread.
         unsafe {
-            if target_ns > 0 && (target_ns - self.target_ns).abs() > self.target_ns / 64 {
-                if (self.api.update_target)(self.session, target_ns) == 0 {
-                    self.target_ns = target_ns;
-                }
+            if target_ns > 0
+                && (target_ns - self.target_ns).abs() > self.target_ns / 64
+                && (self.api.update_target)(self.session, target_ns) == 0
+            {
+                self.target_ns = target_ns;
             }
             (self.api.report_actual)(self.session, actual_ns);
         }

--- a/crates/cranpose/src/android_services.rs
+++ b/crates/cranpose/src/android_services.rs
@@ -458,10 +458,10 @@ pub(crate) fn apply_pending_platform_signals(
             right: INSETS_RIGHT_PX.load(Ordering::Acquire) as f32 / density,
             bottom: INSETS_BOTTOM_PX.load(Ordering::Acquire) as f32 / density,
         };
-        if crate::android::android_platform_env().set_safe_area(insets) {
-            if let Some(shell) = shell {
-                shell.request_root_render();
-            }
+        if crate::android::android_platform_env().set_safe_area(insets)
+            && let Some(shell) = shell
+        {
+            shell.request_root_render();
         }
     }
 }

--- a/justfile
+++ b/justfile
@@ -68,6 +68,26 @@ clippy-wasm:
 clippy-ios:
     cargo clippy -p desktop-app --bin cranpose-ios --target aarch64-apple-ios-sim --no-default-features --features ios -- -D warnings
 
+# Lint the exact package, features and target the Android build ships.
+#
+# `just android` runs Gradle, which does not deny warnings, so Android was the
+# one shipped target with no zero-warning gate: anything behind an
+# android-only `cfg` reached main unlinted. The package, `--lib`,
+# `--no-default-features` and the feature list mirror what
+# `CranposeAndroidPlugin` passes to `cargo ndk` (its `features` convention is
+# `android,renderer-wgpu` and `defaultFeatures` is false); `--platform` is the
+# demo's `minSdk`. Change them together or this stops checking what ships.
+#
+# `missing_const_for_thread_local` is allowed for this target only.
+# `thread_local!` expands differently per target, and the Android expansion
+# defeats the lint's const detection: on the same pinned toolchain and the
+# same source it fires 16 times here and never on host, including on
+# initializers that are already `const {}` and on one that cannot be const at
+# all (`HashMap::default()`). It stays enabled everywhere else, so a genuine
+# non-const initializer is still caught by `just clippy`.
+clippy-android:
+    cargo ndk --platform 24 -t arm64-v8a clippy -p desktop-app-platform --lib --no-default-features --features android,renderer-wgpu -- -D warnings -A clippy::missing_const_for_thread_local
+
 # --- test ------------------------------------------------------------------
 
 # `--profile ci` keeps the debuginfo that the local dev profile strips, so a

--- a/justfile
+++ b/justfile
@@ -68,7 +68,7 @@ clippy-wasm:
 clippy-ios:
     cargo clippy -p desktop-app --bin cranpose-ios --target aarch64-apple-ios-sim --no-default-features --features ios -- -D warnings
 
-# Lint the exact package, features and target the Android build ships.
+# Lint the exact package, features and ABIs the Android build ships.
 #
 # `just android` runs Gradle, which does not deny warnings, so Android was the
 # one shipped target with no zero-warning gate: anything behind an
@@ -78,15 +78,22 @@ clippy-ios:
 # `android,renderer-wgpu` and `defaultFeatures` is false); `--platform` is the
 # demo's `minSdk`. Change them together or this stops checking what ships.
 #
-# `missing_const_for_thread_local` is allowed for this target only.
-# `thread_local!` expands differently per target, and the Android expansion
-# defeats the lint's const detection: on the same pinned toolchain and the
-# same source it fires 16 times here and never on host, including on
-# initializers that are already `const {}` and on one that cannot be const at
-# all (`HashMap::default()`). It stays enabled everywhere else, so a genuine
+# Every ABI `releaseAbis` builds under CI is linted, not just arm64. The
+# 32-bit ones are not redundant: `libc::timespec::tv_sec` is `i64` on
+# aarch64 and `i32` on armeabi-v7a and x86, so a width assumption that is
+# invisible on a 64-bit ABI is a type error on a 32-bit one. An arm64-only
+# gate reported an `as i64` on that field as an unnecessary cast, and taking
+# that advice would have broken the shipped 32-bit build.
+#
+# `missing_const_for_thread_local` is allowed here only. `thread_local!`
+# expands differently per target, and the Android expansion defeats the
+# lint's const detection: on the same pinned toolchain and the same source it
+# fires 16 times here and never on host, including on initializers already
+# written as `const {}` and on one that cannot be const at all
+# (`HashMap::default()`). It stays enabled everywhere else, so a genuine
 # non-const initializer is still caught by `just clippy`.
 clippy-android:
-    cargo ndk --platform 24 -t arm64-v8a clippy -p desktop-app-platform --lib --no-default-features --features android,renderer-wgpu -- -D warnings -A clippy::missing_const_for_thread_local
+    cargo ndk --platform 24 -t arm64-v8a -t armeabi-v7a -t x86 -t x86_64 clippy -p desktop-app-platform --lib --no-default-features --features android,renderer-wgpu -- -D warnings -A clippy::missing_const_for_thread_local
 
 # --- test ------------------------------------------------------------------
 
@@ -319,4 +326,4 @@ ci: fmt-check typos versions test clippy doc budgets
 # Needs a Linux box with the X11 stack, an Android SDK and (on macOS) Xcode.
 
 # Every gate, including the platform builds and the robot suite.
-ci-full: ci clippy-wasm web android robot
+ci-full: ci clippy-wasm clippy-ios clippy-android web android robot


### PR DESCRIPTION
## Problem

Android was the only shipped target with **no zero-warning gate**.

`clippy` (host), `clippy-wasm` and `clippy-ios` all deny warnings. `android` runs `./gradlew :app:assembleRelease`, which does not, and no workflow set `-D warnings` for an Android target. Anything behind an `android`-only `cfg` reached main unlinted.

#513's dead accessor is how that surfaced. It was not the only one — the gate finds **33**.

## The gate

`clippy-android` mirrors what `CranposeAndroidPlugin` hands `cargo ndk` rather than inventing a feature subset: `-p desktop-app-platform --lib --no-default-features --features android,renderer-wgpu`, `--platform` from the demo's `minSdk`. It runs in CI before the APK build, so a lint failure does not wait behind a full release build. `ci-full` now names it — and `clippy-ios`, which that aggregate had also been omitting while claiming to be every gate.

## It lints all four shipped ABIs, and that is load-bearing

**This is the most consequential thing in the PR.** `libc::timespec::tv_sec` is `i64` on the 64-bit ABIs and `i32` on `armeabi-v7a` and `x86`. `releaseAbis` ships all four under CI.

An arm64-only run reports the `as i64` on that field as an unnecessary cast, and `cargo clippy --fix` duly removed it — which is a **type error on the two 32-bit ABIs that CI builds**. Nothing failed to reveal it: the arm64 lint run was green afterwards. It was caught only by reading the autofix diff.

The general form, which is worth carrying: **an autofix is a code change proposed by a tool that saw one target.** Read every hunk for assumptions the checked target happens to satisfy.

That field also has **no lint-clean spelling**: `as i64` trips `unnecessary_cast` on 64-bit, `i64::from` trips `useless_conversion` there instead, and dropping the widening breaks 32-bit. It keeps `i64::from` with a scoped `#[allow]` stating the widening intent, rather than a rewrite that would read as clean and be wrong on two ABIs.

## `missing_const_for_thread_local` is allowed for this recipe only

It fires **16 times on Android and zero times on host** — same pinned toolchain, same source — including on initializers already written `const { ... }` and on one that cannot be const at all (`HashMap::default()`). `thread_local!` expands per-target and the Android expansion defeats the lint's const detection.

I first tried per-item `#[allow]`s and reverted that: sixteen scattered suppressions for one systemic false positive is the wrong shape, and it would have left sixteen misleading comments claiming the code was not const when it plainly was. Allowing it on the one recipe keeps the lint live everywhere else, so a genuinely non-const initializer is still caught by `just clippy`.

## The remaining 31

Reviewed rather than trusted: 18 `collapsible_if` (all `let`-chains with no `else`, so equivalent), 12 `unnecessary_cast` on values already `f32`, one `needless_borrow` passing `&&Adapter`. Plus one genuine `needless_return` in the `cfg(target_os = "android")` branch of `configure_native_client_builder`.

## Verified

`just clippy-android` (all four ABIs), `just clippy`, `just test`, `just fmt`, `just android` — all green locally.

## Note on CI

`architecture budgets (linux)` will fail on this PR. **It is not caused by this change** — main is red for it, from #501's `nokhwa` 0.10 → `nokhwa-bindings-macos` 0.2.4, which pulls a 2020-era macOS stack (`cocoa` 0.20.2, `core-graphics` 0.19.2, `metal` 0.18.0, `core-media-sys` 0.1.2, `core-video-sys` 0.1.4) and with it the `bitflags`, `cfg-if`, `core-foundation`, `core-foundation-sys` and `getrandom` splits. Details are with that PR's owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
