### PR TITLE
Let one sccache serve the whole host

### DIFF
--- a/.github/workflows/heavy-selfhosted.yml
+++ b/.github/workflows/heavy-selfhosted.yml
@@ -25,7 +25,6 @@ jobs:
     runs-on: [self-hosted, Linux, cranpose-heavy]
     timeout-minutes: 90
     env:
-      RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 40G
       CARGO_INCREMENTAL: "0"
     steps:
@@ -54,10 +53,8 @@ jobs:
 
       - name: Start sccache
         run: |
-          command -v sccache >/dev/null || RUSTC_WRAPPER= cargo install sccache --locked
           command -v just >/dev/null || cargo install just --locked
-          sccache --start-server || true
-          sccache --zero-stats || true
+          scripts/ci/start_sccache.sh
 
       - name: Run the robot suite on the GPU
         # The suite relaxes the environment-sensitive frame-rate assertions
@@ -76,7 +73,7 @@ jobs:
 
       - name: sccache stats
         if: always()
-        run: command -v sccache >/dev/null && sccache --show-stats || true
+        run: '"$RUSTC_WRAPPER" --show-stats || true'
 
   robot-capture-software:
     name: robot external captures (software present)
@@ -86,7 +83,6 @@ jobs:
     runs-on: [self-hosted, Linux, cranpose-heavy]
     timeout-minutes: 45
     env:
-      RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 40G
       CARGO_INCREMENTAL: "0"
     steps:
@@ -107,9 +103,8 @@ jobs:
 
       - name: Start sccache
         run: |
-          command -v sccache >/dev/null || RUSTC_WRAPPER= cargo install sccache --locked
           command -v just >/dev/null || cargo install just --locked
-          sccache --start-server || true
+          scripts/ci/start_sccache.sh
 
       - name: Run the external capture trio on software present
         # See robot-e2e-gpu above: this suite and that one share a
@@ -163,7 +158,6 @@ jobs:
     runs-on: [self-hosted, cranpose-heavy]
     timeout-minutes: 90
     env:
-      RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 40G
       CARGO_INCREMENTAL: "0"
     steps:
@@ -211,19 +205,15 @@ jobs:
             armv7-linux-androideabi \
             i686-linux-android \
             x86_64-linux-android
-          command -v sccache >/dev/null \
-            || RUSTC_WRAPPER= cargo install sccache --locked
           command -v just >/dev/null || cargo install just --locked
           command -v cargo-ndk >/dev/null || cargo install cargo-ndk --locked
           if [[ ! -f "$ANDROID_NDK_HOME/source.properties" ]]; then
             yes | sdkmanager "ndk;27.0.12077973"
           fi
           cargo ndk --version
-          sccache --version
+          scripts/ci/start_sccache.sh
           java -version
           test -f "$ANDROID_NDK_HOME/source.properties"
-          sccache --start-server || true
-          sccache --zero-stats || true
 
       - name: Clippy Android ABIs
         # Gradle does not deny warnings, so the APK build below cannot be the
@@ -241,4 +231,4 @@ jobs:
 
       - name: sccache stats
         if: always()
-        run: command -v sccache >/dev/null && sccache --show-stats || true
+        run: '"$RUSTC_WRAPPER" --show-stats || true'

