### PR TITLE
Let the heavy jobs short-circuit a prose-only pull request

### DIFF
--- a/.github/workflows/heavy-selfhosted.yml
+++ b/.github/workflows/heavy-selfhosted.yml
@@ -4,6 +4,19 @@ name: heavy (self-hosted)
 # own runners. Forks are DISABLED on this repository, so pull_request
 # events only ever come from the owner's branches — self-hosted execution
 # is safe for every trigger.
+#
+# These are the most expensive jobs on the board and the two Linux runners
+# that carry [self-hosted, Linux, cranpose-heavy] are the whole pool the
+# robot suite can use, so a prose-only pull request that occupies them
+# delays a release. Every job here therefore checks the diff first and
+# short-circuits to success on one, via scripts/ci/docs_only_change.sh.
+#
+# Deliberately not `paths-ignore`. A trigger filter stops the check from
+# reporting at all, which turns any job that is later made a required
+# status check into a permanent merge block rather than a fast one. Nothing
+# on main is required today, but a `main` ruleset already exists (currently
+# disabled), so the pattern that survives it being enabled is the one used
+# here: run the job, decide inside it.
 on:
   push:
     branches: ["main"]
@@ -29,8 +42,17 @@ jobs:
       CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Both parents of the merge commit, for the diff below.
+          fetch-depth: 2
+
+      - name: Detect a docs-only change
+        id: changes
+        # Why a short-circuit and not paths-ignore: see the header.
+        run: scripts/ci/docs_only_change.sh
 
       - name: Configure machine-local knobs
+        if: steps.changes.outputs.docs_only != 'true'
         env:
           RUNNER_NAME: ${{ runner.name }}
         run: |
@@ -52,11 +74,13 @@ jobs:
           echo "$(eval echo "~$(id -un)")/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Start sccache
+        if: steps.changes.outputs.docs_only != 'true'
         run: |
           command -v just >/dev/null || cargo install just --locked
           scripts/ci/start_sccache.sh
 
       - name: Run the robot suite on the GPU
+        if: steps.changes.outputs.docs_only != 'true'
         # The suite relaxes the environment-sensitive frame-rate assertions
         # itself; the Vulkan ICD here still selects the real GPU. The three
         # external-framebuffer capture tests run in robot-capture-software
@@ -72,7 +96,7 @@ jobs:
         run: just robot-gpu
 
       - name: sccache stats
-        if: always()
+        if: always() && steps.changes.outputs.docs_only != 'true'
         run: '"$RUSTC_WRAPPER" --show-stats || true'
 
   robot-capture-software:
@@ -87,8 +111,17 @@ jobs:
       CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Both parents of the merge commit, for the diff below.
+          fetch-depth: 2
+
+      - name: Detect a docs-only change
+        id: changes
+        # Why a short-circuit and not paths-ignore: see the header.
+        run: scripts/ci/docs_only_change.sh
 
       - name: Configure machine-local knobs
+        if: steps.changes.outputs.docs_only != 'true'
         env:
           RUNNER_NAME: ${{ runner.name }}
         run: |
@@ -102,11 +135,13 @@ jobs:
           echo "$(eval echo "~$(id -un)")/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Start sccache
+        if: steps.changes.outputs.docs_only != 'true'
         run: |
           command -v just >/dev/null || cargo install just --locked
           scripts/ci/start_sccache.sh
 
       - name: Run the external capture trio on software present
+        if: steps.changes.outputs.docs_only != 'true'
         # See robot-e2e-gpu above: this suite and that one share a
         # host-level lock so they never run at once on the same box.
         run: just robot-captures
@@ -119,8 +154,17 @@ jobs:
       CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Both parents of the merge commit, for the diff below.
+          fetch-depth: 2
+
+      - name: Detect a docs-only change
+        id: changes
+        # Why a short-circuit and not paths-ignore: see the header.
+        run: scripts/ci/docs_only_change.sh
 
       - name: Provision iOS Rust targets
+        if: steps.changes.outputs.docs_only != 'true'
         run: |
           # Resolve the account's real home rather than trusting $HOME:
           # actions/checkout temporarily overrides HOME, and a step that runs
@@ -145,12 +189,15 @@ jobs:
             aarch64-apple-ios
 
       - name: Clippy iOS simulator
+        if: steps.changes.outputs.docs_only != 'true'
         run: just clippy-ios
 
       - name: Build iOS device binary
+        if: steps.changes.outputs.docs_only != 'true'
         run: just ios-device
 
       - name: Assemble simulator app bundle
