### PR TITLE
Keep the host-capacity lock out of the hands of every child process

### DIFF
--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -42,6 +42,13 @@ if [ ! -x "${CARGO_RUNNER[0]}" ]; then
     CARGO_RUNNER=(cargo)
 fi
 
+# Before the host lock fd below exists, not after: sccache's server is a
+# long-lived daemon that inherits whatever fds are open in its parent at the
+# moment cargo lazily spawns it, and a lock fd leaked into a daemon that way
+# is held for the daemon's life. Calling this here means the build under the
+# lock further down never has to spawn the server itself.
+enable_local_sccache
+
 # The host lock, in two phases (scripts/ci/with_host_lock.sh owns the file).
 #
 # Phase one, from here: the shared side, the same side every heavy build on
@@ -113,7 +120,6 @@ if ! [[ "$ROBOT_FAILURE_LOG_LINES" =~ ^[1-9][0-9]*$ ]]; then
 fi
 
 enable_local_tmpdir
-enable_local_sccache
 enable_local_cargo_job_limit
 export WINIT_X11_SCALE_FACTOR="${WINIT_X11_SCALE_FACTOR:-1}"
 
@@ -437,7 +443,11 @@ else
         echo "Host was not ready for robot build." | tee -a "$LOG_FILE"
         exit 1
     fi
-    "${CARGO_RUNNER[@]}" build "${BUILD_ARGS[@]}" 2>&1 | tee -a "$LOG_FILE"
+    # 8>&- 9>&-: never let the build inherit the host-capacity lock fds. If
+    # sccache's server is not already running (enable_local_sccache above
+    # failed to start it, or something else killed it), cargo spawning it
+    # here must not hand it a copy of the lock to hold open forever.
+    "${CARGO_RUNNER[@]}" build "${BUILD_ARGS[@]}" 8>&- 9>&- 2>&1 | tee -a "$LOG_FILE"
 
     if [ ${PIPESTATUS[0]} -ne 0 ]; then
         echo "Build failed!" | tee -a "$LOG_FILE"
