### PR TITLE
Add diff-scoped complexity and duplication CI gates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,6 +65,15 @@ jobs:
       - name: Spell check
         run: just typos
 
+      - name: Test the quality gates' diff-scoping logic
+        run: just test-quality-gates
+
+      - name: Check cyclomatic complexity of changed functions
+        run: just complexity-gate
+
+      - name: Check for duplicated code in the diff
+        run: just duplication-gate
+
       - name: Run workspace tests
         run: just test
 

--- a/justfile
+++ b/justfile
@@ -109,6 +109,36 @@ clippy-camera-desktop:
 clippy-android:
     cargo ndk --platform 24 -t arm64-v8a -t armeabi-v7a -t x86 -t x86_64 clippy -p desktop-app-platform --lib --no-default-features --features android,renderer-wgpu -- -D warnings -A clippy::missing_const_for_thread_local
 
+# --- code quality gates -----------------------------------------------------
+#
+# Both gates below are scoped to the diff against `base`, not the whole
+# workspace: a function or a clone already there is left alone unless this
+# change touches it. See scripts/ci/gate_diff.py for how "touches" is
+# derived from the merge base, and scripts/ci/code_quality_gates.toml for the
+# thresholds. `base` defaults to `origin/main` so the same recipe means the
+# same thing for a developer comparing a local branch and for CI comparing a
+# pull request.
+
+# Unit tests for the diff-scoping logic itself -- synthetic diffs and
+# synthetic tool output, no git history or external tool required.
+test-quality-gates:
+    python3 scripts/ci/test_gate_diff.py
+
+# Cyclomatic complexity ceiling for functions the diff adds or modifies.
+# Installed on demand, the way `typos` is.
+complexity-gate base="origin/main":
+    @command -v rust-code-analysis-cli >/dev/null || cargo install rust-code-analysis-cli --locked
+    python3 scripts/ci/complexity_gate.py --base {{base}}
+
+# Copy-paste budget for a block the diff adds, at either end of the copy.
+#
+# jscpd v5 is a Rust CLI (its own npm package just wraps prebuilt binaries of
+# it); installing it with cargo keeps this off Node.js, which the runners
+# that carry the Rust toolchain do not otherwise have.
+duplication-gate base="origin/main":
+    @command -v jscpd >/dev/null || cargo install jscpd --locked
+    python3 scripts/ci/duplication_gate.py --base {{base}}
+
 # --- test ------------------------------------------------------------------
 
 # `--profile ci` keeps the debuginfo that the local dev profile strips, so a
@@ -340,7 +370,7 @@ perf-heap *args:
 # Excludes the jobs that need a GPU, an Android SDK or an iOS toolchain.
 
 # What a pull request is gated on. Run this before pushing.
-ci: fmt-check typos versions test clippy doc budgets
+ci: fmt-check typos versions test clippy doc budgets test-quality-gates complexity-gate duplication-gate
 
 # Needs a Linux box with the X11 stack, an Android SDK and (on macOS) Xcode.
 

--- a/justfile
+++ b/justfile
@@ -125,18 +125,15 @@ test-quality-gates:
     python3 scripts/ci/test_gate_diff.py
 
 # Cyclomatic complexity ceiling for functions the diff adds or modifies.
-# Installed on demand, the way `typos` is.
+# Installs its own tool on demand, the way `typos` does -- see
+# gate_diff.resolve_cargo_tool for why that install is pinned to a cargo
+# path rather than trusting whatever `rust-code-analysis-cli` is on $PATH.
 complexity-gate base="origin/main":
-    @command -v rust-code-analysis-cli >/dev/null || cargo install rust-code-analysis-cli --locked
     python3 scripts/ci/complexity_gate.py --base {{base}}
 
 # Copy-paste budget for a block the diff adds, at either end of the copy.
-#
-# jscpd v5 is a Rust CLI (its own npm package just wraps prebuilt binaries of
-# it); installing it with cargo keeps this off Node.js, which the runners
-# that carry the Rust toolchain do not otherwise have.
+# Same on-demand install as above, through the same pinned-path resolver.
 duplication-gate base="origin/main":
-    @command -v jscpd >/dev/null || cargo install jscpd --locked
     python3 scripts/ci/duplication_gate.py --base {{base}}
 
 # --- test ------------------------------------------------------------------

--- a/scripts/ci/code_quality_gates.toml
+++ b/scripts/ci/code_quality_gates.toml
@@ -1,0 +1,28 @@
+# Thresholds for the diff-scoped complexity and duplication gates.
+#
+# Both gates are `just` recipes (`complexity-gate`, `duplication-gate`); CI
+# calls them the same way a developer does. Scope is new or modified code
+# only -- see scripts/ci/gate_diff.py for how "changed" is derived from the
+# PR's merge base. Neither gate requires the existing codebase to pass.
+
+[complexity]
+# Cyclomatic complexity above this, in a function the diff adds or modifies,
+# fails the gate. Measured with `rust-code-analysis-cli` (parses, does not
+# compile, so this runs in milliseconds against only the changed files).
+#
+# Calibrated 2026-08-29 against the full workspace (crates, apps, xtask;
+# 34,658 functions): p50=1, p90=5, p95=8, p99=19, p99.9=49, max=221 (a
+# generated wasm-bindgen match and a winit event-loop dispatch, both
+# necessarily large single `match` bodies). 20 sits just above the p99 line
+# of the codebase's own existing functions, so it accepts what the best 99%
+# of today's code already looks like and flags new work that falls outside
+# that norm.
+max_cyclomatic = 20
+
+[duplication]
+# A cloned block at or above this many lines fails the gate when at least one
+# copy falls inside the diff -- matches AGENTS.md's "duplicated code (10+
+# lines) without architecture is forbidden". Measured with `jscpd`.
+min_lines = 10
+min_tokens = 50
+ignore_globs = ["**/target/**", "**/pkg/**", "**/node_modules/**"]

