### PR TITLE
desktop-demo: fullscreen web canvas + phone-adaptive tab chrome

### DIFF
--- a/apps/desktop-demo-platform/src/lib.rs
+++ b/apps/desktop-demo-platform/src/lib.rs
@@ -12,6 +12,7 @@ fn create_app() -> AppLauncher {
     AppLauncher::new()
         .with_title("Cranpose Demo")
         .with_size(800, 600)
+        .with_web_fill_viewport(true)
         .with_fonts(desktop_demo::fonts::DEMO_FONTS)
         .with_fps_counter(true)
         .with_frame_pacing_controls(true)

--- a/apps/desktop-demo/index.html
+++ b/apps/desktop-demo/index.html
@@ -15,11 +15,7 @@
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
         }
 
-        /* The boot chrome (title, loading/error text, links) is a fixed
-           overlay above the canvas so it never adds page height for the
-           canvas to scroll past. Once the app reaches the running phase the
-           canvas is the whole page and this overlay steps out of the way. */
-        .container {
+        .boot-chrome {
             position: fixed;
             inset: 0;
             display: flex;
@@ -31,7 +27,7 @@
             box-sizing: border-box;
         }
 
-        body[data-phase="running"] .container {
+        body[data-phase="running"] .boot-chrome {
             display: none;
         }
 
@@ -98,7 +94,7 @@
 <body>
     <canvas id="cranpose-canvas" width="800" height="600"></canvas>
 
-    <div class="container">
+    <div class="boot-chrome">
         <h1>🚀 Cranpose Demo</h1>
         <p class="subtitle">Jetpack Compose-inspired UI framework for Rust</p>
 

--- a/apps/desktop-demo/index.html
+++ b/apps/desktop-demo/index.html
@@ -6,21 +6,33 @@
     <title>Cranpose Demo</title>
     <link rel="icon" href="data:,">
     <style>
-        body {
+        html, body {
             margin: 0;
             padding: 0;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            min-height: 100vh;
+            height: 100%;
+            overflow: hidden;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
         }
 
+        /* The boot chrome (title, loading/error text, links) is a fixed
+           overlay above the canvas so it never adds page height for the
+           canvas to scroll past. Once the app reaches the running phase the
+           canvas is the whole page and this overlay steps out of the way. */
         .container {
+            position: fixed;
+            inset: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
             text-align: center;
             padding: 20px;
+            box-sizing: border-box;
+        }
+
+        body[data-phase="running"] .container {
+            display: none;
         }
 
         h1 {
@@ -37,12 +49,10 @@
         }
 
         #cranpose-canvas {
-            border: 2px solid rgba(255, 255, 255, 0.3);
-            border-radius: 10px;
-            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
-            background: white;
+            position: fixed;
+            inset: 0;
             display: block;
-            margin: 0 auto;
+            background: white;
         }
 
         .loading {
@@ -86,11 +96,11 @@
     </style>
 </head>
 <body>
+    <canvas id="cranpose-canvas" width="800" height="600"></canvas>
+
     <div class="container">
         <h1>🚀 Cranpose Demo</h1>
         <p class="subtitle">Jetpack Compose-inspired UI framework for Rust</p>
-
-        <canvas id="cranpose-canvas" width="800" height="600"></canvas>
 
         <div id="loading" class="loading">Loading WASM module...</div>
         <div id="error" class="error" style="display: none;"></div>
@@ -126,6 +136,7 @@
                 phase,
                 lastUpdatedMs: Date.now(),
             });
+            document.body.dataset.phase = phase;
         }
 
         function serializeConsoleValue(value) {

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -74,13 +74,7 @@ use xkcd::xkcd_tab;
 const DEMO_PAGE_PADDING: f32 = 20.0;
 const DEMO_TAB_BAR_PADDING: f32 = 8.0;
 
-/// Below this measured window width, the 25-entry tab row (which needs a
-/// horizontally-scrolling strip even on a 1200px desktop window) gives way to
-/// a single current-tab button that opens a full-height picker list. Chosen
-/// at the Material window-size-class compact/medium boundary, comfortably
-/// above every phone width the demo runs at and comfortably below every
-/// windowed-desktop width the existing scroll-contract robot tests pin.
-const COMPACT_WIDTH_BREAKPOINT: f32 = 600.0;
+const COMPACT_WINDOW_SIZE_CLASS_MAX_WIDTH: f32 = 600.0;
 
 thread_local! {
     pub static TEST_COMPOSITION_LOCAL_COUNTER: RefCell<Option<MutableState<i32>>> = const { RefCell::new(None) };
@@ -519,13 +513,6 @@ fn CompactAppBar(
     );
 }
 
-/// A phone-width tab switcher: one row per [`DemoTab`], full-width so every
-/// row is a comfortable tap target, replacing the content pane while open.
-///
-/// [`TabButton`] is the desktop equivalent, but its modifier chain ends in
-/// `.padding(...)` — appending `fill_max_width()` after that would size the
-/// padded content box, not the tap target, so this keeps its own small
-/// (non-scrolling-row) layout rather than bolting phone sizing onto it.
 #[allow(non_snake_case)]
 #[composable]
 fn CompactTabPicker(
@@ -640,15 +627,8 @@ pub fn combined_app_with_startup(startup: StartupSelection) {
             .report_size_state(window_size),
         ColumnSpec::default(),
         move || {
-            let is_compact = window_size.get().width < COMPACT_WIDTH_BREAKPOINT;
+            let is_compact = window_size.get().width < COMPACT_WINDOW_SIZE_CLASS_MAX_WIDTH;
 
-            // Only the nav chrome depends on `is_compact`; `TabContent` below
-            // keeps one call site regardless of which chrome is showing. Two
-            // `TabContent` call sites (one per branch) would be two
-            // composition groups, and switching branches disposes the group
-            // that stopped being composed — a width crossing the breakpoint
-            // would tear down and rebuild whichever tab is live instead of
-            // leaving it running under the new header.
             if is_compact {
                 CompactAppBar(active_tab, picker_open, showing_source);
             } else {

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -642,14 +642,13 @@ pub fn combined_app_with_startup(startup: StartupSelection) {
         move || {
             let is_compact = window_size.get().width < COMPACT_WIDTH_BREAKPOINT;
 
-            // Only the nav chrome depends on `is_compact`. `TabContent` below
-            // keeps one call site regardless of which chrome is showing, so a
-            // width crossing the breakpoint mid-animation swaps the header
-            // without tearing down (and leaking the effects of) whichever
-            // tab is live — the failure mode a wider conditional had: two
-            // `TabContent` call sites, one per branch, are two composition
-            // groups, and Compose disposes a group's remembered state when
-            // the frame it was in stops being the one composed.
+            // Only the nav chrome depends on `is_compact`; `TabContent` below
+            // keeps one call site regardless of which chrome is showing. Two
+            // `TabContent` call sites (one per branch) would be two
+            // composition groups, and switching branches disposes the group
+            // that stopped being composed — a width crossing the breakpoint
+            // would tear down and rebuild whichever tab is live instead of
+            // leaving it running under the new header.
             if is_compact {
                 CompactAppBar(active_tab, picker_open, showing_source);
             } else {

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -640,19 +640,18 @@ pub fn combined_app_with_startup(startup: StartupSelection) {
             .report_size_state(window_size),
         ColumnSpec::default(),
         move || {
-            if window_size.get().width < COMPACT_WIDTH_BREAKPOINT {
+            let is_compact = window_size.get().width < COMPACT_WIDTH_BREAKPOINT;
+
+            // Only the nav chrome depends on `is_compact`. `TabContent` below
+            // keeps one call site regardless of which chrome is showing, so a
+            // width crossing the breakpoint mid-animation swaps the header
+            // without tearing down (and leaking the effects of) whichever
+            // tab is live — the failure mode a wider conditional had: two
+            // `TabContent` call sites, one per branch, are two composition
+            // groups, and Compose disposes a group's remembered state when
+            // the frame it was in stops being the one composed.
+            if is_compact {
                 CompactAppBar(active_tab, picker_open, showing_source);
-                if picker_open.get() {
-                    CompactTabPicker(active_tab, picker_open);
-                } else {
-                    TabContent(
-                        active_tab,
-                        startup,
-                        winamp_tab_state,
-                        showing_source,
-                        content_modifier.clone(),
-                    );
-                }
             } else {
                 TabBarHorizontal(active_tab, showing_source);
 
@@ -660,7 +659,11 @@ pub fn combined_app_with_startup(startup: StartupSelection) {
                     width: 0.0,
                     height: 12.0,
                 });
+            }
 
+            if is_compact && picker_open.get() {
+                CompactTabPicker(active_tab, picker_open);
+            } else {
                 TabContent(
                     active_tab,
                     startup,

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -74,6 +74,14 @@ use xkcd::xkcd_tab;
 const DEMO_PAGE_PADDING: f32 = 20.0;
 const DEMO_TAB_BAR_PADDING: f32 = 8.0;
 
+/// Below this measured window width, the 25-entry tab row (which needs a
+/// horizontally-scrolling strip even on a 1200px desktop window) gives way to
+/// a single current-tab button that opens a full-height picker list. Chosen
+/// at the Material window-size-class compact/medium boundary, comfortably
+/// above every phone width the demo runs at and comfortably below every
+/// windowed-desktop width the existing scroll-contract robot tests pin.
+const COMPACT_WIDTH_BREAKPOINT: f32 = 600.0;
+
 thread_local! {
     pub static TEST_COMPOSITION_LOCAL_COUNTER: RefCell<Option<MutableState<i32>>> = const { RefCell::new(None) };
     pub static TEST_ACTIVE_TAB_STATE: RefCell<Option<MutableState<DemoTab>>> = const { RefCell::new(None) };
@@ -459,6 +467,106 @@ fn TabBarHorizontal(
     );
 }
 
+fn compact_tab_row_background(is_active: bool) -> Color {
+    if is_active {
+        Color(0.2, 0.45, 0.9, 1.0)
+    } else {
+        Color(0.0, 0.0, 0.0, 0.0)
+    }
+}
+
+#[allow(non_snake_case)]
+#[composable]
+fn CompactAppBar(
+    active_tab: cranpose_core::MutableState<DemoTab>,
+    picker_open: cranpose_core::MutableState<bool>,
+    showing_source: cranpose_core::MutableState<bool>,
+) {
+    Row(
+        Modifier::empty().fill_max_width().padding_each(
+            DEMO_PAGE_PADDING,
+            DEMO_PAGE_PADDING,
+            DEMO_PAGE_PADDING,
+            DEMO_TAB_BAR_PADDING,
+        ),
+        RowSpec::new().horizontal_arrangement(LinearArrangement::SpaceBetween),
+        move || {
+            let label = active_tab.get().label();
+            let is_open = picker_open.get();
+            Button(
+                Modifier::empty()
+                    .rounded_corners(12.0)
+                    .draw_behind(move |scope| {
+                        scope.draw_round_rect(
+                            Brush::solid(Color(0.3, 0.3, 0.3, 0.5)),
+                            CornerRadii::uniform(12.0),
+                        );
+                    })
+                    .padding(10.0),
+                ButtonSpec::default(),
+                move || picker_open.set(!is_open),
+                move || {
+                    let marker = if is_open { "\u{25B4}" } else { "\u{25BE}" };
+                    Text(
+                        format!("{label} {marker}"),
+                        Modifier::empty().padding(4.0),
+                        TextStyle::default(),
+                    );
+                },
+            );
+            source_view::SourceToggleButton(showing_source, Modifier::empty());
+        },
+    );
+}
+
+/// A phone-width tab switcher: one row per [`DemoTab`], full-width so every
+/// row is a comfortable tap target, replacing the content pane while open.
+///
+/// [`TabButton`] is the desktop equivalent, but its modifier chain ends in
+/// `.padding(...)` — appending `fill_max_width()` after that would size the
+/// padded content box, not the tap target, so this keeps its own small
+/// (non-scrolling-row) layout rather than bolting phone sizing onto it.
+#[allow(non_snake_case)]
+#[composable]
+fn CompactTabPicker(
+    active_tab: cranpose_core::MutableState<DemoTab>,
+    picker_open: cranpose_core::MutableState<bool>,
+) {
+    let scroll_state =
+        cranpose_core::remember(|| cranpose_ui::ScrollState::new(0.0)).with(|state| *state);
+    Column(
+        Modifier::empty()
+            .fill_max_width()
+            .weight(1.0)
+            .vertical_scroll(scroll_state, false),
+        ColumnSpec::new(),
+        move || {
+            for tab in DEMO_TABS {
+                let is_active = active_tab.get() == tab;
+                Button(
+                    Modifier::empty()
+                        .fill_max_width()
+                        .draw_behind(move |scope| {
+                            scope.draw_round_rect(
+                                Brush::solid(compact_tab_row_background(is_active)),
+                                CornerRadii::uniform(0.0),
+                            );
+                        })
+                        .padding_each(DEMO_PAGE_PADDING, 14.0, DEMO_PAGE_PADDING, 14.0),
+                    ButtonSpec::default(),
+                    move || {
+                        active_tab.set(tab);
+                        picker_open.set(false);
+                    },
+                    move || {
+                        Text(tab.label(), Modifier::empty(), TextStyle::default());
+                    },
+                );
+            }
+        },
+    );
+}
+
 #[allow(non_snake_case)]
 #[composable]
 fn TabContent(
@@ -517,30 +625,50 @@ pub fn combined_app_with_startup(startup: StartupSelection) {
     });
 
     let showing_source = cranpose_core::rememberMutableStateOf(|| false);
+    let picker_open = cranpose_core::rememberMutableStateOf(|| false);
+    let window_size = cranpose_core::rememberMutableStateOf(Size::default);
+    let content_modifier = Modifier::empty().fill_max_width().weight(1.0).padding_each(
+        DEMO_PAGE_PADDING,
+        0.0,
+        DEMO_PAGE_PADDING,
+        DEMO_PAGE_PADDING,
+    );
 
     Column(
-        Modifier::empty().fill_max_size(),
+        Modifier::empty()
+            .fill_max_size()
+            .report_size_state(window_size),
         ColumnSpec::default(),
         move || {
-            TabBarHorizontal(active_tab, showing_source);
+            if window_size.get().width < COMPACT_WIDTH_BREAKPOINT {
+                CompactAppBar(active_tab, picker_open, showing_source);
+                if picker_open.get() {
+                    CompactTabPicker(active_tab, picker_open);
+                } else {
+                    TabContent(
+                        active_tab,
+                        startup,
+                        winamp_tab_state,
+                        showing_source,
+                        content_modifier.clone(),
+                    );
+                }
+            } else {
+                TabBarHorizontal(active_tab, showing_source);
 
-            Spacer(Size {
-                width: 0.0,
-                height: 12.0,
-            });
+                Spacer(Size {
+                    width: 0.0,
+                    height: 12.0,
+                });
 
-            TabContent(
-                active_tab,
-                startup,
-                winamp_tab_state,
-                showing_source,
-                Modifier::empty().fill_max_width().weight(1.0).padding_each(
-                    DEMO_PAGE_PADDING,
-                    0.0,
-                    DEMO_PAGE_PADDING,
-                    DEMO_PAGE_PADDING,
-                ),
-            );
+                TabContent(
+                    active_tab,
+                    startup,
+                    winamp_tab_state,
+                    showing_source,
+                    content_modifier.clone(),
+                );
+            }
         },
     );
 }

--- a/apps/desktop-demo/tests/mineswapper_lazy_list_regression.rs
+++ b/apps/desktop-demo/tests/mineswapper_lazy_list_regression.rs
@@ -743,6 +743,17 @@ fn async_runtime_to_other_tabs_after_second_forward_pass_preserves_content() {
     let registered = TEST_ACTIVE_TAB_STATE.with(|cell| cell.borrow().is_some());
     assert!(registered, "active tab state was not registered");
 
+    // One real measure pass before the leak-detection loop below: the app
+    // shell picks compact-vs-desktop chrome off `Modifier::report_size_state`,
+    // which is unset (0x0, so "compact") until the first measurement, and
+    // this harness's first measurement is otherwise the loop's own
+    // `slots_before_wait_dump` capture. Composing that one-time, real,
+    // width-driven chrome swap inside the very window this loop measures
+    // reads as a leak by slot count alone; a real window is already laid
+    // out long before a person can switch tabs, so warming up here matches
+    // that and leaves the loop measuring only per-frame animation cost.
+    let _ = composition_layout_texts(&mut composition);
+
     let tab_markers = [
         (DemoTab::Animations, "Animations Showcase"),
         (DemoTab::TextInput, "Text Input Demo"),

--- a/apps/desktop-demo/tests/mineswapper_lazy_list_regression.rs
+++ b/apps/desktop-demo/tests/mineswapper_lazy_list_regression.rs
@@ -743,16 +743,7 @@ fn async_runtime_to_other_tabs_after_second_forward_pass_preserves_content() {
     let registered = TEST_ACTIVE_TAB_STATE.with(|cell| cell.borrow().is_some());
     assert!(registered, "active tab state was not registered");
 
-    // One real measure pass before the leak-detection loop below: the app
-    // shell picks compact-vs-desktop chrome off `Modifier::report_size_state`,
-    // which is unset (0x0, so "compact") until the first measurement, and
-    // this harness's first measurement is otherwise the loop's own
-    // `slots_before_wait_dump` capture. Composing that one-time, real,
-    // width-driven chrome swap inside the very window this loop measures
-    // reads as a leak by slot count alone; a real window is already laid
-    // out long before a person can switch tabs, so warming up here matches
-    // that and leaves the loop measuring only per-frame animation cost.
-    let _ = composition_layout_texts(&mut composition);
+    settle_breakpoint_transition_before_measuring(&mut composition);
 
     let tab_markers = [
         (DemoTab::Animations, "Animations Showcase"),
@@ -798,6 +789,65 @@ fn async_runtime_to_other_tabs_after_second_forward_pass_preserves_content() {
                 "after switching away from Async Runtime during second forward pass to {:?}",
                 target_tab
             ),
+        );
+    }
+}
+
+fn settle_breakpoint_transition_before_measuring(composition: &mut Composition<MemoryApplier>) {
+    let _ = composition_layout_texts(composition);
+}
+
+fn measure_composition_at(composition: &mut Composition<MemoryApplier>, width: f32, height: f32) {
+    let root = composition.root().expect("composition root");
+    let handle = composition.runtime_handle();
+    let mut applier = composition.applier_mut();
+    applier.set_runtime_handle(handle);
+    let _ = measure_layout_with_options(
+        &mut applier,
+        root,
+        Size::new(width, height),
+        MeasureLayoutOptions {
+            collect_semantics: false,
+            build_layout_tree: true,
+        },
+    )
+    .expect("measure layout for breakpoint-crossing regression");
+    applier.clear_runtime_handle();
+}
+
+#[test]
+fn repeated_breakpoint_crossings_settle_instead_of_leaking() {
+    let (_app_context, _app_context_scope) = app_context_scope();
+    TEST_ACTIVE_TAB_STATE.with(|cell| cell.borrow_mut().take());
+
+    let mut composition = Composition::new(MemoryApplier::new());
+    let key = location_key(file!(), line!(), column!());
+    composition
+        .render(key, combined_app)
+        .expect("install combined app content");
+    drain_all(&mut composition).expect("initial drain");
+
+    const COMPACT_WIDTH: f32 = 400.0;
+    const DESKTOP_WIDTH: f32 = 1200.0;
+    const ROUND_TRIPS: usize = 12;
+
+    let mut counts_after_each_round_trip = Vec::with_capacity(ROUND_TRIPS);
+    for _ in 0..ROUND_TRIPS {
+        measure_composition_at(&mut composition, COMPACT_WIDTH, 800.0);
+        drain_all(&mut composition).expect("drain after compact-width measure");
+        measure_composition_at(&mut composition, DESKTOP_WIDTH, 800.0);
+        drain_all(&mut composition).expect("drain after desktop-width measure");
+        counts_after_each_round_trip.push(composition.debug_dump_slot_entries().len());
+    }
+
+    let first_round_trip = counts_after_each_round_trip[0];
+    for (round, &count) in counts_after_each_round_trip.iter().enumerate() {
+        assert_eq!(
+            count, first_round_trip,
+            "breakpoint round trip {round} left the slot table at {count} \
+             instead of settling back to {first_round_trip}: {counts_after_each_round_trip:?} \
+             — a departing compact/desktop branch is not fully disposing on \
+             each crossing"
         );
     }
 }

--- a/crates/cranpose/src/app_launcher.rs
+++ b/crates/cranpose/src/app_launcher.rs
@@ -40,6 +40,15 @@ pub struct AppSettings {
     pub initial_height: u32,
     /// Whether the initial size was explicitly supplied by the app.
     pub initial_size_explicit: bool,
+    /// Web only: size the canvas to the full browser viewport instead of
+    /// capping it at `initial_width`/`initial_height`.
+    ///
+    /// The default keeps the historical behavior — a canvas that shrinks to
+    /// fit a narrow viewport but never grows past the requested size,
+    /// centered on the page. An app that wants the canvas to fill and track
+    /// the browser window (resizing live as the window does) opts in here;
+    /// other platforms ignore this field.
+    pub web_fill_viewport: bool,
     /// Fonts loaded for text rendering (ordered: primary first, fallbacks last).
     pub fonts: Option<&'static [&'static [u8]]>,
     /// App-supplied font families, already read and parsed.
@@ -109,6 +118,7 @@ impl Default for AppSettings {
             initial_width: 800,
             initial_height: 600,
             initial_size_explicit: false,
+            web_fill_viewport: false,
             fonts: None,
             font_registry: SoftwareTextFontRegistry::new(),
             android_use_system_fonts: false,
@@ -402,6 +412,15 @@ impl AppLauncher {
         self.settings.initial_width = width;
         self.settings.initial_height = height;
         self.settings.initial_size_explicit = true;
+        self
+    }
+
+    /// Web only: size the canvas to the full browser viewport and keep it
+    /// tracking that viewport's size as the window resizes, instead of
+    /// capping it at the size passed to [`Self::with_size`]. Other platforms
+    /// ignore this.
+    pub fn with_web_fill_viewport(mut self, fill: bool) -> Self {
+        self.settings.web_fill_viewport = fill;
         self
     }
 

--- a/crates/cranpose/src/web.rs
+++ b/crates/cranpose/src/web.rs
@@ -110,6 +110,13 @@ impl PlatformFrameDriver for WebPlatformFrameDriver<'_> {
     }
 }
 
+fn set_height_to_dynamic_viewport_height_with_static_fallback(
+    style: &web_sys::CssStyleDeclaration,
+) -> Result<(), JsValue> {
+    style.set_property("height", "100vh")?;
+    style.set_property("height", "100dvh")
+}
+
 /// Runs a web Compose application with wgpu rendering.
 ///
 /// Called by `AppLauncher::run_web()`. This is the framework-level
@@ -153,21 +160,13 @@ pub async fn run(
     // Get device pixel ratio for proper scaling
     let scale_factor = window.device_pixel_ratio();
 
-    // Keep the requested desktop-sized viewport as an upper bound while
-    // fitting phones and narrow browser windows without horizontal scrolling,
-    // unless the app asked the canvas to fill the browser viewport instead.
     let requested_width = settings.initial_width;
     let requested_height = settings.initial_height;
     if let Some(html_element) = canvas.dyn_ref::<web_sys::HtmlElement>() {
         let style = html_element.style();
         if settings.web_fill_viewport {
             style.set_property("width", "100vw")?;
-            // `100dvh` accounts for a mobile browser's collapsing address
-            // bar; older browsers that do not parse the `dvh` unit keep the
-            // `100vh` set just before it, since an unparsable value is a
-            // no-op rather than a reset.
-            style.set_property("height", "100vh")?;
-            style.set_property("height", "100dvh")?;
+            set_height_to_dynamic_viewport_height_with_static_fallback(&style)?;
         } else {
             style.set_property(
                 "width",

--- a/crates/cranpose/src/web.rs
+++ b/crates/cranpose/src/web.rs
@@ -154,19 +154,30 @@ pub async fn run(
     let scale_factor = window.device_pixel_ratio();
 
     // Keep the requested desktop-sized viewport as an upper bound while
-    // fitting phones and narrow browser windows without horizontal scrolling.
+    // fitting phones and narrow browser windows without horizontal scrolling,
+    // unless the app asked the canvas to fill the browser viewport instead.
     let requested_width = settings.initial_width;
     let requested_height = settings.initial_height;
     if let Some(html_element) = canvas.dyn_ref::<web_sys::HtmlElement>() {
         let style = html_element.style();
-        style.set_property(
-            "width",
-            &format!("min({requested_width}px, calc(100vw - 36px))"),
-        )?;
-        style.set_property(
-            "height",
-            &format!("min({requested_height}px, calc(100vh - 36px))"),
-        )?;
+        if settings.web_fill_viewport {
+            style.set_property("width", "100vw")?;
+            // `100dvh` accounts for a mobile browser's collapsing address
+            // bar; older browsers that do not parse the `dvh` unit keep the
+            // `100vh` set just before it, since an unparsable value is a
+            // no-op rather than a reset.
+            style.set_property("height", "100vh")?;
+            style.set_property("height", "100dvh")?;
+        } else {
+            style.set_property(
+                "width",
+                &format!("min({requested_width}px, calc(100vw - 36px))"),
+            )?;
+            style.set_property(
+                "height",
+                &format!("min({requested_height}px, calc(100vh - 36px))"),
+            )?;
+        }
         style.set_property("touch-action", "none")?;
     }
     let width = canvas.client_width().max(1) as u32;


### PR DESCRIPTION
## This is a framework change wearing a demo-app hat

Most of the diff is in `apps/desktop-demo/`, but this touches `crates/cranpose/src/app_launcher.rs` and `crates/cranpose/src/web.rs` and **adds public API**: `AppSettings::web_fill_viewport` and `AppLauncher::with_web_fill_viewport`. Please review it as an API addition, not just a demo tweak.

- New field, default `false` (preserves current behavior for every existing caller, including `apps/isolated-demo`, which does not opt in and is untouched by this PR).
- New builder method `AppLauncher::with_web_fill_viewport(bool)`, called only from `apps/desktop-demo-platform/src/lib.rs::create_app()`.
- When `true`, `crates/cranpose/src/web.rs::run()` sizes the canvas to `100vw` / `100dvh` (falling back to `100vh` on browsers that don't parse `dvh`) instead of `min(requested_px, 100vw/vh - 36px)`. The existing resize plumbing (`reshape`, the `resize` listener, `web_host_surface`) was already fully wired for a canvas whose CSS size changes at runtime; this only changes what CSS size gets set.

## What this does (the actual task)

1. **Fullscreen on web.** The canvas was capped at the app's requested size (800×600 for desktop-demo) and centered with a border/shadow, regardless of browser window size. It now fills the viewport and tracks live resizes. `apps/desktop-demo/index.html` was restructured so the boot chrome (title/loading/error/links) is a fixed overlay that steps aside once the app reaches `running` (tracked via a `data-phase` attribute on `<body>`), rather than adding page height the canvas would have to coexist with.

2. **Phone adaptation.** The 25-tab strip only ever worked as a horizontally-scrolling row — fine on a desktop window, unusable on a phone-width one. `combined_app_with_startup` now reports its measured width via `Modifier::report_size_state` (landed in #545) and, below `COMPACT_WINDOW_SIZE_CLASS_MAX_WIDTH` (600 logical px, the Material compact/medium window-size-class boundary), swaps the tab row for a compact "current tab ▾" button that opens a full-height scrollable picker over all 25 tabs. This is the primitive the task asked for instead of a `BoxWithConstraints` subcompose boundary (see `docs/subcompose_measure_cost.md`, also from today).

3. **Breakpoint choice vs. the existing robot suite.** I enumerated every `.with_size(...)` in `apps/desktop-demo/robot-runners/` that renders the full app (`combined_app`/`DesktopApp`, ~90 of ~145 examples). The narrowest such window is 390×844 (the two Hacker News scroll tests); the next narrowest is 600, then 800/900/1024/1100/1200/1400. 600 sits strictly between them, so every existing full-app robot test at ≥600px still runs the byte-identical pre-existing desktop code path — I did not change that path's behavior at all, only added a separate branch below it. `robot_regression_tabbar_contract` (900×700) explicitly asserts the tab row *overflows* and stays horizontal; that assertion is untouched. Isolated-fixture tests below 600px (e.g. `robot_renderer_micro_contract` at 180×205) never render the tab bar at all, so they're unaffected either way.

## A note on a warm-up call that will look suspicious in review

`apps/desktop-demo/tests/mineswapper_lazy_list_regression.rs` has a call named `settle_breakpoint_transition_before_measuring` sitting right before a slot-growth assertion. On its own that reads exactly like a threshold bent to make a red test green, so here is the story rather than making a reviewer reconstruct it:

- `async_runtime_to_other_tabs_after_second_forward_pass_preserves_content` failed after the layout change: `before=435 after=1457` live composition slots across an animation loop, against a `+32` tolerance.
- Bisection (forcing the branch permanently compact, or permanently desktop — no transition either way) passed clean both times, zero slot growth over 2400 simulated frames. Only the *transition* produced the delta. Root cause: `report_size_state`'s reported width starts at `0×0` ("compact") until the first real measure pass, and this specific test's first real measurement happens *inside* the loop it's asserting over, so the loop's own first iteration composes the one-time, legitimate swap from the compact header to the full desktop tab row (~1000 slots of real content) inside the exact window being measured.
- That explains a one-time cost, but the feature is adaptive layout — a user dragging a window across the breakpoint crosses it many times, not once, while parked on a tab. So before trusting a warm-up as the fix rather than a cover-up, I drove the measured width back and forth across the breakpoint 12 full round trips (24 crossings) in one composition and read the slot count after every round trip: **1706, twelve times, delta 0.** Flat, not linear — a departing branch's subtree fully disposes on every crossing, not just eventually.
- That experiment is now a permanent regression test, `repeated_breakpoint_crossings_settle_instead_of_leaking`, in the same file — it's the thing that would catch it if a future change to `CompactAppBar`/`TabBarHorizontal`/`CompactTabPicker` ever made a departing branch fail to dispose. The single-transition tests can't see that shape of bug.
- `settle_breakpoint_transition_before_measuring` warms the composition through one real measure pass before the original test's loop starts, so that loop measures only per-frame animation cost — which is what it was written to catch — instead of the one-time settle this new code legitimately does once per app launch (or once per resize-across-breakpoint, per the round-trip test above).

## Verification status

Done and clean, locally on this Mac:
- `cargo fmt --check` (nightly toolchain)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --target wasm32-unknown-unknown -p desktop-app-platform --no-default-features --features web,renderer-wgpu -- -D warnings`
- `cargo doc` (workspace, `--all-features`, excluding the demo crates as the recipe does) — inspected the generated HTML for the two new public items directly: `AppSettings::web_fill_viewport`'s doc renders with default/behavior/platform-scope stated, and `AppLauncher::with_web_fill_viewport`'s `[Self::with_size]` intra-doc link resolves to a real `<a>` in the output.
- `cargo test --profile ci --workspace` — full workspace, zero failures
- `apps/desktop-demo/build-web.sh --release` — built, 12M/14.68M wasm size budget
- Manual verification of the built web app in a real browser: fullscreen canvas at 1200×800 (desktop chrome) and live-resized down to 390×844 (compact chrome, picker opens/selects correctly), confirmed via `window.innerWidth`/canvas `clientWidth` matching and `__cranposeAppState.phase === "running"`.
- Manual verification of the release desktop binary via macOS Accessibility API + `screencapture` at 800×600, 390×844, and 900×700 — desktop tab row unchanged at 800/900, compact picker at 390, tab selection through the picker works, and switching back above the breakpoint correctly restores the full tab row.
- A **local** run of the full robot suite (`./run_robot_test.sh --sequential`) on this Mac: 122 passed, 0 failed, 35 skipped (X11-only capability gate, expected on macOS). This run started after its own host-quiet guard gave up waiting for a quiet machine, so its own output says "TREAT ANY TIMING FAILURE BELOW AS UNMEASURED" — reported here only as a crash/panic sanity check (nothing crashed, nothing panicked, nothing failed), superseded by the CI runs below for anything timing-sensitive.

**Authoritative robot suite: complete and green**, both checks on this PR:
- `robot e2e (self-hosted GPU)`: 154/154 passed, 0 failed. Read the job log directly rather than trusting the badge: the host-capacity lock genuinely waited 252s for exclusive access ("Host capacity: waiting for the builds sharing this machine..." → "Host capacity: exclusive after 252s") before the measurement phase started, and no "gave up"/"UNMEASURED" text appears anywhere in the log — this run had real, contested exclusivity for its whole duration, not a race. It's also the first robot-suite run on this branch to run under #552 (merged since), which fixed `with_host_lock.sh` closing its fd on `exec` and releasing the lock in milliseconds instead of holding it — every green on that host before #552 landed was measured with an effectively-released lock; this one wasn't, so it's stronger evidence than it would have been a day earlier.
- `robot external captures (software present)`: 3/3 passed (`robot_underline_screenshot`, `robot_text_strikeout_presented`, `robot_leetcodedaily_full_layout_scroll_stability`). Also read from the job log: host-quiet-guard settled naturally in 15s (load 8.07→6.51), never hit the give-up path.
- Between the two: 154 + 3 = 157, and 122 (local pass) + 35 (local skip, X11-only) − 3 (captures-only examples) = 154 — the GPU run's count reconciles exactly against the local run's, so this is the same full example set, not a truncated one.

## Rebase / version note

Branch is current against `main` as of this writing (`f562a884`/`32d00dbc`/`7c37bac1`/`1849d18e`/`6fca42ed` — through #552, #550, #557 and the v0.1.105 release) — `git merge-tree` reports a clean merge, `gh pr view --json mergeStateStatus` reports `CLEAN`. The only diff against a fresh `main` is the expected `Cargo.lock` crate-version bumps (0.1.104 → 0.1.105) that this branch doesn't itself touch.

Framework `main` now publishes 0.1.105 (includes the subcompose retention work from #548). This PR adds public API (`AppSettings::web_fill_viewport`, `AppLauncher::with_web_fill_viewport`) that hasn't shipped in any release yet — it'll go out in whichever version follows 0.1.105, whenever this merges.

## Ready for review

Both authoritative robot checks are green with logs read and confirmed, not just badges trusted. Marking ready for review.

