### PR TITLE
A child can grow without its parent's child list changing, and both layers assumed it cannot

### DIFF
--- a/apps/desktop-demo/examples/robot_lazy_expansion_reflow.rs
+++ b/apps/desktop-demo/examples/robot_lazy_expansion_reflow.rs
@@ -1,0 +1,183 @@
+#![allow(non_snake_case)]
+//! A lazy row that grows in place must push its siblings' pixels, not only
+//! their layout bounds.
+//!
+//! Reproduces the cranscan "..." regression: after one expansion has settled,
+//! expanding a second row updates layout (semantics move) while the scoped
+//! scene update applies in place without refreshing the shifted siblings, so
+//! the screen keeps the old geometry until a scroll forces a full pass. The
+//! first expansion after launch tends to ride a full rebuild and look correct,
+//! which is why this test expands twice: cold start, expand once, expand
+//! again — the second expansion is the pin.
+//!
+//! The assertion is pixels-versus-semantics: semantics report where layout put
+//! a row, the screenshot reports what the scene drew there. On a stale scene
+//! they disagree.
+
+use cranpose::AppLauncher;
+use cranpose_core::rememberMutableStateOf;
+use cranpose_foundation::lazy::{rememberLazyListState, LazyItems, LazyListScope};
+use cranpose_ui::{
+    composable,
+    widgets::{LazyColumn, LazyColumnSpec},
+    Box, BoxSpec, Button, ButtonSpec, Color, Column, ColumnSpec, LinearArrangement, Modifier, Row,
+    RowSpec, Size, Text, TextStyle,
+};
+
+const ROW_COLORS: [Color; 4] = [
+    Color(0.9, 0.1, 0.1, 1.0),
+    Color(0.1, 0.8, 0.1, 1.0),
+    Color(0.1, 0.2, 0.9, 1.0),
+    Color(0.9, 0.8, 0.1, 1.0),
+];
+const STRIP_COLOR: Color = Color(0.5, 0.0, 0.5, 1.0);
+const SWATCH_WIDTH: f32 = 160.0;
+const SWATCH_HEIGHT: f32 = 48.0;
+const STRIP_HEIGHT: f32 = 60.0;
+
+#[composable]
+fn ExpandableRow(index: usize) {
+    let expanded = rememberMutableStateOf(|| false);
+    Column(
+        Modifier::empty(),
+        ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(4.0)),
+        move || {
+            Row(
+                Modifier::empty(),
+                RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
+                move || {
+                    Button(
+                        Modifier::empty(),
+                        ButtonSpec::default(),
+                        move || expanded.update(|e| *e = !*e),
+                        move || {
+                            Text(
+                                format!("more{index}"),
+                                Modifier::empty(),
+                                TextStyle::default(),
+                            );
+                        },
+                    );
+                    Box(
+                        Modifier::empty()
+                            .size(Size::new(SWATCH_WIDTH, SWATCH_HEIGHT))
+                            .background(ROW_COLORS[index]),
+                        BoxSpec::default(),
+                        || {},
+                    );
+                },
+            );
+            if expanded.get() {
+                Box(
+                    Modifier::empty()
+                        .size(Size::new(300.0, STRIP_HEIGHT))
+                        .background(STRIP_COLOR),
+                    BoxSpec::default(),
+                    || {},
+                );
+            }
+        },
+    );
+}
+
+#[composable]
+fn ExpansionReflowScreen() {
+    let state = rememberLazyListState();
+    LazyColumn(
+        Modifier::empty().fill_max_size(),
+        state,
+        LazyColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
+        |scope| {
+            scope.items(LazyItems::new(ROW_COLORS.len()), ExpandableRow);
+        },
+    );
+}
+
+fn color_at(shot: &cranpose::RobotScreenshot, x: f32, y: f32) -> (u8, u8, u8) {
+    let sx = (x / shot.logical_width * shot.width as f32) as usize;
+    let sy = (y / shot.logical_height * shot.height as f32) as usize;
+    let idx = (sy * shot.width as usize + sx) * 4;
+    (shot.pixels[idx], shot.pixels[idx + 1], shot.pixels[idx + 2])
+}
+
+fn assert_swatch_drawn_at_semantic_bounds(
+    robot: &cranpose::Robot,
+    index: usize,
+    stage: &str,
+) -> Result<(), String> {
+    let (bx, by, bw, bh) = robot
+        .find_button_bounds_exact(&format!("more{index}"))?
+        .ok_or_else(|| format!("{stage}: button more{index} not found in semantics"))?;
+    let shot = robot.screenshot()?;
+    // The swatch sits in the same row, 8dp after the button; its top aligns
+    // with the row top and it is at least as tall as the button, so a point a
+    // few pixels into it is inside the swatch no matter which is taller.
+    let x = bx + bw + 8.0 + 20.0;
+    let y = by + (bh.min(SWATCH_HEIGHT)) / 2.0;
+    let (r, g, b) = color_at(&shot, x, y);
+    let want = ROW_COLORS[index];
+    let (wr, wg, wb) = (
+        (want.0 * 255.0) as i32,
+        (want.1 * 255.0) as i32,
+        (want.2 * 255.0) as i32,
+    );
+    let close = |a: u8, w: i32| (a as i32 - w).abs() <= 40;
+    if close(r, wr) && close(g, wg) && close(b, wb) {
+        Ok(())
+    } else {
+        Err(format!(
+            "{stage}: row {index}'s swatch is not drawn where semantics place it: \
+             semantics put the row at y={by:.0} but the pixel at ({x:.0},{y:.0}) is \
+             rgb({r},{g},{b}), expected ~rgb({wr},{wg},{wb}) — the scene kept stale \
+             geometry after a sibling grew"
+        ))
+    }
+}
+
+fn main() {
+    AppLauncher::new()
+        .with_title("lazy expansion reflow")
+        .with_size(520, 700)
+        .with_fonts(desktop_app::fonts::DEMO_FONTS)
+        .with_headless(std::env::var("CRANPOSE_HEADLESS").as_deref() == Ok("1"))
+        .with_test_driver(move |robot| {
+            robot.pump_frames(6).expect("compose the list");
+            robot.wait_for_idle().expect("settle after launch");
+            for index in 0..ROW_COLORS.len() {
+                assert_swatch_drawn_at_semantic_bounds(&robot, index, "at rest")
+                    .expect("resting frame agrees with semantics");
+            }
+
+            // First expansion: often correct even on broken builds, because
+            // launch-time dirt forces the scoped scene update to give up and
+            // fully rebuild. It is part of the recipe, not the pin.
+            robot.click_by_text("more0").expect("expand row 0");
+            robot.pump_frames(6).expect("compose the first strip");
+            robot.wait_for_idle().expect("settle the first expansion");
+            for index in 0..ROW_COLORS.len() {
+                assert_swatch_drawn_at_semantic_bounds(&robot, index, "after first expansion")
+                    .expect("first expansion reflows");
+            }
+
+            // Second expansion: the pin. Layout shifts rows 2 and 3 down by the
+            // strip height; the scene must follow.
+            robot.click_by_text("more1").expect("expand row 1");
+            robot.pump_frames(6).expect("compose the second strip");
+            robot.wait_for_idle().expect("settle the second expansion");
+            let mut failures = Vec::new();
+            for index in 0..ROW_COLORS.len() {
+                if let Err(e) =
+                    assert_swatch_drawn_at_semantic_bounds(&robot, index, "after second expansion")
+                {
+                    failures.push(e);
+                }
+            }
+            robot.exit().ok();
+            assert!(
+                failures.is_empty(),
+                "second expansion left the scene stale:\n{}",
+                failures.join("\n")
+            );
+        })
+        .run(ExpansionReflowScreen);
+}