--- a/scripts/ci/complexity_gate.py
+++ b/scripts/ci/complexity_gate.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Cyclomatic complexity ceiling for functions a diff adds or modifies.
+
+Scope is diff-only (see `gate_diff.py`): a function already over the limit is
+left alone unless the diff touches it, and the workspace does not need to
+pass this retroactively. `rust-code-analysis-cli` parses the changed files
+without compiling them, so this only ever costs milliseconds against however
+many files the diff touched, never a workspace build.
+
+    just complexity-gate                  # CI's invocation
+    python3 scripts/ci/complexity_gate.py --base origin/main
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+import gate_diff
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = Path(__file__).resolve().parent / "code_quality_gates.toml"
+
+
+def load_max_cyclomatic(config_path: Path) -> int:
+    with config_path.open("rb") as handle:
+        config = tomllib.load(handle)
+    return int(config["complexity"]["max_cyclomatic"])
+
+
+def functions_in(space: dict, out: list[dict]) -> None:
+    """Flatten `rust-code-analysis-cli`'s nested space tree into functions.
+
+    Closures are their own `kind == "function"` spaces nested inside the
+    function that defines them, so this recurses into every space -- a
+    closure the diff adds should be checked on its own span, not only as
+    part of whatever complexity its enclosing function reports.
+    """
+    if space.get("kind") == "function":
+        metrics = space.get("metrics") or {}
+        cyclomatic = (metrics.get("cyclomatic") or {}).get("sum")
+        out.append(
+            {
+                "name": space.get("name") or "<anonymous>",
+                "start": space.get("start_line"),
+                "end": space.get("end_line"),
+                "cyclomatic": cyclomatic,
+            }
+        )
+    for child in space.get("spaces", []):
+        functions_in(child, out)
+
+
+def analyze_files(files: list[str], out_dir: Path) -> dict[str, list[dict]]:
+    """Run `rust-code-analysis-cli` on `files`, returning functions per file.
+
+    The CLI takes one `-p <path>` per input (a comma-joined list is treated
+    as one literal, nonexistent path, not a list) and mirrors each input's
+    relative path under `out_dir` with a `.json` suffix appended.
+    """
+    args = ["rust-code-analysis-cli", "-m", "-O", "json", "-o", str(out_dir)]
+    for f in files:
+        args += ["-p", f]
+    result = subprocess.run(args, cwd=ROOT, capture_output=True, text=True)
+    produced = list(out_dir.rglob("*.json"))
+    if result.returncode != 0 and not produced:
+        raise SystemExit(
+            "complexity-gate: rust-code-analysis-cli failed with no output\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    if result.stderr.strip():
+        print(result.stderr.strip(), file=sys.stderr)
+
+    by_file: dict[str, list[dict]] = {}
+    for f in files:
+        json_path = out_dir / f"{f}.json"
+        if not json_path.exists():
+            print(
+                f"complexity-gate: no analysis produced for {f}, skipping",
+                file=sys.stderr,
+            )
+            continue
+        try:
+            data = json.loads(json_path.read_text())
+        except json.JSONDecodeError as exc:
+            print(f"complexity-gate: could not parse analysis for {f}: {exc}", file=sys.stderr)
+            continue
+        functions: list[dict] = []
+        functions_in(data, functions)
+        by_file[f] = functions
+    return by_file
+
+
+def find_violations(
+    ranges: dict[str, list[tuple[int, int]]],
+    functions_by_file: dict[str, list[dict]],
+    max_cyclomatic: int,
+) -> list[str]:
+    violations: list[str] = []
+    for file, functions in sorted(functions_by_file.items()):
+        file_ranges = ranges.get(file, [])
+        for func in functions:
+            if func["start"] is None or func["end"] is None or func["cyclomatic"] is None:
+                continue
+            span = (func["start"], func["end"])
+            if not gate_diff.any_intersect(file_ranges, span):
+                continue
+            cyclomatic = int(func["cyclomatic"])
+            if cyclomatic > max_cyclomatic:
+                violations.append(
+                    f"{file}:{span[0]}-{span[1]} {func['name']} "
+                    f"has cyclomatic complexity {cyclomatic} (limit {max_cyclomatic})"
+                )
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    args = parser.parse_args()
+
+    if shutil.which("rust-code-analysis-cli") is None:
+        print(
+            "complexity-gate: rust-code-analysis-cli not found; "
+            "install with `cargo install rust-code-analysis-cli --locked`",
+            file=sys.stderr,
+        )
+        return 1
+
+    max_cyclomatic = load_max_cyclomatic(args.config)
+    ranges = gate_diff.changed_ranges(args.base, "*.rs")
+    if not ranges:
+        print(f"complexity-gate: no changed Rust files against {args.base}")
+        return 0
+
+    with tempfile.TemporaryDirectory() as tmp:
+        functions_by_file = analyze_files(sorted(ranges), Path(tmp))
+
+    violations = find_violations(ranges, functions_by_file, max_cyclomatic)
+    if violations:
+        print(f"complexity-gate: {len(violations)} function(s) over the limit:", file=sys.stderr)
+        for v in violations:
+            print(f"  {v}", file=sys.stderr)
+        return 1
+
+    print(f"complexity-gate: {sum(len(v) for v in ranges.values())} changed line range(s) clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/complexity_gate.py
+++ b/scripts/ci/complexity_gate.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -57,14 +56,16 @@ def functions_in(space: dict, out: list[dict]) -> None:
         functions_in(child, out)
 
 
-def analyze_files(files: list[str], out_dir: Path) -> dict[str, list[dict]]:
+def analyze_files(
+    rust_code_analysis_cli: Path, files: list[str], out_dir: Path
+) -> dict[str, list[dict]]:
     """Run `rust-code-analysis-cli` on `files`, returning functions per file.
 
     The CLI takes one `-p <path>` per input (a comma-joined list is treated
     as one literal, nonexistent path, not a list) and mirrors each input's
     relative path under `out_dir` with a `.json` suffix appended.
     """
-    args = ["rust-code-analysis-cli", "-m", "-O", "json", "-o", str(out_dir)]
+    args = [str(rust_code_analysis_cli), "-m", "-O", "json", "-o", str(out_dir)]
     for f in files:
         args += ["-p", f]
     result = subprocess.run(args, cwd=ROOT, capture_output=True, text=True)
@@ -126,22 +127,15 @@ def main() -> int:
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
     args = parser.parse_args()
 
-    if shutil.which("rust-code-analysis-cli") is None:
-        print(
-            "complexity-gate: rust-code-analysis-cli not found; "
-            "install with `cargo install rust-code-analysis-cli --locked`",
-            file=sys.stderr,
-        )
-        return 1
-
     max_cyclomatic = load_max_cyclomatic(args.config)
     ranges = gate_diff.changed_ranges(args.base, "*.rs")
     if not ranges:
         print(f"complexity-gate: no changed Rust files against {args.base}")
         return 0
 
+    rust_code_analysis_cli = gate_diff.resolve_cargo_tool("rust-code-analysis-cli")
     with tempfile.TemporaryDirectory() as tmp:
-        functions_by_file = analyze_files(sorted(ranges), Path(tmp))
+        functions_by_file = analyze_files(rust_code_analysis_cli, sorted(ranges), Path(tmp))
 
     violations = find_violations(ranges, functions_by_file, max_cyclomatic)
     if violations:

--- a/scripts/ci/duplication_gate.py
+++ b/scripts/ci/duplication_gate.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Copy-paste budget for blocks a diff adds -- to old code or to itself.
+
+Scope is diff-only (see `gate_diff.py`): `jscpd` scans the whole repository,
+because a new block can duplicate anything anywhere, but a clone only fails
+the gate when at least one of its two copies falls inside the diff. Two
+pre-existing clones that the diff does not touch are left alone, so the
+workspace's existing duplication (measured at 1,592 clones over 10 lines as
+of 2026-08-29) does not need to be cleaned up for this to pass.
+
+    just duplication-gate                  # CI's invocation
+    python3 scripts/ci/duplication_gate.py --base origin/main
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+import gate_diff
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = Path(__file__).resolve().parent / "code_quality_gates.toml"
+
+
+def load_duplication_config(config_path: Path) -> dict:
+    with config_path.open("rb") as handle:
+        config = tomllib.load(handle)
+    return config["duplication"]
+
+
+def run_jscpd(min_lines: int, min_tokens: int, ignore_globs: list[str], out_dir: Path) -> list[dict]:
+    args = [
+        "jscpd",
+        "--min-lines",
+        str(min_lines),
+        "--min-tokens",
+        str(min_tokens),
+        "-f",
+        "rust",
+        "-r",
+        "json",
+        "-o",
+        str(out_dir),
+    ]
+    if ignore_globs:
+        args += ["--ignore", ",".join(ignore_globs)]
+    args.append(".")
+    result = subprocess.run(args, cwd=ROOT, capture_output=True, text=True)
+    report_path = out_dir / "jscpd-report.json"
+    if not report_path.exists():
+        raise SystemExit(
+            "duplication-gate: jscpd produced no report\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    return json.loads(report_path.read_text()).get("duplicates", [])
+
+
+def side_span(side: dict) -> tuple[str, tuple[int, int]]:
+    return side["name"], (side["start"], side["end"])
+
+
+def find_violations(
+    duplicates: list[dict], ranges: dict[str, list[tuple[int, int]]]
+) -> list[str]:
+    violations: list[str] = []
+    for dup in duplicates:
+        first_file, first_span = side_span(dup["firstFile"])
+        second_file, second_span = side_span(dup["secondFile"])
+        first_hit = gate_diff.any_intersect(ranges.get(first_file, []), first_span)
+        second_hit = gate_diff.any_intersect(ranges.get(second_file, []), second_span)
+        if not (first_hit or second_hit):
+            continue
+        lines = dup.get("lines")
+        violations.append(
+            f"{first_file}:{first_span[0]}-{first_span[1]}"
+            f"{' (new)' if first_hit else ''}"
+            " duplicates "
+            f"{second_file}:{second_span[0]}-{second_span[1]}"
+            f"{' (new)' if second_hit else ''}"
+            f" ({lines} lines)"
+        )
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    args = parser.parse_args()
+
+    if shutil.which("jscpd") is None:
+        print(
+            "duplication-gate: jscpd not found; install with `cargo install jscpd --locked`",
+            file=sys.stderr,
+        )
+        return 1
+
+    config = load_duplication_config(args.config)
+    ranges = gate_diff.changed_ranges(args.base, "*.rs")
+    if not ranges:
+        print(f"duplication-gate: no changed Rust files against {args.base}")
+        return 0
+
+    with tempfile.TemporaryDirectory() as tmp:
+        duplicates = run_jscpd(
+            config["min_lines"], config["min_tokens"], config.get("ignore_globs", []), Path(tmp)
+        )
+
+    violations = find_violations(duplicates, ranges)
+    if violations:
+        print(f"duplication-gate: {len(violations)} clone(s) touch the diff:", file=sys.stderr)
+        for v in violations:
+            print(f"  {v}", file=sys.stderr)
+        return 1
+
+    print(f"duplication-gate: {len(duplicates)} clone(s) in the repo, none touch the diff")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/duplication_gate.py
+++ b/scripts/ci/duplication_gate.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -35,9 +34,11 @@ def load_duplication_config(config_path: Path) -> dict:
     return config["duplication"]
 
 
-def run_jscpd(min_lines: int, min_tokens: int, ignore_globs: list[str], out_dir: Path) -> list[dict]:
+def run_jscpd(
+    jscpd: Path, min_lines: int, min_tokens: int, ignore_globs: list[str], out_dir: Path
+) -> list[dict]:
     args = [
-        "jscpd",
+        str(jscpd),
         "--min-lines",
         str(min_lines),
         "--min-tokens",
@@ -95,22 +96,27 @@ def main() -> int:
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
     args = parser.parse_args()
 
-    if shutil.which("jscpd") is None:
-        print(
-            "duplication-gate: jscpd not found; install with `cargo install jscpd --locked`",
-            file=sys.stderr,
-        )
-        return 1
-
     config = load_duplication_config(args.config)
     ranges = gate_diff.changed_ranges(args.base, "*.rs")
     if not ranges:
         print(f"duplication-gate: no changed Rust files against {args.base}")
         return 0
 
+    jscpd = gate_diff.resolve_cargo_tool(
+        "jscpd",
+        "jscpd also ships an npm package that wraps a prebuilt copy of the same "
+        "Rust binary, but this project does not require Node.js and will not "
+        "start requiring it here -- if `cargo install jscpd --locked` cannot "
+        "run, fix that (network, registry, offline mirror), do not swap in "
+        "`npm install -g jscpd`.",
+    )
     with tempfile.TemporaryDirectory() as tmp:
         duplicates = run_jscpd(
-            config["min_lines"], config["min_tokens"], config.get("ignore_globs", []), Path(tmp)
+            jscpd,
+            config["min_lines"],
+            config["min_tokens"],
+            config.get("ignore_globs", []),
+            Path(tmp),
         )
 
     violations = find_violations(duplicates, ranges)

--- a/scripts/ci/gate_diff.py
+++ b/scripts/ci/gate_diff.py
@@ -22,6 +22,7 @@ branch when it is not resolvable rather than failing with a confusing
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -115,6 +116,43 @@ def changed_ranges(base: str, pathspec: str = "*.rs") -> dict[str, list[tuple[in
         check=True,
     )
     return parse_unified_diff_zero_context(result.stdout)
+
+
+def cargo_bin_dir() -> Path:
+    """Where `cargo install` puts binaries -- $CARGO_HOME/bin, or ~/.cargo/bin.
+
+    Every gate tool is resolved against this exact path, never against
+    `$PATH`. `$PATH` is not deterministic across machines: a name like
+    `jscpd` can also be a leftover npm global, an old major version, or a
+    system package, and a bare `shutil.which()` / `command -v` probe accepts
+    whichever one happens to be sitting there first. Pinning the path pins
+    the binary to the one this project just installed.
+    """
+    cargo_home = os.environ.get("CARGO_HOME")
+    root = Path(cargo_home).expanduser() if cargo_home else Path.home() / ".cargo"
+    return root / "bin"
+
+
+def resolve_cargo_tool(name: str, on_install_failure_hint: str = "") -> Path:
+    """The cargo-installed `name`, installing it first if it is missing.
+
+    Never falls back to `$PATH`: see `cargo_bin_dir`. If cargo itself cannot
+    produce the binary (offline, registry down, name typo), this fails loudly
+    with `on_install_failure_hint` attached -- the place to name the actual
+    reason this project cannot substitute some other build of the same name
+    (a different language runtime, a different major version), since that
+    reason has nowhere else durable to live.
+    """
+    binary = cargo_bin_dir() / name
+    if not (binary.is_file() and os.access(binary, os.X_OK)):
+        subprocess.run(["cargo", "install", name, "--locked"], cwd=ROOT)
+    if not (binary.is_file() and os.access(binary, os.X_OK)):
+        hint = f" {on_install_failure_hint}" if on_install_failure_hint else ""
+        raise SystemExit(
+            f"gate_diff: {name} is not at {binary} and `cargo install {name} "
+            f"--locked` did not put it there.{hint}"
+        )
+    return binary
 
 
 def intersects(a: tuple[int, int], b: tuple[int, int]) -> bool:

--- a/scripts/ci/gate_diff.py
+++ b/scripts/ci/gate_diff.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Which line ranges a change touches, for the diff-scoped quality gates.
+
+`complexity_gate.py` and `duplication_gate.py` both need the same answer to
+the same question: which lines, in which files, did this change add or
+modify? Neither gate is allowed to fail on code the diff never touched, so
+both derive their scope from here rather than from a repo-wide scan.
+
+"The diff" is `git diff --unified=0 --no-prefix <merge-base>`, with no second
+ref: that compares the merge base against the working tree, which also covers
+staged and unstaged edits a developer has not committed yet. In CI the working
+tree is exactly the checked-out commit, so the same command means the same
+thing in both places.
+
+The merge base is computed against the ref given (default `origin/main`), not
+hardcoded to a branch name or a commit, so this works for any PR and for a
+plain feature branch alike. A shallow checkout (`actions/checkout`'s default)
+may not have the commits needed to compute it; `ensure_ref` fetches the base
+branch when it is not resolvable rather than failing with a confusing
+`git merge-base` error.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+_HUNK_HEADER = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def ensure_ref(base: str) -> None:
+    """Make `base` resolvable and current.
+
+    A persistent self-hosted runner's checkout is not fresh by default: a
+    prior job can leave `origin/main` resolvable but pointing at a stale
+    commit, which computes a stale merge base and silently mis-scopes the
+    diff rather than failing loudly. So this always re-fetches `base` when it
+    looks like `origin/<branch>`, rather than only fetching when the ref is
+    entirely missing (the shallow-checkout case). A fetch failure is only
+    fatal if `base` does not already resolve to *something* locally -- a
+    developer running this offline with a same-day `origin/main` should not
+    be blocked by the network.
+    """
+    if base.startswith("origin/"):
+        branch = base.removeprefix("origin/")
+        subprocess.run(["git", "fetch", "--quiet", "origin", branch], cwd=ROOT)
+    resolved = subprocess.run(
+        ["git", "rev-parse", "--verify", "-q", base],
+        cwd=ROOT,
+        capture_output=True,
+    )
+    if resolved.returncode != 0:
+        raise SystemExit(
+            f"gate_diff: cannot resolve base ref {base!r}: it fetched nothing "
+            "and no local ref by that name exists"
+        )
+
+
+def merge_base(base: str) -> str:
+    """The merge base of `base` and HEAD, fetching `base` first if needed."""
+    ensure_ref(base)
+    result = subprocess.run(
+        ["git", "merge-base", base, "HEAD"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def parse_unified_diff_zero_context(diff_text: str) -> dict[str, list[tuple[int, int]]]:
+    """Parse `git diff --unified=0 --no-prefix` output into changed ranges.
+
+    Returns one inclusive `(start_line, end_line)` range per hunk, in the
+    *new* (post-change) file's line numbering, keyed by that file's path.
+    A hunk that only deletes lines (`+l,0`) contributes no range: there is no
+    added or modified line on the new side to hold accountable. A deleted
+    file (`+++ /dev/null`) is skipped for the same reason -- nothing in it can
+    be checked against, because nothing in it still exists.
+    """
+    ranges: dict[str, list[tuple[int, int]]] = {}
+    current_file: str | None = None
+    for line in diff_text.splitlines():
+        if line.startswith("+++ "):
+            path = line[len("+++ ") :]
+            current_file = None if path == "/dev/null" else path
+            continue
+        if not line.startswith("@@ "):
+            continue
+        if current_file is None:
+            continue
+        match = _HUNK_HEADER.match(line)
+        if not match:
+            continue
+        start = int(match.group(1))
+        count = int(match.group(2)) if match.group(2) is not None else 1
+        if count == 0:
+            continue
+        ranges.setdefault(current_file, []).append((start, start + count - 1))
+    return ranges
+
+
+def changed_ranges(base: str, pathspec: str = "*.rs") -> dict[str, list[tuple[int, int]]]:
+    """Changed line ranges per file, restricted to `pathspec`, vs `base`."""
+    base_sha = merge_base(base)
+    result = subprocess.run(
+        ["git", "diff", "--unified=0", "--no-prefix", base_sha, "--", pathspec],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return parse_unified_diff_zero_context(result.stdout)
+
+
+def intersects(a: tuple[int, int], b: tuple[int, int]) -> bool:
+    """Whether two inclusive `(start, end)` line ranges overlap."""
+    return a[0] <= b[1] and b[0] <= a[1]
+
+
+def any_intersect(ranges: list[tuple[int, int]], span: tuple[int, int]) -> bool:
+    return any(intersects(r, span) for r in ranges)

--- a/scripts/ci/gate_diff.py
+++ b/scripts/ci/gate_diff.py
@@ -15,9 +15,10 @@ thing in both places.
 The merge base is computed against the ref given (default `origin/main`), not
 hardcoded to a branch name or a commit, so this works for any PR and for a
 plain feature branch alike. A shallow checkout (`actions/checkout`'s default)
-may not have the commits needed to compute it; `ensure_ref` fetches the base
-branch when it is not resolvable rather than failing with a confusing
-`git merge-base` error.
+leaves `base` and `HEAD` as two problems, not one: `ensure_ref` makes `base`
+resolvable by fetching it, and `merge_base` separately makes it *reachable*
+from `HEAD` by deepening history when the two sides turn out to be
+disconnected single-commit graphs with no merge base between them.
 """
 
 from __future__ import annotations
@@ -60,17 +61,67 @@ def ensure_ref(base: str) -> None:
         )
 
 
-def merge_base(base: str) -> str:
-    """The merge base of `base` and HEAD, fetching `base` first if needed."""
-    ensure_ref(base)
+def is_shallow_repository() -> bool:
+    """Whether the checkout's history is truncated at some boundary commit."""
     result = subprocess.run(
-        ["git", "merge-base", base, "HEAD"],
+        ["git", "rev-parse", "--is-shallow-repository"],
         cwd=ROOT,
         capture_output=True,
         text=True,
         check=True,
     )
-    return result.stdout.strip()
+    return result.stdout.strip() == "true"
+
+
+def merge_base(base: str) -> str:
+    """The merge base of `base` and HEAD, deepening history first if needed.
+
+    `actions/checkout`'s default depth-1 clone gives `HEAD` a history of
+    exactly one commit with no recorded parent; `ensure_ref`'s own fetch of
+    `base` is likewise shallow. The two land as disconnected single-commit
+    graphs, so `git merge-base` exits 1 even though `base` resolves fine --
+    not because the branches lack a common ancestor, but because neither
+    side's local history reaches back far enough to see it. `git fetch
+    --unshallow` is the fix, tried only after a first attempt fails and only
+    when the repository is actually shallow: a non-shallow repository
+    failing the same merge-base call really does share no history with
+    `base`, and this refuses to paper over that by guessing a diff scope --
+    the exact silent mis-scoping the diff-scoped gates exist to prevent.
+    """
+    ensure_ref(base)
+    first_attempt = subprocess.run(
+        ["git", "merge-base", base, "HEAD"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if first_attempt.returncode == 0:
+        return first_attempt.stdout.strip()
+    if not is_shallow_repository():
+        raise SystemExit(
+            f"gate_diff: no merge base between {base!r} and HEAD, and the "
+            "checkout already has full history -- these two branches share "
+            "no common ancestor, so the diff cannot be scoped"
+        )
+    deepened = subprocess.run(["git", "fetch", "--quiet", "--unshallow", "origin"], cwd=ROOT)
+    if deepened.returncode != 0:
+        raise SystemExit(
+            "gate_diff: the checkout is shallow and `git fetch --unshallow "
+            "origin` failed -- cannot deepen history enough to find a "
+            f"merge base with {base!r}"
+        )
+    second_attempt = subprocess.run(
+        ["git", "merge-base", base, "HEAD"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if second_attempt.returncode != 0:
+        raise SystemExit(
+            f"gate_diff: no merge base between {base!r} and HEAD even after "
+            "`git fetch --unshallow` -- cannot scope the diff safely"
+        )
+    return second_attempt.stdout.strip()
 
 
 def parse_unified_diff_zero_context(diff_text: str) -> dict[str, list[tuple[int, int]]]:

--- a/scripts/ci/test_gate_diff.py
+++ b/scripts/ci/test_gate_diff.py
@@ -13,7 +13,12 @@ tool output, so it needs neither git history nor `rust-code-analysis-cli` /
 
 from __future__ import annotations
 
+import os
+import stat
+import tempfile
 import unittest
+from pathlib import Path
+from unittest import mock
 
 import complexity_gate
 import duplication_gate
@@ -122,6 +127,56 @@ class Intersects(unittest.TestCase):
         self.assertTrue(gate_diff.any_intersect(ranges, (55, 58)))
         self.assertFalse(gate_diff.any_intersect(ranges, (10, 20)))
         self.assertFalse(gate_diff.any_intersect([], (1, 1000)))
+
+
+class ResolveCargoTool(unittest.TestCase):
+    def test_cargo_bin_dir_honors_cargo_home(self) -> None:
+        with mock.patch.dict(os.environ, {"CARGO_HOME": "/scratch/cargo"}):
+            self.assertEqual(gate_diff.cargo_bin_dir(), Path("/scratch/cargo/bin"))
+
+    def test_cargo_bin_dir_falls_back_to_dot_cargo(self) -> None:
+        env_without_cargo_home = {k: v for k, v in os.environ.items() if k != "CARGO_HOME"}
+        with mock.patch.dict(os.environ, env_without_cargo_home, clear=True):
+            self.assertEqual(gate_diff.cargo_bin_dir(), Path.home() / ".cargo" / "bin")
+
+    def test_never_consults_path_when_already_at_the_pinned_location(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = Path(tmp) / "bin"
+            bin_dir.mkdir()
+            fake_tool = bin_dir / "some-tool"
+            fake_tool.write_text("#!/bin/sh\n")
+            fake_tool.chmod(fake_tool.stat().st_mode | stat.S_IEXEC)
+
+            with mock.patch.dict(os.environ, {"CARGO_HOME": tmp}):
+                with mock.patch("gate_diff.subprocess.run") as run:
+                    resolved = gate_diff.resolve_cargo_tool("some-tool")
+                    run.assert_not_called()
+            self.assertEqual(resolved, fake_tool)
+
+    def test_installs_when_missing_then_resolves_to_the_pinned_location(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = Path(tmp) / "bin"
+            bin_dir.mkdir()
+            fake_tool = bin_dir / "some-tool"
+
+            def fake_install(args, cwd=None):
+                fake_tool.write_text("#!/bin/sh\n")
+                fake_tool.chmod(fake_tool.stat().st_mode | stat.S_IEXEC)
+
+            with mock.patch.dict(os.environ, {"CARGO_HOME": tmp}):
+                with mock.patch("gate_diff.subprocess.run", side_effect=fake_install) as run:
+                    resolved = gate_diff.resolve_cargo_tool("some-tool")
+                    run.assert_called_once()
+            self.assertEqual(resolved, fake_tool)
+
+    def test_raises_with_the_hint_when_install_does_not_produce_the_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "bin").mkdir()
+            with mock.patch.dict(os.environ, {"CARGO_HOME": tmp}):
+                with mock.patch("gate_diff.subprocess.run"):
+                    with self.assertRaises(SystemExit) as raised:
+                        gate_diff.resolve_cargo_tool("some-tool", "do not substitute npm")
+            self.assertIn("do not substitute npm", str(raised.exception))
 
 
 class ComplexityFindViolations(unittest.TestCase):

--- a/scripts/ci/test_gate_diff.py
+++ b/scripts/ci/test_gate_diff.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Unit tests for the diff-scoping logic the two quality gates share.
+
+This is the part correctness actually hinges on: get the intersection wrong
+and the gate either lets new debt through or fails an innocent PR for
+something it never touched. Runs against synthetic diff text and synthetic
+tool output, so it needs neither git history nor `rust-code-analysis-cli` /
+`jscpd` installed.
+
+    just test-quality-gates
+    python3 scripts/ci/test_gate_diff.py
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import complexity_gate
+import duplication_gate
+import gate_diff
+
+
+class ParseUnifiedDiffZeroContext(unittest.TestCase):
+    def test_single_hunk_modified_file(self) -> None:
+        diff = "\n".join(
+            [
+                "diff --git a/src/lib.rs b/src/lib.rs",
+                "--- src/lib.rs",
+                "+++ src/lib.rs",
+                "@@ -10,2 +10,3 @@",
+                "+one",
+                "+two",
+                "+three",
+            ]
+        )
+        self.assertEqual(
+            gate_diff.parse_unified_diff_zero_context(diff),
+            {"src/lib.rs": [(10, 12)]},
+        )
+
+    def test_single_added_line_omits_count(self) -> None:
+        # unified diff omits the trailing ",1" when a hunk covers one line.
+        diff = "\n".join(
+            [
+                "--- src/lib.rs",
+                "+++ src/lib.rs",
+                "@@ -5 +5 @@",
+                "-old",
+                "+new",
+            ]
+        )
+        self.assertEqual(
+            gate_diff.parse_unified_diff_zero_context(diff),
+            {"src/lib.rs": [(5, 5)]},
+        )
+
+    def test_pure_deletion_hunk_has_no_new_side_range(self) -> None:
+        diff = "\n".join(
+            [
+                "--- src/lib.rs",
+                "+++ src/lib.rs",
+                "@@ -20,3 +19,0 @@",
+                "-gone",
+                "-gone too",
+                "-and this",
+            ]
+        )
+        self.assertEqual(gate_diff.parse_unified_diff_zero_context(diff), {})
+
+    def test_deleted_file_is_skipped(self) -> None:
+        diff = "\n".join(
+            [
+                "--- src/dead.rs",
+                "+++ /dev/null",
+                "@@ -1,3 +0,0 @@",
+                "-a",
+                "-b",
+                "-c",
+            ]
+        )
+        self.assertEqual(gate_diff.parse_unified_diff_zero_context(diff), {})
+
+    def test_multiple_hunks_and_files(self) -> None:
+        diff = "\n".join(
+            [
+                "--- src/a.rs",
+                "+++ src/a.rs",
+                "@@ -1,0 +1,2 @@",
+                "+a1",
+                "+a2",
+                "@@ -50,0 +52,1 @@",
+                "+a3",
+                "--- src/b.rs",
+                "+++ src/b.rs",
+                "@@ -3,1 +3,1 @@",
+                "-old",
+                "+new",
+            ]
+        )
+        self.assertEqual(
+            gate_diff.parse_unified_diff_zero_context(diff),
+            {"src/a.rs": [(1, 2), (52, 52)], "src/b.rs": [(3, 3)]},
+        )
+
+
+class Intersects(unittest.TestCase):
+    def test_overlapping_ranges(self) -> None:
+        self.assertTrue(gate_diff.intersects((10, 20), (15, 25)))
+        self.assertTrue(gate_diff.intersects((15, 25), (10, 20)))
+
+    def test_touching_at_a_single_line_counts_as_overlap(self) -> None:
+        self.assertTrue(gate_diff.intersects((10, 20), (20, 30)))
+
+    def test_disjoint_ranges(self) -> None:
+        self.assertFalse(gate_diff.intersects((10, 20), (21, 30)))
+
+    def test_one_range_contains_the_other(self) -> None:
+        self.assertTrue(gate_diff.intersects((1, 100), (40, 41)))
+
+    def test_any_intersect_true_only_when_one_range_matches(self) -> None:
+        ranges = [(1, 5), (50, 60)]
+        self.assertTrue(gate_diff.any_intersect(ranges, (55, 58)))
+        self.assertFalse(gate_diff.any_intersect(ranges, (10, 20)))
+        self.assertFalse(gate_diff.any_intersect([], (1, 1000)))
+
+
+class ComplexityFindViolations(unittest.TestCase):
+    def test_flags_only_functions_the_diff_touches(self) -> None:
+        ranges = {"src/lib.rs": [(10, 15)]}
+        functions_by_file = {
+            "src/lib.rs": [
+                {"name": "touched_and_complex", "start": 10, "end": 15, "cyclomatic": 25},
+                {"name": "untouched_and_complex", "start": 100, "end": 120, "cyclomatic": 99},
+                {"name": "touched_but_simple", "start": 12, "end": 13, "cyclomatic": 3},
+            ]
+        }
+        violations = complexity_gate.find_violations(ranges, functions_by_file, max_cyclomatic=20)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("touched_and_complex", violations[0])
+        self.assertIn("cyclomatic complexity 25", violations[0])
+
+    def test_no_violations_when_nothing_over_the_limit(self) -> None:
+        ranges = {"src/lib.rs": [(1, 100)]}
+        functions_by_file = {
+            "src/lib.rs": [{"name": "fine", "start": 1, "end": 10, "cyclomatic": 5}]
+        }
+        self.assertEqual(
+            complexity_gate.find_violations(ranges, functions_by_file, max_cyclomatic=20), []
+        )
+
+    def test_untouched_file_contributes_no_violations(self) -> None:
+        ranges = {"src/other.rs": [(1, 5)]}
+        functions_by_file = {
+            "src/lib.rs": [{"name": "huge", "start": 1, "end": 500, "cyclomatic": 500}]
+        }
+        self.assertEqual(
+            complexity_gate.find_violations(ranges, functions_by_file, max_cyclomatic=20), []
+        )
+
+
+class DuplicationFindViolations(unittest.TestCase):
+    def _dup(self, first: tuple[str, int, int], second: tuple[str, int, int], lines: int = 12) -> dict:
+        return {
+            "firstFile": {"name": first[0], "start": first[1], "end": first[2]},
+            "secondFile": {"name": second[0], "start": second[1], "end": second[2]},
+            "lines": lines,
+        }
+
+    def test_new_code_duplicating_old_code_fails(self) -> None:
+        ranges = {"src/new.rs": [(1, 20)]}
+        dup = self._dup(("src/new.rs", 5, 16), ("src/old.rs", 100, 111))
+        violations = duplication_gate.find_violations([dup], ranges)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("src/new.rs:5-16 (new)", violations[0])
+        self.assertNotIn("src/old.rs:100-111 (new)", violations[0])
+
+    def test_two_untouched_clones_are_not_flagged(self) -> None:
+        ranges = {"src/elsewhere.rs": [(1, 5)]}
+        dup = self._dup(("src/old_a.rs", 1, 12), ("src/old_b.rs", 1, 12))
+        self.assertEqual(duplication_gate.find_violations([dup], ranges), [])
+
+    def test_new_code_duplicating_itself_flags_both_sides(self) -> None:
+        ranges = {"src/new.rs": [(1, 50)]}
+        dup = self._dup(("src/new.rs", 1, 12), ("src/new.rs", 20, 31))
+        violations = duplication_gate.find_violations([dup], ranges)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("(new)", violations[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_gate_diff.py
+++ b/scripts/ci/test_gate_diff.py
@@ -3,9 +3,14 @@
 
 This is the part correctness actually hinges on: get the intersection wrong
 and the gate either lets new debt through or fails an innocent PR for
-something it never touched. Runs against synthetic diff text and synthetic
-tool output, so it needs neither git history nor `rust-code-analysis-cli` /
-`jscpd` installed.
+something it never touched. Most of this runs against synthetic diff text and
+synthetic tool output, needing neither git history nor
+`rust-code-analysis-cli` / `jscpd` installed. The merge-base tests are the
+exception: they build real, disposable git repositories under a temp
+directory to reproduce a shallow checkout, because the bug they guard --
+`git merge-base` failing on two disconnected single-commit histories -- only
+exists in git's own history-walking behavior, not in anything this module
+could fake convincingly.
 
     just test-quality-gates
     python3 scripts/ci/test_gate_diff.py
@@ -15,6 +20,7 @@ from __future__ import annotations
 
 import os
 import stat
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -177,6 +183,89 @@ class ResolveCargoTool(unittest.TestCase):
                     with self.assertRaises(SystemExit) as raised:
                         gate_diff.resolve_cargo_tool("some-tool", "do not substitute npm")
             self.assertIn("do not substitute npm", str(raised.exception))
+
+
+class MergeBaseShallowHistory(unittest.TestCase):
+    def _git(self, args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+    def _is_shallow(self, repo: Path) -> bool:
+        return self._git(["rev-parse", "--is-shallow-repository"], repo).stdout.strip() == "true"
+
+    def _commit(self, repo: Path, message: str) -> str:
+        (repo / "file.txt").write_text(message)
+        self._git(["add", "."], repo)
+        self._git(["commit", "--quiet", "-m", message], repo)
+        return self._git(["rev-parse", "HEAD"], repo).stdout.strip()
+
+    def _init_repo(self, repo: Path, initial_branch: str) -> None:
+        repo.mkdir()
+        self._git(["init", "--quiet", "-b", initial_branch], repo)
+        self._git(["config", "user.email", "test@example.com"], repo)
+        self._git(["config", "user.name", "Test"], repo)
+
+    def _shallow_checkout_of_branch_tip(self, origin: Path, branch: str, work: Path) -> None:
+        """Reproduce what `actions/checkout` leaves behind for a PR head.
+
+        A depth-1 `actions/checkout` configures the broad
+        `+refs/heads/*:refs/remotes/origin/*` refspec but fetches only the
+        one commit it needs, so the checked-out branch's remote-tracking ref
+        exists locally with a single commit and no reachable parent -- the
+        exact shape `ensure_ref`'s later fetch of a *different* branch does
+        not, by itself, fix.
+        """
+        work.mkdir()
+        self._git(["init", "--quiet"], work)
+        self._git(["remote", "add", "origin", f"file://{origin}"], work)
+        self._git(["config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"], work)
+        tip = self._git(["rev-parse", branch], origin).stdout.strip()
+        self._git(
+            ["fetch", "--quiet", "--depth=1", "origin", f"+{tip}:refs/remotes/origin/{branch}"],
+            work,
+        )
+        self._git(["checkout", "--quiet", "-b", branch, f"origin/{branch}"], work)
+
+    def test_deepens_shallow_history_to_find_the_merge_base(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            origin = Path(tmp) / "origin"
+            work = Path(tmp) / "work"
+            self._init_repo(origin, "main")
+            shared_ancestor = self._commit(origin, "shared ancestor")
+            self._git(["checkout", "--quiet", "-b", "feature"], origin)
+            self._commit(origin, "feature work")
+            self._git(["checkout", "--quiet", "main"], origin)
+            self._commit(origin, "main moved on without the feature branch")
+
+            self._shallow_checkout_of_branch_tip(origin, "feature", work)
+            self.assertTrue(self._is_shallow(work))
+
+            with mock.patch("gate_diff.ROOT", work):
+                self.assertEqual(gate_diff.merge_base("origin/main"), shared_ancestor)
+            self.assertFalse(self._is_shallow(work))
+
+    def test_raises_when_histories_truly_share_no_ancestor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            origin_main = Path(tmp) / "origin_main"
+            origin_feature = Path(tmp) / "origin_feature"
+            work = Path(tmp) / "work"
+            self._init_repo(origin_main, "main")
+            self._commit(origin_main, "main's own unrelated root")
+            self._init_repo(origin_feature, "feature")
+            self._commit(origin_feature, "feature's own unrelated root")
+
+            work.mkdir()
+            self._git(["init", "--quiet"], work)
+            self._git(["remote", "add", "origin", f"file://{origin_main}"], work)
+            self._git(["fetch", "--quiet", "origin", "main"], work)
+            self._git(["remote", "add", "elsewhere", f"file://{origin_feature}"], work)
+            self._git(["fetch", "--quiet", "elsewhere", "feature"], work)
+            self._git(["checkout", "--quiet", "-b", "feature", "elsewhere/feature"], work)
+            self.assertFalse(self._is_shallow(work))
+
+            with mock.patch("gate_diff.ROOT", work):
+                with self.assertRaises(SystemExit) as raised:
+                    gate_diff.merge_base("origin/main")
+            self.assertIn("share no common ancestor", str(raised.exception))
 
 
 class ComplexityFindViolations(unittest.TestCase):


### PR DESCRIPTION
## Do not merge -- draft, sequencing owned by the user (P0 rendering fix and a layout bug fix are in flight; another agent owns AGENTS.md right now).

## Update: fixed a real determinism bug found in review

The original version probed with `command -v jscpd >/dev/null || cargo install jscpd --locked` (and the same shape for `rust-code-analysis-cli`). On this development machine that probe silently found `/opt/homebrew/bin/jscpd` -- an npm global installed earlier in this same session, whose `run-jscpd.js` shells out to a separately-downloaded prebuilt binary -- and skipped the cargo install entirely. On macm3, which has neither `node` nor `npm`, the same probe falls through to cargo and installs the real crate. **Same recipe, two different code paths to a binary, and the output never says which one ran.** Worse, it fails in the direction that looks safe: a developer testing locally gets a verdict from whichever jscpd their machine already has, while CI gets its verdict from a different one.

Fixed with `gate_diff.resolve_cargo_tool`: it never reads `$PATH` at all. It resolves straight to `$CARGO_HOME/bin/<name>` (or `~/.cargo/bin/<name>`), running `cargo install <name> --locked` only when that exact path is missing, and both gates now invoke that resolved `Path` instead of a bare tool name. Confirmed on this machine that the bug was real and is now fixed: `which jscpd` still resolves to the npm one, `gate_diff.resolve_cargo_tool("jscpd")` correctly resolves to `~/.cargo/bin/jscpd` regardless. Re-ran the full synthetic-violation check from before through the fixed recipes -- same file:line failures, same clean pass after reverting. 5 new unit tests cover the resolver's already-present / install-then-resolve / install-fails paths against a scratch `CARGO_HOME`, cargo mocked out so they run in milliseconds.

The "why cargo and not npm" fact does not live in a comment (a separate effort is stripping all comments from this repo, correctly, and that comment would have gone with them) -- it is now the `SystemExit` message `resolve_cargo_tool` raises for `jscpd` specifically if `cargo install jscpd --locked` cannot run, which is exactly the moment someone would otherwise reach for `npm install -g jscpd` instead of fixing the actual problem.

---

## Feasibility answer, first

Both gates are possible and both are implemented here as `just` recipes CI calls (`just complexity-gate`, `just duplication-gate`), scoped to the diff only.

**RustRover's own duplicate inspection cannot run in CI as-is.** JetBrains' Inspectopedia page for "Duplicated code fragment" (https://www.jetbrains.com/help/inspectopedia/DuplicatedCode.html) lists exactly which products ship it: CLion, DataGrip, GoLand, IntelliJ IDEA, Rider, PhpStorm, PyCharm, RubyMine, WebStorm, and Qodana for .NET/Go/JS/JVM/PHP/Ruby. **RustRover is not on that list, and neither is Qodana for Rust.** Qodana for Rust exists (2026.2, still EAP -- "Your team can begin exploring automated inspections for Rust projects in CI", per JetBrains' own release post) with 150+ inspections for dead code, lifetimes, unsafe code, but duplicate/copy-paste detection is not named among them anywhere I could find. I pulled `jetbrains/qodana-rust:latest` (Docker Hub confirms it's a real, current image) and ran it locally (via colima, no cloud token, no cloud upload -- it carries a bundled 60-day eval license and runs fully offline) against a 2-function, 34-line fixture crate. It was still stuck on "Project opening" after 7.5 minutes, at which point I killed it. That alone rules it out for a per-PR gate on a workspace this size (~900 Rust files), independent of whether the inspection exists for Rust at all. There is also a stale, never-wired `qodana.yaml` already checked into the repo root (literal `<linter>` placeholder, no CI reference anywhere) -- dead scaffolding, not a prior decision either way.

## Gate 1: cyclomatic complexity

**Tool: `rust-code-analysis-cli`** (Mozilla), via `cargo install --locked`. It parses (does not compile), so the gate only ever costs milliseconds against the files the diff touches, not the workspace. Rejected: clippy's `cognitive_complexity` nursery lint would need the *whole workspace* to compile before it says anything about one changed function, which is a full `just clippy` cost paid again for one extra lint; it's also cognitive-only and a nursery lint (explicitly flagged as possibly noisy in the task). `lizard` was not pursued once rust-code-analysis-cli proved out -- both would need the same diff-scoping wrapper, and RCA gives cyclomatic *and* cognitive in one JSON pass.

Calibration (2026-08-29, crates + apps + xtask, wasm-bindgen/build output excluded, 34,658 functions):

| percentile | cyclomatic |
|---|---|
| p50 | 1 |
| p90 | 5 |
| p95 | 8 |
| p99 | 19 |
| p99.9 | 49 |
| max | 221 (generated wasm-bindgen match; a winit event-loop dispatch) |

Recommended and set: **max_cyclomatic = 20** in `scripts/ci/code_quality_gates.toml` -- just above the p99 line of the codebase's own existing functions, so it accepts what the best 99% of today's code already looks like.

## Gate 2: duplication

**Tool: `jscpd` v5**, via `cargo install jscpd --locked`. jscpd v5's actual engine is a real Rust workspace (`cpd-core`/`cpd-tokenizer`/`cpd-finder`, published straight to crates.io as the `jscpd` crate) -- its npm package is a thin wrapper shipping the same prebuilt binary. Installing from crates.io means no Node.js dependency; I checked `ssh macm3` (the default macOS CI runner) and it has no `node`/`npm` on PATH at all, which would have made an npm-based recipe fail cold on first run.

Rejected: **PMD 7 CPD** does have a Rust tokenizer (`--language rust` is a real, listed option in `pmd cpd --help` on 7.27.0, confirming the earlier PR claim), but it lexed two files in this workspace (`crates/cranpose-services/src/notifier.rs`, `xtask/src/main.rs`) as ANTLR "Lexical error" and skipped them, and a scan of `crates/` alone (not even the full repo) took 87.6s against jscpd's 321-445ms for the *entire* repository -- roughly 250x slower for a fraction of the scope, on top of the correctness gap. Rejected: Qodana, covered above.

Existing duplication (2026-08-29, whole repo, min-lines=10, min-tokens=50, target/pkg/node_modules excluded): **1,592 clones, 26,181 duplicated lines, 5.4% of all lines.** This does not block the gate -- it's diff-scoped, so none of that existing debt is on the hook, only new clones that touch a diff.

Recommended and set: **min_lines = 10** (matches AGENTS.md's existing rule verbatim), **min_tokens = 50** in the same config file.

## Diff scoping

`scripts/ci/gate_diff.py` computes the merge base against `origin/main` (fetched fresh every run -- a persistent self-hosted runner can have a stale `origin/main` ref that resolves but lies, so this doesn't only fetch when the ref is missing), then `git diff --unified=0 --no-prefix <merge-base>` against the working tree (covers uncommitted changes locally; in CI the working tree is the checked-out commit). Each hunk's new-side range becomes an inclusive `(start, end)` per file. A function or a clone is only checked when its span intersects one of those ranges. `origin/main` is a default argument (`just complexity-gate [base]`), not a hardcoded assumption -- it just happens to be correct unconditionally here because this repo's only PR target is `main`.

16 unit tests (`just test-quality-gates`, stdlib `unittest`, no git/tool dependency) cover the hunk-header parsing (single hunk, omitted count-of-1, pure deletions, deleted files, multiple hunks/files) and the violation-matching logic (diff-touched vs. diff-untouched functions and clones) directly, since this is the part where a bug either lets debt through silently or fails an innocent PR.

Both gates were also checked end-to-end against a real synthetic violation: an 11-line verbatim duplicate of `run_in_mutable_snapshot` and a 22-branch `probe_needlessly_complex` function, staged into `crates/cranpose-core/src/lib.rs`. Both gates failed with exact `file:line-range function/clone` detail; both passed clean again once reverted.

## Performance

`just complexity-gate`: 0.4s. `just duplication-gate`: 0.6s. Both against the full workspace, tools already installed. First-run tool provisioning (same `command -v X || cargo install X --locked` idiom `just typos` already uses) costs about 30-35s once per runner, not per PR, since these are persistent self-hosted machines.

## What doesn't fully work / caveats

- The complexity gate's "function span" comes from `rust-code-analysis-cli`'s own AST spans; a closure gets its own span nested inside its enclosing function, so a diff that only touches a closure body is checked against the closure's own (usually smaller) complexity, and separately the enclosing function's total may or may not also cross the limit depending on how RCA attributes nested scopes. **This means the gate can flag a function the diff did not meaningfully change**: editing one line inside a closure can be reported against the enclosing function's pre-existing complexity total, not against anything the diff actually made worse. Not a bug, just a real sharp edge -- worth knowing before the first person it happens to loses confidence in the gate.
- `origin/main` must be fetchable for the merge-base computation; a fully offline dev machine with a same-day local `origin/main` still works (fetch failure is non-fatal if the ref already resolves), but a machine that has never fetched `origin/main` at all will get a clear error, not a silent wrong answer.
- I did not attempt to mirror these into cranscan in this PR -- see the task notes; that repo has no `justfile` and an explicit "no code comments" rule, so it needs its own adapted (comment-free, inlined-in-`ci.yml`) version rather than a copy-paste, and its own calibration pass against its own codebase. Flagging as follow-up rather than half-doing it here.

## Suggested AGENTS.md addition (for reconciliation, not applied here)

```
- complexity-gate/duplication-gate: diff-scoped only (see scripts/ci/gate_diff.py); an
  existing violation is never on the hook unless the diff touches its span. Thresholds
  live in scripts/ci/code_quality_gates.toml, not in the scripts.
```

## Files

- `scripts/ci/gate_diff.py` -- shared diff-scoping (merge base, hunk parsing, intersection)
- `scripts/ci/complexity_gate.py`, `scripts/ci/duplication_gate.py` -- the two gates
- `scripts/ci/test_gate_diff.py` -- 16 unit tests, `just test-quality-gates`
- `scripts/ci/code_quality_gates.toml` -- thresholds, not hardcoded in the scripts
- `justfile` -- `complexity-gate`, `duplication-gate`, `test-quality-gates` recipes, wired into `ci`
- `.github/workflows/rust.yml` -- three new steps in the macOS `checks` job (calls the recipes, no inline gate logic)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
