### PR TITLE
Say what the CI runners actually are

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,16 @@
   `ssh macm3` (macOS, Apple toolchains). They are faster than this machine and
   keep long compiles off it. Note macOS logs in over ssh with zsh, which does
   not word-split unquoted expansions, so wrap remote scripts in `bash -lc "..."`.
+- the CI runner names mislead. `mac-idle-Cranpose` is this Mac: it registers
+  only while nobody is at the keyboard and exists for signing, so offline is its
+  normal state, it is not spare macOS capacity, and bringing it up is not a way
+  to speed CI. `dmitriis-mac-Cranpose` is macm3 and is the default macOS runner;
+  every macOS job serialises on it. The Linux heavy pool is two --
+  `samarch-1-cranpose` and `samarch-1-cranpose-2`; the Macs carry
+  `cranpose-heavy` as well but do not match `[self-hosted, Linux, ...]`. A deep
+  queue is queueing, not a stall: the jobs API lags the runner by minutes, so
+  read that runner's own `_diag/Runner_*.log` for JobDispatcher lines and check
+  its load before diagnosing one.
 - perf scripts are perf*.sh at project root
 - e2e robot headless tests is `just robot` (should all pass)
 - do not use big models as subagents (opus, codex xhigh thinking, etc), only small fast & cheap to not waste tokens


### PR DESCRIPTION
Three agents rediscovered the CI runner topology the hard way today, and one of them (me) reported a wrong conclusion to the user off the back of it. The facts are cheap to write down and expensive to re-derive from the runners API alone, because the names actively mislead.

- `mac-idle-Cranpose` reads like a spare macOS runner sitting idle. It is the user's own Mac, it registers only while nobody is at the keyboard, and it exists for signing. Offline is its normal state. I read it as a third host that was down and told the user its absence was a standing capacity problem taxing every release. It is not, and proposing to bring it up is not a way to make CI faster.
- `dmitriis-mac-Cranpose` is macm3 — the default macOS runner, and the one every macOS job serialises on. During the v0.1.103 release that meant five macOS jobs behind one runner for over an hour.
- The Linux heavy pool is two. The Macs carry the `cranpose-heavy` label as well, so a naive label match suggests four; they do not match `[self-hosted, Linux, ...]`.
- A queued job is usually queueing. The jobs API lags the runner by minutes: during the release a job showed `queued` while the runner's own log had already dispatched it, and a job showed `queued` for a quarter of an hour while macm3 sat at load 10 renewing it once a minute. Reading `_diag/Runner_*.log` for JobDispatcher lines and checking load answers it in one command.

Documentation only — no gate, recipe, or workflow changes.