### PR TITLE
gate_diff: scope on semantic change, not textual change

### DIFF
--- a/docs/complexity_debt.md
+++ b/docs/complexity_debt.md
@@ -1,0 +1,107 @@
+# Pre-existing complexity and duplication debt, first made visible by #539
+
+`#539` added `just complexity-gate` and `just duplication-gate`, both scoped
+to the lines a diff actually touches (`scripts/ci/gate_diff.py`). Scoped
+gates only ever check what a PR's own diff reaches, by design -- so nothing
+here is a regression from any specific commit. It is debt that predates the
+gate and was never in scope for any earlier PR to fix, made visible for the
+first time because `docs/comment-policy`'s repo-wide comment-strip diff
+happens to touch a line inside nearly every function in the tree, including
+these.
+
+Confirmed genuine, not a scoping artifact: `fix/gate-diff-comment-scoping`
+(#568) fixed the one real bug in the scoping heuristic itself (comment-only
+line changes wrongly counted as touching a function) and re-ran both gates
+against the same diff afterward. The list below is unchanged by that fix --
+these functions and clones are pulled into scope by a real code-text change
+next to the stripped comments, most often a trivial structural collapse an
+earlier comment-removal pass left behind (an emptied `if` body merging to
+`{}`), not by the comment removal itself.
+
+## Complexity: 37 functions over the limit (20)
+
+The two largest are worth naming on their own: `crates/cranpose/src/web.rs`'s
+`run` at cyclomatic complexity **224**, and `crates/cranpose/src/android.rs`'s
+`run` at **174** -- both roughly an order of magnitude over the ceiling every
+other function here is held to.
+
+```
+apps/desktop-demo/robot-runners/robot_copy_paste.rs:7-284 main (46)
+apps/desktop-demo/robot-runners/robot_copy_paste.rs:16-280 <anonymous> (44)
+apps/desktop-demo/robot-runners/robot_fling.rs:10-215 main (35)
+apps/desktop-demo/robot-runners/robot_fling.rs:21-211 <anonymous> (33)
+apps/desktop-demo/robot-runners/robot_fling_edge_cases.rs:40-324 main (32)
+apps/desktop-demo/robot-runners/robot_fling_edge_cases.rs:50-320 <anonymous> (30)
+apps/desktop-demo/robot-runners/robot_fling_precise.rs:10-303 main (27)
+apps/desktop-demo/robot-runners/robot_fling_precise.rs:20-299 <anonymous> (25)
+apps/desktop-demo/robot-runners/robot_lazy_list_order_bug.rs:7-222 main (37)
+apps/desktop-demo/robot-runners/robot_lazy_list_order_bug.rs:18-218 <anonymous> (35)
+apps/desktop-demo/robot-runners/robot_lazy_tab_test.rs:7-201 main (34)
+apps/desktop-demo/robot-runners/robot_lazy_tab_test.rs:15-199 <anonymous> (33)
+apps/desktop-demo/robot-runners/robot_shader_rect.rs:150-315 main (28)
+apps/desktop-demo/robot-runners/robot_shader_rect.rs:158-313 <anonymous> (27)
+apps/desktop-demo/robot-runners/robot_subcompose_invalidation.rs:9-105 test_app (21)
+apps/desktop-demo/robot-runners/robot_text_input.rs:7-647 main (114)
+apps/desktop-demo/robot-runners/robot_text_input.rs:18-643 <anonymous> (112)
+apps/desktop-demo/robot-runners/robot_text_loupe.rs:43-328 main (25)
+apps/desktop-demo/robot-runners/robot_text_loupe.rs:57-319 <anonymous> (21)
+crates/cranpose-app-shell/src/shell_frame.rs:186-329 run_layout_phase_in_context (33)
+crates/cranpose-liquid/src/widgets/tab_bar.rs:517-757 LiquidTabBarLayout (33)
+crates/cranpose-liquid/src/widgets/tab_bar.rs:537-755 <anonymous> (32)
+crates/cranpose-liquid/src/widgets/tab_bar.rs:575-744 <anonymous> (21)
+crates/cranpose-render/wgpu/src/render.rs:2456-2619 convert_shapes_into_outputs (22)
+crates/cranpose-render/wgpu/src/render.rs:10513-10868 encode_shadow_draw (38)
+crates/cranpose-ui/src/layout/mod.rs:1274-1529 try_measure_subcompose (37)
+crates/cranpose-ui/src/layout/mod.rs:1682-1863 measure_layout_node (24)
+crates/cranpose-ui/src/modifier/scroll.rs:426-556 on_move (31)
+crates/cranpose-ui/src/tests/async_runtime_full_layout_test.rs:49-239 async_runtime_full_layout (22)
+crates/cranpose-ui/src/tests/modifier_nodes_tests.rs:1015-1146 custom_layout_modifier_works_through_retained_chain (27)
+crates/cranpose-ui/src/tests/modifier_nodes_tests.rs:1198-1325 stateful_measure_uses_live_retained_node_state (21)
+crates/cranpose-ui/src/tests/renderer_tests.rs:101-225 renderer_translates_draw_commands (37)
+crates/cranpose-ui/src/text_field_modifier_node.rs:453-645 create_handler (27)
+crates/cranpose/src/android.rs:1494-2438 run (174)
+crates/cranpose/src/android.rs:1737-2023 <anonymous> (50)
+crates/cranpose/src/web.rs:111-924 run (224)
+crates/cranpose/src/web.rs:592-666 <anonymous> (50)
+```
+
+(Line ranges are as measured on `docs/comment-policy`'s branch tip at the
+time this was recorded, 2026-08-30; comment stripping shifts line numbers
+relative to `main`, so re-measure with `just complexity-gate` against
+whichever base is current rather than trusting these ranges to still line up.)
+
+## Duplication: 21 clones touching the diff
+
+```
+apps/desktop-demo/robot-runners/robot_double_click.rs:57-71 <-> apps/desktop-demo/robot-runners/robot_double_click.rs:106-118 (15 lines)
+apps/desktop-demo/robot-runners/robot_lazy_items_rc.rs:18-30 <-> apps/desktop-demo/robot-runners/robot_lazy_varheight_lifecycle.rs:40-52 (13 lines)
+apps/desktop-demo/robot-runners/robot_lazy_list.rs:24-38 <-> apps/desktop-demo/robot-runners/robot_tab_navigation.rs:20-34 (15 lines)
+apps/desktop-demo/robot-runners/robot_lazy_tab_test.rs:12-28 <-> apps/desktop-demo/robot-runners/robot_tab_navigation.rs:12-33 (17 lines)
+apps/desktop-demo/robot-runners/robot_shader_rect.rs:258-269 <-> apps/desktop-demo/robot-runners/robot_shader_rect.rs:277-288 (12 lines)
+crates/cranpose-animation/src/tests/animation_tests.rs:62-73 <-> crates/cranpose-animation/src/tests/color_tests.rs:104-115 (12 lines)
+crates/cranpose-core/src/snapshot_v2/global.rs:66-78 <-> crates/cranpose-core/src/snapshot_v2/mutable.rs:142-154 (13 lines)
+crates/cranpose-core/src/snapshot_v2/global.rs:93-121 <-> crates/cranpose-core/src/snapshot_v2/nested.rs:186-212 (29 lines)
+crates/cranpose-core/src/snapshot_v2/global.rs:95-109 <-> crates/cranpose-core/src/snapshot_v2/mutable.rs:197-211 (15 lines)
+crates/cranpose-core/src/snapshot_v2/mutable.rs:451-464 <-> crates/cranpose-core/src/snapshot_v2/nested.rs:278-292 (14 lines)
+crates/cranpose-core/src/snapshot_v2/readonly.rs:59-85 <-> crates/cranpose-core/src/snapshot_v2/transparent.rs:261-288 (27 lines)
+crates/cranpose-core/src/tests/composer_applier_tests.rs:573-584 <-> crates/cranpose-core/src/tests/composer_applier_tests.rs:1622-1634 (12 lines)
+crates/cranpose-core/src/tests/composer_applier_tests.rs:1618-1628 <-> crates/cranpose-core/src/tests/composer_applier_tests.rs:1644-1654 (11 lines)
+crates/cranpose-render/pixels/src/style.rs:23-34 <-> crates/cranpose-render/wgpu/src/pipeline/style.rs:22-33 (12 lines)
+crates/cranpose-render/wgpu/src/render.rs:10817-10841 <-> crates/cranpose-render/wgpu/src/render.rs:11110-11134 (25 lines)
+crates/cranpose-testing/tests/pointer_hover_gradient_test.rs:41-60 <-> crates/cranpose-testing/tests/pointer_input_end_to_end_test.rs:37-56 (20 lines)
+crates/cranpose-ui/src/layout/policies.rs:538-549 <-> crates/cranpose-ui/src/layout/policies.rs:561-572 (12 lines)
+crates/cranpose-ui/src/modifier_nodes.rs:1885-1904 <-> crates/cranpose-ui/src/modifier_nodes.rs:2020-2039 (20 lines)
+crates/cranpose-ui/src/subcompose_layout.rs:1264-1298 <-> crates/cranpose-ui/src/widgets/nodes/layout_node.rs:962-996 (35 lines)
+crates/cranpose-ui/src/tests/anchor_async_tests.rs:64-96 <-> crates/cranpose-ui/src/tests/async_runtime_full_layout_test.rs:79-116 (33 lines)
+crates/cranpose-ui/src/tests/swipe_to_dismiss_tests.rs:277-287 <-> crates/cranpose-ui/src/tests/swipe_to_dismiss_tests.rs:315-323 (11 lines)
+```
+
+## What this is not
+
+Not `docs/comment-policy`'s job to fix -- that PR strips comments, and
+fixing 37 functions' control flow or de-duplicating 21 code blocks is a
+separate, substantial architecture pass with its own review surface.
+Whoever picks this up should re-run `just complexity-gate --base <sha>` /
+`just duplication-gate --base <sha>` against a throwaway diff (e.g. touch one
+blank line in each file so the whole function is back in scope) to get
+current line numbers before starting, rather than trusting the ranges above.

