### PR TITLE
Compare complexity and duplication before/after, not against the absolute limit

### DIFF
--- a/docs/complexity_debt.md
+++ b/docs/complexity_debt.md
@@ -9,46 +9,90 @@ first time because `docs/comment-policy`'s repo-wide comment-strip diff
 happens to touch a line inside nearly every function in the tree, including
 these.
 
-Confirmed genuine, not a scoping artifact: `fix/gate-diff-comment-scoping`
-(#568) fixed the one real bug in the scoping heuristic itself (comment-only
-line changes wrongly counted as touching a function) and re-ran both gates
-against the same diff afterward. The list below is unchanged by that fix --
-these functions and clones are pulled into scope by a real code-text change
-next to the stripped comments, most often a trivial structural collapse an
-earlier comment-removal pass left behind (an emptied `if` body merging to
-`{}`), not by the comment removal itself.
+## Two gate bugs found and fixed while investigating this list
 
-## Complexity: 37 functions over the limit (20)
+**Comment-only and collapse-only touches (`fix/gate-diff-comment-scoping`,
+#568).** The original scoping counted any hunk with a code byte on its new
+side as "touching" a function, including one where deleting a comment also
+collapsed the surrounding code onto fewer lines (`}) {\n // comment\n}`
+becoming `}) {}`). #568 replaced that with a token-level comparison of each
+hunk's old and new side, so a hunk with no code-level difference -- comment
+gone, whitespace collapsed, a grammar-insignificant trailing comma added or
+dropped -- no longer counts as touching anything. Re-running against
+`docs/comment-policy`'s diff after that fix took the count from 37/21 down
+to 6/2: real progress, but not a full fix, because the remaining hunks are
+genuinely-mandatory rewrites -- a `clippy::single_match` or
+`clippy::collapsible_if` autofix forced once a branch becomes a no-op, or
+`rustfmt` collapsing a now-single-expression block -- that #568, by design,
+does not exempt: those *are* a real code-text difference, even though the
+only reason this diff produced them is that the comment inside had to go.
+
+**Absolute-limit scoping, and a double-count inside it
+(`fix/complexity-duplication-before-after`).** Two further problems, found
+while ranking that remaining 6/2 by how proportionate fixing each would be:
+
+- The complexity gate was comparing a touched function's complexity against
+  the limit directly, with no memory of what it was *before* the diff. A
+  function already over the limit -- most of the list below -- failed
+  every gate run that so much as brushed a nearby comment, demanding a
+  refactor (in `android.rs::run`'s case, from 174 down to 20) as the price
+  of deleting a comment, regardless of whether the diff made the function's
+  own control flow any worse. The gate now compares before and after:
+  unchanged-or-lower complexity passes regardless of the absolute number,
+  higher fails regardless of it. Duplication got the same treatment --
+  `jscpd` is re-run against the pre-change content of every file a
+  candidate clone involves, and a clone already comparably present before
+  the diff passes as existing debt rather than failing as newly introduced.
+- Separately, and independent of that fix: `rust-code-analysis-cli` reports
+  a closure as its own `function`-kind entry nested inside the function
+  that defines it, and the gate was flattening that whole tree into a flat
+  violation list -- so a function built almost entirely out of one large
+  closure (`main` wrapping a `poll_events` callback, `run` wrapping an
+  event-loop closure) was reported *twice*, once under its own name and
+  once as `<anonymous>`, each treated as an independent violation to fix.
+  It is one function, reported as two. The gate now stops descending into
+  a closure once it is already inside some enclosing function (a named
+  `fn` nested inside a closure body is still independently real code and
+  still gets its own entry, however deep the nesting) so a closure with
+  nothing of its own to fold into -- the rare top-level case -- is still
+  reported.
+
+That double-count is why the complexity list below shrank from the 37
+originally measured to 24: 13 of the original 37 entries were an
+`<anonymous>` nested inside a `main` or `run` already on the list, counted
+as a second problem when it was the same one. The 24 remaining are each an
+independently real function; none of them merged away.
+
+With both fixes in place, `docs/comment-policy`'s diff passes
+`complexity-gate` and `duplication-gate` cleanly (0 violations): it does not
+raise any already-over-limit function's complexity, and it does not
+introduce any new duplication between the files it touches. The debt below
+is unaffected by that -- these functions and clones are exactly as complex
+and exactly as duplicated as they were before any of this, still real,
+still nobody's job to fix as a side effect of a comment sweep.
+
+## Complexity: 24 functions over the limit (20)
 
 The two largest are worth naming on their own: `crates/cranpose/src/web.rs`'s
 `run` at cyclomatic complexity **224**, and `crates/cranpose/src/android.rs`'s
 `run` at **174** -- both roughly an order of magnitude over the ceiling every
-other function here is held to.
+other function here is held to. Both numbers already include their own
+nested closures' complexity (see above) -- there is no separate `<anonymous>`
+entry to also fix, because there is no separate problem.
 
 ```
 apps/desktop-demo/robot-runners/robot_copy_paste.rs:7-284 main (46)
-apps/desktop-demo/robot-runners/robot_copy_paste.rs:16-280 <anonymous> (44)
 apps/desktop-demo/robot-runners/robot_fling.rs:10-215 main (35)
-apps/desktop-demo/robot-runners/robot_fling.rs:21-211 <anonymous> (33)
 apps/desktop-demo/robot-runners/robot_fling_edge_cases.rs:40-324 main (32)
-apps/desktop-demo/robot-runners/robot_fling_edge_cases.rs:50-320 <anonymous> (30)
 apps/desktop-demo/robot-runners/robot_fling_precise.rs:10-303 main (27)
-apps/desktop-demo/robot-runners/robot_fling_precise.rs:20-299 <anonymous> (25)
 apps/desktop-demo/robot-runners/robot_lazy_list_order_bug.rs:7-222 main (37)
-apps/desktop-demo/robot-runners/robot_lazy_list_order_bug.rs:18-218 <anonymous> (35)
 apps/desktop-demo/robot-runners/robot_lazy_tab_test.rs:7-201 main (34)
-apps/desktop-demo/robot-runners/robot_lazy_tab_test.rs:15-199 <anonymous> (33)
 apps/desktop-demo/robot-runners/robot_shader_rect.rs:150-315 main (28)
-apps/desktop-demo/robot-runners/robot_shader_rect.rs:158-313 <anonymous> (27)
 apps/desktop-demo/robot-runners/robot_subcompose_invalidation.rs:9-105 test_app (21)
 apps/desktop-demo/robot-runners/robot_text_input.rs:7-647 main (114)
-apps/desktop-demo/robot-runners/robot_text_input.rs:18-643 <anonymous> (112)
 apps/desktop-demo/robot-runners/robot_text_loupe.rs:43-328 main (25)
-apps/desktop-demo/robot-runners/robot_text_loupe.rs:57-319 <anonymous> (21)
 crates/cranpose-app-shell/src/shell_frame.rs:186-329 run_layout_phase_in_context (33)
 crates/cranpose-liquid/src/widgets/tab_bar.rs:517-757 LiquidTabBarLayout (33)
-crates/cranpose-liquid/src/widgets/tab_bar.rs:537-755 <anonymous> (32)
-crates/cranpose-liquid/src/widgets/tab_bar.rs:575-744 <anonymous> (21)
 crates/cranpose-render/wgpu/src/render.rs:2456-2619 convert_shapes_into_outputs (22)
 crates/cranpose-render/wgpu/src/render.rs:10513-10868 encode_shadow_draw (38)
 crates/cranpose-ui/src/layout/mod.rs:1274-1529 try_measure_subcompose (37)
@@ -60,9 +104,7 @@ crates/cranpose-ui/src/tests/modifier_nodes_tests.rs:1198-1325 stateful_measure_
 crates/cranpose-ui/src/tests/renderer_tests.rs:101-225 renderer_translates_draw_commands (37)
 crates/cranpose-ui/src/text_field_modifier_node.rs:453-645 create_handler (27)
 crates/cranpose/src/android.rs:1494-2438 run (174)
-crates/cranpose/src/android.rs:1737-2023 <anonymous> (50)
 crates/cranpose/src/web.rs:111-924 run (224)
-crates/cranpose/src/web.rs:592-666 <anonymous> (50)
 ```
 
 (Line ranges are as measured on `docs/comment-policy`'s branch tip at the
@@ -71,6 +113,16 @@ relative to `main`, so re-measure with `just complexity-gate` against
 whichever base is current rather than trusting these ranges to still line up.)
 
 ## Duplication: 21 clones touching the diff
+
+Unaffected by the nested-closure double-count above (that bug was specific
+to how the complexity gate flattened `rust-code-analysis-cli`'s function
+tree; `jscpd`'s clone list has no equivalent structure to over-count). All
+21 are still real, pre-existing duplication; two of them
+(`pointer_hover_gradient_test.rs` / `pointer_input_end_to_end_test.rs`, and
+the `policies.rs` `min_intrinsic_height` / `max_intrinsic_height` pair) are
+specifically confirmed pre-existing rather than merely plausible: `jscpd`
+run against `docs/comment-policy`'s pre-change content independently found
+each pair already duplicating itself before the diff.
 
 ```
 apps/desktop-demo/robot-runners/robot_double_click.rs:57-71 <-> apps/desktop-demo/robot-runners/robot_double_click.rs:106-118 (15 lines)
@@ -99,9 +151,12 @@ crates/cranpose-ui/src/tests/swipe_to_dismiss_tests.rs:277-287 <-> crates/cranpo
 ## What this is not
 
 Not `docs/comment-policy`'s job to fix -- that PR strips comments, and
-fixing 37 functions' control flow or de-duplicating 21 code blocks is a
-separate, substantial architecture pass with its own review surface.
-Whoever picks this up should re-run `just complexity-gate --base <sha>` /
-`just duplication-gate --base <sha>` against a throwaway diff (e.g. touch one
-blank line in each file so the whole function is back in scope) to get
-current line numbers before starting, rather than trusting the ranges above.
+fixing 24 functions' control flow or de-duplicating 21 code blocks is a
+separate, substantial architecture pass with its own review surface. Nor is
+it something the gate should silently force: the gate compares before and
+after specifically so that touching a line near one of these does not
+retroactively demand fixing it. Whoever picks this debt up deliberately
+should re-run `just complexity-gate --base <sha>` / `just duplication-gate
+--base <sha>` against a throwaway diff (e.g. touch one blank line in each
+file so the whole function is back in scope) to get current line numbers
+before starting, rather than trusting the ranges above.

--- a/scripts/ci/complexity_gate.py
+++ b/scripts/ci/complexity_gate.py
@@ -33,42 +33,64 @@ def load_max_cyclomatic(config_path: Path) -> int:
     return int(config["complexity"]["max_cyclomatic"])
 
 
-def functions_in(space: dict, out: list[dict]) -> None:
+def functions_in(space: dict, out: list[dict], inside_function: bool = False) -> None:
     """Flatten `rust-code-analysis-cli`'s nested space tree into functions.
 
     Closures are their own `kind == "function"` spaces nested inside the
-    function that defines them, so this recurses into every space -- a
-    closure the diff adds should be checked on its own span, not only as
-    part of whatever complexity its enclosing function reports.
+    function that defines them -- `space.get("name")` is unset for exactly
+    these, never for a named `fn` item, however deeply nested. A closure
+    already inside another function is not independently-invocable code, it
+    *is* that function's own body, just packaged as a value; reporting both
+    counted the same bytes twice; every function this diff has ever flagged
+    for having "a real function and an oversized closure nested in it" was
+    one problem being reported as two. Only the outermost boundary of such a
+    chain is reportable -- `inside_function` tracks whether the recursion
+    has already passed one -- so a closure nested in a closure still
+    collapses to just the one enclosing report, while a named `fn` defined
+    inside a closure's body (legal, if unusual, Rust) is still independently
+    real code and is still reported no matter how deep the nesting.
     """
-    if space.get("kind") == "function":
+    is_function = space.get("kind") == "function"
+    raw_name = space.get("name")
+    # `rust-code-analysis-cli` itself already emits the literal string
+    # "<anonymous>" for a closure's own `name` field -- it is not left
+    # `None`/empty, so a plain truthiness check treats every closure as
+    # "named" and never collapses anything. Only a name that is neither
+    # missing nor that exact sentinel is a real, independently-invocable
+    # `fn` item.
+    is_named = bool(raw_name) and raw_name != "<anonymous>"
+    if is_function and (is_named or not inside_function):
         metrics = space.get("metrics") or {}
         cyclomatic = (metrics.get("cyclomatic") or {}).get("sum")
         out.append(
             {
-                "name": space.get("name") or "<anonymous>",
+                "name": raw_name if is_named else "<anonymous>",
                 "start": space.get("start_line"),
                 "end": space.get("end_line"),
                 "cyclomatic": cyclomatic,
             }
         )
     for child in space.get("spaces", []):
-        functions_in(child, out)
+        functions_in(child, out, inside_function=inside_function or is_function)
 
 
 def analyze_files(
-    rust_code_analysis_cli: Path, files: list[str], out_dir: Path
+    rust_code_analysis_cli: Path, files: list[str], out_dir: Path, cwd: Path = ROOT
 ) -> dict[str, list[dict]]:
     """Run `rust-code-analysis-cli` on `files`, returning functions per file.
 
     The CLI takes one `-p <path>` per input (a comma-joined list is treated
     as one literal, nonexistent path, not a list) and mirrors each input's
-    relative path under `out_dir` with a `.json` suffix appended.
+    relative path under `out_dir` with a `.json` suffix appended. `cwd`
+    defaults to the real checkout (`ROOT`) but is overridable so this same
+    function can analyze a disposable directory of pre-change blobs
+    (`gate_diff.write_old_blobs`) for the "before" half of a before/after
+    comparison, keyed by the same relative paths either way.
     """
     args = [str(rust_code_analysis_cli), "-m", "-O", "json", "-o", str(out_dir)]
     for f in files:
         args += ["-p", f]
-    result = subprocess.run(args, cwd=ROOT, capture_output=True, text=True)
+    result = subprocess.run(args, cwd=cwd, capture_output=True, text=True)
     produced = list(out_dir.rglob("*.json"))
     if result.returncode != 0 and not produced:
         raise SystemExit(
@@ -98,26 +120,78 @@ def analyze_files(
     return by_file
 
 
+def old_complexity_by_name(functions: list[dict]) -> dict[str, list[int]]:
+    """Named functions' cyclomatic complexity, in file order, keyed by name.
+
+    A list rather than a single value per name: two unrelated methods can
+    share a bare name in the same file (`fn new()` on two different
+    structs), and matching the Nth occurrence of a name in the old file
+    against the Nth occurrence in the new file is a real, if imperfect,
+    improvement over "last one wins" -- it only misjudges a function whose
+    diff also reordered it past another same-named function, which is both
+    rarer and lower-stakes than silently comparing two unrelated functions
+    because they happened to share a name. Anonymous entries (`<anonymous>`,
+    meaning a closure with no enclosing function to fold into -- see
+    `functions_in`) have no stable identity across a diff and are excluded;
+    a function that cannot be matched has no "before" to compare against.
+    """
+    by_name: dict[str, list[int]] = {}
+    for func in functions:
+        if func["name"] == "<anonymous>" or func["cyclomatic"] is None:
+            continue
+        by_name.setdefault(func["name"], []).append(int(func["cyclomatic"]))
+    return by_name
+
+
 def find_violations(
     ranges: dict[str, list[tuple[int, int]]],
-    functions_by_file: dict[str, list[dict]],
+    new_functions_by_file: dict[str, list[dict]],
+    old_functions_by_file: dict[str, list[dict]],
     max_cyclomatic: int,
 ) -> list[str]:
+    """Functions the diff made worse, not functions it merely touches.
+
+    A function already over `max_cyclomatic` before this diff is existing
+    debt (see `docs/complexity_debt.md`), not something this diff is asked
+    to fix as the price of touching a nearby line. The gate instead compares
+    each touched function's complexity before and after: unchanged or lower
+    passes regardless of the absolute number, higher fails regardless of it
+    -- a diff that pushes a function from 18 to 25 crossed the limit itself
+    and fails exactly like one that pushed 174 to 175, while one that
+    deleted a comment inside a 174-complexity function and left its control
+    flow untouched passes, because it did not make anything worse. A
+    function with no old counterpart (new code, or a name this pass could
+    not match -- see `old_complexity_by_name`) has nothing to be "not worse
+    than," so it is judged against the limit directly, same as before.
+    """
     violations: list[str] = []
-    for file, functions in sorted(functions_by_file.items()):
+    for file, functions in sorted(new_functions_by_file.items()):
         file_ranges = ranges.get(file, [])
+        old_by_name = old_complexity_by_name(old_functions_by_file.get(file, []))
+        cursor: dict[str, int] = {}
         for func in functions:
+            occurrence = cursor.get(func["name"], 0)
+            cursor[func["name"]] = occurrence + 1
             if func["start"] is None or func["end"] is None or func["cyclomatic"] is None:
                 continue
             span = (func["start"], func["end"])
             if not gate_diff.any_intersect(file_ranges, span):
                 continue
-            cyclomatic = int(func["cyclomatic"])
-            if cyclomatic > max_cyclomatic:
-                violations.append(
-                    f"{file}:{span[0]}-{span[1]} {func['name']} "
-                    f"has cyclomatic complexity {cyclomatic} (limit {max_cyclomatic})"
-                )
+            new_cyclomatic = int(func["cyclomatic"])
+            if new_cyclomatic <= max_cyclomatic:
+                continue
+            old_values = old_by_name.get(func["name"], [])
+            old_cyclomatic = old_values[occurrence] if occurrence < len(old_values) else None
+            if old_cyclomatic is not None and new_cyclomatic <= old_cyclomatic:
+                continue
+            reason = (
+                f"was {old_cyclomatic}, is now {new_cyclomatic}"
+                if old_cyclomatic is not None
+                else f"is new at {new_cyclomatic}"
+            )
+            violations.append(
+                f"{file}:{span[0]}-{span[1]} {func['name']} {reason} (limit {max_cyclomatic})"
+            )
     return violations
 
 
@@ -134,10 +208,27 @@ def main() -> int:
         return 0
 
     rust_code_analysis_cli = gate_diff.resolve_cargo_tool("rust-code-analysis-cli")
+    base_sha = gate_diff.merge_base(args.base)
     with tempfile.TemporaryDirectory() as tmp:
-        functions_by_file = analyze_files(rust_code_analysis_cli, sorted(ranges), Path(tmp))
+        tmp_path = Path(tmp)
+        new_out = tmp_path / "new-out"
+        new_out.mkdir()
+        new_functions_by_file = analyze_files(rust_code_analysis_cli, sorted(ranges), new_out)
 
-    violations = find_violations(ranges, functions_by_file, max_cyclomatic)
+        old_src = tmp_path / "old-src"
+        old_src.mkdir()
+        old_files = gate_diff.write_old_blobs(base_sha, sorted(ranges), old_src)
+        old_functions_by_file = {}
+        if old_files:
+            old_out = tmp_path / "old-out"
+            old_out.mkdir()
+            old_functions_by_file = analyze_files(
+                rust_code_analysis_cli, old_files, old_out, cwd=old_src
+            )
+
+    violations = find_violations(
+        ranges, new_functions_by_file, old_functions_by_file, max_cyclomatic
+    )
     if violations:
         print(f"complexity-gate: {len(violations)} function(s) over the limit:", file=sys.stderr)
         for v in violations:

--- a/scripts/ci/duplication_gate.py
+++ b/scripts/ci/duplication_gate.py
@@ -1,12 +1,23 @@
 #!/usr/bin/env python3
-"""Copy-paste budget for blocks a diff adds -- to old code or to itself.
+"""Copy-paste budget for clones a diff introduces -- to old code or to itself.
 
 Scope is diff-only (see `gate_diff.py`): `jscpd` scans the whole repository,
-because a new block can duplicate anything anywhere, but a clone only fails
-the gate when at least one of its two copies falls inside the diff. Two
+because a new block can duplicate anything anywhere, but a clone only enters
+consideration when at least one of its two copies falls inside the diff. Two
 pre-existing clones that the diff does not touch are left alone, so the
 workspace's existing duplication (measured at 1,592 clones over 10 lines as
 of 2026-08-29) does not need to be cleaned up for this to pass.
+
+Touching a clone is not the same as introducing it. A diff can land inside a
+file jscpd already considers duplicated -- most commonly because a nearby
+comment removal collapsed a block onto fewer lines, the same kind of forced,
+comment-removal-triggered rewrite `complexity_gate.py` had to stop punishing
+-- without the pre-existing duplication being that diff's fault or this
+diff's job to pay down (see `docs/complexity_debt.md`). So this gate reruns
+`jscpd` a second time against `base`'s pre-change content for exactly the
+files a candidate clone involves, and only fails when no comparable
+duplication already existed between the same two files: see
+`already_duplicated_before`.
 
     just duplication-gate                  # CI's invocation
     python3 scripts/ci/duplication_gate.py --base origin/main
@@ -35,8 +46,27 @@ def load_duplication_config(config_path: Path) -> dict:
 
 
 def run_jscpd(
-    jscpd: Path, min_lines: int, min_tokens: int, ignore_globs: list[str], out_dir: Path
+    jscpd: Path,
+    min_lines: int,
+    min_tokens: int,
+    ignore_globs: list[str],
+    out_dir: Path,
+    cwd: Path = ROOT,
 ) -> list[dict]:
+    """Run `jscpd` against every file under `cwd` and return its `duplicates`.
+
+    `cwd` defaults to the real checkout (`ROOT`) but is overridable to scan
+    a disposable directory instead -- `already_duplicated_before` needs
+    `jscpd`'s opinion of `base`'s pre-change content for the specific files
+    a candidate clone involves, scoped by pointing `cwd` at a directory
+    holding only those (`gate_diff.write_old_blobs`), not a second
+    full-repo scan. Always scans `cwd` itself (`.`) rather than being handed
+    an explicit file list: `jscpd` reports each match's file under `name`
+    as a bare basename when given explicit paths, but as the full path
+    relative to the scan root when given a directory to walk -- and a full
+    relative path is what lets a result be matched back against `ranges`'s
+    keys or another run's `name` values at all.
+    """
     args = [
         str(jscpd),
         "--min-lines",
@@ -53,7 +83,7 @@ def run_jscpd(
     if ignore_globs:
         args += ["--ignore", ",".join(ignore_globs)]
     args.append(".")
-    result = subprocess.run(args, cwd=ROOT, capture_output=True, text=True)
+    result = subprocess.run(args, cwd=cwd, capture_output=True, text=True)
     report_path = out_dir / "jscpd-report.json"
     if not report_path.exists():
         raise SystemExit(
@@ -67,17 +97,84 @@ def side_span(side: dict) -> tuple[str, tuple[int, int]]:
     return side["name"], (side["start"], side["end"])
 
 
+def file_pair(dup: dict) -> frozenset[str]:
+    """The two files a duplicate spans, as an order-independent identity."""
+    return frozenset({dup["firstFile"]["name"], dup["secondFile"]["name"]})
+
+
+def touches_diff(dup: dict, ranges: dict[str, list[tuple[int, int]]]) -> bool:
+    """Whether either side of `dup` falls inside `ranges`."""
+    first_file, first_span = side_span(dup["firstFile"])
+    second_file, second_span = side_span(dup["secondFile"])
+    return gate_diff.any_intersect(
+        ranges.get(first_file, []), first_span
+    ) or gate_diff.any_intersect(ranges.get(second_file, []), second_span)
+
+
+def already_duplicated_before(candidate: dict, old_duplicates: list[dict]) -> bool:
+    """Whether some comparable duplication already existed between the same
+    two files before this diff.
+
+    Matched by file pair, not by exact line span or byte-identical content:
+    the very cases this exists for are ones where the diff's nearby,
+    comment-removal-forced rewrite (see the module docstring) shifted line
+    numbers or reshaped the matched fragment's exact text without changing
+    what code it is. Requiring an exact match would fail every one of those
+    on a technicality and defeat the point.
+
+    What is still required, so this does not degrade into "these two files
+    have ever duplicated *anything*, so nothing between them ever counts
+    again": the old duplicate's size (`lines`) must be within 2x of the
+    candidate's, in either direction. Two files can plausibly hold more than
+    one, unrelated clone pair; a same-file-pair match at wildly different
+    size is more likely a different clone than the same one reformatted, and
+    the conservative read -- treat it as unproven, not as license -- is the
+    one that does not let a genuinely new clone hide behind an old,
+    unrelated one.
+    """
+    candidate_lines = candidate.get("lines") or 0
+    candidate_pair = file_pair(candidate)
+    for old_dup in old_duplicates:
+        if file_pair(old_dup) != candidate_pair:
+            continue
+        old_lines = old_dup.get("lines") or 0
+        if old_lines == 0 or candidate_lines == 0:
+            continue
+        ratio = old_lines / candidate_lines
+        if 0.5 <= ratio <= 2.0:
+            return True
+    return False
+
+
 def find_violations(
-    duplicates: list[dict], ranges: dict[str, list[tuple[int, int]]]
+    new_duplicates: list[dict],
+    old_duplicates: list[dict],
+    ranges: dict[str, list[tuple[int, int]]],
 ) -> list[str]:
+    """Clones the diff introduces, not clones it happens to touch.
+
+    A clone pair only enters consideration when at least one side falls in
+    `ranges` (unchanged from before: a clone neither side of which the diff
+    touched at all is out of scope regardless of history). Among those, one
+    already comparably duplicated before this diff (see
+    `already_duplicated_before`) is pre-existing debt -- recorded in
+    `docs/complexity_debt.md`, not this diff's to pay down -- and passes;
+    one with nothing comparable on the old side is new, and fails.
+    """
+    old_by_pair: dict[frozenset[str], list[dict]] = {}
+    for old_dup in old_duplicates:
+        old_by_pair.setdefault(file_pair(old_dup), []).append(old_dup)
+
     violations: list[str] = []
-    for dup in duplicates:
+    for dup in new_duplicates:
+        if not touches_diff(dup, ranges):
+            continue
+        if already_duplicated_before(dup, old_by_pair.get(file_pair(dup), [])):
+            continue
         first_file, first_span = side_span(dup["firstFile"])
         second_file, second_span = side_span(dup["secondFile"])
         first_hit = gate_diff.any_intersect(ranges.get(first_file, []), first_span)
         second_hit = gate_diff.any_intersect(ranges.get(second_file, []), second_span)
-        if not (first_hit or second_hit):
-            continue
         lines = dup.get("lines")
         violations.append(
             f"{first_file}:{first_span[0]}-{first_span[1]}"
@@ -85,7 +182,7 @@ def find_violations(
             " duplicates "
             f"{second_file}:{second_span[0]}-{second_span[1]}"
             f"{' (new)' if second_hit else ''}"
-            f" ({lines} lines)"
+            f" ({lines} lines, introduced by this diff)"
         )
     return violations
 
@@ -110,23 +207,55 @@ def main() -> int:
         "run, fix that (network, registry, offline mirror), do not swap in "
         "`npm install -g jscpd`.",
     )
+    base_sha = gate_diff.merge_base(args.base)
     with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        new_out = tmp_path / "new-out"
+        new_out.mkdir()
         duplicates = run_jscpd(
             jscpd,
             config["min_lines"],
             config["min_tokens"],
             config.get("ignore_globs", []),
-            Path(tmp),
+            new_out,
         )
 
-    violations = find_violations(duplicates, ranges)
+        candidates = [dup for dup in duplicates if touches_diff(dup, ranges)]
+        involved_files = sorted(
+            {dup["firstFile"]["name"] for dup in candidates}
+            | {dup["secondFile"]["name"] for dup in candidates}
+        )
+        old_duplicates: list[dict] = []
+        if involved_files:
+            old_src = tmp_path / "old-src"
+            old_src.mkdir()
+            old_files = gate_diff.write_old_blobs(base_sha, involved_files, old_src)
+            if old_files:
+                old_out = tmp_path / "old-out"
+                old_out.mkdir()
+                old_duplicates = run_jscpd(
+                    jscpd,
+                    config["min_lines"],
+                    config["min_tokens"],
+                    config.get("ignore_globs", []),
+                    old_out,
+                    cwd=old_src,
+                )
+
+    violations = find_violations(duplicates, old_duplicates, ranges)
     if violations:
-        print(f"duplication-gate: {len(violations)} clone(s) touch the diff:", file=sys.stderr)
+        print(
+            f"duplication-gate: {len(violations)} clone(s) introduced by this diff:",
+            file=sys.stderr,
+        )
         for v in violations:
             print(f"  {v}", file=sys.stderr)
         return 1
 
-    print(f"duplication-gate: {len(duplicates)} clone(s) in the repo, none touch the diff")
+    print(
+        f"duplication-gate: {len(duplicates)} clone(s) in the repo, "
+        f"{len(candidates)} touch the diff, none introduced by it"
+    )
     return 0
 
 

--- a/scripts/ci/gate_diff.py
+++ b/scripts/ci/gate_diff.py
@@ -441,6 +441,40 @@ def changed_ranges(base: str, pathspec: str = "*.rs") -> dict[str, list[tuple[in
     return semantic_ranges(hunk_spans, read_old, read_new)
 
 
+def write_old_blobs(base_sha: str, files: list[str], dest_root: Path) -> list[str]:
+    """Write each of `files` as it stood at `base_sha` into `dest_root`,
+    preserving relative paths, and return the subset that existed there.
+
+    Some analysis tools (`rust-code-analysis-cli`, `jscpd`) need a real file
+    on disk, take a directory or path list rather than arbitrary text, and
+    report results keyed by relative path -- comparing "before" against
+    "after" for one of them means giving it an actual pre-change checkout to
+    point at, not just the text `changed_ranges`'s own `read_old` reads
+    in-process for its own, per-hunk comparison. Preserving the relative
+    path (rather than flattening into `dest_root` directly) is what lets the
+    tool's own report be matched back to `changed_ranges`'s keys afterward.
+
+    A file the diff added did not exist at `base_sha` and is skipped: there
+    is nothing to check it against, and asking `git show` for it would only
+    fail.
+    """
+    written: list[str] = []
+    for f in files:
+        blob = subprocess.run(
+            ["git", "show", f"{base_sha}:{f}"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if blob.returncode != 0:
+            continue
+        dest = dest_root / f
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(blob.stdout)
+        written.append(f)
+    return written
+
+
 def cargo_bin_dir() -> Path:
     """Where `cargo install` puts binaries -- $CARGO_HOME/bin, or ~/.cargo/bin.
 

--- a/scripts/ci/test_gate_diff.py
+++ b/scripts/ci/test_gate_diff.py
@@ -746,38 +746,211 @@ class ChangedRangesExcludesSemanticallyUnchangedHunks(unittest.TestCase):
             )
 
 
+class FunctionsIn(unittest.TestCase):
+    def _func_space(self, name: str | None, start: int, end: int, cyclomatic: int, children=()) -> dict:
+        return {
+            "kind": "function",
+            "name": name,
+            "start_line": start,
+            "end_line": end,
+            "metrics": {"cyclomatic": {"sum": cyclomatic}},
+            "spaces": list(children),
+        }
+
+    def test_named_function_with_no_closures_is_reported_once(self) -> None:
+        out: list[dict] = []
+        complexity_gate.functions_in(self._func_space("f", 1, 10, 5), out)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["name"], "f")
+
+    def test_closure_nested_in_a_named_function_is_not_reported_separately(self) -> None:
+        # The exact bug: `main` containing a closure that is essentially its
+        # whole body must be one violation, not two, when both are over the
+        # limit -- the closure is not independently-invocable code, it *is*
+        # `main`'s body.
+        closure = self._func_space(None, 2, 9, 25)
+        outer = self._func_space("main", 1, 10, 27, children=[closure])
+        out: list[dict] = []
+        complexity_gate.functions_in(outer, out)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["name"], "main")
+        self.assertEqual(out[0]["cyclomatic"], 27)
+
+    def test_closure_nested_in_a_closure_still_collapses_to_one_report(self) -> None:
+        inner_closure = self._func_space(None, 3, 8, 10)
+        outer_closure = self._func_space(None, 2, 9, 15, children=[inner_closure])
+        outer = self._func_space("run", 1, 10, 20, children=[outer_closure])
+        out: list[dict] = []
+        complexity_gate.functions_in(outer, out)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["name"], "run")
+
+    def test_named_function_nested_inside_a_closure_is_still_reported(self) -> None:
+        # Legal, if unusual, Rust: a closure body can define its own nested
+        # `fn`. That is independently real code -- unlike an anonymous
+        # closure, it is not "the same bytes" as anything enclosing it --
+        # so it must survive the collapse that swallows anonymous closures.
+        nested_fn = self._func_space("helper", 3, 5, 8)
+        closure = self._func_space(None, 2, 6, 9, children=[nested_fn])
+        outer = self._func_space("run", 1, 7, 12, children=[closure])
+        out: list[dict] = []
+        complexity_gate.functions_in(outer, out)
+        names = {f["name"] for f in out}
+        self.assertEqual(names, {"run", "helper"})
+
+    def test_top_level_closure_with_no_enclosing_function_is_still_reported(self) -> None:
+        # A closure with nothing to fold into (e.g. a module-level `static`
+        # initializer) is the only code there -- it must not be dropped.
+        top_level_closure = self._func_space(None, 1, 5, 12)
+        out: list[dict] = []
+        complexity_gate.functions_in(top_level_closure, out)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["name"], "<anonymous>")
+
+    def test_rust_code_analysis_cli_names_a_closure_the_literal_string_anonymous(self) -> None:
+        # The real bug, found by running the real tool rather than trusting
+        # a `None`/empty assumption: `rust-code-analysis-cli` puts the
+        # literal string "<anonymous>" in a closure's own `name` field, it
+        # does not leave it `None` or empty. A plain truthiness check on
+        # `name` treats that literal string as "named" and never collapses
+        # anything -- this pins the real value shape, not an assumed one.
+        closure = self._func_space("<anonymous>", 2, 9, 25)
+        outer = self._func_space("main", 1, 10, 27, children=[closure])
+        out: list[dict] = []
+        complexity_gate.functions_in(outer, out)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["name"], "main")
+
+    def test_sibling_functions_are_both_reported(self) -> None:
+        root = {
+            "kind": "file",
+            "spaces": [
+                self._func_space("a", 1, 5, 5),
+                self._func_space("b", 10, 15, 5),
+            ],
+        }
+        out: list[dict] = []
+        complexity_gate.functions_in(root, out)
+        self.assertEqual({f["name"] for f in out}, {"a", "b"})
+
+
 class ComplexityFindViolations(unittest.TestCase):
     def test_flags_only_functions_the_diff_touches(self) -> None:
         ranges = {"src/lib.rs": [(10, 15)]}
-        functions_by_file = {
+        new_functions = {
             "src/lib.rs": [
                 {"name": "touched_and_complex", "start": 10, "end": 15, "cyclomatic": 25},
                 {"name": "untouched_and_complex", "start": 100, "end": 120, "cyclomatic": 99},
                 {"name": "touched_but_simple", "start": 12, "end": 13, "cyclomatic": 3},
             ]
         }
-        violations = complexity_gate.find_violations(ranges, functions_by_file, max_cyclomatic=20)
+        violations = complexity_gate.find_violations(ranges, new_functions, {}, max_cyclomatic=20)
         self.assertEqual(len(violations), 1)
         self.assertIn("touched_and_complex", violations[0])
-        self.assertIn("cyclomatic complexity 25", violations[0])
+        self.assertIn("is new at 25", violations[0])
 
     def test_no_violations_when_nothing_over_the_limit(self) -> None:
         ranges = {"src/lib.rs": [(1, 100)]}
-        functions_by_file = {
-            "src/lib.rs": [{"name": "fine", "start": 1, "end": 10, "cyclomatic": 5}]
-        }
-        self.assertEqual(
-            complexity_gate.find_violations(ranges, functions_by_file, max_cyclomatic=20), []
-        )
+        new_functions = {"src/lib.rs": [{"name": "fine", "start": 1, "end": 10, "cyclomatic": 5}]}
+        self.assertEqual(complexity_gate.find_violations(ranges, new_functions, {}, 20), [])
 
     def test_untouched_file_contributes_no_violations(self) -> None:
         ranges = {"src/other.rs": [(1, 5)]}
-        functions_by_file = {
+        new_functions = {
             "src/lib.rs": [{"name": "huge", "start": 1, "end": 500, "cyclomatic": 500}]
         }
+        self.assertEqual(complexity_gate.find_violations(ranges, new_functions, {}, 20), [])
+
+    def test_already_over_limit_function_untouched_by_a_real_edit_passes(self) -> None:
+        # The load-bearing case in the other direction: `run` was 174 before
+        # this diff and is still 174 after it (the diff only deleted a
+        # comment elsewhere in its span) -- existing debt, not new, so it
+        # must not trip the gate just because a nearby hunk is in scope.
+        ranges = {"src/lib.rs": [(1, 300)]}
+        new_functions = {"src/lib.rs": [{"name": "run", "start": 1, "end": 300, "cyclomatic": 174}]}
+        old_functions = {"src/lib.rs": [{"name": "run", "start": 1, "end": 305, "cyclomatic": 174}]}
         self.assertEqual(
-            complexity_gate.find_violations(ranges, functions_by_file, max_cyclomatic=20), []
+            complexity_gate.find_violations(ranges, new_functions, old_functions, 20), []
         )
+
+    def test_already_over_limit_function_made_simpler_passes(self) -> None:
+        ranges = {"src/lib.rs": [(1, 300)]}
+        new_functions = {"src/lib.rs": [{"name": "run", "start": 1, "end": 300, "cyclomatic": 150}]}
+        old_functions = {"src/lib.rs": [{"name": "run", "start": 1, "end": 305, "cyclomatic": 174}]}
+        self.assertEqual(
+            complexity_gate.find_violations(ranges, new_functions, old_functions, 20), []
+        )
+
+    def test_already_over_limit_function_made_worse_still_trips_the_gate(self) -> None:
+        # The load-bearing test the whole before/after rule hinges on: this
+        # must still fail, or the gate stops meaning anything. Raising an
+        # already-bad function's complexity is exactly the case a reviewer
+        # needs flagged -- "already over the limit" must never become a
+        # license to make it worse for free.
+        ranges = {"src/lib.rs": [(1, 300)]}
+        new_functions = {"src/lib.rs": [{"name": "run", "start": 1, "end": 300, "cyclomatic": 180}]}
+        old_functions = {"src/lib.rs": [{"name": "run", "start": 1, "end": 305, "cyclomatic": 174}]}
+        violations = complexity_gate.find_violations(ranges, new_functions, old_functions, 20)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("was 174, is now 180", violations[0])
+
+    def test_under_the_limit_before_and_over_after_still_trips_the_gate(self) -> None:
+        ranges = {"src/lib.rs": [(1, 20)]}
+        new_functions = {"src/lib.rs": [{"name": "f", "start": 1, "end": 20, "cyclomatic": 25}]}
+        old_functions = {"src/lib.rs": [{"name": "f", "start": 1, "end": 18, "cyclomatic": 18}]}
+        violations = complexity_gate.find_violations(ranges, new_functions, old_functions, 20)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("was 18, is now 25", violations[0])
+
+    def test_new_function_with_no_old_counterpart_is_judged_against_the_limit(self) -> None:
+        ranges = {"src/lib.rs": [(1, 20)]}
+        new_functions = {"src/lib.rs": [{"name": "brand_new", "start": 1, "end": 20, "cyclomatic": 25}]}
+        violations = complexity_gate.find_violations(ranges, new_functions, {}, 20)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("is new at 25", violations[0])
+
+    def test_same_named_functions_are_matched_by_occurrence_order(self) -> None:
+        # Two unrelated structs each define `fn new()`. The first should be
+        # compared against the first, the second against the second -- not
+        # "last one wins," which would compare the first new-side occurrence
+        # against the second old-side one.
+        ranges = {"src/lib.rs": [(1, 5), (10, 15)]}
+        new_functions = {
+            "src/lib.rs": [
+                {"name": "new", "start": 1, "end": 5, "cyclomatic": 22},
+                {"name": "new", "start": 10, "end": 15, "cyclomatic": 30},
+            ]
+        }
+        old_functions = {
+            "src/lib.rs": [
+                {"name": "new", "start": 1, "end": 5, "cyclomatic": 22},
+                {"name": "new", "start": 9, "end": 14, "cyclomatic": 18},
+            ]
+        }
+        violations = complexity_gate.find_violations(ranges, new_functions, old_functions, 20)
+        # The first `new` (22 -> 22, unchanged) passes; the second
+        # (18 -> 30, worse) fails. A "last one wins" name match would
+        # instead compare 22 against 18 and 30 against 22, getting both
+        # judgements wrong.
+        self.assertEqual(len(violations), 1)
+        self.assertIn(":10-15", violations[0])
+        self.assertIn("was 18, is now 30", violations[0])
+
+    def test_anonymous_function_has_no_old_counterpart_even_if_old_side_has_one(self) -> None:
+        # A top-level anonymous closure (see `FunctionsIn`) has no stable
+        # identity across a diff, so it is always judged against the limit
+        # directly -- it must not accidentally match some unrelated
+        # anonymous entry on the old side.
+        ranges = {"src/lib.rs": [(1, 5)]}
+        new_functions = {
+            "src/lib.rs": [{"name": "<anonymous>", "start": 1, "end": 5, "cyclomatic": 25}]
+        }
+        old_functions = {
+            "src/lib.rs": [{"name": "<anonymous>", "start": 1, "end": 5, "cyclomatic": 99}]
+        }
+        violations = complexity_gate.find_violations(ranges, new_functions, old_functions, 20)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("is new at 25", violations[0])
 
 
 class DuplicationFindViolations(unittest.TestCase):
@@ -791,7 +964,7 @@ class DuplicationFindViolations(unittest.TestCase):
     def test_new_code_duplicating_old_code_fails(self) -> None:
         ranges = {"src/new.rs": [(1, 20)]}
         dup = self._dup(("src/new.rs", 5, 16), ("src/old.rs", 100, 111))
-        violations = duplication_gate.find_violations([dup], ranges)
+        violations = duplication_gate.find_violations([dup], [], ranges)
         self.assertEqual(len(violations), 1)
         self.assertIn("src/new.rs:5-16 (new)", violations[0])
         self.assertNotIn("src/old.rs:100-111 (new)", violations[0])
@@ -799,14 +972,89 @@ class DuplicationFindViolations(unittest.TestCase):
     def test_two_untouched_clones_are_not_flagged(self) -> None:
         ranges = {"src/elsewhere.rs": [(1, 5)]}
         dup = self._dup(("src/old_a.rs", 1, 12), ("src/old_b.rs", 1, 12))
-        self.assertEqual(duplication_gate.find_violations([dup], ranges), [])
+        self.assertEqual(duplication_gate.find_violations([dup], [], ranges), [])
 
     def test_new_code_duplicating_itself_flags_both_sides(self) -> None:
         ranges = {"src/new.rs": [(1, 50)]}
         dup = self._dup(("src/new.rs", 1, 12), ("src/new.rs", 20, 31))
-        violations = duplication_gate.find_violations([dup], ranges)
+        violations = duplication_gate.find_violations([dup], [], ranges)
         self.assertEqual(len(violations), 1)
         self.assertIn("(new)", violations[0])
+
+    def test_touched_clone_already_duplicated_before_passes(self) -> None:
+        # The load-bearing case: this same pair of files already duplicated
+        # each other before the diff (a nearby comment-removal collapse is
+        # what makes one side "touched," not a new clone) -- existing debt,
+        # not introduced by this diff, so it must not trip the gate.
+        ranges = {"src/a.rs": [(10, 12)]}
+        new_dup = self._dup(("src/a.rs", 10, 21), ("src/b.rs", 40, 51), lines=12)
+        old_dup = self._dup(("src/a.rs", 9, 20), ("src/b.rs", 38, 49), lines=12)
+        self.assertEqual(duplication_gate.find_violations([new_dup], [old_dup], ranges), [])
+
+    def test_touched_clone_with_no_old_counterpart_still_fails(self) -> None:
+        # The dual, equally load-bearing case: nothing comparable existed
+        # between these two files before, so this diff genuinely introduced
+        # the duplication and the gate must still catch it.
+        ranges = {"src/a.rs": [(10, 12)]}
+        new_dup = self._dup(("src/a.rs", 10, 21), ("src/b.rs", 40, 51), lines=12)
+        violations = duplication_gate.find_violations([new_dup], [], ranges)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("introduced by this diff", violations[0])
+
+    def test_unrelated_old_clone_between_the_same_files_grants_no_amnesty(self) -> None:
+        # Pinned safety property: two files sharing *some* old duplication
+        # relationship must not blanket-exempt every future clone between
+        # them. A wildly different-sized old clone between the same pair is
+        # treated as a different clone, not the same one reformatted.
+        ranges = {"src/a.rs": [(10, 12)]}
+        new_dup = self._dup(("src/a.rs", 10, 21), ("src/b.rs", 40, 51), lines=12)
+        unrelated_old_dup = self._dup(("src/a.rs", 200, 299), ("src/b.rs", 300, 399), lines=100)
+        violations = duplication_gate.find_violations([new_dup], [unrelated_old_dup], ranges)
+        self.assertEqual(len(violations), 1)
+
+    def test_reformatted_clone_within_size_tolerance_still_matches(self) -> None:
+        # A comment-removal-driven collapse can shrink a clone's line count
+        # a little without changing what code it is -- the match must
+        # tolerate that instead of demanding an exact line count.
+        ranges = {"src/a.rs": [(10, 12)]}
+        new_dup = self._dup(("src/a.rs", 10, 19), ("src/b.rs", 40, 49), lines=10)
+        old_dup = self._dup(("src/a.rs", 9, 20), ("src/b.rs", 38, 49), lines=12)
+        self.assertEqual(duplication_gate.find_violations([new_dup], [old_dup], ranges), [])
+
+
+class FilePair(unittest.TestCase):
+    def test_order_independent(self) -> None:
+        a = {"firstFile": {"name": "x.rs"}, "secondFile": {"name": "y.rs"}}
+        b = {"firstFile": {"name": "y.rs"}, "secondFile": {"name": "x.rs"}}
+        self.assertEqual(duplication_gate.file_pair(a), duplication_gate.file_pair(b))
+
+
+class AlreadyDuplicatedBefore(unittest.TestCase):
+    def _dup(self, first: str, second: str, lines: int) -> dict:
+        return {
+            "firstFile": {"name": first, "start": 1, "end": 1},
+            "secondFile": {"name": second, "start": 1, "end": 1},
+            "lines": lines,
+        }
+
+    def test_no_old_duplicates_at_all(self) -> None:
+        candidate = self._dup("a.rs", "b.rs", 12)
+        self.assertFalse(duplication_gate.already_duplicated_before(candidate, []))
+
+    def test_matching_pair_within_size_tolerance(self) -> None:
+        candidate = self._dup("a.rs", "b.rs", 12)
+        old = [self._dup("a.rs", "b.rs", 10)]
+        self.assertTrue(duplication_gate.already_duplicated_before(candidate, old))
+
+    def test_matching_pair_outside_size_tolerance_does_not_count(self) -> None:
+        candidate = self._dup("a.rs", "b.rs", 12)
+        old = [self._dup("a.rs", "b.rs", 100)]
+        self.assertFalse(duplication_gate.already_duplicated_before(candidate, old))
+
+    def test_different_pair_does_not_count(self) -> None:
+        candidate = self._dup("a.rs", "b.rs", 12)
+        old = [self._dup("a.rs", "c.rs", 12)]
+        self.assertFalse(duplication_gate.already_duplicated_before(candidate, old))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`complexity_gate.py`/`duplication_gate.py` (via `gate_diff.py`, #568) correctly scope to lines a diff touches, and #568 correctly excludes hunks with no code-level difference from comment removal. But once a touched hunk *is* confirmed to be a real code-text change -- most commonly a `clippy::single_match`/`clippy::collapsible_if` autofix or an `rustfmt` block collapse, forced the moment a branch's only content (a comment) is deleted -- both gates still asked "is this over the absolute limit," not "did this diff make it worse." A function already over 20 failed on any touch at all, demanding e.g. a 174 -> 20 refactor of `android.rs::run` as the price of deleting a nearby comment, regardless of whether the diff's own edit changed anything about that function's control flow.

**The fix: compare before and after, not against the absolute limit.**

- `complexity_gate.py` re-analyzes each touched file's pre-change blob (`gate_diff.write_old_blobs` + `rust-code-analysis-cli`) and matches functions by name (occurrence-ordered within a file, so two same-named methods aren't cross-matched). Unchanged-or-lower complexity passes regardless of the absolute number; higher fails regardless of it. A function with no old counterpart (new code, or an unmatched name) is judged against the limit directly, same as before.
- `duplication_gate.py` re-runs `jscpd` against the pre-change content of every file a candidate clone involves, and treats a comparably-sized clone (within 2x) already present between the same two files as existing debt rather than newly introduced.
- The boy-scout rule for a genuine edit is unchanged: a real logic change to an over-limit function, or a diff crossing under-limit to over-limit, still trips the gate exactly as before. "Touched by something nearby" just stops being enough on its own.

**A second, independent bug, found while sizing what this uncovered:** `rust-code-analysis-cli` reports a closure as its own `function`-kind entry nested inside the function that defines it, and the gate was flattening that whole tree into one flat list -- so a function built mostly out of one large closure (`main` wrapping a `poll_events` callback, `run` wrapping an event-loop closure) was reported *twice*: once under its own name, once as `<anonymous>`, as two independent violations for one function. The actual root cause was subtler than "name is `None`": `rust-code-analysis-cli` puts the literal string `"<anonymous>"` in a closure's own `name` field, so a plain truthiness check treats it as "named" and never collapses anything -- found by running the real tool and inspecting its JSON, not by assumption. `functions_in` now stops descending into a nested closure once already inside an enclosing function; a named `fn` nested inside a closure's body (legal, if unusual Rust) still gets its own entry no matter how deep the nesting, and a top-level closure with nothing to fold into is still reported.

## Verification

- Red-first throughout: the before/after comparison, the duplicate-size tolerance, and the anonymous-sentinel bug were each confirmed by bypassing the fix and watching the specific pinned test fail, then reverting.
- **The load-bearing pin, as requested**: `test_already_over_limit_function_made_worse_still_trips_the_gate` -- a diff that raises an already-over-limit function's complexity must still fail. Confirmed it also catches a plausible wrong "blanket immunity for anything already over the limit" implementation, not just the naive absolute-limit-only one.
- Duplication's dual: `test_touched_clone_with_no_old_counterpart_still_fails` (genuinely introduced duplication still fails) alongside `test_touched_clone_already_duplicated_before_passes`.
- Safety pins: same-named functions in one file matched by occurrence order, not "last one wins"; an unrelated old clone between the same two files at a wildly different size grants no amnesty; a reformatted clone within a 2x size tolerance still matches.
- `FunctionsIn`: 7 unit tests directly against `functions_in`, including one pinning the exact real value (`"<anonymous>"` as a literal string) `rust-code-analysis-cli` emits, not an assumed `None`.
- 85/85 tests pass (`just test-quality-gates`). `just fmt-check`, `just typos`, `just versions` clean. No `.rs` files touched by this PR; `just test`/`just clippy` are unaffected by the diff.

## The acceptance test that matters

Re-ran both gates against `docs/comment-policy`'s actual diff (not just fixtures): **complexity-gate 6 -> 0, duplication-gate 2 -> 0.** Neither remaining case from #568 was a logic edit the diff introduced -- both were pre-existing debt that a nearby, comment-removal-forced rewrite happened to touch, and neither made the underlying function or clone any worse.

## docs/complexity_debt.md

Updated, not left stale: the original 37/21 inventory is recounted to 24 functions (13 entries were the double-counted nested-closure artifact above, not independent debt), and the doc now records that both gates compare before/after, so touching a line near this debt no longer retroactively demands fixing it.

## Test plan

- [x] `just test-quality-gates` -- 85/85 pass
- [x] `just fmt-check`, `just typos`, `just versions` -- clean
- [x] Verified against `docs/comment-policy`'s real diff: complexity-gate 6 -> 0, duplication-gate 2 -> 0

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