+        if: steps.changes.outputs.docs_only != 'true'
         run: just ios-sim
 
   android-release:
@@ -162,8 +209,17 @@ jobs:
       CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Both parents of the merge commit, for the diff below.
+          fetch-depth: 2
+
+      - name: Detect a docs-only change
+        id: changes
+        # Why a short-circuit and not paths-ignore: see the header.
+        run: scripts/ci/docs_only_change.sh
 
       - name: Configure machine-local SDK and cache paths
+        if: steps.changes.outputs.docs_only != 'true'
         env:
           RUNNER_NAME: ${{ runner.name }}
           RUNNER_OS: ${{ runner.os }}
@@ -197,6 +253,7 @@ jobs:
           echo "$sdk_root/platform-tools" >> "$GITHUB_PATH"
 
       - name: Provision toolchains and start sccache
+        if: steps.changes.outputs.docs_only != 'true'
         run: |
           # rust-toolchain.toml owns the version; the targets land on it.
           rustc --version
@@ -216,12 +273,14 @@ jobs:
           test -f "$ANDROID_NDK_HOME/source.properties"
 
       - name: Clippy Android ABIs
+        if: steps.changes.outputs.docs_only != 'true'
         # Gradle does not deny warnings, so the APK build below cannot be the
         # zero-warning gate for this target. Runs first: a lint failure should
         # not wait behind a full release APK.
         run: just clippy-android
 
       - name: Build Android release APK
+        if: steps.changes.outputs.docs_only != 'true'
         # --no-daemon: never attach to a shared/foreign Gradle daemon on this
         # self-hosted box. Reused daemons started by other builds on the runner
         # can carry a PATH without ~/.cargo/bin, which makes the cargo-ndk check
@@ -230,5 +289,5 @@ jobs:
         run: just android
 
       - name: sccache stats
-        if: always()
+        if: always() && steps.changes.outputs.docs_only != 'true'
         run: '"$RUSTC_WRAPPER" --show-stats || true'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,13 @@ name: Rust
 # ARM64 MacBooks + the Linux GPU server). Every job explicitly rejects fork
 # heads before allocating a runner; same-repository pull requests remain safe.
 # The robot suite lives in heavy-selfhosted.yml where it runs on the real GPU.
+#
+# `architecture budgets` and `wasm build` both draw on the heavy pool, so they
+# short-circuit on a prose-only diff the same way the heavy workflow's jobs do.
+# `checks` never does, and must not: `just typos` spell-checks docs/ and every
+# .md, `just doc` fails on a broken intra-doc link, and `just test` compiles the
+# doctests that crates/cranpose-core/src/lib.rs pulls in from its README. Prose
+# is exactly what that job gates, so a prose diff is signal there, not waste.
 on:
   push:
     branches: ["main"]
@@ -68,6 +75,11 @@ jobs:
       - name: Test the quality gates' diff-scoping logic
         run: just test-quality-gates
 
+      - name: Check the docs-only trigger filter
+        # The predicate the heavy jobs skip on. It runs in this job because
+        # this job is the one that never skips.
+        run: just test-ci-filters
+
       - name: Check cyclomatic complexity of changed functions
         run: just complexity-gate
 
@@ -104,8 +116,17 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Both parents of the merge commit, for the diff below.
+          fetch-depth: 2
+
+      - name: Detect a docs-only change
+        id: changes
+        # Why a short-circuit and not paths-ignore: see the header.
+        run: scripts/ci/docs_only_change.sh
 
       - name: Provision PATH and sccache
+        if: steps.changes.outputs.docs_only != 'true'
         run: |
           # Both, and in this order. `GITHUB_PATH` only reaches LATER steps,
           # and the `cargo install` on the next line runs in THIS one -- so on
@@ -131,6 +152,7 @@ jobs:
           scripts/ci/start_sccache.sh
 
       - name: Check architecture budgets
+        if: steps.changes.outputs.docs_only != 'true'
         # Featureless and all-features builds, the per-backend winit checks, the
         # duplicate-dependency budgets and the desktop binary-size ceiling.
         run: just budgets
@@ -147,8 +169,17 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Both parents of the merge commit, for the diff below.
+          fetch-depth: 2
+
+      - name: Detect a docs-only change
+        id: changes
+        # Why a short-circuit and not paths-ignore: see the header.
+        run: scripts/ci/docs_only_change.sh
 
       - name: Provision PATH and sccache
+        if: steps.changes.outputs.docs_only != 'true'
         run: |
           # Both, and in this order. `GITHUB_PATH` only reaches LATER steps,
           # and the `cargo install` on the next line runs in THIS one -- so on
