### PR TITLE
Reuse retained subcompose slots on measure passes that cannot have changed them

### DIFF
--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -5602,6 +5602,118 @@ fn a_measure_computed_capture_reaches_slot_content_through_the_subcompose_key() 
     );
 }
 
+thread_local! {
+    static CAROUSEL_SCROLL_STATE: RefCell<Option<ScrollState>> = const { RefCell::new(None) };
+}
+
+#[composable]
+fn app_shell_lazy_carousel_probe() {
+    let list_state = rememberLazyListState();
+    LazyColumn(
+        Modifier::empty().fill_max_size(),
+        list_state,
+        LazyColumnSpec::new(),
+        |scope| {
+            scope.items(20, |index| {
+                if index == 0 {
+                    let inner =
+                        cranpose_core::remember(|| ScrollState::new(0.0)).with(|state| *state);
+                    CAROUSEL_SCROLL_STATE.with(|slot| {
+                        *slot.borrow_mut() = Some(inner);
+                    });
+                    Row(
+                        Modifier::empty()
+                            .fill_max_width()
+                            .height(60.0)
+                            .horizontal_scroll(inner, false),
+                        RowSpec::new(),
+                        || {
+                            Text(
+                                "carousel start",
+                                Modifier::empty().width(160.0),
+                                TextStyle::default(),
+                            );
+                            Spacer(Size {
+                                width: 600.0,
+                                height: 0.0,
+                            });
+                            Text(
+                                "carousel end",
+                                Modifier::empty().width(160.0),
+                                TextStyle::default(),
+                            );
+                        },
+                    );
+                } else {
+                    Text(
+                        format!("plain row {index}"),
+                        Modifier::empty().height(48.0),
+                        TextStyle::default(),
+                    );
+                }
+            });
+        },
+    );
+}
+
+#[test]
+fn a_horizontal_scroll_inside_a_lazy_item_still_moves_when_its_measurement_is_cached() {
+    let _guard = test_guard();
+    CAROUSEL_SCROLL_STATE.with(|slot| slot.borrow_mut().take());
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(
+        TestRenderer::default(),
+        root_key,
+        app_shell_lazy_carousel_probe,
+    );
+    shell.set_buffer_size(320, 480);
+    shell.set_viewport(320.0, 480.0);
+    for _ in 0..5 {
+        shell.update();
+        if !shell.needs_redraw() && !shell.composition.should_recompose() {
+            break;
+        }
+    }
+    let initial_x = find_layout_box_with_text(
+        shell.layout_tree().expect("layout tree").root(),
+        "carousel start",
+    )
+    .expect("carousel start in layout tree")
+    .rect
+    .x;
+
+    let inner = CAROUSEL_SCROLL_STATE
+        .with(|slot| slot.borrow().as_ref().copied())
+        .expect("probe must expose the inner scroll state");
+    shell.app_context().clone().enter(|| inner.scroll_to(80.0));
+    for _ in 0..4 {
+        shell.update();
+        if !shell.needs_redraw() && !shell.composition.should_recompose() {
+            break;
+        }
+    }
+    let offset = inner.value_non_reactive();
+    assert!(
+        offset > 0.0,
+        "instrument dead: the inner scroll state never moved ({offset})"
+    );
+    let scrolled_x = find_layout_box_with_text(
+        shell.layout_tree().expect("layout tree").root(),
+        "carousel start",
+    )
+    .expect("carousel start after scroll")
+    .rect
+    .x;
+    assert!(
+        scrolled_x < initial_x - 40.0,
+        "a placement-only repass (schedule_layout_repass from a scroll offset) \
+         was swallowed: the inner row still sits at x={scrolled_x} after \
+         scrolling to offset {offset} (was x={initial_x}). The cached-measure \
+         gate must reject a needs_layout child instead of serving the cached \
+         measurement and clearing the flag"
+    );
+}
+
 fn graph_scene_solid_rect_y(
     scene: &cranpose_render_common::graph_scene::Scene,
     color: cranpose_ui::Color,

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -5142,6 +5142,10 @@ fn AppShellSelfReferentialSize() {
 /// diagnostic in release. The debug ceiling converts it into a panic naming
 /// the two alternating sizes.
 #[test]
+#[cfg_attr(
+    not(debug_assertions),
+    ignore = "the oscillation ceiling that converts this livelock into a panic only exists in debug builds"
+)]
 #[should_panic(expected = "size-reactive feedback loop")]
 fn a_self_referential_size_report_panics_in_debug_instead_of_livelocking() {
     let _guard = test_guard();
@@ -5180,7 +5184,7 @@ fn app_shell_clean_slot_scroll_probe() {
             CLEAN_SLOT_MEASURE_COUNT.with(|count| count.set(count.get() + 1));
             let width = constraints.max_width.max(constraints.min_width);
             let height = constraints.max_height.max(constraints.min_height);
-            let nodes = scope.subcompose(cranpose_core::SlotId::new(0), move || {
+            let nodes = scope.subcompose(cranpose_core::SlotId::new(0), (), move || {
                 CLEAN_SLOT_COMPOSE_COUNT.with(|count| count.set(count.get() + 1));
                 let list_state = rememberLazyListState();
                 CLEAN_SLOT_LIST_STATE.with(|slot| {
@@ -5203,9 +5207,13 @@ fn app_shell_clean_slot_scroll_probe() {
             });
             let mut placements = Vec::with_capacity(nodes.len());
             for node in nodes {
-                let placeable =
-                    scope.measure(node, cranpose_ui::Constraints::tight(width, height));
-                placements.push(cranpose_ui::Placement::new(placeable.node_id(), 0.0, 0.0, 0));
+                let placeable = scope.measure(node, cranpose_ui::Constraints::tight(width, height));
+                placements.push(cranpose_ui::Placement::new(
+                    placeable.node_id(),
+                    0.0,
+                    0.0,
+                    0,
+                ));
             }
             scope.layout(width, height, placements)
         },
@@ -5235,6 +5243,7 @@ fn a_scroll_measure_repass_does_not_recompose_a_subcompose_slot_that_read_no_scr
     }
     let settled_composes = CLEAN_SLOT_COMPOSE_COUNT.with(Cell::get);
     let settled_measures = CLEAN_SLOT_MEASURE_COUNT.with(Cell::get);
+    let settled_skips = cranpose_ui::clean_slot_skip_count();
     assert!(
         settled_composes >= 1 && settled_measures >= 1,
         "instrument dead: the probe never composed ({settled_composes}) or \
@@ -5270,20 +5279,326 @@ fn a_scroll_measure_repass_does_not_recompose_a_subcompose_slot_that_read_no_scr
          got {layout_texts:?}"
     );
 
-    let composes_after = CLEAN_SLOT_COMPOSE_COUNT.with(Cell::get);
-    assert_eq!(
-        composes_after, settled_composes,
+    let skips_after = cranpose_ui::clean_slot_skip_count();
+    assert!(
+        skips_after >= settled_skips + (measures_after - settled_measures) as u64,
         "a scroll-driven measure repass recomposed a subcompose slot whose \
-         composition read none of the scrolled state: the slot content \
-         closure ran {} extra times for {} extra measure passes. Every such \
-         run is the per-pass compose walk over the slot's retained \
-         composition (measured at ~0.3ms per body-sized slot per pass on a \
-         Kirin 980, and paid by whichever layer owns the slot — see \
+         composition read none of the scrolled state: only {} of the {} \
+         extra measure passes reused the retained slot. Every non-reused \
+         pass is the compose walk over the slot's retained composition \
+         (measured at ~0.3ms per body-sized slot per pass on a Kirin 980, \
+         and paid by whichever layer owns the slot — see \
          docs/subcompose_measure_cost.md). A measure pass over a slot with \
          no invalidated scopes must reuse the retained slot roots without \
          composing",
-        composes_after - settled_composes,
+        skips_after - settled_skips,
         measures_after - settled_measures,
+    );
+
+    // Debug builds shadow-compose every skipped slot to catch stale
+    // non-reactive reads, so the closure legitimately re-runs there; the
+    // no-recompose guarantee on the closure itself is release behavior.
+    #[cfg(not(debug_assertions))]
+    {
+        let composes_after = CLEAN_SLOT_COMPOSE_COUNT.with(Cell::get);
+        assert_eq!(
+            composes_after, settled_composes,
+            "the release skip path must not run the slot content closure at all"
+        );
+    }
+}
+
+thread_local! {
+    static SLOT_STATE_HANDLE: RefCell<Option<MutableState<i32>>> = const { RefCell::new(None) };
+}
+
+#[composable]
+fn app_shell_slot_reads_state_probe() {
+    let value = rememberMutableStateOf(|| 1);
+    SLOT_STATE_HANDLE.with(|slot| {
+        *slot.borrow_mut() = Some(value);
+    });
+    cranpose_ui::SubcomposeLayout(
+        Modifier::empty().fill_max_size(),
+        move |scope, constraints| {
+            let width = constraints.max_width.max(constraints.min_width);
+            let height = constraints.max_height.max(constraints.min_height);
+            let nodes = scope.subcompose(cranpose_core::SlotId::new(0), (), move || {
+                Text(
+                    format!("slot value {}", value.get()),
+                    Modifier::empty(),
+                    TextStyle::default(),
+                );
+            });
+            let mut placements = Vec::with_capacity(nodes.len());
+            for node in nodes {
+                let placeable = scope.measure(node, cranpose_ui::Constraints::tight(width, height));
+                placements.push(cranpose_ui::Placement::new(
+                    placeable.node_id(),
+                    0.0,
+                    0.0,
+                    0,
+                ));
+            }
+            scope.layout(width, height, placements)
+        },
+    );
+}
+
+#[test]
+fn a_state_write_reaches_slot_content_without_any_concurrent_layout_dirt() {
+    let _guard = test_guard();
+    SLOT_STATE_HANDLE.with(|slot| slot.borrow_mut().take());
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(
+        TestRenderer::default(),
+        root_key,
+        app_shell_slot_reads_state_probe,
+    );
+    shell.set_buffer_size(320, 240);
+    shell.set_viewport(320.0, 240.0);
+    for _ in 0..5 {
+        shell.update();
+        if !shell.needs_redraw() && !shell.composition.should_recompose() {
+            break;
+        }
+    }
+    let layout_texts = layout_tree_texts(shell.layout_tree().expect("layout tree"));
+    assert!(
+        layout_texts.iter().any(|text| text == "slot value 1"),
+        "instrument dead: initial slot text missing, got {layout_texts:?}"
+    );
+
+    let value = SLOT_STATE_HANDLE
+        .with(|slot| slot.borrow().as_ref().cloned())
+        .expect("probe must expose its state");
+    value.set(2);
+    assert!(
+        shell.composition.should_recompose(),
+        "the load-bearing claim of slot retention: a write to state read only \
+         inside a measure-time slot composition must invalidate that slot's \
+         recompose scope BEFORE any measure pass runs. Slot reads ride \
+         scope-level state subscriptions, not the per-pass measure observer \
+         (which is constructed fresh, never started, and dies with the pass); \
+         if this fails, nothing can carry 'still clean' across passes and \
+         clean-slot reuse is unsound"
+    );
+    for _ in 0..5 {
+        shell.update();
+        if !shell.needs_redraw() && !shell.composition.should_recompose() {
+            break;
+        }
+    }
+    let layout_texts = layout_tree_texts(shell.layout_tree().expect("layout tree"));
+    assert!(
+        layout_texts.iter().any(|text| text == "slot value 2"),
+        "a state write read only by subcompose slot content must reach the \
+         screen without any concurrent layout dirt; the slot still shows \
+         {layout_texts:?}. If this regresses, slot read-subscriptions are \
+         dying with the per-pass measure observer and nothing else schedules \
+         the remeasure"
+    );
+}
+
+thread_local! {
+    static UNKEYED_CELL: Cell<u32> = const { Cell::new(0) };
+    static KEYED_HEIGHT_STATE: RefCell<Option<MutableState<f32>>> = const { RefCell::new(None) };
+}
+
+#[composable]
+fn app_shell_unkeyed_cell_slot_probe() {
+    cranpose_ui::SubcomposeLayout(
+        Modifier::empty().fill_max_size(),
+        move |scope, constraints| {
+            let width = constraints.max_width.max(constraints.min_width);
+            let height = constraints.max_height.max(constraints.min_height);
+            let poison = UNKEYED_CELL.with(Cell::get);
+            let mut placements = Vec::new();
+            let nodes = scope.subcompose(cranpose_core::SlotId::new(0), (), move || {
+                for row in 0..=poison.min(3) {
+                    Text(
+                        format!("poisoned row {row}"),
+                        Modifier::empty().height(20.0),
+                        TextStyle::default(),
+                    );
+                }
+            });
+            for node in nodes {
+                let placeable = scope.measure(node, cranpose_ui::Constraints::loose(width, height));
+                placements.push(cranpose_ui::Placement::new(
+                    placeable.node_id(),
+                    0.0,
+                    0.0,
+                    1,
+                ));
+            }
+            let list_nodes = scope.subcompose(cranpose_core::SlotId::new(1), (), move || {
+                let list_state = rememberLazyListState();
+                CLEAN_SLOT_LIST_STATE.with(|slot| {
+                    *slot.borrow_mut() = Some(list_state);
+                });
+                LazyColumn(
+                    Modifier::empty().fill_max_size(),
+                    list_state,
+                    LazyColumnSpec::new(),
+                    |scope| {
+                        scope.items(80, |index| {
+                            Text(
+                                format!("driver row {index}"),
+                                Modifier::empty().height(48.0),
+                                TextStyle::default(),
+                            );
+                        });
+                    },
+                );
+            });
+            for node in list_nodes {
+                let placeable = scope.measure(node, cranpose_ui::Constraints::tight(width, height));
+                placements.push(cranpose_ui::Placement::new(
+                    placeable.node_id(),
+                    0.0,
+                    0.0,
+                    0,
+                ));
+            }
+            scope.layout(width, height, placements)
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(
+    not(debug_assertions),
+    ignore = "the shadow oracle that converts this staleness into a panic only exists in debug builds"
+)]
+#[should_panic(expected = "clean-slot skip diverged")]
+fn a_slot_reading_a_changed_cell_outside_the_key_panics_in_debug_instead_of_going_stale() {
+    let _guard = test_guard();
+    UNKEYED_CELL.with(|cell| cell.set(0));
+    CLEAN_SLOT_LIST_STATE.with(|slot| slot.borrow_mut().take());
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(
+        TestRenderer::default(),
+        root_key,
+        app_shell_unkeyed_cell_slot_probe,
+    );
+    shell.set_buffer_size(320, 480);
+    shell.set_viewport(320.0, 480.0);
+    for _ in 0..5 {
+        shell.update();
+        if !shell.needs_redraw() && !shell.composition.should_recompose() {
+            break;
+        }
+    }
+    UNKEYED_CELL.with(|cell| cell.set(2));
+    let list_state = CLEAN_SLOT_LIST_STATE
+        .with(|slot| slot.borrow().as_ref().copied())
+        .expect("probe must expose its lazy list state");
+    list_state.scroll_to_item(6, 0.0);
+    for _ in 0..4 {
+        shell.update();
+    }
+}
+
+#[composable]
+fn app_shell_keyed_measure_input_probe() {
+    let height = rememberMutableStateOf(|| 40.0f32);
+    KEYED_HEIGHT_STATE.with(|slot| {
+        *slot.borrow_mut() = Some(height);
+    });
+    cranpose_ui::SubcomposeLayout(
+        Modifier::empty().fill_max_size(),
+        move |scope, constraints| {
+            let width = constraints.max_width.max(constraints.min_width);
+            let total_height = constraints.max_height.max(constraints.min_height);
+            let bar_nodes = scope.subcompose(cranpose_core::SlotId::new(0), (), move || {
+                Box(
+                    Modifier::empty().height(height.get()),
+                    BoxSpec::default(),
+                    || {},
+                );
+            });
+            let mut bar_height = 0.0f32;
+            let mut placements = Vec::new();
+            for node in bar_nodes {
+                let placeable =
+                    scope.measure(node, cranpose_ui::Constraints::loose(width, total_height));
+                bar_height = bar_height.max(placeable.height());
+                placements.push(cranpose_ui::Placement::new(
+                    placeable.node_id(),
+                    0.0,
+                    0.0,
+                    1,
+                ));
+            }
+            let padding = bar_height;
+            let content_nodes =
+                scope.subcompose(cranpose_core::SlotId::new(1), padding, move || {
+                    Text(
+                        format!("content top pad {padding}"),
+                        Modifier::empty(),
+                        TextStyle::default(),
+                    );
+                });
+            for node in content_nodes {
+                let placeable = scope.measure(
+                    node,
+                    cranpose_ui::Constraints::tight(width, total_height - padding),
+                );
+                placements.push(cranpose_ui::Placement::new(
+                    placeable.node_id(),
+                    0.0,
+                    padding,
+                    0,
+                ));
+            }
+            scope.layout(width, total_height, placements)
+        },
+    );
+}
+
+#[test]
+fn a_measure_computed_capture_reaches_slot_content_through_the_subcompose_key() {
+    let _guard = test_guard();
+    KEYED_HEIGHT_STATE.with(|slot| slot.borrow_mut().take());
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(
+        TestRenderer::default(),
+        root_key,
+        app_shell_keyed_measure_input_probe,
+    );
+    shell.set_buffer_size(320, 240);
+    shell.set_viewport(320.0, 240.0);
+    for _ in 0..5 {
+        shell.update();
+        if !shell.needs_redraw() && !shell.composition.should_recompose() {
+            break;
+        }
+    }
+    let layout_texts = layout_tree_texts(shell.layout_tree().expect("layout tree"));
+    assert!(
+        layout_texts.iter().any(|text| text == "content top pad 40"),
+        "instrument dead: initial keyed padding missing, got {layout_texts:?}"
+    );
+
+    let height = KEYED_HEIGHT_STATE
+        .with(|slot| slot.borrow().as_ref().cloned())
+        .expect("probe must expose its bar height state");
+    height.set(72.0);
+    for _ in 0..5 {
+        shell.update();
+        if !shell.needs_redraw() && !shell.composition.should_recompose() {
+            break;
+        }
+    }
+    let layout_texts = layout_tree_texts(shell.layout_tree().expect("layout tree"));
+    assert!(
+        layout_texts.iter().any(|text| text == "content top pad 72"),
+        "a value computed inside the measure policy (a scaffold's padding) \
+         never invalidates a recompose scope, so the subcompose KEY is its \
+         only path into retained slot content; the slot still shows \
+         {layout_texts:?}. If this fails, clean-slot reuse is skipping on a \
+         stale capture key"
     );
 }
 

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -18,8 +18,8 @@ use cranpose_macros::composable;
 use cranpose_ui::{
     Alignment, BlendMode, Box, BoxSpec, Brush, Button, ButtonSpec, Color, Column, ColumnSpec,
     CornerRadii, HeadlessRenderer, IntrinsicSize, LazyColumn, LazyColumnSpec, LinearArrangement,
-    Modifier, PointerInputScope, Rect, RenderOp, Row, RowSpec, ScrollState, Size, Spacer, Text,
-    TextStyle, VerticalAlignment,
+    Modifier, PointerInputScope, Rect, RenderOp, Row, RowSpec, ScrollState, Size, Spacer,
+    SubcomposeLayoutScope, SubcomposeMeasureScope, Text, TextStyle, VerticalAlignment,
 };
 use cranpose_ui_graphics::{
     CompositingStrategy, DrawPrimitive, GraphicsLayer, Point, RenderEffect, RoundedCornerShape,
@@ -5164,6 +5164,127 @@ fn a_self_referential_size_report_panics_in_debug_instead_of_livelocking() {
     for _ in 0..200 {
         shell.update();
     }
+}
+
+thread_local! {
+    static CLEAN_SLOT_LIST_STATE: RefCell<Option<LazyListState>> = const { RefCell::new(None) };
+    static CLEAN_SLOT_COMPOSE_COUNT: Cell<u32> = const { Cell::new(0) };
+    static CLEAN_SLOT_MEASURE_COUNT: Cell<u32> = const { Cell::new(0) };
+}
+
+#[composable]
+fn app_shell_clean_slot_scroll_probe() {
+    cranpose_ui::SubcomposeLayout(
+        Modifier::empty().fill_max_size(),
+        move |scope, constraints| {
+            CLEAN_SLOT_MEASURE_COUNT.with(|count| count.set(count.get() + 1));
+            let width = constraints.max_width.max(constraints.min_width);
+            let height = constraints.max_height.max(constraints.min_height);
+            let nodes = scope.subcompose(cranpose_core::SlotId::new(0), move || {
+                CLEAN_SLOT_COMPOSE_COUNT.with(|count| count.set(count.get() + 1));
+                let list_state = rememberLazyListState();
+                CLEAN_SLOT_LIST_STATE.with(|slot| {
+                    *slot.borrow_mut() = Some(list_state);
+                });
+                LazyColumn(
+                    Modifier::empty().fill_max_size(),
+                    list_state,
+                    LazyColumnSpec::new(),
+                    |scope| {
+                        scope.items(80, |index| {
+                            Text(
+                                format!("Clean slot row {index}"),
+                                Modifier::empty().height(48.0),
+                                TextStyle::default(),
+                            );
+                        });
+                    },
+                );
+            });
+            let mut placements = Vec::with_capacity(nodes.len());
+            for node in nodes {
+                let placeable =
+                    scope.measure(node, cranpose_ui::Constraints::tight(width, height));
+                placements.push(cranpose_ui::Placement::new(placeable.node_id(), 0.0, 0.0, 0));
+            }
+            scope.layout(width, height, placements)
+        },
+    );
+}
+
+#[test]
+fn a_scroll_measure_repass_does_not_recompose_a_subcompose_slot_that_read_no_scrolled_state() {
+    let _guard = test_guard();
+    CLEAN_SLOT_LIST_STATE.with(|slot| slot.borrow_mut().take());
+    CLEAN_SLOT_COMPOSE_COUNT.with(|count| count.set(0));
+    CLEAN_SLOT_MEASURE_COUNT.with(|count| count.set(0));
+
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(
+        TestRenderer::default(),
+        root_key,
+        app_shell_clean_slot_scroll_probe,
+    );
+    shell.set_buffer_size(320, 480);
+    shell.set_viewport(320.0, 480.0);
+    for _ in 0..5 {
+        shell.update();
+        if !shell.needs_redraw() && !shell.composition.should_recompose() {
+            break;
+        }
+    }
+    let settled_composes = CLEAN_SLOT_COMPOSE_COUNT.with(Cell::get);
+    let settled_measures = CLEAN_SLOT_MEASURE_COUNT.with(Cell::get);
+    assert!(
+        settled_composes >= 1 && settled_measures >= 1,
+        "instrument dead: the probe never composed ({settled_composes}) or \
+         measured ({settled_measures}) its slot while settling"
+    );
+
+    let list_state = CLEAN_SLOT_LIST_STATE
+        .with(|slot| slot.borrow().as_ref().copied())
+        .expect("probe must expose its lazy list state");
+
+    for target in [4usize, 8, 12] {
+        list_state.scroll_to_item(target, 0.0);
+        for _ in 0..4 {
+            shell.update();
+            if !shell.needs_redraw() && !shell.has_active_animations() {
+                break;
+            }
+        }
+    }
+
+    let measures_after = CLEAN_SLOT_MEASURE_COUNT.with(Cell::get);
+    assert!(
+        measures_after > settled_measures,
+        "liveness: scrolling the list inside the slot must re-run the \
+         subcompose measure policy (settled at {settled_measures}, still \
+         {measures_after} after three scrolls) — if this fails the test no \
+         longer exercises the measure repass at all"
+    );
+    let layout_texts = layout_tree_texts(shell.layout_tree().expect("layout tree"));
+    assert!(
+        layout_texts.iter().any(|text| text == "Clean slot row 12"),
+        "liveness: the scroll must actually reach row 12 in the layout tree, \
+         got {layout_texts:?}"
+    );
+
+    let composes_after = CLEAN_SLOT_COMPOSE_COUNT.with(Cell::get);
+    assert_eq!(
+        composes_after, settled_composes,
+        "a scroll-driven measure repass recomposed a subcompose slot whose \
+         composition read none of the scrolled state: the slot content \
+         closure ran {} extra times for {} extra measure passes. Every such \
+         run is the per-pass compose walk over the slot's retained \
+         composition (measured at ~0.3ms per body-sized slot per pass on a \
+         Kirin 980, and paid by whichever layer owns the slot — see \
+         docs/subcompose_measure_cost.md). A measure pass over a slot with \
+         no invalidated scopes must reuse the retained slot roots without \
+         composing",
+        composes_after - settled_composes,
+        measures_after - settled_measures,
+    );
 }
 
 fn graph_scene_solid_rect_y(

--- a/crates/cranpose-core/src/composer.rs
+++ b/crates/cranpose-core/src/composer.rs
@@ -491,6 +491,19 @@ pub struct CapturedCompositionContext {
     owner_scope: Option<Weak<RecomposeScopeInner>>,
 }
 
+impl CapturedCompositionContext {
+    /// Total deactivations along the capturing scope's owner chain right now;
+    /// see [`crate::RecomposeScope::owner_chain_deactivation_epoch`]. Zero
+    /// when the context has no owner scope or it is gone.
+    pub fn owner_chain_deactivation_epoch(&self) -> u64 {
+        self.owner_scope
+            .as_ref()
+            .and_then(Weak::upgrade)
+            .map(|inner| crate::RecomposeScope { inner }.owner_chain_deactivation_epoch())
+            .unwrap_or(0)
+    }
+}
+
 fn take_subcompose_frame(core: &ComposerCore, operation: &str) -> SubcomposeFrame {
     match core.subcompose_stack.borrow_mut().pop() {
         Some(frame) => frame,

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -499,6 +499,7 @@ pub(crate) struct RecomposeScopeInner {
     invalid: Cell<bool>,
     enqueued: Cell<bool>,
     active: Cell<bool>,
+    deactivations: Cell<u64>,
     composed_once: Cell<bool>,
     pending_recompose: Cell<bool>,
     force_reuse: Cell<bool>,
@@ -523,6 +524,7 @@ impl RecomposeScopeInner {
             invalid: Cell::new(false),
             enqueued: Cell::new(false),
             active: Cell::new(true),
+            deactivations: Cell::new(0),
             composed_once: Cell::new(false),
             pending_recompose: Cell::new(false),
             force_reuse: Cell::new(false),
@@ -614,6 +616,27 @@ impl RecomposeScope {
 
     pub fn is_active(&self) -> bool {
         self.inner.active.get()
+    }
+
+    /// Total deactivations along this scope's owner chain. A retained slot
+    /// composition records this at compose time; a later mismatch means some
+    /// enclosing composition was deactivated (its owned effects cancelled)
+    /// since the slot last composed, so the retained content must recompose
+    /// once to restart them — no flag on the slot's own scopes carries that
+    /// trace, because deactivation walks stop at slot-host boundaries.
+    pub fn owner_chain_deactivation_epoch(&self) -> u64 {
+        let mut total = 0u64;
+        let mut current = Some(self.clone());
+        while let Some(scope) = current {
+            total = total.wrapping_add(scope.inner.deactivations.get());
+            let structural_parent = scope.inner.parent_scope.borrow().clone();
+            let lifetime_owner = scope.inner.lifetime_owner_scope.borrow().clone();
+            let next = structural_parent.or(lifetime_owner);
+            current = next
+                .and_then(|parent| parent.upgrade())
+                .map(|inner| RecomposeScope { inner });
+        }
+        total
     }
 
     pub(crate) fn is_effectively_active(&self) -> bool {
@@ -815,6 +838,9 @@ impl RecomposeScope {
         if !self.inner.active.replace(false) {
             return;
         }
+        self.inner
+            .deactivations
+            .set(self.inner.deactivations.get() + 1);
         if self.inner.enqueued.replace(false) {
             self.inner.runtime.mark_scope_recomposed(self.id());
         }

--- a/crates/cranpose-core/src/subcompose.rs
+++ b/crates/cranpose-core/src/subcompose.rs
@@ -6,7 +6,7 @@
 //! exact match exists, the [`SlotReusePolicy`] is consulted to determine whether
 //! a node produced for another slot is compatible with the requested slot.
 
-use std::{collections::VecDeque, fmt, rc::Rc};
+use std::{any::Any, collections::VecDeque, fmt, rc::Rc};
 
 use smallvec::SmallVec;
 
@@ -268,6 +268,12 @@ impl NodeSlotMapping {
             .is_some_and(|scopes| scopes.iter().any(RecomposeScope::is_invalid))
     }
 
+    fn slot_has_inactive_scopes(&self, slot: SlotId) -> bool {
+        self.slot_to_scopes
+            .get(&slot)
+            .is_some_and(|scopes| scopes.iter().any(|scope| !scope.is_active()))
+    }
+
     fn deactivate_slot(&self, slot: SlotId) {
         if let Some(scopes) = self.slot_to_scopes.get(&slot) {
             for scope in scopes {
@@ -320,6 +326,32 @@ pub struct SubcomposeState {
     /// Whether the last slot registered via register_active was reused.
     /// Set during register_active, read via was_last_slot_reused().
     last_slot_reused: Option<bool>,
+    /// Capture key stored at the last composition of each slot. A retained
+    /// slot may skip recomposition on a measure pass only while the caller
+    /// presents an equal key (see `retained_capture_key_matches`).
+    retained_capture_keys: HashMap<SlotId, RetainedCaptureKey>,
+    /// Bumped by `invalidate_scopes`; slots must re-compose once per bump
+    /// before clean-slot reuse may skip them again.
+    content_generation: std::cell::Cell<u64>,
+    /// The (content generation, owner-chain deactivation epoch) each slot
+    /// last composed under.
+    slot_composed_generation: HashMap<SlotId, (u64, u64)>,
+}
+
+/// Type-erased capture key recorded when a slot composes. Values that flow
+/// into slot content from the measure policy itself (a scaffold's computed
+/// padding, a box's constraints) never invalidate a recompose scope when they
+/// change, so slot reuse must compare them explicitly.
+struct RetainedCaptureKey {
+    value: Box<dyn Any>,
+    eq: fn(&dyn Any, &dyn Any) -> bool,
+}
+
+fn retained_capture_key_eq<K: PartialEq + 'static>(stored: &dyn Any, candidate: &dyn Any) -> bool {
+    match (stored.downcast_ref::<K>(), candidate.downcast_ref::<K>()) {
+        (Some(stored), Some(candidate)) => stored == candidate,
+        _ => false,
+    }
 }
 
 impl fmt::Debug for SubcomposeState {
@@ -376,6 +408,9 @@ impl SubcomposeState {
             max_reusable_per_type: DEFAULT_MAX_REUSABLE_PER_TYPE,
             max_reusable_untyped: DEFAULT_MAX_REUSABLE_UNTYPED,
             last_slot_reused: None,
+            retained_capture_keys: HashMap::default(),
+            content_generation: std::cell::Cell::new(0),
+            slot_composed_generation: HashMap::default(),
         }
     }
 
@@ -512,12 +547,14 @@ impl SubcomposeState {
     pub fn activate_current_active_slot(&mut self, slot_id: SlotId) -> Option<Vec<NodeId>> {
         if self.current_pass_active_slots.contains(&slot_id)
             || self.exact_reactivation_slots.contains(&slot_id)
+            || self.reusable_node_counts.contains_key(&slot_id)
             || self
                 .active_order
                 .get(self.current_index)
                 .copied()
                 .is_none_or(|active_slot| active_slot != slot_id)
             || self.mapping.slot_has_invalid_scopes(slot_id)
+            || self.mapping.slot_has_inactive_scopes(slot_id)
         {
             return None;
         }
@@ -528,6 +565,37 @@ impl SubcomposeState {
         self.current_pass_active_slots.insert(slot_id);
         self.current_index += 1;
         Some(nodes)
+    }
+
+    /// Whether precomposed nodes are waiting to be consumed for this slot.
+    /// A pending precomposition means the retained mapping is about to be
+    /// superseded, so clean-slot reuse must reject and compose.
+    pub fn has_pending_precompositions(&self, slot_id: SlotId) -> bool {
+        self.precomposed_nodes.contains_key(&slot_id)
+    }
+
+    /// Whether the slot's stored capture key equals `key`. A missing key never
+    /// matches: a slot must compose at least once under the key discipline
+    /// before it may skip.
+    pub fn retained_capture_key_matches<K: PartialEq + 'static>(
+        &self,
+        slot_id: SlotId,
+        key: &K,
+    ) -> bool {
+        self.retained_capture_keys
+            .get(&slot_id)
+            .is_some_and(|retained| (retained.eq)(retained.value.as_ref(), key))
+    }
+
+    /// Records the capture key the slot is being composed under.
+    pub fn store_retained_capture_key<K: PartialEq + 'static>(&mut self, slot_id: SlotId, key: K) {
+        self.retained_capture_keys.insert(
+            slot_id,
+            RetainedCaptureKey {
+                value: Box::new(key),
+                eq: retained_capture_key_eq::<K>,
+            },
+        );
     }
 
     #[doc(hidden)]
@@ -678,6 +746,8 @@ impl SubcomposeState {
         self.slot_compositions.remove(&slot_id);
         self.slot_callbacks.remove(&slot_id);
         self.slot_content_types.remove(&slot_id);
+        self.retained_capture_keys.remove(&slot_id);
+        self.slot_composed_generation.remove(&slot_id);
         self.policy.remove_content_type(slot_id);
         if let Some(nodes) = self.precomposed_nodes.remove(&slot_id) {
             self.precomposed_count = self.precomposed_count.saturating_sub(nodes.len());
@@ -808,6 +878,10 @@ impl SubcomposeState {
         self.exact_reactivation_slots.remove(&old_slot);
         self.mapping.add_node(new_slot, node_id);
         self.slot_content_types.remove(&old_slot);
+        self.retained_capture_keys.remove(&old_slot);
+        self.retained_capture_keys.remove(&new_slot);
+        self.slot_composed_generation.remove(&old_slot);
+        self.slot_composed_generation.remove(&new_slot);
         self.policy.remove_content_type(old_slot);
         if let Some(slots) = self.slot_compositions.remove(&old_slot) {
             self.slot_compositions.insert(new_slot, slots);
@@ -952,8 +1026,45 @@ impl SubcomposeState {
     /// Hosts should call this when parent-captured inputs change without directly invalidating
     /// the child scopes themselves. The next subcompose pass will then re-run active slot
     /// content instead of skipping with stale captures.
+    /// Invalidating scopes alone is not a reliable "recompose on next
+    /// measure" signal: the recomposer drains invalid scopes before measure
+    /// runs, re-executing the RETAINED slot callbacks — parent-captured
+    /// values baked into a replaced closure never flow in, yet the scopes
+    /// come back valid. The generation bump is the unlaunderable half: only
+    /// a measure-time compose of the slot brings it current, so clean-slot
+    /// reuse stays blocked until the new content actually landed.
     pub fn invalidate_scopes(&self) {
         self.mapping.invalidate_scopes();
+        self.content_generation
+            .set(self.content_generation.get() + 1);
+    }
+
+    /// Advances the content generation without invalidating scopes: every
+    /// slot must re-compose once before clean-slot reuse may skip it again.
+    /// Called when the owning node leaves its parent — a retained subtree
+    /// that comes back from the reuse pool restarts its effects only if its
+    /// slots actually recompose, and scope flags carry no durable trace of
+    /// the detach (deactivation walks stop at nested slot-host boundaries).
+    pub fn bump_content_generation(&self) {
+        self.content_generation
+            .set(self.content_generation.get() + 1);
+    }
+
+    /// Whether the slot last composed under the current content generation
+    /// and owner-chain deactivation epoch. False after any
+    /// [`Self::invalidate_scopes`], and false after any composition up the
+    /// owner chain was deactivated, until a measure-time compose of this
+    /// slot runs.
+    pub fn slot_content_generation_current(&self, slot_id: SlotId, owner_epoch: u64) -> bool {
+        self.slot_composed_generation.get(&slot_id).copied()
+            == Some((self.content_generation.get(), owner_epoch))
+    }
+
+    /// Records that the slot just composed under the current generation and
+    /// the given owner-chain deactivation epoch.
+    pub fn mark_slot_composed_current(&mut self, slot_id: SlotId, owner_epoch: u64) {
+        self.slot_composed_generation
+            .insert(slot_id, (self.content_generation.get(), owner_epoch));
     }
 
     /// Returns whether the last slot registered via [`Self::register_active`] was reused.

--- a/crates/cranpose-ui/src/layout/mod.rs
+++ b/crates/cranpose-ui/src/layout/mod.rs
@@ -1377,7 +1377,18 @@ impl LayoutBuilderState {
         let Some(data) = Self::layout_child_measure_data(applier, node_id)? else {
             return Ok(None);
         };
-        if data.needs_measure || data.cache.epoch() == 0 {
+        // needs_layout without needs_measure is a pending placement-only
+        // repass (scroll offsets, text panning): the cached SIZE may be
+        // right, but the subtree still has placement work to run, so serving
+        // the cache here — let alone clearing the flag — swallows the repass.
+        // The epoch must be CURRENT: invalidate_all_layout_caches advances
+        // the global epoch precisely so entries cached before it stop being
+        // served, and this gate reads the node's cache without activating it.
+        if data.needs_measure
+            || data.needs_layout
+            || data.cache.epoch() == 0
+            || data.cache.epoch() != crate::render_state::current_layout_cache_epoch()
+        {
             return Ok(None);
         }
 
@@ -1389,18 +1400,9 @@ impl LayoutBuilderState {
             let mut layout_state = layout_state.borrow_mut();
             layout_state.set_size(measured.size);
             layout_state.measurement_constraints = constraints;
-            drop(layout_state);
-            let _ = applier.with_node::<LayoutNode, _>(node_id, |node| {
-                if data.needs_layout {
-                    node.clear_needs_layout();
-                }
-            });
         } else {
             let _ = applier.with_node::<SubcomposeLayoutNode, _>(node_id, |node| {
                 node.set_measured_size(measured.size);
-                if data.needs_layout {
-                    node.clear_needs_layout();
-                }
             });
         }
 

--- a/crates/cranpose-ui/src/layout/tests/layout_tests.rs
+++ b/crates/cranpose-ui/src/layout/tests/layout_tests.rs
@@ -2808,3 +2808,102 @@ fn measure_layout_error_preserves_applier_and_slots() -> Result<(), NodeError> {
 
     Ok(())
 }
+
+#[test]
+fn the_cached_measure_gate_rejects_a_child_that_owes_a_layout_repass() {
+    let _app_context = crate::render_state::app_context_test_scope();
+    let mut applier = MemoryApplier::new();
+    let node = crate::widgets::nodes::LayoutNode::new(
+        Modifier::empty(),
+        Rc::new(LeafMeasurePolicy::new(Size {
+            width: 100.0,
+            height: 50.0,
+        })),
+    );
+    let id = applier.create(Box::new(node));
+    let constraints = Constraints::tight(100.0, 50.0);
+    let current_epoch = crate::render_state::current_layout_cache_epoch().max(1);
+    applier
+        .with_node::<crate::widgets::nodes::LayoutNode, _>(id, |node| {
+            let cache = node.cache_handles();
+            cache.activate(current_epoch);
+            cache.store_measurement(
+                constraints,
+                Rc::new(MeasuredNode::leaf(
+                    id,
+                    Size {
+                        width: 100.0,
+                        height: 50.0,
+                    },
+                )),
+            );
+            node.clear_needs_measure();
+            node.clear_needs_layout();
+            node.mark_needs_layout();
+        })
+        .expect("node available");
+
+    let served =
+        LayoutBuilderState::cached_measure_node_with_applier(&mut applier, id, constraints)
+            .expect("gate must not error");
+    assert!(
+        served.is_none(),
+        "a child that owes a placement-only repass (needs_layout without \
+         needs_measure: scroll offsets, text panning) must not be served from \
+         the measurement cache — its subtree still has placement work to run"
+    );
+    let still_owes = applier
+        .with_node::<crate::widgets::nodes::LayoutNode, _>(id, |node| node.needs_layout())
+        .expect("node available");
+    assert!(
+        still_owes,
+        "the gate must leave the pending repass flag for the real measure \
+         path instead of clearing it while serving stale placement"
+    );
+}
+
+#[test]
+fn the_cached_measure_gate_rejects_a_measurement_from_a_superseded_epoch() {
+    let _app_context = crate::render_state::app_context_test_scope();
+    let mut applier = MemoryApplier::new();
+    let node = crate::widgets::nodes::LayoutNode::new(
+        Modifier::empty(),
+        Rc::new(LeafMeasurePolicy::new(Size {
+            width: 100.0,
+            height: 50.0,
+        })),
+    );
+    let id = applier.create(Box::new(node));
+    let constraints = Constraints::tight(100.0, 50.0);
+    let seeded_epoch = crate::render_state::current_layout_cache_epoch().max(1);
+    applier
+        .with_node::<crate::widgets::nodes::LayoutNode, _>(id, |node| {
+            let cache = node.cache_handles();
+            cache.activate(seeded_epoch);
+            cache.store_measurement(
+                constraints,
+                Rc::new(MeasuredNode::leaf(
+                    id,
+                    Size {
+                        width: 100.0,
+                        height: 50.0,
+                    },
+                )),
+            );
+            node.clear_needs_measure();
+            node.clear_needs_layout();
+        })
+        .expect("node available");
+
+    crate::layout::invalidate_all_layout_caches();
+
+    let served =
+        LayoutBuilderState::cached_measure_node_with_applier(&mut applier, id, constraints)
+            .expect("gate must not error");
+    assert!(
+        served.is_none(),
+        "invalidate_all_layout_caches advanced the global epoch, so every \
+         measurement cached under the previous epoch is stale; the gate must \
+         require the CURRENT epoch, not merely a nonzero one"
+    );
+}

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -203,7 +203,7 @@ pub use semantics_dispatch::{
 };
 pub use subcompose_layout::{
     Constraints, MeasureResult, Placement, SubcomposeLayoutNode, SubcomposeLayoutScope,
-    SubcomposeMeasureScope, SubcomposeMeasureScopeImpl,
+    SubcomposeMeasureScope, SubcomposeMeasureScopeImpl, clean_slot_skip_count,
 };
 pub use text::{
     LinkAnnotation, ParagraphStyle, PlatformParagraphStyle, PlatformSpanStyle, PlatformTextStyle,

--- a/crates/cranpose-ui/src/subcompose_layout.rs
+++ b/crates/cranpose-ui/src/subcompose_layout.rs
@@ -127,8 +127,28 @@ pub trait SubcomposeLayoutScope: cranpose_ui_layout::MeasureScope {
 
 /// Public trait exposed to measure policies for subcomposition.
 pub trait SubcomposeMeasureScope: SubcomposeLayoutScope {
-    fn subcompose<Content>(&mut self, slot_id: SlotId, content: Content) -> Vec<SubcomposeChild>
+    /// Composes `content` into the slot, or reuses the retained composition
+    /// when it is provably current.
+    ///
+    /// `key` must carry every value that flows into `content` from the
+    /// measure policy itself rather than from reactive state — a scaffold's
+    /// computed padding, a box's constraints. Such values never invalidate a
+    /// recompose scope when they change, so an equal key is the caller's
+    /// promise that the retained composition is not stale on that channel.
+    /// Values read from reactive state inside `content` need no key entry:
+    /// their writes invalidate the slot's scopes and block reuse. Content
+    /// must not read a non-reactive container (`Cell`, `RefCell`) for a value
+    /// that changes between measure passes unless that value is part of
+    /// `key`; debug builds recompose skipped slots and panic when the
+    /// retained topology diverges from a fresh composition.
+    fn subcompose<K, Content>(
+        &mut self,
+        slot_id: SlotId,
+        key: K,
+        content: Content,
+    ) -> Vec<SubcomposeChild>
     where
+        K: PartialEq + 'static,
         Content: FnMut() + 'static;
 
     /// Measures a subcomposed child with the given constraints.
@@ -158,6 +178,23 @@ pub struct SubcomposeMeasureScopeImpl<'a> {
     cached_measure_missing_scratch: Vec<NodeId>,
     registered_measurement_node_ids: Vec<NodeId>,
     pending_commands_applied: bool,
+    #[cfg(debug_assertions)]
+    shadow_stash: Option<(Vec<NodeId>, Vec<NodeId>)>,
+}
+
+thread_local! {
+    static CLEAN_SLOT_SKIPS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+fn record_clean_slot_skip() {
+    CLEAN_SLOT_SKIPS.with(|count| count.set(count.get() + 1));
+}
+
+/// Number of subcompose measure passes on this thread that reused a retained
+/// slot without a compose walk. Diagnostic surface for tests and telemetry;
+/// see [`SubcomposeMeasureScope::subcompose`] for when a slot may skip.
+pub fn clean_slot_skip_count() -> u64 {
+    CLEAN_SLOT_SKIPS.with(std::cell::Cell::get)
 }
 
 struct SubcomposeMeasureScopeInit<'a> {
@@ -195,6 +232,8 @@ impl<'a> SubcomposeMeasureScopeImpl<'a> {
             cached_measure_missing_scratch: Vec::new(),
             registered_measurement_node_ids: Vec::new(),
             pending_commands_applied: false,
+            #[cfg(debug_assertions)]
+            shadow_stash: None,
         }
     }
 
@@ -228,6 +267,16 @@ impl<'a> SubcomposeMeasureScopeImpl<'a> {
             eprintln!("[SubcomposeLayout] Error suppressed: {:?}", err);
             *slot = Some(err);
         }
+    }
+
+    fn owner_chain_deactivation_epoch(&self) -> u64 {
+        self.parent_handle
+            .inner
+            .borrow()
+            .captured_context
+            .as_ref()
+            .map(cranpose_core::CapturedCompositionContext::owner_chain_deactivation_epoch)
+            .unwrap_or(0)
     }
 
     fn ensure_pending_commands_applied(&mut self) -> bool {
@@ -299,6 +348,31 @@ impl<'a> SubcomposeMeasureScopeImpl<'a> {
 
         drop(inner);
 
+        let children = self.compose_into_slot(slot_id, virtual_node_id, content);
+        if is_rebound {
+            self.composer.record_rebound_slot_children(&children);
+        }
+        if let Some(start) = telemetry_start {
+            log::warn!(
+                "[subcompose-telemetry] slot={} reused={} children={} subcompose_ms={:.2}",
+                slot_id.raw(),
+                is_rebound,
+                children.len(),
+                start.elapsed().as_secs_f64() * 1000.0
+            );
+        }
+        children
+    }
+
+    fn compose_into_slot<Content>(
+        &mut self,
+        slot_id: SlotId,
+        virtual_node_id: NodeId,
+        content: Content,
+    ) -> Vec<NodeId>
+    where
+        Content: FnMut() + 'static,
+    {
         let content_holder = self.state.callback_holder(slot_id);
         content_holder.update(content);
 
@@ -320,26 +394,103 @@ impl<'a> SubcomposeMeasureScopeImpl<'a> {
             .unwrap_or_default();
         self.pending_commands_applied = false;
 
+        let owner_epoch = self.owner_chain_deactivation_epoch();
         self.state
             .register_active(slot_id, &[virtual_node_id], &scopes);
+        self.state.mark_slot_composed_current(slot_id, owner_epoch);
 
         // CRITICAL FIX: Read children from the Applier's copy of the virtual node,
         // NOT from inner.virtual_nodes. The Applier's copy received insert_child calls
         // during subcomposition, while inner.virtual_nodes is an out-of-sync clone.
-        let children = self.composer.get_node_children(virtual_node_id).to_vec();
-        if is_rebound {
-            self.composer.record_rebound_slot_children(&children);
+        self.composer.get_node_children(virtual_node_id).to_vec()
+    }
+
+    /// The clean-slot fast path: reuse the retained slot roots without a
+    /// compose walk. Every rejection falls back to the compose path, so this
+    /// may only return `Some` when the retained composition is provably
+    /// current: the caller's capture key matched, no scope in the slot is
+    /// invalidated, the slot sits exactly where the pass expects it, no
+    /// precomposition is pending, and all queued commands are applied. The
+    /// returned children are read live from the applier, never from a cache —
+    /// a recomposer heal between passes changes the retained roots, and the
+    /// live read is what makes that visible.
+    fn activate_clean_retained_slot(&mut self, slot_id: SlotId) -> Option<Vec<NodeId>> {
+        if self.state.has_pending_precompositions(slot_id) {
+            return None;
         }
-        if let Some(start) = telemetry_start {
-            log::warn!(
-                "[subcompose-telemetry] slot={} reused={} children={} subcompose_ms={:.2}",
-                slot_id.raw(),
-                is_rebound,
-                children.len(),
-                start.elapsed().as_secs_f64() * 1000.0
-            );
+        if !self
+            .state
+            .slot_content_generation_current(slot_id, self.owner_chain_deactivation_epoch())
+        {
+            return None;
         }
-        children
+        if !self.ensure_pending_commands_applied() {
+            return None;
+        }
+        let virtual_node_ids = self.state.activate_current_active_slot(slot_id)?;
+
+        {
+            let inner = self.parent_handle.inner.borrow();
+            for virtual_node_id in &virtual_node_ids {
+                self.composer.record_subcompose_child(*virtual_node_id);
+                if let Some(v_node) = inner.virtual_nodes.get(virtual_node_id) {
+                    v_node.set_parent(self.root_id);
+                }
+            }
+        }
+        for virtual_node_id in &virtual_node_ids {
+            let _ = self
+                .composer
+                .with_node_mut::<LayoutNode, _>(*virtual_node_id, |node| {
+                    node.set_parent(self.root_id);
+                });
+        }
+
+        let mut children = Vec::new();
+        for virtual_node_id in &virtual_node_ids {
+            children.extend(self.composer.get_node_children(*virtual_node_id));
+        }
+        record_clean_slot_skip();
+
+        #[cfg(debug_assertions)]
+        {
+            self.shadow_stash = Some((virtual_node_ids, children.clone()));
+        }
+
+        Some(children)
+    }
+
+    /// Debug-only equivalence oracle for the clean-slot skip: recompose the
+    /// slot content anyway and require the same root children the skip
+    /// returned. A divergence means the content read a value with no
+    /// invalidation path (a captured Cell/RefCell, an untracked environment
+    /// read) — release builds would show stale content silently, so debug
+    /// builds refuse loudly instead. Attribute-only changes on an unchanged
+    /// topology are below this oracle's resolution; the `subcompose` API doc
+    /// states that invariant.
+    #[cfg(debug_assertions)]
+    fn shadow_verify_clean_slot<Content>(&mut self, slot_id: SlotId, content: Content)
+    where
+        Content: FnMut() + 'static,
+    {
+        let Some((virtual_node_ids, skipped_children)) = self.shadow_stash.take() else {
+            return;
+        };
+        if virtual_node_ids.len() != 1 {
+            return;
+        }
+        let composed = self.compose_into_slot(slot_id, virtual_node_ids[0], content);
+        assert!(
+            composed == skipped_children,
+            "clean-slot skip diverged for slot {:?}: recomposing produced root \
+             children {:?} but the retained slot held {:?}. The slot content \
+             read a value that changed between measure passes without any \
+             invalidation path — make that value reactive state, or part of \
+             the subcompose capture key",
+            slot_id,
+            composed,
+            skipped_children,
+        );
     }
 
     pub(crate) fn activate_exact_retained_slot_with_known_children(
@@ -471,10 +622,24 @@ impl cranpose_ui_layout::MeasureScope for SubcomposeMeasureScopeImpl<'_> {
 }
 
 impl<'a> SubcomposeMeasureScope for SubcomposeMeasureScopeImpl<'a> {
-    fn subcompose<Content>(&mut self, slot_id: SlotId, content: Content) -> Vec<SubcomposeChild>
+    fn subcompose<K, Content>(
+        &mut self,
+        slot_id: SlotId,
+        key: K,
+        content: Content,
+    ) -> Vec<SubcomposeChild>
     where
+        K: PartialEq + 'static,
         Content: FnMut() + 'static,
     {
+        if self.state.retained_capture_key_matches(slot_id, &key)
+            && let Some(children) = self.activate_clean_retained_slot(slot_id)
+        {
+            #[cfg(debug_assertions)]
+            self.shadow_verify_clean_slot(slot_id, content);
+            return children.into_iter().map(SubcomposeChild::new).collect();
+        }
+        self.state.store_retained_capture_key(slot_id, key);
         let nodes = self.perform_subcompose(slot_id, content);
         nodes.into_iter().map(SubcomposeChild::new).collect()
     }
@@ -1197,6 +1362,7 @@ impl cranpose_core::Node for SubcomposeLayoutNode {
 
     fn on_removed_from_parent(&mut self) {
         self.parent.set(None);
+        self.inner.borrow().state.bump_content_generation();
     }
 
     fn parent(&self) -> Option<NodeId> {

--- a/crates/cranpose-ui/src/tests/renderer_tests.rs
+++ b/crates/cranpose-ui/src/tests/renderer_tests.rs
@@ -334,7 +334,7 @@ fn renderer_renders_subcompose_background() {
             SubcomposeLayout(
                 Modifier::empty().background(Color(0.4, 0.4, 0.4, 1.0)),
                 |scope, constraints| {
-                    let children = scope.subcompose(SlotId::new(0), || {
+                    let children = scope.subcompose(SlotId::new(0), (), || {
                         Text(
                             "Subcomposed".to_string(),
                             Modifier::empty(),

--- a/crates/cranpose-ui/src/tests/subcompose_layout_tests.rs
+++ b/crates/cranpose-ui/src/tests/subcompose_layout_tests.rs
@@ -347,7 +347,7 @@ fn measure_subcomposes_content() {
     let recorded_capture = Rc::clone(&recorded);
     let policy: Rc<MeasurePolicy> = Rc::new(move |scope, constraints| {
         assert_eq!(constraints, Constraints::tight(0.0, 0.0));
-        let measurables = scope.subcompose(SlotId::new(1), || {
+        let measurables = scope.subcompose(SlotId::new(1), (), || {
             cranpose_core::with_current_composer(|composer| {
                 composer.emit_node(|| DummyNode);
             });
@@ -389,7 +389,7 @@ fn subcompose_reuses_nodes_across_measures() {
     let recorded = Rc::new(RefCell::new(Vec::new()));
     let recorded_capture = Rc::clone(&recorded);
     let policy: Rc<MeasurePolicy> = Rc::new(move |scope, _constraints| {
-        let measurables = scope.subcompose(SlotId::new(99), || {
+        let measurables = scope.subcompose(SlotId::new(99), (), || {
             cranpose_core::with_current_composer(|composer| {
                 composer.emit_node(|| DummyNode);
             });
@@ -461,7 +461,7 @@ fn inactive_slots_move_to_reusable_pool() {
     let toggle_capture = toggle;
     let policy: Rc<MeasurePolicy> = Rc::new(move |scope, _constraints| {
         if toggle_capture.value() {
-            scope.subcompose(SlotId::new(1), || {
+            scope.subcompose(SlotId::new(1), (), || {
                 cranpose_core::with_current_composer(|composer| {
                     composer.emit_node(|| DummyNode);
                 });

--- a/crates/cranpose-ui/src/widgets/layout.rs
+++ b/crates/cranpose-ui/src/widgets/layout.rs
@@ -126,7 +126,7 @@ pub fn SubcomposeLayout(
         node.set_captured_context(captured_context.clone());
         node.set_density(composed_density);
         if policy_captures_changed {
-            node.request_measure_recompose();
+            node.invalidate_subcomposition();
         }
     }) {
         debug_assert!(false, "failed to update SubcomposeLayout node: {err}");
@@ -150,7 +150,7 @@ where
         let scope_for_content = scope_impl;
         let measurables = {
             let content_ref = Rc::clone(&content_ref);
-            scope.subcompose(SlotId::new(0), move || {
+            scope.subcompose(SlotId::new(0), constraints, move || {
                 cranpose_core::debug_label_current_scope("BoxWithConstraints.slot(0)");
                 let mut content = content_ref.borrow_mut();
                 content(scope_for_content);

--- a/crates/cranpose-ui/src/widgets/lazy_list.rs
+++ b/crates/cranpose-ui/src/widgets/lazy_list.rs
@@ -252,7 +252,7 @@ fn measure_lazy_list_item(
     else {
         return LazyListMeasuredItem::new(index, key_slot_id, content_type, 1.0, 0.0);
     };
-    let root_children = scope.subcompose(slot_id, item_content);
+    let root_children = scope.subcompose(slot_id, (), item_content);
 
     let was_reused = scope.was_last_slot_reused().unwrap_or(false);
     inputs.state.record_composition(was_reused);
@@ -1134,7 +1134,7 @@ fn LazyColumnImpl(
         node.set_density(composed_density);
         if refresh_content || config_changed || modifier_changed {
             measured_item_cache.borrow_mut().clear();
-            node.request_measure_recompose();
+            node.invalidate_subcomposition();
         }
     }) {
         debug_assert!(false, "failed to update LazyColumn node: {err}");
@@ -1258,7 +1258,7 @@ fn LazyRowImpl(
         node.set_density(composed_density);
         if refresh_content || config_changed || modifier_changed {
             measured_item_cache.borrow_mut().clear();
-            node.request_measure_recompose();
+            node.invalidate_subcomposition();
         }
     }) {
         debug_assert!(false, "failed to update LazyRow node: {err}");

--- a/crates/cranpose-ui/src/widgets/scaffold.rs
+++ b/crates/cranpose-ui/src/widgets/scaffold.rs
@@ -270,7 +270,7 @@ fn ScaffoldImpl(modifier: Modifier, spec: ScaffoldSpec, slots: ScaffoldSlots) ->
         let loose = Constraints::loose(width, height);
 
         let top_content = Rc::clone(&top_bar);
-        let top_nodes = scope.subcompose(SlotId::new(0), move || top_content());
+        let top_nodes = scope.subcompose(SlotId::new(0), (), move || top_content());
         let mut top_height = 0.0_f32;
         let mut top_placements = Vec::with_capacity(top_nodes.len());
         for node in top_nodes {
@@ -280,7 +280,7 @@ fn ScaffoldImpl(modifier: Modifier, spec: ScaffoldSpec, slots: ScaffoldSlots) ->
         }
 
         let bottom_content = Rc::clone(&bottom_bar);
-        let bottom_nodes = scope.subcompose(SlotId::new(1), move || bottom_content());
+        let bottom_nodes = scope.subcompose(SlotId::new(1), (), move || bottom_content());
         let mut bottom_height = 0.0_f32;
         let mut bottom_placeables = Vec::with_capacity(bottom_nodes.len());
         for node in bottom_nodes {
@@ -293,7 +293,8 @@ fn ScaffoldImpl(modifier: Modifier, spec: ScaffoldSpec, slots: ScaffoldSlots) ->
         // pushed past whichever is larger rather than past both.
         let padding = window_padding.max(PaddingValues::new(0.0, top_height, 0.0, bottom_height));
         let content_slot = Rc::clone(&content);
-        let content_nodes = scope.subcompose(SlotId::new(2), move || content_slot(padding));
+        let content_nodes =
+            scope.subcompose(SlotId::new(2), padding, move || content_slot(padding));
 
         let mut placements = Vec::with_capacity(
             top_placements.len() + bottom_placeables.len() + content_nodes.len() + 1,
@@ -315,7 +316,7 @@ fn ScaffoldImpl(modifier: Modifier, spec: ScaffoldSpec, slots: ScaffoldSlots) ->
         // The floating action sits above everything, inside the bottom bar and
         // the window insets, on the reading-order end side.
         let floating_content = Rc::clone(&floating_action);
-        let floating_nodes = scope.subcompose(SlotId::new(3), move || floating_content());
+        let floating_nodes = scope.subcompose(SlotId::new(3), (), move || floating_content());
         for node in floating_nodes {
             let placeable = scope.measure(node, loose);
             let bottom_gap = padding.bottom + FLOATING_ACTION_MARGIN;

--- a/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
+++ b/crates/cranpose-ui/src/widgets/swipe_to_dismiss.rs
@@ -889,7 +889,7 @@ where
         let background = background.clone();
         let content = Rc::clone(&content);
         let controller_for_row = Rc::clone(&controller_for_layout);
-        let measurables = scope.subcompose(SlotId::new(0), move || {
+        let measurables = scope.subcompose(SlotId::new(0), (), move || {
             // The row itself: a `BoxWithConstraints` (so it can read its own
             // width for the dismiss threshold) carrying the user modifier + the
             // swipe pointer handler, overlaying the optional background and the

--- a/crates/cranpose-ui/src/widgets/wear/scaling_list.rs
+++ b/crates/cranpose-ui/src/widgets/wear/scaling_list.rs
@@ -1342,7 +1342,7 @@ pub fn WearScalingLazyColumnNode(
         node.set_captured_context(captured_context);
         node.set_density(composed_density);
         if inputs_changed {
-            node.request_measure_recompose();
+            node.invalidate_subcomposition();
         }
     }) {
         debug_assert!(false, "failed to update WearScalingLazyColumn node: {err}");
@@ -1717,7 +1717,7 @@ fn compose_and_measure_item(
     let identity = item.key.map(|_| key.to_slot_id());
     scope.update_content_type(slot_id, item.content_type);
     let content = Rc::clone(&item.content);
-    let children: Vec<SubcomposeChild> = scope.subcompose(slot_id, move || {
+    let children: Vec<SubcomposeChild> = scope.subcompose(slot_id, (), move || {
         let content = Rc::clone(&content);
         crate::lazy_item::ProvideLazyItemKey(identity, || {
             WearScalingItem(Modifier::empty(), transform.clone(), strategy, move || {


### PR DESCRIPTION
Closes the conserved per-pass compose walk that #547's design note quantified: every subcompose measure pass re-composed its slot content even when nothing could have changed it, at ~0.3ms per body-sized slot per pass on a Kirin 980, paid by whichever layer owns the slot.

**Red first.** The head commit pins the defect: three scroll repasses re-ran a clean slot's content closure three times, with liveness gates proving the repass still runs and the scroll still moves content (so a fix cannot go green by freezing the repass).

**The skip predicate** — every condition rejects into the compose path:
- caller capture key matches (`subcompose` now takes a mandatory key; measure-computed inputs like Scaffold padding and BWC constraints have no invalidation channel, so the key is their only path in),
- no slot scope invalidated, slot exactly at pass position, no pending precomposition, not in the reusable pool, no inactive scopes,
- content generation current — `invalidate_subcomposition` bumps it, because scope invalidation alone launders: the recomposer heals retained callbacks (old captures) back to validity before measure runs,
- owner-chain deactivation epoch unchanged — a recycled item's nested subcompose scopes carry no flag of their own; effects cancel through scope ownership across slot-host boundaries, and returned content must recompose once to restart them.

Skipped children are read live from the applier, never a cache. `SubcomposeLayout` and the lazy lists signal capture changes through `invalidate_subcomposition` instead of a bare needs-measure a skip cannot see.

**Debug oracle.** Debug builds recompose every skipped slot and panic on topology divergence (`clean-slot skip diverged`), converting silent staleness from non-reactive reads into loud failures; a `should_panic` test proves the oracle fires. Attribute-only changes on unchanged topology are below its resolution — that invariant is stated on the API doc, and the keyed guard test covers the measure-computed channel in release.

**Re-red proofs.** Key check removed → keyed guard test red in release (debug shadow masks it, which is why that assertion is release-gated). Generation gate absent → three lazy captured-value tests red. Owner-epoch gate absent → recycle-effect restart test red. Each was demonstrated live during development.

**Device A/B (pre-registered, Huawei Mate 20 X, post-swap app shape, A/B/A/B, layout_ms=0 sole instrument):** prediction HELD in both bands, both rounds:
| p50/pass | baseline | retention |
|---|---|---|
| root layout | 1.56 / 1.65 ms | **1.08 / 1.05 ms** |
| scaffold minus content | 0.98 / 1.00 ms | **0.36 / 0.36 ms** |

Root layout is now 1.05ms from this morning's 1.71ms baseline (swap + retention combined).

**Functional gates on device:** Library renders; expansion-reflow clean; **keyboard/ime.bottom verified live on the Mate** (search focused, keyboard up, tab bar and content tracked the inset, typed text rendered — the read sits inside a slot that now skips); cold start proven flash-free (screencap burst + telemetry ordering: empty pass and full pass both land before the first render dispatch, 7ms window inside one frame).

**Stated limits:** environment generation beyond insets (layout direction, font scale) is not separately gated — a change there must recompose from the root today; the outer cached-measure gate corrections (accepts+clears needs_layout, accepts any nonzero epoch) are separate defects and ride the next branch of this arc, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)