### PR TITLE
Fold backdrop glass shader tails into the batched composite pass

### DIFF
--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -241,6 +241,11 @@ Signature → cause → what to do. One lesson per line, no incident history.
   the LOCAL calendar day (every run between local midnight and UTC midnight
   grew an extra date header and shifted all content ~26 px), which reads
   exactly like an environment failure and follows the clock, not the box.
+  Cheaper still than the rerun: the red window is exactly local midnight to
+  UTC midnight (00:00-02:00 CEST), so the FIRST question on such a red is
+  the failed run's wall-clock time — inside the window the branch is not
+  the suspect, and the same commit goes green after 02:00 with no fix
+  aboard (measured across four cranscan PRs in one night).
 
 - **`std::thread::available_parallelism()` reports the calling thread's
   affinity mask, not the machine** — after `sched_setaffinity` restricted a

--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -341,3 +341,12 @@ Signature → cause → what to do. One lesson per line, no incident history.
   the ancestors were already marked by something else, so marking them again
   cost the walk and nothing more. Count the work you remove, then measure the
   time, and believe the second number.
+
+- **logcat's ring evicts the head of a capture, and the surviving tail
+  reads as a result** — a 24-frame remnant of a triple-telemetry round
+  (three per-frame stage switches spamming the ring) said "scene stage
+  unchanged post-fix"; the full 225-line single-switch rerun showed p50
+  moved 2.0 -> 1.18ms. The bias is systematic, not noise: the ring keeps
+  the END of the run, which over-samples whatever phase ran last. Check
+  line counts against expected frame counts before believing any logcat
+  capture, and keep per-frame switches to the one being read.

--- a/crates/cranpose-core/src/composer.rs
+++ b/crates/cranpose-core/src/composer.rs
@@ -833,6 +833,23 @@ impl Composer {
         self.core.applier.borrow_dyn()
     }
 
+    /// Records nodes whose retained subtrees a reused subcompose slot just
+    /// rebound to new content.
+    ///
+    /// The rebinding recomposes inline during measure, so every repass it
+    /// schedules is consumed by the layout pass already running — nothing
+    /// else survives to tell the scoped scene update these subtrees changed,
+    /// and a translate-only update would keep their stale layers (measured:
+    /// a 60pt lazy scroll presented the old row's text at the new row's
+    /// position). The structural-change set is the one channel drained
+    /// after layout, so the rebound children ride it.
+    pub fn record_rebound_slot_children(&self, children: &[NodeId]) {
+        let mut applier = self.borrow_applier();
+        for &child in children {
+            applier.record_structural_change(child);
+        }
+    }
+
     /// Registers a virtual node in the Applier.
     ///
     /// This is used by SubcomposeLayoutNode to register virtual container nodes

--- a/crates/cranpose-core/src/subcompose.rs
+++ b/crates/cranpose-core/src/subcompose.rs
@@ -685,20 +685,22 @@ impl SubcomposeState {
     }
 
     /// Returns the node that previously rendered this slot, if it is still
-    /// considered reusable. Content-type buckets narrow the candidate set, then
-    /// the reuse policy makes the final compatibility decision.
+    /// considered reusable, and whether it was REBOUND — taken from another
+    /// slot, so its retained subtree is about to show different content. An
+    /// exact-slot reactivation hands the same item its own subtree back and
+    /// is not a rebinding.
     ///
     /// Lookup order:
-    /// 1. Exact slot match in the appropriate pool
+    /// 1. Exact slot match in the appropriate pool (not a rebinding)
     /// 2. Any policy-compatible node from the same content-type pool
     /// 3. Fallback to untyped pool with policy compatibility check
