### PR TITLE
Expose the size-reporter seam as observable state, so size-reactive topology needs no subcompose boundary

### DIFF
--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -5111,6 +5111,61 @@ fn size_reactive_topology_switches_on_resize_and_settles() {
     );
 }
 
+#[composable]
+#[allow(non_snake_case)]
+fn AppShellSelfReferentialSize() {
+    let size = rememberMutableStateOf(cranpose_ui::Size::default);
+    // The onSizeChanged self-reference hazard, on purpose: the reported size
+    // decides the content's height, so the node's own measured size flips
+    // between two values forever — a cross-frame livelock no equality gate
+    // can decide, because every write IS a genuine change.
+    let height = if size.get().height < 100.0 {
+        200.0
+    } else {
+        50.0
+    };
+    cranpose_ui::Box(
+        Modifier::empty().fill_max_width().report_size_state(size),
+        cranpose_ui::BoxSpec::default(),
+        move || {
+            cranpose_ui::Box(
+                Modifier::empty().size(cranpose_ui::Size::new(80.0, height)),
+                cranpose_ui::BoxSpec::default(),
+                || {},
+            );
+        },
+    );
+}
+
+/// The class the settle test cannot see: self-referential sizing is a
+/// livelock of genuine changes, one recomposition per frame forever, with no
+/// diagnostic in release. The debug ceiling converts it into a panic naming
+/// the two alternating sizes.
+#[test]
+#[should_panic(expected = "size-reactive feedback loop")]
+fn a_self_referential_size_report_panics_in_debug_instead_of_livelocking() {
+    let _guard = test_guard();
+    let root_key = location_key(file!(), line!(), column!());
+    let rebuilds = Rc::new(Cell::new(0));
+    let updates = Rc::new(Cell::new(0));
+    let last_dirty_nodes = Rc::new(RefCell::new(Vec::new()));
+
+    let mut shell = AppShell::new(
+        ScopedUpdateCountingRenderer::new(
+            Rc::clone(&rebuilds),
+            Rc::clone(&updates),
+            Rc::clone(&last_dirty_nodes),
+        ),
+        root_key,
+        AppShellSelfReferentialSize,
+    );
+    shell.set_buffer_size(320, 240);
+    shell.set_viewport(320.0, 240.0);
+    for _ in 0..200 {
+        shell.update();
+    }
+}
+
 fn graph_scene_solid_rect_y(
     scene: &cranpose_render_common::graph_scene::Scene,
     color: cranpose_ui::Color,

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -5029,6 +5029,88 @@ fn AppShellOrdinaryColumnSiblings() {
     );
 }
 
+#[composable]
+#[allow(non_snake_case)]
+fn AppShellSizeReactiveTopology() {
+    let size = rememberMutableStateOf(cranpose_ui::Size::default);
+    cranpose_ui::Box(
+        Modifier::empty().fill_max_size().report_size_state(size),
+        cranpose_ui::BoxSpec::default(),
+        move || {
+            if size.get().width < 700.0 {
+                Text(
+                    "compact".to_string(),
+                    Modifier::empty(),
+                    TextStyle::default(),
+                );
+            } else {
+                Text("wide".to_string(), Modifier::empty(), TextStyle::default());
+            }
+        },
+    );
+}
+
+/// The correctness test for replacing a `BoxWithConstraints` wrapper with
+/// `report_size_state`: the work the wrapper was doing is switching composed
+/// topology when the available size crosses a threshold, so THAT is what the
+/// replacement must be shown to still do — and a resize must SETTLE, because
+/// an unconditional state write during measure would recompose, re-measure
+/// and loop, a frame-rate collapse no pixel assertion sees.
+#[test]
+fn size_reactive_topology_switches_on_resize_and_settles() {
+    let _guard = test_guard();
+    let root_key = location_key(file!(), line!(), column!());
+    let rebuilds = Rc::new(Cell::new(0));
+    let updates = Rc::new(Cell::new(0));
+    let last_dirty_nodes = Rc::new(RefCell::new(Vec::new()));
+
+    let mut shell = AppShell::new(
+        ScopedUpdateCountingRenderer::new(
+            Rc::clone(&rebuilds),
+            Rc::clone(&updates),
+            Rc::clone(&last_dirty_nodes),
+        ),
+        root_key,
+        AppShellSizeReactiveTopology,
+    );
+    shell.set_buffer_size(320, 240);
+    shell.set_viewport(320.0, 240.0);
+    for _ in 0..5 {
+        shell.update();
+        if !shell.needs_redraw() {
+            break;
+        }
+    }
+    let labels = graph_scene_text_values(shell.renderer.scene());
+    assert!(
+        labels.iter().any(|l| l == "compact") && !labels.iter().any(|l| l == "wide"),
+        "at 320dp the size-reactive topology must be compact: {labels:?}"
+    );
+
+    shell.set_buffer_size(900, 600);
+    shell.set_viewport(900.0, 600.0);
+    let mut settle_frames = 0;
+    for _ in 0..5 {
+        shell.update();
+        settle_frames += 1;
+        if !shell.needs_redraw() && !shell.composition.should_recompose() {
+            break;
+        }
+    }
+    assert!(
+        !shell.needs_redraw() && !shell.composition.should_recompose(),
+        "a single resize must settle within 5 frames; a pending recomposition \
+         here is the unconditional-write feedback loop (a size write during \
+         measure that is not equality-gated recomposes forever)"
+    );
+    let labels = graph_scene_text_values(shell.renderer.scene());
+    assert!(
+        labels.iter().any(|l| l == "wide") && !labels.iter().any(|l| l == "compact"),
+        "crossing 700dp must switch the composed topology to wide within \
+         {settle_frames} settle frames: {labels:?}"
+    );
+}
+
 fn graph_scene_solid_rect_y(
     scene: &cranpose_render_common::graph_scene::Scene,
     color: cranpose_ui::Color,

--- a/crates/cranpose-ui/src/bring_into_view.rs
+++ b/crates/cranpose-ui/src/bring_into_view.rs
@@ -164,6 +164,24 @@ impl Modifier {
             crate::modifier_nodes::SizeReporterElement::new(sink),
         ))
     }
