### PR TITLE
Turn the isolated demo into a three-screen starter template

### DIFF
--- a/apps/isolated-demo/Cargo.lock
+++ b/apps/isolated-demo/Cargo.lock
@@ -1650,6 +1650,8 @@ dependencies = [
  "console_error_panic_hook",
  "cranpose",
  "cranpose-core",
+ "cranpose-foundation",
+ "cranpose-ui",
  "env_logger",
  "getrandom 0.3.4",
  "js-sys",

--- a/apps/isolated-demo/Cargo.toml
+++ b/apps/isolated-demo/Cargo.toml
@@ -75,3 +75,6 @@ wasm-bindgen-futures = "0.4.71"
 inherits = "release"
 opt-level = "z"
 lto = "fat"
+strip = true
+panic = "abort"
+codegen-units = 1

--- a/apps/isolated-demo/Cargo.toml
+++ b/apps/isolated-demo/Cargo.toml
@@ -29,13 +29,13 @@ web = ["cranpose/web", "dep:wasm-bindgen", "dep:wasm-logger"]
 logging = ["dep:env_logger"]
 
 [dependencies]
-# Default features stay on: the isolated demo ships no fonts of its own and
-# renders text through the framework's embedded fallback font.
 cranpose = { version = "0.1.105" }
 log = "0.4"
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-logger = { version = "0.2", optional = true }
 cranpose-core = "0.1.105"
+cranpose-ui = "0.1.105"
+cranpose-foundation = "0.1.105"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = { version = "0.11", optional = true }

--- a/apps/isolated-demo/README.md
+++ b/apps/isolated-demo/README.md
@@ -1,14 +1,27 @@
 # Cranpose Isolated Demo
 
 This is the standalone Cranpose starter project. It is a separate Cargo
-workspace and depends on the published `cranpose` and `cranpose-core` crates
-from crates.io, so it can be copied out of this repository without path
-dependencies.
+workspace and depends only on published crates.io releases of `cranpose` and
+its sibling crates, so it can be copied out of this repository without path
+dependencies and still build.
 
-The demo shows a counter, state-driven accent-color changes, layout, buttons,
-and the framework's embedded fallback font. Its supported targets are desktop,
-Android, and web. iOS is intentionally not part of this template; the
-repository's iOS reference is [`../ios-demo`](../ios-demo/README.md).
+Three screens, reachable through a bottom navigation bar, cover the concerns
+a real app needs and a bare counter does not: **Home** is state and layout (a
+counter, a toggled card); **Tasks** is a text field and a `LazyColumn` backed
+by app-owned list state (add, remove, and check off tasks); **Settings** is
+the one flag that switches the whole app's [`Palette`](src/theme.rs) between
+its light and dark constants. `dark_mode` and the task list both live in
+[`IsolatedDemoApp`](src/app.rs), the composable at the top of the tree, and
+are passed down into whichever screen is showing — hoisted there because both
+must survive switching screens, which state remembered inside a screen would
+not. Its supported targets are desktop, Android, and web. iOS is
+intentionally not part of this template; the repository's iOS reference is
+[`../ios-demo`](../ios-demo/README.md).
+
+Cranpose ships no theme system of its own (see the doc comment on
+[`WearColors`](../../crates/cranpose-ui/src/widgets/wear/theme.rs) for why):
+a `Palette` is an app-level struct a caller passes down explicitly, the same
+way this template does.
 
 ## Requirements
 
@@ -16,6 +29,17 @@ repository's iOS reference is [`../ios-demo`](../ios-demo/README.md).
 - A working native graphics environment for desktop builds.
 - `cargo-ndk` and the Android SDK/NDK for Android builds.
 - `wasm-pack` for web builds.
+
+## Dependencies beyond `cranpose`
+
+`Cargo.toml` also depends directly on published `cranpose-ui` (for
+`Scaffold`, the window-inset-aware app shell used for the top and bottom
+bars) and `cranpose-foundation` (for `TextFieldState`, which `BasicTextField`
+needs). Neither is re-exported by `cranpose::prelude`, so an app that wants a
+system-inset-aware shell or a text field reaches for the crate that defines
+it directly, the same way this one does. `scripts/sync_isolated_demo.py`
+bumps every `cranpose*` dependency in this manifest together, so adding one
+does not create a version to track by hand.
 
 ## Desktop
 
@@ -87,13 +111,27 @@ used by the web build to be available.
 
 ```text
 apps/isolated-demo/
-├── src/                 # Shared Cranpose app and platform entry points
-├── android/             # Gradle host; the Cranpose plugin configures it
-├── build-web.sh         # wasm-pack build for the browser
-├── index.html           # Canvas host page
-├── Cargo.toml           # Standalone package and published dependencies
+├── src/
+│   ├── main.rs         # Desktop binary entry point
+│   ├── lib.rs          # Android and web platform entry points
+│   ├── app.rs          # Root composable: nav state, theme state, shell
+│   ├── theme.rs        # Palette and text-style helpers
+│   ├── fonts.rs        # Font bundle (empty: uses the embedded fallback)
+│   └── screens/        # One module per screen; add new screens here
+│       ├── home.rs
+│       ├── tasks.rs
+│       └── settings.rs
+├── android/            # Gradle host; the Cranpose plugin configures it
+├── build-web.sh        # wasm-pack build for the browser
+├── index.html          # Canvas host page
+├── Cargo.toml          # Standalone package and published dependencies
 └── Cargo.lock
 ```
 
-To start a new app from this template, copy this directory and change the
-package metadata and the `cranpose` dependency in `Cargo.toml` as needed.
+To start a new app from this template, copy this directory, change the
+package metadata and the `cranpose*` dependency versions in `Cargo.toml` as
+needed, then replace the screens under `src/screens/` with your own —
+`rememberTasksState` in `src/screens/tasks.rs` is a worked example of a
+`#[cfg(test)]` module exercising a composable's state through
+`cranpose_ui::run_test_composition`, which is the pattern to follow for any
+new state you add.

--- a/apps/isolated-demo/src/app.rs
+++ b/apps/isolated-demo/src/app.rs
@@ -2,9 +2,33 @@
 
 use cranpose::prelude::*;
 use cranpose_core::rememberMutableStateOf;
+use cranpose_ui::widgets::{PaddingValues, Scaffold};
+
+use crate::{
+    screens::{rememberTasksState, HomeScreen, SettingsScreen, TasksScreen},
+    theme::{body_text_style, heading_text_style, Palette},
+};
 
 const TITLE: &str = "Cranpose Isolated Demo";
-const SUBTITLE: &str = "Published crates only";
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Screen {
+    Home,
+    Tasks,
+    Settings,
+}
+
+impl Screen {
+    const ALL: [Screen; 3] = [Screen::Home, Screen::Tasks, Screen::Settings];
+
+    fn label(self) -> &'static str {
+        match self {
+            Screen::Home => "Home",
+            Screen::Tasks => "Tasks",
+            Screen::Settings => "Settings",
+        }
+    }
+}
 
 pub(crate) fn create_app() -> AppLauncher {
     AppLauncher::new()
@@ -16,94 +40,97 @@ pub(crate) fn create_app() -> AppLauncher {
 
 #[composable]
 pub(crate) fn IsolatedDemoApp() {
-    let counter = rememberMutableStateOf(|| 0i32);
-    let accent = rememberMutableStateOf(|| false);
+    let screen = rememberMutableStateOf(|| Screen::Home);
+    let dark_mode = rememberMutableStateOf(|| false);
+    let tasks = rememberTasksState();
+    let palette = Palette::for_mode(dark_mode.value());
 
-    let accent_color = if accent.value() {
-        Color::rgba(0.18, 0.62, 0.42, 1.0)
-    } else {
-        Color::rgba(0.58, 0.24, 0.33, 1.0)
-    };
-
-    Column(
-        Modifier::empty().fill_max_size().padding(24.0),
-        ColumnSpec::default().vertical_arrangement(LinearArrangement::spaced_by(16.0)),
-        move || {
-            Text(TITLE, Modifier::empty(), TextStyle::default());
-            Text(SUBTITLE, Modifier::empty(), TextStyle::default());
-
-            Row(
-                Modifier::empty(),
-                RowSpec::default().horizontal_arrangement(LinearArrangement::spaced_by(12.0)),
-                move || {
-                    Button(
-                        Modifier::empty()
-                            .padding(12.0)
-                            .background(Color::rgba(0.12, 0.16, 0.26, 1.0)),
-                        ButtonSpec::default(),
-                        {
-                            let counter = counter;
-                            move || counter.set(counter.get() + 1)
-                        },
-                        {
-                            let counter = counter;
-                            move || {
-                                Text(
-                                    format!("Count: {}", counter.value()),
-                                    Modifier::empty(),
-                                    TextStyle::default(),
-                                );
-                            }
-                        },
-                    );
-
-                    Button(
-                        Modifier::empty()
-                            .padding(12.0)
-                            .background(Color::rgba(0.2, 0.2, 0.2, 1.0)),
-                        ButtonSpec::default(),
-                        {
-                            let accent = accent;
-                            move || accent.set(!accent.get())
-                        },
-                        {
-                            let accent = accent;
-                            move || {
-                                Text(
-                                    if accent.value() {
-                                        "Accent: On"
-                                    } else {
-                                        "Accent: Off"
-                                    },
-                                    Modifier::empty(),
-                                    TextStyle::default(),
-                                );
-                            }
-                        },
-                    );
+    Scaffold(
+        Modifier::empty()
+            .fill_max_size()
+            .background(palette.background),
+        move || TopBar(palette, screen.value().label()),
+        move || BottomNav(palette, screen),
+        move |padding: PaddingValues| {
+            let tasks_for_screen = tasks.clone();
+            Box(
+                padding.apply_to(Modifier::empty().fill_max_size()),
+                BoxSpec::default(),
+                move || match screen.value() {
+                    Screen::Home => HomeScreen(palette),
+                    Screen::Tasks => TasksScreen(palette, tasks_for_screen.clone()),
+                    Screen::Settings => SettingsScreen(palette, dark_mode),
                 },
             );
+        },
+    );
+}
 
+#[composable]
+fn TopBar(palette: Palette, active_label: &'static str) {
+    Row(
+        Modifier::empty()
+            .fill_max_width()
+            .padding(16.0)
+            .background(palette.surface),
+        RowSpec::default().vertical_alignment(VerticalAlignment::CenterVertically),
+        move || {
+            Text(TITLE, Modifier::empty(), heading_text_style(palette.text));
             Spacer(Size {
-                width: 0.0,
-                height: 8.0,
+                width: 12.0,
+                height: 0.0,
             });
+            Text(
+                active_label,
+                Modifier::empty(),
+                body_text_style(palette.muted_text),
+            );
+        },
+    );
+}
 
-            Box(
-                Modifier::empty()
-                    .size(Size {
-                        width: 320.0,
-                        height: 120.0,
-                    })
-                    .background(accent_color),
-                BoxSpec::default().content_alignment(Alignment::CENTER),
-                move || {
-                    Text(
-                        "Tap the accent button to swap themes",
-                        Modifier::empty(),
-                        TextStyle::default(),
-                    );
-                },
+#[composable]
+fn BottomNav(palette: Palette, screen: MutableState<Screen>) {
+    Row(
+        Modifier::empty()
+            .fill_max_width()
+            .padding(12.0)
+            .background(palette.surface),
+        RowSpec::default().horizontal_arrangement(LinearArrangement::SpaceEvenly),
+        move || {
+            for candidate in Screen::ALL {
+                NavButton(palette, candidate, screen);
+            }
+        },
+    );
+}
+
+#[composable]
+fn NavButton(palette: Palette, candidate: Screen, screen: MutableState<Screen>) {
+    let active = screen.value() == candidate;
+    let background = if active {
+        palette.primary
+    } else {
+        palette.surface
+    };
+    let label_color = if active {
+        palette.on_primary
+    } else {
+        palette.muted_text
+    };
+
+    Button(
+        Modifier::empty()
+            .padding(10.0)
+            .background(background)
+            .rounded_corners(8.0),
+        ButtonSpec::default(),
+        move || screen.set(candidate),
+        move || {
+            Text(
+                candidate.label(),
+                Modifier::empty(),
+                body_text_style(label_color),
             );
         },
     );

--- a/apps/isolated-demo/src/lib.rs
+++ b/apps/isolated-demo/src/lib.rs
@@ -4,6 +4,10 @@
 mod app;
 #[cfg(any(target_os = "android", all(feature = "web", target_arch = "wasm32")))]
 mod fonts;
+#[cfg(any(target_os = "android", all(feature = "web", target_arch = "wasm32")))]
+mod screens;
+#[cfg(any(target_os = "android", all(feature = "web", target_arch = "wasm32")))]
+mod theme;
 
 cranpose::android_main! {
     launcher: app::create_app(),

--- a/apps/isolated-demo/src/main.rs
+++ b/apps/isolated-demo/src/main.rs
@@ -2,6 +2,8 @@
 
 mod app;
 mod fonts;
+mod screens;
+mod theme;
 
 fn main() {
     #[cfg(feature = "logging")]

--- a/apps/isolated-demo/src/screens/home.rs
+++ b/apps/isolated-demo/src/screens/home.rs
@@ -1,0 +1,100 @@
+#![allow(non_snake_case)]
+
+use cranpose::prelude::*;
+use cranpose_core::rememberMutableStateOf;
+
+use crate::theme::{body_text_style, heading_text_style, Palette};
+
+#[composable]
+pub(crate) fn HomeScreen(palette: Palette) {
+    let counter = rememberMutableStateOf(|| 0i32);
+    let celebrating = rememberMutableStateOf(|| false);
+
+    let card_background = if celebrating.value() {
+        palette.primary
+    } else {
+        palette.surface
+    };
+    let card_text = if celebrating.value() {
+        palette.on_primary
+    } else {
+        palette.text
+    };
+
+    Column(
+        Modifier::empty().fill_max_size().padding(24.0),
+        ColumnSpec::default().vertical_arrangement(LinearArrangement::spaced_by(16.0)),
+        move || {
+            Text(
+                "Counter and layout",
+                Modifier::empty(),
+                heading_text_style(palette.text),
+            );
+            Text(
+                "A plain button drives a plain state value. Start reading the \
+                 template here, then follow Tasks and Settings for input, \
+                 lists, and app-level theming.",
+                Modifier::empty(),
+                body_text_style(palette.muted_text),
+            );
+
+            Row(
+                Modifier::empty(),
+                RowSpec::default().horizontal_arrangement(LinearArrangement::spaced_by(12.0)),
+                move || {
+                    Button(
+                        Modifier::empty()
+                            .padding(12.0)
+                            .background(palette.primary)
+                            .rounded_corners(8.0),
+                        ButtonSpec::default(),
+                        move || counter.set(counter.value() + 1),
+                        move || {
+                            Text(
+                                format!("Count: {}", counter.value()),
+                                Modifier::empty(),
+                                body_text_style(palette.on_primary),
+                            );
+                        },
+                    );
+
+                    Button(
+                        Modifier::empty()
+                            .padding(12.0)
+                            .background(palette.surface)
+                            .rounded_corners(8.0),
+                        ButtonSpec::default(),
+                        move || celebrating.set(!celebrating.value()),
+                        move || {
+                            Text(
+                                if celebrating.value() {
+                                    "Celebrating"
+                                } else {
+                                    "Celebrate"
+                                },
+                                Modifier::empty(),
+                                body_text_style(palette.text),
+                            );
+                        },
+                    );
+                },
+            );
+
+            Box(
+                Modifier::empty()
+                    .fill_max_width()
+                    .height(120.0)
+                    .background(card_background)
+                    .rounded_corners(12.0),
+                BoxSpec::default().content_alignment(Alignment::CENTER),
+                move || {
+                    Text(
+                        "Toggle the button above to swap this card's colors",
+                        Modifier::empty(),
+                        body_text_style(card_text),
+                    );
+                },
+            );
+        },
+    );
+}

--- a/apps/isolated-demo/src/screens/mod.rs
+++ b/apps/isolated-demo/src/screens/mod.rs
@@ -1,0 +1,7 @@
+mod home;
+mod settings;
+mod tasks;
+
+pub(crate) use home::HomeScreen;
+pub(crate) use settings::SettingsScreen;
+pub(crate) use tasks::{rememberTasksState, TasksScreen};

--- a/apps/isolated-demo/src/screens/settings.rs
+++ b/apps/isolated-demo/src/screens/settings.rs
@@ -1,0 +1,61 @@
+#![allow(non_snake_case)]
+
+use cranpose::prelude::*;
+
+use crate::theme::{body_text_style, heading_text_style, Palette};
+
+#[composable]
+pub(crate) fn SettingsScreen(palette: Palette, dark_mode: MutableState<bool>) {
+    Column(
+        Modifier::empty().fill_max_size().padding(24.0),
+        ColumnSpec::default().vertical_arrangement(LinearArrangement::spaced_by(16.0)),
+        move || {
+            Text(
+                "Settings",
+                Modifier::empty(),
+                heading_text_style(palette.text),
+            );
+            Text(
+                "Cranpose ships no theme system: colors are plain values a \
+                 caller passes down. This screen owns the one state value \
+                 that picks between Palette::for_mode's two constants; a \
+                 real app's own palette and settings belong here.",
+                Modifier::empty(),
+                body_text_style(palette.muted_text),
+            );
+
+            Row(
+                Modifier::empty()
+                    .fill_max_width()
+                    .padding(12.0)
+                    .background(palette.surface)
+                    .rounded_corners(8.0),
+                RowSpec::default()
+                    .horizontal_arrangement(LinearArrangement::SpaceBetween)
+                    .vertical_alignment(VerticalAlignment::CenterVertically),
+                move || {
+                    Text(
+                        "Dark mode",
+                        Modifier::empty(),
+                        body_text_style(palette.text),
+                    );
+                    Button(
+                        Modifier::empty()
+                            .padding(10.0)
+                            .background(palette.primary)
+                            .rounded_corners(8.0),
+                        ButtonSpec::default(),
+                        move || dark_mode.set(!dark_mode.value()),
+                        move || {
+                            Text(
+                                if dark_mode.value() { "On" } else { "Off" },
+                                Modifier::empty(),
+                                body_text_style(palette.on_primary),
+                            );
+                        },
+                    );
+                },
+            );
+        },
+    );
+}

--- a/apps/isolated-demo/src/screens/tasks.rs
+++ b/apps/isolated-demo/src/screens/tasks.rs
@@ -1,0 +1,352 @@
+#![allow(non_snake_case)]
+
+use cranpose::prelude::*;
+use cranpose_core::mutableStateListOf;
+use cranpose_foundation::text::TextFieldState;
+
+use crate::theme::{body_text_style, heading_text_style, Palette};
+
+#[derive(Clone, PartialEq)]
+struct Task {
+    id: u64,
+    title: String,
+    done: bool,
+}
+
+#[derive(Clone)]
+pub(crate) struct TasksState {
+    items: SnapshotStateList<Task>,
+    next_id: MutableState<u64>,
+}
+
+impl PartialEq for TasksState {
+    fn eq(&self, other: &Self) -> bool {
+        self.next_id == other.next_id
+    }
+}
+
+impl TasksState {
+    fn snapshot(&self) -> Vec<Task> {
+        self.items.to_vec()
+    }
+
+    fn add(&self, title: &str) {
+        let title = title.trim();
+        if title.is_empty() {
+            return;
+        }
+        let id = self.next_id.value();
+        self.next_id.set(id + 1);
+        self.items.push(Task {
+            id,
+            title: title.to_string(),
+            done: false,
+        });
+    }
+
+    fn remove(&self, id: u64) {
+        self.items.retain(|task| task.id != id);
+    }
+
+    fn toggle_done(&self, id: u64) {
+        let items = self.items.to_vec();
+        if let Some(index) = items.iter().position(|task| task.id == id) {
+            let mut task = items[index].clone();
+            task.done = !task.done;
+            self.items.set(index, task);
+        }
+    }
+}
+
+fn starter_tasks() -> Vec<Task> {
+    vec![
+        Task {
+            id: 0,
+            title: "Copy this template".to_string(),
+            done: true,
+        },
+        Task {
+            id: 1,
+            title: "Rename the package in Cargo.toml".to_string(),
+            done: false,
+        },
+        Task {
+            id: 2,
+            title: "Replace these tasks with your own screens".to_string(),
+            done: false,
+        },
+    ]
+}
+
+pub(crate) fn rememberTasksState() -> TasksState {
+    let items = remember(|| mutableStateListOf(starter_tasks())).with(|list| list.clone());
+    let next_id = rememberMutableStateOf(|| starter_tasks().len() as u64);
+    TasksState { items, next_id }
+}
+
+#[composable]
+pub(crate) fn TasksScreen(palette: Palette, tasks: TasksState) {
+    let input = remember(|| TextFieldState::new("")).with(|state| *state);
+    let items = tasks.snapshot();
+
+    Column(
+        Modifier::empty().fill_max_size().padding(24.0),
+        ColumnSpec::default().vertical_arrangement(LinearArrangement::spaced_by(16.0)),
+        move || {
+            Text("Tasks", Modifier::empty(), heading_text_style(palette.text));
+
+            NewTaskField(palette, input, tasks.clone());
+
+            if items.is_empty() {
+                Text(
+                    "No tasks yet. Add one above.",
+                    Modifier::empty(),
+                    body_text_style(palette.muted_text),
+                );
+            } else {
+                let list_state = rememberLazyListState();
+                let items = items.clone();
+                let tasks = tasks.clone();
+                LazyColumn(
+                    Modifier::empty().fill_max_size(),
+                    list_state,
+                    LazyColumnSpec::default(),
+                    move |scope| {
+                        let row_items = items.clone();
+                        let tasks = tasks.clone();
+                        scope.items(
+                            LazyItems::new(items.len()).key(move |index| items[index].id),
+                            move |index| {
+                                TaskRow(palette, row_items[index].clone(), tasks.clone());
+                            },
+                        );
+                    },
+                );
+            }
+        },
+    );
+}
+
+#[composable]
+fn NewTaskField(palette: Palette, input: TextFieldState, tasks: TasksState) {
+    Row(
+        Modifier::empty().fill_max_width(),
+        RowSpec::default()
+            .horizontal_arrangement(LinearArrangement::spaced_by(8.0))
+            .vertical_alignment(VerticalAlignment::CenterVertically),
+        move || {
+            Box(
+                Modifier::empty()
+                    .weight(1.0)
+                    .padding(10.0)
+                    .background(palette.surface)
+                    .rounded_corners(8.0),
+                BoxSpec::default(),
+                move || {
+                    if input.text().is_empty() {
+                        Text(
+                            "Add a task...",
+                            Modifier::empty(),
+                            body_text_style(palette.muted_text),
+                        );
+                    }
+                    BasicTextField(
+                        input,
+                        Modifier::empty().fill_max_width(),
+                        body_text_style(palette.text),
+                    );
+                },
+            );
+
+            let tasks_for_add = tasks.clone();
+            Button(
+                Modifier::empty()
+                    .padding(12.0)
+                    .background(palette.primary)
+                    .rounded_corners(8.0),
+                ButtonSpec::default(),
+                move || {
+                    tasks_for_add.add(&input.text());
+                    input.set_text("");
+                },
+                move || {
+                    Text(
+                        "Add",
+                        Modifier::empty(),
+                        body_text_style(palette.on_primary),
+                    );
+                },
+            );
+        },
+    );
+}
+
+#[composable]
+fn TaskRow(palette: Palette, task: Task, tasks: TasksState) {
+    let id = task.id;
+    let done = task.done;
+    let title = task.title;
+    let title_color = if done {
+        palette.muted_text
+    } else {
+        palette.text
+    };
+
+    Row(
+        Modifier::empty()
+            .fill_max_width()
+            .padding(10.0)
+            .background(palette.surface)
+            .rounded_corners(8.0),
+        RowSpec::default()
+            .horizontal_arrangement(LinearArrangement::SpaceBetween)
+            .vertical_alignment(VerticalAlignment::CenterVertically),
+        move || {
+            let tasks_for_toggle = tasks.clone();
+            Button(
+                Modifier::empty().padding(8.0),
+                ButtonSpec::default(),
+                move || tasks_for_toggle.toggle_done(id),
+                move || {
+                    Text(
+                        if done { "[x]" } else { "[ ]" },
+                        Modifier::empty(),
+                        body_text_style(palette.primary),
+                    );
+                },
+            );
+
+            Text(
+                title.clone(),
+                Modifier::empty()
+                    .weight(1.0)
+                    .padding_each(8.0, 0.0, 8.0, 0.0),
+                body_text_style(title_color),
+            );
+
+            let tasks_for_remove = tasks.clone();
+            Button(
+                Modifier::empty().padding(8.0),
+                ButtonSpec::default(),
+                move || tasks_for_remove.remove(id),
+                move || {
+                    Text("Remove", Modifier::empty(), body_text_style(palette.danger));
+                },
+            );
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use cranpose_ui::run_test_composition;
+
+    use super::rememberTasksState;
+
+    #[test]
+    fn a_fresh_tasks_state_holds_the_three_starter_tasks() {
+        run_test_composition(|| {
+            let tasks = rememberTasksState();
+            let titles: Vec<String> = tasks
+                .snapshot()
+                .into_iter()
+                .map(|task| task.title)
+                .collect();
+            assert_eq!(
+                titles,
+                vec![
+                    "Copy this template",
+                    "Rename the package in Cargo.toml",
+                    "Replace these tasks with your own screens",
+                ]
+            );
+        });
+    }
+
+    #[test]
+    fn adding_a_task_appends_it_with_a_fresh_id() {
+        run_test_composition(|| {
+            let tasks = rememberTasksState();
+            let starter_count = tasks.snapshot().len();
+
+            tasks.add("Write the README");
+
+            let snapshot = tasks.snapshot();
+            assert_eq!(snapshot.len(), starter_count + 1);
+            let added = snapshot.last().expect("just added a task");
+            assert_eq!(added.title, "Write the README");
+            assert!(!added.done);
+            assert!(
+                snapshot[..starter_count]
+                    .iter()
+                    .all(|task| task.id != added.id),
+                "a fresh task must not reuse an existing id"
+            );
+        });
+    }
+
+    #[test]
+    fn adding_a_blank_or_whitespace_title_does_nothing() {
+        run_test_composition(|| {
+            let tasks = rememberTasksState();
+            let starter_count = tasks.snapshot().len();
+
+            tasks.add("   ");
+            tasks.add("");
+
+            assert_eq!(tasks.snapshot().len(), starter_count);
+        });
+    }
+
+    #[test]
+    fn toggling_done_flips_only_the_targeted_task() {
+        run_test_composition(|| {
+            let tasks = rememberTasksState();
+            let target_id = tasks.snapshot()[1].id;
+            let untouched_id = tasks.snapshot()[2].id;
+
+            tasks.toggle_done(target_id);
+
+            let snapshot = tasks.snapshot();
+            let target = snapshot.iter().find(|task| task.id == target_id).unwrap();
+            let untouched = snapshot
+                .iter()
+                .find(|task| task.id == untouched_id)
+                .unwrap();
+            assert!(target.done, "toggling should have marked the task done");
+            assert!(!untouched.done, "toggling one task must not affect another");
+        });
+    }
+
+    #[test]
+    fn removing_a_task_drops_it_by_id_regardless_of_position() {
+        run_test_composition(|| {
+            let tasks = rememberTasksState();
+            let removed_id = tasks.snapshot()[0].id;
+            let starter_count = tasks.snapshot().len();
+
+            tasks.remove(removed_id);
+
+            let snapshot = tasks.snapshot();
+            assert_eq!(snapshot.len(), starter_count - 1);
+            assert!(snapshot.iter().all(|task| task.id != removed_id));
+        });
+    }
+
+    #[test]
+    fn removed_ids_are_never_reused() {
+        run_test_composition(|| {
+            let tasks = rememberTasksState();
+            let removed_id = tasks.snapshot()[0].id;
+            tasks.remove(removed_id);
+
+            tasks.add("Replacement task");
+
+            let snapshot = tasks.snapshot();
+            assert!(
+                snapshot.iter().filter(|task| task.id == removed_id).count() <= 1,
+                "a removed id must not be handed to a new task"
+            );
+        });
+    }
+}

--- a/apps/isolated-demo/src/theme.rs
+++ b/apps/isolated-demo/src/theme.rs
@@ -1,0 +1,65 @@
+use cranpose::prelude::*;
+use cranpose_ui::text::{FontWeight, TextUnit};
+
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) struct Palette {
+    pub(crate) background: Color,
+    pub(crate) surface: Color,
+    pub(crate) primary: Color,
+    pub(crate) on_primary: Color,
+    pub(crate) text: Color,
+    pub(crate) muted_text: Color,
+    pub(crate) danger: Color,
+}
+
+const LIGHT_PALETTE: Palette = Palette {
+    background: Color(0.96, 0.96, 0.97, 1.0),
+    surface: Color(1.0, 1.0, 1.0, 1.0),
+    primary: Color(0.16, 0.40, 0.85, 1.0),
+    on_primary: Color(1.0, 1.0, 1.0, 1.0),
+    text: Color(0.10, 0.10, 0.12, 1.0),
+    muted_text: Color(0.42, 0.44, 0.48, 1.0),
+    danger: Color(0.74, 0.20, 0.24, 1.0),
+};
+
+const DARK_PALETTE: Palette = Palette {
+    background: Color(0.07, 0.08, 0.10, 1.0),
+    surface: Color(0.14, 0.15, 0.18, 1.0),
+    primary: Color(0.42, 0.62, 0.98, 1.0),
+    on_primary: Color(0.05, 0.06, 0.09, 1.0),
+    text: Color(0.93, 0.94, 0.96, 1.0),
+    muted_text: Color(0.62, 0.64, 0.68, 1.0),
+    danger: Color(0.92, 0.42, 0.46, 1.0),
+};
+
+impl Palette {
+    pub(crate) fn for_mode(dark: bool) -> Self {
+        if dark {
+            DARK_PALETTE
+        } else {
+            LIGHT_PALETTE
+        }
+    }
+}
+
+pub(crate) fn body_text_style(color: Color) -> TextStyle {
+    TextStyle {
+        span_style: SpanStyle {
+            color: Some(color),
+            ..SpanStyle::default()
+        },
+        ..TextStyle::default()
+    }
+}
+
+pub(crate) fn heading_text_style(color: Color) -> TextStyle {
+    TextStyle {
+        span_style: SpanStyle {
+            color: Some(color),
+            font_size: TextUnit::Sp(20.0),
+            font_weight: Some(FontWeight::BOLD),
+            ..SpanStyle::default()
+        },
+        ..TextStyle::default()
+    }
+}


### PR DESCRIPTION
## Summary

The isolated demo is the only app in this repo that consumes Cranpose from published crates.io releases rather than the workspace — the canary that proves an outside project can actually build against a release. It was a bare counter with an accent-color toggle: enough to prove the crates link and run, but nothing a newcomer could learn a real screen's shape from.

It now has three screens behind a bottom nav built on `Scaffold`:
- **Home** — state and layout (a counter, a toggled card): the smallest possible starting point.
- **Tasks** — `BasicTextField` input plus a `LazyColumn` over app-owned list state (add / remove / check off).
- **Settings** — the one flag that switches `Palette::for_mode` between its light and dark constants.

Screen-select state, dark-mode state, and the task list are all hoisted to the root composable (`IsolatedDemoApp`) so they survive switching screens — the state-hoisting pattern a real app needs and a single-screen demo never has to get right. `src/screens/` is where a newcomer copying this template adds their own screens; `src/theme.rs` is the app-level palette Cranpose itself deliberately does not provide (see the doc comment on `WearColors` for why).

`Scaffold` and `TextFieldState` are not re-exported by `cranpose::prelude`, so `apps/isolated-demo/Cargo.toml` now depends directly on published `cranpose-ui` and `cranpose-foundation` alongside `cranpose`/`cranpose-core`. `scripts/sync_isolated_demo.py` already bumps any `cranpose*`-prefixed dependency, so this adds nothing to track by hand at release time. The canary role is unchanged — `cargo tree` still resolves every Cranpose crate from crates.io (checked, no `[patch]`), and `just versions` / the size-budget gate both still pass (11.45 MiB against the 16 MiB ceiling).

Comments are removed from the touched Rust source per current project direction (explanation moved into names, README prose, and test names instead) — matches the shape of the in-flight `docs-comment-policy` branch, applied independently here since that branch is unmerged.

## What I verified vs. assumed

- **Desktop**: builds, `clippy --all-targets -D warnings` clean, `cargo fmt --check` clean, `cargo test` (6 new unit tests for `TasksState`) pass, and the binary actually runs (GPU pipelines initialize, no panics).
- **Web**: `wasm-pack` build succeeds; served and driven end-to-end in a real browser — navigation between all three screens, dark-mode theming propagating through every screen, and add/remove/toggle-done on the task list all confirmed via screenshots. `clippy --target wasm32-unknown-unknown --features web,renderer-wgpu -D warnings` clean. (Aside: the browser tool's own `type` action doesn't dispatch real `KeyboardEvent`s that a canvas app's keydown listener sees — confirmed by dispatching synthetic `keydown` events directly, which worked fine. That's a gap in the test tool, not the app.)
- **Android**: `./gradlew :app:assembleRelease` succeeds via `cargo-ndk`, produces a real APK. `clippy --target aarch64-linux-android --features android,renderer-wgpu -D warnings` clean. Not run on a device/emulator.
- **iOS**: unchanged — intentionally out of scope for this template (README already pointed to `../ios-demo`).

## What I found but did not fix here (flagged as separate follow-ups)

- **No clippy gate for `apps/isolated-demo` anywhere** — only `fmt`, `just versions`, and the size-budget check (which patches in the workspace path version, so it isn't linting the published build) touch this app in CI. All three feature sets I checked are clean today, but nothing stops that from silently rotting. Flagged as a follow-up task rather than expanding this PR into CI-matrix work.
- **`cranpose::prelude` doesn't re-export `TextFieldState`/`TextFieldLineLimits`** (or `mutableStateListOf`), so any app wanting text input has to add `cranpose-foundation` as a second direct dependency — the exact "reaching past the facade" problem the existing `LazyListState` re-export's own comment says it exists to prevent. Flagged as a separate framework-level follow-up (it's an unreleased-prelude change, so it wouldn't help this app until a release ships anyway).

## Test plan

- [x] `cargo build/test/clippy/fmt --check` for `apps/isolated-demo` (desktop features)
- [x] `cargo clippy --target wasm32-unknown-unknown --features web,renderer-wgpu -D warnings`
- [x] `cargo clippy --target aarch64-linux-android --features android,renderer-wgpu -D warnings`
- [x] `./build-web.sh` + manual browser verification of all three screens
- [x] `./gradlew :app:assembleRelease`
- [x] `python3 scripts/check_cranpose_versions.py`
- [x] `cargo xtask binary-size ... --max-bytes 16777216` (11.45 MiB, within budget)
- [ ] Not merging — opening for review per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)