--- a/scripts/ci/gate_diff.py
+++ b/scripts/ci/gate_diff.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -156,8 +157,164 @@ def parse_unified_diff_zero_context(diff_text: str) -> dict[str, list[tuple[int,
     return ranges
 
 
+_RAW_STRING_START = re.compile(r"(?:b?r)(?P<hashes>#{0,255})\"")
+_CHAR_LITERAL = re.compile(r"'(?:\\(?:x[0-9a-fA-F]{2}|u\{[0-9a-fA-F]{1,6}\}|.)|[^'\\\n])'")
+_IDENT_CHAR = re.compile(r"[A-Za-z0-9_]")
+
+
+def line_has_code(text: str) -> list[bool]:
+    r"""Per physical line of `text` (0-indexed), whether it holds a token
+    that is not whitespace and not comment text -- i.e. whether a diff hunk
+    confined to lines where this is `False` could not possibly have changed
+    control flow or introduced/removed a clone, because nothing but comment
+    or blank bytes moved.
+
+    A single forward scan over the *whole* file, not just a hunk in
+    isolation: a `git diff --unified=0` hunk carries no surrounding context,
+    so a block comment that opened on an earlier, unchanged line is
+    invisible to anything that only looks at the hunk's own text. Scanning
+    from byte zero of the real file tracks block-comment depth (Rust nests
+    `/* /* */ */`) and string state correctly regardless of where a hunk's
+    boundaries happen to fall.
+
+    Deliberately conservative in one direction only: every ambiguous case
+    below resolves toward "this is code", never toward "this is a comment".
+    Classifying a real code byte as comment would silently shrink the
+    gate's scope; classifying a comment byte as code only costs the
+    hunk-level precision the gate already accepts (see `drop_comment_only_ranges`).
+    A bare quote is the sharp edge: `'a` is a lifetime, not the start of an
+    unterminated char literal, so it is only treated as opening a char
+    literal when a closing quote is visible within a few characters,
+    matching a real `'c'` or a `'\n'` / `'\x41'` / `'\u{1F600}'` escape --
+    otherwise the quote is left as an ordinary code byte and scanning
+    continues normally, so a lifetime can never swallow the rest of the file.
+    """
+    lines = text.split("\n")
+    has_code = [False] * len(lines)
+    line_idx = 0
+    i = 0
+    n = len(text)
+    block_depth = 0
+
+    while i < n:
+        ch = text[i]
+
+        if ch == "\n":
+            line_idx += 1
+            i += 1
+            continue
+
+        if block_depth > 0:
+            if text.startswith("/*", i):
+                block_depth += 1
+                i += 2
+            elif text.startswith("*/", i):
+                block_depth -= 1
+                i += 2
+            else:
+                i += 1
+            continue
+
+        if ch in " \t\r":
+            i += 1
+            continue
+
+        if text.startswith("//", i):
+            end = text.find("\n", i)
+            i = n if end == -1 else end
+            continue
+
+        if text.startswith("/*", i):
+            block_depth = 1
+            i += 2
+            continue
+
+        prev_char = text[i - 1] if i > 0 else ""
+        if not _IDENT_CHAR.match(prev_char):
+            raw_match = _RAW_STRING_START.match(text, i)
+            if raw_match:
+                has_code[line_idx] = True
+                end_marker = '"' + raw_match.group("hashes")
+                end = text.find(end_marker, raw_match.end())
+                if end == -1:
+                    for idx in range(line_idx, len(lines)):
+                        has_code[idx] = True
+                    i = n
+                    continue
+                span_end = end + len(end_marker)
+                for _ in range(text.count("\n", i, span_end)):
+                    line_idx += 1
+                    has_code[line_idx] = True
+                i = span_end
+                continue
+
+        if ch == '"':
+            has_code[line_idx] = True
+            i += 1
+            while i < n:
+                c = text[i]
+                if c == "\\" and i + 1 < n:
+                    i += 2
+                    continue
+                if c == "\n":
+                    line_idx += 1
+                    has_code[line_idx] = True
+                    i += 1
+                    continue
+                i += 1
+                if c == '"':
+                    break
+            continue
+
+        if ch == "'":
+            has_code[line_idx] = True
+            match = _CHAR_LITERAL.match(text, i)
+            i = match.end() if match else i + 1
+            continue
+
+        has_code[line_idx] = True
+        i += 1
+
+    return has_code
+
+
+def drop_comment_only_ranges(
+    ranges: dict[str, list[tuple[int, int]]],
+    read_file: Callable[[str], str],
+) -> dict[str, list[tuple[int, int]]]:
+    """`ranges`, minus any hunk whose changed lines are all comment/blank.
+
+    A hunk keeps its full (start, end) span the moment even one line in it
+    has real code: the existing "touching a bad function makes you fix it"
+    behavior for a genuine logic edit is unchanged, deliberately -- only a
+    hunk that is *entirely* comment or whitespace, once read back from the
+    actual current file content rather than guessed from the diff text
+    alone, is excluded.
+    """
+    filtered: dict[str, list[tuple[int, int]]] = {}
+    for file, file_ranges in ranges.items():
+        code_lines = line_has_code(read_file(file))
+        kept = [
+            span
+            for span in file_ranges
+            if any(code_lines[i] for i in range(span[0] - 1, min(span[1], len(code_lines))))
+        ]
+        if kept:
+            filtered[file] = kept
+    return filtered
+
+
 def changed_ranges(base: str, pathspec: str = "*.rs") -> dict[str, list[tuple[int, int]]]:
-    """Changed line ranges per file, restricted to `pathspec`, vs `base`."""
+    """Changed line ranges per file, restricted to `pathspec`, vs `base`.
+
+    Excludes any hunk that only added or modified comment or blank lines:
+    see `drop_comment_only_ranges`. Read from the working tree, matching
+    what the diff itself compares against (see the module docstring) --
+    a path the diff reports as changed but that no longer exists on disk
+    (renamed since, or this run's `pathspec` disagrees with a prior one)
+    contributes no range rather than raising, since a deleted file cannot
+    have touched anything still there to check.
+    """
     base_sha = merge_base(base)
     result = subprocess.run(
         ["git", "diff", "--unified=0", "--no-prefix", base_sha, "--", pathspec],
@@ -166,7 +323,16 @@ def changed_ranges(base: str, pathspec: str = "*.rs") -> dict[str, list[tuple[in
         text=True,
         check=True,
     )
-    return parse_unified_diff_zero_context(result.stdout)
+    ranges = parse_unified_diff_zero_context(result.stdout)
+
+    def read_file(file: str) -> str:
+        path = ROOT / file
+        try:
+            return path.read_text()
+        except (FileNotFoundError, UnicodeDecodeError):
+            return ""
+
+    return drop_comment_only_ranges(ranges, read_file)
 
 
 def cargo_bin_dir() -> Path:

--- a/scripts/ci/gate_diff.py
+++ b/scripts/ci/gate_diff.py
@@ -31,7 +31,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 
-_HUNK_HEADER = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 
 
 def ensure_ref(base: str) -> None:
@@ -125,17 +125,24 @@ def merge_base(base: str) -> str:
     return second_attempt.stdout.strip()
 
 
-def parse_unified_diff_zero_context(diff_text: str) -> dict[str, list[tuple[int, int]]]:
-    """Parse `git diff --unified=0 --no-prefix` output into changed ranges.
+def parse_hunk_spans(
+    diff_text: str,
+) -> dict[str, list[tuple[tuple[int, int] | None, tuple[int, int] | None]]]:
+    """Parse `git diff --unified=0 --no-prefix` output into per-hunk spans.
 
-    Returns one inclusive `(start_line, end_line)` range per hunk, in the
-    *new* (post-change) file's line numbering, keyed by that file's path.
-    A hunk that only deletes lines (`+l,0`) contributes no range: there is no
-    added or modified line on the new side to hold accountable. A deleted
-    file (`+++ /dev/null`) is skipped for the same reason -- nothing in it can
-    be checked against, because nothing in it still exists.
+    Each hunk becomes one `(old_span, new_span)` pair, keyed by the file's
+    *new*-side path. `old_span` is the hunk's inclusive `(start, end)` range
+    in the pre-change file's line numbering, `new_span` the same in the
+    post-change file's; either is `None` when that side contributed zero
+    lines (`old_span` for a pure addition, `new_span` for a pure deletion).
+
+    `semantic_ranges` needs both sides: deciding whether a hunk changed
+    anything a reader would call code means reading what was actually there
+    before, not just guessing from the new side alone. A deleted file
+    (`+++ /dev/null`) is skipped -- nothing in it can be checked against,
+    because nothing in it still exists.
     """
-    ranges: dict[str, list[tuple[int, int]]] = {}
+    hunks: dict[str, list[tuple[tuple[int, int] | None, tuple[int, int] | None]]] = {}
     current_file: str | None = None
     for line in diff_text.splitlines():
         if line.startswith("+++ "):
@@ -149,12 +156,14 @@ def parse_unified_diff_zero_context(diff_text: str) -> dict[str, list[tuple[int,
         match = _HUNK_HEADER.match(line)
         if not match:
             continue
-        start = int(match.group(1))
-        count = int(match.group(2)) if match.group(2) is not None else 1
-        if count == 0:
-            continue
-        ranges.setdefault(current_file, []).append((start, start + count - 1))
-    return ranges
+        old_start = int(match.group(1))
+        old_count = int(match.group(2)) if match.group(2) is not None else 1
+        new_start = int(match.group(3))
+        new_count = int(match.group(4)) if match.group(4) is not None else 1
+        old_span = None if old_count == 0 else (old_start, old_start + old_count - 1)
+        new_span = None if new_count == 0 else (new_start, new_start + new_count - 1)
+        hunks.setdefault(current_file, []).append((old_span, new_span))
+    return hunks
 
 
 _RAW_STRING_START = re.compile(r"(?:b?r)(?P<hashes>#{0,255})\"")
@@ -162,12 +171,9 @@ _CHAR_LITERAL = re.compile(r"'(?:\\(?:x[0-9a-fA-F]{2}|u\{[0-9a-fA-F]{1,6}\}|.)|[
 _IDENT_CHAR = re.compile(r"[A-Za-z0-9_]")
 
 
-def line_has_code(text: str) -> list[bool]:
-    r"""Per physical line of `text` (0-indexed), whether it holds a token
-    that is not whitespace and not comment text -- i.e. whether a diff hunk
-    confined to lines where this is `False` could not possibly have changed
-    control flow or introduced/removed a clone, because nothing but comment
-    or blank bytes moved.
+def code_tokens_by_line(text: str) -> list[list[str]]:
+    r"""Per physical line of `text` (0-indexed), the code tokens that start
+    on it -- comments and whitespace contribute nothing.
 
     A single forward scan over the *whole* file, not just a hunk in
     isolation: a `git diff --unified=0` hunk carries no surrounding context,
@@ -177,20 +183,37 @@ def line_has_code(text: str) -> list[bool]:
     `/* /* */ */`) and string state correctly regardless of where a hunk's
     boundaries happen to fall.
 
-    Deliberately conservative in one direction only: every ambiguous case
-    below resolves toward "this is code", never toward "this is a comment".
-    Classifying a real code byte as comment would silently shrink the
-    gate's scope; classifying a comment byte as code only costs the
-    hunk-level precision the gate already accepts (see `drop_comment_only_ranges`).
-    A bare quote is the sharp edge: `'a` is a lifetime, not the start of an
-    unterminated char literal, so it is only treated as opening a char
-    literal when a closing quote is visible within a few characters,
-    matching a real `'c'` or a `'\n'` / `'\x41'` / `'\u{1F600}'` escape --
-    otherwise the quote is left as an ordinary code byte and scanning
-    continues normally, so a lifetime can never swallow the rest of the file.
+    Deliberately coarse-grained, on purpose: a maximal run of identifier
+    characters (`[A-Za-z0-9_]`) is one token, because a real lexer boundary
+    is the one thing whitespace or its absence actually decides (`let x` is
+    two tokens, `letx` is one, and that distinction must survive). Every
+    other significant byte -- each individual operator or punctuation
+    character, and each string / raw string / char literal as a single
+    whole -- is its own token. This never conflates two different inputs:
+    splitting a multi-character operator like `->` into two single-
+    character tokens only ever adds detail that could distinguish two
+    snippets, it never merges anything that was distinct before. Two
+    renderings of the same code -- different indentation, a comment removed,
+    a multi-line block collapsed onto one line -- always produce equal token
+    lists; nothing that changes what the code actually does can produce an
+    equal one, because it must add, remove, or replace at least one token.
+
+    Deliberately conservative in one direction only, same as the scan this
+    replaced: every ambiguous case below resolves toward "this is code",
+    never toward "this is a comment". Classifying a real code byte as
+    comment would silently shrink the gate's scope; classifying a comment
+    byte as code only costs `semantic_ranges` the precision of noticing two
+    sides are equal when they truly are not (it still never lets something
+    through the gate). A bare quote is the sharp edge: `'a` is a lifetime,
+    not the start of an unterminated char literal, so it is only treated as
+    opening a char literal when a closing quote is visible within a few
+    characters, matching a real `'c'` or a `'\n'` / `'\x41'` / `'\u{1F600}'`
+    escape -- otherwise the quote is emitted as its own one-character token
+    and scanning continues normally, so a lifetime can never swallow the
+    rest of the file.
     """
     lines = text.split("\n")
-    has_code = [False] * len(lines)
+    tokens: list[list[str]] = [[] for _ in lines]
     line_idx = 0
     i = 0
     n = len(text)
@@ -233,87 +256,161 @@ def line_has_code(text: str) -> list[bool]:
         if not _IDENT_CHAR.match(prev_char):
             raw_match = _RAW_STRING_START.match(text, i)
             if raw_match:
-                has_code[line_idx] = True
                 end_marker = '"' + raw_match.group("hashes")
                 end = text.find(end_marker, raw_match.end())
                 if end == -1:
-                    for idx in range(line_idx, len(lines)):
-                        has_code[idx] = True
+                    tokens[line_idx].append(text[i:])
                     i = n
                     continue
                 span_end = end + len(end_marker)
-                for _ in range(text.count("\n", i, span_end)):
-                    line_idx += 1
-                    has_code[line_idx] = True
+                tokens[line_idx].append(text[i:span_end])
+                line_idx += text.count("\n", i, span_end)
                 i = span_end
                 continue
 
         if ch == '"':
-            has_code[line_idx] = True
+            start = i
             i += 1
             while i < n:
                 c = text[i]
                 if c == "\\" and i + 1 < n:
                     i += 2
                     continue
-                if c == "\n":
-                    line_idx += 1
-                    has_code[line_idx] = True
-                    i += 1
-                    continue
                 i += 1
                 if c == '"':
                     break
+            span = text[start:i]
+            tokens[line_idx].append(span)
+            line_idx += span.count("\n")
             continue
 
         if ch == "'":
-            has_code[line_idx] = True
             match = _CHAR_LITERAL.match(text, i)
-            i = match.end() if match else i + 1
+            if match:
+                tokens[line_idx].append(text[i : match.end()])
+                i = match.end()
+            else:
+                tokens[line_idx].append(ch)
+                i += 1
             continue
 
-        has_code[line_idx] = True
+        if _IDENT_CHAR.match(ch):
+            start = i
+            while i < n and _IDENT_CHAR.match(text[i]):
+                i += 1
+            tokens[line_idx].append(text[start:i])
+            continue
+
+        tokens[line_idx].append(ch)
         i += 1
 
-    return has_code
+    return tokens
 
 
-def drop_comment_only_ranges(
-    ranges: dict[str, list[tuple[int, int]]],
-    read_file: Callable[[str], str],
-) -> dict[str, list[tuple[int, int]]]:
-    """`ranges`, minus any hunk whose changed lines are all comment/blank.
+def _tokens_in_span(tokens_by_line: list[list[str]], span: tuple[int, int] | None) -> list[str]:
+    """The tokens `code_tokens_by_line` attributed to lines `span[0]..=span[1]`."""
+    if span is None:
+        return []
+    start, end = span
+    result: list[str] = []
+    for i in range(start - 1, min(end, len(tokens_by_line))):
+        result.extend(tokens_by_line[i])
+    return result
 
-    A hunk keeps its full (start, end) span the moment even one line in it
-    has real code: the existing "touching a bad function makes you fix it"
-    behavior for a genuine logic edit is unchanged, deliberately -- only a
-    hunk that is *entirely* comment or whitespace, once read back from the
-    actual current file content rather than guessed from the diff text
-    alone, is excluded.
+
+_CLOSING_DELIMITERS = frozenset({")", "]", "}"})
+
+
+def _drop_trailing_commas(tokens: list[str]) -> list[str]:
+    """`tokens`, minus every `,` immediately followed by a closing delimiter.
+
+    A trailing comma right before `)`, `]`, or `}` is never semantically
+    significant in Rust: a tuple, array, function call, generic argument
+    list, struct literal, or the last arm of a `match` parses identically
+    with or without one. Whether rustfmt emits it depends only on its
+    multi-line-vs-single-line layout choice for the surrounding
+    expression -- which can flip purely because a comment that used to
+    keep the expression multi-line is gone, with nothing about the code
+    itself changed. That is exactly the "same code, different whitespace"
+    class `semantic_ranges` exists to see through, so this one narrow,
+    always-valid comma is dropped before old and new token lists are
+    compared, on both sides alike.
+
+    Deliberately this narrow: this is a fact about Rust's grammar, not a
+    general "whitespace doesn't matter" rule, and it changes nothing about
+    how any other token is compared.
     """
-    filtered: dict[str, list[tuple[int, int]]] = {}
-    for file, file_ranges in ranges.items():
-        code_lines = line_has_code(read_file(file))
-        kept = [
-            span
-            for span in file_ranges
-            if any(code_lines[i] for i in range(span[0] - 1, min(span[1], len(code_lines))))
-        ]
+    return [
+        tok
+        for idx, tok in enumerate(tokens)
+        if not (tok == "," and idx + 1 < len(tokens) and tokens[idx + 1] in _CLOSING_DELIMITERS)
+    ]
+
+
+def semantic_ranges(
+    hunk_spans: dict[str, list[tuple[tuple[int, int] | None, tuple[int, int] | None]]],
+    read_old: Callable[[str], str],
+    read_new: Callable[[str], str],
+) -> dict[str, list[tuple[int, int]]]:
+    """`hunk_spans`, narrowed to the hunks that changed actual code.
+
+    A hunk keeps its `new_span` the moment the tokens it changed differ from
+    what was there before: the existing "touching a bad function makes you
+    fix it" behavior for a genuine logic edit is unchanged, deliberately.
+    What is new is *how* "differ" gets decided -- both sides of the hunk are
+    read back from their real files (the pre-change blob via `read_old`, the
+    post-change file via `read_new`, both keyed by the new-side path) and
+    tokenized with `code_tokens_by_line`, then passed through
+    `_drop_trailing_commas` (see there for why that one further step is
+    Rust-grammar-safe rather than a general whitespace rule), so a hunk is
+    dropped exactly when its old and new token lists are equal: a comment
+    deleted, a comment added with nothing else, a multi-line block
+    reformatted or collapsed onto one line with no token added or removed.
+    This subsumes the narrower "hunk is entirely comment" rule this
+    replaced without a separate code path for it: a comment-only hunk's old
+    and new token lists were already both empty, so it always falls out of
+    the same single comparison.
+
+    A pure-deletion hunk (`new_span` is `None`) is dropped unconditionally,
+    regardless of what its old side tokenizes to: there is no line left on
+    the new side to hold accountable.
+    """
+    ranges: dict[str, list[tuple[int, int]]] = {}
+    old_cache: dict[str, list[list[str]]] = {}
+    new_cache: dict[str, list[list[str]]] = {}
+    for file, spans in hunk_spans.items():
+        if file not in new_cache:
+            new_cache[file] = code_tokens_by_line(read_new(file))
+        if file not in old_cache:
+            old_cache[file] = code_tokens_by_line(read_old(file))
+        old_tokens_by_line = old_cache[file]
+        new_tokens_by_line = new_cache[file]
+        kept: list[tuple[int, int]] = []
+        for old_span, new_span in spans:
+            if new_span is None:
+                continue
+            old_tokens = _drop_trailing_commas(_tokens_in_span(old_tokens_by_line, old_span))
+            new_tokens = _drop_trailing_commas(_tokens_in_span(new_tokens_by_line, new_span))
+            if old_tokens == new_tokens:
+                continue
+            kept.append(new_span)
         if kept:
-            filtered[file] = kept
-    return filtered
+            ranges[file] = kept
+    return ranges
 
 
 def changed_ranges(base: str, pathspec: str = "*.rs") -> dict[str, list[tuple[int, int]]]:
     """Changed line ranges per file, restricted to `pathspec`, vs `base`.
 
-    Excludes any hunk that only added or modified comment or blank lines:
-    see `drop_comment_only_ranges`. Read from the working tree, matching
-    what the diff itself compares against (see the module docstring) --
-    a path the diff reports as changed but that no longer exists on disk
-    (renamed since, or this run's `pathspec` disagrees with a prior one)
-    contributes no range rather than raising, since a deleted file cannot
-    have touched anything still there to check.
+    Excludes any hunk whose old and new sides are the same code once
+    comments and incidental whitespace are gone: see `semantic_ranges`. The
+    new side is read from the working tree, matching what the diff itself
+    compares against (see the module docstring); the old side is read from
+    `base`'s commit via `git show`, since the pre-change blob does not
+    otherwise exist anywhere on disk. Either side missing -- a path the diff
+    reports as changed but that no longer exists on disk, or a file that did
+    not exist at `base` -- reads back as empty rather than raising, since
+    there is nothing there to compare against.
     """
     base_sha = merge_base(base)
     result = subprocess.run(
@@ -323,16 +420,25 @@ def changed_ranges(base: str, pathspec: str = "*.rs") -> dict[str, list[tuple[in
         text=True,
         check=True,
     )
-    ranges = parse_unified_diff_zero_context(result.stdout)
+    hunk_spans = parse_hunk_spans(result.stdout)
 
-    def read_file(file: str) -> str:
+    def read_new(file: str) -> str:
         path = ROOT / file
         try:
             return path.read_text()
         except (FileNotFoundError, UnicodeDecodeError):
             return ""
 
-    return drop_comment_only_ranges(ranges, read_file)
+    def read_old(file: str) -> str:
+        blob = subprocess.run(
+            ["git", "show", f"{base_sha}:{file}"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        return blob.stdout if blob.returncode == 0 else ""
+
+    return semantic_ranges(hunk_spans, read_old, read_new)
 
 
 def cargo_bin_dir() -> Path:

--- a/scripts/ci/test_gate_diff.py
+++ b/scripts/ci/test_gate_diff.py
@@ -31,7 +31,7 @@ import duplication_gate
 import gate_diff
 
 
-class ParseUnifiedDiffZeroContext(unittest.TestCase):
+class ParseHunkSpans(unittest.TestCase):
     def test_single_hunk_modified_file(self) -> None:
         diff = "\n".join(
             [
@@ -45,11 +45,11 @@ class ParseUnifiedDiffZeroContext(unittest.TestCase):
             ]
         )
         self.assertEqual(
-            gate_diff.parse_unified_diff_zero_context(diff),
-            {"src/lib.rs": [(10, 12)]},
+            gate_diff.parse_hunk_spans(diff),
+            {"src/lib.rs": [((10, 11), (10, 12))]},
         )
 
-    def test_single_added_line_omits_count(self) -> None:
+    def test_single_line_hunk_omits_count(self) -> None:
         # unified diff omits the trailing ",1" when a hunk covers one line.
         diff = "\n".join(
             [
@@ -61,11 +61,11 @@ class ParseUnifiedDiffZeroContext(unittest.TestCase):
             ]
         )
         self.assertEqual(
-            gate_diff.parse_unified_diff_zero_context(diff),
-            {"src/lib.rs": [(5, 5)]},
+            gate_diff.parse_hunk_spans(diff),
+            {"src/lib.rs": [((5, 5), (5, 5))]},
         )
 
-    def test_pure_deletion_hunk_has_no_new_side_range(self) -> None:
+    def test_pure_deletion_hunk_has_no_new_side_span(self) -> None:
         diff = "\n".join(
             [
                 "--- src/lib.rs",
@@ -76,7 +76,24 @@ class ParseUnifiedDiffZeroContext(unittest.TestCase):
                 "-and this",
             ]
         )
-        self.assertEqual(gate_diff.parse_unified_diff_zero_context(diff), {})
+        self.assertEqual(
+            gate_diff.parse_hunk_spans(diff),
+            {"src/lib.rs": [((20, 22), None)]},
+        )
+
+    def test_pure_addition_hunk_has_no_old_side_span(self) -> None:
+        diff = "\n".join(
+            [
+                "--- src/lib.rs",
+                "+++ src/lib.rs",
+                "@@ -50,0 +52,1 @@",
+                "+a3",
+            ]
+        )
+        self.assertEqual(
+            gate_diff.parse_hunk_spans(diff),
+            {"src/lib.rs": [(None, (52, 52))]},
+        )
 
     def test_deleted_file_is_skipped(self) -> None:
         diff = "\n".join(
@@ -89,7 +106,7 @@ class ParseUnifiedDiffZeroContext(unittest.TestCase):
                 "-c",
             ]
         )
-        self.assertEqual(gate_diff.parse_unified_diff_zero_context(diff), {})
+        self.assertEqual(gate_diff.parse_hunk_spans(diff), {})
 
     def test_multiple_hunks_and_files(self) -> None:
         diff = "\n".join(
@@ -109,116 +126,303 @@ class ParseUnifiedDiffZeroContext(unittest.TestCase):
             ]
         )
         self.assertEqual(
-            gate_diff.parse_unified_diff_zero_context(diff),
-            {"src/a.rs": [(1, 2), (52, 52)], "src/b.rs": [(3, 3)]},
+            gate_diff.parse_hunk_spans(diff),
+            {
+                "src/a.rs": [(None, (1, 2)), (None, (52, 52))],
+                "src/b.rs": [((3, 3), (3, 3))],
+            },
         )
 
 
-class LineHasCode(unittest.TestCase):
+class CodeTokensByLine(unittest.TestCase):
     def test_plain_code_line(self) -> None:
-        self.assertEqual(gate_diff.line_has_code("let x = 1;"), [True])
+        self.assertEqual(
+            gate_diff.code_tokens_by_line("let x = 1;"),
+            [["let", "x", "=", "1", ";"]],
+        )
 
     def test_blank_line(self) -> None:
-        self.assertEqual(gate_diff.line_has_code(""), [False])
-        self.assertEqual(gate_diff.line_has_code("   \t  "), [False])
+        self.assertEqual(gate_diff.code_tokens_by_line(""), [[]])
+        self.assertEqual(gate_diff.code_tokens_by_line("   \t  "), [[]])
 
     def test_pure_line_comment(self) -> None:
-        self.assertEqual(gate_diff.line_has_code("// just a note"), [False])
+        self.assertEqual(gate_diff.code_tokens_by_line("// just a note"), [[]])
 
-    def test_code_with_trailing_comment_counts_as_code(self) -> None:
-        self.assertEqual(gate_diff.line_has_code("let x = 1; // trailing"), [True])
+    def test_code_with_trailing_comment_yields_only_the_codes_tokens(self) -> None:
+        self.assertEqual(
+            gate_diff.code_tokens_by_line("let x = 1; // trailing"),
+            [["let", "x", "=", "1", ";"]],
+        )
 
-    def test_slash_slash_inside_a_string_is_not_a_comment(self) -> None:
+    def test_slash_slash_inside_a_string_is_one_string_token_not_a_comment(self) -> None:
         text = 'let url = "https://example.com";'
-        self.assertEqual(gate_diff.line_has_code(text), [True])
+        self.assertEqual(
+            gate_diff.code_tokens_by_line(text),
+            [["let", "url", "=", '"https://example.com"', ";"]],
+        )
 
     def test_string_spanning_a_naive_comment_check_does_not_start_one(self) -> None:
         # A string literal containing `//` followed by a real comment on the
         # next line: the `//` inside the string must not be mistaken for the
         # start of a comment that swallows the rest of the string plus the
         # next, genuinely-commented, line.
-        text = '\n'.join(['let s = "a // b";', "// this really is a comment"])
-        self.assertEqual(gate_diff.line_has_code(text), [True, False])
+        text = "\n".join(['let s = "a // b";', "// this really is a comment"])
+        self.assertEqual(
+            gate_diff.code_tokens_by_line(text),
+            [["let", "s", "=", '"a // b"', ";"], []],
+        )
 
     def test_single_line_block_comment(self) -> None:
-        self.assertEqual(gate_diff.line_has_code("/* note */"), [False])
+        self.assertEqual(gate_diff.code_tokens_by_line("/* note */"), [[]])
 
-    def test_single_line_block_comment_with_trailing_code_counts_as_code(self) -> None:
-        self.assertEqual(gate_diff.line_has_code("/* note */ let x = 1;"), [True])
+    def test_single_line_block_comment_with_trailing_code(self) -> None:
+        self.assertEqual(
+            gate_diff.code_tokens_by_line("/* note */ let x = 1;"),
+            [["let", "x", "=", "1", ";"]],
+        )
 
     def test_multi_line_block_comment_is_all_blank(self) -> None:
         text = "\n".join(["/* start", "middle line", "end */"])
-        self.assertEqual(gate_diff.line_has_code(text), [False, False, False])
+        self.assertEqual(gate_diff.code_tokens_by_line(text), [[], [], []])
 
     def test_multi_line_block_comment_with_code_before_and_after(self) -> None:
         text = "\n".join(["let a = 1; /* start", "middle line", "end */ let b = 2;"])
-        self.assertEqual(gate_diff.line_has_code(text), [True, False, True])
+        self.assertEqual(
+            gate_diff.code_tokens_by_line(text),
+            [["let", "a", "=", "1", ";"], [], ["let", "b", "=", "2", ";"]],
+        )
 
     def test_nested_block_comments(self) -> None:
         # Rust block comments nest, unlike C's.
         text = "\n".join(["/* outer /* inner */ still commented", "*/ let x = 1;"])
-        self.assertEqual(gate_diff.line_has_code(text), [False, True])
+        self.assertEqual(
+            gate_diff.code_tokens_by_line(text),
+            [[], ["let", "x", "=", "1", ";"]],
+        )
 
-    def test_raw_string_containing_slashes_and_quotes(self) -> None:
+    def test_raw_string_containing_slashes_and_quotes_is_one_token(self) -> None:
         text = 'let s = r#"// not a comment, and "quoted" too"#;'
-        self.assertEqual(gate_diff.line_has_code(text), [True])
+        raw_token = 'r#"// not a comment, and "quoted" too"#'
+        self.assertEqual(
+            gate_diff.code_tokens_by_line(text),
+            [["let", "s", "=", raw_token, ";"]],
+        )
 
-    def test_raw_string_spanning_lines(self) -> None:
+    def test_raw_string_spanning_lines_is_one_token_on_its_start_line(self) -> None:
         text = "\n".join(['let s = r"line one', "// still string content", 'line three";'])
-        self.assertEqual(gate_diff.line_has_code(text), [True, True, True])
+        raw_token = 'r"line one\n// still string content\nline three"'
+        self.assertEqual(
+            gate_diff.code_tokens_by_line(text),
+            [["let", "s", "=", raw_token], [], [";"]],
+        )
 
     def test_raw_string_prefix_not_misdetected_mid_identifier(self) -> None:
         # `bar` ends in `r`; the `"` that follows belongs to a separate,
         # ordinary string literal, not a raw string starting at that `r`.
         text = 'let bar = 1; let s = "text";'
-        self.assertEqual(gate_diff.line_has_code(text), [True])
+        self.assertEqual(
+            gate_diff.code_tokens_by_line(text),
+            [["let", "bar", "=", "1", ";", "let", "s", "=", '"text"', ";"]],
+        )
 
     def test_char_literal_does_not_start_a_comment(self) -> None:
         text = "let c = '/';"
-        self.assertEqual(gate_diff.line_has_code(text), [True])
+        self.assertEqual(
+            gate_diff.code_tokens_by_line(text),
+            [["let", "c", "=", "'/'", ";"]],
+        )
 
     def test_escaped_char_literal(self) -> None:
         text = r"let c = '\n';"
-        self.assertEqual(gate_diff.line_has_code(text), [True])
+        self.assertEqual(
+            gate_diff.code_tokens_by_line(text),
+            [["let", "c", "=", r"'\n'", ";"]],
+        )
 
     def test_lifetime_is_not_treated_as_an_unterminated_char_literal(self) -> None:
         # If `'a` were treated as opening a char literal that never closes,
         # scanning would run past the real comment below looking for a
-        # closing quote, hiding it from the result.
+        # closing quote, hiding it from the result. The exact token
+        # breakdown of the lifetime-heavy line is not the point (each bare
+        # `'` and the identifier after it fall out as separate tokens); what
+        # matters is that it terminates and the comment on the next line is
+        # correctly seen as holding no code at all.
         text = "\n".join(["fn f<'a>(x: &'a str) -> &'a str { x }", "// a real comment"])
-        self.assertEqual(gate_diff.line_has_code(text), [True, False])
+        tokens = gate_diff.code_tokens_by_line(text)
+        self.assertTrue(tokens[0], "the code line must yield at least one token")
+        self.assertEqual(tokens[1], [])
 
-    def test_string_containing_an_escaped_quote(self) -> None:
+    def test_string_containing_an_escaped_quote_is_one_token(self) -> None:
         text = r'let s = "she said \"hi\"";'
-        self.assertEqual(gate_diff.line_has_code(text), [True])
-
-
-class DropCommentOnlyRanges(unittest.TestCase):
-    def test_hunk_that_is_entirely_comment_is_dropped(self) -> None:
-        ranges = {"src/lib.rs": [(2, 2)]}
-        files = {"src/lib.rs": "fn f() {\n    // just a comment\n}\n"}
-        self.assertEqual(gate_diff.drop_comment_only_ranges(ranges, files.get), {})
-
-    def test_hunk_with_any_real_code_line_is_kept_in_full(self) -> None:
-        ranges = {"src/lib.rs": [(2, 3)]}
-        files = {"src/lib.rs": "fn f() {\n    // a comment\n    let x = 1;\n}\n"}
+        string_token = r'"she said \"hi\""'
         self.assertEqual(
-            gate_diff.drop_comment_only_ranges(ranges, files.get),
+            gate_diff.code_tokens_by_line(text),
+            [["let", "s", "=", string_token, ";"]],
+        )
+
+
+class DropTrailingCommas(unittest.TestCase):
+    def test_comma_before_closing_paren_is_dropped(self) -> None:
+        self.assertEqual(
+            gate_diff._drop_trailing_commas(["f", "(", "a", ",", ")"]),
+            ["f", "(", "a", ")"],
+        )
+
+    def test_comma_before_closing_bracket_is_dropped(self) -> None:
+        self.assertEqual(
+            gate_diff._drop_trailing_commas(["[", "1", ",", "]"]),
+            ["[", "1", "]"],
+        )
+
+    def test_comma_before_closing_brace_is_dropped(self) -> None:
+        self.assertEqual(
+            gate_diff._drop_trailing_commas(["{", "x", ":", "1", ",", "}"]),
+            ["{", "x", ":", "1", "}"],
+        )
+
+    def test_comma_between_arguments_is_kept(self) -> None:
+        self.assertEqual(
+            gate_diff._drop_trailing_commas(["f", "(", "a", ",", "b", ")"]),
+            ["f", "(", "a", ",", "b", ")"],
+        )
+
+    def test_trailing_comma_at_the_very_end_of_the_list_is_kept(self) -> None:
+        # No token follows it at all, so there is no closing delimiter to
+        # confirm it precedes -- the conservative, safe default is to leave
+        # it as a real token rather than guess.
+        self.assertEqual(gate_diff._drop_trailing_commas(["a", ","]), ["a", ","])
+
+
+class SemanticRanges(unittest.TestCase):
+    def test_comment_only_edit_is_dropped(self) -> None:
+        hunk_spans = {"src/lib.rs": [((2, 2), (2, 2))]}
+        old = {"src/lib.rs": "fn f() {\n    let x = 1;  // set x\n}\n"}
+        new = {"src/lib.rs": "fn f() {\n    let x = 1;\n}\n"}
+        self.assertEqual(gate_diff.semantic_ranges(hunk_spans, old.get, new.get), {})
+
+    def test_hunk_with_a_real_code_change_is_kept_in_full(self) -> None:
+        hunk_spans = {"src/lib.rs": [((2, 3), (2, 3))]}
+        old = {"src/lib.rs": "fn f() {\n    // a comment\n    let x = 0;\n}\n"}
+        new = {"src/lib.rs": "fn f() {\n    // updated comment\n    let x = 1;\n}\n"}
+        self.assertEqual(
+            gate_diff.semantic_ranges(hunk_spans, old.get, new.get),
             {"src/lib.rs": [(2, 3)]},
         )
 
-    def test_only_the_comment_only_hunk_is_dropped_others_survive(self) -> None:
-        ranges = {"src/lib.rs": [(2, 2), (4, 4)]}
-        files = {"src/lib.rs": "fn f() {\n    // comment\n    let x = 1;\n    let y = 2;\n}\n"}
+    def test_only_the_semantically_unchanged_hunk_is_dropped_others_survive(self) -> None:
+        hunk_spans = {"src/lib.rs": [((2, 2), (2, 2)), ((4, 4), (4, 4))]}
+        old = {"src/lib.rs": "fn f() {\n    // comment\n    let x = 1;\n    let y = 1;\n}\n"}
+        new = {"src/lib.rs": "fn f() {\n    // different comment\n    let x = 1;\n    let y = 2;\n}\n"}
         self.assertEqual(
-            gate_diff.drop_comment_only_ranges(ranges, files.get),
+            gate_diff.semantic_ranges(hunk_spans, old.get, new.get),
             {"src/lib.rs": [(4, 4)]},
         )
 
     def test_file_with_no_surviving_ranges_is_dropped_entirely(self) -> None:
-        ranges = {"src/only_comments.rs": [(1, 1)]}
-        files = {"src/only_comments.rs": "// nothing but this\n"}
-        self.assertEqual(gate_diff.drop_comment_only_ranges(ranges, files.get), {})
+        hunk_spans = {"src/only_comments.rs": [((1, 1), (1, 1))]}
+        old = {"src/only_comments.rs": "// nothing but this\n"}
+        new = {"src/only_comments.rs": "// nothing but this, reworded\n"}
+        self.assertEqual(gate_diff.semantic_ranges(hunk_spans, old.get, new.get), {})
+
+    def test_pure_deletion_hunk_contributes_no_range_regardless_of_content(self) -> None:
+        hunk_spans = {"src/lib.rs": [((5, 7), None)]}
+        old = {"src/lib.rs": "fn f() {\n    let x = 1;\n    let y = 2;\n    let z = 3;\n}\n"}
+        new = {"src/lib.rs": "fn f() {\n}\n"}
+        self.assertEqual(gate_diff.semantic_ranges(hunk_spans, old.get, new.get), {})
+
+    def test_comment_removal_that_collapses_a_block_onto_one_line_is_dropped(self) -> None:
+        # The mechanism actually found in #540's diff: an `if` block whose
+        # only content is a comment collapses, once the comment is deleted
+        # and the formatter merges the now-empty block, from three lines to
+        # one (`if cond {\n    // ...\n}` -> `if cond {}`). The surviving
+        # line still contains code bytes (`if cond {}`), so a check that
+        # only asked "does the new side have code" would keep this hunk in
+        # scope for no reason -- the fix has to compare old and new tokens,
+        # not just ask whether the new side is nonempty.
+        hunk_spans = {"src/lib.rs": [((2, 4), (2, 2))]}
+        old = {
+            "src/lib.rs": "\n".join(
+                [
+                    "fn f(cond: bool) {",
+                    "    if cond {",
+                    "        // Found something",
+                    "    }",
+                    "}",
+                    "",
+                ]
+            )
+        }
+        new = {
+            "src/lib.rs": "\n".join(
+                [
+                    "fn f(cond: bool) {",
+                    "    if cond {}",
+                    "}",
+                    "",
+                ]
+            )
+        }
+        self.assertEqual(gate_diff.semantic_ranges(hunk_spans, old.get, new.get), {})
+
+    def test_whitespace_reorder_bundled_with_a_real_token_change_is_kept(self) -> None:
+        # Pinned safety property: normalizing away comments/whitespace must
+        # never mask an actual token-level change riding along with a
+        # reformat.
+        hunk_spans = {"src/lib.rs": [((1, 1), (1, 2))]}
+        old = {"src/lib.rs": "let x = 1;\n"}
+        new = {"src/lib.rs": "let   x =\n    2;\n"}
+        self.assertEqual(
+            gate_diff.semantic_ranges(hunk_spans, old.get, new.get),
+            {"src/lib.rs": [(1, 2)]},
+        )
+
+    def test_string_literal_content_is_compared_not_discarded(self) -> None:
+        # Pinned safety property: a string literal that itself contains
+        # comment-like or whitespace-significant text is a single atomic
+        # token, never split or normalized internally -- so two different
+        # string values are never mistaken for the same code just because
+        # both superficially resemble a comment.
+        hunk_spans = {"src/lib.rs": [((1, 1), (1, 1))]}
+        old = {"src/lib.rs": 'let s = "// keep me A";\n'}
+        new = {"src/lib.rs": 'let s = "// keep me B";\n'}
+        self.assertEqual(
+            gate_diff.semantic_ranges(hunk_spans, old.get, new.get),
+            {"src/lib.rs": [(1, 1)]},
+        )
+
+    def test_call_reformatted_onto_fewer_lines_drops_only_its_trailing_comma(self) -> None:
+        # The exact mechanism found in #540's diff (e.g. `tab_bar.rs`): a
+        # leading comment on one call argument holds the call multi-line;
+        # once it is deleted, rustfmt's line-length heuristic reflows the
+        # call, which also removes the trailing comma before the closing
+        # paren that a multi-line call gets and a single-line one does not.
+        # Nothing about the call's arguments changed.
+        hunk_spans = {"src/lib.rs": [((1, 5), (1, 1))]}
+        old = {
+            "src/lib.rs": "\n".join(
+                [
+                    "f(",
+                    "    // pick the material",
+                    "    material(),",
+                    "    move || dynamics(),",
+                    ");",
+                    "",
+                ]
+            )
+        }
+        new = {"src/lib.rs": "f(material(), move || dynamics());\n"}
+        self.assertEqual(gate_diff.semantic_ranges(hunk_spans, old.get, new.get), {})
+
+    def test_trailing_comma_change_bundled_with_a_real_edit_is_still_kept(self) -> None:
+        # Pinned safety property: dropping one grammar-insignificant comma
+        # must never mask an actual argument change riding along with it.
+        hunk_spans = {"src/lib.rs": [((1, 1), (1, 1))]}
+        old = {"src/lib.rs": "f(a, b,);\n"}
+        new = {"src/lib.rs": "f(a, c);\n"}
+        self.assertEqual(
+            gate_diff.semantic_ranges(hunk_spans, old.get, new.get),
+            {"src/lib.rs": [(1, 1)]},
+        )
 
 
 class Intersects(unittest.TestCase):
@@ -375,7 +579,7 @@ class MergeBaseShallowHistory(unittest.TestCase):
             self.assertIn("share no common ancestor", str(raised.exception))
 
 
-class ChangedRangesExcludesCommentOnlyHunks(unittest.TestCase):
+class ChangedRangesExcludesSemanticallyUnchangedHunks(unittest.TestCase):
     """The end-to-end fixture: a real repo, a real over-limit function, and
     the exact `changed_ranges` pipeline `complexity_gate`/`duplication_gate`
     call in CI -- not a synthetic diff string standing in for one.
@@ -477,6 +681,69 @@ class ChangedRangesExcludesCommentOnlyHunks(unittest.TestCase):
 
             self.assertIn("src/lib.rs", ranges)
             self.assertTrue(gate_diff.any_intersect(ranges["src/lib.rs"], (1, 13)))
+
+    def test_comment_deletion_that_collapses_a_branch_onto_one_line_does_not_touch_it(
+        self,
+    ) -> None:
+        # This is the pattern #540's real diff actually hits: a branch whose
+        # body is only a comment collapses from multiple lines to one empty
+        # block once the comment goes and a format/clippy pass merges the
+        # braces. The surviving line still contains code bytes (`{}`), so a
+        # rule that only asked "does the new side have code" -- the first,
+        # too-narrow fix -- kept this hunk in scope for no reason.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            self._init_repo_with_base_commit(repo)
+
+            with_comment_block = self._OVER_LIMIT_FUNCTION.replace(
+                "    if x == 9 { return 9; }",
+                "\n".join(
+                    [
+                        "    if x == 9 {",
+                        "        // nothing special about nine",
+                        "    }",
+                    ]
+                ),
+            )
+            self._write_and_commit(repo, with_comment_block + "\n", "expand nine's branch")
+
+            collapsed = self._OVER_LIMIT_FUNCTION.replace(
+                "    if x == 9 { return 9; }", "    if x == 9 {}"
+            )
+            self._write_and_commit(repo, collapsed + "\n", "delete the comment, collapse the block")
+
+            with mock.patch("gate_diff.ROOT", repo):
+                ranges = gate_diff.changed_ranges("HEAD~1")
+
+            self.assertEqual(
+                ranges,
+                {},
+                "deleting a comment and collapsing its now-empty block is not a "
+                f"logic edit, got {ranges}",
+            )
+
+    def test_reformatting_a_line_while_also_changing_it_still_touches_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            self._init_repo_with_base_commit(repo)
+
+            edited = self._OVER_LIMIT_FUNCTION.replace(
+                "    if x == 9 { return 9; }",
+                "    if x == 9 {\n        return 90;\n    }",
+            )
+            self._write_and_commit(
+                repo, edited + "\n", "reformat the branch onto three lines and change its value"
+            )
+
+            with mock.patch("gate_diff.ROOT", repo):
+                ranges = gate_diff.changed_ranges("HEAD~1")
+
+            self.assertIn("src/lib.rs", ranges)
+            self.assertTrue(
+                gate_diff.any_intersect(ranges["src/lib.rs"], (1, 13)),
+                "a real value change bundled with a reformat must not be normalized away, "
+                f"got {ranges}",
+            )
 
 
 class ComplexityFindViolations(unittest.TestCase):

--- a/scripts/ci/test_gate_diff.py
+++ b/scripts/ci/test_gate_diff.py
@@ -114,6 +114,113 @@ class ParseUnifiedDiffZeroContext(unittest.TestCase):
         )
 
 
+class LineHasCode(unittest.TestCase):
+    def test_plain_code_line(self) -> None:
+        self.assertEqual(gate_diff.line_has_code("let x = 1;"), [True])
+
+    def test_blank_line(self) -> None:
+        self.assertEqual(gate_diff.line_has_code(""), [False])
+        self.assertEqual(gate_diff.line_has_code("   \t  "), [False])
+
+    def test_pure_line_comment(self) -> None:
+        self.assertEqual(gate_diff.line_has_code("// just a note"), [False])
+
+    def test_code_with_trailing_comment_counts_as_code(self) -> None:
+        self.assertEqual(gate_diff.line_has_code("let x = 1; // trailing"), [True])
+
+    def test_slash_slash_inside_a_string_is_not_a_comment(self) -> None:
+        text = 'let url = "https://example.com";'
+        self.assertEqual(gate_diff.line_has_code(text), [True])
+
+    def test_string_spanning_a_naive_comment_check_does_not_start_one(self) -> None:
+        # A string literal containing `//` followed by a real comment on the
+        # next line: the `//` inside the string must not be mistaken for the
+        # start of a comment that swallows the rest of the string plus the
+        # next, genuinely-commented, line.
+        text = '\n'.join(['let s = "a // b";', "// this really is a comment"])
+        self.assertEqual(gate_diff.line_has_code(text), [True, False])
+
+    def test_single_line_block_comment(self) -> None:
+        self.assertEqual(gate_diff.line_has_code("/* note */"), [False])
+
+    def test_single_line_block_comment_with_trailing_code_counts_as_code(self) -> None:
+        self.assertEqual(gate_diff.line_has_code("/* note */ let x = 1;"), [True])
+
+    def test_multi_line_block_comment_is_all_blank(self) -> None:
+        text = "\n".join(["/* start", "middle line", "end */"])
+        self.assertEqual(gate_diff.line_has_code(text), [False, False, False])
+
+    def test_multi_line_block_comment_with_code_before_and_after(self) -> None:
+        text = "\n".join(["let a = 1; /* start", "middle line", "end */ let b = 2;"])
+        self.assertEqual(gate_diff.line_has_code(text), [True, False, True])
+
+    def test_nested_block_comments(self) -> None:
+        # Rust block comments nest, unlike C's.
+        text = "\n".join(["/* outer /* inner */ still commented", "*/ let x = 1;"])
+        self.assertEqual(gate_diff.line_has_code(text), [False, True])
+
+    def test_raw_string_containing_slashes_and_quotes(self) -> None:
+        text = 'let s = r#"// not a comment, and "quoted" too"#;'
+        self.assertEqual(gate_diff.line_has_code(text), [True])
+
+    def test_raw_string_spanning_lines(self) -> None:
+        text = "\n".join(['let s = r"line one', "// still string content", 'line three";'])
+        self.assertEqual(gate_diff.line_has_code(text), [True, True, True])
+
+    def test_raw_string_prefix_not_misdetected_mid_identifier(self) -> None:
+        # `bar` ends in `r`; the `"` that follows belongs to a separate,
+        # ordinary string literal, not a raw string starting at that `r`.
+        text = 'let bar = 1; let s = "text";'
+        self.assertEqual(gate_diff.line_has_code(text), [True])
+
+    def test_char_literal_does_not_start_a_comment(self) -> None:
+        text = "let c = '/';"
+        self.assertEqual(gate_diff.line_has_code(text), [True])
+
+    def test_escaped_char_literal(self) -> None:
+        text = r"let c = '\n';"
+        self.assertEqual(gate_diff.line_has_code(text), [True])
+
+    def test_lifetime_is_not_treated_as_an_unterminated_char_literal(self) -> None:
+        # If `'a` were treated as opening a char literal that never closes,
+        # scanning would run past the real comment below looking for a
+        # closing quote, hiding it from the result.
+        text = "\n".join(["fn f<'a>(x: &'a str) -> &'a str { x }", "// a real comment"])
+        self.assertEqual(gate_diff.line_has_code(text), [True, False])
+
+    def test_string_containing_an_escaped_quote(self) -> None:
+        text = r'let s = "she said \"hi\"";'
+        self.assertEqual(gate_diff.line_has_code(text), [True])
+
+
+class DropCommentOnlyRanges(unittest.TestCase):
+    def test_hunk_that_is_entirely_comment_is_dropped(self) -> None:
+        ranges = {"src/lib.rs": [(2, 2)]}
+        files = {"src/lib.rs": "fn f() {\n    // just a comment\n}\n"}
+        self.assertEqual(gate_diff.drop_comment_only_ranges(ranges, files.get), {})
+
+    def test_hunk_with_any_real_code_line_is_kept_in_full(self) -> None:
+        ranges = {"src/lib.rs": [(2, 3)]}
+        files = {"src/lib.rs": "fn f() {\n    // a comment\n    let x = 1;\n}\n"}
+        self.assertEqual(
+            gate_diff.drop_comment_only_ranges(ranges, files.get),
+            {"src/lib.rs": [(2, 3)]},
+        )
+
+    def test_only_the_comment_only_hunk_is_dropped_others_survive(self) -> None:
+        ranges = {"src/lib.rs": [(2, 2), (4, 4)]}
+        files = {"src/lib.rs": "fn f() {\n    // comment\n    let x = 1;\n    let y = 2;\n}\n"}
+        self.assertEqual(
+            gate_diff.drop_comment_only_ranges(ranges, files.get),
+            {"src/lib.rs": [(4, 4)]},
+        )
+
+    def test_file_with_no_surviving_ranges_is_dropped_entirely(self) -> None:
+        ranges = {"src/only_comments.rs": [(1, 1)]}
+        files = {"src/only_comments.rs": "// nothing but this\n"}
+        self.assertEqual(gate_diff.drop_comment_only_ranges(ranges, files.get), {})
+
+
 class Intersects(unittest.TestCase):
     def test_overlapping_ranges(self) -> None:
         self.assertTrue(gate_diff.intersects((10, 20), (15, 25)))
@@ -266,6 +373,110 @@ class MergeBaseShallowHistory(unittest.TestCase):
                 with self.assertRaises(SystemExit) as raised:
                     gate_diff.merge_base("origin/main")
             self.assertIn("share no common ancestor", str(raised.exception))
+
+
+class ChangedRangesExcludesCommentOnlyHunks(unittest.TestCase):
+    """The end-to-end fixture: a real repo, a real over-limit function, and
+    the exact `changed_ranges` pipeline `complexity_gate`/`duplication_gate`
+    call in CI -- not a synthetic diff string standing in for one.
+    """
+
+    _OVER_LIMIT_FUNCTION = "\n".join(
+        [
+            "fn deeply_branching(x: i32) -> i32 {",
+            "    if x == 0 { return 0; }",
+            "    if x == 1 { return 1; }",
+            "    if x == 2 { return 2; }",
+            "    if x == 3 { return 3; }",
+            "    if x == 4 { return 4; }",
+            "    if x == 5 { return 5; }",
+            "    if x == 6 { return 6; }",
+            "    if x == 7 { return 7; }",
+            "    if x == 8 { return 8; }",
+            "    if x == 9 { return 9; }",
+            "    x",
+            "}",
+        ]
+    )
+
+    def _git(self, args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+    def _init_repo_with_base_commit(self, repo: Path) -> None:
+        repo.mkdir()
+        self._git(["init", "--quiet", "-b", "main"], repo)
+        self._git(["config", "user.email", "test@example.com"], repo)
+        self._git(["config", "user.name", "Test"], repo)
+        (repo / "src").mkdir()
+        (repo / "src" / "lib.rs").write_text(self._OVER_LIMIT_FUNCTION + "\n")
+        self._git(["add", "."], repo)
+        self._git(["commit", "--quiet", "-m", "base"], repo)
+
+    def _write_and_commit(self, repo: Path, contents: str, message: str) -> None:
+        (repo / "src" / "lib.rs").write_text(contents)
+        self._git(["add", "."], repo)
+        self._git(["commit", "--quiet", "-m", message], repo)
+
+    def test_removing_a_comment_inside_the_function_does_not_touch_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            self._init_repo_with_base_commit(repo)
+
+            with_comment = self._OVER_LIMIT_FUNCTION.replace(
+                "    x\n}", "    // fall through for anything else\n    x\n}"
+            )
+            self._write_and_commit(repo, with_comment + "\n", "add a comment")
+
+            comment_removed = with_comment.replace(
+                "    // fall through for anything else\n", ""
+            )
+            self._write_and_commit(repo, comment_removed + "\n", "remove only the comment")
+
+            with mock.patch("gate_diff.ROOT", repo):
+                ranges = gate_diff.changed_ranges("HEAD~1")
+
+            self.assertEqual(
+                ranges,
+                {},
+                "a hunk that only deleted a comment line must not touch anything",
+            )
+
+    def test_a_genuine_logic_edit_in_the_same_function_still_touches_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            self._init_repo_with_base_commit(repo)
+
+            edited = self._OVER_LIMIT_FUNCTION.replace(
+                "    if x == 9 { return 9; }", "    if x == 9 { return 90; }"
+            )
+            self._write_and_commit(repo, edited + "\n", "change a return value")
+
+            with mock.patch("gate_diff.ROOT", repo):
+                ranges = gate_diff.changed_ranges("HEAD~1")
+
+            self.assertIn("src/lib.rs", ranges)
+            touched = ranges["src/lib.rs"]
+            self.assertTrue(
+                gate_diff.any_intersect(touched, (1, 13)),
+                f"a real logic edit must still land inside the function's span, got {touched}",
+            )
+
+    def test_mixed_hunk_of_comment_and_logic_still_touches_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            self._init_repo_with_base_commit(repo)
+
+            edited = self._OVER_LIMIT_FUNCTION.replace(
+                "    x\n}",
+                "    // fall through for anything else\n    x + 1\n}",
+            )
+            self._write_and_commit(repo, edited + "\n", "comment plus a real edit, one hunk")
+
+            with mock.patch("gate_diff.ROOT", repo):
+                ranges = gate_diff.changed_ranges("HEAD~1")
+
+            self.assertIn("src/lib.rs", ranges)
+            self.assertTrue(gate_diff.any_intersect(ranges["src/lib.rs"], (1, 13)))
 
 
 class ComplexityFindViolations(unittest.TestCase):


### PR DESCRIPTION
## Summary

`complexity_gate.py` and `duplication_gate.py` scope themselves to lines a diff added or modified, via `gate_diff.changed_ranges`. The first version of this fix (below the fold) only compared a hunk's new side against itself ("does the new text have any code"), which correctly drops a bare comment deletion but says nothing about a hunk where deleting a comment also collapsed the code around it — `}) {\n    // comment\n}` becoming `}) {}` still has code on the new side, so that narrower rule kept it in scope for no reason. Verified against `docs/comment-policy`'s actual diff: the narrower rule left all 37 complexity and 21 duplication violations it originally tripped completely unchanged.

This PR replaces it with a comparison of both sides:

- `parse_hunk_spans` now keeps each hunk's *old*-side line range alongside its new-side one (previously only the new side was kept).
- `code_tokens_by_line` tokenizes a file (comments and whitespace contribute nothing; a maximal run of identifier characters is one token; every other significant byte — punctuation, and each string/raw-string/char literal as a whole — is its own token).
- `semantic_ranges` tokenizes both the old and new side of each hunk and drops the hunk only when the two token lists are equal. A pure comment-only hunk still falls out through this exact same comparison (its old and new token lists were already both empty), so this subsumes the narrower rule rather than sitting beside it.
- `_drop_trailing_commas` adds one further, Rust-grammar-safe normalization: a comma immediately before a closing delimiter (`)`, `]`, `}`) is never syntactically significant in Rust, and rustfmt's choice to add or drop one depends only on whether the surrounding expression is still multi-line once a comment is gone — not on anything about what the code does.

This is still a scoping fix, not an exemption: nothing keys off "this diff is comment-only." A hunk with a genuine token-level difference — including one bundled with a comment removal or a reformat — keeps its full span and still trips the gate exactly as before.

## Verification

- Red-first, twice: bypassing `semantic_ranges`'s comparison reproduces the original bug (a comment-only or collapse-only hunk still marks its function touched); separately, bypassing `_drop_trailing_commas` reproduces a hunk whose only difference is a grammar-insignificant trailing comma still marking its function touched. Both fail red before their fix, pass green after.
- Pinned safety properties, per reviewer request: a real logic edit inside an over-limit function still trips the gate; a hunk that reorders whitespace **and** changes a token is still caught (normalization never masks a real change riding along with a reformat); a string literal containing comment-like or whitespace-significant text is treated as one atomic token and never mangled by the normalizer.
- 62/62 tests pass in `test_gate_diff.py` (`just test-quality-gates`), including an end-to-end fixture reproducing the exact `#540` mechanism (an `if`-block whose only content is a comment collapsing to `{}` once it's deleted).
- Verified against `docs/comment-policy`'s actual diff, not just fixtures: **37 → 6 complexity violations, 21 → 2 duplication violations.**

## What's left, precisely (not zero — see below)

The remaining 6 complexity / 2 duplication violations do **not** trace to comment removal being mis-scoped. Each was individually traced to a specific hunk and confirmed, by directly reproducing it in isolation against `rustfmt`/`cargo clippy --all-targets -- -D warnings` (the exact flags `just fmt`/`just clippy` use), to be a **mandatory** rewrite forced by this repo's own existing zero-warnings gates once a comment's removal leaves the surrounding code eligible for their auto-fix:

- `clippy::single_match` (`-D warnings` promotes it to a hard error): a two-arm `match` whose second arm becomes a no-op `_ => {}` once its comment is gone must be rewritten to `if let` — `crates/cranpose/src/android.rs::run`.
- `clippy::collapsible_if`, same enforcement: a nested `if { if let PAT = EXPR { .. } }` whose outer body becomes just that inner `if let` once its comment is gone must be rewritten to a let-chain (`if COND && let PAT = EXPR { .. }`) — `crates/cranpose-ui/src/layout/mod.rs`.
- Plain `rustfmt` (no clippy involved) unconditionally collapses a match arm or block whose only content becomes a single tail expression once its comment is gone, from `X => {\n    expr\n}` to `X => expr,` — `apps/desktop-demo/robot-runners/robot_fling_precise.rs`, `crates/cranpose-ui/src/layout/policies.rs`, `crates/cranpose-testing/tests/pointer_input_end_to_end_test.rs` (closure-body form).

None of these are optional formatting choices #540 (or its tooling) could simply decline — reverting any of them to their pre-collapse shape while keeping the comment deleted fails `just fmt-check`/`just clippy` outright (confirmed directly, not assumed). Closing this gap fully needs Rust-grammar-level equivalence (proving `match X { A => B, _ => {} }` ≡ `if let A = X { B }`, nested-if ≡ let-chain, `{ expr }` ≡ `expr`), not text/token normalization — a materially bigger and riskier undertaking than this PR's scope, and exactly the "normalizing too aggressively, fails quietly" direction to stay well clear of without a deliberate decision to take it on. Flagging this as a decision point rather than guessing further or special-casing these specific patterns ad hoc.

## Test plan

- [x] `just test-quality-gates` — 62/62 pass
- [x] `just fmt-check`, `just typos`, `just versions` — clean
- [x] No `.rs` files touched by this PR; `just test`/`just clippy` are unaffected by the diff

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
