### PR TITLE
Stop re-lowering the whole subtree for a child list that did not change

### DIFF
--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -283,3 +283,26 @@ Signature → cause → what to do. One lesson per line, no incident history.
   regimes then ran concurrently on samarch-1, and only one of them could
   kill the server. When a change claims a host-wide invariant, grep the
   whole `.github/workflows` tree for the pattern before believing it holds.
+
+- **`CRANPOSE_FRAME_STAGE_TELEMETRY_MS` produces nothing under
+  `CRANPOSE_HEADLESS=1`** — the desktop frame-stage instrument sits on the
+  present path, which a headless run never takes, so a headless capture with
+  that variable set yields two samples and reads as "no slow frames" rather
+  than "no instrument". It also goes through `log::warn!`, so even on a
+  presenting run it needs `RUST_LOG=warn` (env_logger defaults to `error`) and
+  a binary built with the `logging` feature — `robot-app` pulls it, a plain
+  build does not. Headless, use `CRANPOSE_UPDATE_STAGE_TELEMETRY_MS=0`: it is
+  `eprintln!`, so it needs neither the feature nor `RUST_LOG`. Cost one
+  measurement round before anyone noticed the arms were empty rather than
+  equal.
+
+- **Aggregate structural-change counts hide the thing you are looking for** —
+  chasing a scroll frame that re-lowered 51 layers, per-parent totals said only
+  "node 60 is structurally dirty every frame", which reads like a busy list.
+  Printing each record with its reason, parent AND child
+  (`CRANPOSE_STRUCTURAL_DIAG=1`) showed the parent had exactly two distinct
+  children over 82,420 frames, each cycled 11,067 times in a perfectly regular
+  attach/detach pair: the same unchanged child, not many changing ones. The
+  sequence was the evidence; no aggregate over it could have been. When a
+  counter says "this fires constantly", print the identities before theorising
+  about the cause.

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -1912,6 +1912,7 @@ impl Command {
                     parent_node.move_child(from_index, to_index);
                 }
                 bubble.apply(applier, parent_id);
+                note_structural_move(parent_id, from_index, to_index);
                 applier.record_structural_change(parent_id);
                 Ok(())
             }
@@ -2493,13 +2494,21 @@ fn insert_child_with_reparenting(applier: &mut dyn Applier, parent_id: NodeId, c
         }
         bubble_layout_dirty(applier, old_parent_id);
         bubble_measure_dirty(applier, old_parent_id);
+        note_structural("reparent-detach", old_parent_id, child_id);
         applier.record_structural_change(old_parent_id);
     }
 
+    // `insert_child` returns early when the child is already in this parent's
+    // list, so re-inserting it changes nothing -- and a structural change
+    // recorded for it costs a full re-lowering of the parent's subtree.
+    let already_attached_here = old_parent == Some(parent_id);
     if let Ok(parent_node) = applier.get_mut(parent_id) {
         parent_node.insert_child(child_id);
     }
-    applier.record_structural_change(parent_id);
+    if !already_attached_here {
+        note_structural("attach", parent_id, child_id);
+        applier.record_structural_change(parent_id);
+    }
     if let Ok(child_node) = applier.get_mut(child_id) {
         child_node.on_attached_to_parent(parent_id);
     }