+
+    /// Publishes this node's measured size into observable state, so an
+    /// actual size change schedules recomposition — size-reactive topology
+    /// without a `BoxWithConstraints` subcompose boundary. Writes are
+    /// equality-gated by `MutableState::set`, so a pass that re-measures the
+    /// node at its current size schedules nothing and a threshold-style use
+    /// (state feeds the CONTENT, the node's own size does not depend on it)
+    /// settles in one extra pass. Content whose measured size depends on the
+    /// reported size can still oscillate — the same self-referential hazard
+    /// as Compose's `onSizeChanged`, and no gate can decide it for you.
+    pub fn report_size_state(
+        self,
+        sink: cranpose_core::MutableState<cranpose_ui_graphics::Size>,
+    ) -> Self {
+        self.then(Modifier::with_element(
+            crate::modifier_nodes::SizeReporterElement::from_state(sink),
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/crates/cranpose-ui/src/modifier_nodes.rs
+++ b/crates/cranpose-ui/src/modifier_nodes.rs
@@ -1710,6 +1710,15 @@ impl SizeSink for StateSizeSink {
 pub struct SizeReporterNode {
     sink: Rc<dyn SizeSink>,
     state: NodeState,
+    /// Debug-only oscillation detector: (last, second_last, alternations).
+    /// A self-referential size — content whose measured size depends on the
+    /// size this node reports — presents as a cross-frame livelock (one
+    /// recomposition per frame, forever) with no diagnostic. Exact A-B-A
+    /// alternation is that loop's signature and matches no animation, which
+    /// moves monotonically or along a curve rather than flipping between two
+    /// identical values.
+    #[cfg(debug_assertions)]
+    oscillation: Cell<(Size, Size, u32)>,
 }
 
 impl SizeReporterNode {
@@ -1717,7 +1726,32 @@ impl SizeReporterNode {
         Self {
             sink,
             state: NodeState::new(),
+            #[cfg(debug_assertions)]
+            oscillation: Cell::new((Size::default(), Size::default(), 0)),
         }
+    }
+
+    #[cfg(debug_assertions)]
+    fn check_oscillation(&self, size: Size) {
+        const ALTERNATION_CEILING: u32 = 64;
+        let (last, second_last, count) = self.oscillation.get();
+        let count = if size == second_last && size != last {
+            count + 1
+        } else if size == last {
+            count
+        } else {
+            0
+        };
+        assert!(
+            count <= ALTERNATION_CEILING,
+            "size-reactive feedback loop: this node's measured size has \
+             alternated between {last:?} and {size:?} for {count} passes — \
+             its content's size depends on the size it reports (the \
+             onSizeChanged self-reference hazard). Break the cycle by making \
+             the reported size feed only content that does not change this \
+             node's own measured size."
+        );
+        self.oscillation.set((size, last, count));
     }
 }
 
@@ -1749,6 +1783,8 @@ impl LayoutModifierNode for SizeReporterNode {
             width: placeable.width(),
             height: placeable.height(),
         };
+        #[cfg(debug_assertions)]
+        self.check_oscillation(size);
         self.sink.set(size);
         cranpose_ui_layout::LayoutModifierMeasureResult::new(size, 0.0, 0.0)
     }

--- a/crates/cranpose-ui/src/modifier_nodes.rs
+++ b/crates/cranpose-ui/src/modifier_nodes.rs
@@ -1679,18 +1679,41 @@ impl ModifierNodeElement for WindowRectReporterElement {
 // Size Reporter Modifier Node
 // ============================================================================
 
-/// Node that publishes its measured size (logical px) into a shared cell on
+/// Where a [`SizeReporterNode`] publishes its measured size. A plain `Cell`
+/// is invisible to composition; the `MutableState` sink schedules
+/// recomposition on an actual change (`MutableState::set` is
+/// equality-gated), which is what makes size-reactive topology settle: a
+/// re-measure that produces the same size writes nothing and cannot loop.
+pub trait SizeSink {
+    fn set(&self, size: Size);
+}
+
+impl SizeSink for Cell<Size> {
+    fn set(&self, size: Size) {
+        Cell::set(self, size);
+    }
+}
+
+struct StateSizeSink(cranpose_core::MutableState<Size>);
+
+impl SizeSink for StateSizeSink {
+    fn set(&self, size: Size) {
+        self.0.set(size);
+    }
+}
+
+/// Node that publishes its measured size (logical px) into its sink on
 /// every measure pass — the Compose `onSizeChanged` seam for consumers that
 /// need their node's resolved size outside layout (e.g. shader morph
 /// geometry expressed in node-local pixels). Transparent for layout, draws
 /// nothing.
 pub struct SizeReporterNode {
-    sink: Rc<Cell<Size>>,
+    sink: Rc<dyn SizeSink>,
     state: NodeState,
 }
 
 impl SizeReporterNode {
-    pub fn new(sink: Rc<Cell<Size>>) -> Self {
+    pub fn new(sink: Rc<dyn SizeSink>) -> Self {
         Self {
             sink,
             state: NodeState::new(),
@@ -1734,12 +1757,20 @@ impl LayoutModifierNode for SizeReporterNode {
 /// Element for [`SizeReporterNode`]; reuses the node, swapping the sink.
 #[derive(Clone)]
 pub struct SizeReporterElement {
-    sink: Rc<Cell<Size>>,
+    sink: Rc<dyn SizeSink>,
 }
 
 impl SizeReporterElement {
     pub fn new(sink: Rc<Cell<Size>>) -> Self {
         Self { sink }
+    }
+
+    /// Publishes into observable state, so an actual size change schedules
+    /// recomposition — the sink for size-reactive topology.
+    pub fn from_state(sink: cranpose_core::MutableState<Size>) -> Self {
+        Self {
+            sink: Rc::new(StateSizeSink(sink)),
+        }
     }
 }
 
@@ -1751,13 +1782,13 @@ impl std::fmt::Debug for SizeReporterElement {
 
 impl PartialEq for SizeReporterElement {
     fn eq(&self, other: &Self) -> bool {
-        Rc::ptr_eq(&self.sink, &other.sink)
+        std::ptr::addr_eq(Rc::as_ptr(&self.sink), Rc::as_ptr(&other.sink))
     }
 }
 
 impl Hash for SizeReporterElement {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        (Rc::as_ptr(&self.sink) as usize).hash(state);
+        (Rc::as_ptr(&self.sink) as *const () as usize).hash(state);
     }
 }
 


### PR DESCRIPTION
First slice of the subcompose-chain work, per the reviewed order: the wrapper audit found cranscan's scaffold-content `BoxWithConstraints` receiving FIXED constraints (min==max both axes) and burning ~0.4 ms/pass on the Mate re-deriving `Ctx{compact,width,height}` — values that change only on window resize. A `BoxWithConstraints` whose constraints cannot vary cannot be doing constraint-dependent composition; that is arithmetic, not argument.

`SizeReporterNode` already publishes the measured size every pass ("the Compose onSizeChanged seam"); the missing piece was a sink composition can observe. This exposes it:

- `SizeSink` trait (existing `Cell` impl unchanged, `report_size` untouched), plus a `MutableState` sink and `Modifier::report_size_state`.
- Change-gating is the state mechanism's own equality gate, not caller discipline: a pass that re-measures at the current size writes nothing, so threshold-style use settles in one extra pass. The self-referential hazard (content size depending on the reported size) is the same as Compose's `onSizeChanged` and is stated on the API.

Per the correctness-first rule, this ships with the test that fails when the replacement is wrong: `size_reactive_topology_switches_on_resize_and_settles` drives the viewport across the 700dp threshold and asserts the composed topology switches AND the frame settles (no pending recomposition within five frames). Verified red by severing the state sink — the topology stays compact forever.

The cranscan-side swap (BWC → `Box` + `report_size_state`) follows after this merges, with the same on-device layout_ms A/B; predicted ~0.4 ms/pass back out of the 1.71. Scaffold's ~0.68 ms bar re-measure is the dirty-id-retention work and is deliberately not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)