@@ -179,6 +210,7 @@ jobs:
           wasm-opt --version || echo "no system binaryen; wasm-pack supplies its own"
 
       - name: Run wasm clippy
+        if: steps.changes.outputs.docs_only != 'true'
         # A build alone (below) does not lint: `Arc<dyn Trait>` values that are
         # not `Send + Sync` on the single-threaded wasm target compile fine but
         # pay for synchronisation the target cannot use. Only clippy catches
@@ -186,4 +218,5 @@ jobs:
         run: just clippy-wasm
 
       - name: Build web demo
+        if: steps.changes.outputs.docs_only != 'true'
         run: just web

--- a/justfile
+++ b/justfile
@@ -150,6 +150,12 @@ test-features:
     cargo test --profile ci -p cranpose-core --features std-hash
     cargo test --profile ci -p cranpose-core --features internal
 
+# The docs-only trigger filter that lets the heavy jobs skip a prose diff.
+# A wrong answer there disables the robot suite silently, so the predicate is
+# pinned by the same gate that runs everywhere else.
+test-ci-filters:
+    scripts/ci/docs_only_change_test.sh
+
 # The deterministic slot-table model check, at the frame count CI uses.
 test-property:
     cargo test --profile ci -p cranpose-core deterministic_model_render_frames_match_slot_table

--- a/scripts/ci/docs_only_change.sh
+++ b/scripts/ci/docs_only_change.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Decide whether a pull request touches nothing a build can observe.
+#
+# Prints `true` or `false`, and sets the `docs_only` step output when it runs
+# under Actions. Jobs that compile, link or render anything guard their steps
+# on it; the jobs that genuinely gate prose (`just typos`, `just doc` and the
+# doctests `just test` compiles out of crates/cranpose-core/README.md) must not.
+#
+# The predicate is deliberately narrow: a path counts as docs only when it ends
+# in `.md`. Everything else -- images under docs/, tools/, scripts/, workflow
+# files -- keeps the full board. A wrong `true` silently disables the robot
+# suite, so every branch that cannot prove the diff is prose answers `false`.
+set -euo pipefail
+
+emit() {
+    printf '%s\n' "$1"
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        printf 'docs_only=%s\n' "$1" >> "$GITHUB_OUTPUT"
+    fi
+    exit 0
+}
+
+# Only a pull request carries a base to diff against. A push to main, a tag and
+# a manual dispatch all run the full board.
+[[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]] || emit false
+
+# actions/checkout leaves the pull request's merge commit at HEAD, so HEAD^1 is
+# the base and HEAD^2 the head. Both parents need `fetch-depth: 2`; without it,
+# or when a job checks out some other ref, the diff is unknowable -- not empty.
+git rev-parse --verify --quiet HEAD^1 >/dev/null || emit false
+git rev-parse --verify --quiet HEAD^2 >/dev/null || emit false
+
+# --no-renames is load-bearing. With rename detection a source file renamed to
+# a .md reports only the .md destination, which would read as a prose-only
+# diff; listing both sides means the vanished .rs is seen.
+files="$(git diff --no-renames --name-only HEAD^1 HEAD)" || emit false
+
+# An empty diff means the assumption above is wrong somewhere. Run everything.
+[[ -n "$files" ]] || emit false
+
+while IFS= read -r file; do
+    case "$file" in
+        *.md) ;;
+        *) emit false ;;
+    esac
+done <<< "$files"
+
+emit true