--- a/scripts/ci/start_sccache.sh
+++ b/scripts/ci/start_sccache.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# One sccache binary, one server, for every job sharing a runner host.
+#
+# The jobs used to set `RUSTC_WRAPPER: sccache` and let PATH decide, but they do
+# not build the same PATH: the Android job adds ~/.local/bin as well as
+# ~/.cargo/bin, the robot jobs add only ~/.cargo/bin. samarch-1 accumulated
+# sccache 0.17.0 in one and 0.16.0 in the other, both binding port 4226, so the
+# second job to start lost the race and died with
+#
+#   sccache: error: Server startup failed: Address in use
+#   ##[error]Process completed with exit code 143
+#
+# before a single robot example ran. Two robot jobs start together on that host,
+# so the collision is the normal case, not the unlucky one. Resolve the wrapper
+# to one absolute path here and export it, so every job on the host drives the
+# same binary against the same daemon.
+set -euo pipefail
+
+home="$(eval echo "~$(id -un)")"
+sccache_bin="$home/.cargo/bin/sccache"
+
+if [ ! -x "$sccache_bin" ]; then
+    # Unset the wrapper for the bootstrap build: cargo would otherwise try to
+    # drive the sccache that is not installed yet.
+    RUSTC_WRAPPER='' cargo install sccache --locked
+fi
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+    echo "RUSTC_WRAPPER=$sccache_bin" >> "$GITHUB_ENV"
+fi
+
+# --start-server is idempotent but not instantaneous, and that window is what
+# bites: a second job starting while the first daemon is still binding sees the
+# port taken and exits non-zero. Ask once, tolerate losing the race, then wait
+# for the server to actually answer -- a compile that starts before it does is
+# the failure this script exists to prevent.
+wait_for_server() {
+    local i
+    for ((i = 0; i < 30; i++)); do
+        if "$sccache_bin" --show-stats >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+"$sccache_bin" --start-server >/dev/null 2>&1 || true
+
+if ! wait_for_server; then
+    # Either nothing came up, or the port is held by a daemon this binary will
+    # not talk to -- a host that has accumulated a second sccache of another
+    # version is exactly how this failure was found. Take the port back once,
+    # rather than leaving every later job to lose the same race.
+    echo "sccache did not answer; reclaiming the port" >&2
+    "$sccache_bin" --stop-server >/dev/null 2>&1 || true
+    "$sccache_bin" --start-server >/dev/null 2>&1 || true
+    if ! wait_for_server; then
+        echo "sccache still did not answer; refusing to compile without it" >&2
+        exit 1
+    fi
+fi
+
+"$sccache_bin" --version


### PR DESCRIPTION
Two robot jobs on #524 failed today without running a single example:

```
sccache: error: Server startup failed: Address in use
##[error]Process completed with exit code 143
```

The cause is that `RUSTC_WRAPPER: sccache` resolved through PATH, and the jobs on a shared host do not build the same PATH. The android-release job adds `$HOME/.local/bin` as well as `~/.cargo/bin`; the robot jobs add only `~/.cargo/bin`. samarch-1 had accumulated **sccache 0.17.0** in one and **0.16.0** in the other, both binding port 4226, so which binary a job drove depended on which job it was.

On top of that, `--start-server` is idempotent but not instantaneous. `robot-e2e-gpu` and `robot-capture-software` start within seconds of each other on the same box, so the second one regularly asked for a port the first was still binding, got a non-zero exit, and died before the suite began. The collision is the normal case there, not the unlucky one.

This is worth fixing rather than dropping sccache: the cache is doing real work. `--show-stats` on samarch-1 currently reads a **99.86% hit rate** — 693 hits against 1 miss across 698 executed requests, with exactly one actual compilation — over an 11G cache. Without it every robot, budget and build job compiles cold on a two-runner Linux pool.

What changes:

- `scripts/ci/start_sccache.sh` resolves sccache to one absolute path, `~/.cargo/bin/sccache`, and exports `RUSTC_WRAPPER` as that path so every job on the host drives the same binary against the same daemon.
- The three job-level `RUSTC_WRAPPER: sccache` keys are removed. They would otherwise take precedence over `GITHUB_ENV` and put the bare name straight back.
- The script waits for the server to actually answer before returning, so no compile starts against a daemon that is still binding. If it never answers — the port held by a foreign-version daemon is exactly how this was found — it reclaims the port once rather than leaving every later job to lose the same race.
- The android-release job started the server a second time, with the bare name, after provisioning had already started it. That duplicate is gone.
- The `sccache stats` steps report through the pinned wrapper instead of whatever PATH finds.
- `--zero-stats` is dropped. Two jobs share one daemon on this host, so a per-job reset was already zeroing the other job's numbers mid-run; lifetime stats are the only honest ones to print.

The host still carries the stale sccache 0.16.0 in `~/.local/bin`. Nothing drives it after this change, and the script reclaims the port if it is holding one, so no flag-day is needed — but it should be retired separately once the runners are idle.