### PR TITLE
Record the frame cost attribution: unchanged layers cost GPU every frame

### DIFF
--- a/docs/frame_cost_attribution.md
+++ b/docs/frame_cost_attribution.md
@@ -1,0 +1,102 @@
+# Frame cost attribution on the Kirin 980 (Mate 20 X / EVR-AL00)
+
+Device-measured findings from 2026-08-29, taken with the
+`debug.cranpose.frame_telemetry` stage instrument on two real apps:
+cranscan (list scrolling) and cranpose-orbit (animated showcase). Two
+of these findings are statements about Cranpose itself, independent of
+either app. Every number is a real-device capture; the methods notes at
+the end are the traps that produced wrong readings before the right
+ones.
+
+## Finding 1 — the GPU redraws unchanged layers every presented frame
+
+**Claim.** Cranpose has no layer-level GPU reuse and no damage
+scissoring: on every presented frame, the full scene is re-rendered on
+the GPU, including layers whose pixels provably did not change. Any app
+that presents continuously — which is any app with an ambient
+animation, a cursor blink, or a progress indicator — pays full fill
+cost for its static backdrop on every frame.
+
+**Evidence.** A fullscreen decorative layer (one radial-gradient rect
+plus 160 solid circles) was measured three ways on the same screen,
+single variable per arm, order-alternated, temperature-logged:
+
+| arm | fps | render encode p50 | present p50 |
+|---|---|---|---|
+| layer animated (baseline) | 22.5-24.6 | 11.8 ms | 31.9 ms |
+| layer frozen, primitives present | 33-35 | 5.6-6.0 ms | 21.7-22.9 ms |
+| layer removed | 42.2 | 5.7 ms | 16.4 ms |
+
+Freezing the layer returns the CPU encode to the removed level — the
+retained scene is not re-encoded, retention works — but present
+recovers only half: ~6 ms of GPU per frame remains for pixels that
+never change, and only removal recovers it. Texture-caching stable
+layers or damage-rect scissoring would recover that cost for every
+decorated app. This is an architectural piece of work, scheduled after
+the v0.1.105 release; it should not be attempted as a side change.
+
+## Finding 2 — re-recording costs ~37µs per solid-brush primitive
+
+When a `draw_behind` layer IS invalid (its animation genuinely changed
+it), re-recording its primitives costs ~37µs per solid circle on this
+device: 160 circles = ~6 ms of encode per frame. Two different bugs
+with two different owners live here, and they must not be merged:
+
+- **App-side (Orbit's, and any app with a particle backdrop):** do not
+  re-record hundreds of primitives per frame for an effect a single
+  fullscreen shader or an alpha-animated cached layer can carry.
+- **Framework-side (ours):** whether a re-recorded solid circle needs
+  to cost 37µs at all is a question about the encode path
+  (shape-convert, brush upload, per-primitive bookkeeping), and it
+  stays open until that path is profiled. Fixing the app hides the
+  meter; it does not fix the rate.
+
+## Finding 3 — frame-driven animation recomposes the world
+
+cranpose-orbit at IDLE spends 13-19 ms of `update` per frame because an
+app-level ambient animation recomposes the entire tree every frame and
+rebuilds fourteen `RuntimeShader` objects from shared source. Even with
+the backdrop removed entirely, the app tops out at 42 fps on this CPU
+cost alone. The remedies are the ones the retention work built:
+clean-slot reuse (#548) once apps can pin a release carrying it,
+leaf-scoped state reads so a per-frame value invalidates leaves rather
+than the root, and an answer to whether per-frame
+`RuntimeShader::from_shared_source` rebuilds defeat the sharing they
+exist for.
+
+## Where cranscan landed for contrast (post-#548, scrolling)
+
+update 2.1 / render 4.2 / present 2.4 / cpu 9.2 ms p50, fps pinned at
+~58 by the 60Hz panel. Acquire (~12 ms) is backpressure slack, proven
+by its GROWTH when retention removed ~1 ms of CPU: less work, longer
+wait, period constant. Never optimize a wait that expands to absorb
+wins. Against a 120 fps budget (8.33 ms), render is the largest
+remaining stage.
+
+## Reading the instrument (before doing any arithmetic on it)
+
+`cpu = update + sync + render + present`; `poll` and `acquire` are
+excluded BY DESIGN as waits, and `acquire` measures only
+`get_current_texture`. Per-stage percentiles are computed from
+independently sorted arrays: **cross-stage p50 comparisons are
+marginals, not per-frame statements** — the same window can order two
+stages one way at p50 and the opposite way at mean. Means are the
+additive statistic; confirm any cross-stage claim on means. Orbit's
+cpu > period crossing (pipelined against the swapchain) holds on means
+in all three idle windows — 56.5/60.3/60.0 vs 40.0/41.5/41.5 — which is
+what makes it structural rather than distribution shape.
+
+## Methods notes (the traps)
+
+- xvfb frame rates are software presentation, not the GPU.
+- Thermal drift on this device is ~2 fps across a back-to-back arm
+  sequence at 38-39°C battery temperature; alternate arm order and log
+  temps, or a late-running baseline reads as a regression.
+- Force AOT (`cmd package compile -m speed -f`) and md5-verify the
+  on-device APK against the host file before trusting an arm.
+- One anomalous fast baseline window (30.3 fps against 23-25
+  everywhere else) is recorded and NOT explained; single-window
+  captures are not evidence.
+- Orbit's detail screen (fullscreen fbm sun, 13-15 fps) is UNRESOLVED:
+  1-2 telemetry blocks per arm, all removal arms within noise of each
+  other. Longer captures are required before any claim about it.


### PR DESCRIPTION
The repo record of today's device attribution on the Kirin 980, written for readers who did not run the captures — three agents are already reasoning from these numbers.

The lead finding is about Cranpose, not about any app: **the renderer redraws unchanged layers on the GPU every presented frame** — no layer reuse, no damage scissoring. Measured at ~6ms/frame for a provably static fullscreen backdrop (animated 31.9ms present / frozen ~22 / removed 16.4, with CPU encode returning fully to baseline when frozen — retention works on the CPU side, nothing skips on the GPU side). Layer texture-caching or damage rects is scheduled as its own architectural work after v0.1.105; this note is its scoping document.

Also recorded: the ~37µs-per-primitive re-record rate (app-side and framework-side halves kept separate, with owners), the frame-driven-animation recomposition ceiling that #548's retention addresses, cranscan's post-#548 stage profile for contrast, and the instrument-reading rules (cross-stage p50s are marginals; means are the additive check; acquire is slack that grows to absorb wins — proven by retention's win being absorbed into acquire on a vsync-pinned panel).

Honesty markers preserved: one anomalous baseline window recorded-and-unexplained; the Orbit detail screen explicitly UNRESOLVED on thin data.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)