--- a/scripts/ci/docs_only_change_test.sh
+++ b/scripts/ci/docs_only_change_test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Regression test for docs_only_change.sh.
+#
+# A wrong `false` costs one redundant run. A wrong `true` skips the robot
+# suite, the Android build and the iOS build on a change that could break any
+# of them, and the board stays green while it does. That asymmetry is why the
+# fail-safe branches are pinned here alongside the happy path.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+detector="$script_dir/docs_only_change.sh"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+failures=0
+
+# Build a pull request the way actions/checkout presents one: a merge commit
+# whose first parent is the base and whose second is the branch head.
+open_pr() {
+    local branch="$1"
+    git -C "$repo" checkout -q -b "$branch" main
+}
+
+merge_pr() {
+    local branch="$1"
+    git -C "$repo" checkout -q main
+    git -C "$repo" merge -q --no-ff "$branch" -m "merge $branch"
+}
+
+check() {
+    local label="$1" want="$2" got="$3"
+    if [[ "$got" == "$want" ]]; then
+        printf 'ok    %-42s %s\n' "$label" "$got"
+    else
+        printf 'FAIL  %-42s got %s, want %s\n' "$label" "$got" "$want"
+        failures=$((failures + 1))
+    fi
+}
+
+detect() {
+    (cd "$repo" && GITHUB_EVENT_NAME="${1:-pull_request}" bash "$detector")
+}
+
+repo="$workdir/repo"
+mkdir -p "$repo"
+git -C "$repo" init -q -b main
+git -C "$repo" config user.email ci@example.invalid
+git -C "$repo" config user.name ci
+mkdir -p "$repo/docs/render-reference" "$repo/crates/foo/src" "$repo/tools/api-surface/src"
+echo prose > "$repo/docs/guide.md"
+echo prose > "$repo/README.md"
+echo 'fn main() {}' > "$repo/crates/foo/src/lib.rs"
+echo 'pub fn helper() {}' > "$repo/crates/foo/src/helper.rs"
+echo 'fn main() {}' > "$repo/tools/api-surface/src/main.rs"
+printf 'not-really-a-png' > "$repo/docs/render-reference/contract.png"
+git -C "$repo" add -A
+git -C "$repo" commit -qm base
+
+# A nested prose file is the case the filter exists for.
+open_pr prose-nested
+echo more >> "$repo/docs/guide.md"
+git -C "$repo" commit -qam .
+merge_pr prose-nested
+check "nested .md only" true "$(detect)"
+
+# Root-level prose too: TIME_WASTERS.md and AGENTS.md live there, and the
+# `**/*.md` glob that looks like the obvious filter does not match them.
+open_pr prose-root
+echo more >> "$repo/README.md"
+git -C "$repo" commit -qam .
+merge_pr prose-root
+check "root-level .md only" true "$(detect)"
+
+# The shape that motivated the filter: prose plus a source file. The source
+# file wins, because it is the half a build can observe.
+open_pr prose-and-source
+echo more >> "$repo/docs/guide.md"
+echo '// tweak' >> "$repo/crates/foo/src/lib.rs"
+git -C "$repo" commit -qam .
+merge_pr prose-and-source
+check "prose + .rs" false "$(detect)"
+
+# tools/ is Rust that no gate currently builds. It still runs the full board:
+# nothing pins it that way, and the cost of being wrong is one-sided.
+open_pr tools-only
+echo '// tweak' >> "$repo/tools/api-surface/src/main.rs"
+git -C "$repo" commit -qam .
+merge_pr tools-only
+check "tools/ source only" false "$(detect)"
+
+# Images under docs/ are not prose. The render reference is a fixture.
+open_pr docs-image
+printf 'changed' > "$repo/docs/render-reference/contract.png"
+git -C "$repo" commit -qam .
+merge_pr docs-image
+check "docs/ image" false "$(detect)"
+
+# Rename detection would report only the .md destination and read as prose.
+open_pr rename-source-to-md
+git -C "$repo" mv crates/foo/src/lib.rs crates/foo/src/lib.md
+git -C "$repo" commit -qam .
+merge_pr rename-source-to-md
+check ".rs renamed to .md" false "$(detect)"
+
+# Deleting a source file is not prose either.
+open_pr delete-source
+git -C "$repo" rm -q crates/foo/src/helper.rs
+git -C "$repo" commit -qam .
+merge_pr delete-source
+check "source deletion" false "$(detect)"
+
+# Workflow edits must run the workflows they edit.
+open_pr workflow-edit
+mkdir -p "$repo/.github/workflows"
+echo 'name: x' > "$repo/.github/workflows/x.yml"
+git -C "$repo" add -A
+git -C "$repo" commit -qm .
+merge_pr workflow-edit
+check "workflow file" false "$(detect)"
+
+# Events without a base to diff against never skip.
+check "push event" false "$(detect push)"
+check "workflow_dispatch event" false "$(detect workflow_dispatch)"
+
+# A HEAD that is not a merge commit means the diff is unknowable, not empty.
+git -C "$repo" checkout -q workflow-edit
+check "HEAD is not a merge commit" false "$(detect)"
+git -C "$repo" checkout -q main
+
+# The step output the workflows read must actually be written.
+output_file="$workdir/github_output"
+: > "$output_file"
+(cd "$repo" && GITHUB_EVENT_NAME=pull_request GITHUB_OUTPUT="$output_file" bash "$detector" >/dev/null)
+check "step output written" "docs_only=false" "$(cat "$output_file")"
+
+if [[ "$failures" -ne 0 ]]; then
+    printf '\n%d case(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf '\nall docs-only filter cases pass\n'