-    pub fn take_node_from_reusables(&mut self, slot_id: SlotId) -> Option<NodeId> {
+    pub fn take_node_from_reusables(&mut self, slot_id: SlotId) -> Option<(NodeId, bool)> {
         if let Some(nodes) = self.mapping.get_nodes(&slot_id) {
             let first_node = nodes.first().copied();
             if let Some(node_id) = first_node {
                 let _ = self.remove_from_reusable_pools(node_id);
                 self.exact_reactivation_slots.remove(&slot_id);
-                return Some(node_id);
+                return Some((node_id, false));
             }
         }
 
@@ -709,7 +711,7 @@ impl SubcomposeState {
         {
             self.decrement_reusable_slot(old_slot);
             self.move_node_to_slot(node_id, old_slot, slot_id);
-            return Some(node_id);
+            return Some((node_id, true));
         }
 
         let exact_reactivation_slots = &self.exact_reactivation_slots;
@@ -727,7 +729,7 @@ impl SubcomposeState {
         {
             self.decrement_reusable_slot(old_slot);
             self.move_node_to_slot(node_id, old_slot, slot_id);
-            return Some(node_id);
+            return Some((node_id, true));
         }
 
         None

--- a/crates/cranpose-core/src/tests/subcompose_tests.rs
+++ b/crates/cranpose-core/src/tests/subcompose_tests.rs
@@ -68,7 +68,11 @@ fn exact_reuse_wins() {
     state.dispose_or_reuse_starting_from_index(0);
     assert_eq!(state.reusable(), &[10]);
     let reused = state.take_node_from_reusables(SlotId::new(1));
-    assert_eq!(reused, Some(10));
+    assert_eq!(
+        reused,
+        Some((10, false)),
+        "exact-slot reuse is not a rebinding"
+    );
 }
 
 #[test]
@@ -78,7 +82,11 @@ fn policy_based_compatibility() {
     state.dispose_or_reuse_starting_from_index(0);
     assert_eq!(state.reusable(), &[42]);
     let reused = state.take_node_from_reusables(SlotId::new(4));
-    assert_eq!(reused, Some(42));
+    assert_eq!(
+        reused,
+        Some((42, true)),
+        "cross-slot reuse rebinds the subtree"
+    );
 }
 
 #[test]
@@ -136,7 +144,7 @@ fn reordering_keyed_children_preserves_nodes() {
     let reordered = [SlotId::new(3), SlotId::new(1), SlotId::new(2)];
     let mut reused_nodes = Vec::new();
     for slot in reordered {
-        let node = state
+        let (node, _rebound) = state
             .take_node_from_reusables(slot)
             .expect("expected node for reordered slot");
         reused_nodes.push(node);
@@ -455,7 +463,11 @@ fn content_type_policy_reuses_untyped_slots_in_subcompose_state() {
     state.register_active(SlotId::new(1), &[10], &[]);
     state.dispose_or_reuse_starting_from_index(0);
 
-    assert_eq!(state.take_node_from_reusables(SlotId::new(2)), Some(10));
+    assert_eq!(
+        state.take_node_from_reusables(SlotId::new(2)),
+        Some((10, true)),
+        "an untyped cross-slot reuse rebinds the subtree"
+    );
     assert_eq!(state.reusable_count, 0);
 }
 
@@ -474,7 +486,7 @@ fn cross_slot_reuse_moves_slot_host_and_callback_holder() {
     state.register_active(old_slot, &[10], &[]);
     state.dispose_or_reuse_starting_from_index(0);
 
-    assert_eq!(state.take_node_from_reusables(new_slot), Some(10));
+    assert_eq!(state.take_node_from_reusables(new_slot), Some((10, true)));
     let new_host = state.get_or_create_slots(new_slot);
     assert!(std::rc::Rc::ptr_eq(&old_host, &new_host));
 
@@ -508,8 +520,8 @@ fn content_type_reuse_in_subcompose_state() {
     let reused = state.take_node_from_reusables(SlotId::new(3));
     assert_eq!(
         reused,
-        Some(10),
-        "Should reuse node across slots with same content type"
+        Some((10, true)),
+        "Should reuse node across slots with same content type, as a rebinding"
     );
 }
 
@@ -591,7 +603,7 @@ fn moving_last_reusable_node_transfers_slot_composition() {
     assert_eq!(state.reusable_count, 1);
 
     let reused = state.take_node_from_reusables(slot_b);
-    assert_eq!(reused, Some(10));
+    assert_eq!(reused, Some((10, true)));
     let transferred_host = state.get_or_create_slots(slot_b);
     assert!(std::rc::Rc::ptr_eq(&host, &transferred_host));
     assert!(!state.slot_compositions.contains_key(&slot_a));

--- a/crates/cranpose-render/common/src/scene_builder.rs
+++ b/crates/cranpose-render/common/src/scene_builder.rs
@@ -3789,7 +3789,7 @@ mod tests {
             reset_lowered_layer_count();
             let report =
                 update_graph_from_applier_report(&mut applier, &mut graph, &dirty_nodes, 1.0);
-            assert!(report.applied, "delta {delta}: boundary frame must apply");
+            assert!(report.applied(), "delta {delta}: boundary frame must apply");
             // The rebound-slot recording must stay proportional to real
             // content change: a scroll the beyond-bounds buffer absorbs
             // rebinds nothing and must lower nothing — the recording

--- a/crates/cranpose-render/common/src/scene_builder.rs
+++ b/crates/cranpose-render/common/src/scene_builder.rs
@@ -3786,9 +3786,22 @@ mod tests {
             dirty_nodes.extend(applier.take_structural_change_parents_attached_to(root));
             dirty_nodes.sort_unstable();
             dirty_nodes.dedup();
+            reset_lowered_layer_count();
             let report =
                 update_graph_from_applier_report(&mut applier, &mut graph, &dirty_nodes, 1.0);
             assert!(report.applied, "delta {delta}: boundary frame must apply");
+            // The rebound-slot recording must stay proportional to real
+            // content change: a scroll the beyond-bounds buffer absorbs
+            // rebinds nothing and must lower nothing — the recording
+            // firing on steady-state frames would re-lower unchanged rows
+            // on every scrolled frame.
+            if delta == -30.0 {
+                assert_eq!(
+                    lowered_layer_count(),
+                    0,
+                    "a buffer-absorbed scroll must not lower any layer"
+                );
+            }
 
             let fresh =
                 build_graph_from_applier(&mut applier, root, 1.0).expect("fresh comparison graph");

--- a/crates/cranpose-render/common/src/scene_builder.rs
+++ b/crates/cranpose-render/common/src/scene_builder.rs
@@ -3677,6 +3677,133 @@ mod tests {
         assert_dirty_hash_road_matches_full_walk(&graph);
     }
 
+    /// Every visible text with its mapped top, for whole-scene content
+    /// comparison between a patched graph and a from-scratch build.
+    fn collect_text_tops(layer: &LayerNode) -> std::collections::BTreeMap<String, i64> {
+        fn walk(
+            layer: &LayerNode,
+            transform: ProjectiveTransform,
+            out: &mut std::collections::BTreeMap<String, i64>,
+        ) {
+            for child in &layer.children {
+                match child {
+                    RenderNode::Primitive(primitive) => {
+                        if let PrimitiveNode::Text(text) = &primitive.node {
+                            let quad = transform.map_rect(text.rect);
+                            let top = quad
+                                .iter()
+                                .map(|point| point[1])
+                                .fold(f32::INFINITY, f32::min);
+                            if top.is_finite() {
+                                // Tenth-of-a-point buckets: parity, not
+                                // float-identical arithmetic.
+                                out.insert(text.text.text.clone(), (top * 10.0).round() as i64);
+                            }
+                        }
+                    }
+                    RenderNode::Layer(child_layer) => {
+                        let child_transform = child_layer.transform_to_parent.then(transform);
+                        walk(child_layer, child_transform, out);
+                    }
+                    RenderNode::DrawRun(_) => {}
+                }
+            }
+        }
+        let mut out = std::collections::BTreeMap::new();
+        walk(layer, ProjectiveTransform::identity(), &mut out);
+        out
+    }
+
+    #[test]
+    fn a_lazy_jump_of_any_distance_patches_to_what_a_fresh_build_shows() {
+        // Lowered-layer counts do not scale with scroll distance (a 300pt
+        // jump lowers fewer than a 96pt nudge), because a large jump lands
+        // every entering row in a recycled, already-dirty slot that rebuilds
+        // through the ordinary dirty path instead of the translate path's
+        // entering-row lowering. That accounting is fine ONLY if the patched
+        // scene's content is indistinguishable from a from-scratch build at
+        // every distance — which is what this pins, text by text.
+        for delta in [-30.0f32, -60.0, -96.0, -180.0, -300.0] {
+            let state_holder: Rc<RefCell<Option<LazyListState>>> = Rc::new(RefCell::new(None));
+            let state_holder_for_comp = state_holder.clone();
+            let mut composition = cranpose_ui::run_test_composition(move || {
+                let list_state = rememberLazyListState();
+                *state_holder_for_comp.borrow_mut() = Some(list_state);
+                LazyColumn(
+                    Modifier::empty().size_points(240.0, 320.0),
+                    list_state,
+                    LazyColumnSpec::default(),
+                    |scope| {
+                        scope.items(60, |index| {
+                            cranpose_ui::Box(
+                                Modifier::empty()
+                                    .size_points(240.0, 60.0)
+                                    .background(Color(0.9, 0.9, 0.92, 1.0)),
+                                cranpose_ui::BoxSpec::default(),
+                                move || {
+                                    Text(
+                                        format!("row {index}"),
+                                        Modifier::empty(),
+                                        TextStyle::default(),
+                                    );
+                                },
+                            );
+                        });
+                    },
+                );
+            });
+
+            let root = composition.root().expect("composition root");
+            let viewport = Size {
+                width: 240.0,
+                height: 320.0,
+            };
+            let handle = composition.runtime_handle();
+            let mut applier = composition.applier_mut();
+            applier.set_runtime_handle(handle);
+            applier
+                .compute_layout(root, viewport)
+                .expect("initial lazy layout");
+            let mut graph =
+                build_graph_from_applier(&mut applier, root, 1.0).expect("initial graph");
+            graph.root.recompute_raster_cache_hashes();
+            let _ = applier.take_structural_change_parents_attached_to(root);
+            applier.clear_runtime_handle();
+            drop(applier);
+
+            let list_state = (*state_holder.borrow()).expect("list state should be captured");
+            let consumed = list_state.dispatch_scroll_delta(delta);
+            assert!(consumed != 0.0, "delta {delta}: the scroll must consume");
+            let mut dirty_nodes = cranpose_ui::pending_layout_repass_nodes_snapshot();
+            dirty_nodes.extend(cranpose_ui::pending_measure_repass_nodes_snapshot());
+
+            let handle = composition.runtime_handle();
+            let mut applier = composition.applier_mut();
+            applier.set_runtime_handle(handle);
+            applier
+                .compute_layout(root, viewport)
+                .expect("scrolled lazy layout");
+            dirty_nodes.extend(applier.take_structural_change_parents_attached_to(root));
+            dirty_nodes.sort_unstable();
+            dirty_nodes.dedup();
+            let report =
+                update_graph_from_applier_report(&mut applier, &mut graph, &dirty_nodes, 1.0);
+            assert!(report.applied, "delta {delta}: boundary frame must apply");
+
+            let fresh =
+                build_graph_from_applier(&mut applier, root, 1.0).expect("fresh comparison graph");
+            applier.clear_runtime_handle();
+
+            let patched_texts = collect_text_tops(&graph.root);
+            let fresh_texts = collect_text_tops(&fresh.root);
+            assert_eq!(
+                patched_texts, fresh_texts,
+                "delta {delta}: the patched scene must show exactly what a \
+                 fresh build shows (dirty={dirty_nodes:?})"
+            );
+        }
+    }
+
     #[test]
     fn update_graph_from_applier_keeps_parent_content_offset_for_dirty_scroll_child() {
         let label_holder: Rc<RefCell<Option<cranpose_core::MutableState<String>>>> =

--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -22,6 +22,27 @@ use crate::{
     shaders,
 };
 
+/// The size for a `Chain(Blur, Shader)` tail intermediate: the blur's own
+/// scratch size. The vertical axis otherwise writes every destination pixel
+/// — sixteen times the horizontal pass's work at a quarter-scale scratch —
+/// only for the shader to consume a texture whose extra resolution a
+/// radius-16+ Gaussian already destroyed. The shader receives the logical
+/// extent separately, so its pixel-calibrated offsets stay correct.
+pub(crate) fn direct_tail_intermediate_size(
+    first_effect: &RenderEffect,
+    width: u32,
+    height: u32,
+) -> (u32, u32) {
+    if let RenderEffect::Blur {
+        radius_x, radius_y, ..
+    } = first_effect
+        && (*radius_x > 0.0 || *radius_y > 0.0)
+    {
+        return blur_scratch_size(*radius_x, *radius_y, width, height);
+    }
+    (width, height)
+}
+
 pub(crate) fn blur_scratch_size(
     radius_x: f32,
     radius_y: f32,
@@ -425,6 +446,12 @@ struct ShaderPassOptions {
     scissor: Option<(u32, u32, u32, u32)>,
     dest_viewport: Option<(f32, f32, f32, f32)>,
     pipeline_mode: RuntimeShaderPipelineMode,
+    /// The logical pixel extent the source texture REPRESENTS, when it is
+    /// rasterized smaller than that (a blur chain's scratch-size
+    /// intermediate). The shader divides pixel-calibrated offsets by this
+    /// instead of `textureDimensions`, which would inflate them by the
+    /// downscale factor. `None` means the source is at its logical size.
+    source_logical_size: Option<(f32, f32)>,
 }
 
 #[derive(Clone, Copy)]
@@ -1473,6 +1500,7 @@ impl EffectRenderer {
                 scissor: None,
                 dest_viewport: None,
                 pipeline_mode: RuntimeShaderPipelineMode::Replace,
+                source_logical_size: None,
             },
         )
     }
@@ -1489,6 +1517,7 @@ impl EffectRenderer {
         load_op: wgpu::LoadOp<wgpu::Color>,
         scissor: Option<(u32, u32, u32, u32)>,
         dest_viewport: (f32, f32, f32, f32),
+        source_logical_size: Option<(f32, f32)>,
     ) -> bool {
         if dest_viewport.2 <= 0.0 || dest_viewport.3 <= 0.0 {
             return false;
@@ -1505,6 +1534,7 @@ impl EffectRenderer {
                 scissor,
                 dest_viewport: Some(dest_viewport),
                 pipeline_mode: RuntimeShaderPipelineMode::PremultipliedSrcOver,
+                source_logical_size,
             },
         )
     }
@@ -1662,6 +1692,10 @@ impl EffectRenderer {
         padded[slot + 1] = layer_pixel_rect[1];
         padded[slot + 2] = layer_pixel_rect[2];
         padded[slot + 3] = layer_pixel_rect[3];
+        if let Some((logical_width, logical_height)) = options.source_logical_size {
+            padded[slot + 4] = logical_width;
+            padded[slot + 5] = logical_height;
+        }
         let uniform_bind_group = recorder.upload_uniform(
             UploadAllocatorId::EffectUniform,
             effect_uniform_spec(),
@@ -2400,7 +2434,36 @@ fn composite_sampling_mode_value(sample_mode: CompositeSampleMode) -> f32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{BlurUniforms, projective_dest_bounds_rect};
+    use super::{BlurUniforms, direct_tail_intermediate_size, projective_dest_bounds_rect};
+    use cranpose_ui_graphics::{RenderEffect, RuntimeShader};
+
+    #[test]
+    fn a_frost_chain_tail_intermediate_shrinks_to_the_blur_scratch() {
+        let frost = RenderEffect::Blur {
+            radius_x: 24.0,
+            radius_y: 24.0,
+            edge_treatment: Default::default(),
+        };
+        // Radius 24 downsamples 4x on each side.
+        assert_eq!(direct_tail_intermediate_size(&frost, 1080, 360), (270, 90));
+
+        // A zero blur is the composite fast path; nothing shrinks.
+        let no_frost = RenderEffect::Blur {
+            radius_x: 0.0,
+            radius_y: 0.0,
+            edge_treatment: Default::default(),
+        };
+        assert_eq!(
+            direct_tail_intermediate_size(&no_frost, 1080, 360),
+            (1080, 360)
+        );
+
+        // A shader first stage samples at texel precision; full size.
+        let lens = RenderEffect::Shader {
+            shader: RuntimeShader::new("fn f() {}"),
+        };
+        assert_eq!(direct_tail_intermediate_size(&lens, 1080, 360), (1080, 360));
+    }
 
     #[test]
     fn blur_uniforms_use_vec4_packing_for_gl_backends() {

--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -2434,8 +2434,9 @@ fn composite_sampling_mode_value(sample_mode: CompositeSampleMode) -> f32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{BlurUniforms, direct_tail_intermediate_size, projective_dest_bounds_rect};
     use cranpose_ui_graphics::{RenderEffect, RuntimeShader};
+
+    use super::{BlurUniforms, direct_tail_intermediate_size, projective_dest_bounds_rect};
 
     #[test]
     fn a_frost_chain_tail_intermediate_shrinks_to_the_blur_scratch() {

--- a/crates/cranpose-render/wgpu/src/frame_graph.rs
+++ b/crates/cranpose-render/wgpu/src/frame_graph.rs
@@ -727,7 +727,7 @@ fn take_render_pass_labels() -> Vec<(String, u32)> {
     RENDER_PASS_LABELS.with(|labels| std::mem::take(&mut *labels.borrow_mut()))
 }
 
-fn frame_graph_pass_telemetry_threshold_ms() -> Option<f64> {
+pub(crate) fn frame_graph_pass_telemetry_threshold_ms() -> Option<f64> {
     crate::debug_toggles::debug_toggle("CRANPOSE_WGPU_RENDER_STAGE_TELEMETRY_MS")
         .and_then(|raw| raw.parse::<f64>().ok())
         .filter(|threshold| *threshold >= 0.0)

--- a/crates/cranpose-render/wgpu/src/frame_graph.rs
+++ b/crates/cranpose-render/wgpu/src/frame_graph.rs
@@ -661,9 +661,17 @@ impl WgpuFrameGraphExecutor {
         let finish_ms = submit_start.duration_since(finish_start).as_secs_f64() * 1000.0;
         let submit_ms = submit_end.duration_since(submit_start).as_secs_f64() * 1000.0;
         let upload_writes = take_upload_write_calls();
+        let pass_labels = take_render_pass_labels();
         if finish_ms + submit_ms >= threshold_ms {
+            let pass_total: u32 = pass_labels.iter().map(|(_, count)| count).sum();
+            let mut split = String::new();
+            for (label, count) in &pass_labels {
+                use std::fmt::Write;
+                let _ = write!(split, " [{label}]={count}");
+            }
             log::warn!(
-                "[wgpu-render-stage:submit] finish_ms={finish_ms:.3} submit_ms={submit_ms:.3} upload_writes={upload_writes}"
+                "[wgpu-render-stage:submit] finish_ms={finish_ms:.3} submit_ms={submit_ms:.3} \
+                 upload_writes={upload_writes} passes={pass_total}{split}"
             );
         }
         submission
@@ -686,6 +694,37 @@ fn note_upload_write() {
 
 fn take_upload_write_calls() -> u32 {
     UPLOAD_WRITE_CALLS.with(|calls| calls.replace(0))
+}
+
+std::thread_local! {
+    /// Render passes begun since the last submit on this thread, counted per
+    /// pass label. On a tiler every pass is a tile load/store cycle whatever
+    /// its draw count, so the per-frame submit stall has to be attributable
+    /// to *which* passes ran, not just how long encoding took — the 60-frame
+    /// GPU stats cadence cannot be joined against a per-frame stall. Only
+    /// populated while the stage telemetry threshold is set; the label copy
+    /// is a diagnostic cost, not a shipping one.
+    static RENDER_PASS_LABELS: std::cell::RefCell<Vec<(String, u32)>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+pub(crate) fn note_render_pass(label: Option<&str>) {
+    if frame_graph_pass_telemetry_threshold_ms().is_none() {
+        return;
+    }
+    let label = label.unwrap_or("<unlabeled>");
+    RENDER_PASS_LABELS.with(|labels| {
+        let mut labels = labels.borrow_mut();
+        if let Some(entry) = labels.iter_mut().find(|(name, _)| name == label) {
+            entry.1 += 1;
+        } else {
+            labels.push((label.to_owned(), 1));
+        }
+    });
+}
+
+fn take_render_pass_labels() -> Vec<(String, u32)> {
+    RENDER_PASS_LABELS.with(|labels| std::mem::take(&mut *labels.borrow_mut()))
 }
 
 fn frame_graph_pass_telemetry_threshold_ms() -> Option<f64> {

--- a/crates/cranpose-render/wgpu/src/pass_timing.rs
+++ b/crates/cranpose-render/wgpu/src/pass_timing.rs
@@ -376,6 +376,7 @@ pub(crate) fn begin_timed_render_pass<'encoder>(
     encoder: &'encoder mut wgpu::CommandEncoder,
     descriptor: &wgpu::RenderPassDescriptor<'_>,
 ) -> wgpu::RenderPass<'encoder> {
+    crate::frame_graph::note_render_pass(descriptor.label);
     let timing = pass_timer.and_then(|timer| {
         timer
             .begin_pass(descriptor.label.unwrap_or("<unlabeled pass>"))

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -9451,6 +9451,24 @@ impl GpuRenderer {
             .merge_and_reset_debug_counters(&self.frame_stats);
         self.frame_graph_executor.reset_upload_allocators();
         let snapshot = self.frame_stats.snapshot();
+        // The eprintln-based 60-frame stats never reach logcat on devices
+        // whose stdio pump forwards nothing (Mate 20 X measured zero pump
+        // lines), so the per-frame surface/cache counters ride the stage
+        // telemetry switch through the logger, where the submit line
+        // carrying the pass split already arrives.
+        if crate::frame_graph::frame_graph_pass_telemetry_threshold_ms().is_some() {
+            log::warn!(
+                "[wgpu-render-stage:frame-stats] layer_hit={} layer_miss={} miss_px={} \
+                 offscreen_acq={} offscreen_new={} isolated={} draws={}",
+                snapshot.layer_cache_hits,
+                snapshot.layer_cache_misses,
+                snapshot.layer_cache_miss_pixels,
+                snapshot.offscreen_acquires,
+                snapshot.offscreen_news,
+                snapshot.isolated_layer_renders,
+                snapshot.draw_calls,
+            );
+        }
         self.last_frame_stats = Some(snapshot);
         PRESENTED_FRAMES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         update_frame_warmup_budget(&mut self.pending_frame_warmup_frames, &snapshot);

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -8018,6 +8018,7 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
                     load_op,
                     scissor,
                     viewport,
+                    None,
                 );
             if shader_applied {
                 self.renderer
@@ -8169,10 +8170,16 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
         dest_viewport: (f32, f32, f32, f32),
     ) -> Result<bool, String> {
         let device = self.renderer.device.clone();
+        let (intermediate_width, intermediate_height) =
+            crate::effect_renderer::direct_tail_intermediate_size(
+                first_effect,
+                source.width,
+                source.height,
+            );
         let intermediate_descriptor = self.renderer.transient_offscreen_descriptor(
             "Render Effect Direct Shader Tail Intermediate",
-            source.width,
-            source.height,
+            intermediate_width,
+            intermediate_height,
         );
         let intermediate = self
             .recorder
@@ -8226,6 +8233,8 @@ impl<C: FrameCommandRecorder> RecordingSurfaceBackend<'_, '_, C> {
                 load_op,
                 scissor,
                 dest_viewport,
+                ((intermediate_width, intermediate_height) != (source.width, source.height))
+                    .then_some((source.width as f32, source.height as f32)),
             );
         self.recorder
             .record_passes(first_passes.saturating_add(u32::from(shader_applied)));

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -9127,6 +9127,54 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
         )
     }
 
+    fn materialize_effect_direct(
+        &mut self,
+        source: &OffscreenTarget,
+        effect: &RenderEffect,
+        effect_rect: [f32; 4],
+        target: &OffscreenTarget,
+    ) -> Result<bool, String> {
+        // encode_effect emits its result at the destination view's own
+        // resolution, so a size mismatch would silently rescale the output.
+        if target.width != source.width || target.height != source.height {
+            return Ok(false);
+        }
+        let device = self.renderer.device.clone();
+        let effect_scratch_targets = self
+            .renderer
+            .effect_renderer
+            .acquire_recorded_effect_scratch_targets(
+                self.recorder,
+                &device,
+                effect,
+                source.width,
+                source.height,
+                self.renderer.composition_format,
+            );
+        let effect_passes = {
+            let mut effect_scratch_refs = effect_scratch_targets.refs();
+            self.renderer
+                .effect_renderer
+                .encode_effect(
+                    self.recorder,
+                    &device,
+                    source,
+                    &target.view,
+                    effect,
+                    effect_rect,
+                    &mut effect_scratch_refs,
+                )
+                .and_then(|pass_count| {
+                    effect_scratch_refs.assert_consumed()?;
+                    Ok(pass_count)
+                })
+        };
+        effect_scratch_targets.release_into(self.recorder);
+        let effect_passes = effect_passes?;
+        self.recorder.record_passes(effect_passes);
+        Ok(true)
+    }
+
     fn apply_shader_and_composite_to_view(
         &mut self,
         source: &OffscreenTarget,

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -9220,6 +9220,13 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
     }
 
     fn record_layer_cache_miss(&self, key: &LayerRasterCacheKey, width: u32, height: u32) {
+        // Whole key on purpose: two consecutive frames' misses for the same
+        // stable id show WHICH field moved (content hash, bounds, size),
+        // which is the difference between "content legitimately changed"
+        // and "the key is position-poisoned".
+        if cranpose_core::env_flag!("CRANPOSE_LAYER_RENDER_DIAG") {
+            log::warn!("[layer-cache-miss] {width}x{height} {key:?}");
+        }
         self.renderer
             .frame_stats
             .record_layer_cache_miss(key, width, height);

--- a/crates/cranpose-render/wgpu/src/surface_executor/backend.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/backend.rs
@@ -287,6 +287,18 @@ pub(crate) trait SurfaceExecutionBackend {
         dest_viewport: Option<(f32, f32, f32, f32)>,
         sample_mode: CompositeSampleMode,
     ) -> Result<(), String>;
+    /// Encode `effect` from `source` straight into `target`'s view — the
+    /// materialize shape: opaque SrcOver onto a fully-owned target with a
+    /// 1:1 texel mapping. Returns Ok(false) when the backend cannot encode
+    /// directly (e.g. the sizes differ); the caller then composites through
+    /// the generic scratch route.
+    fn materialize_effect_direct(
+        &mut self,
+        source: &OffscreenTarget,
+        effect: &RenderEffect,
+        effect_rect: [f32; 4],
+        target: &OffscreenTarget,
+    ) -> Result<bool, String>;
     #[allow(clippy::too_many_arguments)]
     fn apply_shader_and_composite_to_view(
         &mut self,

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -2365,17 +2365,57 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                     height,
                     root_scale,
                     Some(backdrop_input_hash),
+                    true,
                 )? {
-                    if pending_composites.is_empty() {
-                        pending_composite_load_op = Some(next_load_op);
+                    let PreparedBackdropComposite {
+                        surface: prepared_surface,
+                        dest_quad: prepared_dest_quad,
+                        scissor: prepared_scissor,
+                    } = prepared;
+                    if prepared_surface.deferred_effect.is_some() {
+                        // The capture flush above landed every pending write
+                        // that touches this backdrop's output rect, so the
+                        // shader queue's earlier flush slot cannot be overdrawn
+                        // by a blit queued before this glass.
+                        match direct_shader_layer_composite(
+                            prepared_surface,
+                            child.z_index,
+                            prepared_dest_quad,
+                            prepared_scissor,
+                        ) {
+                            Ok(pending) => {
+                                if pending_shader_composites.is_empty() {
+                                    pending_shader_load_op = Some(next_load_op);
+                                }
+                                pending_shader_composites.push(pending);
+                                next_load_op = wgpu::LoadOp::Load;
+                            }
+                            Err(prepared_surface) => {
+                                composite_layer_surface_to_view(
+                                    backend,
+                                    &prepared_surface,
+                                    surface_view,
+                                    (width, height),
+                                    prepared_dest_quad,
+                                    next_load_op,
+                                    prepared_scissor,
+                                )?;
+                                next_load_op = wgpu::LoadOp::Load;
+                                backend.release_layer_surface_target(prepared_surface.target);
+                            }
+                        }
+                    } else {
+                        if pending_composites.is_empty() {
+                            pending_composite_load_op = Some(next_load_op);
+                        }
+                        pending_composites.push(PendingLayerComposite {
+                            z_index: child.z_index,
+                            surface: prepared_surface,
+                            dest_quad: prepared_dest_quad,
+                            scissor: prepared_scissor,
+                        });
+                        next_load_op = wgpu::LoadOp::Load;
                     }
-                    pending_composites.push(PendingLayerComposite {
-                        z_index: child.z_index,
-                        surface: prepared.surface,
-                        dest_quad: prepared.dest_quad,
-                        scissor: prepared.scissor,
-                    });
-                    next_load_op = wgpu::LoadOp::Load;
                 } else {
                     apply_backdrop_layer_to_target(
                         backend,
@@ -2882,6 +2922,17 @@ fn materialize_render_effect_to_target<B: SurfaceExecutionBackend>(
         return Ok(());
     }
 
+    // An effect without a shader tail encodes straight into the target:
+    // the generic composite route below would bounce it through a scratch
+    // surface and spend an extra render pass presenting a 1:1 opaque copy.
+    // Shader-tailed chains stay on the generic route — its direct-tail path
+    // owns the shrunk-intermediate fill optimization.
+    if split_backdrop_effect(effect).1.is_none()
+        && backend.materialize_effect_direct(source, effect, layer_pixel_rect, target)?
+    {
+        return Ok(());
+    }
+
     backend.apply_effect_and_composite_to_view(
         source,
         effect,
@@ -3032,6 +3083,7 @@ fn backdrop_prefix_child_contribution(
     }
 }
 
+#[cfg(test)]
 fn backdrop_effect_cache_key(
     layer: &BackdropLayer,
     input_content_hash: u64,
@@ -3039,14 +3091,48 @@ fn backdrop_effect_cache_key(
     pixel_size: (u32, u32),
     root_scale: f32,
 ) -> Option<LayerRasterCacheKey> {
-    Some(LayerRasterCacheKey::backdrop_effect(
-        layer.node_id,
+    backdrop_effect_cache_key_for_effect_hash(
+        layer,
         input_content_hash,
         retained_render_effect_hash(&layer.effect),
         visible_rect,
         pixel_size,
+        root_scale,
+    )
+}
+
+fn backdrop_effect_cache_key_for_effect_hash(
+    layer: &BackdropLayer,
+    input_content_hash: u64,
+    effect_hash: u64,
+    visible_rect: Rect,
+    pixel_size: (u32, u32),
+    root_scale: f32,
+) -> Option<LayerRasterCacheKey> {
+    Some(LayerRasterCacheKey::backdrop_effect(
+        layer.node_id,
+        input_content_hash,
+        effect_hash,
+        visible_rect,
+        pixel_size,
         ScaleBucket::from_scale(root_scale),
     ))
+}
+
+/// Splits a backdrop effect into the part worth materializing into the
+/// cached surface and a runtime-shader tail worth deferring to the
+/// composite batch. The tail's pass then folds into the batched composite
+/// that already runs, and — because the tail's uniforms leave the cache
+/// key — per-frame glass dynamics stop invalidating the blurred capture.
+fn split_backdrop_effect(effect: &RenderEffect) -> (Option<&RenderEffect>, Option<&RuntimeShader>) {
+    match effect {
+        RenderEffect::Shader { shader } => (None, Some(shader)),
+        RenderEffect::Chain { first, second } => match second.as_ref() {
+            RenderEffect::Shader { shader } => (Some(first.as_ref()), Some(shader)),
+            _ => (Some(effect), None),
+        },
+        _ => (Some(effect), None),
+    }
 }
 
 fn retained_render_effect_hash(effect: &RenderEffect) -> u64 {
@@ -4772,6 +4858,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                 height,
                 target_scale,
                 Some(backdrop_input_hash),
+                false,
             )? {
                 if pending_composites.is_empty() {
                     pending_composite_load_op = Some(next_load_op);
@@ -5610,6 +5697,7 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
     height: u32,
     root_scale: f32,
     input_content_hash: Option<u64>,
+    allow_deferred_tail: bool,
 ) -> Result<Option<PreparedBackdropComposite>, String> {
     let diag = backdrop_diag_enabled();
     let (layer_rect, layer_clip) = snapped_backdrop_geometry(layer, root_scale);
@@ -5687,15 +5775,29 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
     let (backdrop_width, backdrop_height) = copy_plan.map(|plan| plan.size).unwrap_or_else(|| {
         surface_target_size(capture_rect, backdrop_scale, backend.max_texture_dim())
     });
+    // The runtime-shader tail defers to the batched composite when the
+    // caller runs one: its pass folds into the batch, and its uniforms
+    // leave the cache key so per-frame glass dynamics stop invalidating
+    // the blurred capture. The materialized part alone names the cache
+    // content.
+    let (materialized_effect, deferred_tail) = if allow_deferred_tail {
+        split_backdrop_effect(&layer.effect)
+    } else {
+        (Some(&layer.effect), None)
+    };
+    let materialized_effect_hash = materialized_effect
+        .map(retained_render_effect_hash)
+        .unwrap_or(0);
     let Some(cache_key) = input_content_hash.and_then(|hash| {
         (backdrop_underlay.is_none()
             && backend.is_render_effect_supported(&layer.effect)
             && offscreen_byte_size(backdrop_width, backdrop_height)
                 <= MAX_LAYER_SURFACE_CACHE_BYTES)
             .then(|| {
-                backdrop_effect_cache_key(
+                backdrop_effect_cache_key_for_effect_hash(
                     layer,
                     hash,
+                    materialized_effect_hash,
                     capture_rect,
                     (backdrop_width, backdrop_height),
                     root_scale,
@@ -5717,53 +5819,87 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
             backdrop_width,
             backdrop_height,
         );
-        let snapshot = backend.acquire_frame_surface(backdrop_width, backdrop_height);
-        let copied_snapshot = copy_plan.is_some_and(|plan| {
-            backend.copy_texture_region_to_target(target, plan.source_origin, &snapshot, plan.size)
-        });
-        if !copied_snapshot {
-            copy_projective_backdrop_inputs_to_view(
-                backend,
-                None,
-                target,
-                capture_rect,
-                &snapshot.view,
-                (backdrop_width, backdrop_height),
-                backdrop_scale,
-            )?;
-        }
-
         let effect_target = backend.acquire_retained_surface(backdrop_width, backdrop_height);
-        if diag {
-            eprintln!(
-                "[backdrop-diag] prepare MISS copied={} plan={:?} backdrop_size=({},{}) scale={}",
-                copied_snapshot,
-                copy_plan.map(|plan| (plan.source_origin, plan.size, plan.effect_pixel_rect)),
-                backdrop_width,
-                backdrop_height,
-                backdrop_scale,
-            );
+        if let Some(effect) = materialized_effect {
+            let snapshot = backend.acquire_frame_surface(backdrop_width, backdrop_height);
+            let copied_snapshot = copy_plan.is_some_and(|plan| {
+                backend.copy_texture_region_to_target(
+                    target,
+                    plan.source_origin,
+                    &snapshot,
+                    plan.size,
+                )
+            });
+            if !copied_snapshot {
+                copy_projective_backdrop_inputs_to_view(
+                    backend,
+                    None,
+                    target,
+                    capture_rect,
+                    &snapshot.view,
+                    (backdrop_width, backdrop_height),
+                    backdrop_scale,
+                )?;
+            }
+            if diag {
+                eprintln!(
+                    "[backdrop-diag] prepare MISS copied={} plan={:?} backdrop_size=({},{}) scale={}",
+                    copied_snapshot,
+                    copy_plan.map(|plan| (plan.source_origin, plan.size, plan.effect_pixel_rect)),
+                    backdrop_width,
+                    backdrop_height,
+                    backdrop_scale,
+                );
+            }
+            materialize_render_effect_to_target(
+                backend,
+                &snapshot,
+                effect,
+                &effect_target,
+                copy_plan
+                    .map(|plan| plan.effect_pixel_rect)
+                    .unwrap_or_else(|| {
+                        let capture = surface_pixel_rect(capture_rect, backdrop_scale);
+                        let effect = surface_pixel_rect(layer_rect, backdrop_scale);
+                        [
+                            effect.x - capture.x,
+                            effect.y - capture.y,
+                            effect.width,
+                            effect.height,
+                        ]
+                    }),
+                CompositeSampleMode::Linear,
+            )?;
+            backend.release_frame_surface(snapshot);
+        } else {
+            // The whole effect is a deferred shader tail: the cached surface
+            // is the capture itself — a texture copy when the 1:1 plan holds,
+            // never a materialize pass.
+            let copied_capture = copy_plan.is_some_and(|plan| {
+                backend.copy_texture_region_to_target(
+                    target,
+                    plan.source_origin,
+                    &effect_target,
+                    plan.size,
+                )
+            });
+            if !copied_capture {
+                copy_projective_backdrop_inputs_to_view(
+                    backend,
+                    None,
+                    target,
+                    capture_rect,
+                    &effect_target.view,
+                    (backdrop_width, backdrop_height),
+                    backdrop_scale,
+                )?;
+            }
+            if diag {
+                eprintln!(
+                    "[backdrop-diag] prepare MISS copied={copied_capture} deferred-tail capture backdrop_size=({backdrop_width},{backdrop_height}) scale={backdrop_scale}"
+                );
+            }
         }
-        materialize_render_effect_to_target(
-            backend,
-            &snapshot,
-            &layer.effect,
-            &effect_target,
-            copy_plan
-                .map(|plan| plan.effect_pixel_rect)
-                .unwrap_or_else(|| {
-                    let capture = surface_pixel_rect(capture_rect, backdrop_scale);
-                    let effect = surface_pixel_rect(layer_rect, backdrop_scale);
-                    [
-                        effect.x - capture.x,
-                        effect.y - capture.y,
-                        effect.width,
-                        effect.height,
-                    ]
-                }),
-            CompositeSampleMode::Linear,
-        )?;
-        backend.release_frame_surface(snapshot);
         LayerSurfaceTexture::Cached(backend.insert_cached_layer_surface(
             cache_key,
             effect_target,
@@ -5771,19 +5907,44 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
         ))
     };
 
+    let (surface_logical_rect, deferred_effect, effect_content_rect) = match deferred_tail {
+        Some(shader) => {
+            // The composite must address the surface texels exactly as the
+            // copy plan laid them down: the plan spans
+            // floor(origin)..ceil(origin+extent), up to a texel wider than
+            // the capture rect, and the tail shader's dp mapping keys off
+            // this window.
+            let window = copy_plan
+                .map(|plan| Rect {
+                    x: plan.source_origin.0 as f32 / root_scale,
+                    y: plan.source_origin.1 as f32 / root_scale,
+                    width: plan.size.0 as f32 / root_scale,
+                    height: plan.size.1 as f32 / root_scale,
+                })
+                .unwrap_or(capture_rect);
+            (
+                window,
+                Some(RenderEffect::Shader {
+                    shader: shader.clone(),
+                }),
+                Some(layer_rect),
+            )
+        }
+        None => (capture_rect, None, None),
+    };
     Ok(Some(PreparedBackdropComposite {
         surface: LayerSurface {
             target: target_texture,
-            logical_rect: capture_rect,
+            logical_rect: surface_logical_rect,
             composite_alpha: 1.0,
             blend_mode: BlendMode::SrcOver,
             rounded_clip: None,
             backdrop: None,
-            deferred_effect: None,
-            effect_content_rect: None,
+            deferred_effect,
+            effect_content_rect,
             sample_mode: CompositeSampleMode::Linear,
         },
-        dest_quad: scaled_quad(crate::rect_to_quad(capture_rect), root_scale),
+        dest_quad: scaled_quad(crate::rect_to_quad(surface_logical_rect), root_scale),
         scissor: Some(scissor),
     }))
 }
@@ -5819,6 +5980,7 @@ pub(crate) fn apply_backdrop_layer_to_target<B: SurfaceExecutionBackend>(
         height,
         root_scale,
         input_content_hash,
+        false,
     )? {
         if backdrop_diag_enabled() {
             eprintln!(
@@ -6242,16 +6404,17 @@ mod tests {
         MAX_MOTION_SENSITIVE_DIRECT_SCENE_CACHE_DRAW_BYTES, MIN_DIRECT_SCENE_RANGE_CACHE_DRAW_OPS,
         SceneBrush, anchored_composite_dest_quad, axis_aligned_backdrop_copy_region,
         axis_aligned_backdrop_snapshot_copy_plan, backdrop_effect_cache_key,
-        backdrop_scene_prefix_hash, backdrop_underlay_is_covered_by_local_content,
-        child_composite_visible, composite_dest_viewport, dest_quad_intersects_rect,
-        direct_scene_range_cache_chunk_end, direct_scene_range_cache_enabled_for_policy,
-        direct_scene_range_cache_key, direct_scene_range_chunk_fits_cache_entry,
-        direct_scene_range_snapped_bounds, exact_translation_sample_mode, layer_source_cache_key,
+        backdrop_effect_cache_key_for_effect_hash, backdrop_scene_prefix_hash,
+        backdrop_underlay_is_covered_by_local_content, child_composite_visible,
+        composite_dest_viewport, dest_quad_intersects_rect, direct_scene_range_cache_chunk_end,
+        direct_scene_range_cache_enabled_for_policy, direct_scene_range_cache_key,
+        direct_scene_range_chunk_fits_cache_entry, direct_scene_range_snapped_bounds,
+        exact_translation_sample_mode, layer_source_cache_key,
         layer_source_uses_external_backdrop_underlay, layer_surface_dest_quad,
         layer_surface_translation_context, minimum_surface_scale_for_composite, quad_bounds_rect,
         rects_intersect, render_string_scene_hash, retained_render_effect_hash,
         rounded_fill_covers_rect, scene_backdrop_input_hashes, snapped_backdrop_geometry,
-        surface_target_size, underlay_fill_scissor, underlay_sample_rect,
+        split_backdrop_effect, surface_target_size, underlay_fill_scissor, underlay_sample_rect,
         visible_backdrop_capture_rect,
     };
     use crate::{
@@ -6737,6 +6900,79 @@ mod tests {
             retained_render_effect_hash(&RenderEffect::runtime_shader(first)),
             retained_render_effect_hash(&RenderEffect::runtime_shader(second)),
             "retained backdrop cache keys must distinguish runtime shader uniforms"
+        );
+    }
+
+    #[test]
+    fn a_bare_shader_backdrop_defers_entirely_and_materializes_nothing() {
+        let effect = RenderEffect::runtime_shader(RuntimeShader::new("// lens"));
+        let (materialized, tail) = split_backdrop_effect(&effect);
+        assert!(materialized.is_none(), "a lens caches the raw capture");
+        assert!(tail.is_some(), "the lens shader must defer to the batch");
+    }
+
+    #[test]
+    fn a_frost_chain_materializes_the_blur_and_defers_the_shader_tail() {
+        let effect = RenderEffect::blur(12.0).then(RenderEffect::runtime_shader(
+            RuntimeShader::new("// frost tail"),
+        ));
+        let (materialized, tail) = split_backdrop_effect(&effect);
+        assert!(
+            matches!(materialized, Some(RenderEffect::Blur { .. })),
+            "the blur prefix alone names the cached surface"
+        );
+        assert!(tail.is_some(), "the frost tail must defer to the batch");
+    }
+
+    #[test]
+    fn an_effect_without_a_shader_tail_materializes_whole() {
+        let bare_blur = RenderEffect::blur(8.0);
+        let (materialized, tail) = split_backdrop_effect(&bare_blur);
+        assert_eq!(materialized, Some(&bare_blur));
+        assert!(tail.is_none());
+
+        let blur_chain = RenderEffect::blur(8.0).then(RenderEffect::blur(4.0));
+        let (materialized, tail) = split_backdrop_effect(&blur_chain);
+        assert_eq!(
+            materialized,
+            Some(&blur_chain),
+            "a chain that does not end in a shader stays intact"
+        );
+        assert!(tail.is_none());
+    }
+
+    #[test]
+    fn deferring_the_tail_keys_the_cache_off_the_prefix_not_the_dynamics() {
+        let layer_rect = Rect {
+            x: 10.0,
+            y: 10.0,
+            width: 60.0,
+            height: 40.0,
+        };
+        let mut morning = RuntimeShader::new("// frost tail");
+        morning.set_float(0, 0.25);
+        let mut evening = RuntimeShader::new("// frost tail");
+        evening.set_float(0, 0.75);
+        let key_for = |tail: RuntimeShader| {
+            let effect = RenderEffect::blur(12.0).then(RenderEffect::runtime_shader(tail));
+            let layer = BackdropLayer {
+                effect,
+                ..test_backdrop_layer(layer_rect)
+            };
+            let (materialized, _) = split_backdrop_effect(&layer.effect);
+            backdrop_effect_cache_key_for_effect_hash(
+                &layer,
+                7,
+                materialized.map(retained_render_effect_hash).unwrap_or(0),
+                layer.rect,
+                (60, 40),
+                1.0,
+            )
+        };
+        assert_eq!(
+            key_for(morning),
+            key_for(evening),
+            "per-frame tail uniforms must not invalidate the blurred capture"
         );
     }
 

--- a/crates/cranpose-render/wgpu/tests/backdrop_pass_batching.rs
+++ b/crates/cranpose-render/wgpu/tests/backdrop_pass_batching.rs
@@ -207,12 +207,14 @@ fn scrolled_pass_counts(glass_count: usize) -> Vec<u32> {
 }
 
 /// Each extra disjoint fixed glass pays exactly its own small-target work —
-/// the separable blur pair plus the materialize pass that produces its
-/// cacheable surface — and NOTHING on the root target: its capture is a
-/// copy, not a pass, and its composite rides the shared batch. Before the
-/// pre-capture flushes were dependency-gated, every capture flushed the
-/// whole pending batch, so each glass also fragmented the composites into
-/// its own root-target pass (issue #500, cause 2).
+/// the separable blur pair, nothing more — and NOTHING on the root target:
+/// its capture is a copy, not a pass, the blur's second tap writes the
+/// cacheable surface directly, and its optical shader tail defers into the
+/// shared batched shader composite. Before the pre-capture flushes were
+/// dependency-gated, every capture flushed the whole pending batch, so each
+/// glass also fragmented the composites into its own root-target pass
+/// (issue #500, cause 2); before the tail deferred, each glass also paid a
+/// materialize pass baking per-frame shader dynamics into its cache key.
 #[test]
 fn each_extra_fixed_glass_adds_only_its_blur_chain() {
     let single: Vec<u32> = scrolled_pass_counts(1);
@@ -229,10 +231,10 @@ fn each_extra_fixed_glass_adds_only_its_blur_chain() {
     );
     assert_eq!(
         triple_steady,
-        single_steady + 6,
-        "two extra fixed glasses must add exactly their blur pairs and \
-         materialize passes (3 small-target passes each), with every \
-         composite riding the shared batch: single={single:?} triple={triple:?}"
+        single_steady + 4,
+        "two extra fixed glasses must add exactly their blur pairs (2 \
+         small-target passes each), with the shader tails and composites \
+         riding the shared batches: single={single:?} triple={triple:?}"
     );
 }
 

--- a/crates/cranpose-ui-graphics/shaders/liquid_glass.wgsl
+++ b/crates/cranpose-ui-graphics/shaders/liquid_glass.wgsl
@@ -493,7 +493,17 @@ fn scene_sdf(
 @fragment
 fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     let uv = input.uv;
-    let tex_size = vec2<f32>(textureDimensions(input_texture));
+    // Renderer-reserved slot 252/253: the LOGICAL pixel extent the input
+    // texture represents, injected when it is rasterized smaller than that
+    // (a blur chain's scratch-size intermediate). Pixel-calibrated offsets
+    // divide by the logical extent — dividing by the physical dimensions of
+    // a quarter-scale texture would inflate every displacement fourfold.
+    // Zero means the input is at its logical size.
+    let logical_size = get_vec2(252u);
+    var tex_size = vec2<f32>(textureDimensions(input_texture));
+    if (logical_size.x > 0.5 && logical_size.y > 0.5) {
+        tex_size = logical_size;
+    }
     let material_activity = clamp(get_float(111u), 0.0, 1.0);
 
     // Effect layer pixel rect injected by the renderer at uniform slot 62

--- a/crates/cranpose-ui/benches/slot_table_v2.rs
+++ b/crates/cranpose-ui/benches/slot_table_v2.rs
@@ -531,6 +531,7 @@ impl SubcomposeScrollFixture {
     fn next_node_for_slot(&mut self, slot_id: SlotId) -> usize {
         self.state
             .take_node_from_reusables(slot_id)
+            .map(|(node_id, _rebound)| node_id)
             .unwrap_or_else(|| {
                 let node_id = self.next_node_id;
                 self.next_node_id += 1;

--- a/crates/cranpose-ui/src/subcompose_layout.rs
+++ b/crates/cranpose-ui/src/subcompose_layout.rs
@@ -324,6 +324,9 @@ impl<'a> SubcomposeMeasureScopeImpl<'a> {
         // NOT from inner.virtual_nodes. The Applier's copy received insert_child calls
         // during subcomposition, while inner.virtual_nodes is an out-of-sync clone.
         let children = self.composer.get_node_children(virtual_node_id).to_vec();
+        if is_reused {
+            self.composer.record_rebound_slot_children(&children);
+        }
         if let Some(start) = telemetry_start {
             log::warn!(
                 "[subcompose-telemetry] slot={} reused={} children={} subcompose_ms={:.2}",

--- a/crates/cranpose-ui/src/subcompose_layout.rs
+++ b/crates/cranpose-ui/src/subcompose_layout.rs
@@ -258,10 +258,13 @@ impl<'a> SubcomposeMeasureScopeImpl<'a> {
         let telemetry_start = subcompose_telemetry_enabled().then(Instant::now);
         let mut inner = self.parent_handle.inner.borrow_mut();
 
-        // Reuse or create virtual node
-        let (virtual_node_id, is_reused) =
-            if let Some(node_id) = self.state.take_node_from_reusables(slot_id) {
-                (node_id, true)
+        // Reuse or create virtual node. `rebound` narrows `reused`: an
+        // exact-slot reactivation gives the same item its own subtree back,
+        // while a rebound node's retained subtree is about to recompose to a
+        // DIFFERENT item's content.
+        let (virtual_node_id, is_rebound) =
+            if let Some((node_id, rebound)) = self.state.take_node_from_reusables(slot_id) {
+                (node_id, rebound)
             } else {
                 let id = allocate_virtual_node_id();
                 let node = LayoutNode::new_virtual();
@@ -324,14 +327,14 @@ impl<'a> SubcomposeMeasureScopeImpl<'a> {
         // NOT from inner.virtual_nodes. The Applier's copy received insert_child calls
         // during subcomposition, while inner.virtual_nodes is an out-of-sync clone.
         let children = self.composer.get_node_children(virtual_node_id).to_vec();
-        if is_reused {
+        if is_rebound {
             self.composer.record_rebound_slot_children(&children);
         }
         if let Some(start) = telemetry_start {
             log::warn!(
                 "[subcompose-telemetry] slot={} reused={} children={} subcompose_ms={:.2}",
                 slot_id.raw(),
-                is_reused,
+                is_rebound,
                 children.len(),
                 start.elapsed().as_secs_f64() * 1000.0
             );


### PR DESCRIPTION
Stacked on #531 (contains its commits until it merges; will rebase after).

Every glass backdrop paid its own render pass for the runtime-shader tail on the Mali-bound frame, where pass boundaries cost ~0.13ms each and writes are nearly free. This folds them:

- `prepare_cached_backdrop_layer_composite` splits `Chain(Blur, Shader)`: only the blur prefix materializes into the cached surface; the tail rides `LayerSurface.deferred_effect` into the batched shader composite the frame already runs (`direct_shader_layer_composite` → `pending_shader_composites`).
- A bare-`Shader` lens materializes **nothing** — its cached surface is the capture itself, laid down by `copy_texture_to_texture`, not a pass.
- The cache key hashes the materialized prefix only, so per-frame glass dynamics uniforms stop invalidating the blurred capture.
- `materialize_effect_direct`: a tail-less effect (the split frost prefix is a bare `Blur`) encodes straight into the retained target; the generic route bounced it through a scratch surface plus an extra 1:1 opaque composite pass. Shader-tailed chains keep the generic route, whose direct-tail path owns the shrunk-intermediate fill optimization.

Ordering: the pre-capture flush lands every pending write intersecting capture∪output, so nothing left in the blit queue can overlap the glass output, and the glass child's own body queues after the tail. The overlapping-capture contract test passes unchanged.

Measured on the Huawei Mate 20 X (cranscan library screen, device capture):

| frame class | before | after |
|---|---|---|
| heavy scroll | 13 passes, [Shader Effect]×4 | **10 passes**, [Batched Shader Effect]×1 |
| glass-idle | 5 passes | 6 passes (tail re-runs in the batch; queue unification reclaims this) |

Alternating A/B/A/B on the same device session against the pre-fold parent (`8bbb24be`), identical drive program, battery temp flat at 32.0-33.0C, layout stage as the unchanged control:

| round | total p50 | scene p50 | layout p50 |
|---|---|---|---|
| A1 (base) | 4.06 | 2.45 | 1.67 |
| B1 (fold) | **3.33** | **1.55** | 1.68 |
| A2 (base) | 3.90 | 2.43 | 1.69 |
| B2 (fold) | **3.51** | **1.98** | 1.63 |

Both fold rounds beat both base rounds on total p50: **-0.4 to -0.55 ms/frame producer p50**. Read per pass, -0.4 to -0.55 ms over three removed boundaries is 0.13-0.18 ms/pass — independently agreeing with the ~0.13 ms/pass class-delta estimate (two methods, one constant), with the caveat that producer-side encode savings ride the same delta, so 0.13-0.18 is an upper bound on the pure boundary cost.

Contract updated: each extra fixed glass now adds exactly its blur pair (+2, was +3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
