### PR TITLE
Seed debug.cranpose.layout_ms so the per-node layout instrument is reachable on device

### DIFF
--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -75,8 +75,12 @@ fn property_flag(name: &str) -> bool {
 /// any length — so a name may run right up to or past that pre-O limit, as
 /// `debug.cranpose.retained_mesh_px2` does; every deployment target is far
 /// past O.)
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 42] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 43] = [
     ("debug.cranpose.root_direct", "CRANPOSE_ROOT_DIRECT_DIAG"),
+    (
+        "debug.cranpose.layout_ms",
+        "CRANPOSE_LAYOUT_MEASURE_TELEMETRY_MS",
+    ),
     ("debug.cranpose.core_pin", "CRANPOSE_CORE_PIN"),
     ("debug.cranpose.gpu_stats", "CRANPOSE_GPU_STATS"),
     ("debug.cranpose.pass_timing", "CRANPOSE_GPU_PASS_TIMING"),


### PR DESCRIPTION
One property-backed environment entry: `debug.cranpose.layout_ms` → `CRANPOSE_LAYOUT_MEASURE_TELEMETRY_MS`, joining the family that already ships (`frame_telemetry`, `update_stage_ms`, `render_stage_ms`).

An instrument that exists only on a scratch branch means the measurement can only be taken in a configuration that is not the one that ships — both device A/Bs that settled this week's layout work (the BWC swap null and the retention win, samoylenkodmitry/Cranpose#548) ran on exactly this entry cherry-picked onto scratch branches. The retention baselines after #548 merges should be takeable on main as it ships.

Inert unless the property is set; presence-gated like every sibling entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)