@@ -787,12 +797,17 @@ run_test() {
             robot_env_args+=("$entry")
         done < <(robot_process_env "$headless_env" "${example_env[@]}")
 
+        # 8>&- 9>&-: the same reasoning as the build above, for the example
+        # binary itself. fd 8 is already closed process-wide by this point
+        # (the exclusive phase closed it), but closing both here as well
+        # means no lock fd survives into this child even if that ever
+        # changes, and even if the exclusive holder below dies mid-run.
         if command -v timeout >/dev/null 2>&1; then
-            env -i "${robot_env_args[@]}" timeout --kill-after=15s "${timeout_secs}s" "$example_bin" > "$attempt_output" 2>&1
+            env -i "${robot_env_args[@]}" timeout --kill-after=15s "${timeout_secs}s" "$example_bin" > "$attempt_output" 2>&1 8>&- 9>&-
             local exit_code=$?
         else
             run_with_portable_timeout "$timeout_secs" 15 "$attempt_output" \
-                env -i "${robot_env_args[@]}" "$example_bin"
+                env -i "${robot_env_args[@]}" "$example_bin" 8>&- 9>&-
             local exit_code=$?
         fi
 

--- a/scripts/ci/with_host_lock.sh
+++ b/scripts/ci/with_host_lock.sh
@@ -31,6 +31,10 @@ set -euo pipefail
 # releases it immediately. There is no PID file to go stale and no cleanup
 # step that a crash can skip.
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../dev_build_common.sh"
+
 readonly lock_file="/tmp/cranpose-host-capacity.lock"
 # Long enough for a neighbour's Android or wasm build to finish, short enough
 # to stay inside the robot job's 90-minute cap. On expiry the command runs
@@ -61,6 +65,20 @@ if ! command -v flock >/dev/null 2>&1; then
   exec "$@"
 fi
 
+# Before the lock fd below exists, not after: this wrapper's whole job is to
+# run a build (`--shared`) or a measurement (`--exclusive`) underneath it,
+# and that command is frequently `cargo`. sccache's server is a long-lived
+# daemon that cargo spawns lazily on the first wrapped rustc call, and a
+# daemon spawned while fd 9 is open inherits a copy of it that it then holds
+# for as long as it lives -- which is indefinite. Since flock's shared and
+# exclusive modes are enforced across every open file description on the
+# file, not just the one this script itself still holds, that inherited copy
+# alone is enough to block every later exclusive acquire, even long after
+# this script has exited. See run_robot_test.sh for the reproduction; the
+# mechanism here is identical, just reached through the android/web/budgets
+# `--shared` builds instead of the robot suite's own build step.
+enable_local_sccache
+
 exec 9>"$lock_file"
 
 flock_mode="-s"
@@ -79,4 +97,11 @@ else
   fi
 fi
 
-exec "$@"
+# 8>&- 9>&-: never let the wrapped command inherit this lock's fd. If
+# sccache's server is not already running (enable_local_sccache above failed
+# or found nothing to start), the command spawning it here -- directly, or
+# indirectly by execing further into another script -- must not hand it a
+# copy of the lock to hold open forever. fd 8 is not opened by this script,
+# but closing it too costs nothing and matches the same guard everywhere else
+# this lock file is touched.
+exec "$@" 8>&- 9>&-

--- a/scripts/dev_build_common.sh
+++ b/scripts/dev_build_common.sh
@@ -18,22 +18,35 @@ is_ci_env() {
 }
 
 enable_local_sccache() {
-    local sccache_bin
+    local sccache_bin="${RUSTC_WRAPPER:-}"
 
-    if is_ci_env; then
-        return 0
-    fi
-    if [ "${CRANPOSE_USE_SCCACHE:-1}" = "0" ]; then
-        return 0
-    fi
-    if [ -n "${RUSTC_WRAPPER:-}" ]; then
-        return 0
-    fi
-    if ! sccache_bin="$(find_local_tool sccache)"; then
-        return 0
+    if [ -z "$sccache_bin" ]; then
+        if is_ci_env || [ "${CRANPOSE_USE_SCCACHE:-1}" = "0" ]; then
+            return 0
+        fi
+        if ! sccache_bin="$(find_local_tool sccache)"; then
+            return 0
+        fi
+        export RUSTC_WRAPPER="$sccache_bin"
     fi
 
-    export RUSTC_WRAPPER="$sccache_bin"
+    # Start the daemon now, on purpose, before any caller has a chance to
+    # open a lock fd: sccache spawns its server lazily on the first wrapped
+    # rustc call, and that server is a long-lived daemon that inherits
+    # whatever file descriptors its parent (cargo, and above it this script)
+    # happens to have open at that moment. A flock fd leaked into it that way
+    # stays held for the daemon's lifetime, which can be forever -- see
+    # run_robot_test.sh's host-capacity lock for why that matters. Starting
+    # the server here, before a caller's lock section begins, means the later
+    # build never needs to spawn it. --start-server is a no-op against an
+    # already-running server, so calling this more than once is harmless.
+    # Only ever touch a binary actually named sccache: RUSTC_WRAPPER can
+    # point at anything, and most wrappers do not understand this flag.
+    case "$(basename -- "$sccache_bin")" in
+        sccache|sccache.exe) ;;
+        *) return 0 ;;
+    esac
+    command -v "$sccache_bin" >/dev/null 2>&1 || return 0
     "$sccache_bin" --start-server >/dev/null 2>&1 || true
 }
 


### PR DESCRIPTION
## The bug

`run_robot_test.sh` guards timed robot runs with an flock on `/tmp/cranpose-host-capacity.lock`: a shared lock (fd 8) during the build, dropped and replaced with an exclusive lock (fd 9) for the timed run itself.

Child processes inherit open file descriptors across `fork`/`exec` unless a caller explicitly closes them. `cargo` spawns the `sccache` compiler-cache server lazily, on the first wrapped `rustc` invocation, when one isn't already running — and that server is a long-lived daemon. If it gets spawned while the script has fd 8 (or 9) open, the daemon inherits a duplicate of that descriptor and keeps it open for as long as the daemon lives, which is indefinite. Since `flock`'s shared/exclusive semantics are enforced across all open file descriptions on the file (not just the one the script itself still holds), that inherited copy alone is enough to block every later exclusive acquire, forever — even after the script that opened fd 8 has itself moved on and closed its own copy.

## Evidence (from samarch-1, `lsof /tmp/cranpose-host-capacity.lock`)

```
run_robot 3581949 9w   /tmp/cranpose-host-capacity.lock
sccache   3581962 8w   /tmp/cranpose-host-capacity.lock     <-- the daemon, same start second
flock     3600132 9w   (waiting)
run_robot 3617990 9w
flock     3640112 9w   (waiting)
```

