### PR TITLE
Stop shooting the sccache server, and mean it host-wide

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTC_WRAPPER: sccache
   SCCACHE_CACHE_SIZE: 40G
   CARGO_INCREMENTAL: "0"
   MACOSX_DEPLOYMENT_TARGET: "12.0"
@@ -52,11 +51,10 @@ jobs:
             echo "cargo not found. HOME=$HOME real_home=$real_home PATH=$PATH" >&2
             exit 1
           }
-          command -v sccache >/dev/null || RUSTC_WRAPPER= cargo install sccache --locked
           # CI runs the same recipes a developer runs, so a gate cannot mean
           # one thing locally and another thing here.
           command -v just >/dev/null || cargo install just --locked
-          sccache --start-server || true
+          scripts/ci/start_sccache.sh
 
       - name: Check formatting
         run: just fmt-check
@@ -118,11 +116,10 @@ jobs:
             echo "cargo not found. HOME=$HOME real_home=$real_home PATH=$PATH" >&2
             exit 1
           }
-          command -v sccache >/dev/null || RUSTC_WRAPPER= cargo install sccache --locked
           # CI runs the same recipes a developer runs, so a gate cannot mean
           # one thing locally and another thing here.
           command -v just >/dev/null || cargo install just --locked
-          sccache --start-server || true
+          scripts/ci/start_sccache.sh
 
       - name: Check architecture budgets
         # Featureless and all-features builds, the per-backend winit checks, the
@@ -162,11 +159,10 @@ jobs:
             echo "cargo not found. HOME=$HOME real_home=$real_home PATH=$PATH" >&2
             exit 1
           }
-          command -v sccache >/dev/null || RUSTC_WRAPPER= cargo install sccache --locked
           # CI runs the same recipes a developer runs, so a gate cannot mean
           # one thing locally and another thing here.
           command -v just >/dev/null || cargo install just --locked
-          sccache --start-server || true
+          scripts/ci/start_sccache.sh
           rustup target add wasm32-unknown-unknown
           command -v wasm-pack >/dev/null || cargo install wasm-pack --version 0.13.1 --locked
           # wasm-pack fetches its own binaryen when the host has none, so a

--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -262,3 +262,24 @@ Signature → cause → what to do. One lesson per line, no incident history.
   CI" advice needs a check first: if the runner is mid-job, wait or use the
   second checkout with its own SCCACHE_DIR/port, or skip sccache
   (`SCCACHE_DISABLE=1`/unset RUSTC_WRAPPER) for the validation build.
+
+- **A recovery path keyed on a timeout is a guard that lies under load** —
+  `scripts/ci/start_sccache.sh` reclaimed the sccache port
+  (`--stop-server` then `--start-server`) when the server failed to answer
+  within 30s. It was written for a host carrying two sccache versions
+  fighting over port 4226; that second binary was retired the same evening
+  and the reclaim outlived its reason. A shared server under concurrent
+  load is precisely what misses a fixed timeout while being alive and
+  mid-compile for another job, so the reclaim killed healthy servers and
+  two builds died with "The server looks like it shut down unexpectedly,
+  compiling locally instead". Nothing may stop a daemon it did not start:
+  if a shared service will not answer, fail loudly rather than restarting
+  it underneath whoever is using it.
+
+- **Fixing the workflow in front of you is not the same as establishing the
+  property you named** — #526 was titled "Let one sccache serve the whole
+  host" but only rewired `heavy-selfhosted.yml`; `rust.yml` kept the bare
+  `RUSTC_WRAPPER: sccache` and its own `--start-server`. Two provisioning
+  regimes then ran concurrently on samarch-1, and only one of them could
+  kill the server. When a change claims a host-wide invariant, grep the
+  whole `.github/workflows` tree for the pattern before believing it holds.

--- a/scripts/ci/start_sccache.sh
+++ b/scripts/ci/start_sccache.sh
@@ -47,18 +47,22 @@ wait_for_server() {
 
 "$sccache_bin" --start-server >/dev/null 2>&1 || true
 
+# Nothing here stops a server it did not start. An earlier version of this
+# script reclaimed the port -- `--stop-server` then `--start-server` -- when the
+# wait timed out, on the theory that a foreign-version daemon was squatting it.
+# That daemon no longer exists (the host's second sccache was retired the same
+# evening), but the reclaim outlived its reason and killed two builds:
+#
+#   sccache: warning: The server looks like it shut down unexpectedly,
+#   compiling locally instead
+#
+# A shared server under concurrent load is exactly what fails to answer inside
+# a fixed timeout while being perfectly alive and mid-compile for another job,
+# so a recovery path keyed on that timeout is a guard that lies under load. If
+# the server will not answer, say so and stop; do not shoot it.
 if ! wait_for_server; then
-    # Either nothing came up, or the port is held by a daemon this binary will
-    # not talk to -- a host that has accumulated a second sccache of another
-    # version is exactly how this failure was found. Take the port back once,
-    # rather than leaving every later job to lose the same race.
-    echo "sccache did not answer; reclaiming the port" >&2
-    "$sccache_bin" --stop-server >/dev/null 2>&1 || true
-    "$sccache_bin" --start-server >/dev/null 2>&1 || true
-    if ! wait_for_server; then
-        echo "sccache still did not answer; refusing to compile without it" >&2
-        exit 1
-    fi
+    echo "sccache did not answer within 30s; refusing to compile without it" >&2
+    exit 1
 fi
 
 "$sccache_bin" --version


### PR DESCRIPTION
Two builds on samarch-1 died in 2.5 hours with

```
sccache: warning: The server looks like it shut down unexpectedly, compiling locally instead
```

followed by connection failures mid-crate — once on #527's board at 23:37Z, once on main at 01:58Z. Both were `architecture budgets (linux)`. Neither was code; `ed2450db` passed budgets forty minutes before the second one.

This is a regression from #526, and it has two halves.

**The reclaim path killed healthy servers.** `scripts/ci/start_sccache.sh` waited 30s for the server to answer and, on timeout, ran `--stop-server` then `--start-server`. That was written for a host carrying sccache 0.17.0 in `~/.cargo/bin` and 0.16.0 in `~/.local/bin`, both binding port 4226 — a genuine squatter needing eviction. The 0.16 binary was retired the same evening, so the condition ended while the recovery path did not.

A shared server under concurrent load is exactly what fails to answer inside a fixed timeout while being perfectly alive and mid-compile for somebody else. So the reclaim fired against a working server and took another job's build down with it. `budgets` is the long Linux job most likely to be compiling when a heavy job starts beside it, which is why it was hit both times.

A recovery path keyed on a timeout is a guard that lies under load. The invariant is now explicit in the script: nothing stops a daemon it did not start. If the server will not answer, the job fails loudly instead of restarting it underneath whoever is using it.

**And #526 did not establish the property it was named for.** It rewired `heavy-selfhosted.yml` and left `rust.yml` on the old pattern — workflow-level `RUSTC_WRAPPER: sccache`, `command -v sccache`, `sccache --start-server || true`, no pinning and no wait. So the box ran two provisioning regimes at once and only one of them could kill the server. All three `rust.yml` jobs now call the same script, and `grep -rE "RUSTC_WRAPPER: sccache|sccache --start-server|command -v sccache" .github/workflows/` returns nothing.

Two TIME_WASTERS entries: the timeout-keyed recovery path, and fixing the workflow in front of you rather than the invariant you claimed.

Verified: shellcheck clean, `bash -n` clean, both workflows parse with all jobs intact, typos clean.