--- a/crates/cranpose-app-shell/src/shell_frame.rs
+++ b/crates/cranpose-app-shell/src/shell_frame.rs
@@ -307,9 +307,13 @@ where
                         self.scoped_layout_scene_nodes.clear();
                         let _ = cranpose_ui::take_geometry_scene_nodes();
                     } else {
+                        // HashSet dedup: a big pass can move thousands of
+                        // nodes, and Vec::contains per id is quadratic.
+                        let mut seen: HashSet<NodeId> =
+                            self.scoped_layout_scene_nodes.iter().copied().collect();
                         if has_scoped_repasses {
                             for node in scoped_layout_nodes {
-                                if !self.scoped_layout_scene_nodes.contains(&node) {
+                                if seen.insert(node) {
                                     self.scoped_layout_scene_nodes.push(node);
                                 }
                             }
@@ -319,9 +323,15 @@ where
                         // down by another row's growth starts nothing, and a
                         // scoped scene update that never hears about it keeps
                         // drawing it at the old geometry until the next full
-                        // pass.
+                        // pass. Each id is resolved the way structural records
+                        // are — nearest non-virtual ancestor, still attached —
+                        // because an id the graph cannot resolve forces the
+                        // scoped update to give up and rebuild the whole scene.
                         for node in cranpose_ui::take_geometry_scene_nodes() {
-                            if !self.scoped_layout_scene_nodes.contains(&node) {
+                            let Some(node) = applier.scene_node_attached_to(node, root) else {
+                                continue;
+                            };
+                            if seen.insert(node) {
                                 self.scoped_layout_scene_nodes.push(node);
                             }
                         }

--- a/crates/cranpose-app-shell/src/shell_frame.rs
+++ b/crates/cranpose-app-shell/src/shell_frame.rs
@@ -305,8 +305,22 @@ where
                     // app-wide relayout, where scoping means nothing, clears.
                     if global_layout_invalidation || force_layout_pass {
                         self.scoped_layout_scene_nodes.clear();
-                    } else if has_scoped_repasses {
-                        for node in scoped_layout_nodes {
+                        let _ = cranpose_ui::take_geometry_scene_nodes();
+                    } else {
+                        if has_scoped_repasses {
+                            for node in scoped_layout_nodes {
+                                if !self.scoped_layout_scene_nodes.contains(&node) {
+                                    self.scoped_layout_scene_nodes.push(node);
+                                }
+                            }
+                        }
+                        // Nodes the pass actually moved or resized. Repass ids
+                        // only say where invalidation STARTED; a sibling pushed
+                        // down by another row's growth starts nothing, and a
+                        // scoped scene update that never hears about it keeps
+                        // drawing it at the old geometry until the next full
+                        // pass.
+                        for node in cranpose_ui::take_geometry_scene_nodes() {
                             if !self.scoped_layout_scene_nodes.contains(&node) {
                                 self.scoped_layout_scene_nodes.push(node);
                             }
@@ -321,6 +335,7 @@ where
                     self.semantics_snapshot_revision =
                         self.semantics_snapshot_revision.wrapping_add(1);
                     self.scoped_layout_scene_nodes.clear();
+                    let _ = cranpose_ui::take_geometry_scene_nodes();
                     self.scene_dirty = true;
                 }
             }
@@ -330,6 +345,7 @@ where
             self.semantics_tree = None;
             self.semantics_snapshot_revision = self.semantics_snapshot_revision.wrapping_add(1);
             self.scoped_layout_scene_nodes.clear();
+            let _ = cranpose_ui::take_geometry_scene_nodes();
             self.scene_dirty = true;
             self.layout_requested = false;
             self.force_layout_pass = false;

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -1643,6 +1643,10 @@ impl Renderer for ScopedUpdateCountingRenderer {
             )
         });
         if !updated {
+            // A failed scoped update falls back to a whole-scene rebuild, and
+            // that IS a rebuild: tests asserting `rebuilds == 0` mean "the
+            // scoped path carried it", so the fallback must not hide here.
+            self.rebuilds.set(self.rebuilds.get() + 1);
             self.scene.clear();
             if let Some(graph) =
                 cranpose_render_common::scene_builder::build_graph_from_applier(applier, root, 1.0)
@@ -1671,6 +1675,10 @@ impl Renderer for ScopedUpdateCountingRenderer {
             )
         });
         if !updated {
+            // A failed scoped update falls back to a whole-scene rebuild, and
+            // that IS a rebuild: tests asserting `rebuilds == 0` mean "the
+            // scoped path carried it", so the fallback must not hide here.
+            self.rebuilds.set(self.rebuilds.get() + 1);
             self.scene.clear();
             if let Some(graph) =
                 cranpose_render_common::scene_builder::build_graph_from_applier(applier, root, 1.0)
@@ -4972,6 +4980,258 @@ fn AppShellGrowingFirstRow() {
                 });
             });
         },
