### PR TITLE
Read the GPU stats toggle where it is used, not where the renderer was built

### DIFF
--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -6159,7 +6159,6 @@ pub struct GpuRenderer {
     last_frame_stats: Option<gpu_stats::FrameStatsSnapshot>,
     pending_frame_warmup_frames: u8,
     frame_count: u64,
-    gpu_stats_enabled: bool,
     warning_state: RendererWarningState,
     #[cfg(not(target_arch = "wasm32"))]
     replay_upload_stats: ReplayUploadStats,
@@ -6986,7 +6985,6 @@ impl GpuRenderer {
             last_frame_stats: None,
             pending_frame_warmup_frames: 0,
             frame_count: 0,
-            gpu_stats_enabled: gpu_stats_enabled(),
             warning_state: RendererWarningState::default(),
             #[cfg(not(target_arch = "wasm32"))]
             replay_upload_stats: ReplayUploadStats::default(),
@@ -9456,12 +9454,13 @@ impl GpuRenderer {
         self.last_frame_stats = Some(snapshot);
         PRESENTED_FRAMES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         update_frame_warmup_budget(&mut self.pending_frame_warmup_frames, &snapshot);
-        self.frame_stats.maybe_print_snapshot(
-            snapshot,
-            &mut self.frame_count,
-            self.gpu_stats_enabled,
-        );
-        if self.gpu_stats_enabled && self.frame_count.is_multiple_of(60) {
+        // Read at the use site, not latched at construction: the toggle is a
+        // debug.cranpose.* property that must respond to setprop on a live
+        // app like every other entry in the table. Once per frame is free.
+        let gpu_stats_on = gpu_stats_enabled();
+        self.frame_stats
+            .maybe_print_snapshot(snapshot, &mut self.frame_count, gpu_stats_on);
+        if gpu_stats_on && self.frame_count.is_multiple_of(60) {
             gpu_stats::print_gpu_memory_report(&self.device, self.frame_count);
         }
         self.frame_graph_executor

--- a/crates/cranpose-render/wgpu/tests/render_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/render_contract.rs
@@ -1213,6 +1213,19 @@ fn gpu_stats_env_flag_is_not_process_cached() {
         !gpu_stats_source.contains("OnceLock") && !gpu_stats_source.contains("static ENABLED"),
         "GPU stats env flag must not be latched in a process-global cache"
     );
+
+    // A cache does not have to be process-global to latch the toggle: a
+    // renderer that copies the answer into a struct field at construction
+    // freezes `debug.cranpose.gpu_stats` for its lifetime, while this test's
+    // name promises the opposite. The flag is read where it is used — once
+    // per sixty frames, so there is nothing to cache.
+    let render_source = std::fs::read_to_string(crate_dir.join("src/render.rs"))
+        .expect("failed to read WGPU renderer source");
+    assert!(
+        !render_source.contains("gpu_stats_enabled:"),
+        "GPU stats env flag must not be latched in a renderer field either — \
+         read gpu_stats_enabled() at the use site"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Found tonight when `setprop debug.cranpose.gpu_stats 1` on a running build produced silence that read exactly like "nothing to report": the renderer latched `gpu_stats_enabled()` into a field at construction (render.rs), so the property only ever worked when set before launch — while `gpu_stats_env_flag_is_not_process_cached` kept passing, because it greps `gpu_stats.rs` for `OnceLock` and the latch lived one file over.

- The field is deleted; the flag is read at the print site, once per frame (a HashMap lookup).
- The guard test now also refuses a `gpu_stats_enabled` field in render.rs — it was red against the latch before the fix, green after, and its name finally tells the truth.

Fourth silent-nothing instrument found today (after robot Skipping-instead-of-fail, telemetry into an uninitialized logger, and the wear gate hiding its numbers on pass): every one of them looked identical to "nothing to report".

🤖 Generated with [Claude Code](https://claude.com/claude-code)