Two `flock -w 2700 -x 9` waiters sat stuck for 10-15 minutes on a host at load 0.54 with every worker under 1% CPU — nothing was actually contending for the machine, the lock file itself was just stuck held. Two `robot external captures` jobs were separately observed killing each other at the same millisecond (`2026-08-28T08:51:07.118`, `signal 15` / exit `143`, no assertion, no capture diff), consistent with two runs each waiting out the other's dead-daemon-held lock until something external (job timeout) intervened. When one such job had the host to itself, it passed in 16m0s.

## A third door onto the same lock

`scripts/ci/with_host_lock.sh` takes the identical `/tmp/cranpose-host-capacity.lock` — the justfile uses it to wrap the android, web, and budgets `--shared` builds — and it ends in `exec "$@"` after acquiring fd 9, so the wrapped command (frequently `cargo`) inherits fd 9 directly. Same mechanism, same file, third call site: an android build can spawn the sccache daemon while holding the shared side of this lock, and hours later a robot capture job's `--exclusive` acquire hangs with nothing in the capture job's own log to explain why, because the thing holding it open was never in that job's process tree. This was found while fixing `run_robot_test.sh` and is fixed here too rather than left as a second, harder-to-diagnose way to hit the same bug.

## The fix

1. `scripts/dev_build_common.sh`: `enable_local_sccache` now starts the sccache server (via `--start-server`, idempotent and non-fatal) whenever `RUSTC_WRAPPER` already names `sccache` — not just in the local/non-CI auto-discovery path it previously covered.
2. `run_robot_test.sh` calls `enable_local_sccache` *before* the host-lock file descriptor is opened at all, so the daemon already exists by the time any cargo build runs under the lock, and cargo never needs to spawn it itself. Every cargo/test-binary invocation inside the locked region (`cargo build`, and both the `timeout`- and `python3`-based robot-binary runners) also explicitly closes fds 8 and 9 for the child (`8>&- 9>&-`) as defense in depth — even if the daemon dies mid-run and something respawns it, or a future call site is added without going through `enable_local_sccache` first, nothing spawned at these sites can inherit the lock.
3. `scripts/ci/with_host_lock.sh` gets the same two-part treatment: it now sources `dev_build_common.sh` and calls `enable_local_sccache` before `exec 9>"$lock_file"`, and its final `exec "$@"` becomes `exec "$@" 8>&- 9>&-` so the wrapped command can never inherit either descriptor.

Lock semantics, wait budgets, and the load guard are unchanged in all three files. The guard itself is not disabled anywhere.

## What this does NOT fix

The workflow-level race: `.github/workflows/heavy-selfhosted.yml` sets `concurrency.group: heavy-${{ github.ref }}`, which is ref-keyed, so a PR run and a main run land in different groups and never queue against each other on GitHub's side — they only ever meet at this file-based host lock. A job-level concurrency group on the capture job, not keyed on ref, with `cancel-in-progress: false`, would be the complementary fix. Leaving that for a separate PR/session.

## Verification

- `just fmt` — clean, no diff, across all three commits.
- `bash -n` on `run_robot_test.sh`, `scripts/dev_build_common.sh`, and `scripts/ci/with_host_lock.sh` — all pass.
- `shellcheck` on all three files, before/after comparison: `run_robot_test.sh` carries three pre-existing info/style findings (SC2086, SC2329, SC2129) at both HEAD and this branch, unchanged by this diff; `dev_build_common.sh` and `with_host_lock.sh` are clean (zero findings) both before and after. No new findings anywhere.
- Manually verified the `8>&- 9>&-` mechanism in isolation — for a plain external-command redirection, for a bash function call that internally spawns a subprocess, and for the `exec "$@" 8>&- 9>&-` replace-the-process form used in `with_host_lock.sh` — in each case the resulting process has neither fd open.
- Ran `with_host_lock.sh` end-to-end with a stubbed `flock` (this Mac has no real `flock(1)`): confirmed `enable_local_sccache` fires before the lock fd is opened, and the wrapped child's fd table has neither 8 nor 9 open.

**Not run**: the full robot suite (`just robot`, ~45 min) and any on-runner reproduction, since this requires the actual contended host (samarch-1) this bug is about and was explicitly out of scope for this change. No Rust code was touched, so `just clippy` / `just test` are not applicable to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