+    );
+}
+
+thread_local! {
+    static APP_SHELL_GROWER_STATE: RefCell<Option<MutableState<bool>>> =
+        const { RefCell::new(None) };
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn AppShellGrowerBox() {
+    let grown = rememberMutableStateOf(|| false);
+    APP_SHELL_GROWER_STATE.with(|slot| *slot.borrow_mut() = Some(grown));
+    let height = if grown.get() { 64.0 } else { 24.0 };
+    Text(
+        "grower".to_string(),
+        Modifier::empty().height(height),
+        TextStyle::default(),
+    );
+}
+
+const ORDINARY_SIBLING_COLOR: cranpose_ui::Color = cranpose_ui::Color(0.9, 0.05, 0.55, 1.0);
+
+#[composable]
+#[allow(non_snake_case)]
+fn AppShellOrdinaryColumnSiblings() {
+    // A plain Column, NOT a lazy list: ordinary children are placed through
+    // the layout engine's direct `LayoutState` handle, not through the node
+    // setters. The growth state is read inside the grower's own scope, so the
+    // siblings recompose nothing when it flips. The moved sibling is a solid
+    // Box, NOT a Text: re-measuring a text re-shapes it and schedules a draw
+    // repass, which sneaks the row into the scene scope and hides a missing
+    // geometry record — a plain box has no such rescue.
+    Column(
+        Modifier::empty().fill_max_size(),
+        ColumnSpec::default(),
+        move || {
+            AppShellGrowerBox();
+            cranpose_ui::Box(
+                Modifier::empty()
+                    .size(cranpose_ui::Size::new(120.0, 24.0))
+                    .background(ORDINARY_SIBLING_COLOR),
+                cranpose_ui::BoxSpec::default(),
+                || {},
+            );
+        },
+    );
+}
+
+fn graph_scene_solid_rect_y(
+    scene: &cranpose_render_common::graph_scene::Scene,
+    color: cranpose_ui::Color,
+) -> Option<f32> {
+    fn brush_matches(brush: &cranpose_ui_graphics::Brush, color: cranpose_ui::Color) -> bool {
+        matches!(brush, cranpose_ui_graphics::Brush::Solid(c) if (c.0 - color.0).abs() < 0.01
+            && (c.1 - color.1).abs() < 0.01
+            && (c.2 - color.2).abs() < 0.01)
+    }
+
+    fn walk(
+        layer: &cranpose_render_common::graph::LayerNode,
+        offset_y: f32,
+        color: cranpose_ui::Color,
+    ) -> Option<f32> {
+        let base = offset_y
+            + layer
+                .transform_to_parent
+                .map_point(cranpose_ui_graphics::Point { x: 0.0, y: 0.0 })
+                .y
+            + layer.content_offset.y;
+        for child in &layer.children {
+            match child {
+                cranpose_render_common::graph::RenderNode::Layer(child_layer) => {
+                    if let Some(y) = walk(child_layer, base, color) {
+                        return Some(y);
+                    }
+                }
+                cranpose_render_common::graph::RenderNode::Primitive(entry) => {
+                    if let cranpose_render_common::graph::PrimitiveNode::Draw(draw) = &entry.node {
+                        match &draw.primitive {
+                            cranpose_ui_graphics::DrawPrimitive::Rect { rect, brush, .. }
+                            | cranpose_ui_graphics::DrawPrimitive::RoundRect {
+                                rect, brush, ..
+                            } if brush_matches(brush, color) => {
+                                return Some(base + rect.y);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                cranpose_render_common::graph::RenderNode::DrawRun(run) => {
+                    for primitive in run.primitives.iter() {
+                        match primitive {
+                            cranpose_ui_graphics::DrawPrimitive::Rect { rect, brush, .. }
+                            | cranpose_ui_graphics::DrawPrimitive::RoundRect {
+                                rect, brush, ..
+                            } if brush_matches(brush, color) => {
+                                return Some(base + rect.y);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    let graph = scene.graph.as_ref()?;
+    walk(&graph.root, 0.0, color)
+}
+
+/// Finding 1 of the #538 review: ordinary (non-lazy) children are placed by
+/// writing the shared `LayoutState` directly, bypassing the instrumented node
+/// setters — so a sibling moved by an ordinary row's growth recorded nothing
+/// and kept stale scene geometry exactly like the lazy case this branch
+/// already fixes.
+#[test]
+fn sibling_in_an_ordinary_column_moves_in_the_scene_when_a_row_grows() {
+    let _guard = test_guard();
+    APP_SHELL_GROWER_STATE.with(|slot| slot.borrow_mut().take());
+    let root_key = location_key(file!(), line!(), column!());
+    let rebuilds = Rc::new(Cell::new(0));
+    let updates = Rc::new(Cell::new(0));
+    let last_dirty_nodes = Rc::new(RefCell::new(Vec::new()));
+
+    let mut shell = AppShell::new(
+        ScopedUpdateCountingRenderer::new(
+            Rc::clone(&rebuilds),
+            Rc::clone(&updates),
+            Rc::clone(&last_dirty_nodes),
+        ),
+        root_key,
+        AppShellOrdinaryColumnSiblings,
+    );
+    shell.set_buffer_size(320, 240);
+    shell.set_viewport(320.0, 240.0);
+    shell.update();
+
+    let grown = APP_SHELL_GROWER_STATE
+        .with(|slot| *slot.borrow())
+        .expect("grower probe should expose its state");
+    let resting_sibling_y =
+        graph_scene_solid_rect_y(shell.renderer.scene(), ORDINARY_SIBLING_COLOR)
+            .expect("resting scene should contain the sibling box");
+
+    rebuilds.set(0);
+    updates.set(0);
+
+    grown.set_value(true);
+    shell.update();
+
+    let moved_sibling_y = graph_scene_solid_rect_y(shell.renderer.scene(), ORDINARY_SIBLING_COLOR)
+        .expect("grown scene should still contain the sibling box");
+    assert!(
+        moved_sibling_y >= resting_sibling_y + 39.0,
+        "an ordinary column's sibling must move in the SCENE when the row \
+         above grows 24->64: resting y={resting_sibling_y}, after growth \
+         y={moved_sibling_y}"
+    );
+    assert_eq!(
+        rebuilds.get(),
+        0,
+        "the moved sibling must reach the SCOPED update; a whole-scene rebuild \
+         hides the missing geometry channel and pays O(app) for one grown row"
+    );
+    assert!(
+        updates.get() >= 1,
+        "the growth frame must run at least one scoped update"
+    );
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn AppShellGrowerAboveNestedLazy() {
+    Column(
+        Modifier::empty().fill_max_size(),
+        ColumnSpec::default(),
+        move || {
+            AppShellGrowerBox();
+            let nested_state = rememberLazyListState();
+            LazyColumn(
+                Modifier::empty().fill_max_width().height(120.0),
+                nested_state,
+                LazyColumnSpec::default(),
+                |scope| {
+                    scope.items(3, move |index| {
+                        Text(
+                            format!("nested {index}"),
+                            Modifier::empty().height(24.0),
+                            TextStyle::default(),
+                        );
+                    });
+                },
+            );
+        },
+    );
+}
+
+/// The mutation this pins: strip the recording from ONLY the
+/// SubcomposeLayoutNode setters and every other test in this diff stays
+/// green, because they move ordinary rows inside a stationary lazy list.
+/// Here the moving node IS a SubcomposeLayoutNode — a nested LazyColumn
+/// pushed down by an ordinary sibling's growth — so its content drifts if
+/// that half of the recorder disappears.
+#[test]
+fn a_nested_lazy_list_moves_in_the_scene_when_the_row_above_grows() {
+    let _guard = test_guard();
+    APP_SHELL_GROWER_STATE.with(|slot| slot.borrow_mut().take());
+    APP_SHELL_LAZY_LIST_STATE.with(|slot| slot.borrow_mut().take());
+    let root_key = location_key(file!(), line!(), column!());
+    let rebuilds = Rc::new(Cell::new(0));
+    let updates = Rc::new(Cell::new(0));
+    let last_dirty_nodes = Rc::new(RefCell::new(Vec::new()));
+
+    let mut shell = AppShell::new(
+        ScopedUpdateCountingRenderer::new(
+            Rc::clone(&rebuilds),
+            Rc::clone(&updates),
+            Rc::clone(&last_dirty_nodes),
+        ),
+        root_key,
+        AppShellGrowerAboveNestedLazy,
+    );
+    shell.set_buffer_size(320, 240);
+    shell.set_viewport(320.0, 240.0);
+    shell.update();
+
+    let grown = APP_SHELL_GROWER_STATE
+        .with(|slot| *slot.borrow())
+        .expect("grower probe should expose its state");
+    let resting_nested_y = graph_scene_text_y(shell.renderer.scene(), "nested 0")
+        .expect("resting scene should contain the nested list's first row");
+
+    rebuilds.set(0);
+    updates.set(0);
+
+    grown.set_value(true);
+    shell.update();
+
+    let moved_nested_y = graph_scene_text_y(shell.renderer.scene(), "nested 0")
+        .expect("grown scene should still contain the nested list's first row");
+    assert!(
+        moved_nested_y >= resting_nested_y + 39.0,
+        "a nested lazy list must move in the SCENE when the row above grows \
+         24->64: resting y={resting_nested_y}, after growth y={moved_nested_y}"
+    );
+    assert_eq!(
+        rebuilds.get(),
+        0,
+        "the moved nested list must reach the SCOPED update, not ride a \
+         whole-scene rebuild"
     );
 }
 

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -4917,6 +4917,171 @@ fn rendered_text_values(scene: &cranpose_ui::RecordedRenderScene) -> Vec<String>
         .collect()
 }
 
+thread_local! {
+    static APP_SHELL_EXPANSION_STATE: RefCell<Option<MutableState<bool>>> =
+        const { RefCell::new(None) };
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn AppShellGrowingFirstRow() {
+    let expanded = rememberMutableStateOf(|| false);
+    APP_SHELL_EXPANSION_STATE.with(|slot| *slot.borrow_mut() = Some(expanded));
+    let list_state = rememberLazyListState();
+    // A lazy list, not a plain Column: each item composes in its own scope, so
+    // growing item 0 recomposes NOTHING in its siblings — exactly the
+    // isolation that makes the moved sibling invisible to compose-derived
+    // dirt. A plain Column would recompose the whole body and hide the hole.
+    LazyColumn(
+        Modifier::empty().fill_max_size(),
+        list_state,
+        LazyColumnSpec::default(),
+        |scope| {
+            // Each item wraps its content in its own Column, like a real list
+            // row: the strip's attach then lands on item 0's wrapper, not on
+            // the lazy container, so no structural dirt reaches the node whose
+            // re-lowering would refresh the siblings.
+            scope.items(3, move |index| {
+                Column(Modifier::empty(), ColumnSpec::default(), move || {
+                    if index == 0 {
+                        Text(
+                            "grower".to_string(),
+                            Modifier::empty().height(24.0),
+                            TextStyle::default(),
+                        );
+                        if expanded.get() {
+                            Text(
+                                "strip".to_string(),
+                                Modifier::empty().height(40.0),
+                                TextStyle::default(),
+                            );
+                        }
+                    } else if index == 1 {
+                        Text(
+                            "sibling".to_string(),
+                            Modifier::empty().height(24.0),
+                            TextStyle::default(),
+                        );
+                    } else {
+                        Text(
+                            "tail".to_string(),
+                            Modifier::empty().height(24.0),
+                            TextStyle::default(),
+                        );
+                    }
+                });
+            });
+        },
+    );
+}
+
+fn graph_scene_text_y(
+    scene: &cranpose_render_common::graph_scene::Scene,
+    needle: &str,
+) -> Option<f32> {
+    fn walk(
+        layer: &cranpose_render_common::graph::LayerNode,
+        offset_y: f32,
+        needle: &str,
+    ) -> Option<f32> {
+        // A layer's position lives in its transform (pure translation in this
+        // scene); local_bounds always starts at the origin.
+        let base = offset_y
+            + layer
+                .transform_to_parent
+                .map_point(cranpose_ui_graphics::Point { x: 0.0, y: 0.0 })
+                .y
+            + layer.content_offset.y;
+        for child in &layer.children {
+            match child {
+                cranpose_render_common::graph::RenderNode::Layer(child_layer) => {
+                    if let Some(y) = walk(child_layer, base, needle) {
+                        return Some(y);
+                    }
+                }
+                cranpose_render_common::graph::RenderNode::Primitive(entry) => {
+                    if let cranpose_render_common::graph::PrimitiveNode::Text(text) = &entry.node
+                        && text.text.text == needle
+                    {
+                        return Some(base + text.rect.y);
+                    }
+                }
+                cranpose_render_common::graph::RenderNode::DrawRun(_) => {}
+            }
+        }
+        None
+    }
+
+    let graph = scene.graph.as_ref()?;
+    walk(&graph.root, 0.0, needle)
+}
+
+/// One wrong assumption implemented twice: "the child list did not change,
+/// therefore there is nothing to invalidate". A child can grow without any
+/// membership changing, and a sibling pushed down by that growth recomposes
+/// nothing and raises no repass of its own — the only party that knows it
+/// moved is the layout pass that moved it. This is the scene-side enforcement
+/// point of that invariant (the core-side one is
+/// `reattaching_a_dirty_child_still_bubbles_to_ancestors`): the moved
+/// sibling's geometry must reach the scoped scene update, without the rescue
+/// of a full rebuild.
+#[test]
+fn sibling_moved_by_another_rows_growth_reaches_the_scoped_scene_update() {
+    let _guard = test_guard();
+    APP_SHELL_EXPANSION_STATE.with(|slot| slot.borrow_mut().take());
+    let root_key = location_key(file!(), line!(), column!());
+    let rebuilds = Rc::new(Cell::new(0));
+    let updates = Rc::new(Cell::new(0));
+    let last_dirty_nodes = Rc::new(RefCell::new(Vec::new()));
+
+    let mut shell = AppShell::new(
+        ScopedUpdateCountingRenderer::new(
+            Rc::clone(&rebuilds),
+            Rc::clone(&updates),
+            Rc::clone(&last_dirty_nodes),
+        ),
+        root_key,
+        AppShellGrowingFirstRow,
+    );
+    shell.set_buffer_size(320, 240);
+    shell.set_viewport(320.0, 240.0);
+    shell.update();
+
+    let expanded = APP_SHELL_EXPANSION_STATE
+        .with(|slot| *slot.borrow())
+        .expect("expansion probe should expose its state");
+    let resting_sibling_y = graph_scene_text_y(shell.renderer.scene(), "sibling")
+        .expect("resting scene should contain the sibling row");
+
+    rebuilds.set(0);
+    updates.set(0);
+
+    expanded.set_value(true);
+    shell.update();
+
+    let strip_y = graph_scene_text_y(shell.renderer.scene(), "strip")
+        .expect("expanded scene should contain the strip");
+    let moved_sibling_y = graph_scene_text_y(shell.renderer.scene(), "sibling")
+        .expect("expanded scene should still contain the sibling row");
+    assert!(
+        moved_sibling_y > resting_sibling_y + 1.0,
+        "the sibling below a grown row must move down in the SCENE, not only in \
+         layout: resting y={resting_sibling_y}, after growth y={moved_sibling_y}, \
+         strip y={strip_y}"
+    );
+    assert!(
+        strip_y < moved_sibling_y,
+        "the strip must sit above the pushed sibling: strip y={strip_y}, \
+         sibling y={moved_sibling_y}"
+    );
+    assert_eq!(
+        rebuilds.get(),
+        0,
+        "the moved sibling must reach the SCOPED update; a full rebuild hides \
+         the missing geometry channel and pays O(whole app) for one grown row"
+    );
+}
+
 fn graph_scene_text_values(scene: &cranpose_render_common::graph_scene::Scene) -> Vec<String> {
     fn collect(layer: &cranpose_render_common::graph::LayerNode, out: &mut Vec<String>) {
         for child in &layer.children {

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -1897,10 +1897,22 @@ impl Command {
             } => {
                 // Bubbling marks every ancestor up to the root as needing
                 // measure, and re-measuring a tree that did not change is the
-                // most expensive way to do nothing. Only an insert that
-                // actually changed the child list has anything to invalidate.
+                // most expensive way to do nothing. An insert that changed the
+                // child list has something to invalidate — and so does a
+                // re-attach of a child that carries pending measure or layout
+                // dirt: an unchanged list says nothing about unchanged
+                // geometry, and the attach-time bubble is the only road that
+                // child's dirt has to the root. Swallowing it strands a grown
+                // subtree at its old geometry until an unrelated pass runs.
                 if insert_child_with_reparenting(applier, parent_id, child_id) {
                     bubble.apply(applier, parent_id);
+                } else if let Ok(child) = applier.get_mut(child_id) {
+                    let dirty_bubble = DirtyBubble {
+                        layout: child.needs_layout(),
+                        measure: child.needs_measure(),
+                        semantics: child.needs_semantics(),
+                    };
+                    dirty_bubble.apply(applier, parent_id);
                 }
                 Ok(())
             }

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -1907,10 +1907,16 @@ impl Command {
                 if insert_child_with_reparenting(applier, parent_id, child_id) {
                     bubble.apply(applier, parent_id);
                 } else if let Ok(child) = applier.get_mut(child_id) {
+                    // Semantics stays out of this bubble: attach never bubbled
+                    // it (LAYOUT_AND_MEASURE carries semantics: false), and
+                    // production nodes START semantics-dirty until a semantics
+                    // tree is built — with semantics off, "is the child
+                    // semantics-dirty" is always yes, which would turn every
+                    // clean re-attach on a steady scroll into an ancestor walk.
                     let dirty_bubble = DirtyBubble {
                         layout: child.needs_layout(),
                         measure: child.needs_measure(),
-                        semantics: child.needs_semantics(),
+                        semantics: false,
                     };
                     dirty_bubble.apply(applier, parent_id);
                 }
@@ -3001,6 +3007,16 @@ impl MemoryApplier {
     /// is reported as its nearest non-virtual ancestor: that is the node
     /// whose graph child set the change altered, and an id the graph cannot
     /// resolve would force the scoped scene update to give up and rebuild.
+    /// Resolves a scene-scope candidate the way structural records are
+    /// resolved: to its nearest non-virtual ancestor, and only while still
+    /// attached to `root`. A node detached after recording must not reach the
+    /// scoped scene update — an id the graph cannot resolve forces it to give
+    /// up and rebuild the whole scene.
+    pub fn scene_node_attached_to(&mut self, node_id: NodeId, root: NodeId) -> Option<NodeId> {
+        let resolved = self.first_non_virtual_ancestor(node_id)?;
+        self.is_attached_to(resolved, root).then_some(resolved)
+    }
+
     pub fn take_structural_change_parents_attached_to(&mut self, root: NodeId) -> Vec<NodeId> {
         let recorded = std::mem::take(&mut self.structural_change_parents);
         let mut attached = Vec::with_capacity(recorded.len());

--- a/crates/cranpose-core/src/tests/composer_applier_tests.rs
+++ b/crates/cranpose-core/src/tests/composer_applier_tests.rs
@@ -2078,12 +2078,31 @@ fn reparenting_records_a_structural_change_on_both_parents() {
     );
 }
 
-#[derive(Default)]
 struct DirtyFlagNode {
     children: Vec<NodeId>,
     parent: Option<NodeId>,
     needs_measure: Cell<bool>,
     needs_layout: Cell<bool>,
+    // True by default, like production nodes: a real LayoutNode starts
+    // semantics-dirty and stays so until a semantics tree is built, which
+    // never happens while semantics are off. Any re-attach logic that treats
+    // "child is semantics-dirty" as a reason to walk ancestors therefore
+    // walks on EVERY no-op re-attach of a steady scroll.
+    needs_semantics: Cell<bool>,
+    semantics_marks: Cell<usize>,
+}
+
+impl Default for DirtyFlagNode {
+    fn default() -> Self {
+        Self {
+            children: Vec::new(),
+            parent: None,
+            needs_measure: Cell::new(false),
+            needs_layout: Cell::new(false),
+            needs_semantics: Cell::new(true),
+            semantics_marks: Cell::new(0),
+        }
+    }
 }
 
 impl Node for DirtyFlagNode {
@@ -2131,6 +2150,15 @@ impl Node for DirtyFlagNode {
 
     fn needs_layout(&self) -> bool {
         self.needs_layout.get()
+    }
+
+    fn mark_needs_semantics(&self) {
+        self.needs_semantics.set(true);
+        self.semantics_marks.set(self.semantics_marks.get() + 1);
+    }
+
+    fn needs_semantics(&self) -> bool {
+        self.needs_semantics.get()
     }
 }
 
@@ -2214,15 +2242,26 @@ fn reattaching_a_clean_child_bubbles_nothing() {
         ("grandparent", grandparent),
         ("child", child),
     ] {
-        let (measure, layout) = applier
+        let (measure, layout, semantics_marks) = applier
             .with_node::<DirtyFlagNode, _>(id, |node| {
-                (node.needs_measure.get(), node.needs_layout.get())
+                (
+                    node.needs_measure.get(),
+                    node.needs_layout.get(),
+                    node.semantics_marks.get(),
+                )
             })
             .expect("tree node exists");
         assert!(
             !measure && !layout,
             "{label} must stay clean when an already-present, clean child \
              re-attaches: bubbling a no-op re-measures the tree every frame"
+        );
+        assert_eq!(
+            semantics_marks, 0,
+            "{label} must take no semantics walk either: production nodes are \
+             semantics-dirty by default while semantics are off, so keying a \
+             re-attach bubble on that flag walks ancestors on every no-op \
+             re-attach of a steady scroll"
         );
     }
 }

--- a/crates/cranpose-core/src/tests/composer_applier_tests.rs
+++ b/crates/cranpose-core/src/tests/composer_applier_tests.rs
@@ -2077,3 +2077,152 @@ fn reparenting_records_a_structural_change_on_both_parents() {
         "the new parent gained a child"
     );
 }
+
+#[derive(Default)]
+struct DirtyFlagNode {
+    children: Vec<NodeId>,
+    parent: Option<NodeId>,
+    needs_measure: Cell<bool>,
+    needs_layout: Cell<bool>,
+}
+
+impl Node for DirtyFlagNode {
+    fn insert_child(&mut self, child: NodeId) -> bool {
+        if self.children.contains(&child) {
+            return false;
+        }
+        self.children.push(child);
+        true
+    }
+
+    fn remove_child(&mut self, child: NodeId) -> bool {
+        let before = self.children.len();
+        self.children.retain(|&id| id != child);
+        self.children.len() < before
+    }
+
+    fn children(&self) -> Vec<NodeId> {
+        self.children.clone()
+    }
+
+    fn on_attached_to_parent(&mut self, parent: NodeId) {
+        self.parent = Some(parent);
+    }
+
+    fn on_removed_from_parent(&mut self) {
+        self.parent = None;
+    }
+
+    fn parent(&self) -> Option<NodeId> {
+        self.parent
+    }
+
+    fn mark_needs_measure(&self) {
+        self.needs_measure.set(true);
+    }
+
+    fn needs_measure(&self) -> bool {
+        self.needs_measure.get()
+    }
+
+    fn mark_needs_layout(&self) {
+        self.needs_layout.set(true);
+    }
+
+    fn needs_layout(&self) -> bool {
+        self.needs_layout.get()
+    }
+}
+
+fn dirty_flag_tree(applier: &mut MemoryApplier) -> (NodeId, NodeId, NodeId) {
+    let grandparent = applier.create(Box::new(DirtyFlagNode::default()));
+    let parent = applier.create(Box::new(DirtyFlagNode::default()));
+    let child = applier.create(Box::new(DirtyFlagNode::default()));
+    insert_child_with_reparenting(applier, grandparent, parent);
+    insert_child_with_reparenting(applier, parent, child);
+    for id in [grandparent, parent, child] {
+        applier
+            .with_node::<DirtyFlagNode, _>(id, |node| {
+                node.needs_measure.set(false);
+                node.needs_layout.set(false);
+            })
+            .expect("tree node exists");
+    }
+    (grandparent, parent, child)
+}
+
+/// One wrong assumption implemented twice: "the child list did not change,
+/// therefore there is nothing to invalidate". A child can grow without
+/// membership changing. This is the core-side enforcement point of that
+/// invariant (the scene-side one is the app shell's
+/// `sibling_moved_by_another_rows_growth_reaches_the_scoped_scene_update`):
+/// re-attaching a child that carries pending measure or layout dirt must
+/// still bubble, because the attach-time bubble is the only road that dirt
+/// has to the root's layout gate — swallow it and the grown subtree keeps its
+/// old geometry until an unrelated pass runs.
+#[test]
+fn reattaching_a_dirty_child_still_bubbles_to_ancestors() {
+    let mut applier = test_applier();
+    let (grandparent, parent, child) = dirty_flag_tree(&mut applier);
+
+    applier
+        .with_node::<DirtyFlagNode, _>(child, |node| node.needs_measure.set(true))
+        .expect("child exists");
+
+    let mut commands = CommandQueue::default();
+    commands.push(Command::AttachChild {
+        parent_id: parent,
+        child_id: child,
+        bubble: DirtyBubble::LAYOUT_AND_MEASURE,
+    });
+    commands
+        .apply(&mut applier)
+        .expect("re-attach of an existing child succeeds");
+
+    for (label, id) in [("parent", parent), ("grandparent", grandparent)] {
+        let marked = applier
+            .with_node::<DirtyFlagNode, _>(id, |node| node.needs_measure.get())
+            .expect("ancestor exists");
+        assert!(
+            marked,
+            "{label} must be marked needs_measure when a dirty child re-attaches: \
+             the unchanged child list says nothing about unchanged geometry"
+        );
+    }
+}
+
+/// The guard the test above must not undo: a re-attach of a CLEAN child is
+/// the steady-state scroll pattern, and bubbling it re-measures the whole
+/// tree every frame for nothing (#534's win).
+#[test]
+fn reattaching_a_clean_child_bubbles_nothing() {
+    let mut applier = test_applier();
+    let (grandparent, parent, child) = dirty_flag_tree(&mut applier);
+
+    let mut commands = CommandQueue::default();
+    commands.push(Command::AttachChild {
+        parent_id: parent,
+        child_id: child,
+        bubble: DirtyBubble::LAYOUT_AND_MEASURE,
+    });
+    commands
+        .apply(&mut applier)
+        .expect("re-attach of an existing child succeeds");
+
+    for (label, id) in [
+        ("parent", parent),
+        ("grandparent", grandparent),
+        ("child", child),
+    ] {
+        let (measure, layout) = applier
+            .with_node::<DirtyFlagNode, _>(id, |node| {
+                (node.needs_measure.get(), node.needs_layout.get())
+            })
+            .expect("tree node exists");
+        assert!(
+            !measure && !layout,
+            "{label} must stay clean when an already-present, clean child \
+             re-attaches: bubbling a no-op re-measures the tree every frame"
+        );
+    }
+}

--- a/crates/cranpose-render/common/src/scene_builder.rs
+++ b/crates/cranpose-render/common/src/scene_builder.rs
@@ -502,9 +502,9 @@ fn try_translate_scrolled_layer(
         resolved_modifiers: _,
         children: fresh_children,
     } = data;
-    if !layout_state.is_placed
-        || layout_state.size.width != container.local_bounds.width
-        || layout_state.size.height != container.local_bounds.height
+    if !layout_state.is_placed()
+        || layout_state.size().width != container.local_bounds.width
+        || layout_state.size().height != container.local_bounds.height
     {
         return translate_bail("container unplaced or resized");
     }
@@ -560,7 +560,7 @@ fn try_translate_scrolled_layer(
         let Ok(state) = state else {
             continue;
         };
-        if !state.is_placed {
+        if !state.is_placed() {
             continue;
         }
         placed_fresh.push((*child_id, state));
@@ -580,8 +580,8 @@ fn try_translate_scrolled_layer(
         if layer.has_origin_sinks {
             return translate_bail("child subtree publishes window origins");
         }
-        if state.size.width != layer.local_bounds.width
-            || state.size.height != layer.local_bounds.height
+        if state.size().width != layer.local_bounds.width
+            || state.size().height != layer.local_bounds.height
         {
             return translate_bail("child resized");
         }
@@ -595,8 +595,8 @@ fn try_translate_scrolled_layer(
         .map(|layer| (layer.translation_x, layer.translation_y))
         .unwrap_or((0.0, 0.0));
     let top_left = Point {
-        x: parent_abs.content_origin.x + layout_state.position.x,
-        y: parent_abs.content_origin.y + layout_state.position.y,
+        x: parent_abs.content_origin.x + layout_state.position().x,
+        y: parent_abs.content_origin.y + layout_state.position().y,
     };
     let layer_translation = Point {
         x: parent_abs.layer_translation.x + translation_x,
@@ -662,7 +662,7 @@ fn try_translate_scrolled_layer(
     // computes for each field.
     let mut transform = layer_transform_to_parent(
         container.local_bounds,
-        layout_state.position,
+        layout_state.position(),
         &graphics_layer,
     );
     if parent_content_offset != Point::default() {
@@ -689,8 +689,8 @@ fn try_translate_scrolled_layer(
         sink.set(Rect {
             x: window_origin.x,
             y: window_origin.y,
-            width: layout_state.size.width,
-            height: layout_state.size.height,
+            width: layout_state.size().width,
+            height: layout_state.size().height,
         });
     }
     container.scene_children_origin = child_origin;
@@ -721,7 +721,7 @@ fn try_translate_scrolled_layer(
             if !dirty_nodes.contains(child_id) {
                 let mut child_transform = layer_transform_to_parent(
                     layer.local_bounds,
-                    state.position,
+                    state.position(),
                     &layer.graphics_layer,
                 );
                 if content_offset != Point::default() {
@@ -732,8 +732,8 @@ fn try_translate_scrolled_layer(
                 }
                 layer.transform_to_parent = child_transform;
                 let new_children_origin = Point {
-                    x: child_origin.x + state.position.x + layer.content_offset.x,
-                    y: child_origin.y + state.position.y + layer.content_offset.y,
+                    x: child_origin.x + state.position().x + layer.content_offset.x,
+                    y: child_origin.y + state.position().y + layer.content_offset.y,
                 };
                 let origin_delta = Point {
                     x: new_children_origin.x - layer.scene_children_origin.x,
@@ -1093,23 +1093,23 @@ fn build_layer_node_from_data(
         resolved_modifiers,
         children,
     } = data;
-    if !layout_state.is_placed {
+    if !layout_state.is_placed() {
         return None;
     }
 
     let local_bounds = Rect {
         x: 0.0,
         y: 0.0,
-        width: layout_state.size.width,
-        height: layout_state.size.height,
+        width: layout_state.size().width,
+        height: layout_state.size().height,
     };
     if cranpose_core::env_flag!("CRANPOSE_SCENE_UPDATE_DIAG") {
         eprintln!(
             "[scene-update-diag] build layer node={node_id:?} size=({:.2},{:.2}) pos=({:.2},{:.2})",
-            layout_state.size.width,
-            layout_state.size.height,
-            layout_state.position.x,
-            layout_state.position.y,
+            layout_state.size().width,
+            layout_state.size().height,
+            layout_state.position().x,
+            layout_state.position().y,
         );
     }
     let clip_to_bounds = modifier_slices.clip_to_bounds();
@@ -1120,7 +1120,7 @@ fn build_layer_node_from_data(
         local_bounds,
     );
     let transform_to_parent =
-        layer_transform_to_parent(local_bounds, layout_state.position, &graphics_layer);
+        layer_transform_to_parent(local_bounds, layout_state.position(), &graphics_layer);
     let isolation = isolation_reasons(&graphics_layer);
     let cache_policy = if isolation.has_any() {
         CachePolicy::Auto
@@ -1143,7 +1143,7 @@ fn build_layer_node_from_data(
     // only pass that runs in the app runtime, and it runs before the frame's
     // pointer dispatch, so handlers see the current size (and track resizes)
     // whether or not an event has arrived yet.
-    modifier_slices.publish_pointer_input_size(layout_state.size);
+    modifier_slices.publish_pointer_input_size(layout_state.size());
 
     let node_motion_context_animated =
         inherited_motion_context_animated || modifier_slices.motion_context_animated();
@@ -1174,8 +1174,8 @@ fn build_layer_node_from_data(
             .map(|layer| (layer.translation_x, layer.translation_y))
             .unwrap_or((0.0, 0.0));
         let top_left = Point {
-            x: parent.content_origin.x + layout_state.position.x,
-            y: parent.content_origin.y + layout_state.position.y,
+            x: parent.content_origin.x + layout_state.position().x,
+            y: parent.content_origin.y + layout_state.position().y,
         };
         let layer_translation = Point {
             x: parent.layer_translation.x + tx,
@@ -1195,8 +1195,8 @@ fn build_layer_node_from_data(
             sink.set(Rect {
                 x: window_origin.x,
                 y: window_origin.y,
-                width: layout_state.size.width,
-                height: layout_state.size.height,
+                width: layout_state.size().width,
+                height: layout_state.size().height,
             });
         }
     }
@@ -1219,7 +1219,7 @@ fn build_layer_node_from_data(
         node_id,
         modifier_slices.draw_commands(),
         DrawPlacement::Behind,
-        layout_state.size,
+        layout_state.size(),
         PrimitivePhase::BeforeChildren,
     );
     if let Some(text) = text_node_from_parts(TextNodeParts {
@@ -1268,7 +1268,7 @@ fn build_layer_node_from_data(
         node_id,
         modifier_slices.draw_commands(),
         DrawPlacement::Overlay,
-        layout_state.size,
+        layout_state.size(),
         PrimitivePhase::AfterChildren,
     ));
     let has_hit_targets = hit_test.is_some()
@@ -5069,7 +5069,7 @@ mod tests {
                 if let Ok(summary) = applier.with_node::<LayoutNode, _>(child_id, |node| {
                     format!(
                         "layout#{child_id} placed={} text={:?} children={:?}",
-                        node.layout_state().is_placed,
+                        node.layout_state().is_placed(),
                         node.modifier_slices_snapshot()
                             .text_content()
                             .map(str::to_string),
@@ -5081,7 +5081,7 @@ mod tests {
                     applier.with_node::<SubcomposeLayoutNode, _>(child_id, |node| {
                         format!(
                             "subcompose#{child_id} placed={} active_children={:?}",
-                            node.layout_state().is_placed,
+                            node.layout_state().is_placed(),
                             node.active_children()
                         )
                     })

--- a/crates/cranpose-ui/src/layout/mod.rs
+++ b/crates/cranpose-ui/src/layout/mod.rs
@@ -756,19 +756,19 @@ pub fn build_layout_tree_from_applier(
         let Some((state, child_ids)) = snapshot(applier, node_id)? else {
             return Ok(None);
         };
-        if !state.is_placed {
+        if !state.is_placed() {
             return Ok(None);
         }
 
         let top_left = Point {
-            x: parent_content_origin.x + state.position.x,
-            y: parent_content_origin.y + state.position.y,
+            x: parent_content_origin.x + state.position().x,
+            y: parent_content_origin.y + state.position().y,
         };
         let rect = GeometryRect {
             x: top_left.x,
             y: top_left.y,
-            width: state.size.width,
-            height: state.size.height,
+            width: state.size().width,
+            height: state.size().height,
         };
         let info = runtime_metadata_for(applier, node_id)?;
         let kind = layout_kind_from_metadata(node_id, &info);
@@ -808,15 +808,15 @@ pub fn build_layout_tree_from_applier(
             sink.set(GeometryRect {
                 x: top_left.x + layer_translation.x,
                 y: top_left.y + layer_translation.y,
-                width: state.size.width,
-                height: state.size.height,
+                width: state.size().width,
+                height: state.size().height,
             });
         }
 
         // Publish this node's resolved size to its `pointer_input` handlers so
         // `PointerInputScope::size()` reports the node's real dimensions (the
         // box the dispatched event positions are local to), not `0x0`.
-        modifier_slices.publish_pointer_input_size(state.size);
+        modifier_slices.publish_pointer_input_size(state.size());
 
         let data = LayoutNodeData::new(modifier, resolved_modifiers, modifier_slices, kind);
         let child_origin = Point {
@@ -857,7 +857,7 @@ pub fn build_semantics_tree_from_applier(
     ) -> Result<Option<SemanticsNode>, NodeError> {
         match applier.with_node::<LayoutNode, _>(node_id, |layout| {
             let state = layout.layout_state();
-            if !state.is_placed {
+            if !state.is_placed() {
                 return None;
             }
             let role = role_from_modifier_slices(&layout.modifier_slices_snapshot());
@@ -884,7 +884,7 @@ pub fn build_semantics_tree_from_applier(
 
         match applier.with_node::<SubcomposeLayoutNode, _>(node_id, |subcompose| {
             let state = subcompose.layout_state();
-            if !state.is_placed {
+            if !state.is_placed() {
                 return None;
             }
             let config = collect_semantics_from_modifier(&subcompose.modifier());
@@ -1387,7 +1387,7 @@ impl LayoutBuilderState {
 
         if let Some(layout_state) = data.layout_state {
             let mut layout_state = layout_state.borrow_mut();
-            layout_state.size = measured.size;
+            layout_state.set_size(measured.size);
             layout_state.measurement_constraints = constraints;
             drop(layout_state);
             let _ = applier.with_node::<LayoutNode, _>(node_id, |node| {
@@ -2805,9 +2805,7 @@ impl LayoutChildMeasureState {
     fn place_retained(&self, position: Point) {
         self.set_last_position(position);
         if let Some(layout_state) = self.layout_state() {
-            let mut layout_state = layout_state.borrow_mut();
-            layout_state.position = position;
-            layout_state.is_placed = true;
+            layout_state.borrow_mut().place(position);
             return;
         }
         let Some(applier) = self.applier() else {
@@ -2965,7 +2963,7 @@ impl Measurable for LayoutChildMeasurable {
 
         if let Some(layout_state) = state.layout_state() {
             let mut layout_state = layout_state.borrow_mut();
-            layout_state.size = measured_size;
+            layout_state.set_size(measured_size);
             layout_state.measurement_constraints = constraints;
         } else if let Some(applier) = state.applier() {
             let Ok(mut applier) = applier.try_borrow_typed() else {

--- a/crates/cranpose-ui/src/layout/tests/layout_tests.rs
+++ b/crates/cranpose-ui/src/layout/tests/layout_tests.rs
@@ -586,7 +586,7 @@ fn width_after_graphics_layer_constrains_measurement() -> Result<(), NodeError> 
     measure_layout(&mut applier, root_id, Size::new(800.0, 600.0))?;
 
     let size = applier
-        .with_node::<LayoutNode, _>(root_id, |node| node.layout_state().size)
+        .with_node::<LayoutNode, _>(root_id, |node| node.layout_state().size())
         .expect("root layout state");
     assert_eq!(
         size.width, 50.0,

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -187,8 +187,9 @@ pub use render_state::{
     prune_draw_observations_to_nodes, request_current_draw_redraw, request_focus_invalidation,
     request_layout_invalidation, request_pointer_invalidation, request_render_invalidation,
     schedule_draw_repass, schedule_layout_repass, schedule_measure_repass, take_draw_repass_nodes,
-    take_focus_invalidation, take_layout_invalidation, take_layout_repass_nodes,
-    take_measure_repass_nodes, take_pointer_invalidation, take_render_invalidation,
+    take_focus_invalidation, take_geometry_scene_nodes, take_layout_invalidation,
+    take_layout_repass_nodes, take_measure_repass_nodes, take_pointer_invalidation,
+    take_render_invalidation,
 };
 pub use renderer::{HeadlessRenderer, PaintLayer, RecordedRenderScene, RenderOp};
 pub use safe_area::{WindowInsets, local_ime_insets, local_safe_area_insets, window_insets};

--- a/crates/cranpose-ui/src/render_state.rs
+++ b/crates/cranpose-ui/src/render_state.rs
@@ -25,6 +25,12 @@ struct RenderState {
     measure_repasses: Mutex<LayoutRepassManager>,
     draw_repasses: Mutex<DrawRepassManager>,
     modifier_slice_repasses: Mutex<LayoutRepassManager>,
+    /// Nodes whose position or size actually changed in the current layout
+    /// pass. The scene phase folds these into its scoped graph update: a node
+    /// moved by a *sibling's* growth never recomposes and raises no repass of
+    /// its own, so without this channel the scoped update patches only the
+    /// grown subtree and keeps drawing the moved node at its old geometry.
+    geometry_scene_nodes: Mutex<LayoutRepassManager>,
     render_invalidated: AtomicBool,
     pointer_invalidated: AtomicBool,
     focus_invalidated: AtomicBool,
@@ -158,6 +164,7 @@ impl RenderState {
             measure_repasses: Mutex::new(LayoutRepassManager::new()),
             draw_repasses: Mutex::new(DrawRepassManager::new()),
             modifier_slice_repasses: Mutex::new(LayoutRepassManager::new()),
+            geometry_scene_nodes: Mutex::new(LayoutRepassManager::new()),
             render_invalidated: AtomicBool::new(false),
             pointer_invalidated: AtomicBool::new(false),
             focus_invalidated: AtomicBool::new(false),
@@ -842,6 +849,25 @@ pub(crate) fn take_modifier_slice_repass_nodes() -> Vec<NodeId> {
     with_render_state(|state| {
         lock_repass_manager(&state.modifier_slice_repasses).take_dirty_nodes()
     })
+}
+
+/// Records that the current layout pass gave `node_id` a new position or size.
+///
+/// Called from the retained geometry setters, so only an actual change lands
+/// here — a pass that re-places a node where it already was records nothing.
+pub(crate) fn record_geometry_scene_node(node_id: NodeId) {
+    with_render_state(|state| {
+        lock_repass_manager(&state.geometry_scene_nodes).schedule_repass(node_id);
+    });
+}
+
+/// Takes the nodes whose geometry the last layout pass actually changed.
+///
+/// The scene phase merges these into its scoped update scope. Consuming them
+/// is mandatory whenever layout ran: geometry recorded by one pass is
+/// meaningless to the next.
+pub fn take_geometry_scene_nodes() -> Vec<NodeId> {
+    with_render_state(|state| lock_repass_manager(&state.geometry_scene_nodes).take_dirty_nodes())
 }
 
 /// Returns the current density scale factor (logical px per dp).

--- a/crates/cranpose-ui/src/renderer.rs
+++ b/crates/cranpose-ui/src/renderer.rs
@@ -342,19 +342,19 @@ impl HeadlessRenderer {
         let (layout_state, modifier_slices, children) = node_data;
 
         // Skip nodes that weren't placed
-        if !layout_state.is_placed {
+        if !layout_state.is_placed() {
             return;
         }
 
         // Calculate absolute position
-        let abs_x = parent_offset.x + layout_state.position.x;
-        let abs_y = parent_offset.y + layout_state.position.y;
+        let abs_x = parent_offset.x + layout_state.position().x;
+        let abs_y = parent_offset.y + layout_state.position().y;
 
         let rect = Rect {
             x: abs_x,
             y: abs_y,
-            width: layout_state.size.width,
-            height: layout_state.size.height,
+            width: layout_state.size().width,
+            height: layout_state.size().height,
         };
 
         let size = Size {

--- a/crates/cranpose-ui/src/subcompose_layout.rs
+++ b/crates/cranpose-ui/src/subcompose_layout.rs
@@ -878,16 +878,34 @@ impl SubcomposeLayoutNode {
     }
 
     /// Updates the position of this node. Called during placement.
+    ///
+    /// An actual move self-reports to the scene phase: a node moved by a
+    /// sibling's growth never recomposes and raises no repass of its own, so
+    /// this record is the only way the scoped scene update learns its layer
+    /// is stale.
     pub fn set_position(&self, position: Point) {
         let mut state = self.layout_state.borrow_mut();
-        state.position = position;
+        if state.position != position {
+            if let Some(id) = self.id.get() {
+                crate::render_state::record_geometry_scene_node(id);
+            }
+            state.position = position;
+        }
         state.is_placed = true;
     }
 
     /// Updates the measured size of this node. Called during measurement.
+    ///
+    /// An actual change self-reports to the scene phase, for the same reason
+    /// as [`Self::set_position`].
     pub fn set_measured_size(&self, size: Size) {
         let mut state = self.layout_state.borrow_mut();
-        state.size = size;
+        if state.size != size {
+            if let Some(id) = self.id.get() {
+                crate::render_state::record_geometry_scene_node(id);
+            }
+            state.size = size;
+        }
     }
 
     /// Clears the is_placed flag. Called at the start of a layout pass.

--- a/crates/cranpose-ui/src/subcompose_layout.rs
+++ b/crates/cranpose-ui/src/subcompose_layout.rs
@@ -878,39 +878,21 @@ impl SubcomposeLayoutNode {
     }
 
     /// Updates the position of this node. Called during placement.
-    ///
-    /// An actual move self-reports to the scene phase: a node moved by a
-    /// sibling's growth never recomposes and raises no repass of its own, so
-    /// this record is the only way the scoped scene update learns its layer
-    /// is stale.
+    /// [`LayoutState::place`] self-reports actual moves to the scene phase.
     pub fn set_position(&self, position: Point) {
-        let mut state = self.layout_state.borrow_mut();
-        if state.position != position {
-            if let Some(id) = self.id.get() {
-                crate::render_state::record_geometry_scene_node(id);
-            }
-            state.position = position;
-        }
-        state.is_placed = true;
+        self.layout_state.borrow_mut().place(position);
     }
 
     /// Updates the measured size of this node. Called during measurement.
-    ///
-    /// An actual change self-reports to the scene phase, for the same reason
-    /// as [`Self::set_position`].
+    /// [`LayoutState::set_size`] self-reports actual changes to the scene
+    /// phase.
     pub fn set_measured_size(&self, size: Size) {
-        let mut state = self.layout_state.borrow_mut();
-        if state.size != size {
-            if let Some(id) = self.id.get() {
-                crate::render_state::record_geometry_scene_node(id);
-            }
-            state.size = size;
-        }
+        self.layout_state.borrow_mut().set_size(size);
     }
 
     /// Clears the is_placed flag. Called at the start of a layout pass.
     pub fn clear_placed(&self) {
-        self.layout_state.borrow_mut().is_placed = false;
+        self.layout_state.borrow_mut().clear_placed();
     }
 
     /// Returns the modifier slices snapshot for rendering.
@@ -1204,6 +1186,7 @@ impl cranpose_core::Node for SubcomposeLayoutNode {
 
     fn set_node_id(&mut self, id: NodeId) {
         self.id.set(Some(id));
+        self.layout_state.borrow_mut().set_node_id(id);
         self.inner.borrow_mut().modifier_chain.set_node_id(Some(id));
         self.update_modifier_slices_cache();
     }

--- a/crates/cranpose-ui/src/widgets/nodes/layout_node.rs
+++ b/crates/cranpose-ui/src/widgets/nodes/layout_node.rs
@@ -77,12 +77,20 @@ fn log_layout_invalidation_dispatch(
 /// LayoutTree reconstruction.
 #[derive(Clone, Debug)]
 pub struct LayoutState {
-    /// The measured size of this node (width, height).
-    pub size: Size,
-    /// Position relative to parent's content origin.
-    pub position: Point,
+    /// The measured size of this node (width, height). Private: every write
+    /// must go through [`Self::set_size`], which self-reports actual changes
+    /// to the scene phase — a node resized or moved by a SIBLING's growth
+    /// recomposes nothing and raises no repass, so the write is the only
+    /// place that fact exists. Field privacy makes a bypass fail to compile.
+    size: Size,
+    /// Position relative to parent's content origin. Private for the same
+    /// reason as `size`: writes go through [`Self::place`].
+    position: Point,
     /// True if this node has been placed in the current layout pass.
-    pub is_placed: bool,
+    is_placed: bool,
+    /// The id this state belongs to, for the geometry self-report. `None`
+    /// only before the node is mounted (no scene exists to go stale then).
+    node_id: Option<NodeId>,
     /// The constraints used for the last measurement.
     pub measurement_constraints: Constraints,
     /// Offset of the content box relative to the node origin (e.g. due to padding).
@@ -95,6 +103,7 @@ impl Default for LayoutState {
             size: Size::default(),
             position: Point::default(),
             is_placed: false,
+            node_id: None,
             measurement_constraints: Constraints {
                 min_width: 0.0,
                 max_width: f32::INFINITY,
@@ -103,6 +112,52 @@ impl Default for LayoutState {
             },
             content_offset: Point::default(),
         }
+    }
+}
+
+impl LayoutState {
+    pub fn size(&self) -> Size {
+        self.size
+    }
+
+    pub fn position(&self) -> Point {
+        self.position
+    }
+
+    pub fn is_placed(&self) -> bool {
+        self.is_placed
+    }
+
+    pub(crate) fn set_node_id(&mut self, node_id: NodeId) {
+        self.node_id = Some(node_id);
+    }
+
+    /// Writes the measured size, self-reporting an actual change to the
+    /// scene phase.
+    pub fn set_size(&mut self, size: Size) {
+        if self.size != size {
+            if let Some(id) = self.node_id {
+                crate::render_state::record_geometry_scene_node(id);
+            }
+            self.size = size;
+        }
+    }
+
+    /// Writes the placed position and marks the node placed, self-reporting
+    /// an actual move to the scene phase.
+    pub fn place(&mut self, position: Point) {
+        if self.position != position {
+            if let Some(id) = self.node_id {
+                crate::render_state::record_geometry_scene_node(id);
+            }
+            self.position = position;
+        }
+        self.is_placed = true;
+    }
+
+    /// Clears the placed flag at the start of a layout pass.
+    pub fn clear_placed(&mut self) {
+        self.is_placed = false;
     }
 }
 
@@ -627,6 +682,7 @@ impl LayoutNode {
         {
             unregister_layout_node(owner_context_id, existing);
         }
+        self.layout_state.borrow_mut().set_node_id(id);
         let owner_context_id = register_layout_node(id, self);
         self.owner_context_id.set(Some(owner_context_id));
         self.refresh_registry_state();
@@ -774,34 +830,16 @@ impl LayoutNode {
     }
 
     /// Updates the measured size of this node. Called during measurement.
-    ///
-    /// An actual change self-reports to the scene phase: a node resized by a
-    /// sibling's growth never recomposes, so this record is the only way the
-    /// scoped scene update learns its layer is stale.
+    /// [`LayoutState::set_size`] self-reports actual changes to the scene
+    /// phase.
     pub fn set_measured_size(&self, size: Size) {
-        let mut state = self.layout_state.borrow_mut();
-        if state.size != size {
-            if let Some(id) = self.id.get() {
-                crate::render_state::record_geometry_scene_node(id);
-            }
-            state.size = size;
-        }
+        self.layout_state.borrow_mut().set_size(size);
     }
 
     /// Updates the position of this node. Called during placement.
-    ///
-    /// An actual move self-reports to the scene phase, for the same reason as
-    /// [`Self::set_measured_size`]: siblings pushed by another node's growth
-    /// raise no dirt of their own.
+    /// [`LayoutState::place`] self-reports actual moves to the scene phase.
     pub fn set_position(&self, position: Point) {
-        let mut state = self.layout_state.borrow_mut();
-        if state.position != position {
-            if let Some(id) = self.id.get() {
-                crate::render_state::record_geometry_scene_node(id);
-            }
-            state.position = position;
-        }
-        state.is_placed = true;
+        self.layout_state.borrow_mut().place(position);
     }
 
     /// Records the constraints used for measurement. Used for relayout optimization.

--- a/crates/cranpose-ui/src/widgets/nodes/layout_node.rs
+++ b/crates/cranpose-ui/src/widgets/nodes/layout_node.rs
@@ -774,15 +774,33 @@ impl LayoutNode {
     }
 
     /// Updates the measured size of this node. Called during measurement.
+    ///
+    /// An actual change self-reports to the scene phase: a node resized by a
+    /// sibling's growth never recomposes, so this record is the only way the
+    /// scoped scene update learns its layer is stale.
     pub fn set_measured_size(&self, size: Size) {
         let mut state = self.layout_state.borrow_mut();
-        state.size = size;
+        if state.size != size {
+            if let Some(id) = self.id.get() {
+                crate::render_state::record_geometry_scene_node(id);
+            }
+            state.size = size;
+        }
     }
 
     /// Updates the position of this node. Called during placement.
+    ///
+    /// An actual move self-reports to the scene phase, for the same reason as
+    /// [`Self::set_measured_size`]: siblings pushed by another node's growth
+    /// raise no dirt of their own.
     pub fn set_position(&self, position: Point) {
         let mut state = self.layout_state.borrow_mut();
-        state.position = position;
+        if state.position != position {
+            if let Some(id) = self.id.get() {
+                crate::render_state::record_geometry_scene_node(id);
+            }
+            state.position = position;
+        }
         state.is_placed = true;
     }
 


### PR DESCRIPTION
On the Huawei, tapping a second row's "..." drew the action strip translucently over the unmoved rows below, and nothing reflowed until a scroll forced a full pass. Convicted on-device by adjacent revisions: correct at f72e4aef, ghosting at 9b169765 (#530), same protocol, one commit apart — then reproduced headlessly in a desktop robot example that flips on the same boundary.

## One wrong assumption, implemented twice

"The child list did not change, therefore there is nothing to invalidate." #530 applied it to structural records (scene re-lowering), #534 to the attach-time dirty bubble (layout). Both are real, measured wins — and both removed the every-frame attach/detach churn that was silently carrying widgets whose growth changes no child list at the guarded level. A child can grow without membership changing, and a sibling pushed down by that growth recomposes nothing and raises no repass of its own: the scene diag on the broken frame shows `dirty=[row, strip]` — the moved siblings appear in no dirty set at all, because repass ids only say where invalidation *started*.

## The fix: growth announces itself, at both layers

- **Scene**: the retained geometry setters (`LayoutNode`/`SubcomposeLayoutNode` `set_position` and `set_measured_size`) record their node id when the value actually changes; the shell folds those ids into the scoped scene update's scope. The layout pass that moved a node is the only party that knows it moved, and the setters that write geometry are the single place that truth exists — which is why the alternative (teaching the membership guard to also consult geometry) was rejected: a guard that must ask another subsystem's question will be optimised wrong again.
- **Core**: `AttachChild` of an already-present child that carries pending measure/layout dirt still bubbles — the attach-time bubble is the only road that dirt has to the root's layout gate. A clean re-attach still bubbles nothing (#534's win), pinned as the guard's positive control.

## Pins — each verified RED first by severing the mechanism

- `robot_lazy_expansion_reflow`: cold start, expand once, expand again — the second expansion is the pin (the first tends to ride a full-rebuild rescue and passed on every broken arm). Asserts pixels-versus-semantics from a screenshot, because pass counts cannot see this class of bug.
- app-shell `sibling_moved_by_another_rows_growth_reaches_the_scoped_scene_update`: per-item-scoped lazy list; the moved sibling must reach the **scoped** update with `rebuilds == 0`, so the full-rebuild rescue cannot hide the hole. (A plain-Column probe recomposes the whole body and cannot catch it; a bare-Text-per-item probe lands the strip's structural dirt on the container and rescues the frame — the item wrapper is load-bearing.)
- core `reattaching_a_dirty_child_still_bubbles_to_ancestors` + `reattaching_a_clean_child_bubbles_nothing`.

## The wins stay wins — measured, not argued

Same instruments that earned them, one diag switch per capture, identical probe scene both arms (LazyColumn, 300 fixed rows, 120 presented scroll frames after warmup), main d1656846 vs this branch:

| instrument | main | fix |
|---|---|---|
| scene layer builds in window (#530's metric) | 4 | 4 |
| structural events in window (#534's metric) | 0 | 0 |
| scoped updates in window | 1 | 1 |

The feared failure mode — scroll writing a changed position per visible child per frame, flooding the scope — does not occur: steady scroll moves the container's content offset and relative child positions stay put, so the setters record nothing. On the one slot-rebind frame where relative positions genuinely changed, the fix arm's dirty set carried 18 extra ids and they rode the translate fast path: zero additional layer builds.

Device verification on the Huawei (three-symptom protocol, multi-row "...") follows in the comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Second commit: the recorder lives where geometry is written (review findings, all mutation-verified)

An independent deep review found five defects in the first commit, and CI stepped into the worst one before the fix landed: `robot_drag_selection` red with the handle at 154.8 while the pointer sat at 111.5. Confirmed by removal, three arms, same recipe: main **PASS**, first-commit head **FAIL**, completion **PASS**.

**Partial coverage was worse than none.** The first commit recorded geometry only in the node setters — but the engine places ordinary children by writing the shared `LayoutState` directly (probed: only the root ever reaches `set_position`; every ordinary child goes through the direct handle). The recorded ids switched frames onto the scoped path, and the fallback full-rebuild that had been rescuing the unrecorded nodes went away with it. A half-applied invalidation scheme is not a half-fix; it is a new bug. Treat any optimisation that is "correct for the cases we enumerated" with the same suspicion.

The completion: `LayoutState`'s `size`/`position`/`is_placed` are **private**, the only writers are `LayoutState::set_size` and `LayoutState::place`, both self-reporting, and the state knows its node id. A write path added next year that bypasses the recorder does not compile — the rule lives in the type system, not in a reviewer's head.

Also fixed, each proven red by mutation first:
- **Semantics dropped from the re-attach bubble**: production nodes start semantics-dirty and stay so while semantics are off, so keying on that flag walked ancestors on every no-op re-attach of a steady scroll. The test double now defaults `needs_semantics = true` like production and counts marks.
- **Geometry ids are attachment-filtered** like structural ids (shared core resolver: nearest non-virtual ancestor, still attached), so a node detached between recording and the scene phase cannot force a whole-scene rebuild.
- **The counting test renderer counts its internal fallback as a rebuild**, so `rebuilds == 0` proves the scoped path carried the frame.
- **HashSet dedup** for the scope ids (Vec::contains was quadratic).

Two traps for the next scene-test author, found because the first constructions lied:
- A moved **Text** sibling rescues itself: re-measuring a text re-shapes it and schedules its own draw repass, which sneaks the row into the scene scope. A pin for missing geometry records must move a **solid box**.
- In tiny scenes the retained-redraw sweep floods the scope and rescues everything; a green there proves nothing. The lazy-list pins (per-item scopes, `rebuilds == 0`) are the ones that bite.

New pins in the second commit: the ordinary-Column solid-box sibling, and a nested LazyColumn (a `SubcomposeLayoutNode`) pushed down by an ordinary sibling's growth — the motion case none of the first commit's tests exercised.

Device cost re-measurement (same A/B protocol) follows in the comments once the board is green — the semantics fix plausibly moves the +0.3–0.4 ms figure and the number must stay honest either way.