--- a/scripts/ci/docs_only_change_test.sh
+++ b/scripts/ci/docs_only_change_test.sh
@@ -2,9 +2,17 @@
 # Regression test for docs_only_change.sh.
 #
 # A wrong `false` costs one redundant run. A wrong `true` skips the robot
-# suite, the Android build and the iOS build on a change that could break any
-# of them, and the board stays green while it does. That asymmetry is why the
-# fail-safe branches are pinned here alongside the happy path.
+# suite, the Android build, the iOS build, the architecture budgets and the
+# wasm build on a change that could break any of them, and the board stays
+# green while it does. That asymmetry is the whole design: every case that
+# must not be mistaken for prose is pinned here.
+#
+# The second pass is what keeps this file honest. Asserting `false` proves
+# nothing on its own -- the fail-safe branches answer `false` too, so a
+# negative case can pass while testing nothing. So each path-based negative is
+# replayed against a mutant detector whose path predicate is inverted, and must
+# flip to `true`. A case that does not flip is not exercising the predicate.
+# Positives are excluded: they already report `true`, so they cannot flip.
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -12,129 +20,151 @@ detector="$script_dir/docs_only_change.sh"
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
+repo="$workdir/repo"
+cases="$workdir/cases"
 failures=0
+: > "$cases"
 
-# Build a pull request the way actions/checkout presents one: a merge commit
-# whose first parent is the base and whose second is the branch head.
-open_pr() {
-    local branch="$1"
-    git -C "$repo" checkout -q -b "$branch" main
-}
+open_pr() { git -C "$repo" checkout -q -b "$1" main; }
 
