### PR TITLE
fix: stop has_focused_field from double-borrowing focused_field

### DIFF
--- a/crates/cranpose-ui/src/text_field_focus.rs
+++ b/crates/cranpose-ui/src/text_field_focus.rs
@@ -168,16 +168,39 @@ impl TextFieldFocusState {
     }
 
     fn has_focused_field(&self) -> bool {
-        let mut current = self.focused_field.borrow_mut();
-        if let Some(ref weak) = *current {
-            if weak.upgrade().is_some() {
-                return true;
-            }
-            *current = None;
-            *self.focused_handler.borrow_mut() = None;
-            crate::cursor_animation::stop_cursor_blink();
+        if self.focused_field_is_live() {
+            return true;
         }
+        self.clear_stale_focus();
         false
+    }
+
+    /// Whether the registered field's weak handle still resolves to a live field.
+    fn focused_field_is_live(&self) -> bool {
+        self.focused_field
+            .borrow()
+            .as_ref()
+            .is_some_and(|weak| weak.upgrade().is_some())
+    }
+
+    /// Drops a registration whose field was torn down without going through
+    /// [`Self::clear_focus`] (e.g. composition removed the node). A no-op
+    /// when nothing is registered.
+    fn clear_stale_focus(&self) {
+        let stale_node = self
+            .focused_handler
+            .borrow()
+            .as_ref()
+            .and_then(|handler| handler.node_id());
+        let had_entry = self.focused_field.borrow_mut().take().is_some();
+        if !had_entry {
+            return;
+        }
+        self.focused_handler.borrow_mut().take();
+        if let Some(node_id) = stale_node {
+            crate::schedule_draw_repass(node_id);
+        }
+        crate::cursor_animation::stop_cursor_blink();
     }
 
     fn focused_handler(&self) -> Option<Rc<dyn FocusedTextFieldHandler>> {
@@ -698,6 +721,51 @@ mod tests {
             handler.total_calls(),
             0,
             "stale focused-field handlers must not receive input"
+        );
+    }
+
+    #[test]
+    fn stale_focus_cleanup_after_hidden_blink_does_not_reenter_the_focus_registry_borrow() {
+        let _app_context = crate::render_state::app_context_test_scope();
+
+        let focus = Rc::new(RefCell::new(false));
+        request_focus(focus.clone(), Rc::new(NodeBackedHandler(3)), 0);
+
+        let past_interval = web_time::Instant::now()
+            + crate::cursor_animation::CursorAnimationState::BLINK_INTERVAL
+            + std::time::Duration::from_millis(1);
+        assert!(
+            crate::cursor_animation::tick_cursor_blink_at(past_interval),
+            "the blink must already have toggled to hidden, matching the real \
+             timing where the bug's stop_cursor_blink() call is a visibility \
+             change and therefore reaches invalidate_focused_caret()"
+        );
+
+        drop(focus);
+
+        assert!(
+            !has_focused_field(),
+            "a field dropped without clear_focus must read back as unfocused \
+             instead of panicking on a reentrant borrow of focused_field"
+        );
+    }
+
+    #[test]
+    fn stale_focus_cleanup_repasses_the_node_that_lost_its_caret() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        let _ = crate::render_state::take_draw_repass_nodes();
+
+        let focus = Rc::new(RefCell::new(false));
+        request_focus(focus.clone(), Rc::new(NodeBackedHandler(11)), 0);
+        let _ = crate::render_state::take_draw_repass_nodes();
+
+        drop(focus);
+
+        assert!(!has_focused_field());
+        assert!(
+            crate::render_state::take_draw_repass_nodes().contains(&11),
+            "discovering a stale field lazily must repass its node just like \
+             an explicit clear_focus does, or its caret is left stale on screen"
         );
     }
 


### PR DESCRIPTION
## Summary

Reproduces and fixes a hard crash reported by a user: focus a text field, move the caret, switch to another tab, switch back — `panicked at crates/cranpose-ui/src/text_field_focus.rs:171:46: RefCell already borrowed`.

**Root cause.** `has_focused_field()` is a query that opportunistically cleans up a dead `Weak` while still holding `focused_field.borrow_mut()`. That cleanup calls `cursor_animation::stop_cursor_blink()`, which (when the blink was mid-toggle) calls `invalidate_focused_caret() -> focused_field_node() -> focused_handler() -> has_focused_field()` again — re-entering the same `RefCell` while the outer borrow is still alive. A tab switch drops the old field's `is_focused` `Rc` without going through `clear_focus`, so the registry is left holding a dead `Weak`; the next liveness check (on the newly-composed Text tab) walks straight into the reentrant borrow.

**Fix.** Split the pure liveness check (`focused_field_is_live`, a single `.borrow()` with no side effects) from the cleanup (`clear_stale_focus`), and restructured the cleanup so every `RefCell` borrow it takes is a short-lived temporary that's released *before* it calls into `cursor_animation` — so a reentrant call from that chain never observes a live borrow. `clear_stale_focus` also now captures the stale field's node before clearing state, so the lazily-discovered case gets the same scoped draw repass an explicit `clear_focus()` call already gets (previously lost because `focused_handler` was cleared before the repass lookup could run).

**Confirmed root cause before fixing**, per house rule: temporarily removed the `stop_cursor_blink()` call from the cleanup branch — the new test went green, proving that call (and its reentrant chain) is what causes the panic, not something in `request_focus`/`clear_focus`.

**What I rejected:** wrapping the inner `borrow_mut()` in `try_borrow_mut` and returning early. That would silence the panic but leave `focused_handler` cleared while `focused_field` still points at a dead weak (or vice versa, depending on where it's inserted) — an inconsistent registry — and papers over the real issue, which is a query with a side effect that assumes it owns the only borrow on the stack.

**Other write-borrowing queries in this file:** none. `focused_at_depth` and `focused_handler` both call `has_focused_field()` but never hold their own borrow across that call, so they inherit the fix. `request_focus` and `clear_focus` hold `borrow_mut()` across their whole bodies too, but never call into another module while holding it (the outer `pub fn` wrappers call `cursor_animation`/`schedule_draw_repass` only *after* the inner closure — and its borrow — has returned), so they were never at risk of this reentrancy.

## Test plan

- [x] New test `stale_focus_cleanup_after_hidden_blink_does_not_reenter_the_focus_registry_borrow` reduces the repro to: focus a field, tick the blink past its interval (matching real timing, where the user's steps take >500ms), drop the field's `Rc` without `clear_focus` (simulating a tab switch tearing down the composition), then call `has_focused_field()`. Confirmed this panics at the exact reported location on unfixed `main`, and passes with the fix.
- [x] New test `stale_focus_cleanup_repasses_the_node_that_lost_its_caret` covers the node-capture-before-clear correctness fix.
- [x] `cargo test -p cranpose-ui` (unit + doctests) — all green.
- [x] `cargo test --profile ci --workspace` (`just test`) — all green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (`just clippy`) — zero warnings.
- [x] `just fmt` — no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)