@@ -2528,12 +2537,25 @@ fn detach_child_from_parent(
     parent_id: NodeId,
     child_id: NodeId,
 ) -> Result<(), NodeError> {
+    // A child that is not this parent's child cannot be removed from it: the
+    // `remove_child` below is then a no-op, and the checks further down bail
+    // out for exactly that case. Decide here, before the record, or a repeated
+    // detach of an already-detached child marks the parent structurally dirty
+    // every frame and re-lowers its whole subtree for nothing.
+    let was_attached_here = applier
+        .get_mut(child_id)
+        .ok()
+        .and_then(|node| node.parent())
+        == Some(parent_id);
     if let Ok(parent_node) = applier.get_mut(parent_id) {
         parent_node.remove_child(child_id);
     }
     bubble_layout_dirty(applier, parent_id);
     bubble_measure_dirty(applier, parent_id);
-    applier.record_structural_change(parent_id);
+    if was_attached_here {
+        note_structural("detach", parent_id, child_id);
+        applier.record_structural_change(parent_id);
+    }
 
     if let Ok(node) = applier.get_mut(child_id) {
         match node.parent() {
@@ -4440,3 +4462,23 @@ pub mod hash;
 pub mod test_scratch;
 #[cfg(any(test, feature = "test-helpers"))]
 pub use test_scratch::test_scratch_dir;
+
+/// Traces every structural change back to the operation that recorded it.
+///
+/// A structural change re-lowers the parent's whole subtree, so what matters is
+/// not how many are recorded but which operation keeps recording them: an
+/// aggregate count hides a single child cycling every frame, and the sequence
+/// makes it obvious.
+pub(crate) fn note_structural(reason: &str, parent_id: NodeId, child_id: NodeId) {
+    if env_flag!("CRANPOSE_STRUCTURAL_DIAG") {
+        eprintln!("[structural] {reason} parent={parent_id} child={child_id}");
+    }
+}
+
+/// A move names indices rather than a child, so it gets its own line instead of
+/// a placeholder id that would read as a real node.
+pub(crate) fn note_structural_move(parent_id: NodeId, from_index: usize, to_index: usize) {
+    if env_flag!("CRANPOSE_STRUCTURAL_DIAG") {
+        eprintln!("[structural] move parent={parent_id} from={from_index} to={to_index}");
+    }
+}

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -1171,8 +1171,21 @@ pub trait Node: Any {
     fn mount(&mut self) {}
     fn update(&mut self) {}
     fn unmount(&mut self) {}
-    fn insert_child(&mut self, _child: NodeId) {}
-    fn remove_child(&mut self, _child: NodeId) {}
+    /// Adds `child` to this node's child list, returning whether the list
+    /// actually changed. A node that already holds the child returns `false`:
+    /// callers record a structural change from this answer, and a structural
+    /// change re-lowers the whole subtree, so claiming one for a no-op costs a
+    /// full rebuild per call.
+    fn insert_child(&mut self, _child: NodeId) -> bool {
+        false
+    }
+    /// Removes `child` from this node's child list, returning whether the list
+    /// actually changed. Only this node can answer that: a caller inspecting
+    /// the child's parent pointer gets it wrong when the child was reparented
+    /// while still listed here.
+    fn remove_child(&mut self, _child: NodeId) -> bool {
+        false
+    }
     fn move_child(&mut self, _from: usize, _to: usize) {}
     fn update_children(&mut self, _children: &[NodeId]) {}
     fn children(&self) -> Vec<NodeId> {
@@ -2486,26 +2499,27 @@ fn insert_child_with_reparenting(applier: &mut dyn Applier, parent_id: NodeId, c
     if let Some(old_parent_id) = old_parent
         && old_parent_id != parent_id
     {
-        if let Ok(old_parent_node) = applier.get_mut(old_parent_id) {
-            old_parent_node.remove_child(child_id);
-        }
+        let removed = applier
+            .get_mut(old_parent_id)
+            .is_ok_and(|old_parent_node| old_parent_node.remove_child(child_id));
         if let Ok(child_node) = applier.get_mut(child_id) {
             child_node.on_removed_from_parent();
         }
         bubble_layout_dirty(applier, old_parent_id);
         bubble_measure_dirty(applier, old_parent_id);
-        note_structural("reparent-detach", old_parent_id, child_id);
-        applier.record_structural_change(old_parent_id);
+        if removed {
+            note_structural("reparent-detach", old_parent_id, child_id);
+            applier.record_structural_change(old_parent_id);
+        }
     }
 
-    // `insert_child` returns early when the child is already in this parent's
-    // list, so re-inserting it changes nothing -- and a structural change
-    // recorded for it costs a full re-lowering of the parent's subtree.
-    let already_attached_here = old_parent == Some(parent_id);
-    if let Ok(parent_node) = applier.get_mut(parent_id) {
-        parent_node.insert_child(child_id);
-    }
-    if !already_attached_here {
+    // Only record a structural change if the list actually gained the child.
+    // Re-attaching a child to the parent it already has is a no-op, and a
+    // structural change re-lowers the parent's whole subtree.
+    let inserted = applier
+        .get_mut(parent_id)
+        .is_ok_and(|parent_node| parent_node.insert_child(child_id));
+    if inserted {
         note_structural("attach", parent_id, child_id);
         applier.record_structural_change(parent_id);
     }
@@ -2537,22 +2551,17 @@ fn detach_child_from_parent(
     parent_id: NodeId,
     child_id: NodeId,
 ) -> Result<(), NodeError> {
-    // A child that is not this parent's child cannot be removed from it: the
-    // `remove_child` below is then a no-op, and the checks further down bail
-    // out for exactly that case. Decide here, before the record, or a repeated
-    // detach of an already-detached child marks the parent structurally dirty
-    // every frame and re-lowers its whole subtree for nothing.
-    let was_attached_here = applier
-        .get_mut(child_id)
-        .ok()
-        .and_then(|node| node.parent())
-        == Some(parent_id);
-    if let Ok(parent_node) = applier.get_mut(parent_id) {
-        parent_node.remove_child(child_id);
-    }
+    // Ask the parent whether its list changed rather than inferring it from the
+    // child's parent pointer: a child reparented while still listed here must
+    // still count, or its layers stay in the render graph as a ghost. A repeat
+    // detach of an already-detached child removes nothing and must not count,
+    // or the parent is structurally dirty every frame for nothing.
+    let removed = applier
+        .get_mut(parent_id)
+        .is_ok_and(|parent_node| parent_node.remove_child(child_id));
     bubble_layout_dirty(applier, parent_id);
     bubble_measure_dirty(applier, parent_id);
-    if was_attached_here {
+    if removed {
         note_structural("detach", parent_id, child_id);
         applier.record_structural_change(parent_id);
     }

--- a/crates/cranpose-core/src/tests/composer_applier_tests.rs
+++ b/crates/cranpose-core/src/tests/composer_applier_tests.rs
@@ -1550,12 +1550,18 @@ fn remove_balanced_tree_uses_depth_bounded_traversal_stack() {
     }
 
     impl Node for TreeNode {
-        fn insert_child(&mut self, child: NodeId) {
+        fn insert_child(&mut self, child: NodeId) -> bool {
+            if self.children.contains(&child) {
+                return false;
+            }
             self.children.push(child);
+            true
         }
 
-        fn remove_child(&mut self, child: NodeId) {
+        fn remove_child(&mut self, child: NodeId) -> bool {
+            let before = self.children.len();
             self.children.retain(|&id| id != child);
+            self.children.len() < before
         }
 
         fn children(&self) -> Vec<NodeId> {

--- a/crates/cranpose-core/src/tests/composer_applier_tests.rs
+++ b/crates/cranpose-core/src/tests/composer_applier_tests.rs
@@ -1990,3 +1990,84 @@ fn param_state_update_reuses_existing_buffer_via_clone_from() {
         "ParamState::update should reuse the existing String allocation when capacity permits",
     );
 }
+
+/// A structural change costs the renderer a full re-lowering of the parent's
+/// subtree, so it must be recorded only when the child list actually changed.
+/// A steady scroll re-attaches retained children and detaches already-detached
+/// ones every frame; recording those marked the list structurally dirty on
+/// every frame and rebuilt ~51 layers for a frame in which one row moved.
+#[test]
+fn reattaching_a_child_to_its_current_parent_records_no_structural_change() {
+    let mut applier = test_applier();
+    let parent = applier.create(Box::new(RecordingNode::default()));
+    let child = applier.create(Box::new(RecordingNode::default()));
+
+    insert_child_with_reparenting(&mut applier, parent, child);
+    let _ = applier.take_structural_change_parents_attached_to(parent);
+
+    insert_child_with_reparenting(&mut applier, parent, child);
+
+    assert_eq!(
+        applier.take_structural_change_parents_attached_to(parent),
+        Vec::<NodeId>::new(),
+        "re-attaching a child that is already this parent's child changes nothing"
+    );
+}
+
+#[test]
+fn detaching_a_child_that_is_not_attached_records_no_structural_change() {
+    let mut applier = test_applier();
+    let parent = applier.create(Box::new(RecordingNode::default()));
+    let child = applier.create(Box::new(RecordingNode::default()));
+
+    detach_child_from_parent(&mut applier, parent, child).expect("detach of a non-child");
+
+    assert_eq!(
+        applier.take_structural_change_parents_attached_to(parent),
+        Vec::<NodeId>::new(),
+        "detaching a child this parent never had removes nothing"
+    );
+}
+
+/// The positive control for the two guards above: without it they would pass
+/// just as well if structural changes were never recorded at all.
+#[test]
+fn a_real_attach_and_a_real_detach_each_record_a_structural_change() {
+    let mut applier = test_applier();
+    let parent = applier.create(Box::new(RecordingNode::default()));
+    let child = applier.create(Box::new(RecordingNode::default()));
+
+    insert_child_with_reparenting(&mut applier, parent, child);
+    assert_eq!(
+        applier.take_structural_change_parents_attached_to(parent),
+        vec![parent],
+        "attaching a new child is a structural change"
+    );
+
+    detach_child_from_parent(&mut applier, parent, child).expect("detach of a real child");
+    assert_eq!(
+        applier.take_structural_change_parents_attached_to(parent),
+        vec![parent],
+        "detaching a child this parent actually had is a structural change"
+    );
+}
+
+#[test]
+fn reparenting_records_a_structural_change_on_both_parents() {
+    let mut applier = test_applier();
+    let old_parent = applier.create(Box::new(RecordingNode::default()));
+    let new_parent = applier.create(Box::new(RecordingNode::default()));
+    let child = applier.create(Box::new(RecordingNode::default()));
+
+    insert_child_with_reparenting(&mut applier, old_parent, child);
+    let _ = applier.take_structural_change_parents_attached_to(old_parent);
+    let _ = applier.take_structural_change_parents_attached_to(new_parent);
+
+    insert_child_with_reparenting(&mut applier, new_parent, child);
+
+    assert_eq!(
+        applier.take_structural_change_parents_attached_to(new_parent),
+        vec![new_parent],
+        "the new parent gained a child"
+    );
+}

--- a/crates/cranpose-core/src/tests/composition_and_recompose_scope_tests.rs
+++ b/crates/cranpose-core/src/tests/composition_and_recompose_scope_tests.rs
@@ -4207,14 +4207,18 @@ fn scoped_recompose_after_root_replay_does_not_self_parent_root() {
             self.raw_parent = None;
         }
 
-        fn insert_child(&mut self, child: NodeId) {
-            if !self.children.contains(&child) {
-                self.children.push(child);
+        fn insert_child(&mut self, child: NodeId) -> bool {
+            if self.children.contains(&child) {
+                return false;
             }
+            self.children.push(child);
+            true
         }
 
-        fn remove_child(&mut self, child: NodeId) {
+        fn remove_child(&mut self, child: NodeId) -> bool {
+            let before = self.children.len();
             self.children.retain(|&id| id != child);
+            self.children.len() < before
         }
 
         fn children(&self) -> Vec<NodeId> {

--- a/crates/cranpose-core/src/tests/mod.rs
+++ b/crates/cranpose-core/src/tests/mod.rs
@@ -469,14 +469,23 @@ impl Node for RecordingNode {
         self.children.clone()
     }
 
-    fn insert_child(&mut self, child: NodeId) {
+    fn insert_child(&mut self, child: NodeId) -> bool {
+        if self.children.contains(&child) {
+            return false;
+        }
         self.children.push(child);
         self.operations.push(Operation::Insert(child));
+        true
     }
 
-    fn remove_child(&mut self, child: NodeId) {
+    fn remove_child(&mut self, child: NodeId) -> bool {
+        let before = self.children.len();
         self.children.retain(|&c| c != child);
-        self.operations.push(Operation::Remove(child));
+        let removed = self.children.len() < before;
+        if removed {
+            self.operations.push(Operation::Remove(child));
+        }
+        removed
     }
 
     fn move_child(&mut self, from: usize, to: usize) {
@@ -540,12 +549,18 @@ impl Node for UnmountTrackingNode {
         self.unmounts.set(self.unmounts.get() + 1);
     }
 
-    fn insert_child(&mut self, child: NodeId) {
+    fn insert_child(&mut self, child: NodeId) -> bool {
+        if self.children.contains(&child) {
+            return false;
+        }
         self.children.push(child);
+        true
     }
 
-    fn remove_child(&mut self, child: NodeId) {
+    fn remove_child(&mut self, child: NodeId) -> bool {
+        let before = self.children.len();
         self.children.retain(|&id| id != child);
+        self.children.len() < before
     }
 
     fn children(&self) -> Vec<NodeId> {

--- a/crates/cranpose-render/common/src/scene_builder.rs
+++ b/crates/cranpose-render/common/src/scene_builder.rs
@@ -55,10 +55,50 @@ struct SnapshotNodeData {
     children: Vec<NodeId>,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+/// Why a scoped scene update could not be applied, forcing the caller to throw
+/// the render graph away and build it again from the applier.
+///
+/// The reason has to travel with the outcome because the shell picks the
+/// scoped path from the shape of the dirty set, before this code runs, and
+/// logs that choice. A frame that chose the scoped path and then rebuilt the
+/// whole scene is the expensive case, and in the log it reads exactly like a
+/// cheap patch -- so the fallback says so itself.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GraphRebuildReason {
+    /// The root was dirty and its replacement layer could not be built.
+    RootLayerUnavailable,
+    /// A dirty subtree's replacement layer could not be built.
+    DirtyLayerUnavailable,
+    /// This many dirty nodes own no layer in the render graph, so the scoped
+    /// walk never reached them. A node enters the graph only as a `LayerNode`;
+    /// a dirty node that never produced one -- or whose layer left the graph
+    /// this frame -- cannot be patched in place.
+    UnmatchedDirtyNodes(usize),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GraphUpdate {
+    Patched,
+    NeedsRebuild(GraphRebuildReason),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GraphUpdateReport {
-    pub applied: bool,
+    pub update: GraphUpdate,
     pub hit_graph_dirty: bool,
+}
+
+impl GraphUpdateReport {
+    pub fn applied(self) -> bool {
+        matches!(self.update, GraphUpdate::Patched)
+    }
+
+    pub fn rebuild_reason(self) -> Option<GraphRebuildReason> {
+        match self.update {
+            GraphUpdate::Patched => None,
+            GraphUpdate::NeedsRebuild(reason) => Some(reason),
+        }
+    }
 }
 
 // Counts full layer lowerings so tests can assert what a scoped update did
@@ -108,7 +148,7 @@ pub fn update_graph_from_applier(
     dirty_nodes: &[NodeId],
     scale: f32,
 ) -> bool {
-    update_graph_from_applier_report(applier, graph, dirty_nodes, scale).applied
+    update_graph_from_applier_report(applier, graph, dirty_nodes, scale).applied()
 }
 
 pub fn update_graph_from_applier_report(
@@ -128,9 +168,34 @@ pub fn update_graph_from_applier_report_into(
     scale: f32,
     changed_nodes: &mut Vec<NodeId>,
 ) -> GraphUpdateReport {
+    let report = update_graph_from_applier_report_into_inner(
+        applier,
+        graph,
+        dirty_nodes,
+        scale,
+        changed_nodes,
+    );
+    if let GraphUpdate::NeedsRebuild(reason) = report.update
+        && cranpose_core::env_flag!("CRANPOSE_SCENE_UPDATE_DIAG")
+    {
+        eprintln!(
+            "[scene-update-diag] scoped update abandoned, whole scene rebuilt: {reason:?} dirty={}",
+            dirty_nodes.len()
+        );
+    }
+    report
+}
+
+fn update_graph_from_applier_report_into_inner(
+    applier: &mut MemoryApplier,
+    graph: &mut RenderGraph,
+    dirty_nodes: &[NodeId],
+    scale: f32,
+    changed_nodes: &mut Vec<NodeId>,
+) -> GraphUpdateReport {
     if dirty_nodes.is_empty() {
         return GraphUpdateReport {
-            applied: true,
+            update: GraphUpdate::Patched,
             hit_graph_dirty: false,
         };
     }
@@ -159,7 +224,7 @@ pub fn update_graph_from_applier_report_into(
         ) {
             if remaining_dirty_nodes.is_empty() {
                 return GraphUpdateReport {
-                    applied: true,
+                    update: GraphUpdate::Patched,
                     hit_graph_dirty: true,
                 };
             }
@@ -172,15 +237,14 @@ pub fn update_graph_from_applier_report_into(
                 false,
                 changed_nodes,
             );
-            let applied = walked.is_some() && remaining_dirty_nodes.is_empty();
             return GraphUpdateReport {
-                applied,
+                update: classify_walk(walked.is_some(), &remaining_dirty_nodes),
                 hit_graph_dirty: true,
             };
         }
         let Some(root) = build_layer_node_from_applier(applier, root_id, scale, false) else {
             return GraphUpdateReport {
-                applied: false,
+                update: GraphUpdate::NeedsRebuild(GraphRebuildReason::RootLayerUnavailable),
                 hit_graph_dirty: true,
             };
         };
@@ -190,7 +254,7 @@ pub fn update_graph_from_applier_report_into(
         graph.root.recompute_raster_cache_hashes();
         collect_layer_node_ids(&graph.root, changed_nodes);
         return GraphUpdateReport {
-            applied: true,
+            update: GraphUpdate::Patched,
             hit_graph_dirty,
         };
     }
@@ -207,22 +271,37 @@ pub fn update_graph_from_applier_report_into(
         Some(report) => report,
         None => {
             return GraphUpdateReport {
-                applied: false,
+                update: GraphUpdate::NeedsRebuild(GraphRebuildReason::DirtyLayerUnavailable),
                 hit_graph_dirty: true,
             };
         }
     };
 
-    if !remaining_dirty_nodes.is_empty() {
-        return GraphUpdateReport {
-            applied: false,
+    match classify_walk(true, &remaining_dirty_nodes) {
+        GraphUpdate::Patched => GraphUpdateReport {
+            update: GraphUpdate::Patched,
+            hit_graph_dirty: report.hit_graph_dirty,
+        },
+        update => GraphUpdateReport {
+            update,
             hit_graph_dirty: true,
-        };
+        },
     }
+}
 
-    GraphUpdateReport {
-        applied: true,
-        hit_graph_dirty: report.hit_graph_dirty,
+/// Both scoped walks end the same way: the walk either failed outright, or it
+/// succeeded and left dirty nodes it could not find a layer for. Either way the
+/// caller rebuilds the whole scene, and the reason is the only thing that says
+/// which.
+fn classify_walk(walked: bool, remaining_dirty_nodes: &HashSet<NodeId>) -> GraphUpdate {
+    if !walked {
+        GraphUpdate::NeedsRebuild(GraphRebuildReason::DirtyLayerUnavailable)
+    } else if !remaining_dirty_nodes.is_empty() {
+        GraphUpdate::NeedsRebuild(GraphRebuildReason::UnmatchedDirtyNodes(
+            remaining_dirty_nodes.len(),
+        ))
+    } else {
+        GraphUpdate::Patched
     }
 }
 
@@ -2897,7 +2976,11 @@ mod tests {
         let report = update_graph_from_applier_report(&mut applier, &mut graph, &[child_id], 1.0);
         applier.clear_runtime_handle();
 
-        assert!(report.applied, "dirty child update should apply in place");
+        assert!(
+            report.applied(),
+            "dirty child update should apply in place, got {:?}",
+            report.update
+        );
         assert_dirty_hash_road_matches_full_walk(&graph);
     }
 
@@ -2976,7 +3059,11 @@ mod tests {
         let report = update_graph_from_applier_report(&mut applier, &mut graph, &[column_id], 1.0);
         applier.clear_runtime_handle();
 
-        assert!(report.applied, "structural update should apply in place");
+        assert!(
+            report.applied(),
+            "structural update should apply in place, got {:?}",
+            report.update
+        );
         let mut labels = Vec::new();
         collect_text_labels(&graph.root, &mut labels);
         assert!(
@@ -3083,7 +3170,7 @@ mod tests {
         assert_eq!(
             report,
             GraphUpdateReport {
-                applied: false,
+                update: GraphUpdate::NeedsRebuild(GraphRebuildReason::DirtyLayerUnavailable),
                 hit_graph_dirty: true,
             },
             "dirty child graph updates must not report success when the replacement cannot be rebuilt"
@@ -3178,7 +3265,11 @@ mod tests {
         let report = update_graph_from_applier_report(&mut applier, &mut graph, &dirty_nodes, 1.0);
         applier.clear_runtime_handle();
 
-        assert!(report.applied, "scroll update should apply in place");
+        assert!(
+            report.applied(),
+            "scroll update should apply in place, got {:?}",
+            report.update
+        );
         assert_dirty_hash_road_matches_full_walk(&graph);
     }
 
@@ -3247,7 +3338,11 @@ mod tests {
         let report = update_graph_from_applier_report(&mut applier, &mut graph, &dirty_nodes, 1.0);
         applier.clear_runtime_handle();
 
-        assert!(report.applied, "scroll graph update should apply in place");
+        assert!(
+            report.applied(),
+            "scroll graph update should apply in place, got {:?}",
+            report.update
+        );
         let updated_target_top =
             find_text_top(&graph.root, "scroll target").expect("updated target text");
         assert!(
@@ -3355,7 +3450,11 @@ mod tests {
         let report = update_graph_from_applier_report(&mut applier, &mut graph, &dirty_nodes, 1.0);
         applier.clear_runtime_handle();
 
-        assert!(report.applied, "chain update should apply in place");
+        assert!(
+            report.applied(),
+            "chain update should apply in place, got {:?}",
+            report.update
+        );
         let lowered = lowered_layer_count();
         assert_eq!(
             lowered, 0,
@@ -3450,7 +3549,11 @@ mod tests {
         let report = update_graph_from_applier_report(&mut applier, &mut graph, &dirty_nodes, 1.0);
         applier.clear_runtime_handle();
 
-        assert!(report.applied, "scroll update should apply in place");
+        assert!(
+            report.applied(),
+            "scroll update should apply in place, got {:?}",
+            report.update
+        );
         let lowered = lowered_layer_count();
         assert_eq!(
             lowered, 0,
@@ -3550,7 +3653,11 @@ mod tests {
         let report = update_graph_from_applier_report(&mut applier, &mut graph, &dirty_nodes, 1.0);
         applier.clear_runtime_handle();
 
-        assert!(report.applied, "the boundary frame must apply in place");
+        assert!(
+            report.applied(),
+            "the boundary frame must apply in place, got {:?}",
+            report.update
+        );
         let lowered = lowered_layer_count();
         assert!(
             lowered > 0,
@@ -3667,7 +3774,11 @@ mod tests {
         let report = update_graph_from_applier_report(&mut applier, &mut graph, &[child_id], 1.0);
         applier.clear_runtime_handle();
 
-        assert!(report.applied, "dirty child graph update should apply");
+        assert!(
+            report.applied(),
+            "dirty child graph update should apply, got {:?}",
+            report.update
+        );
         let updated = find_layer_by_node_id(&graph.root, child_id).expect("updated child layer");
         assert_eq!(
             updated.transform_to_parent, scrolled_transform,
@@ -3814,7 +3925,11 @@ mod tests {
         let report = update_graph_from_applier_report(&mut applier, &mut graph, &[overlay_id], 1.0);
         applier.clear_runtime_handle();
 
-        assert!(report.applied, "dirty overlay graph update should apply");
+        assert!(
+            report.applied(),
+            "dirty overlay graph update should apply, got {:?}",
+            report.update
+        );
         let updated_underlay_origin =
             find_layer_origin(&graph.root, underlay_id).expect("updated underlay origin");
         let updated_overlay_origin =
@@ -3887,8 +4002,9 @@ mod tests {
         applier.set_runtime_handle(handle);
         let report = update_graph_from_applier_report(&mut applier, &mut graph, &[node_id], 1.0);
         assert!(
-            report.applied,
-            "dirty graphics layer should be replaceable from retained applier state"
+            report.applied(),
+            "dirty graphics layer should be replaceable from retained applier state, got {:?}",
+            report.update
         );
         assert!(
             !report.hit_graph_dirty,
@@ -3963,8 +4079,9 @@ mod tests {
         applier.clear_runtime_handle();
 
         assert!(
-            report.applied,
-            "dirty clickable graphics layer should be replaceable from retained applier state"
+            report.applied(),
+            "dirty clickable graphics layer should be replaceable from retained applier state, got {:?}",
+            report.update
         );
         assert!(
             report.hit_graph_dirty,

--- a/crates/cranpose-render/wgpu/src/pipeline.rs
+++ b/crates/cranpose-render/wgpu/src/pipeline.rs
@@ -2066,7 +2066,7 @@ pub(crate) fn update_from_applier(
         render_from_applier(applier, root, scene, scale);
         return SceneUpdateOutcome::Rebuilt;
     };
-    if !update_report.applied {
+    if !update_report.applied() {
         scene.clear();
         render_from_applier(applier, root, scene, scale);
         return SceneUpdateOutcome::Rebuilt;

--- a/crates/cranpose-render/wgpu/src/surface_plan.rs
+++ b/crates/cranpose-render/wgpu/src/surface_plan.rs
@@ -1454,7 +1454,7 @@ mod carried_plan_tests {
             &mut changed_nodes,
         );
         applier.clear_runtime_handle();
-        assert!(report.applied, "the patch should apply in place");
+        assert!(report.applied(), "the patch should apply in place");
 
         for node_id in &changed_nodes {
             cache.remove(node_id);
@@ -1559,7 +1559,10 @@ mod carried_plan_structure_tests {
             &mut changed_nodes,
         );
         applier.clear_runtime_handle();
-        assert!(report.applied, "the structural patch should apply in place");
+        assert!(
+            report.applied(),
+            "the structural patch should apply in place"
+        );
 
         for node_id in &changed_nodes {
             cache.remove(node_id);

--- a/crates/cranpose-ui/src/subcompose_layout.rs
+++ b/crates/cranpose-ui/src/subcompose_layout.rs
@@ -1126,28 +1126,31 @@ impl cranpose_core::Node for SubcomposeLayoutNode {
             .detach_nodes();
     }
 
-    fn insert_child(&mut self, child: NodeId) {
+    fn insert_child(&mut self, child: NodeId) -> bool {
         let mut inner = self.inner.borrow_mut();
         if inner.children.contains(&child) {
-            return;
+            return false;
         }
         if is_virtual_node(child) {
             let count = self.virtual_children_count.get();
             self.virtual_children_count.set(count + 1);
         }
         inner.children.push(child);
+        true
     }
 
-    fn remove_child(&mut self, child: NodeId) {
+    fn remove_child(&mut self, child: NodeId) -> bool {
         let mut inner = self.inner.borrow_mut();
         let before = inner.children.len();
         inner.children.retain(|&id| id != child);
-        if inner.children.len() < before && is_virtual_node(child) {
+        let removed = inner.children.len() < before;
+        if removed && is_virtual_node(child) {
             let count = self.virtual_children_count.get();
             if count > 0 {
                 self.virtual_children_count.set(count - 1);
             }
         }
+        removed
     }
 
     fn move_child(&mut self, from: usize, to: usize) {

--- a/crates/cranpose-ui/src/widgets/nodes/layout_node.rs
+++ b/crates/cranpose-ui/src/widgets/nodes/layout_node.rs
@@ -888,9 +888,9 @@ impl Node for LayoutNode {
         LayoutNode::set_node_id(self, id);
     }
 
-    fn insert_child(&mut self, child: NodeId) {
+    fn insert_child(&mut self, child: NodeId) -> bool {
         if self.children.contains(&child) {
-            return;
+            return false;
         }
         if is_virtual_node(child) {
             let count = self.virtual_children_count.get();
@@ -899,12 +899,14 @@ impl Node for LayoutNode {
         self.children.push(child);
         self.cache.clear();
         self.mark_needs_measure();
+        true
     }
 
-    fn remove_child(&mut self, child: NodeId) {
+    fn remove_child(&mut self, child: NodeId) -> bool {
         let before = self.children.len();
         self.children.retain(|&id| id != child);
-        if self.children.len() < before {
+        let removed = self.children.len() < before;
+        if removed {
             if is_virtual_node(child) {
                 let count = self.virtual_children_count.get();
                 if count > 0 {
@@ -914,6 +916,7 @@ impl Node for LayoutNode {
             self.cache.clear();
             self.mark_needs_measure();
         }
+        removed
     }
 
     fn move_child(&mut self, from: usize, to: usize) {


### PR DESCRIPTION
Scene build was 92% of the CPU frame on scroll frames. It was rebuilding 51 layers for a frame in which one row moved.

## The bug

A structural change on a parent costs the renderer a full re-lowering of that parent's subtree. Two paths recorded one for an operation that changed nothing:

- `insert_child_with_reparenting` recorded unconditionally. Every `insert_child` implementation returns early when the child is already in the list, so re-attaching a child to the parent it already has is a no-op — and the reparent branch directly above it is skipped in exactly that case, so the record was the only thing that happened.
- `detach_child_from_parent` recorded *before* checking whether the child was ever this parent's child. When it was not, `remove_child` is a no-op and the code below the record bails out for that very case.

Both fire on every frame of a scroll.

## Evidence

Hacker-news list, release build, real display, 82,420 frames. `CRANPOSE_STRUCTURAL_DIAG=1` prints every record with its reason, parent and child:

- 86,794 attaches, 79,463 detaches, **zero moves**
- the pane node had **exactly two distinct children across the whole run**, each cycled 11,067 times — the same unchanged child, attached and detached about once per frame
- the list content node: 121,641 events across 16 children

Aggregate counts could not have found this: they say only "structurally dirty every frame", which reads like a busy list. The per-event sequence shows a perfectly regular attach/detach rhythm on unchanged children.

## Result

| | before | after |
|---|---|---|
| structural events | 166,257 | 291 |
| layer builds per frame | 50.8 | 11.3 |
| scene_ms p50 | 0.77 | **0.25** (−68%) |
| scene_ms p95 | 1.48 | **0.35** (−76%) |
| scene_ms max | 11.31 | **2.01** (−82%) |
| frame total p50 | 0.84 | **0.31** |

Framework-wide: every app on cranpose was paying this.

## Why the node answers, not the caller

The first version of the guard keyed on the child's parent pointer and reported 166,257 → **6**. That was too good, and wrong in the direction that ships bugs: a child reparented while still listed under its old parent has a pointer that no longer names the old parent, so the removal that *does* change the old parent's list would go unrecorded — leaving the removed subtree's layers in the persistent render graph. That is the cross-tab ghost `run_render_phase_in_context` already warns about.

Only the node owns its child list, so only the node can answer. `insert_child` and `remove_child` now return whether the list changed. Both production implementations already computed that boolean and discarded it. The four test doubles pushed unconditionally and so did not honour the contract the trait states; deduplicating them makes the doubles agree with the nodes they stand in for.

291, not 6. The extra 285 are real list changes, and the cheaper number was the wrong one.

## Also here

- The scoped scene update now reports *why* it abandoned a patch instead of a bare `applied: bool`. The shell picks the scoped path before any of this runs and logs `path=update`, so a frame that rebuilt the whole scene read in the log exactly like a cheap patch. This is what let me establish there were **zero** rebuild fallbacks in 82k frames and rule that hypothesis out.
- Two `TIME_WASTERS.md` entries: the frame-stage telemetry produces nothing headless (it is on the present path, and goes through `log::warn!`), and aggregate structural counts hide the identity that explains them.

## Tests

Four new tests pin the invariant from both sides. The third is the positive control — without it the two guard tests would pass equally well if structural changes were never recorded at all, which is the failure mode this repo keeps rediscovering.

`just ci` clean end to end: 158 suites, zero clippy warnings, fmt clean. cranpose-core 830, cranpose-ui 1011.