-merge_pr() {
-    local branch="$1"
+# Land the branch as a merge commit, the shape actions/checkout gives a job:
+# first parent the base, second the head. Record it as a replayable case.
+land() {
+    local branch="$1" expect="$2" kind="$3" label="$4"
     git -C "$repo" checkout -q main
     git -C "$repo" merge -q --no-ff "$branch" -m "merge $branch"
+    printf '%s\t%s\t%s\t%s\n' "$(git -C "$repo" rev-parse HEAD)" "$expect" "$kind" "$label" >> "$cases"
+}
+
+detect_at() { # sha, detector
+    git -C "$repo" checkout -q --detach "$1"
+    (cd "$repo" && GITHUB_EVENT_NAME=pull_request bash "$2")
 }
 
 check() {
     local label="$1" want="$2" got="$3"
     if [[ "$got" == "$want" ]]; then
-        printf 'ok    %-42s %s\n' "$label" "$got"
+        printf 'ok    %-44s %s\n' "$label" "$got"
     else
-        printf 'FAIL  %-42s got %s, want %s\n' "$label" "$got" "$want"
+        printf 'FAIL  %-44s got %s, want %s\n' "$label" "$got" "$want"
         failures=$((failures + 1))
     fi
 }
 
-detect() {
-    (cd "$repo" && GITHUB_EVENT_NAME="${1:-pull_request}" bash "$detector")
-}
-
-repo="$workdir/repo"
+# --- fixtures -------------------------------------------------------------
 mkdir -p "$repo"
 git -C "$repo" init -q -b main
 git -C "$repo" config user.email ci@example.invalid
 git -C "$repo" config user.name ci
-mkdir -p "$repo/docs/render-reference" "$repo/crates/foo/src" "$repo/tools/api-surface/src"
+mkdir -p "$repo/docs/render-reference" "$repo/crates/foo/src" \
+         "$repo/crates/foo/shaders" "$repo/tools/api-surface/src" \
+         "$repo/.github/workflows"
 echo prose > "$repo/docs/guide.md"
 echo prose > "$repo/README.md"
 echo 'fn main() {}' > "$repo/crates/foo/src/lib.rs"
-echo 'pub fn helper() {}' > "$repo/crates/foo/src/helper.rs"
+echo 'fn helper() {}' > "$repo/crates/foo/src/helper.rs"
+echo 'fn shade() {}' > "$repo/crates/foo/shaders/blur.wgsl"
+echo '[package]' > "$repo/crates/foo/Cargo.toml"
 echo 'fn main() {}' > "$repo/tools/api-surface/src/main.rs"
+echo 'name: ci' > "$repo/.github/workflows/ci.yml"
 printf 'not-really-a-png' > "$repo/docs/render-reference/contract.png"
 git -C "$repo" add -A
 git -C "$repo" commit -qm base
 
-# A nested prose file is the case the filter exists for.
-open_pr prose-nested
-echo more >> "$repo/docs/guide.md"
-git -C "$repo" commit -qam .
-merge_pr prose-nested
-check "nested .md only" true "$(detect)"
+# Prose, the case the filter exists for. Nested and root-level both count:
+# TIME_WASTERS.md and AGENTS.md live at the root, and the `**/*.md` glob that
+# looks like the obvious filter does not match them.
+open_pr prose-nested; echo more >> "$repo/docs/guide.md"
+git -C "$repo" commit -qam .; land prose-nested true path "nested .md only"
 
-# Root-level prose too: TIME_WASTERS.md and AGENTS.md live there, and the
-# `**/*.md` glob that looks like the obvious filter does not match them.
-open_pr prose-root
-echo more >> "$repo/README.md"
-git -C "$repo" commit -qam .
-merge_pr prose-root
-check "root-level .md only" true "$(detect)"
+open_pr prose-root; echo more >> "$repo/README.md"
+git -C "$repo" commit -qam .; land prose-root true path "root-level .md only"
 
-# The shape that motivated the filter: prose plus a source file. The source
-# file wins, because it is the half a build can observe.
-open_pr prose-and-source
-echo more >> "$repo/docs/guide.md"
+# Everything a build can observe. Each of these must outvote the prose in the
+# same diff, so the mixed case carries a doc edit alongside the source edit.
+open_pr mixed; echo more >> "$repo/docs/guide.md"
 echo '// tweak' >> "$repo/crates/foo/src/lib.rs"
-git -C "$repo" commit -qam .
-merge_pr prose-and-source
-check "prose + .rs" false "$(detect)"
+git -C "$repo" commit -qam .; land mixed false path "mixed: one doc + one .rs"
+
+open_pr source-only; echo '// tweak' >> "$repo/crates/foo/src/helper.rs"
+git -C "$repo" commit -qam .; land source-only false path ".rs only"
+
+open_pr shader-only; echo '// tweak' >> "$repo/crates/foo/shaders/blur.wgsl"
+git -C "$repo" commit -qam .; land shader-only false path "shader (.wgsl) only"
+
+open_pr manifest-only; echo 'edition = "2024"' >> "$repo/crates/foo/Cargo.toml"
+git -C "$repo" commit -qam .; land manifest-only false path "Cargo.toml only"
+
+open_pr workflow-only; echo '# tweak' >> "$repo/.github/workflows/ci.yml"
+git -C "$repo" commit -qam .; land workflow-only false path "workflow file only"
 
 # tools/ is Rust that no gate currently builds. It still runs the full board:
 # nothing pins it that way, and the cost of being wrong is one-sided.
-open_pr tools-only
-echo '// tweak' >> "$repo/tools/api-surface/src/main.rs"
-git -C "$repo" commit -qam .
-merge_pr tools-only
-check "tools/ source only" false "$(detect)"
+open_pr tools-only; echo '// tweak' >> "$repo/tools/api-surface/src/main.rs"
+git -C "$repo" commit -qam .; land tools-only false path "tools/ source only"
 
-# Images under docs/ are not prose. The render reference is a fixture.
-open_pr docs-image
-printf 'changed' > "$repo/docs/render-reference/contract.png"
-git -C "$repo" commit -qam .
-merge_pr docs-image
-check "docs/ image" false "$(detect)"
+# Images under docs/ are fixtures, not prose.
+open_pr docs-image; printf changed > "$repo/docs/render-reference/contract.png"
+git -C "$repo" commit -qam .; land docs-image false path "docs/ image"
 
 # Rename detection would report only the .md destination and read as prose.
-open_pr rename-source-to-md
-git -C "$repo" mv crates/foo/src/lib.rs crates/foo/src/lib.md
-git -C "$repo" commit -qam .
-merge_pr rename-source-to-md
-check ".rs renamed to .md" false "$(detect)"
+open_pr rename-to-md; git -C "$repo" mv crates/foo/src/lib.rs crates/foo/src/lib.md
+git -C "$repo" commit -qam .; land rename-to-md false path ".rs renamed to .md"
 
-# Deleting a source file is not prose either.
-open_pr delete-source
-git -C "$repo" rm -q crates/foo/src/helper.rs
-git -C "$repo" commit -qam .
-merge_pr delete-source
-check "source deletion" false "$(detect)"
+open_pr delete-source; git -C "$repo" rm -q crates/foo/src/helper.rs
+git -C "$repo" commit -qam .; land delete-source false path "source deletion"
 
-# Workflow edits must run the workflows they edit.
-open_pr workflow-edit
-mkdir -p "$repo/.github/workflows"
-echo 'name: x' > "$repo/.github/workflows/x.yml"
-git -C "$repo" add -A
-git -C "$repo" commit -qm .
-merge_pr workflow-edit
-check "workflow file" false "$(detect)"
+# --- pass 1: the predicate itself ----------------------------------------
+echo "-- predicate --"
+while IFS=$'\t' read -r sha expect kind label; do
+    check "$label" "$expect" "$(detect_at "$sha" "$detector")"
+done < "$cases"
 
-# Events without a base to diff against never skip.
-check "push event" false "$(detect push)"
-check "workflow_dispatch event" false "$(detect workflow_dispatch)"
-
-# A HEAD that is not a merge commit means the diff is unknowable, not empty.
-git -C "$repo" checkout -q workflow-edit
-check "HEAD is not a merge commit" false "$(detect)"
+# Events with no base to diff against, and a HEAD that is not a merge commit,
+# never skip: the diff is unknowable, not empty.
 git -C "$repo" checkout -q main
+check "push event" false "$(cd "$repo" && GITHUB_EVENT_NAME=push bash "$detector")"
+check "workflow_dispatch event" false \
+    "$(cd "$repo" && GITHUB_EVENT_NAME=workflow_dispatch bash "$detector")"
+git -C "$repo" checkout -q --detach "$(git -C "$repo" rev-parse main^2)"
+check "HEAD is not a merge commit" false \
+    "$(cd "$repo" && GITHUB_EVENT_NAME=pull_request bash "$detector")"
 
-# The step output the workflows read must actually be written.
-output_file="$workdir/github_output"
-: > "$output_file"
-(cd "$repo" && GITHUB_EVENT_NAME=pull_request GITHUB_OUTPUT="$output_file" bash "$detector" >/dev/null)
+# The step output the workflows read on must actually be written.
+git -C "$repo" checkout -q main
+output_file="$workdir/github_output"; : > "$output_file"
+(cd "$repo" && GITHUB_EVENT_NAME=pull_request GITHUB_OUTPUT="$output_file" \
+    bash "$detector" >/dev/null)
 check "step output written" "docs_only=false" "$(cat "$output_file")"
+
+# --- pass 2: the assertions must be load-bearing --------------------------
+# Invert the path predicate so every path is accepted as prose. Every
+# path-based case must now report `true`; one that still reports `false` is
+# passing for some unrelated reason and is not testing what it claims.
+mutant="$workdir/mutant.sh"
+sed 's|^        \*) emit false ;;$|        *) ;;|' "$detector" > "$mutant"
+if cmp -s "$detector" "$mutant"; then
+    echo "FAIL  mutation did not apply -- the predicate moved, update this test" >&2
+    exit 1
+fi
+
+# Only the negatives carry information here: a positive case already reports
+# `true`, so it would "flip" to `true` without proving anything.
+echo "-- mutation: inverted predicate must break every negative assertion --"
+while IFS=$'\t' read -r sha expect kind label; do
+    [[ "$kind" == "path" && "$expect" == "false" ]] || continue
+    got="$(detect_at "$sha" "$mutant")"
+    if [[ "$got" == "true" ]]; then
+        printf 'ok    %-44s flips under mutation\n' "$label"
+    else
+        printf 'FAIL  %-44s did NOT flip (got %s): assertion is not load-bearing\n' \
+            "$label" "$got"
+        failures=$((failures + 1))
+    fi
+done < "$cases"
 
 if [[ "$failures" -ne 0 ]]; then
     printf '\n%d case(s) failed\n' "$failures" >&2
     exit 1
 fi
-printf '\nall docs-only filter cases pass\n'
+printf '\nall docs-only filter cases pass, and every negative assertion is load-bearing\n'


### PR DESCRIPTION
The four `heavy (self-hosted)` jobs, plus `architecture budgets (linux)` and
`wasm build` from `rust.yml`, ran in full on every pull request — including
ones that changed nothing a build can observe. Only `samarch-1-cranpose` and
`samarch-1-cranpose-2` carry `[self-hosted, Linux, cranpose-heavy]`, so a
prose pull request holding one delays a release. #553 and #557 each did.

Each of those jobs now runs `scripts/ci/docs_only_change.sh` immediately after
checkout and guards its remaining steps on the result, releasing the runner in
seconds instead of up to 90 minutes.

### Short-circuit, not `paths-ignore`

`paths-ignore` stops the check reporting at all, which turns any job later made
a required status check into a permanent merge block rather than a fast pass.
`main` has no branch protection today and its ruleset is `enforcement:
disabled` with only `deletion`/`non_fast_forward` rules — but a dormant ruleset
is a standing invitation to enable one, and the pattern that survives that
costs seconds.

### `rust.yml`'s `checks` job deliberately still runs on prose

It is the job that gates prose:

- `just typos` spell-checks `docs/` and every `.md` (verified by planting a
  typo in `docs/frame_cost_attribution.md` — it failed).
- `just doc` runs with `RUSTDOCFLAGS="-D warnings"`, so a broken intra-doc link
  fails it.
- `just test` is a plain `cargo test`, so it compiles the doctests
  `crates/cranpose-core/src/lib.rs:1` pulls in via
  `#![doc = include_str!("../README.md")]` — that README has 64 rust fences,
  one of them a live `rust,no_run`.

A prose diff is signal there, not waste. Filtering the workflow at the trigger
would have silently disabled all three.

### The predicate

Answers `true` only when every changed path ends in `.md`, and answers `false`
whenever it cannot prove otherwise: a non-pull-request event, a `HEAD` that is
not a merge commit, an empty diff. `--no-renames` is load-bearing — with rename
detection a source file renamed to a `.md` reports only the destination and
would read as prose.

Left on the full board on purpose:

- **`tools/`** — `tools/api-surface` is a *detached* workspace (its own
  `[workspace]` table, absent from `cargo metadata`) that no justfile recipe,
  script, or workflow builds. Nothing pins it that way, and the cost of being
  wrong is one-sided. This does mean a #553-shaped pull request (prose + a
  `tools/` binary) still runs the full board.
- **Images under `docs/`** — `docs/render-reference/main_renderer_micro_contract.png`
  is a reference fixture, not prose.

`**/*.md` is not the filter, and would have been a bug: under GitHub's glob
semantics it does not match root-level `TIME_WASTERS.md` or `AGENTS.md`.

### Why this does not merge into `scripts/ci/gate_diff.py`

#539 added `gate_diff.py`, which also looks at the diff. The two are close
enough that someone will eventually want to collapse them, so: they answer
different questions and, more importantly, they have deliberately **opposite
failure semantics**.

| | `gate_diff.py` | `docs_only_change.sh` |
|---|---|---|
| Question | which *line ranges* in `*.rs` did this change touch | is *every changed path* prose |
| Purpose | scope a correctness gate | decide whether to skip work |
| On uncertainty | fails **loudly** (`raise SystemExit`) | fails **safe** — answers `false`, runs everything |
| Base | merge base vs `origin/main` | the merge commit's own two parents |

The failure semantics are the load-bearing difference. A correctness gate that
guesses its scope is worse than useless, so `gate_diff` refuses to guess. A skip
decision that guesses wrong silently drops coverage, so this one refuses to skip
unless it is certain — every ambiguous branch returns `false`.

The base differs for a reason too. `gate_diff.ensure_ref` exists because a
persistent self-hosted runner can leave `origin/main` resolvable but stale,
which would silently mis-scope. This script never consults `origin/main` at all
— it reads `HEAD^1`/`HEAD^2` off the pull request's own merge commit — so that
hazard cannot reach it, and it needs no `--unshallow`.

If they are ever unified, unify toward *two callers of one helper*, not by
making either call the other. Collapsing the skip decision onto a helper that
raises on uncertainty would turn "cannot tell" into a broken run; collapsing the
correctness gate onto one that fails safe would turn "cannot tell" into a silent
pass.

### Tests

`just test-ci-filters` pins 15 predicate cases and runs inside `checks`, the job
that never skips.

Asserting `false` proves nothing on its own — the fail-safe branches answer
`false` too, so a negative case can pass while testing nothing. So each of the 9
path-based negatives is replayed against a mutant detector whose path predicate
is inverted, and must flip to `true`; one that does not flip fails the suite as
not load-bearing. Positives are excluded from that pass: they already report
`true`, so they cannot flip and would only report a false pass.

Negatives covered: `.rs`, a shader (`.wgsl`), a `Cargo.toml`, a workflow file, a
mixed commit (one doc + one source file), `tools/`, a `docs/` image, the rename
trap, and a source deletion — plus `push`/`workflow_dispatch` events, a `HEAD`
that is not a merge commit, and the step-output wiring.

A wrong `false` costs one redundant run; a wrong `true` disables the robot suite
while the board stays green.

### Known gaps, on purpose

- A LICENSE rename (#560's shape) still runs the full board — `LICENSE-APACHE`
  has no `.md` extension.
- A #553-shaped PR (prose + a `tools/` file) still runs the full board.

Both are deliberate. Widening the predicate to cover them is a follow-up that
should come with its own negative cases, not an unproven broadening here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

