### PR TITLE
Fix load-dependent lazy-list re-anchor race (not the suspected thread-local)

### DIFF
--- a/crates/cranpose-foundation/src/lazy/item_measurer.rs
+++ b/crates/cranpose-foundation/src/lazy/item_measurer.rs
@@ -222,13 +222,6 @@ where
         pass
     }
 
-    /// The backfill walk is capped by `MAX_VISIBLE_ITEMS_SAFETY`, not by a wall
-    /// clock. This correction is what makes the first visible item and scroll
-    /// offset correct after a viewport grows, so it must finish deterministically:
-    /// bailing out early under CPU scheduling pressure (a real clock can read
-    /// past a budget after nothing but an OS-preempted thread, with zero extra
-    /// work done) used to leave the list visibly under-corrected — a blank gap
-    /// at the bottom that a slower frame, not a larger one, produced.
     fn fill_end_gap(
         &mut self,
         visible_items: &mut Vec<LazyListMeasuredItem>,
@@ -486,23 +479,6 @@ mod tests {
 
     #[test]
     fn fill_end_gap_backfills_fully_even_when_item_measurement_is_slow() {
-        // Regression test for a real, load-dependent CI flake: `fill_end_gap`'s
-        // backward walk used to bail out once wall-clock time exceeded
-        // `DEFAULT_TIME_BUDGET`, even though how much work was left to do had
-        // not changed at all. Under CPU scheduling pressure (many other
-        // threads competing for the CPU, e.g. the rest of the test suite
-        // running concurrently) that wall clock could read past the budget
-        // after measuring only a couple of items, leaving the list
-        // under-corrected: a stale first-visible-item/offset that still left
-        // a blank gap at the bottom of a viewport that had just grown. The
-        // backfill must be bounded by how much work is left (a fixed item
-        // count, `MAX_VISIBLE_ITEMS_SAFETY`), never by how slow the clock on
-        // the host machine happened to look.
-        //
-        // Each measured item sleeps 2ms; measuring the five initially visible
-        // items alone (10ms) already exceeds the old 6ms budget, so the old
-        // code would perform zero backfill iterations here, deterministically
-        // (not flakily) leaving `start_index` at 15 instead of 7.
         let config = LazyListMeasureConfig::default();
         let mut measure = |i| {
             std::thread::sleep(Duration::from_millis(2));
@@ -510,12 +486,8 @@ mod tests {
         };
         let mut measurer =
             ItemMeasurer::new(&mut measure, &config, 20, 500.0, 40.0, VecDeque::new())
-                // Isolate the backfill: skip the separate before-bounds
-                // prefetch pass so this test only exercises `fill_end_gap`.
                 .with_include_before_beyond_bounds(false);
 
-        // Start near the end of the list, as if scrolled to the bottom of a
-        // smaller viewport, then measure with a larger one (the viewport grew).
         let pass = measurer.measure_all(15, 0.0);
 
         assert_eq!(

--- a/crates/cranpose-foundation/src/lazy/item_measurer.rs
+++ b/crates/cranpose-foundation/src/lazy/item_measurer.rs
@@ -164,7 +164,6 @@ where
                 current_offset,
                 content_end,
                 first_item_index,
-                start_time,
             )
             .unwrap_or(first_item_index);
         let backfilled = effective_first_index != first_item_index;
@@ -223,6 +222,13 @@ where
         pass
     }
 
+    /// The backfill walk is capped by `MAX_VISIBLE_ITEMS_SAFETY`, not by a wall
+    /// clock. This correction is what makes the first visible item and scroll
+    /// offset correct after a viewport grows, so it must finish deterministically:
+    /// bailing out early under CPU scheduling pressure (a real clock can read
+    /// past a budget after nothing but an OS-preempted thread, with zero extra
+    /// work done) used to leave the list visibly under-corrected — a blank gap
+    /// at the bottom that a slower frame, not a larger one, produced.
     fn fill_end_gap(
         &mut self,
         visible_items: &mut Vec<LazyListMeasuredItem>,
@@ -230,7 +236,6 @@ where
         current_offset: f32,
         viewport_end: f32,
         first_item_index: usize,
-        start_time: Instant,
     ) -> Option<usize> {
         if current_index < self.items_count || first_item_index == 0 || visible_items.is_empty() {
             return None;
@@ -244,10 +249,10 @@ where
         }
         let mut top = visible_items[0].offset;
         let mut idx = first_item_index;
-        while idx > 0 && top > self.config.before_content_padding + 0.5 {
-            if start_time.elapsed() > DEFAULT_TIME_BUDGET {
-                break;
-            }
+        while idx > 0
+            && top > self.config.before_content_padding + 0.5
+            && visible_items.len() < MAX_VISIBLE_ITEMS_SAFETY
+        {
             idx -= 1;
             let mut item = self
                 .take_pre_measured(idx)
@@ -476,6 +481,55 @@ mod tests {
         assert_eq!(
             measured, 5,
             "configured beyond-bounds rows are part of deterministic retained layout"
+        );
+    }
+
+    #[test]
+    fn fill_end_gap_backfills_fully_even_when_item_measurement_is_slow() {
+        // Regression test for a real, load-dependent CI flake: `fill_end_gap`'s
+        // backward walk used to bail out once wall-clock time exceeded
+        // `DEFAULT_TIME_BUDGET`, even though how much work was left to do had
+        // not changed at all. Under CPU scheduling pressure (many other
+        // threads competing for the CPU, e.g. the rest of the test suite
+        // running concurrently) that wall clock could read past the budget
+        // after measuring only a couple of items, leaving the list
+        // under-corrected: a stale first-visible-item/offset that still left
+        // a blank gap at the bottom of a viewport that had just grown. The
+        // backfill must be bounded by how much work is left (a fixed item
+        // count, `MAX_VISIBLE_ITEMS_SAFETY`), never by how slow the clock on
+        // the host machine happened to look.
+        //
+        // Each measured item sleeps 2ms; measuring the five initially visible
+        // items alone (10ms) already exceeds the old 6ms budget, so the old
+        // code would perform zero backfill iterations here, deterministically
+        // (not flakily) leaving `start_index` at 15 instead of 7.
+        let config = LazyListMeasureConfig::default();
+        let mut measure = |i| {
+            std::thread::sleep(Duration::from_millis(2));
+            create_test_item(i, 40.0)
+        };
+        let mut measurer =
+            ItemMeasurer::new(&mut measure, &config, 20, 500.0, 40.0, VecDeque::new())
+                // Isolate the backfill: skip the separate before-bounds
+                // prefetch pass so this test only exercises `fill_end_gap`.
+                .with_include_before_beyond_bounds(false);
+
+        // Start near the end of the list, as if scrolled to the bottom of a
+        // smaller viewport, then measure with a larger one (the viewport grew).
+        let pass = measurer.measure_all(15, 0.0);
+
+        assert_eq!(
+            pass.start_index, 7,
+            "the backfill must pull in every preceding item needed to fill the \
+             grown viewport, not stop partway because measuring was slow: {pass:?}"
+        );
+        let indices: Vec<usize> = pass.items.iter().map(|item| item.index).collect();
+        assert_eq!(indices, (7..=19).collect::<Vec<_>>());
+        let last = pass.items.last().expect("measured items");
+        let last_end = last.offset + last.main_axis_size;
+        assert!(
+            (last_end - 500.0).abs() < 0.01,
+            "content bottom must align with the grown viewport end: {last_end}"
         );
     }
 

--- a/crates/cranpose-ui/src/tests/lazy_list_recompose_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_list_recompose_tests.rs
@@ -170,10 +170,6 @@ fn ScrollIndicatorLazyList(captured_state: Rc<RefCell<Option<LazyListState>>>) {
     });
 }
 
-/// Renders `ScrollIndicatorLazyList` under a fresh `Composition`, returning
-/// the app-context guard (kept alive by the caller for the test's duration),
-/// the composition, and a freshly captured (never shared or cached) handle
-/// to the list state it composed.
 fn render_scroll_indicator_lazy_list() -> (
     crate::render_state::TestAppContextScope,
     Composition<MemoryApplier>,
@@ -304,12 +300,6 @@ fn StableKeyedCountingLazyList(
     );
 }
 
-/// Renders a `(item_invocations, captured_state)`-shaped composable (as
-/// `ReactiveSiblingLazyList` and `StableKeyedCountingLazyList` both are)
-/// under a fresh `Composition`, returning the app-context guard (kept alive
-/// by the caller for the test's duration), the composition, and freshly
-/// captured (never shared or cached) handles to the item-invocation counter
-/// and the list state.
 type RenderedCountingLazyList = (
     crate::render_state::TestAppContextScope,
     Composition<MemoryApplier>,

--- a/crates/cranpose-ui/src/tests/lazy_list_recompose_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_list_recompose_tests.rs
@@ -15,12 +15,6 @@ use crate::{
     text_layout_result::TextLayoutResult,
 };
 
-thread_local! {
-    static LAST_LAZY_STATE: RefCell<Option<LazyListState>> = const { RefCell::new(None) };
-    static GROWING_LAZY_LIST_CALL_COUNT: Cell<usize> = const { Cell::new(0) };
-    static LAST_INNER_ROW_SCROLL_STATE: RefCell<Option<ScrollState>> = const { RefCell::new(None) };
-}
-
 struct CountingPreparedTextMeasurer {
     prepare_calls: Rc<Cell<usize>>,
 }
@@ -144,11 +138,9 @@ impl TextMeasurer for TallMultilineTextMeasurer {
 
 #[composable]
 #[allow(non_snake_case)]
-fn ScrollIndicatorLazyList() {
+fn ScrollIndicatorLazyList(captured_state: Rc<RefCell<Option<LazyListState>>>) {
     let list_state = rememberLazyListState();
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = Some(list_state);
-    });
+    *captured_state.borrow_mut() = Some(list_state);
 
     Column(Modifier::empty(), ColumnSpec::default(), move || {
         Text(
@@ -193,11 +185,9 @@ fn ChildScrollIndicator(list_state: LazyListState) {
 
 #[composable]
 #[allow(non_snake_case)]
-fn ChildScrollIndicatorLazyList() {
+fn ChildScrollIndicatorLazyList(captured_state: Rc<RefCell<Option<LazyListState>>>) {
     let list_state = rememberLazyListState();
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = Some(list_state);
-    });
+    *captured_state.borrow_mut() = Some(list_state);
 
     Column(Modifier::empty(), ColumnSpec::default(), move || {
         ChildScrollIndicator(list_state);
@@ -220,11 +210,12 @@ fn ChildScrollIndicatorLazyList() {
 
 #[composable]
 #[allow(non_snake_case)]
-fn ReactiveSiblingLazyList(item_invocations: Rc<Cell<usize>>) {
+fn ReactiveSiblingLazyList(
+    item_invocations: Rc<Cell<usize>>,
+    captured_state: Rc<RefCell<Option<LazyListState>>>,
+) {
     let list_state = rememberLazyListState();
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = Some(list_state);
-    });
+    *captured_state.borrow_mut() = Some(list_state);
 
     Column(Modifier::empty(), ColumnSpec::default(), move || {
         Text(
@@ -258,11 +249,12 @@ fn ReactiveSiblingLazyList(item_invocations: Rc<Cell<usize>>) {
 
 #[composable]
 #[allow(non_snake_case)]
-fn StableKeyedCountingLazyList(item_invocations: Rc<Cell<usize>>) {
+fn StableKeyedCountingLazyList(
+    item_invocations: Rc<Cell<usize>>,
+    captured_state: Rc<RefCell<Option<LazyListState>>>,
+) {
     let list_state = rememberLazyListState();
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = Some(list_state);
-    });
+    *captured_state.borrow_mut() = Some(list_state);
 
     LazyColumn(
         Modifier::empty().fill_max_width().height(240.0),
@@ -289,11 +281,13 @@ fn StableKeyedCountingLazyList(item_invocations: Rc<Cell<usize>>) {
 
 #[composable]
 #[allow(non_snake_case)]
-fn StatefulCachedLazyList(item_invocations: Rc<Cell<usize>>, label_state: MutableState<usize>) {
+fn StatefulCachedLazyList(
+    item_invocations: Rc<Cell<usize>>,
+    label_state: MutableState<usize>,
+    captured_state: Rc<RefCell<Option<LazyListState>>>,
+) {
     let list_state = rememberLazyListState();
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = Some(list_state);
-    });
+    *captured_state.borrow_mut() = Some(list_state);
 
     LazyColumn(
         Modifier::empty().fill_max_width().height(120.0),
@@ -320,11 +314,12 @@ fn StatefulCachedLazyList(item_invocations: Rc<Cell<usize>>, label_state: Mutabl
 
 #[composable]
 #[allow(non_snake_case)]
-fn VariableHeightCachedLazyList(short_body_state: MutableState<bool>) {
+fn VariableHeightCachedLazyList(
+    short_body_state: MutableState<bool>,
+    captured_state: Rc<RefCell<Option<LazyListState>>>,
+) {
     let list_state = rememberLazyListState();
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = Some(list_state);
-    });
+    *captured_state.borrow_mut() = Some(list_state);
 
     LazyColumn(
         Modifier::empty().fill_max_width().height(320.0),
@@ -395,11 +390,9 @@ fn AnimatedLazyItemList() {
 
 #[composable]
 #[allow(non_snake_case)]
-fn TallCachedLazyTextList(body: Rc<String>) {
+fn TallCachedLazyTextList(body: Rc<String>, captured_state: Rc<RefCell<Option<LazyListState>>>) {
     let list_state = rememberLazyListState();
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = Some(list_state);
-    });
+    *captured_state.borrow_mut() = Some(list_state);
 
     LazyColumn(
         Modifier::empty().fill_max_width().height(640.0),
@@ -416,12 +409,10 @@ fn TallCachedLazyTextList(body: Rc<String>) {
 
 #[composable]
 #[allow(non_snake_case)]
-fn LazyItemWithScrollableRow() {
+fn LazyItemWithScrollableRow(captured_row_scroll: Rc<RefCell<Option<ScrollState>>>) {
     let list_state = rememberLazyListState();
     let row_scroll = cranpose_core::remember(|| ScrollState::new(0.0)).with(ScrollState::clone);
-    LAST_INNER_ROW_SCROLL_STATE.with(|cell| {
-        *cell.borrow_mut() = Some(row_scroll);
-    });
+    *captured_row_scroll.borrow_mut() = Some(row_scroll);
 
     LazyColumn(
         Modifier::empty().fill_max_width().height(240.0),
@@ -593,11 +584,12 @@ fn assert_consecutive_rows(indices: &[usize], context: &str) {
 
 #[composable]
 #[allow(non_snake_case)]
-fn SelectableScrolledLazyList(selected_index: MutableState<usize>) {
+fn SelectableScrolledLazyList(
+    selected_index: MutableState<usize>,
+    captured_state: Rc<RefCell<Option<LazyListState>>>,
+) {
     let list_state = rememberLazyListState();
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = Some(list_state);
-    });
+    *captured_state.borrow_mut() = Some(list_state);
 
     LazyColumn(
         Modifier::empty().fill_max_width().height(210.0),
@@ -742,18 +734,22 @@ fn scroll_state_recomposition_does_not_reprepare_stable_lazy_rows() {
     crate::text::set_text_measurer(CountingPreparedTextMeasurer::new(Rc::clone(&prepare_calls)));
 
     let item_invocations = Rc::new(Cell::new(0));
+    let captured_state = Rc::new(RefCell::new(None));
     let mut composition = Composition::new(MemoryApplier::new());
     let key = location_key(file!(), line!(), column!());
     composition
         .render(key, {
             let item_invocations = Rc::clone(&item_invocations);
-            move || ReactiveSiblingLazyList(Rc::clone(&item_invocations))
+            let captured_state = Rc::clone(&captured_state);
+            move || {
+                ReactiveSiblingLazyList(Rc::clone(&item_invocations), Rc::clone(&captured_state))
+            }
         })
         .expect("initial render");
 
     let root = composition.root().expect("lazy list root");
     let _ = render_texts(&mut composition, root);
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
 
     list_state.dispatch_scroll_delta(-160.0);
     let _ = render_texts(&mut composition, root);
@@ -781,13 +777,14 @@ fn scroll_state_recomposition_does_not_reprepare_stable_lazy_rows() {
 fn gesture_scroll_recomposes_scroll_position_observers() {
     let _app_context = crate::render_state::app_context_test_scope();
     let mut composition = Composition::new(MemoryApplier::new());
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
+    let captured_state = Rc::new(RefCell::new(None));
 
     composition
-        .render(location_key(file!(), line!(), column!()), || {
-            ScrollIndicatorLazyList();
+        .render(location_key(file!(), line!(), column!()), {
+            let captured_state = Rc::clone(&captured_state);
+            move || {
+                ScrollIndicatorLazyList(Rc::clone(&captured_state));
+            }
         })
         .expect("initial render");
 
@@ -809,7 +806,7 @@ fn gesture_scroll_recomposes_scroll_position_observers() {
         "test must subscribe a composition scope to lazy scroll bounds"
     );
 
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     list_state.dispatch_scroll_delta(-320.0);
     measure_root(&mut composition, root, viewport);
 
@@ -843,22 +840,25 @@ fn gesture_scroll_recomposes_scroll_position_observers() {
             .any(|text| text == "Can scroll back true"),
         "scroll observer text did not track gesture-updated backward capability; got {scrolled_texts:?}"
     );
-
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }
 
 #[test]
 fn repeated_measure_of_stable_keyed_lazy_list_reuses_retained_item_content() {
     let _app_context = crate::render_state::app_context_test_scope();
     let item_invocations = Rc::new(Cell::new(0));
+    let captured_state = Rc::new(RefCell::new(None));
     let mut composition = Composition::new(MemoryApplier::new());
     let key = location_key(file!(), line!(), column!());
     composition
         .render(key, {
             let item_invocations = Rc::clone(&item_invocations);
-            move || StableKeyedCountingLazyList(Rc::clone(&item_invocations))
+            let captured_state = Rc::clone(&captured_state);
+            move || {
+                StableKeyedCountingLazyList(
+                    Rc::clone(&item_invocations),
+                    Rc::clone(&captured_state),
+                )
+            }
         })
         .expect("initial render");
 
@@ -887,12 +887,19 @@ fn repeated_measure_of_stable_keyed_lazy_list_reuses_retained_item_content() {
 fn large_forward_lazy_scroll_reuses_skipped_active_slots_in_same_measure_pass() {
     let _app_context = crate::render_state::app_context_test_scope();
     let item_invocations = Rc::new(Cell::new(0));
+    let captured_state = Rc::new(RefCell::new(None));
     let mut composition = Composition::new(MemoryApplier::new());
     let key = location_key(file!(), line!(), column!());
     composition
         .render(key, {
             let item_invocations = Rc::clone(&item_invocations);
-            move || StableKeyedCountingLazyList(Rc::clone(&item_invocations))
+            let captured_state = Rc::clone(&captured_state);
+            move || {
+                StableKeyedCountingLazyList(
+                    Rc::clone(&item_invocations),
+                    Rc::clone(&captured_state),
+                )
+            }
         })
         .expect("initial render");
 
@@ -902,7 +909,7 @@ fn large_forward_lazy_scroll_reuses_skipped_active_slots_in_same_measure_pass() 
         height: 260.0,
     };
     measure_root(&mut composition, root, viewport);
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     let reuse_count_before = list_state.stats().reuse_count;
 
     list_state.dispatch_scroll_delta(-800.0);
@@ -926,10 +933,12 @@ fn cached_lazy_item_keeps_unbounded_child_measurement_when_placed() {
             .join("\n"),
     );
     let mut composition = Composition::new(MemoryApplier::new());
+    let captured_state = Rc::new(RefCell::new(None));
     composition
         .render(location_key(file!(), line!(), column!()), {
             let body = Rc::clone(&body);
-            move || TallCachedLazyTextList(Rc::clone(&body))
+            let captured_state = Rc::clone(&captured_state);
+            move || TallCachedLazyTextList(Rc::clone(&body), Rc::clone(&captured_state))
         })
         .expect("initial render");
     let root = composition.root().expect("lazy list root");
@@ -963,11 +972,12 @@ fn cached_lazy_item_keeps_unbounded_child_measurement_when_placed() {
 fn scrolling_a_row_inside_a_cached_lazy_item_moves_its_rendered_children() {
     let _app_context = crate::render_state::app_context_test_scope();
     let mut composition = Composition::new(MemoryApplier::new());
+    let captured_row_scroll = Rc::new(RefCell::new(None));
     composition
-        .render(
-            location_key(file!(), line!(), column!()),
-            LazyItemWithScrollableRow,
-        )
+        .render(location_key(file!(), line!(), column!()), {
+            let captured_row_scroll = Rc::clone(&captured_row_scroll);
+            move || LazyItemWithScrollableRow(Rc::clone(&captured_row_scroll))
+        })
         .expect("initial render");
     let root = composition.root().expect("lazy list root");
 
@@ -978,9 +988,7 @@ fn scrolling_a_row_inside_a_cached_lazy_item_moves_its_rendered_children() {
     let initial_records = render_text_records_with_size(&mut composition, root, viewport);
     let initial_x = text_x(&initial_records, "Chip B");
 
-    let row_scroll = LAST_INNER_ROW_SCROLL_STATE
-        .with(|cell| *cell.borrow())
-        .expect("inner row scroll state captured");
+    let row_scroll = (*captured_row_scroll.borrow()).expect("inner row scroll state captured");
     assert!(
         row_scroll.max_value() > 100.0,
         "inner row must actually overflow its viewport, max_value={}",
@@ -1011,11 +1019,19 @@ fn invalidated_cached_lazy_item_recomposes_instead_of_reusing_stale_content() {
     let mut composition = Composition::new(MemoryApplier::new());
     let runtime = composition.runtime_handle();
     let label_state = MutableState::with_runtime(0usize, runtime);
+    let captured_state = Rc::new(RefCell::new(None));
     let key = location_key(file!(), line!(), column!());
     composition
         .render(key, {
             let item_invocations = Rc::clone(&item_invocations);
-            move || StatefulCachedLazyList(Rc::clone(&item_invocations), label_state)
+            let captured_state = Rc::clone(&captured_state);
+            move || {
+                StatefulCachedLazyList(
+                    Rc::clone(&item_invocations),
+                    label_state,
+                    Rc::clone(&captured_state),
+                )
+            }
         })
         .expect("initial render");
 
@@ -1042,10 +1058,11 @@ fn invalidated_cached_lazy_item_remeasures_when_text_height_shrinks() {
     let mut composition = Composition::new(MemoryApplier::new());
     let runtime = composition.runtime_handle();
     let short_body_state = MutableState::with_runtime(false, runtime);
+    let captured_state = Rc::new(RefCell::new(None));
     let key = location_key(file!(), line!(), column!());
     composition
         .render(key, move || {
-            VariableHeightCachedLazyList(short_body_state);
+            VariableHeightCachedLazyList(short_body_state, Rc::clone(&captured_state));
         })
         .expect("initial render");
 
@@ -1121,13 +1138,14 @@ fn scrolled_lazy_list_scoped_row_recompose_does_not_ghost_old_rows() {
     let mut composition = Composition::new(MemoryApplier::new());
     let runtime = composition.runtime_handle();
     let selected_index = MutableState::with_runtime(usize::MAX, runtime);
+    let captured_state = Rc::new(RefCell::new(None));
 
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
     composition
-        .render(location_key(file!(), line!(), column!()), || {
-            SelectableScrolledLazyList(selected_index);
+        .render(location_key(file!(), line!(), column!()), {
+            let captured_state = Rc::clone(&captured_state);
+            move || {
+                SelectableScrolledLazyList(selected_index, Rc::clone(&captured_state));
+            }
         })
         .expect("initial render");
 
@@ -1138,7 +1156,7 @@ fn scrolled_lazy_list_scoped_row_recompose_does_not_ghost_old_rows() {
     };
     measure_root(&mut composition, root, viewport);
 
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     list_state.scroll_to_item(24, 0.0);
     measure_root(&mut composition, root, viewport);
 
@@ -1215,23 +1233,19 @@ fn scrolled_lazy_list_scoped_row_recompose_does_not_ghost_old_rows() {
         }
         previous_y = Some(record.y);
     }
-
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }
 
 #[composable]
 #[allow(non_snake_case)]
-fn GrowingLazyList(item_count: MutableState<usize>) {
+fn GrowingLazyList(
+    item_count: MutableState<usize>,
+    captured_state: Rc<RefCell<Option<LazyListState>>>,
+    call_count: Rc<Cell<usize>>,
+) {
     let list_state = rememberLazyListState();
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = Some(list_state);
-    });
+    *captured_state.borrow_mut() = Some(list_state);
     let count = item_count.value();
-    GROWING_LAZY_LIST_CALL_COUNT.with(|call_count| {
-        call_count.set(call_count.get() + 1);
-    });
+    call_count.set(call_count.get() + 1);
 
     Column(Modifier::empty(), ColumnSpec::default(), move || {
         Text(
@@ -1268,12 +1282,21 @@ fn lazy_list_updates_scroll_bounds_when_item_count_grows_without_scrolling() {
     let mut composition = Composition::new(MemoryApplier::new());
     let runtime = composition.runtime_handle();
     let item_count = MutableState::with_runtime(2usize, runtime.clone());
+    let captured_state = Rc::new(RefCell::new(None));
+    let call_count = Rc::new(Cell::new(0));
 
-    GROWING_LAZY_LIST_CALL_COUNT.with(|call_count| call_count.set(0));
     let key = location_key(file!(), line!(), column!());
     composition
-        .render(key, || {
-            GrowingLazyList(item_count);
+        .render(key, {
+            let captured_state = Rc::clone(&captured_state);
+            let call_count = Rc::clone(&call_count);
+            move || {
+                GrowingLazyList(
+                    item_count,
+                    Rc::clone(&captured_state),
+                    Rc::clone(&call_count),
+                );
+            }
         })
         .expect("initial render");
 
@@ -1284,7 +1307,7 @@ fn lazy_list_updates_scroll_bounds_when_item_count_grows_without_scrolling() {
     };
     measure_root(&mut composition, root, viewport);
 
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     assert_eq!(list_state.layout_info().total_items_count, 2);
     assert!(
         !list_state.can_scroll_forward(),
@@ -1303,12 +1326,10 @@ fn lazy_list_updates_scroll_bounds_when_item_count_grows_without_scrolling() {
         recomposed,
         "expected composition to re-run after item count growth"
     );
-    GROWING_LAZY_LIST_CALL_COUNT.with(|call_count| {
-        assert!(
-            call_count.get() >= 2,
-            "expected LazyColumn parent composable to execute again after item count growth"
-        );
-    });
+    assert!(
+        call_count.get() >= 2,
+        "expected LazyColumn parent composable to execute again after item count growth"
+    );
     measure_root(&mut composition, root, viewport);
 
     assert_eq!(list_state.layout_info().total_items_count, 24);
@@ -1321,23 +1342,20 @@ fn lazy_list_updates_scroll_bounds_when_item_count_grows_without_scrolling() {
         texts.iter().any(|text| text == "Count 24"),
         "expected parent composition to observe the grown item count"
     );
-
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }
 
 #[test]
 fn scroll_to_item_invalidates_indicator_scope_and_updates_visible_index_text() {
     let _app_context = crate::render_state::app_context_test_scope();
     let mut composition = Composition::new(MemoryApplier::new());
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
+    let captured_state = Rc::new(RefCell::new(None));
 
     composition
-        .render(location_key(file!(), line!(), column!()), || {
-            ScrollIndicatorLazyList();
+        .render(location_key(file!(), line!(), column!()), {
+            let captured_state = Rc::clone(&captured_state);
+            move || {
+                ScrollIndicatorLazyList(Rc::clone(&captured_state));
+            }
         })
         .expect("initial render");
 
@@ -1354,7 +1372,7 @@ fn scroll_to_item_invalidates_indicator_scope_and_updates_visible_index_text() {
         "expected initial indicator text before scrolling"
     );
 
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     list_state.scroll_to_item(20, 0.0);
 
     assert!(
@@ -1382,10 +1400,6 @@ fn scroll_to_item_invalidates_indicator_scope_and_updates_visible_index_text() {
         texts.iter().any(|text| text == "First visible 20"),
         "expected indicator text to track scroll_to_item target; texts={texts:?}"
     );
-
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }
 
 #[test]
@@ -1393,11 +1407,14 @@ fn scroll_to_item_updates_child_indicator_scope() {
     let _app_context = crate::render_state::app_context_test_scope();
     let mut composition = Composition::new(MemoryApplier::new());
     let key = location_key(file!(), line!(), column!());
-    LAST_LAZY_STATE.with(|cell| cell.borrow_mut().take());
+    let captured_state = Rc::new(RefCell::new(None));
 
     composition
-        .render(key, || {
-            ChildScrollIndicatorLazyList();
+        .render(key, {
+            let captured_state = Rc::clone(&captured_state);
+            move || {
+                ChildScrollIndicatorLazyList(Rc::clone(&captured_state));
+            }
         })
         .expect("initial render");
 
@@ -1410,7 +1427,7 @@ fn scroll_to_item_updates_child_indicator_scope() {
         "expected initial child indicator text, got {initial_texts:?}"
     );
 
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     list_state.scroll_to_item(20, 0.0);
 
     assert!(

--- a/crates/cranpose-ui/src/tests/lazy_list_recompose_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_list_recompose_tests.rs
@@ -170,6 +170,31 @@ fn ScrollIndicatorLazyList(captured_state: Rc<RefCell<Option<LazyListState>>>) {
     });
 }
 
+/// Renders `ScrollIndicatorLazyList` under a fresh `Composition`, returning
+/// the app-context guard (kept alive by the caller for the test's duration),
+/// the composition, and a freshly captured (never shared or cached) handle
+/// to the list state it composed.
+fn render_scroll_indicator_lazy_list() -> (
+    crate::render_state::TestAppContextScope,
+    Composition<MemoryApplier>,
+    Rc<RefCell<Option<LazyListState>>>,
+) {
+    let _app_context = crate::render_state::app_context_test_scope();
+    let mut composition = Composition::new(MemoryApplier::new());
+    let captured_state = Rc::new(RefCell::new(None));
+
+    composition
+        .render(location_key(file!(), line!(), column!()), {
+            let captured_state = Rc::clone(&captured_state);
+            move || {
+                ScrollIndicatorLazyList(Rc::clone(&captured_state));
+            }
+        })
+        .expect("initial render");
+
+    (_app_context, composition, captured_state)
+}
+
 #[composable]
 #[allow(non_snake_case)]
 fn ChildScrollIndicator(list_state: LazyListState) {
@@ -277,6 +302,38 @@ fn StableKeyedCountingLazyList(
             }
         },
     );
+}
+
+/// Renders a `(item_invocations, captured_state)`-shaped composable (as
+/// `ReactiveSiblingLazyList` and `StableKeyedCountingLazyList` both are)
+/// under a fresh `Composition`, returning the app-context guard (kept alive
+/// by the caller for the test's duration), the composition, and freshly
+/// captured (never shared or cached) handles to the item-invocation counter
+/// and the list state.
+type RenderedCountingLazyList = (
+    crate::render_state::TestAppContextScope,
+    Composition<MemoryApplier>,
+    Rc<Cell<usize>>,
+    Rc<RefCell<Option<LazyListState>>>,
+);
+
+fn render_counting_lazy_list_composable(
+    mut build: impl FnMut(Rc<Cell<usize>>, Rc<RefCell<Option<LazyListState>>>) + 'static,
+) -> RenderedCountingLazyList {
+    let _app_context = crate::render_state::app_context_test_scope();
+    let item_invocations = Rc::new(Cell::new(0));
+    let captured_state = Rc::new(RefCell::new(None));
+    let mut composition = Composition::new(MemoryApplier::new());
+    let key = location_key(file!(), line!(), column!());
+    composition
+        .render(key, {
+            let item_invocations = Rc::clone(&item_invocations);
+            let captured_state = Rc::clone(&captured_state);
+            move || build(Rc::clone(&item_invocations), Rc::clone(&captured_state))
+        })
+        .expect("initial render");
+
+    (_app_context, composition, item_invocations, captured_state)
 }
 
 #[composable]
@@ -775,18 +832,7 @@ fn scroll_state_recomposition_does_not_reprepare_stable_lazy_rows() {
 
 #[test]
 fn gesture_scroll_recomposes_scroll_position_observers() {
-    let _app_context = crate::render_state::app_context_test_scope();
-    let mut composition = Composition::new(MemoryApplier::new());
-    let captured_state = Rc::new(RefCell::new(None));
-
-    composition
-        .render(location_key(file!(), line!(), column!()), {
-            let captured_state = Rc::clone(&captured_state);
-            move || {
-                ScrollIndicatorLazyList(Rc::clone(&captured_state));
-            }
-        })
-        .expect("initial render");
+    let (_app_context, mut composition, captured_state) = render_scroll_indicator_lazy_list();
 
     let root = composition.root().expect("lazy list root");
     let viewport = Size {
@@ -844,23 +890,8 @@ fn gesture_scroll_recomposes_scroll_position_observers() {
 
 #[test]
 fn repeated_measure_of_stable_keyed_lazy_list_reuses_retained_item_content() {
-    let _app_context = crate::render_state::app_context_test_scope();
-    let item_invocations = Rc::new(Cell::new(0));
-    let captured_state = Rc::new(RefCell::new(None));
-    let mut composition = Composition::new(MemoryApplier::new());
-    let key = location_key(file!(), line!(), column!());
-    composition
-        .render(key, {
-            let item_invocations = Rc::clone(&item_invocations);
-            let captured_state = Rc::clone(&captured_state);
-            move || {
-                StableKeyedCountingLazyList(
-                    Rc::clone(&item_invocations),
-                    Rc::clone(&captured_state),
-                )
-            }
-        })
-        .expect("initial render");
+    let (_app_context, mut composition, item_invocations, _captured_state) =
+        render_counting_lazy_list_composable(StableKeyedCountingLazyList);
 
     let root = composition.root().expect("lazy list root");
     let viewport = Size {
@@ -885,23 +916,8 @@ fn repeated_measure_of_stable_keyed_lazy_list_reuses_retained_item_content() {
 
 #[test]
 fn large_forward_lazy_scroll_reuses_skipped_active_slots_in_same_measure_pass() {
-    let _app_context = crate::render_state::app_context_test_scope();
-    let item_invocations = Rc::new(Cell::new(0));
-    let captured_state = Rc::new(RefCell::new(None));
-    let mut composition = Composition::new(MemoryApplier::new());
-    let key = location_key(file!(), line!(), column!());
-    composition
-        .render(key, {
-            let item_invocations = Rc::clone(&item_invocations);
-            let captured_state = Rc::clone(&captured_state);
-            move || {
-                StableKeyedCountingLazyList(
-                    Rc::clone(&item_invocations),
-                    Rc::clone(&captured_state),
-                )
-            }
-        })
-        .expect("initial render");
+    let (_app_context, mut composition, _item_invocations, captured_state) =
+        render_counting_lazy_list_composable(StableKeyedCountingLazyList);
 
     let root = composition.root().expect("lazy list root");
     let viewport = Size {
@@ -1346,18 +1362,7 @@ fn lazy_list_updates_scroll_bounds_when_item_count_grows_without_scrolling() {
 
 #[test]
 fn scroll_to_item_invalidates_indicator_scope_and_updates_visible_index_text() {
-    let _app_context = crate::render_state::app_context_test_scope();
-    let mut composition = Composition::new(MemoryApplier::new());
-    let captured_state = Rc::new(RefCell::new(None));
-
-    composition
-        .render(location_key(file!(), line!(), column!()), {
-            let captured_state = Rc::clone(&captured_state);
-            move || {
-                ScrollIndicatorLazyList(Rc::clone(&captured_state));
-            }
-        })
-        .expect("initial render");
+    let (_app_context, mut composition, captured_state) = render_scroll_indicator_lazy_list();
 
     let root = composition.root().expect("root node");
     let viewport = Size {

--- a/crates/cranpose-ui/src/tests/lazy_list_viewport_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_list_viewport_tests.rs
@@ -71,11 +71,6 @@ fn measure_tree(
     layout
 }
 
-/// Composes `content` under a freshly `remember`-ed `LazyListState` and hands
-/// back both the composition and a freshly captured (never shared or cached)
-/// handle to that state -- every call gets its own `Rc`, so tests stay
-/// isolated from one another the same way the removed `thread_local!` was
-/// not.
 fn compose_with_list_state(
     mut content: impl FnMut(LazyListState) + 'static,
 ) -> (TestComposition, Rc<RefCell<Option<LazyListState>>>) {
@@ -91,8 +86,6 @@ fn compose_with_list_state(
     (composition, captured_state)
 }
 
-/// As [`compose_with_list_state`], but starting from a restored scroll
-/// position via `rememberLazyListStateWithPosition`.
 fn compose_with_list_state_at(
     index: usize,
     offset: f32,
@@ -110,9 +103,6 @@ fn compose_with_list_state_at(
     (composition, captured_state)
 }
 
-/// Shared body for the reverse-scroll "keeps rendered items ordered" tests:
-/// asserts the currently visible items are non-empty and index-ordered, and
-/// that the top item only ever moves in the direction the scroll implies.
 fn assert_visible_items_stay_ordered(
     visible: &[(usize, f32)],
     step: usize,

--- a/crates/cranpose-ui/src/tests/lazy_list_viewport_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_list_viewport_tests.rs
@@ -10,27 +10,20 @@ use super::*;
 
 #[test]
 fn lazy_column_unbounded_height_matches_effective_viewport() {
-    let captured_state = Rc::new(RefCell::new(None));
-    let mut composition = run_test_composition({
-        let captured_state = Rc::clone(&captured_state);
-        move || {
-            let list_state = rememberLazyListState();
-            *captured_state.borrow_mut() = Some(list_state);
-
-            LazyColumn(
-                Modifier::empty(),
-                list_state,
-                LazyColumnSpec::default(),
-                |scope| {
-                    scope.items(100, |_| {
-                        Spacer(Size {
-                            width: 0.0,
-                            height: 100.0,
-                        });
+    let (mut composition, captured_state) = compose_with_list_state(|list_state| {
+        LazyColumn(
+            Modifier::empty(),
+            list_state,
+            LazyColumnSpec::default(),
+            |scope| {
+                scope.items(100, |_| {
+                    Spacer(Size {
+                        width: 0.0,
+                        height: 100.0,
                     });
-                },
-            );
-        }
+                });
+            },
+        );
     });
 
     let root = composition.root().expect("lazy column root");
@@ -76,6 +69,82 @@ fn measure_tree(
         .expect("lazy list viewport test requested a layout tree");
     applier.clear_runtime_handle();
     layout
+}
+
+/// Composes `content` under a freshly `remember`-ed `LazyListState` and hands
+/// back both the composition and a freshly captured (never shared or cached)
+/// handle to that state -- every call gets its own `Rc`, so tests stay
+/// isolated from one another the same way the removed `thread_local!` was
+/// not.
+fn compose_with_list_state(
+    mut content: impl FnMut(LazyListState) + 'static,
+) -> (TestComposition, Rc<RefCell<Option<LazyListState>>>) {
+    let captured_state = Rc::new(RefCell::new(None));
+    let composition = run_test_composition({
+        let captured_state = Rc::clone(&captured_state);
+        move || {
+            let list_state = rememberLazyListState();
+            *captured_state.borrow_mut() = Some(list_state);
+            content(list_state);
+        }
+    });
+    (composition, captured_state)
+}
+
+/// As [`compose_with_list_state`], but starting from a restored scroll
+/// position via `rememberLazyListStateWithPosition`.
+fn compose_with_list_state_at(
+    index: usize,
+    offset: f32,
+    mut content: impl FnMut(LazyListState) + 'static,
+) -> (TestComposition, Rc<RefCell<Option<LazyListState>>>) {
+    let captured_state = Rc::new(RefCell::new(None));
+    let composition = run_test_composition({
+        let captured_state = Rc::clone(&captured_state);
+        move || {
+            let list_state = rememberLazyListStateWithPosition(index, offset);
+            *captured_state.borrow_mut() = Some(list_state);
+            content(list_state);
+        }
+    });
+    (composition, captured_state)
+}
+
+/// Shared body for the reverse-scroll "keeps rendered items ordered" tests:
+/// asserts the currently visible items are non-empty and index-ordered, and
+/// that the top item only ever moves in the direction the scroll implies.
+fn assert_visible_items_stay_ordered(
+    visible: &[(usize, f32)],
+    step: usize,
+    direction: f32,
+    context: impl std::fmt::Display,
+    last_top_item: &mut Option<usize>,
+) {
+    assert!(
+        !visible.is_empty(),
+        "step {step}: expected at least one visible item after {context}"
+    );
+    for pair in visible.windows(2) {
+        assert!(
+            pair[1].0 > pair[0].0,
+            "step {step}: rendered item order regressed after {context}: {visible:?}"
+        );
+    }
+    if let Some(previous_top_item) = *last_top_item {
+        let current_top_item = visible[0].0;
+        if direction < 0.0 {
+            assert!(
+                current_top_item >= previous_top_item,
+                "step {step}: forward movement moved top item backward from                  {previous_top_item} to {current_top_item} after {context}"
+            );
+        } else if direction > 0.0 {
+            assert!(
+                current_top_item <= previous_top_item,
+                "step {step}: reverse movement backtracked from top item                  {previous_top_item} to {current_top_item} after {context}"
+            );
+        }
+    }
+    *last_top_item = Some(visible[0].0);
 }
 
 fn collect_visible_item_texts(
@@ -171,14 +240,9 @@ fn find_nearest_draw_ancestor_for_text<'a>(
 #[test]
 fn lazy_column_jump_does_not_alias_remembered_item_state() {
     let captured_slots = Rc::new(RefCell::new(HashMap::new()));
-    let captured_state = Rc::new(RefCell::new(None));
-    let mut composition = run_test_composition({
+    let (mut composition, captured_state) = compose_with_list_state({
         let captured_slots = Rc::clone(&captured_slots);
-        let captured_state = Rc::clone(&captured_state);
-        move || {
-            let list_state = rememberLazyListState();
-            *captured_state.borrow_mut() = Some(list_state);
-
+        move |list_state| {
             LazyColumn(
                 Modifier::empty(),
                 list_state,
@@ -300,45 +364,38 @@ fn lazy_column_jump_does_not_alias_remembered_item_state() {
 
 #[test]
 fn lazy_column_variable_height_reverse_scroll_keeps_rendered_items_ordered() {
-    let captured_state = Rc::new(RefCell::new(None));
-    let mut composition = run_test_composition({
-        let captured_state = Rc::clone(&captured_state);
-        move || {
-            let list_state = rememberLazyListState();
-            *captured_state.borrow_mut() = Some(list_state);
-
-            LazyColumn(
-                Modifier::empty(),
-                list_state,
-                LazyColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
-                |scope| {
-                    scope.items(120, |index| {
-                        let height = match index % 9 {
-                            0 => 32.0,
-                            1 => 48.0,
-                            2 => 240.0,
-                            3 => 56.0,
-                            4 => 72.0,
-                            5 => 180.0,
-                            6 => 40.0,
-                            7 => 96.0,
-                            _ => 56.0,
-                        };
-                        Column(
-                            Modifier::empty().fill_max_width().height(height),
-                            ColumnSpec::default(),
-                            move || {
-                                Text(
-                                    format!("Item {}", index),
-                                    Modifier::empty(),
-                                    TextStyle::default(),
-                                );
-                            },
-                        );
-                    });
-                },
-            );
-        }
+    let (mut composition, captured_state) = compose_with_list_state(|list_state| {
+        LazyColumn(
+            Modifier::empty(),
+            list_state,
+            LazyColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
+            |scope| {
+                scope.items(120, |index| {
+                    let height = match index % 9 {
+                        0 => 32.0,
+                        1 => 48.0,
+                        2 => 240.0,
+                        3 => 56.0,
+                        4 => 72.0,
+                        5 => 180.0,
+                        6 => 40.0,
+                        7 => 96.0,
+                        _ => 56.0,
+                    };
+                    Column(
+                        Modifier::empty().fill_max_width().height(height),
+                        ColumnSpec::default(),
+                        move || {
+                            Text(
+                                format!("Item {}", index),
+                                Modifier::empty(),
+                                TextStyle::default(),
+                            );
+                        },
+                    );
+                });
+            },
+        );
     });
 
     let root = composition.root().expect("lazy column root");
@@ -367,78 +424,49 @@ fn lazy_column_variable_height_reverse_scroll_keeps_rendered_items_ordered() {
             },
         );
 
-        assert!(
-            !visible.is_empty(),
-            "step {step}: expected at least one visible item after delta {delta}"
+        assert_visible_items_stay_ordered(
+            &visible,
+            step,
+            delta,
+            format_args!("delta {delta}"),
+            &mut last_top_item,
         );
-
-        for pair in visible.windows(2) {
-            assert!(
-                pair[1].0 > pair[0].0,
-                "step {step}: rendered item order regressed after delta {delta}: {:?}",
-                visible
-            );
-        }
-
-        if let Some(previous_top_item) = last_top_item {
-            let current_top_item = visible[0].0;
-            if delta < 0.0 {
-                assert!(
-                    current_top_item >= previous_top_item,
-                    "step {step}: forward scroll moved top item backward from {previous_top_item} to {current_top_item}"
-                );
-            } else if delta > 0.0 {
-                assert!(
-                    current_top_item <= previous_top_item,
-                    "step {step}: reverse scroll backtracked from top item {previous_top_item} to {current_top_item}"
-                );
-            }
-        }
-
-        last_top_item = Some(visible[0].0);
     }
 }
 
 #[test]
 fn lazy_column_content_type_reuse_reverse_scroll_keeps_rendered_items_ordered() {
-    let captured_state = Rc::new(RefCell::new(None));
-    let mut composition = run_test_composition({
-        let captured_state = Rc::clone(&captured_state);
-        move || {
-            let list_state = rememberLazyListState();
-            *captured_state.borrow_mut() = Some(list_state);
-
-            LazyColumn(
-                Modifier::empty(),
-                list_state,
-                LazyColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(6.0)),
-                |scope| {
-                    scope.items(
-                        LazyItems::new(240).content_type(|index: usize| (index % 5) as u64),
-                        |index| {
-                            let height = match index % 5 {
-                                0 => 44.0,
-                                1 => 72.0,
-                                2 => 96.0,
-                                3 => 56.0,
-                                _ => 128.0,
-                            };
-                            Column(
-                                Modifier::empty().fill_max_width().height(height),
-                                ColumnSpec::default(),
-                                move || {
-                                    Text(
-                                        format!("Item {}", index),
-                                        Modifier::empty(),
-                                        TextStyle::default(),
-                                    );
-                                },
-                            );
-                        },
-                    );
-                },
-            );
-        }
+    let (mut composition, captured_state) = compose_with_list_state(|list_state| {
+        LazyColumn(
+            Modifier::empty(),
+            list_state,
+            LazyColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(6.0)),
+            |scope| {
+                scope.items(
+                    LazyItems::new(240).content_type(|index: usize| (index % 5) as u64),
+                    |index| {
+                        let height = match index % 5 {
+                            0 => 44.0,
+                            1 => 72.0,
+                            2 => 96.0,
+                            3 => 56.0,
+                            _ => 128.0,
+                        };
+                        Column(
+                            Modifier::empty().fill_max_width().height(height),
+                            ColumnSpec::default(),
+                            move || {
+                                Text(
+                                    format!("Item {}", index),
+                                    Modifier::empty(),
+                                    TextStyle::default(),
+                                );
+                            },
+                        );
+                    },
+                );
+            },
+        );
     });
 
     let root = composition.root().expect("lazy column root");
@@ -467,81 +495,52 @@ fn lazy_column_content_type_reuse_reverse_scroll_keeps_rendered_items_ordered() 
             },
         );
 
-        assert!(
-            !visible.is_empty(),
-            "step {step}: expected at least one visible item after delta {delta}"
+        assert_visible_items_stay_ordered(
+            &visible,
+            step,
+            delta,
+            format_args!("delta {delta}"),
+            &mut last_top_item,
         );
-
-        for pair in visible.windows(2) {
-            assert!(
-                pair[1].0 > pair[0].0,
-                "step {step}: rendered item order regressed after delta {delta}: {:?}",
-                visible
-            );
-        }
-
-        if let Some(previous_top_item) = last_top_item {
-            let current_top_item = visible[0].0;
-            if delta < 0.0 {
-                assert!(
-                    current_top_item >= previous_top_item,
-                    "step {step}: forward scroll moved top item backward from {previous_top_item} to {current_top_item}"
-                );
-            } else if delta > 0.0 {
-                assert!(
-                    current_top_item <= previous_top_item,
-                    "step {step}: reverse scroll backtracked from top item {previous_top_item} to {current_top_item}"
-                );
-            }
-        }
-
-        last_top_item = Some(visible[0].0);
     }
 }
 
 #[test]
 fn lazy_column_variable_height_bursty_reverse_scroll_keeps_rendered_items_ordered() {
-    let captured_state = Rc::new(RefCell::new(None));
-    let mut composition = run_test_composition({
-        let captured_state = Rc::clone(&captured_state);
-        move || {
-            let list_state = rememberLazyListState();
-            *captured_state.borrow_mut() = Some(list_state);
-
-            LazyColumn(
-                Modifier::empty(),
-                list_state,
-                LazyColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
-                |scope| {
-                    scope.items(
-                        LazyItems::new(240).content_type(|index: usize| (index % 4) as u64),
-                        |index| {
-                            let height = match index % 8 {
-                                0 => 36.0,
-                                1 => 48.0,
-                                2 => 220.0,
-                                3 => 64.0,
-                                4 => 84.0,
-                                5 => 156.0,
-                                6 => 52.0,
-                                _ => 108.0,
-                            };
-                            Column(
-                                Modifier::empty().fill_max_width().height(height),
-                                ColumnSpec::default(),
-                                move || {
-                                    Text(
-                                        format!("Item {}", index),
-                                        Modifier::empty(),
-                                        TextStyle::default(),
-                                    );
-                                },
-                            );
-                        },
-                    );
-                },
-            );
-        }
+    let (mut composition, captured_state) = compose_with_list_state(|list_state| {
+        LazyColumn(
+            Modifier::empty(),
+            list_state,
+            LazyColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
+            |scope| {
+                scope.items(
+                    LazyItems::new(240).content_type(|index: usize| (index % 4) as u64),
+                    |index| {
+                        let height = match index % 8 {
+                            0 => 36.0,
+                            1 => 48.0,
+                            2 => 220.0,
+                            3 => 64.0,
+                            4 => 84.0,
+                            5 => 156.0,
+                            6 => 52.0,
+                            _ => 108.0,
+                        };
+                        Column(
+                            Modifier::empty().fill_max_width().height(height),
+                            ColumnSpec::default(),
+                            move || {
+                                Text(
+                                    format!("Item {}", index),
+                                    Modifier::empty(),
+                                    TextStyle::default(),
+                                );
+                            },
+                        );
+                    },
+                );
+            },
+        );
     });
 
     let root = composition.root().expect("lazy column root");
@@ -579,39 +578,13 @@ fn lazy_column_variable_height_bursty_reverse_scroll_keeps_rendered_items_ordere
             },
         );
 
-        assert!(
-            !visible.is_empty(),
-            "step {step}: expected at least one visible item after burst {:?}",
-            burst
+        assert_visible_items_stay_ordered(
+            &visible,
+            step,
+            total_delta,
+            format_args!("burst {burst:?}"),
+            &mut last_top_item,
         );
-
-        for pair in visible.windows(2) {
-            assert!(
-                pair[1].0 > pair[0].0,
-                "step {step}: rendered item order regressed after burst {:?}: {:?}",
-                burst,
-                visible
-            );
-        }
-
-        if let Some(previous_top_item) = last_top_item {
-            let current_top_item = visible[0].0;
-            if total_delta < 0.0 {
-                assert!(
-                    current_top_item >= previous_top_item,
-                    "step {step}: forward burst moved top item backward from {previous_top_item} to {current_top_item} after {:?}",
-                    burst
-                );
-            } else if total_delta > 0.0 {
-                assert!(
-                    current_top_item <= previous_top_item,
-                    "step {step}: reverse burst backtracked from top item {previous_top_item} to {current_top_item} after {:?}",
-                    burst
-                );
-            }
-        }
-
-        last_top_item = Some(visible[0].0);
     }
 }
 
@@ -621,15 +594,9 @@ fn lazy_column_tall_text_item_keeps_rendered_height_in_sync_with_lazy_measuremen
         "This comment body is intentionally long so the first lazy item becomes taller than the viewport once it wraps to the available width. "
             .repeat(20),
     );
-    let captured_state = Rc::new(RefCell::new(None));
-
-    let mut composition = run_test_composition({
+    let (mut composition, captured_state) = compose_with_list_state_at(0, 180.0, {
         let tall_body = Rc::clone(&tall_body);
-        let captured_state = Rc::clone(&captured_state);
-        move || {
-            let list_state = rememberLazyListStateWithPosition(0, 180.0);
-            *captured_state.borrow_mut() = Some(list_state);
-
+        move |list_state| {
             LazyColumn(
                 Modifier::empty(),
                 list_state,
@@ -722,27 +689,20 @@ fn lazy_column_tall_text_item_keeps_rendered_height_in_sync_with_lazy_measuremen
 }
 
 fn drag_lazy_column_to_end(item_heights: &'static [f32], viewport_height: f32) -> (usize, f32) {
-    let captured_state = Rc::new(RefCell::new(None));
-    let mut composition = run_test_composition({
-        let captured_state = Rc::clone(&captured_state);
-        move || {
-            let list_state = rememberLazyListState();
-            *captured_state.borrow_mut() = Some(list_state);
-
-            LazyColumn(
-                Modifier::empty(),
-                list_state,
-                LazyColumnSpec::default(),
-                move |scope| {
-                    scope.items(item_heights.len(), move |index| {
-                        Spacer(Size {
-                            width: 100.0,
-                            height: item_heights[index],
-                        });
+    let (mut composition, captured_state) = compose_with_list_state(move |list_state| {
+        LazyColumn(
+            Modifier::empty(),
+            list_state,
+            LazyColumnSpec::default(),
+            move |scope| {
+                scope.items(item_heights.len(), move |index| {
+                    Spacer(Size {
+                        width: 100.0,
+                        height: item_heights[index],
                     });
-                },
-            );
-        }
+                });
+            },
+        );
     });
 
     let root = composition.root().expect("lazy column root");
@@ -807,26 +767,20 @@ fn unbounded_lazy_column_with_tall_item_reports_true_content_height() {
     let heights: &'static [f32] = &[
         50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 800.0, 50.0, 50.0, 50.0, 50.0,
     ];
-    let captured_state = Rc::new(RefCell::new(None));
-    let mut composition = run_test_composition({
-        let captured_state = Rc::clone(&captured_state);
-        move || {
-            let list_state = rememberLazyListState();
-            *captured_state.borrow_mut() = Some(list_state);
-            LazyColumn(
-                Modifier::empty(),
-                list_state,
-                LazyColumnSpec::default(),
-                move |scope| {
-                    scope.items(heights.len(), move |index| {
-                        Spacer(Size {
-                            width: 100.0,
-                            height: heights[index],
-                        });
+    let (mut composition, captured_state) = compose_with_list_state(move |list_state| {
+        LazyColumn(
+            Modifier::empty(),
+            list_state,
+            LazyColumnSpec::default(),
+            move |scope| {
+                scope.items(heights.len(), move |index| {
+                    Spacer(Size {
+                        width: 100.0,
+                        height: heights[index],
                     });
-                },
-            );
-        }
+                });
+            },
+        );
     });
     let root = composition.root().expect("root");
     let handle = composition.runtime_handle();
@@ -864,26 +818,20 @@ fn lazy_column_refills_when_viewport_grows_after_scroll_to_end() {
     let heights: &'static [f32] = &[
         100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0,
     ];
-    let captured_state = Rc::new(RefCell::new(None));
-    let mut composition = run_test_composition({
-        let captured_state = Rc::clone(&captured_state);
-        move || {
-            let list_state = rememberLazyListState();
-            *captured_state.borrow_mut() = Some(list_state);
-            LazyColumn(
-                Modifier::empty(),
-                list_state,
-                LazyColumnSpec::default(),
-                move |scope| {
-                    scope.items(heights.len(), move |index| {
-                        Spacer(Size {
-                            width: 100.0,
-                            height: heights[index],
-                        });
+    let (mut composition, captured_state) = compose_with_list_state(move |list_state| {
+        LazyColumn(
+            Modifier::empty(),
+            list_state,
+            LazyColumnSpec::default(),
+            move |scope| {
+                scope.items(heights.len(), move |index| {
+                    Spacer(Size {
+                        width: 100.0,
+                        height: heights[index],
                     });
-                },
-            );
-        }
+                });
+            },
+        );
     });
     let root = composition.root().expect("lazy column root");
     let list_state = (*captured_state.borrow()).expect("state captured");

--- a/crates/cranpose-ui/src/tests/lazy_list_viewport_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_list_viewport_tests.rs
@@ -8,31 +8,29 @@ use cranpose_ui_graphics::{Rect, Size as ViewportSize};
 
 use super::*;
 
-thread_local! {
-    static LAST_LAZY_STATE: RefCell<Option<LazyListState>> = const { RefCell::new(None) };
-}
-
 #[test]
 fn lazy_column_unbounded_height_matches_effective_viewport() {
-    let mut composition = run_test_composition(|| {
-        let list_state = rememberLazyListState();
-        LAST_LAZY_STATE.with(|cell| {
-            *cell.borrow_mut() = Some(list_state);
-        });
+    let captured_state = Rc::new(RefCell::new(None));
+    let mut composition = run_test_composition({
+        let captured_state = Rc::clone(&captured_state);
+        move || {
+            let list_state = rememberLazyListState();
+            *captured_state.borrow_mut() = Some(list_state);
 
-        LazyColumn(
-            Modifier::empty(),
-            list_state,
-            LazyColumnSpec::default(),
-            |scope| {
-                scope.items(100, |_| {
-                    Spacer(Size {
-                        width: 0.0,
-                        height: 100.0,
+            LazyColumn(
+                Modifier::empty(),
+                list_state,
+                LazyColumnSpec::default(),
+                |scope| {
+                    scope.items(100, |_| {
+                        Spacer(Size {
+                            width: 0.0,
+                            height: 100.0,
+                        });
                     });
-                });
-            },
-        );
+                },
+            );
+        }
     });
 
     let root = composition.root().expect("lazy column root");
@@ -53,7 +51,7 @@ fn lazy_column_unbounded_height_matches_effective_viewport() {
         result
     };
 
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     let expected_height = list_state.layout_info().viewport_size;
     let actual_height = measurements.root_size().height;
 
@@ -62,10 +60,6 @@ fn lazy_column_unbounded_height_matches_effective_viewport() {
         (actual_height - expected_height).abs() < 0.01,
         "expected lazy column height to match effective viewport {expected_height}, got {actual_height}"
     );
-
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }
 
 fn measure_tree(
@@ -177,13 +171,13 @@ fn find_nearest_draw_ancestor_for_text<'a>(
 #[test]
 fn lazy_column_jump_does_not_alias_remembered_item_state() {
     let captured_slots = Rc::new(RefCell::new(HashMap::new()));
+    let captured_state = Rc::new(RefCell::new(None));
     let mut composition = run_test_composition({
         let captured_slots = Rc::clone(&captured_slots);
+        let captured_state = Rc::clone(&captured_state);
         move || {
             let list_state = rememberLazyListState();
-            LAST_LAZY_STATE.with(|cell| {
-                *cell.borrow_mut() = Some(list_state);
-            });
+            *captured_state.borrow_mut() = Some(list_state);
 
             LazyColumn(
                 Modifier::empty(),
@@ -219,7 +213,7 @@ fn lazy_column_jump_does_not_alias_remembered_item_state() {
     });
 
     let root = composition.root().expect("lazy column root");
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     let viewport_size = ViewportSize {
         width: 320.0,
         height: 180.0,
@@ -302,55 +296,53 @@ fn lazy_column_jump_does_not_alias_remembered_item_state() {
         restored_count > 0,
         "jumping back should restore at least one initially visible keyed item: {restored_visible:?}",
     );
-
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }
 
 #[test]
 fn lazy_column_variable_height_reverse_scroll_keeps_rendered_items_ordered() {
-    let mut composition = run_test_composition(|| {
-        let list_state = rememberLazyListState();
-        LAST_LAZY_STATE.with(|cell| {
-            *cell.borrow_mut() = Some(list_state);
-        });
+    let captured_state = Rc::new(RefCell::new(None));
+    let mut composition = run_test_composition({
+        let captured_state = Rc::clone(&captured_state);
+        move || {
+            let list_state = rememberLazyListState();
+            *captured_state.borrow_mut() = Some(list_state);
 
-        LazyColumn(
-            Modifier::empty(),
-            list_state,
-            LazyColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
-            |scope| {
-                scope.items(120, |index| {
-                    let height = match index % 9 {
-                        0 => 32.0,
-                        1 => 48.0,
-                        2 => 240.0,
-                        3 => 56.0,
-                        4 => 72.0,
-                        5 => 180.0,
-                        6 => 40.0,
-                        7 => 96.0,
-                        _ => 56.0,
-                    };
-                    Column(
-                        Modifier::empty().fill_max_width().height(height),
-                        ColumnSpec::default(),
-                        move || {
-                            Text(
-                                format!("Item {}", index),
-                                Modifier::empty(),
-                                TextStyle::default(),
-                            );
-                        },
-                    );
-                });
-            },
-        );
+            LazyColumn(
+                Modifier::empty(),
+                list_state,
+                LazyColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
+                |scope| {
+                    scope.items(120, |index| {
+                        let height = match index % 9 {
+                            0 => 32.0,
+                            1 => 48.0,
+                            2 => 240.0,
+                            3 => 56.0,
+                            4 => 72.0,
+                            5 => 180.0,
+                            6 => 40.0,
+                            7 => 96.0,
+                            _ => 56.0,
+                        };
+                        Column(
+                            Modifier::empty().fill_max_width().height(height),
+                            ColumnSpec::default(),
+                            move || {
+                                Text(
+                                    format!("Item {}", index),
+                                    Modifier::empty(),
+                                    TextStyle::default(),
+                                );
+                            },
+                        );
+                    });
+                },
+            );
+        }
     });
 
     let root = composition.root().expect("lazy column root");
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     let viewport_size = ViewportSize {
         width: 320.0,
         height: 260.0,
@@ -405,54 +397,52 @@ fn lazy_column_variable_height_reverse_scroll_keeps_rendered_items_ordered() {
 
         last_top_item = Some(visible[0].0);
     }
-
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }
 
 #[test]
 fn lazy_column_content_type_reuse_reverse_scroll_keeps_rendered_items_ordered() {
-    let mut composition = run_test_composition(|| {
-        let list_state = rememberLazyListState();
-        LAST_LAZY_STATE.with(|cell| {
-            *cell.borrow_mut() = Some(list_state);
-        });
+    let captured_state = Rc::new(RefCell::new(None));
+    let mut composition = run_test_composition({
+        let captured_state = Rc::clone(&captured_state);
+        move || {
+            let list_state = rememberLazyListState();
+            *captured_state.borrow_mut() = Some(list_state);
 
-        LazyColumn(
-            Modifier::empty(),
-            list_state,
-            LazyColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(6.0)),
-            |scope| {
-                scope.items(
-                    LazyItems::new(240).content_type(|index: usize| (index % 5) as u64),
-                    |index| {
-                        let height = match index % 5 {
-                            0 => 44.0,
-                            1 => 72.0,
-                            2 => 96.0,
-                            3 => 56.0,
-                            _ => 128.0,
-                        };
-                        Column(
-                            Modifier::empty().fill_max_width().height(height),
-                            ColumnSpec::default(),
-                            move || {
-                                Text(
-                                    format!("Item {}", index),
-                                    Modifier::empty(),
-                                    TextStyle::default(),
-                                );
-                            },
-                        );
-                    },
-                );
-            },
-        );
+            LazyColumn(
+                Modifier::empty(),
+                list_state,
+                LazyColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(6.0)),
+                |scope| {
+                    scope.items(
+                        LazyItems::new(240).content_type(|index: usize| (index % 5) as u64),
+                        |index| {
+                            let height = match index % 5 {
+                                0 => 44.0,
+                                1 => 72.0,
+                                2 => 96.0,
+                                3 => 56.0,
+                                _ => 128.0,
+                            };
+                            Column(
+                                Modifier::empty().fill_max_width().height(height),
+                                ColumnSpec::default(),
+                                move || {
+                                    Text(
+                                        format!("Item {}", index),
+                                        Modifier::empty(),
+                                        TextStyle::default(),
+                                    );
+                                },
+                            );
+                        },
+                    );
+                },
+            );
+        }
     });
 
     let root = composition.root().expect("lazy column root");
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     let viewport_size = ViewportSize {
         width: 320.0,
         height: 260.0,
@@ -507,57 +497,55 @@ fn lazy_column_content_type_reuse_reverse_scroll_keeps_rendered_items_ordered() 
 
         last_top_item = Some(visible[0].0);
     }
-
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }
 
 #[test]
 fn lazy_column_variable_height_bursty_reverse_scroll_keeps_rendered_items_ordered() {
-    let mut composition = run_test_composition(|| {
-        let list_state = rememberLazyListState();
-        LAST_LAZY_STATE.with(|cell| {
-            *cell.borrow_mut() = Some(list_state);
-        });
+    let captured_state = Rc::new(RefCell::new(None));
+    let mut composition = run_test_composition({
+        let captured_state = Rc::clone(&captured_state);
+        move || {
+            let list_state = rememberLazyListState();
+            *captured_state.borrow_mut() = Some(list_state);
 
-        LazyColumn(
-            Modifier::empty(),
-            list_state,
-            LazyColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
-            |scope| {
-                scope.items(
-                    LazyItems::new(240).content_type(|index: usize| (index % 4) as u64),
-                    |index| {
-                        let height = match index % 8 {
-                            0 => 36.0,
-                            1 => 48.0,
-                            2 => 220.0,
-                            3 => 64.0,
-                            4 => 84.0,
-                            5 => 156.0,
-                            6 => 52.0,
-                            _ => 108.0,
-                        };
-                        Column(
-                            Modifier::empty().fill_max_width().height(height),
-                            ColumnSpec::default(),
-                            move || {
-                                Text(
-                                    format!("Item {}", index),
-                                    Modifier::empty(),
-                                    TextStyle::default(),
-                                );
-                            },
-                        );
-                    },
-                );
-            },
-        );
+            LazyColumn(
+                Modifier::empty(),
+                list_state,
+                LazyColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
+                |scope| {
+                    scope.items(
+                        LazyItems::new(240).content_type(|index: usize| (index % 4) as u64),
+                        |index| {
+                            let height = match index % 8 {
+                                0 => 36.0,
+                                1 => 48.0,
+                                2 => 220.0,
+                                3 => 64.0,
+                                4 => 84.0,
+                                5 => 156.0,
+                                6 => 52.0,
+                                _ => 108.0,
+                            };
+                            Column(
+                                Modifier::empty().fill_max_width().height(height),
+                                ColumnSpec::default(),
+                                move || {
+                                    Text(
+                                        format!("Item {}", index),
+                                        Modifier::empty(),
+                                        TextStyle::default(),
+                                    );
+                                },
+                            );
+                        },
+                    );
+                },
+            );
+        }
     });
 
     let root = composition.root().expect("lazy column root");
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     let viewport_size = ViewportSize {
         width: 320.0,
         height: 260.0,
@@ -625,10 +613,6 @@ fn lazy_column_variable_height_bursty_reverse_scroll_keeps_rendered_items_ordere
 
         last_top_item = Some(visible[0].0);
     }
-
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }
 
 #[test]
@@ -637,14 +621,14 @@ fn lazy_column_tall_text_item_keeps_rendered_height_in_sync_with_lazy_measuremen
         "This comment body is intentionally long so the first lazy item becomes taller than the viewport once it wraps to the available width. "
             .repeat(20),
     );
+    let captured_state = Rc::new(RefCell::new(None));
 
     let mut composition = run_test_composition({
         let tall_body = Rc::clone(&tall_body);
+        let captured_state = Rc::clone(&captured_state);
         move || {
             let list_state = rememberLazyListStateWithPosition(0, 180.0);
-            LAST_LAZY_STATE.with(|cell| {
-                *cell.borrow_mut() = Some(list_state);
-            });
+            *captured_state.borrow_mut() = Some(list_state);
 
             LazyColumn(
                 Modifier::empty(),
@@ -710,7 +694,7 @@ fn lazy_column_tall_text_item_keeps_rendered_height_in_sync_with_lazy_measuremen
         height: 260.0,
     };
     let layout = measure_tree(&mut composition, root, viewport_size);
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     let layout_info = list_state.layout_info();
     let measured_first = layout_info
         .visible_items_info
@@ -735,32 +719,30 @@ fn lazy_column_tall_text_item_keeps_rendered_height_in_sync_with_lazy_measuremen
         "expected only list spacing between first and second items, got gap {:.1}px",
         rendered_gap
     );
-
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }
 
 fn drag_lazy_column_to_end(item_heights: &'static [f32], viewport_height: f32) -> (usize, f32) {
-    let mut composition = run_test_composition(move || {
-        let list_state = rememberLazyListState();
-        LAST_LAZY_STATE.with(|cell| {
-            *cell.borrow_mut() = Some(list_state);
-        });
+    let captured_state = Rc::new(RefCell::new(None));
+    let mut composition = run_test_composition({
+        let captured_state = Rc::clone(&captured_state);
+        move || {
+            let list_state = rememberLazyListState();
+            *captured_state.borrow_mut() = Some(list_state);
 
-        LazyColumn(
-            Modifier::empty(),
-            list_state,
-            LazyColumnSpec::default(),
-            move |scope| {
-                scope.items(item_heights.len(), move |index| {
-                    Spacer(Size {
-                        width: 100.0,
-                        height: item_heights[index],
+            LazyColumn(
+                Modifier::empty(),
+                list_state,
+                LazyColumnSpec::default(),
+                move |scope| {
+                    scope.items(item_heights.len(), move |index| {
+                        Spacer(Size {
+                            width: 100.0,
+                            height: item_heights[index],
+                        });
                     });
-                });
-            },
-        );
+                },
+            );
+        }
     });
 
     let root = composition.root().expect("lazy column root");
@@ -770,7 +752,7 @@ fn drag_lazy_column_to_end(item_heights: &'static [f32], viewport_height: f32) -
     };
     measure_tree(&mut composition, root, viewport);
 
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
 
     let mut stuck_drags = 0;
     for _ in 0..200 {
@@ -792,9 +774,6 @@ fn drag_lazy_column_to_end(item_heights: &'static [f32], viewport_height: f32) -
         }
     }
 
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
     (
         list_state.first_visible_item_index_non_reactive(),
         list_state.first_visible_item_scroll_offset_non_reactive(),
@@ -828,24 +807,26 @@ fn unbounded_lazy_column_with_tall_item_reports_true_content_height() {
     let heights: &'static [f32] = &[
         50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 800.0, 50.0, 50.0, 50.0, 50.0,
     ];
-    let mut composition = run_test_composition(move || {
-        let list_state = rememberLazyListState();
-        LAST_LAZY_STATE.with(|cell| {
-            *cell.borrow_mut() = Some(list_state);
-        });
-        LazyColumn(
-            Modifier::empty(),
-            list_state,
-            LazyColumnSpec::default(),
-            move |scope| {
-                scope.items(heights.len(), move |index| {
-                    Spacer(Size {
-                        width: 100.0,
-                        height: heights[index],
+    let captured_state = Rc::new(RefCell::new(None));
+    let mut composition = run_test_composition({
+        let captured_state = Rc::clone(&captured_state);
+        move || {
+            let list_state = rememberLazyListState();
+            *captured_state.borrow_mut() = Some(list_state);
+            LazyColumn(
+                Modifier::empty(),
+                list_state,
+                LazyColumnSpec::default(),
+                move |scope| {
+                    scope.items(heights.len(), move |index| {
+                        Spacer(Size {
+                            width: 100.0,
+                            height: heights[index],
+                        });
                     });
-                });
-            },
-        );
+                },
+            );
+        }
     });
     let root = composition.root().expect("root");
     let handle = composition.runtime_handle();
@@ -864,7 +845,7 @@ fn unbounded_lazy_column_with_tall_item_reports_true_content_height() {
         applier.clear_runtime_handle();
         result
     };
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     let true_content: f32 = heights.iter().sum();
 
     assert!(
@@ -876,9 +857,6 @@ fn unbounded_lazy_column_with_tall_item_reports_true_content_height() {
         !list_state.can_scroll_forward_non_reactive(),
         "a fully realized unbounded LazyColumn must not claim internal scrollability"
     );
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }
 
 #[test]
@@ -886,27 +864,29 @@ fn lazy_column_refills_when_viewport_grows_after_scroll_to_end() {
     let heights: &'static [f32] = &[
         100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0,
     ];
-    let mut composition = run_test_composition(move || {
-        let list_state = rememberLazyListState();
-        LAST_LAZY_STATE.with(|cell| {
-            *cell.borrow_mut() = Some(list_state);
-        });
-        LazyColumn(
-            Modifier::empty(),
-            list_state,
-            LazyColumnSpec::default(),
-            move |scope| {
-                scope.items(heights.len(), move |index| {
-                    Spacer(Size {
-                        width: 100.0,
-                        height: heights[index],
+    let captured_state = Rc::new(RefCell::new(None));
+    let mut composition = run_test_composition({
+        let captured_state = Rc::clone(&captured_state);
+        move || {
+            let list_state = rememberLazyListState();
+            *captured_state.borrow_mut() = Some(list_state);
+            LazyColumn(
+                Modifier::empty(),
+                list_state,
+                LazyColumnSpec::default(),
+                move |scope| {
+                    scope.items(heights.len(), move |index| {
+                        Spacer(Size {
+                            width: 100.0,
+                            height: heights[index],
+                        });
                     });
-                });
-            },
-        );
+                },
+            );
+        }
     });
     let root = composition.root().expect("lazy column root");
-    let list_state = LAST_LAZY_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
 
     let small = ViewportSize {
         width: 320.0,
@@ -936,7 +916,4 @@ fn lazy_column_refills_when_viewport_grows_after_scroll_to_end() {
          content fills it (offset 200), but it stayed at effective offset \
          {effective}, leaving a {blank_gap}px blank gap"
     );
-    LAST_LAZY_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }

--- a/crates/cranpose-ui/src/tests/lazy_recycle_effect_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_recycle_effect_tests.rs
@@ -1,4 +1,7 @@
-use std::{cell::RefCell, rc::Rc};
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
 
 use cranpose_core::NodeId;
 use cranpose_foundation::lazy::{LazyItems, LazyListScope, LazyListState, rememberLazyListState};
@@ -116,31 +119,30 @@ fn a_recycled_lazy_row_stops_the_effect_of_a_widget_one_subcompose_deeper() {
     );
 }
 
-thread_local! {
-    static DROPPED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
-}
-
-struct DropMark;
+struct DropMark(Rc<Cell<usize>>);
 
 impl Drop for DropMark {
     fn drop(&mut self) {
-        DROPPED.with(|count| count.set(count.get() + 1));
+        self.0.set(self.0.get() + 1);
     }
 }
 
 #[composable]
 #[allow(non_snake_case)]
-fn MarkGroup() {
-    cranpose_core::remember(|| DropMark);
+fn MarkGroup(dropped: Rc<Cell<usize>>) {
+    cranpose_core::remember(move || DropMark(dropped));
 }
 
 #[composable]
 #[allow(non_snake_case)]
-fn BusyRow(index: usize, state: cranpose_core::MutableState<bool>) {
+fn BusyRow(index: usize, state: cranpose_core::MutableState<bool>, dropped: Rc<Cell<usize>>) {
     let busy = state.get() && index == 0;
     if busy {
-        cranpose_core::remember(|| DropMark);
-        MarkGroup();
+        cranpose_core::remember({
+            let dropped = Rc::clone(&dropped);
+            move || DropMark(dropped)
+        });
+        MarkGroup(dropped);
         cranpose_core::LaunchedEffectAsync!(0u32, move |_scope| {
             Box::pin(async move {
                 std::future::pending::<()>().await;
@@ -735,25 +737,30 @@ struct SwapSample {
 fn samples_across_swap(nested: bool) -> Vec<SwapSample> {
     let held: Rc<RefCell<Option<cranpose_core::MutableState<bool>>>> = Rc::new(RefCell::new(None));
     let keeper = Rc::clone(&held);
-    let mut composition = run_test_composition(move || {
-        let busy = cranpose_core::rememberMutableStateOf(|| true);
-        *keeper.borrow_mut() = Some(busy);
-        match nested {
-            true => {
-                let list_state = rememberLazyListState();
-                LazyColumn(
-                    Modifier::empty().fill_max_size(),
-                    list_state,
-                    LazyColumnSpec::default(),
-                    move |scope| {
-                        scope.items(
-                            LazyItems::new(ROWS).key(|index: usize| index as u64),
-                            move |index| BusyRow(index, busy),
-                        );
-                    },
-                );
+    let dropped = Rc::new(Cell::new(0));
+    let mut composition = run_test_composition({
+        let dropped = Rc::clone(&dropped);
+        move || {
+            let busy = cranpose_core::rememberMutableStateOf(|| true);
+            *keeper.borrow_mut() = Some(busy);
+            match nested {
+                true => {
+                    let list_state = rememberLazyListState();
+                    let dropped = Rc::clone(&dropped);
+                    LazyColumn(
+                        Modifier::empty().fill_max_size(),
+                        list_state,
+                        LazyColumnSpec::default(),
+                        move |scope| {
+                            scope.items(
+                                LazyItems::new(ROWS).key(|index: usize| index as u64),
+                                move |index| BusyRow(index, busy, Rc::clone(&dropped)),
+                            );
+                        },
+                    );
+                }
+                false => BusyRow(0, busy, Rc::clone(&dropped)),
             }
-            false => BusyRow(0, busy),
         }
     });
 
@@ -762,7 +769,7 @@ fn samples_across_swap(nested: bool) -> Vec<SwapSample> {
     composition.runtime_handle().drain_ui();
     let mut samples = vec![SwapSample {
         tasks: composition.runtime_handle().debug_stats().tasks_len,
-        drops: DROPPED.with(|count| count.get()),
+        drops: dropped.get(),
     }];
 
     let busy = (*held.borrow()).expect("busy state");
@@ -775,7 +782,7 @@ fn samples_across_swap(nested: bool) -> Vec<SwapSample> {
     composition.runtime_handle().drain_ui();
     samples.push(SwapSample {
         tasks: composition.runtime_handle().debug_stats().tasks_len,
-        drops: DROPPED.with(|count| count.get()),
+        drops: dropped.get(),
     });
     samples
 }
@@ -788,10 +795,9 @@ fn task_counts_across_swap(nested: bool) -> Vec<usize> {
 }
 
 fn drop_counts_across_swap(nested: bool) -> Vec<usize> {
-    let base = DROPPED.with(|count| count.get());
     samples_across_swap(nested)
         .iter()
-        .map(|sample| sample.drops - base)
+        .map(|sample| sample.drops)
         .collect()
 }
 

--- a/crates/cranpose-ui/src/tests/lazy_row_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_row_tests.rs
@@ -1,4 +1,8 @@
-use std::cell::RefCell;
+
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
 
 use cranpose_core::{Composition, MemoryApplier, MutableState, NodeId, location_key};
 use cranpose_foundation::lazy::{LazyListScope, LazyListState, rememberLazyListState};
@@ -6,32 +10,29 @@ use cranpose_ui_graphics::Size as ViewportSize;
 
 use super::*;
 
-thread_local! {
-    static LAST_LAZY_ROW_STATE: RefCell<Option<LazyListState>> = const { RefCell::new(None) };
-    static GROWING_LAZY_ROW_CALL_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
-}
-
 #[test]
 fn lazy_row_unbounded_width_matches_effective_viewport() {
-    let mut composition = run_test_composition(|| {
-        let list_state = rememberLazyListState();
-        LAST_LAZY_ROW_STATE.with(|cell| {
-            *cell.borrow_mut() = Some(list_state);
-        });
+    let captured_state = Rc::new(RefCell::new(None));
+    let mut composition = run_test_composition({
+        let captured_state = Rc::clone(&captured_state);
+        move || {
+            let list_state = rememberLazyListState();
+            *captured_state.borrow_mut() = Some(list_state);
 
-        LazyRow(
-            Modifier::empty(),
-            list_state,
-            LazyRowSpec::default(),
-            |scope| {
-                scope.items(100, |_| {
-                    Spacer(Size {
-                        width: 100.0,
-                        height: 0.0,
+            LazyRow(
+                Modifier::empty(),
+                list_state,
+                LazyRowSpec::default(),
+                |scope| {
+                    scope.items(100, |_| {
+                        Spacer(Size {
+                            width: 100.0,
+                            height: 0.0,
+                        });
                     });
-                });
-            },
-        );
+                },
+            );
+        }
     });
 
     let root = composition.root().expect("lazy row root");
@@ -52,7 +53,7 @@ fn lazy_row_unbounded_width_matches_effective_viewport() {
         result
     };
 
-    let list_state = LAST_LAZY_ROW_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     let expected_width = list_state.layout_info().viewport_size;
     let actual_width = measurements.root_size().width;
 
@@ -61,23 +62,19 @@ fn lazy_row_unbounded_width_matches_effective_viewport() {
         (actual_width - expected_width).abs() < 0.01,
         "expected lazy row width to match effective viewport {expected_width}, got {actual_width}"
     );
-
-    LAST_LAZY_ROW_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }
 
 #[composable]
 #[allow(non_snake_case)]
-fn GrowingLazyRow(item_count: MutableState<usize>) {
+fn GrowingLazyRow(
+    item_count: MutableState<usize>,
+    captured_state: Rc<RefCell<Option<LazyListState>>>,
+    call_count: Rc<Cell<usize>>,
+) {
     let list_state = rememberLazyListState();
-    LAST_LAZY_ROW_STATE.with(|cell| {
-        *cell.borrow_mut() = Some(list_state);
-    });
+    *captured_state.borrow_mut() = Some(list_state);
     let count = item_count.value();
-    GROWING_LAZY_ROW_CALL_COUNT.with(|call_count| {
-        call_count.set(call_count.get() + 1);
-    });
+    call_count.set(call_count.get() + 1);
 
     Column(Modifier::empty(), ColumnSpec::default(), move || {
         Text(
@@ -114,12 +111,21 @@ fn lazy_row_updates_scroll_bounds_when_item_count_grows_without_scrolling() {
     let mut composition = Composition::new(MemoryApplier::new());
     let runtime = composition.runtime_handle();
     let item_count = MutableState::with_runtime(2usize, runtime.clone());
+    let captured_state = Rc::new(RefCell::new(None));
+    let call_count = Rc::new(Cell::new(0));
 
-    GROWING_LAZY_ROW_CALL_COUNT.with(|call_count| call_count.set(0));
     let key = location_key(file!(), line!(), column!());
     composition
-        .render(key, || {
-            GrowingLazyRow(item_count);
+        .render(key, {
+            let captured_state = Rc::clone(&captured_state);
+            let call_count = Rc::clone(&call_count);
+            move || {
+                GrowingLazyRow(
+                    item_count,
+                    Rc::clone(&captured_state),
+                    Rc::clone(&call_count),
+                );
+            }
         })
         .expect("initial render");
 
@@ -130,7 +136,7 @@ fn lazy_row_updates_scroll_bounds_when_item_count_grows_without_scrolling() {
     };
     measure_root(&mut composition, root, viewport);
 
-    let list_state = LAST_LAZY_ROW_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     assert_eq!(list_state.layout_info().total_items_count, 2);
     assert!(
         !list_state.can_scroll_forward(),
@@ -149,12 +155,10 @@ fn lazy_row_updates_scroll_bounds_when_item_count_grows_without_scrolling() {
         recomposed,
         "expected composition to re-run after item count growth"
     );
-    GROWING_LAZY_ROW_CALL_COUNT.with(|call_count| {
-        assert!(
-            call_count.get() >= 2,
-            "expected LazyRow parent composable to execute again after item count growth"
-        );
-    });
+    assert!(
+        call_count.get() >= 2,
+        "expected LazyRow parent composable to execute again after item count growth"
+    );
     measure_root(&mut composition, root, viewport);
 
     assert_eq!(list_state.layout_info().total_items_count, 24);
@@ -167,19 +171,13 @@ fn lazy_row_updates_scroll_bounds_when_item_count_grows_without_scrolling() {
         texts.iter().any(|text| text == "Count 24"),
         "expected parent composition to observe the grown item count"
     );
-
-    LAST_LAZY_ROW_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }
 
 #[composable]
 #[allow(non_snake_case)]
-fn HorizontalScrollIndicatorLazyRow() {
+fn HorizontalScrollIndicatorLazyRow(captured_state: Rc<RefCell<Option<LazyListState>>>) {
     let list_state = rememberLazyListState();
-    LAST_LAZY_ROW_STATE.with(|cell| {
-        *cell.borrow_mut() = Some(list_state);
-    });
+    *captured_state.borrow_mut() = Some(list_state);
 
     Column(Modifier::empty(), ColumnSpec::default(), move || {
         Text(
@@ -213,13 +211,14 @@ fn HorizontalScrollIndicatorLazyRow() {
 fn lazy_row_gesture_scroll_moves_rendered_items_along_the_horizontal_axis() {
     let _app_context = crate::render_state::app_context_test_scope();
     let mut composition = Composition::new(MemoryApplier::new());
-    LAST_LAZY_ROW_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
+    let captured_state = Rc::new(RefCell::new(None));
 
     composition
-        .render(location_key(file!(), line!(), column!()), || {
-            HorizontalScrollIndicatorLazyRow();
+        .render(location_key(file!(), line!(), column!()), {
+            let captured_state = Rc::clone(&captured_state);
+            move || {
+                HorizontalScrollIndicatorLazyRow(Rc::clone(&captured_state));
+            }
         })
         .expect("initial render");
 
@@ -244,7 +243,7 @@ fn lazy_row_gesture_scroll_moves_rendered_items_along_the_horizontal_axis() {
     let initial_item_0_x = text_x(&initial_records, "Item 0");
     let initial_item_0_y = text_y(&initial_records, "Item 0");
 
-    let list_state = LAST_LAZY_ROW_STATE.with(|cell| (*cell.borrow()).expect("state captured"));
+    let list_state = (*captured_state.borrow()).expect("state captured");
     list_state.dispatch_scroll_delta(-40.0);
     measure_root(&mut composition, root, viewport);
 
@@ -280,10 +279,6 @@ fn lazy_row_gesture_scroll_moves_rendered_items_along_the_horizontal_axis() {
         "scrolling a lazy row must not move its rendered items along y: \
          initial_y={initial_item_0_y}, scrolled_y={scrolled_item_0_y}"
     );
-
-    LAST_LAZY_ROW_STATE.with(|cell| {
-        *cell.borrow_mut() = None;
-    });
 }
 
 #[derive(Debug)]

--- a/crates/cranpose-ui/src/tests/lazy_row_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_row_tests.rs
@@ -1,4 +1,3 @@
-
 use std::{
     cell::{Cell, RefCell},
     rc::Rc,

--- a/crates/cranpose-ui/src/tests/primitives_tests.rs
+++ b/crates/cranpose-ui/src/tests/primitives_tests.rs
@@ -28,13 +28,6 @@ use crate::{
 type CapturedLazyListState = Rc<RefCell<Option<LazyListState>>>;
 type CapturedNodeId = Rc<RefCell<Option<NodeId>>>;
 
-/// Bundles the two output slots the `BoxWithConstraints` conditional-branch
-/// tests capture out of a composable (its `LazyListState` and the `NodeId`
-/// the composable produced), so re-threading them through several levels of
-/// nested `Row`/`Column` closures is one `.clone()` per level instead of two
-/// independent `Rc::clone` calls. Every `CapturedLazyListSlot::new()` starts
-/// both slots empty and owned only by that call -- cloning shares the same
-/// two `Rc`s, never a slot from a different test.
 #[derive(Clone, PartialEq)]
 struct CapturedLazyListSlot {
     state: CapturedLazyListState,

--- a/crates/cranpose-ui/src/tests/primitives_tests.rs
+++ b/crates/cranpose-ui/src/tests/primitives_tests.rs
@@ -5,7 +5,7 @@ use std::{
 
 use cranpose_core::{
     self, Applier, Composer, Composition, ConcreteApplierHost, MemoryApplier, NodeId, Phase,
-    SlotTable, SlotsHost, SnapshotStateObserver, State, location_key,
+    SlotTable, SlotsHost, SnapshotStateObserver, location_key,
 };
 use cranpose_foundation::lazy::{LazyListScope, LazyListState, rememberLazyListState};
 use cranpose_ui_layout::{HorizontalAlignment, LinearArrangement, VerticalAlignment};
@@ -20,17 +20,13 @@ use crate::{
     subcompose_layout::{Constraints, SubcomposeLayoutNode},
     text::TextStyle,
     widgets::{
-        BoxWithConstraints, Column, ColumnSpec, DynamicTextSource, LazyColumn, LazyColumnSpec, Row,
-        RowSpec, Spacer, Text, nodes::LayoutNode,
+        BoxWithConstraints, Column, ColumnSpec, LazyColumn, LazyColumnSpec, Row, RowSpec, Spacer,
+        Text, nodes::LayoutNode,
     },
 };
 
-thread_local! {
-    static COUNTER_ROW_INVOCATIONS: Cell<usize> = const { Cell::new(0) };
-    static COUNTER_TEXT_ID: RefCell<Option<NodeId>> = const { RefCell::new(None) };
-    static CONDITIONAL_LAZY_LIST_STATE: RefCell<Option<LazyListState>> = const { RefCell::new(None) };
-    static CONDITIONAL_LAZY_LIST_NODE_ID: RefCell<Option<NodeId>> = const { RefCell::new(None) };
-}
+type CapturedLazyListState = Rc<RefCell<Option<LazyListState>>>;
+type CapturedNodeId = Rc<RefCell<Option<NodeId>>>;
 
 fn prepare_measure_composer(
     slots: &mut SlotTable,
@@ -296,26 +292,6 @@ fn assert_box_with_constraints_branch_toggle<F>(
 }
 
 #[composable]
-fn CounterRow(label: &'static str, count: State<i32>) -> NodeId {
-    COUNTER_ROW_INVOCATIONS.with(|calls| calls.set(calls.get() + 1));
-    Column(Modifier::empty(), ColumnSpec::default(), move || {
-        Text(label, Modifier::empty(), TextStyle::default());
-        let count_for_text = count;
-        let text_id = Text(
-            DynamicTextSource::new(move || {
-                Rc::new(crate::text::AnnotatedString::from(format!(
-                    "Count = {}",
-                    count_for_text.value()
-                )))
-            }),
-            Modifier::empty(),
-            TextStyle::default(),
-        );
-        COUNTER_TEXT_ID.with(|slot| *slot.borrow_mut() = Some(text_id));
-    })
-}
-
-#[composable]
 fn PrimitiveStoriesBranch() {
     Text("Stories", Modifier::empty(), TextStyle::default());
 }
@@ -370,10 +346,12 @@ fn PrimitiveStoriesListBranch(list_state: LazyListState) {
 }
 
 #[composable]
-fn PrimitiveScrollReactiveStoriesBranch(list_state: LazyListState) {
-    CONDITIONAL_LAZY_LIST_STATE.with(|slot| {
-        *slot.borrow_mut() = Some(list_state);
-    });
+fn PrimitiveScrollReactiveStoriesBranch(
+    list_state: LazyListState,
+    captured_state: CapturedLazyListState,
+    captured_node_id: CapturedNodeId,
+) {
+    *captured_state.borrow_mut() = Some(list_state);
 
     Column(
         Modifier::empty().fill_max_size(),
@@ -398,25 +376,32 @@ fn PrimitiveScrollReactiveStoriesBranch(list_state: LazyListState) {
                     });
                 },
             );
-            CONDITIONAL_LAZY_LIST_NODE_ID.with(|slot| {
-                *slot.borrow_mut() = Some(node_id);
-            });
+            *captured_node_id.borrow_mut() = Some(node_id);
         },
     );
 }
 
 #[composable]
-fn PrimitiveStoriesPaneWithIndicator(modifier: Modifier, list_state: LazyListState) {
+fn PrimitiveStoriesPaneWithIndicator(
+    modifier: Modifier,
+    list_state: LazyListState,
+    captured_state: CapturedLazyListState,
+    captured_node_id: CapturedNodeId,
+) {
     Column(
         modifier,
         ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(8.0)),
         move || {
             Text("Top stories", Modifier::empty(), TextStyle::default());
             Text("40 loaded of 40", Modifier::empty(), TextStyle::default());
+            let captured_state = Rc::clone(&captured_state);
+            let captured_node_id = Rc::clone(&captured_node_id);
             Row(
                 Modifier::empty().fill_max_width().weight(1.0),
                 RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
                 move || {
+                    let captured_state = Rc::clone(&captured_state);
+                    let captured_node_id = Rc::clone(&captured_node_id);
                     Column(
                         Modifier::empty().weight(1.0).fill_max_height(),
                         ColumnSpec::default(),
@@ -435,12 +420,8 @@ fn PrimitiveStoriesPaneWithIndicator(modifier: Modifier, list_state: LazyListSta
                                     });
                                 },
                             );
-                            CONDITIONAL_LAZY_LIST_STATE.with(|slot| {
-                                *slot.borrow_mut() = Some(list_state);
-                            });
-                            CONDITIONAL_LAZY_LIST_NODE_ID.with(|slot| {
-                                *slot.borrow_mut() = Some(node_id);
-                            });
+                            *captured_state.borrow_mut() = Some(list_state);
+                            *captured_node_id.borrow_mut() = Some(node_id);
                         },
                     );
                     Column(
@@ -465,6 +446,8 @@ fn PrimitiveStoriesPaneWithDynamicStatus(
     modifier: Modifier,
     list_state: LazyListState,
     loaded_count: cranpose_core::MutableState<usize>,
+    captured_state: CapturedLazyListState,
+    captured_node_id: CapturedNodeId,
 ) {
     Column(
         modifier,
@@ -476,10 +459,14 @@ fn PrimitiveStoriesPaneWithDynamicStatus(
                 Modifier::empty(),
                 TextStyle::default(),
             );
+            let captured_state = Rc::clone(&captured_state);
+            let captured_node_id = Rc::clone(&captured_node_id);
             Row(
                 Modifier::empty().fill_max_width().weight(1.0),
                 RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
                 move || {
+                    let captured_state = Rc::clone(&captured_state);
+                    let captured_node_id = Rc::clone(&captured_node_id);
                     Column(
                         Modifier::empty().weight(1.0).fill_max_height(),
                         ColumnSpec::default(),
@@ -498,12 +485,8 @@ fn PrimitiveStoriesPaneWithDynamicStatus(
                                     });
                                 },
                             );
-                            CONDITIONAL_LAZY_LIST_STATE.with(|slot| {
-                                *slot.borrow_mut() = Some(list_state);
-                            });
-                            CONDITIONAL_LAZY_LIST_NODE_ID.with(|slot| {
-                                *slot.borrow_mut() = Some(node_id);
-                            });
+                            *captured_state.borrow_mut() = Some(list_state);
+                            *captured_node_id.borrow_mut() = Some(node_id);
                         },
                     );
                     Column(
@@ -523,14 +506,12 @@ fn PrimitiveStoriesPaneWithDynamicStatus(
     );
 }
 
-fn captured_conditional_lazy_list_state() -> LazyListState {
-    CONDITIONAL_LAZY_LIST_STATE
-        .with(|slot| (*slot.borrow()).expect("conditional lazy list state should be captured"))
+fn captured_conditional_lazy_list_state(captured_state: &CapturedLazyListState) -> LazyListState {
+    (*captured_state.borrow()).expect("conditional lazy list state should be captured")
 }
 
-fn captured_conditional_lazy_list_node_id() -> NodeId {
-    CONDITIONAL_LAZY_LIST_NODE_ID
-        .with(|slot| (*slot.borrow()).expect("conditional lazy list node id should be captured"))
+fn captured_conditional_lazy_list_node_id(captured_node_id: &CapturedNodeId) -> NodeId {
+    (*captured_node_id.borrow()).expect("conditional lazy list node id should be captured")
 }
 
 fn node_generation(composition: &mut Composition<MemoryApplier>, node_id: NodeId) -> u32 {
@@ -969,36 +950,43 @@ fn box_with_constraints_restored_lazy_list_branch_keeps_host_generation_during_s
     let mut composition = Composition::new(MemoryApplier::new());
     let runtime = composition.runtime_handle();
     let selected_story = cranpose_core::MutableState::with_runtime(None::<u64>, runtime.clone());
-
-    CONDITIONAL_LAZY_LIST_STATE.with(|slot| {
-        *slot.borrow_mut() = None;
-    });
-    CONDITIONAL_LAZY_LIST_NODE_ID.with(|slot| {
-        *slot.borrow_mut() = None;
-    });
+    let captured_state: CapturedLazyListState = Rc::new(RefCell::new(None));
+    let captured_node_id: CapturedNodeId = Rc::new(RefCell::new(None));
 
     composition
-        .render(location_key(file!(), line!(), column!()), || {
-            let list_state = rememberLazyListState();
-            BoxWithConstraints(Modifier::empty().fill_max_size(), move |_scope| {
-                Column(
-                    Modifier::empty().fill_max_size(),
-                    ColumnSpec::default(),
-                    move || {
-                        Text("Header", Modifier::empty(), TextStyle::default());
-                        let single_pane_key = selected_story.value();
-                        cranpose_core::with_key(&single_pane_key, move || {
-                            if single_pane_key.is_some() {
-                                PrimitiveThreadPaneLike(
-                                    Modifier::empty().fill_max_width().weight(1.0),
-                                );
-                            } else {
-                                PrimitiveScrollReactiveStoriesBranch(list_state);
-                            }
-                        });
-                    },
-                );
-            });
+        .render(location_key(file!(), line!(), column!()), {
+            let captured_state = Rc::clone(&captured_state);
+            let captured_node_id = Rc::clone(&captured_node_id);
+            move || {
+                let list_state = rememberLazyListState();
+                let captured_state = Rc::clone(&captured_state);
+                let captured_node_id = Rc::clone(&captured_node_id);
+                BoxWithConstraints(Modifier::empty().fill_max_size(), move |_scope| {
+                    Column(Modifier::empty().fill_max_size(), ColumnSpec::default(), {
+                        let captured_state = Rc::clone(&captured_state);
+                        let captured_node_id = Rc::clone(&captured_node_id);
+                        move || {
+                            Text("Header", Modifier::empty(), TextStyle::default());
+                            let single_pane_key = selected_story.value();
+                            let captured_state = Rc::clone(&captured_state);
+                            let captured_node_id = Rc::clone(&captured_node_id);
+                            cranpose_core::with_key(&single_pane_key, move || {
+                                if single_pane_key.is_some() {
+                                    PrimitiveThreadPaneLike(
+                                        Modifier::empty().fill_max_width().weight(1.0),
+                                    );
+                                } else {
+                                    PrimitiveScrollReactiveStoriesBranch(
+                                        list_state,
+                                        Rc::clone(&captured_state),
+                                        Rc::clone(&captured_node_id),
+                                    );
+                                }
+                            });
+                        }
+                    });
+                });
+            }
         })
         .expect("initial render");
 
@@ -1009,14 +997,14 @@ fn box_with_constraints_restored_lazy_list_branch_keeps_host_generation_during_s
     };
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let list_state = captured_conditional_lazy_list_state();
-    let fresh_node_id = captured_conditional_lazy_list_node_id();
+    let list_state = captured_conditional_lazy_list_state(&captured_state);
+    let fresh_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
     let fresh_generation = node_generation(&mut composition, fresh_node_id);
 
     list_state.dispatch_scroll_delta(-120.0);
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let fresh_after_node_id = captured_conditional_lazy_list_node_id();
+    let fresh_after_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
     let fresh_after_generation = node_generation(&mut composition, fresh_after_node_id);
     assert_eq!(
         (fresh_after_node_id, fresh_after_generation),
@@ -1042,14 +1030,14 @@ fn box_with_constraints_restored_lazy_list_branch_keeps_host_generation_during_s
     }
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let restored_node_id = captured_conditional_lazy_list_node_id();
+    let restored_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
     let restored_generation = node_generation(&mut composition, restored_node_id);
 
     let mut seen = Vec::new();
     for _ in 0..4 {
         list_state.dispatch_scroll_delta(-120.0);
         settle_scroll_recomposition(&mut composition, root, size);
-        let node_id = captured_conditional_lazy_list_node_id();
+        let node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
         let generation = node_generation(&mut composition, node_id);
         seen.push((node_id, generation));
     }
@@ -1067,39 +1055,48 @@ fn box_with_constraints_restored_weighted_lazy_list_branch_keeps_host_generation
     let mut composition = Composition::new(MemoryApplier::new());
     let runtime = composition.runtime_handle();
     let selected_story = cranpose_core::MutableState::with_runtime(None::<u64>, runtime.clone());
-
-    CONDITIONAL_LAZY_LIST_STATE.with(|slot| {
-        *slot.borrow_mut() = None;
-    });
-    CONDITIONAL_LAZY_LIST_NODE_ID.with(|slot| {
-        *slot.borrow_mut() = None;
-    });
+    let captured_state: CapturedLazyListState = Rc::new(RefCell::new(None));
+    let captured_node_id: CapturedNodeId = Rc::new(RefCell::new(None));
 
     composition
-        .render(location_key(file!(), line!(), column!()), || {
-            let list_state = rememberLazyListState();
-            BoxWithConstraints(Modifier::empty().fill_max_size(), move |_scope| {
-                Column(
-                    Modifier::empty().fill_max_size(),
-                    ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(12.0)),
-                    move || {
-                        Text("Header", Modifier::empty(), TextStyle::default());
-                        let single_pane_key = selected_story.value();
-                        cranpose_core::with_key(&single_pane_key, move || {
-                            if single_pane_key.is_some() {
-                                PrimitiveThreadPaneLike(
-                                    Modifier::empty().fill_max_width().weight(1.0),
-                                );
-                            } else {
-                                PrimitiveStoriesPaneWithIndicator(
-                                    Modifier::empty().fill_max_width().weight(1.0),
-                                    list_state,
-                                );
+        .render(location_key(file!(), line!(), column!()), {
+            let captured_state = Rc::clone(&captured_state);
+            let captured_node_id = Rc::clone(&captured_node_id);
+            move || {
+                let list_state = rememberLazyListState();
+                let captured_state = Rc::clone(&captured_state);
+                let captured_node_id = Rc::clone(&captured_node_id);
+                BoxWithConstraints(Modifier::empty().fill_max_size(), move |_scope| {
+                    Column(
+                        Modifier::empty().fill_max_size(),
+                        ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(12.0)),
+                        {
+                            let captured_state = Rc::clone(&captured_state);
+                            let captured_node_id = Rc::clone(&captured_node_id);
+                            move || {
+                                Text("Header", Modifier::empty(), TextStyle::default());
+                                let single_pane_key = selected_story.value();
+                                let captured_state = Rc::clone(&captured_state);
+                                let captured_node_id = Rc::clone(&captured_node_id);
+                                cranpose_core::with_key(&single_pane_key, move || {
+                                    if single_pane_key.is_some() {
+                                        PrimitiveThreadPaneLike(
+                                            Modifier::empty().fill_max_width().weight(1.0),
+                                        );
+                                    } else {
+                                        PrimitiveStoriesPaneWithIndicator(
+                                            Modifier::empty().fill_max_width().weight(1.0),
+                                            list_state,
+                                            Rc::clone(&captured_state),
+                                            Rc::clone(&captured_node_id),
+                                        );
+                                    }
+                                });
                             }
-                        });
-                    },
-                );
-            });
+                        },
+                    );
+                });
+            }
         })
         .expect("initial render");
 
@@ -1110,14 +1107,14 @@ fn box_with_constraints_restored_weighted_lazy_list_branch_keeps_host_generation
     };
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let list_state = captured_conditional_lazy_list_state();
-    let fresh_node_id = captured_conditional_lazy_list_node_id();
+    let list_state = captured_conditional_lazy_list_state(&captured_state);
+    let fresh_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
     let fresh_generation = node_generation(&mut composition, fresh_node_id);
 
     list_state.dispatch_scroll_delta(-120.0);
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let fresh_after_node_id = captured_conditional_lazy_list_node_id();
+    let fresh_after_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
     let fresh_after_generation = node_generation(&mut composition, fresh_after_node_id);
     assert_eq!(
         (fresh_after_node_id, fresh_after_generation),
@@ -1143,14 +1140,14 @@ fn box_with_constraints_restored_weighted_lazy_list_branch_keeps_host_generation
     }
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let restored_node_id = captured_conditional_lazy_list_node_id();
+    let restored_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
     let restored_generation = node_generation(&mut composition, restored_node_id);
 
     let mut seen = Vec::new();
     for _ in 0..4 {
         list_state.dispatch_scroll_delta(-120.0);
         settle_scroll_recomposition(&mut composition, root, size);
-        let node_id = captured_conditional_lazy_list_node_id();
+        let node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
         let generation = node_generation(&mut composition, node_id);
         seen.push((node_id, generation));
     }
@@ -1169,40 +1166,49 @@ fn box_with_constraints_restored_weighted_lazy_list_branch_keeps_host_during_sta
     let runtime = composition.runtime_handle();
     let selected_story = cranpose_core::MutableState::with_runtime(None::<u64>, runtime.clone());
     let loaded_count = cranpose_core::MutableState::with_runtime(20usize, runtime.clone());
-
-    CONDITIONAL_LAZY_LIST_STATE.with(|slot| {
-        *slot.borrow_mut() = None;
-    });
-    CONDITIONAL_LAZY_LIST_NODE_ID.with(|slot| {
-        *slot.borrow_mut() = None;
-    });
+    let captured_state: CapturedLazyListState = Rc::new(RefCell::new(None));
+    let captured_node_id: CapturedNodeId = Rc::new(RefCell::new(None));
 
     composition
-        .render(location_key(file!(), line!(), column!()), || {
-            let list_state = rememberLazyListState();
-            BoxWithConstraints(Modifier::empty().fill_max_size(), move |_scope| {
-                Column(
-                    Modifier::empty().fill_max_size(),
-                    ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(12.0)),
-                    move || {
-                        Text("Header", Modifier::empty(), TextStyle::default());
-                        let single_pane_key = selected_story.value();
-                        cranpose_core::with_key(&single_pane_key, move || {
-                            if single_pane_key.is_some() {
-                                PrimitiveThreadPaneLike(
-                                    Modifier::empty().fill_max_width().weight(1.0),
-                                );
-                            } else {
-                                PrimitiveStoriesPaneWithDynamicStatus(
-                                    Modifier::empty().fill_max_width().weight(1.0),
-                                    list_state,
-                                    loaded_count,
-                                );
+        .render(location_key(file!(), line!(), column!()), {
+            let captured_state = Rc::clone(&captured_state);
+            let captured_node_id = Rc::clone(&captured_node_id);
+            move || {
+                let list_state = rememberLazyListState();
+                let captured_state = Rc::clone(&captured_state);
+                let captured_node_id = Rc::clone(&captured_node_id);
+                BoxWithConstraints(Modifier::empty().fill_max_size(), move |_scope| {
+                    Column(
+                        Modifier::empty().fill_max_size(),
+                        ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(12.0)),
+                        {
+                            let captured_state = Rc::clone(&captured_state);
+                            let captured_node_id = Rc::clone(&captured_node_id);
+                            move || {
+                                Text("Header", Modifier::empty(), TextStyle::default());
+                                let single_pane_key = selected_story.value();
+                                let captured_state = Rc::clone(&captured_state);
+                                let captured_node_id = Rc::clone(&captured_node_id);
+                                cranpose_core::with_key(&single_pane_key, move || {
+                                    if single_pane_key.is_some() {
+                                        PrimitiveThreadPaneLike(
+                                            Modifier::empty().fill_max_width().weight(1.0),
+                                        );
+                                    } else {
+                                        PrimitiveStoriesPaneWithDynamicStatus(
+                                            Modifier::empty().fill_max_width().weight(1.0),
+                                            list_state,
+                                            loaded_count,
+                                            Rc::clone(&captured_state),
+                                            Rc::clone(&captured_node_id),
+                                        );
+                                    }
+                                });
                             }
-                        });
-                    },
-                );
-            });
+                        },
+                    );
+                });
+            }
         })
         .expect("initial render");
 
@@ -1231,13 +1237,13 @@ fn box_with_constraints_restored_weighted_lazy_list_branch_keeps_host_during_sta
     }
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let restored_node_id = captured_conditional_lazy_list_node_id();
+    let restored_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
     let restored_generation = node_generation(&mut composition, restored_node_id);
 
     loaded_count.set_value(40);
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let after_node_id = captured_conditional_lazy_list_node_id();
+    let after_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
     let after_generation = node_generation(&mut composition, after_node_id);
 
     assert_eq!(
@@ -1253,39 +1259,48 @@ fn box_with_constraints_restored_weighted_branch_after_header_toggle_keeps_host_
     let mut composition = Composition::new(MemoryApplier::new());
     let runtime = composition.runtime_handle();
     let selected_story = cranpose_core::MutableState::with_runtime(None::<u64>, runtime.clone());
-
-    CONDITIONAL_LAZY_LIST_STATE.with(|slot| {
-        *slot.borrow_mut() = None;
-    });
-    CONDITIONAL_LAZY_LIST_NODE_ID.with(|slot| {
-        *slot.borrow_mut() = None;
-    });
+    let captured_state: CapturedLazyListState = Rc::new(RefCell::new(None));
+    let captured_node_id: CapturedNodeId = Rc::new(RefCell::new(None));
 
     composition
-        .render(location_key(file!(), line!(), column!()), || {
-            let list_state = rememberLazyListState();
-            BoxWithConstraints(Modifier::empty().fill_max_size(), move |_scope| {
-                Column(
-                    Modifier::empty().fill_max_size(),
-                    ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(12.0)),
-                    move || {
-                        PrimitiveHeaderWithOptionalBack(selected_story.value().is_some());
-                        let single_pane_key = selected_story.value();
-                        cranpose_core::with_key(&single_pane_key, move || {
-                            if single_pane_key.is_some() {
-                                PrimitiveThreadPaneLike(
-                                    Modifier::empty().fill_max_width().weight(1.0),
-                                );
-                            } else {
-                                PrimitiveStoriesPaneWithIndicator(
-                                    Modifier::empty().fill_max_width().weight(1.0),
-                                    list_state,
-                                );
+        .render(location_key(file!(), line!(), column!()), {
+            let captured_state = Rc::clone(&captured_state);
+            let captured_node_id = Rc::clone(&captured_node_id);
+            move || {
+                let list_state = rememberLazyListState();
+                let captured_state = Rc::clone(&captured_state);
+                let captured_node_id = Rc::clone(&captured_node_id);
+                BoxWithConstraints(Modifier::empty().fill_max_size(), move |_scope| {
+                    Column(
+                        Modifier::empty().fill_max_size(),
+                        ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(12.0)),
+                        {
+                            let captured_state = Rc::clone(&captured_state);
+                            let captured_node_id = Rc::clone(&captured_node_id);
+                            move || {
+                                PrimitiveHeaderWithOptionalBack(selected_story.value().is_some());
+                                let single_pane_key = selected_story.value();
+                                let captured_state = Rc::clone(&captured_state);
+                                let captured_node_id = Rc::clone(&captured_node_id);
+                                cranpose_core::with_key(&single_pane_key, move || {
+                                    if single_pane_key.is_some() {
+                                        PrimitiveThreadPaneLike(
+                                            Modifier::empty().fill_max_width().weight(1.0),
+                                        );
+                                    } else {
+                                        PrimitiveStoriesPaneWithIndicator(
+                                            Modifier::empty().fill_max_width().weight(1.0),
+                                            list_state,
+                                            Rc::clone(&captured_state),
+                                            Rc::clone(&captured_node_id),
+                                        );
+                                    }
+                                });
                             }
-                        });
-                    },
-                );
-            });
+                        },
+                    );
+                });
+            }
         })
         .expect("initial render");
 
@@ -1296,16 +1311,19 @@ fn box_with_constraints_restored_weighted_branch_after_header_toggle_keeps_host_
     };
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let list_state = captured_conditional_lazy_list_state();
-    let fresh_node_id = captured_conditional_lazy_list_node_id();
+    let list_state = captured_conditional_lazy_list_state(&captured_state);
+    let fresh_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
     let fresh_generation = node_generation(&mut composition, fresh_node_id);
 
     list_state.dispatch_scroll_delta(-120.0);
     settle_scroll_recomposition(&mut composition, root, size);
     assert_eq!(
         (
-            captured_conditional_lazy_list_node_id(),
-            node_generation(&mut composition, captured_conditional_lazy_list_node_id())
+            captured_conditional_lazy_list_node_id(&captured_node_id),
+            node_generation(
+                &mut composition,
+                captured_conditional_lazy_list_node_id(&captured_node_id)
+            )
         ),
         (fresh_node_id, fresh_generation),
         "fresh scroll should not recreate the lazy list host",
@@ -1329,14 +1347,14 @@ fn box_with_constraints_restored_weighted_branch_after_header_toggle_keeps_host_
     }
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let restored_node_id = captured_conditional_lazy_list_node_id();
+    let restored_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
     let restored_generation = node_generation(&mut composition, restored_node_id);
 
     let mut seen = Vec::new();
     for _ in 0..4 {
         list_state.dispatch_scroll_delta(-120.0);
         settle_scroll_recomposition(&mut composition, root, size);
-        let node_id = captured_conditional_lazy_list_node_id();
+        let node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
         let generation = node_generation(&mut composition, node_id);
         seen.push((node_id, generation));
     }

--- a/crates/cranpose-ui/src/tests/primitives_tests.rs
+++ b/crates/cranpose-ui/src/tests/primitives_tests.rs
@@ -28,6 +28,28 @@ use crate::{
 type CapturedLazyListState = Rc<RefCell<Option<LazyListState>>>;
 type CapturedNodeId = Rc<RefCell<Option<NodeId>>>;
 
+/// Bundles the two output slots the `BoxWithConstraints` conditional-branch
+/// tests capture out of a composable (its `LazyListState` and the `NodeId`
+/// the composable produced), so re-threading them through several levels of
+/// nested `Row`/`Column` closures is one `.clone()` per level instead of two
+/// independent `Rc::clone` calls. Every `CapturedLazyListSlot::new()` starts
+/// both slots empty and owned only by that call -- cloning shares the same
+/// two `Rc`s, never a slot from a different test.
+#[derive(Clone, PartialEq)]
+struct CapturedLazyListSlot {
+    state: CapturedLazyListState,
+    node_id: CapturedNodeId,
+}
+
+impl CapturedLazyListSlot {
+    fn new() -> Self {
+        Self {
+            state: Rc::new(RefCell::new(None)),
+            node_id: Rc::new(RefCell::new(None)),
+        }
+    }
+}
+
 fn prepare_measure_composer(
     slots: &mut SlotTable,
     applier: &mut MemoryApplier,
@@ -346,12 +368,8 @@ fn PrimitiveStoriesListBranch(list_state: LazyListState) {
 }
 
 #[composable]
-fn PrimitiveScrollReactiveStoriesBranch(
-    list_state: LazyListState,
-    captured_state: CapturedLazyListState,
-    captured_node_id: CapturedNodeId,
-) {
-    *captured_state.borrow_mut() = Some(list_state);
+fn PrimitiveScrollReactiveStoriesBranch(list_state: LazyListState, captures: CapturedLazyListSlot) {
+    *captures.state.borrow_mut() = Some(list_state);
 
     Column(
         Modifier::empty().fill_max_size(),
@@ -376,7 +394,7 @@ fn PrimitiveScrollReactiveStoriesBranch(
                     });
                 },
             );
-            *captured_node_id.borrow_mut() = Some(node_id);
+            *captures.node_id.borrow_mut() = Some(node_id);
         },
     );
 }
@@ -385,8 +403,7 @@ fn PrimitiveScrollReactiveStoriesBranch(
 fn PrimitiveStoriesPaneWithIndicator(
     modifier: Modifier,
     list_state: LazyListState,
-    captured_state: CapturedLazyListState,
-    captured_node_id: CapturedNodeId,
+    captures: CapturedLazyListSlot,
 ) {
     Column(
         modifier,
@@ -394,14 +411,12 @@ fn PrimitiveStoriesPaneWithIndicator(
         move || {
             Text("Top stories", Modifier::empty(), TextStyle::default());
             Text("40 loaded of 40", Modifier::empty(), TextStyle::default());
-            let captured_state = Rc::clone(&captured_state);
-            let captured_node_id = Rc::clone(&captured_node_id);
+            let captures = captures.clone();
             Row(
                 Modifier::empty().fill_max_width().weight(1.0),
                 RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
                 move || {
-                    let captured_state = Rc::clone(&captured_state);
-                    let captured_node_id = Rc::clone(&captured_node_id);
+                    let captures = captures.clone();
                     Column(
                         Modifier::empty().weight(1.0).fill_max_height(),
                         ColumnSpec::default(),
@@ -420,8 +435,8 @@ fn PrimitiveStoriesPaneWithIndicator(
                                     });
                                 },
                             );
-                            *captured_state.borrow_mut() = Some(list_state);
-                            *captured_node_id.borrow_mut() = Some(node_id);
+                            *captures.state.borrow_mut() = Some(list_state);
+                            *captures.node_id.borrow_mut() = Some(node_id);
                         },
                     );
                     Column(
@@ -446,8 +461,7 @@ fn PrimitiveStoriesPaneWithDynamicStatus(
     modifier: Modifier,
     list_state: LazyListState,
     loaded_count: cranpose_core::MutableState<usize>,
-    captured_state: CapturedLazyListState,
-    captured_node_id: CapturedNodeId,
+    captures: CapturedLazyListSlot,
 ) {
     Column(
         modifier,
@@ -459,14 +473,12 @@ fn PrimitiveStoriesPaneWithDynamicStatus(
                 Modifier::empty(),
                 TextStyle::default(),
             );
-            let captured_state = Rc::clone(&captured_state);
-            let captured_node_id = Rc::clone(&captured_node_id);
+            let captures = captures.clone();
             Row(
                 Modifier::empty().fill_max_width().weight(1.0),
                 RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
                 move || {
-                    let captured_state = Rc::clone(&captured_state);
-                    let captured_node_id = Rc::clone(&captured_node_id);
+                    let captures = captures.clone();
                     Column(
                         Modifier::empty().weight(1.0).fill_max_height(),
                         ColumnSpec::default(),
@@ -485,8 +497,8 @@ fn PrimitiveStoriesPaneWithDynamicStatus(
                                     });
                                 },
                             );
-                            *captured_state.borrow_mut() = Some(list_state);
-                            *captured_node_id.borrow_mut() = Some(node_id);
+                            *captures.state.borrow_mut() = Some(list_state);
+                            *captures.node_id.borrow_mut() = Some(node_id);
                         },
                     );
                     Column(
@@ -950,26 +962,21 @@ fn box_with_constraints_restored_lazy_list_branch_keeps_host_generation_during_s
     let mut composition = Composition::new(MemoryApplier::new());
     let runtime = composition.runtime_handle();
     let selected_story = cranpose_core::MutableState::with_runtime(None::<u64>, runtime.clone());
-    let captured_state: CapturedLazyListState = Rc::new(RefCell::new(None));
-    let captured_node_id: CapturedNodeId = Rc::new(RefCell::new(None));
+    let captures = CapturedLazyListSlot::new();
 
     composition
         .render(location_key(file!(), line!(), column!()), {
-            let captured_state = Rc::clone(&captured_state);
-            let captured_node_id = Rc::clone(&captured_node_id);
+            let captures = captures.clone();
             move || {
                 let list_state = rememberLazyListState();
-                let captured_state = Rc::clone(&captured_state);
-                let captured_node_id = Rc::clone(&captured_node_id);
+                let captures = captures.clone();
                 BoxWithConstraints(Modifier::empty().fill_max_size(), move |_scope| {
                     Column(Modifier::empty().fill_max_size(), ColumnSpec::default(), {
-                        let captured_state = Rc::clone(&captured_state);
-                        let captured_node_id = Rc::clone(&captured_node_id);
+                        let captures = captures.clone();
                         move || {
                             Text("Header", Modifier::empty(), TextStyle::default());
                             let single_pane_key = selected_story.value();
-                            let captured_state = Rc::clone(&captured_state);
-                            let captured_node_id = Rc::clone(&captured_node_id);
+                            let captures = captures.clone();
                             cranpose_core::with_key(&single_pane_key, move || {
                                 if single_pane_key.is_some() {
                                     PrimitiveThreadPaneLike(
@@ -978,8 +985,7 @@ fn box_with_constraints_restored_lazy_list_branch_keeps_host_generation_during_s
                                 } else {
                                     PrimitiveScrollReactiveStoriesBranch(
                                         list_state,
-                                        Rc::clone(&captured_state),
-                                        Rc::clone(&captured_node_id),
+                                        captures.clone(),
                                     );
                                 }
                             });
@@ -997,14 +1003,14 @@ fn box_with_constraints_restored_lazy_list_branch_keeps_host_generation_during_s
     };
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let list_state = captured_conditional_lazy_list_state(&captured_state);
-    let fresh_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
+    let list_state = captured_conditional_lazy_list_state(&captures.state);
+    let fresh_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
     let fresh_generation = node_generation(&mut composition, fresh_node_id);
 
     list_state.dispatch_scroll_delta(-120.0);
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let fresh_after_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
+    let fresh_after_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
     let fresh_after_generation = node_generation(&mut composition, fresh_after_node_id);
     assert_eq!(
         (fresh_after_node_id, fresh_after_generation),
@@ -1030,14 +1036,14 @@ fn box_with_constraints_restored_lazy_list_branch_keeps_host_generation_during_s
     }
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let restored_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
+    let restored_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
     let restored_generation = node_generation(&mut composition, restored_node_id);
 
     let mut seen = Vec::new();
     for _ in 0..4 {
         list_state.dispatch_scroll_delta(-120.0);
         settle_scroll_recomposition(&mut composition, root, size);
-        let node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
+        let node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
         let generation = node_generation(&mut composition, node_id);
         seen.push((node_id, generation));
     }
@@ -1055,29 +1061,24 @@ fn box_with_constraints_restored_weighted_lazy_list_branch_keeps_host_generation
     let mut composition = Composition::new(MemoryApplier::new());
     let runtime = composition.runtime_handle();
     let selected_story = cranpose_core::MutableState::with_runtime(None::<u64>, runtime.clone());
-    let captured_state: CapturedLazyListState = Rc::new(RefCell::new(None));
-    let captured_node_id: CapturedNodeId = Rc::new(RefCell::new(None));
+    let captures = CapturedLazyListSlot::new();
 
     composition
         .render(location_key(file!(), line!(), column!()), {
-            let captured_state = Rc::clone(&captured_state);
-            let captured_node_id = Rc::clone(&captured_node_id);
+            let captures = captures.clone();
             move || {
                 let list_state = rememberLazyListState();
-                let captured_state = Rc::clone(&captured_state);
-                let captured_node_id = Rc::clone(&captured_node_id);
+                let captures = captures.clone();
                 BoxWithConstraints(Modifier::empty().fill_max_size(), move |_scope| {
                     Column(
                         Modifier::empty().fill_max_size(),
                         ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(12.0)),
                         {
-                            let captured_state = Rc::clone(&captured_state);
-                            let captured_node_id = Rc::clone(&captured_node_id);
+                            let captures = captures.clone();
                             move || {
                                 Text("Header", Modifier::empty(), TextStyle::default());
                                 let single_pane_key = selected_story.value();
-                                let captured_state = Rc::clone(&captured_state);
-                                let captured_node_id = Rc::clone(&captured_node_id);
+                                let captures = captures.clone();
                                 cranpose_core::with_key(&single_pane_key, move || {
                                     if single_pane_key.is_some() {
                                         PrimitiveThreadPaneLike(
@@ -1087,8 +1088,7 @@ fn box_with_constraints_restored_weighted_lazy_list_branch_keeps_host_generation
                                         PrimitiveStoriesPaneWithIndicator(
                                             Modifier::empty().fill_max_width().weight(1.0),
                                             list_state,
-                                            Rc::clone(&captured_state),
-                                            Rc::clone(&captured_node_id),
+                                            captures.clone(),
                                         );
                                     }
                                 });
@@ -1107,14 +1107,14 @@ fn box_with_constraints_restored_weighted_lazy_list_branch_keeps_host_generation
     };
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let list_state = captured_conditional_lazy_list_state(&captured_state);
-    let fresh_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
+    let list_state = captured_conditional_lazy_list_state(&captures.state);
+    let fresh_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
     let fresh_generation = node_generation(&mut composition, fresh_node_id);
 
     list_state.dispatch_scroll_delta(-120.0);
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let fresh_after_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
+    let fresh_after_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
     let fresh_after_generation = node_generation(&mut composition, fresh_after_node_id);
     assert_eq!(
         (fresh_after_node_id, fresh_after_generation),
@@ -1140,14 +1140,14 @@ fn box_with_constraints_restored_weighted_lazy_list_branch_keeps_host_generation
     }
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let restored_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
+    let restored_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
     let restored_generation = node_generation(&mut composition, restored_node_id);
 
     let mut seen = Vec::new();
     for _ in 0..4 {
         list_state.dispatch_scroll_delta(-120.0);
         settle_scroll_recomposition(&mut composition, root, size);
-        let node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
+        let node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
         let generation = node_generation(&mut composition, node_id);
         seen.push((node_id, generation));
     }
@@ -1166,29 +1166,24 @@ fn box_with_constraints_restored_weighted_lazy_list_branch_keeps_host_during_sta
     let runtime = composition.runtime_handle();
     let selected_story = cranpose_core::MutableState::with_runtime(None::<u64>, runtime.clone());
     let loaded_count = cranpose_core::MutableState::with_runtime(20usize, runtime.clone());
-    let captured_state: CapturedLazyListState = Rc::new(RefCell::new(None));
-    let captured_node_id: CapturedNodeId = Rc::new(RefCell::new(None));
+    let captures = CapturedLazyListSlot::new();
 
     composition
         .render(location_key(file!(), line!(), column!()), {
-            let captured_state = Rc::clone(&captured_state);
-            let captured_node_id = Rc::clone(&captured_node_id);
+            let captures = captures.clone();
             move || {
                 let list_state = rememberLazyListState();
-                let captured_state = Rc::clone(&captured_state);
-                let captured_node_id = Rc::clone(&captured_node_id);
+                let captures = captures.clone();
                 BoxWithConstraints(Modifier::empty().fill_max_size(), move |_scope| {
                     Column(
                         Modifier::empty().fill_max_size(),
                         ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(12.0)),
                         {
-                            let captured_state = Rc::clone(&captured_state);
-                            let captured_node_id = Rc::clone(&captured_node_id);
+                            let captures = captures.clone();
                             move || {
                                 Text("Header", Modifier::empty(), TextStyle::default());
                                 let single_pane_key = selected_story.value();
-                                let captured_state = Rc::clone(&captured_state);
-                                let captured_node_id = Rc::clone(&captured_node_id);
+                                let captures = captures.clone();
                                 cranpose_core::with_key(&single_pane_key, move || {
                                     if single_pane_key.is_some() {
                                         PrimitiveThreadPaneLike(
@@ -1199,8 +1194,7 @@ fn box_with_constraints_restored_weighted_lazy_list_branch_keeps_host_during_sta
                                             Modifier::empty().fill_max_width().weight(1.0),
                                             list_state,
                                             loaded_count,
-                                            Rc::clone(&captured_state),
-                                            Rc::clone(&captured_node_id),
+                                            captures.clone(),
                                         );
                                     }
                                 });
@@ -1237,13 +1231,13 @@ fn box_with_constraints_restored_weighted_lazy_list_branch_keeps_host_during_sta
     }
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let restored_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
+    let restored_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
     let restored_generation = node_generation(&mut composition, restored_node_id);
 
     loaded_count.set_value(40);
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let after_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
+    let after_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
     let after_generation = node_generation(&mut composition, after_node_id);
 
     assert_eq!(
@@ -1259,29 +1253,24 @@ fn box_with_constraints_restored_weighted_branch_after_header_toggle_keeps_host_
     let mut composition = Composition::new(MemoryApplier::new());
     let runtime = composition.runtime_handle();
     let selected_story = cranpose_core::MutableState::with_runtime(None::<u64>, runtime.clone());
-    let captured_state: CapturedLazyListState = Rc::new(RefCell::new(None));
-    let captured_node_id: CapturedNodeId = Rc::new(RefCell::new(None));
+    let captures = CapturedLazyListSlot::new();
 
     composition
         .render(location_key(file!(), line!(), column!()), {
-            let captured_state = Rc::clone(&captured_state);
-            let captured_node_id = Rc::clone(&captured_node_id);
+            let captures = captures.clone();
             move || {
                 let list_state = rememberLazyListState();
-                let captured_state = Rc::clone(&captured_state);
-                let captured_node_id = Rc::clone(&captured_node_id);
+                let captures = captures.clone();
                 BoxWithConstraints(Modifier::empty().fill_max_size(), move |_scope| {
                     Column(
                         Modifier::empty().fill_max_size(),
                         ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(12.0)),
                         {
-                            let captured_state = Rc::clone(&captured_state);
-                            let captured_node_id = Rc::clone(&captured_node_id);
+                            let captures = captures.clone();
                             move || {
                                 PrimitiveHeaderWithOptionalBack(selected_story.value().is_some());
                                 let single_pane_key = selected_story.value();
-                                let captured_state = Rc::clone(&captured_state);
-                                let captured_node_id = Rc::clone(&captured_node_id);
+                                let captures = captures.clone();
                                 cranpose_core::with_key(&single_pane_key, move || {
                                     if single_pane_key.is_some() {
                                         PrimitiveThreadPaneLike(
@@ -1291,8 +1280,7 @@ fn box_with_constraints_restored_weighted_branch_after_header_toggle_keeps_host_
                                         PrimitiveStoriesPaneWithIndicator(
                                             Modifier::empty().fill_max_width().weight(1.0),
                                             list_state,
-                                            Rc::clone(&captured_state),
-                                            Rc::clone(&captured_node_id),
+                                            captures.clone(),
                                         );
                                     }
                                 });
@@ -1311,18 +1299,18 @@ fn box_with_constraints_restored_weighted_branch_after_header_toggle_keeps_host_
     };
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let list_state = captured_conditional_lazy_list_state(&captured_state);
-    let fresh_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
+    let list_state = captured_conditional_lazy_list_state(&captures.state);
+    let fresh_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
     let fresh_generation = node_generation(&mut composition, fresh_node_id);
 
     list_state.dispatch_scroll_delta(-120.0);
     settle_scroll_recomposition(&mut composition, root, size);
     assert_eq!(
         (
-            captured_conditional_lazy_list_node_id(&captured_node_id),
+            captured_conditional_lazy_list_node_id(&captures.node_id),
             node_generation(
                 &mut composition,
-                captured_conditional_lazy_list_node_id(&captured_node_id)
+                captured_conditional_lazy_list_node_id(&captures.node_id)
             )
         ),
         (fresh_node_id, fresh_generation),
@@ -1347,14 +1335,14 @@ fn box_with_constraints_restored_weighted_branch_after_header_toggle_keeps_host_
     }
     settle_scroll_recomposition(&mut composition, root, size);
 
-    let restored_node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
+    let restored_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
     let restored_generation = node_generation(&mut composition, restored_node_id);
 
     let mut seen = Vec::new();
     for _ in 0..4 {
         list_state.dispatch_scroll_delta(-120.0);
         settle_scroll_recomposition(&mut composition, root, size);
-        let node_id = captured_conditional_lazy_list_node_id(&captured_node_id);
+        let node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
         let generation = node_generation(&mut composition, node_id);
         seen.push((node_id, generation));
     }

--- a/crates/cranpose-ui/src/tests/tab_switching_tests.rs
+++ b/crates/cranpose-ui/src/tests/tab_switching_tests.rs
@@ -1,4 +1,7 @@
-use std::cell::{Cell, RefCell};
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
 
 use cranpose_core::{Composition, MemoryApplier, MutableState, NodeId, location_key};
 use cranpose_macros::composable;
@@ -8,13 +11,6 @@ use crate::{
     layout::{LayoutEngine, MeasureLayoutOptions},
     measure_layout_with_options,
 };
-
-thread_local! {
-    static PROGRESS_TAB_RENDERS: Cell<usize> = const { Cell::new(0) };
-    static PROGRESS_BAR_BRANCH_CALLS: Cell<usize> = const { Cell::new(0) };
-    static RESTORED_COUNTER_STATE: RefCell<Option<MutableState<i32>>> = const { RefCell::new(None) };
-    static RESTORED_POINTER_STATE: RefCell<Option<MutableState<i32>>> = const { RefCell::new(None) };
-}
 
 fn expected_layout_counts(depth: usize, horizontal: bool) -> (usize, usize) {
     if depth <= 1 {
@@ -31,11 +27,6 @@ fn expected_layout_counts(depth: usize, horizontal: bool) -> (usize, usize) {
         let two = 1 + 1 + left_two + right_two;
         (total, two)
     }
-}
-
-fn reset_progress_counters() {
-    PROGRESS_TAB_RENDERS.with(|c| c.set(0));
-    PROGRESS_BAR_BRANCH_CALLS.with(|c| c.set(0));
 }
 
 fn composition_layout_texts(composition: &mut Composition<MemoryApplier>) -> Vec<String> {
@@ -102,8 +93,12 @@ fn run_recursive_depth_cycle(
 }
 
 #[composable]
-fn progress_tab(progress: MutableState<f32>) {
-    PROGRESS_TAB_RENDERS.with(|c| c.set(c.get() + 1));
+fn progress_tab(
+    progress: MutableState<f32>,
+    renders: Rc<Cell<usize>>,
+    branch_calls: Rc<Cell<usize>>,
+) {
+    renders.set(renders.get() + 1);
     let progress_value = progress.value();
 
     Column(
@@ -122,9 +117,10 @@ fn progress_tab(progress: MutableState<f32>) {
                     .then(Modifier::empty().height(12.0)),
                 RowSpec::default(),
                 {
+                    let branch_calls = Rc::clone(&branch_calls);
                     move || {
                         if progress_value > 0.0 {
-                            PROGRESS_BAR_BRANCH_CALLS.with(|c| c.set(c.get() + 1));
+                            branch_calls.set(branch_calls.get() + 1);
                             Row(
                                 Modifier::empty()
                                     .width(200.0 * progress_value)
@@ -155,9 +151,14 @@ fn summary_tab() {
     );
 }
 
-fn make_tab_renderer(active_tab: MutableState<i32>, progress: MutableState<f32>) -> impl FnMut() {
+fn make_tab_renderer(
+    active_tab: MutableState<i32>,
+    progress: MutableState<f32>,
+    renders: Rc<Cell<usize>>,
+    branch_calls: Rc<Cell<usize>>,
+) -> impl FnMut() {
     move || match active_tab.value() {
-        0 => progress_tab(progress),
+        0 => progress_tab(progress, Rc::clone(&renders), Rc::clone(&branch_calls)),
         _ => summary_tab(),
     }
 }
@@ -182,17 +183,16 @@ fn scrollable_test_tab(label: &'static str) {
 }
 
 #[composable]
-fn wrapped_stateful_counter_tab() {
+fn wrapped_stateful_counter_tab(
+    restored_counter: Rc<RefCell<Option<MutableState<i32>>>>,
+    restored_pointer: Rc<RefCell<Option<MutableState<i32>>>>,
+) {
     let scroll_state = cranpose_core::remember(|| ScrollState::new(0.0)).with(|state| *state);
     let counter = cranpose_core::rememberMutableStateOf(|| 0i32);
     let pointer = cranpose_core::rememberMutableStateOf(|| 0i32);
     let is_even = counter.value() % 2 == 0;
-    RESTORED_COUNTER_STATE.with(|slot| {
-        *slot.borrow_mut() = Some(counter);
-    });
-    RESTORED_POINTER_STATE.with(|slot| {
-        *slot.borrow_mut() = Some(pointer);
-    });
+    *restored_counter.borrow_mut() = Some(counter);
+    *restored_pointer.borrow_mut() = Some(pointer);
 
     Column(
         Modifier::empty()
@@ -267,7 +267,11 @@ fn mixed_scrollable_tab_host(active_tab: MutableState<i32>, counter: MutableStat
 }
 
 #[composable]
-fn wrapped_tab_switching_host(active_tab: MutableState<i32>) {
+fn wrapped_tab_switching_host(
+    active_tab: MutableState<i32>,
+    restored_counter: Rc<RefCell<Option<MutableState<i32>>>>,
+    restored_pointer: Rc<RefCell<Option<MutableState<i32>>>>,
+) {
     Column(
         Modifier::empty().fill_max_size(),
         ColumnSpec::default(),
@@ -281,13 +285,20 @@ fn wrapped_tab_switching_host(active_tab: MutableState<i32>) {
             Box(
                 Modifier::empty().fill_max_width().weight(1.0),
                 BoxSpec::default(),
-                move || {
-                    let active = active_tab.value();
-                    cranpose_core::with_key(&active, || match active {
-                        0 => wrapped_stateful_counter_tab(),
-                        1 => scrollable_test_tab("Composition Local Marker"),
-                        _ => scrollable_test_tab("Web Fetch Marker"),
-                    });
+                {
+                    let restored_counter = Rc::clone(&restored_counter);
+                    let restored_pointer = Rc::clone(&restored_pointer);
+                    move || {
+                        let active = active_tab.value();
+                        cranpose_core::with_key(&active, || match active {
+                            0 => wrapped_stateful_counter_tab(
+                                Rc::clone(&restored_counter),
+                                Rc::clone(&restored_pointer),
+                            ),
+                            1 => scrollable_test_tab("Composition Local Marker"),
+                            _ => scrollable_test_tab("Web Fetch Marker"),
+                        });
+                    }
                 },
             );
         },
@@ -303,18 +314,24 @@ fn tab_switching_restores_conditional_layout_nodes() {
     let progress = MutableState::with_runtime(0.75f32, runtime.clone());
 
     let key = location_key(file!(), line!(), column!());
-    let mut render = make_tab_renderer(active_tab, progress);
+    let renders = Rc::new(Cell::new(0));
+    let branch_calls = Rc::new(Cell::new(0));
+    let mut render = make_tab_renderer(
+        active_tab,
+        progress,
+        Rc::clone(&renders),
+        Rc::clone(&branch_calls),
+    );
 
-    reset_progress_counters();
     composition
         .render(key, &mut render)
         .expect("initial render");
     assert!(
-        PROGRESS_TAB_RENDERS.with(|c| c.get()) > 0,
+        renders.get() > 0,
         "progress tab should render on initial composition"
     );
     assert!(
-        PROGRESS_BAR_BRANCH_CALLS.with(|c| c.get()) > 0,
+        branch_calls.get() > 0,
         "conditional progress bar should be built on initial render"
     );
 
@@ -334,16 +351,17 @@ fn tab_switching_restores_conditional_layout_nodes() {
         .expect("update progress while hidden");
 
     active_tab.set_value(0);
-    reset_progress_counters();
+    renders.set(0);
+    branch_calls.set(0);
     composition
         .render(key, &mut render)
         .expect("render primary tab after switch");
     assert!(
-        PROGRESS_TAB_RENDERS.with(|c| c.get()) > 0,
+        renders.get() > 0,
         "progress tab should render after switching back"
     );
     assert!(
-        PROGRESS_BAR_BRANCH_CALLS.with(|c| c.get()) > 0,
+        branch_calls.get() > 0,
         "conditional progress bar should rebuild after switching back"
     );
 }
@@ -396,8 +414,8 @@ fn scrollable_tab_host_preserves_content_across_mixed_switches() {
 #[test]
 fn restored_wrapped_counter_tab_updates_after_mixed_tab_walk() {
     let _app_context = crate::render_state::app_context_test_scope();
-    RESTORED_COUNTER_STATE.with(|slot| slot.borrow_mut().take());
-    RESTORED_POINTER_STATE.with(|slot| slot.borrow_mut().take());
+    let restored_counter = Rc::new(RefCell::new(None));
+    let restored_pointer = Rc::new(RefCell::new(None));
 
     let mut composition = Composition::new(MemoryApplier::new());
     let runtime = composition.runtime_handle();
@@ -405,7 +423,17 @@ fn restored_wrapped_counter_tab_updates_after_mixed_tab_walk() {
     let key = location_key(file!(), line!(), column!());
 
     composition
-        .render(key, || wrapped_tab_switching_host(active_tab))
+        .render(key, {
+            let restored_counter = Rc::clone(&restored_counter);
+            let restored_pointer = Rc::clone(&restored_pointer);
+            move || {
+                wrapped_tab_switching_host(
+                    active_tab,
+                    Rc::clone(&restored_counter),
+                    Rc::clone(&restored_pointer),
+                )
+            }
+        })
         .expect("initial render");
     drain_all(&mut composition);
 
@@ -436,11 +464,15 @@ fn restored_wrapped_counter_tab_updates_after_mixed_tab_walk() {
 
     active_tab.set_value(0);
     drain_all(&mut composition);
-    let restored_counter = RESTORED_COUNTER_STATE
-        .with(|slot| slot.borrow().as_ref().copied())
+    let restored_counter = restored_counter
+        .borrow()
+        .as_ref()
+        .copied()
         .expect("restored counter state registered");
-    let restored_pointer = RESTORED_POINTER_STATE
-        .with(|slot| slot.borrow().as_ref().copied())
+    let restored_pointer = restored_pointer
+        .borrow()
+        .as_ref()
+        .copied()
         .expect("restored pointer state registered");
 
     restored_pointer.set_value(1);
@@ -472,7 +504,14 @@ fn tab_switching_multiple_toggle_cycles_stays_responsive() {
     let progress = MutableState::with_runtime(0.4f32, runtime.clone());
 
     let key = location_key(file!(), line!(), column!());
-    let mut render = make_tab_renderer(active_tab, progress);
+    let renders = Rc::new(Cell::new(0));
+    let branch_calls = Rc::new(Cell::new(0));
+    let mut render = make_tab_renderer(
+        active_tab,
+        progress,
+        Rc::clone(&renders),
+        Rc::clone(&branch_calls),
+    );
 
     composition
         .render(key, &mut render)
@@ -490,12 +529,12 @@ fn tab_switching_multiple_toggle_cycles_stays_responsive() {
             .expect("process progress change while hidden");
 
         active_tab.set_value(0);
-        reset_progress_counters();
+        renders.set(0);
         composition
             .render(key, &mut render)
             .expect("render progress tab after switch");
         assert!(
-            PROGRESS_TAB_RENDERS.with(|c| c.get()) > 0,
+            renders.get() > 0,
             "cycle {cycle}: progress tab should render after returning"
         );
     }
@@ -510,7 +549,12 @@ fn tab_switching_layout_pass_handles_conditional_nodes() {
     let progress = MutableState::with_runtime(0.8f32, runtime.clone());
 
     let key = location_key(file!(), line!(), column!());
-    let mut render = make_tab_renderer(active_tab, progress);
+    let mut render = make_tab_renderer(
+        active_tab,
+        progress,
+        Rc::new(Cell::new(0)),
+        Rc::new(Cell::new(0)),
+    );
 
     composition
         .render(key, &mut render)
@@ -926,7 +970,12 @@ fn tab_switching_node_vec_does_not_grow_unboundedly() {
     let progress = MutableState::with_runtime(0.5f32, runtime);
 
     let key = location_key(file!(), line!(), column!());
-    let mut render = make_tab_renderer(active_tab, progress);
+    let mut render = make_tab_renderer(
+        active_tab,
+        progress,
+        Rc::new(Cell::new(0)),
+        Rc::new(Cell::new(0)),
+    );
 
     composition.render(key, &mut render).expect("initial");
     active_tab.set_value(1);

--- a/crates/cranpose-ui/src/tests/tab_switching_tests.rs
+++ b/crates/cranpose-ui/src/tests/tab_switching_tests.rs
@@ -163,6 +163,51 @@ fn make_tab_renderer(
     }
 }
 
+/// Shared harness for the `progress_tab`/`summary_tab` switching tests: owns
+/// the composition, the render closure, and the render/branch-call counters
+/// so each test only supplies the one thing that varies between them (the
+/// initial progress value) instead of re-deriving this scaffold by hand.
+/// Every call builds a fresh composition and fresh `Rc<Cell<usize>>`
+/// counters -- nothing here is shared or cached across tests.
+struct ProgressTabHarness {
+    _app_context: crate::render_state::TestAppContextScope,
+    composition: Composition<MemoryApplier>,
+    active_tab: MutableState<i32>,
+    progress: MutableState<f32>,
+    key: cranpose_core::Key,
+    render: Box<dyn FnMut()>,
+    renders: Rc<Cell<usize>>,
+    branch_calls: Rc<Cell<usize>>,
+}
+
+fn render_progress_tab_host(initial_progress: f32) -> ProgressTabHarness {
+    let _app_context = crate::render_state::app_context_test_scope();
+    let composition = Composition::new(MemoryApplier::new());
+    let runtime = composition.runtime_handle();
+    let active_tab = MutableState::with_runtime(0i32, runtime.clone());
+    let progress = MutableState::with_runtime(initial_progress, runtime.clone());
+    let key = location_key(file!(), line!(), column!());
+    let renders = Rc::new(Cell::new(0));
+    let branch_calls = Rc::new(Cell::new(0));
+    let render: Box<dyn FnMut()> = Box::new(make_tab_renderer(
+        active_tab,
+        progress,
+        Rc::clone(&renders),
+        Rc::clone(&branch_calls),
+    ));
+
+    ProgressTabHarness {
+        _app_context,
+        composition,
+        active_tab,
+        progress,
+        key,
+        render,
+        renders,
+        branch_calls,
+    }
+}
+
 #[composable]
 fn scrollable_test_tab(label: &'static str) {
     let scroll_state = cranpose_core::remember(|| ScrollState::new(0.0)).with(|state| *state);
@@ -307,61 +352,52 @@ fn wrapped_tab_switching_host(
 
 #[test]
 fn tab_switching_restores_conditional_layout_nodes() {
-    let _app_context = crate::render_state::app_context_test_scope();
-    let mut composition = Composition::new(MemoryApplier::new());
-    let runtime = composition.runtime_handle();
-    let active_tab = MutableState::with_runtime(0i32, runtime.clone());
-    let progress = MutableState::with_runtime(0.75f32, runtime.clone());
+    let mut harness = render_progress_tab_host(0.75);
 
-    let key = location_key(file!(), line!(), column!());
-    let renders = Rc::new(Cell::new(0));
-    let branch_calls = Rc::new(Cell::new(0));
-    let mut render = make_tab_renderer(
-        active_tab,
-        progress,
-        Rc::clone(&renders),
-        Rc::clone(&branch_calls),
-    );
-
-    composition
-        .render(key, &mut render)
+    harness
+        .composition
+        .render(harness.key, &mut harness.render)
         .expect("initial render");
     assert!(
-        renders.get() > 0,
+        harness.renders.get() > 0,
         "progress tab should render on initial composition"
     );
     assert!(
-        branch_calls.get() > 0,
+        harness.branch_calls.get() > 0,
         "conditional progress bar should be built on initial render"
     );
 
-    progress.set_value(0.0);
-    composition
+    harness.progress.set_value(0.0);
+    harness
+        .composition
         .process_invalid_scopes()
         .expect("recompose after collapsing progress");
 
-    active_tab.set_value(1);
-    composition
-        .render(key, &mut render)
+    harness.active_tab.set_value(1);
+    harness
+        .composition
+        .render(harness.key, &mut harness.render)
         .expect("render secondary tab");
 
-    progress.set_value(0.65);
-    composition
+    harness.progress.set_value(0.65);
+    harness
+        .composition
         .process_invalid_scopes()
         .expect("update progress while hidden");
 
-    active_tab.set_value(0);
-    renders.set(0);
-    branch_calls.set(0);
-    composition
-        .render(key, &mut render)
+    harness.active_tab.set_value(0);
+    harness.renders.set(0);
+    harness.branch_calls.set(0);
+    harness
+        .composition
+        .render(harness.key, &mut harness.render)
         .expect("render primary tab after switch");
     assert!(
-        renders.get() > 0,
+        harness.renders.get() > 0,
         "progress tab should render after switching back"
     );
     assert!(
-        branch_calls.get() > 0,
+        harness.branch_calls.get() > 0,
         "conditional progress bar should rebuild after switching back"
     );
 }
@@ -497,44 +533,36 @@ fn restored_wrapped_counter_tab_updates_after_mixed_tab_walk() {
 
 #[test]
 fn tab_switching_multiple_toggle_cycles_stays_responsive() {
-    let _app_context = crate::render_state::app_context_test_scope();
-    let mut composition = Composition::new(MemoryApplier::new());
-    let runtime = composition.runtime_handle();
-    let active_tab = MutableState::with_runtime(0i32, runtime.clone());
-    let progress = MutableState::with_runtime(0.4f32, runtime.clone());
+    let mut harness = render_progress_tab_host(0.4);
 
-    let key = location_key(file!(), line!(), column!());
-    let renders = Rc::new(Cell::new(0));
-    let branch_calls = Rc::new(Cell::new(0));
-    let mut render = make_tab_renderer(
-        active_tab,
-        progress,
-        Rc::clone(&renders),
-        Rc::clone(&branch_calls),
-    );
-
-    composition
-        .render(key, &mut render)
+    harness
+        .composition
+        .render(harness.key, &mut harness.render)
         .expect("initial render");
 
     for cycle in 0..6 {
-        active_tab.set_value(1);
-        composition
-            .render(key, &mut render)
+        harness.active_tab.set_value(1);
+        harness
+            .composition
+            .render(harness.key, &mut harness.render)
             .expect("render summary tab");
 
-        progress.set_value(if cycle % 2 == 0 { 0.0 } else { 0.9 });
-        composition
+        harness
+            .progress
+            .set_value(if cycle % 2 == 0 { 0.0 } else { 0.9 });
+        harness
+            .composition
             .process_invalid_scopes()
             .expect("process progress change while hidden");
 
-        active_tab.set_value(0);
-        renders.set(0);
-        composition
-            .render(key, &mut render)
+        harness.active_tab.set_value(0);
+        harness.renders.set(0);
+        harness
+            .composition
+            .render(harness.key, &mut harness.render)
             .expect("render progress tab after switch");
         assert!(
-            renders.get() > 0,
+            harness.renders.get() > 0,
             "cycle {cycle}: progress tab should render after returning"
         );
     }
@@ -542,48 +570,42 @@ fn tab_switching_multiple_toggle_cycles_stays_responsive() {
 
 #[test]
 fn tab_switching_layout_pass_handles_conditional_nodes() {
-    let _app_context = crate::render_state::app_context_test_scope();
-    let mut composition = Composition::new(MemoryApplier::new());
-    let runtime = composition.runtime_handle();
-    let active_tab = MutableState::with_runtime(0i32, runtime.clone());
-    let progress = MutableState::with_runtime(0.8f32, runtime.clone());
+    let mut harness = render_progress_tab_host(0.8);
 
-    let key = location_key(file!(), line!(), column!());
-    let mut render = make_tab_renderer(
-        active_tab,
-        progress,
-        Rc::new(Cell::new(0)),
-        Rc::new(Cell::new(0)),
-    );
-
-    composition
-        .render(key, &mut render)
+    harness
+        .composition
+        .render(harness.key, &mut harness.render)
         .expect("initial render");
 
-    progress.set_value(0.0);
-    composition
+    harness.progress.set_value(0.0);
+    harness
+        .composition
         .process_invalid_scopes()
         .expect("collapse progress to zero");
 
-    active_tab.set_value(1);
-    composition
-        .render(key, &mut render)
+    harness.active_tab.set_value(1);
+    harness
+        .composition
+        .render(harness.key, &mut harness.render)
         .expect("render inactive summary tab");
 
-    progress.set_value(0.55);
-    composition
+    harness.progress.set_value(0.55);
+    harness
+        .composition
         .process_invalid_scopes()
         .expect("update progress while hidden");
 
-    active_tab.set_value(0);
-    composition
-        .render(key, &mut render)
+    harness.active_tab.set_value(0);
+    harness
+        .composition
+        .render(harness.key, &mut harness.render)
         .expect("render progress tab again");
 
-    let root = composition
+    let root = harness
+        .composition
         .root()
         .expect("composition should have a root node");
-    let mut applier = composition.applier_mut();
+    let mut applier = harness.composition.applier_mut();
     let viewport = crate::modifier::Size {
         width: 800.0,
         height: 600.0,
@@ -963,40 +985,47 @@ fn recursive_layout_depth_decrease_then_increase_restores_branches() {
 
 #[test]
 fn tab_switching_node_vec_does_not_grow_unboundedly() {
-    let _app_context = crate::render_state::app_context_test_scope();
-    let mut composition = Composition::new(MemoryApplier::new());
-    let runtime = composition.runtime_handle();
-    let active_tab = MutableState::with_runtime(0i32, runtime.clone());
-    let progress = MutableState::with_runtime(0.5f32, runtime);
+    let mut harness = render_progress_tab_host(0.5);
 
-    let key = location_key(file!(), line!(), column!());
-    let mut render = make_tab_renderer(
-        active_tab,
-        progress,
-        Rc::new(Cell::new(0)),
-        Rc::new(Cell::new(0)),
-    );
+    harness
+        .composition
+        .render(harness.key, &mut harness.render)
+        .expect("initial");
+    harness.active_tab.set_value(1);
+    while harness
+        .composition
+        .process_invalid_scopes()
+        .expect("switch")
+    {}
+    harness.active_tab.set_value(0);
+    while harness
+        .composition
+        .process_invalid_scopes()
+        .expect("switch back")
+    {}
 
-    composition.render(key, &mut render).expect("initial");
-    active_tab.set_value(1);
-    while composition.process_invalid_scopes().expect("switch") {}
-    active_tab.set_value(0);
-    while composition.process_invalid_scopes().expect("switch back") {}
-
-    let baseline_active = composition.applier_mut().len();
-    let baseline_capacity = composition.applier_mut().capacity();
-    let baseline_slots = composition.debug_dump_slot_entries().len();
+    let baseline_active = harness.composition.applier_mut().len();
+    let baseline_capacity = harness.composition.applier_mut().capacity();
+    let baseline_slots = harness.composition.debug_dump_slot_entries().len();
 
     for _ in 0..50 {
-        active_tab.set_value(1);
-        while composition.process_invalid_scopes().expect("to tab 1") {}
-        active_tab.set_value(0);
-        while composition.process_invalid_scopes().expect("to tab 0") {}
+        harness.active_tab.set_value(1);
+        while harness
+            .composition
+            .process_invalid_scopes()
+            .expect("to tab 1")
+        {}
+        harness.active_tab.set_value(0);
+        while harness
+            .composition
+            .process_invalid_scopes()
+            .expect("to tab 0")
+        {}
     }
 
-    let final_active = composition.applier_mut().len();
-    let final_capacity = composition.applier_mut().capacity();
-    let final_slots = composition.debug_dump_slot_entries().len();
+    let final_active = harness.composition.applier_mut().len();
+    let final_capacity = harness.composition.applier_mut().capacity();
+    let final_slots = harness.composition.debug_dump_slot_entries().len();
 
     assert_eq!(
         baseline_active, final_active,

--- a/crates/cranpose-ui/src/tests/tab_switching_tests.rs
+++ b/crates/cranpose-ui/src/tests/tab_switching_tests.rs
@@ -163,12 +163,6 @@ fn make_tab_renderer(
     }
 }
 
-/// Shared harness for the `progress_tab`/`summary_tab` switching tests: owns
-/// the composition, the render closure, and the render/branch-call counters
-/// so each test only supplies the one thing that varies between them (the
-/// initial progress value) instead of re-deriving this scaffold by hand.
-/// Every call builds a fresh composition and fresh `Rc<Cell<usize>>`
-/// counters -- nothing here is shared or cached across tests.
 struct ProgressTabHarness {
     _app_context: crate::render_state::TestAppContextScope,
     composition: Composition<MemoryApplier>,

--- a/crates/cranpose-ui/src/tests/wear_widget_tests.rs
+++ b/crates/cranpose-ui/src/tests/wear_widget_tests.rs
@@ -878,13 +878,6 @@ fn compose_credits_screen() -> (TestComposition, CapturedListState) {
                         inner,
                         WearScalingLazyColumnSpec::default().content_padding(30.0, SCREEN_VERTICAL),
                         move |scope| {
-                            // Six lines and then the button, rather than four: a
-                            // scaling list stacks its DRAWN boxes a gap apart, so a
-                            // shrunken row does not push the one after it down and
-                            // a short list keeps more of itself on the first
-                            // screen. `a_row_below_the_fold_paints_once_it_is_scrolled_to`
-                            // needs the button genuinely off screen at rest, and
-                            // with four lines above it no longer is.
                             let lines = [
                                 "ORBIT BREAKER",
                                 "Version 1.0.0-debug",

--- a/crates/cranpose-ui/src/tests/wear_widget_tests.rs
+++ b/crates/cranpose-ui/src/tests/wear_widget_tests.rs
@@ -30,10 +30,6 @@ const SCREEN_VERTICAL: f32 = 34.0;
 const HEADER_HEIGHT: f32 = 48.0;
 const ROW_HEIGHT: f32 = 52.0;
 
-thread_local! {
-    static LAST_STATE: RefCell<Option<WearScalingListState>> = const { RefCell::new(None) };
-}
-
 fn measured_colors() -> WearColors {
     WearColors {
         primary: Color::from_rgb_u8(0xB9, 0xF2, 0xFF),
@@ -56,36 +52,46 @@ fn settings_spec() -> WearScalingLazyColumnSpec {
     WearScalingLazyColumnSpec::default().content_padding(SETTINGS_SIDE, SCREEN_VERTICAL)
 }
 
-fn compose_fixed_rows(heights: Vec<f32>, spec: WearScalingLazyColumnSpec) -> TestComposition {
-    run_test_composition(move || {
-        crate::set_density(PX);
-        let state = rememberWearScalingListState(CentreAnchor::default());
-        LAST_STATE.with(|cell| *cell.borrow_mut() = Some(state));
-        let heights = heights.clone();
-        WearScalingLazyColumn(
-            Modifier::empty().fill_max_size(),
-            state,
-            spec,
-            move |scope| {
-                let heights = heights.clone();
-                scope.items(
-                    LazyItems::new(heights.len()).key(|index: usize| index as u64),
-                    move |index| {
-                        Spacer(Size {
-                            width: 0.0,
-                            height: heights[index],
-                        });
-                    },
-                );
-            },
-        );
-    })
+type CapturedListState = Rc<RefCell<Option<WearScalingListState>>>;
+
+fn compose_fixed_rows(
+    heights: Vec<f32>,
+    spec: WearScalingLazyColumnSpec,
+) -> (TestComposition, CapturedListState) {
+    let captured_state: CapturedListState = Rc::new(RefCell::new(None));
+    let composition = run_test_composition({
+        let captured_state = Rc::clone(&captured_state);
+        move || {
+            crate::set_density(PX);
+            let state = rememberWearScalingListState(CentreAnchor::default());
+            *captured_state.borrow_mut() = Some(state);
+            let heights = heights.clone();
+            WearScalingLazyColumn(
+                Modifier::empty().fill_max_size(),
+                state,
+                spec,
+                move |scope| {
+                    let heights = heights.clone();
+                    scope.items(
+                        LazyItems::new(heights.len()).key(|index: usize| index as u64),
+                        move |index| {
+                            Spacer(Size {
+                                width: 0.0,
+                                height: heights[index],
+                            });
+                        },
+                    );
+                },
+            );
+        }
+    });
+    (composition, captured_state)
 }
 
 use crate::widgets::wear::rememberWearScalingListState;
 
-fn state() -> WearScalingListState {
-    LAST_STATE.with(|cell| (*cell.borrow()).expect("state captured"))
+fn state(captured_state: &CapturedListState) -> WearScalingListState {
+    (*captured_state.borrow()).expect("state captured")
 }
 
 fn tree(composition: &mut TestComposition, root: NodeId) -> crate::LayoutTree {
@@ -127,7 +133,8 @@ fn item_layers(tree: &crate::LayoutTree) -> Vec<(f32, f32, Rc<ModifierNodeSlices
 
 #[test]
 fn the_settings_screen_puts_its_first_two_rows_where_the_framebuffer_has_them() {
-    let mut composition = compose_fixed_rows(vec![HEADER_HEIGHT, ROW_HEIGHT], settings_spec());
+    let (mut composition, _captured_state) =
+        compose_fixed_rows(vec![HEADER_HEIGHT, ROW_HEIGHT], settings_spec());
     let root = composition.root().expect("list root");
     let tree = tree(&mut composition, root);
     let layers = item_layers(&tree);
@@ -140,7 +147,8 @@ fn the_settings_screen_puts_its_first_two_rows_where_the_framebuffer_has_them() 
 
 #[test]
 fn content_padding_is_absorbed_by_auto_centring_rather_than_stacking_on_it() {
-    let mut composition = compose_fixed_rows(vec![HEADER_HEIGHT, ROW_HEIGHT], settings_spec());
+    let (mut composition, _captured_state) =
+        compose_fixed_rows(vec![HEADER_HEIGHT, ROW_HEIGHT], settings_spec());
     let root = composition.root().expect("list root");
     let tree = tree(&mut composition, root);
     let layers = item_layers(&tree);
@@ -151,7 +159,7 @@ fn content_padding_is_absorbed_by_auto_centring_rather_than_stacking_on_it() {
 
 #[test]
 fn a_list_with_no_content_padding_centres_its_anchor_in_the_same_place() {
-    let mut composition = compose_fixed_rows(
+    let (mut composition, _captured_state) = compose_fixed_rows(
         vec![HEADER_HEIGHT, ROW_HEIGHT],
         WearScalingLazyColumnSpec::default(),
     );
@@ -163,7 +171,7 @@ fn a_list_with_no_content_padding_centres_its_anchor_in_the_same_place() {
 
 #[test]
 fn a_top_aligned_list_still_starts_one_content_padding_down() {
-    let mut composition = compose_fixed_rows(
+    let (mut composition, _captured_state) = compose_fixed_rows(
         vec![HEADER_HEIGHT, ROW_HEIGHT],
         settings_spec().auto_centering(None),
     );
@@ -175,10 +183,11 @@ fn a_top_aligned_list_still_starts_one_content_padding_down() {
 
 #[test]
 fn a_row_is_placed_from_the_full_heights_above_it_not_the_scaled_ones() {
-    let mut composition = compose_fixed_rows(vec![ROW_HEIGHT; 6], settings_spec());
+    let (mut composition, captured_state) =
+        compose_fixed_rows(vec![ROW_HEIGHT; 6], settings_spec());
     let root = composition.root().expect("list root");
     let _ = tree(&mut composition, root);
-    state().scroll_by(ROW_HEIGHT * 2.0);
+    state(&captured_state).scroll_by(ROW_HEIGHT * 2.0);
     composition
         .process_invalid_scopes()
         .expect("scroll recomposition");
@@ -236,9 +245,10 @@ fn a_row_shrinks_and_fades_by_the_amounts_the_pixels_show() {
 
 #[test]
 fn the_scale_a_frame_draws_with_is_the_scale_that_frame_measured() {
-    let mut composition = compose_fixed_rows(vec![ROW_HEIGHT; 8], settings_spec());
+    let (mut composition, captured_state) =
+        compose_fixed_rows(vec![ROW_HEIGHT; 8], settings_spec());
     let root = composition.root().expect("list root");
-    let state = state();
+    let state = state(&captured_state);
 
     let mut seen = Vec::new();
     for step in 0..5 {
@@ -304,7 +314,8 @@ fn expected_rows(count: usize, anchor: CentreAnchor) -> Vec<crate::round_scaling
 
 #[test]
 fn a_shrunk_item_reaches_the_renderer_through_a_layer_pinned_to_its_top_edge() {
-    let mut composition = compose_fixed_rows(vec![ROW_HEIGHT; 6], settings_spec());
+    let (mut composition, _captured_state) =
+        compose_fixed_rows(vec![ROW_HEIGHT; 6], settings_spec());
     let root = composition.root().expect("list root");
     let tree = tree(&mut composition, root);
     for (_, _, slices) in item_layers(&tree) {
@@ -318,11 +329,12 @@ fn a_shrunk_item_reaches_the_renderer_through_a_layer_pinned_to_its_top_edge() {
 
 #[test]
 fn an_item_off_the_bottom_is_neither_composed_nor_placed() {
-    let mut composition = compose_fixed_rows(vec![ROW_HEIGHT; 30], settings_spec());
+    let (mut composition, captured_state) =
+        compose_fixed_rows(vec![ROW_HEIGHT; 30], settings_spec());
     let root = composition.root().expect("list root");
     let tree = tree(&mut composition, root);
     let layers = item_layers(&tree);
-    let info = state().layout_info();
+    let info = state(&captured_state).layout_info();
     assert_eq!(info.item_count, 30, "the list still knows how long it is");
     assert!(info.visible > 0 && info.visible < 30, "{info:?}");
     assert_eq!(
@@ -344,16 +356,16 @@ fn an_item_off_the_bottom_is_neither_composed_nor_placed() {
 
 #[test]
 fn the_composed_window_does_not_grow_with_the_list() {
-    let mut short = compose_fixed_rows(vec![ROW_HEIGHT; 9], settings_spec());
+    let (mut short, short_state) = compose_fixed_rows(vec![ROW_HEIGHT; 9], settings_spec());
     let root = short.root().expect("list root");
     let _ = tree(&mut short, root);
-    let nine = state().layout_info();
+    let nine = state(&short_state).layout_info();
     drop(short);
 
-    let mut long = compose_fixed_rows(vec![ROW_HEIGHT; 60], settings_spec());
+    let (mut long, long_state) = compose_fixed_rows(vec![ROW_HEIGHT; 60], settings_spec());
     let root = long.root().expect("list root");
     let _ = tree(&mut long, root);
-    let sixty = state().layout_info();
+    let sixty = state(&long_state).layout_info();
 
     assert_eq!(nine.item_count, 9);
     assert_eq!(sixty.item_count, 60);
@@ -366,13 +378,15 @@ fn the_composed_window_does_not_grow_with_the_list() {
 
 #[test]
 fn the_anchored_items_top_does_not_depend_on_the_heights_above_it() {
-    let mut thin = compose_fixed_rows(vec![7.5, ROW_HEIGHT, ROW_HEIGHT], settings_spec());
+    let (mut thin, _thin_state) =
+        compose_fixed_rows(vec![7.5, ROW_HEIGHT, ROW_HEIGHT], settings_spec());
     let root = thin.root().expect("list root");
     let tree_thin = tree(&mut thin, root);
     let thin_anchor = item_layers(&tree_thin)[1].0;
     drop(thin);
 
-    let mut fat = compose_fixed_rows(vec![101.5, ROW_HEIGHT, ROW_HEIGHT], settings_spec());
+    let (mut fat, _fat_state) =
+        compose_fixed_rows(vec![101.5, ROW_HEIGHT, ROW_HEIGHT], settings_spec());
     let root = fat.root().expect("list root");
     let tree_fat = tree(&mut fat, root);
     let fat_layers = item_layers(&tree_fat);
@@ -394,10 +408,11 @@ fn the_anchored_items_top_does_not_depend_on_the_heights_above_it() {
 
 #[test]
 fn the_indicator_travel_runs_between_the_first_and_last_row_centres() {
-    let mut composition = compose_fixed_rows(vec![ROW_HEIGHT; 10], settings_spec());
+    let (mut composition, captured_state) =
+        compose_fixed_rows(vec![ROW_HEIGHT; 10], settings_spec());
     let root = composition.root().expect("list root");
     let _ = tree(&mut composition, root);
-    let info = state().layout_info();
+    let info = state(&captured_state).layout_info();
     assert_eq!(info.item_count, 10);
     assert_eq!(info.travel(), 9.0 * (ROW_HEIGHT + 4.0));
 }
@@ -588,7 +603,6 @@ fn a_scaffold_draws_its_indicator_over_the_content_and_not_beside_it() {
     let mut composition = run_test_composition(|| {
         crate::set_density(PX);
         let state = rememberWearScalingListState(CentreAnchor::default());
-        LAST_STATE.with(|cell| *cell.borrow_mut() = Some(state));
         let inner = state;
         ScreenScaffold(
             Modifier::empty(),
@@ -635,18 +649,18 @@ fn header_and_rows() -> Vec<f32> {
 
 fn indicator_at_vertical_padding(vertical: f32) -> IndicatorGeometry {
     let spec = WearScalingLazyColumnSpec::default().content_padding(SETTINGS_SIDE, vertical);
-    let mut composition = compose_fixed_rows(header_and_rows(), spec);
+    let (mut composition, captured_state) = compose_fixed_rows(header_and_rows(), spec);
     let root = composition.root().expect("list root");
     let _ = tree(&mut composition, root);
-    indicator_for_scaling_list(&state()).expect("a ten-row list is scrollable")
+    indicator_for_scaling_list(&state(&captured_state)).expect("a ten-row list is scrollable")
 }
 
 #[test]
 fn the_composed_indicator_reads_item_indices_where_the_flat_model_reads_pixels() {
-    let mut composition = compose_fixed_rows(header_and_rows(), settings_spec());
+    let (mut composition, captured_state) = compose_fixed_rows(header_and_rows(), settings_spec());
     let root = composition.root().expect("list root");
     let _ = tree(&mut composition, root);
-    let list = state();
+    let list = state(&captured_state);
     let wear = indicator_for_scaling_list(&list).expect("a ten-row list is scrollable");
 
     let span = list.with_indicator_list(|_, items| {
@@ -672,10 +686,10 @@ fn the_composed_indicator_reads_item_indices_where_the_flat_model_reads_pixels()
 
 #[test]
 fn the_window_the_indicator_reads_carries_the_lists_own_item_indices() {
-    let mut composition = compose_fixed_rows(header_and_rows(), settings_spec());
+    let (mut composition, captured_state) = compose_fixed_rows(header_and_rows(), settings_spec());
     let root = composition.root().expect("list root");
     let _ = tree(&mut composition, root);
-    let list = state();
+    let list = state(&captured_state);
     let at_rest = indicator_for_scaling_list(&list).expect("indicator");
     assert_eq!(
         list.with_indicator_list(|_, items| items.visible.first().map(|item| item.index)),
@@ -689,7 +703,7 @@ fn the_window_the_indicator_reads_carries_the_lists_own_item_indices() {
         .process_invalid_scopes()
         .expect("scroll recomposition");
     let _ = tree(&mut composition, root);
-    let list = state();
+    let list = state(&captured_state);
     let indices = list
         .with_indicator_list(|_, items| items.visible.iter().map(|i| i.index).collect::<Vec<_>>());
     assert_eq!(
@@ -710,10 +724,10 @@ fn the_window_the_indicator_reads_carries_the_lists_own_item_indices() {
 
 #[test]
 fn the_thumb_keeps_the_length_it_was_first_measured_at() {
-    let mut composition = compose_fixed_rows(header_and_rows(), settings_spec());
+    let (mut composition, captured_state) = compose_fixed_rows(header_and_rows(), settings_spec());
     let root = composition.root().expect("list root");
     let _ = tree(&mut composition, root);
-    let list = state();
+    let list = state(&captured_state);
     let at_rest = indicator_for_scaling_list(&list).expect("indicator");
 
     list.scroll_by(list.layout_info().travel() * 0.5);
@@ -721,7 +735,7 @@ fn the_thumb_keeps_the_length_it_was_first_measured_at() {
         .process_invalid_scopes()
         .expect("scroll recomposition");
     let _ = tree(&mut composition, root);
-    let list = state();
+    let list = state(&captured_state);
     let scrolled = indicator_for_scaling_list(&list).expect("indicator");
     assert_eq!(scrolled.thumb, at_rest.thumb, "the thumb changed length");
     assert!(scrolled.offset > at_rest.offset, "and it did move");
@@ -756,10 +770,11 @@ fn the_indicator_counts_the_vertical_padding_this_list_was_given() {
 
 #[test]
 fn a_list_that_fits_on_its_screen_has_no_indicator_at_all() {
-    let mut composition = compose_fixed_rows(vec![ROW_HEIGHT; 2], settings_spec());
+    let (mut composition, captured_state) =
+        compose_fixed_rows(vec![ROW_HEIGHT; 2], settings_spec());
     let root = composition.root().expect("list root");
     let _ = tree(&mut composition, root);
-    assert_eq!(indicator_for_scaling_list(&state()), None);
+    assert_eq!(indicator_for_scaling_list(&state(&captured_state)), None);
 }
 
 #[test]
@@ -843,78 +858,90 @@ fn the_switch_slots_resolve_to_the_colours_the_framebuffer_shows() {
     );
 }
 
-fn compose_credits_screen() -> TestComposition {
-    run_test_composition(|| {
-        crate::set_density(PX);
-        let state = rememberWearScalingListState(CentreAnchor::default());
-        LAST_STATE.with(|cell| *cell.borrow_mut() = Some(state));
-        let inner = state;
-        ScreenScaffold(
-            Modifier::empty().fill_max_size(),
-            state,
-            ScreenScaffoldSpec::default()
-                .indicator(ScrollIndicatorSpec::default().colors(measured_colors())),
-            move || {
-                WearScalingLazyColumn(
-                    Modifier::empty().fill_max_size(),
-                    inner,
-                    WearScalingLazyColumnSpec::default().content_padding(30.0, SCREEN_VERTICAL),
-                    move |scope| {
-                        let lines = [
-                            "ORBIT BREAKER",
-                            "Version 1.0.0-debug",
-                            "Designed and built for Wear OS.",
-                            "Every graphic and sound in this game is generated inside the project.",
-                            "No third-party assets, no downloads, nothing loaded at runtime.",
-                            "Built on Cranpose, a Compose-shaped UI framework written in Rust.",
-                            "Back",
-                        ];
-                        let button = lines.len() - 1;
-                        scope.items(
-                            LazyItems::new(lines.len()).key(|index: usize| index as u64),
-                            move |index| match index {
-                                0 => {
-                                    ListHeader(
-                                        Modifier::empty(),
-                                        ListHeaderSpec::default().colors(measured_colors()),
-                                        lines[0].to_string(),
-                                    );
-                                }
-                                other if other == button => {
-                                    WearButton(
-                                        Modifier::empty().fill_max_width(),
-                                        WearButtonSpec::default().colors(measured_colors()),
-                                        lines[button].to_string(),
-                                        None,
-                                        || {},
-                                    );
-                                }
-                                other => {
-                                    Text(
-                                        lines[other].to_string(),
-                                        Modifier::empty().fill_max_width(),
-                                        WearTextStyle::BODY_LARGE
-                                            .at_size(12.0)
-                                            .with_line_height(16.0)
-                                            .resolve(measured_colors().content),
-                                    );
-                                }
-                            },
-                        );
-                    },
-                );
-            },
-        );
-    })
+fn compose_credits_screen() -> (TestComposition, CapturedListState) {
+    let captured_state: CapturedListState = Rc::new(RefCell::new(None));
+    let composition = run_test_composition({
+        let captured_state = Rc::clone(&captured_state);
+        move || {
+            crate::set_density(PX);
+            let state = rememberWearScalingListState(CentreAnchor::default());
+            *captured_state.borrow_mut() = Some(state);
+            let inner = state;
+            ScreenScaffold(
+                Modifier::empty().fill_max_size(),
+                state,
+                ScreenScaffoldSpec::default()
+                    .indicator(ScrollIndicatorSpec::default().colors(measured_colors())),
+                move || {
+                    WearScalingLazyColumn(
+                        Modifier::empty().fill_max_size(),
+                        inner,
+                        WearScalingLazyColumnSpec::default().content_padding(30.0, SCREEN_VERTICAL),
+                        move |scope| {
+                            // Six lines and then the button, rather than four: a
+                            // scaling list stacks its DRAWN boxes a gap apart, so a
+                            // shrunken row does not push the one after it down and
+                            // a short list keeps more of itself on the first
+                            // screen. `a_row_below_the_fold_paints_once_it_is_scrolled_to`
+                            // needs the button genuinely off screen at rest, and
+                            // with four lines above it no longer is.
+                            let lines = [
+                                "ORBIT BREAKER",
+                                "Version 1.0.0-debug",
+                                "Designed and built for Wear OS.",
+                                "Every graphic and sound in this game is generated inside the project.",
+                                "No third-party assets, no downloads, nothing loaded at runtime.",
+                                "Built on Cranpose, a Compose-shaped UI framework written in Rust.",
+                                "Back",
+                            ];
+                            let button = lines.len() - 1;
+                            scope.items(
+                                LazyItems::new(lines.len()).key(|index: usize| index as u64),
+                                move |index| match index {
+                                    0 => {
+                                        ListHeader(
+                                            Modifier::empty(),
+                                            ListHeaderSpec::default().colors(measured_colors()),
+                                            lines[0].to_string(),
+                                        );
+                                    }
+                                    other if other == button => {
+                                        WearButton(
+                                            Modifier::empty().fill_max_width(),
+                                            WearButtonSpec::default().colors(measured_colors()),
+                                            lines[button].to_string(),
+                                            None,
+                                            || {},
+                                        );
+                                    }
+                                    other => {
+                                        Text(
+                                            lines[other].to_string(),
+                                            Modifier::empty().fill_max_width(),
+                                            WearTextStyle::BODY_LARGE
+                                                .at_size(12.0)
+                                                .with_line_height(16.0)
+                                                .resolve(measured_colors().content),
+                                        );
+                                    }
+                                },
+                            );
+                        },
+                    );
+                },
+            );
+        }
+    });
+    (composition, captured_state)
 }
 
 #[test]
 fn a_credits_screen_of_text_measured_rows_places_rows_that_are_not_empty() {
-    let mut composition = compose_credits_screen();
+    let (mut composition, captured_state) = compose_credits_screen();
     let root = composition.root().expect("credits root");
     let tree = tree(&mut composition, root);
     let layers = item_layers(&tree);
-    let info = state().layout_info();
+    let info = state(&captured_state).layout_info();
     assert_eq!(info.item_count, 7);
     assert_eq!(
         layers.len(),
@@ -942,7 +969,7 @@ fn a_credits_screen_of_text_measured_rows_places_rows_that_are_not_empty() {
 
 #[test]
 fn a_credits_screen_emits_a_text_primitive_for_every_row_it_placed() {
-    let mut composition = compose_credits_screen();
+    let (mut composition, _captured_state) = compose_credits_screen();
     let root = composition.root().expect("credits root");
     let tree = tree(&mut composition, root);
     let texts = scene_texts(&tree);
@@ -958,9 +985,9 @@ fn a_credits_screen_emits_a_text_primitive_for_every_row_it_placed() {
 
 #[test]
 fn a_row_below_the_fold_paints_once_it_is_scrolled_to() {
-    let mut composition = compose_credits_screen();
+    let (mut composition, captured_state) = compose_credits_screen();
     let root = composition.root().expect("credits root");
-    let list = state();
+    let list = state(&captured_state);
     assert!(
         !scene_texts(&tree(&mut composition, root)).contains(&"Back".to_string()),
         "the button starts below the fold, or this test proves nothing"


### PR DESCRIPTION
## This is a real, user-visible correctness bug — not a flaky test

**A `LazyColumn` can leave a permanent blank gap at the end of its content on any sufficiently loaded or slow device.** The CI flake was just the symptom: `fill_end_gap` — the code that re-anchors a lazy list's scroll position after its viewport grows (e.g. the soft keyboard hiding) — was bounded by a 6ms *wall clock*, not by how much work was actually left to do. Any time slice long enough to eat that budget (CI contention today, a loaded phone tomorrow) makes the list stop correcting itself early and strand the content above the bottom of the now-larger viewport. This PR fixes that defect. The `thread_local!` cleanup below is hygiene found while investigating; it is not what makes the bug go away.

## The bug the task asked about was real, but not where it suspected

`lazy_list_viewport_tests::lazy_column_refills_when_viewport_grows_after_scroll_to_end` genuinely fails under concurrent test load, with exactly the symptom the CI log showed: *"...but it stayed at effective offset 400, leaving a 200px blank gap."* But the suspected mechanism — libtest reusing OS threads across `#[test]` invocations and leaking `LAST_LAZY_STATE` between tests — does not hold.

**Disproving the suspected mechanism:** I wrote a standalone probe crate with 400 tests, each checking on entry whether a thread-local `Cell<u64>` already held a value left by another test, then writing its own id and re-checking after doing work. Run at `--test-threads=800` (2x the test count, guaranteeing thread reuse *if it happens*) for 30 rounds — **12,000 executions, zero leaks, zero clobbers.** libtest gives every `#[test]` a fresh OS thread with zeroed TLS; it does not pool them. (Separately, the same probe against the *actual* suite showed the failing test only ever produces numbers intrinsic to its own scenario, never a foreign list's data — also inconsistent with cross-test contamination.)

**Finding the real cause:** With the theory dead, I isolated the failing test with `--test-threads=1`, solo, for **1000 iterations: 0 failures.** It only reproduces alongside the rest of the suite. That pointed at something sensitive to *real* scheduling delays, not shared memory. Reading `crates/cranpose-foundation/src/lazy/item_measurer.rs::fill_end_gap` (the code that runs exactly in this test's scenario — viewport grows past the end of the list, pull earlier items back in to fill the freed space) found it:

```rust
while idx > 0 && top > self.config.before_content_padding + 0.5 {
    if start_time.elapsed() > DEFAULT_TIME_BUDGET {  // 6ms wall clock
        break;
    }
    ...
}
```

Under CPU contention from the rest of the suite running concurrently, the OS can preempt this thread for a few milliseconds having done *no extra work* — the wall clock reads past budget after one or two backfill iterations instead of the eight or so actually needed, leaving the list's first-visible-item stuck at a stale, partially-corrected value. On a device, the equivalent contention is a loaded CPU, a thermal throttle, or a background task — not a CI artifact.

## Reproduction

```
cargo test --profile ci -p cranpose-ui --lib --no-run
./target/ci/deps/cranpose_ui-<hash> --test-threads=64   # loop this
```
Looped on a 12-core box: fails at rates from 1-in-17 to 1-in-~200 depending on host load, always this one test, always this exact symptom. The same binary run solo (`--test-threads=1`, this test alone) never failed once in 1000 iterations.

## Removal experiment (confirming the cause, per AGENTS.md)

Neutralized only the wall-clock check in `fill_end_gap`'s backward-fill loop (`if false && start_time.elapsed() > DEFAULT_TIME_BUDGET`), rebuilt, reran the same loop under the same concurrent load that had been reliably reproducing it: **0 failures / 500 iterations.**

## The fix

Replaced the wall-clock bail with the same deterministic item-count safety net `measure_visible`'s primary walk already uses (`MAX_VISIBLE_ITEMS_SAFETY`, 10,000 items) — a bound on *how much work is left*, not on *how slow the clock looked*. `fill_end_gap` no longer takes a `start_time` parameter at all.

**Why this cannot regress:** `measure_visible` — the primary, always-executed measurement walk — has never been time-bounded, only count-bounded, and has shipped that way without incident. Extending the identical, already-trusted bound to `fill_end_gap`'s backfill isn't a new risk class; it's closing the one place that still depended on wall-clock luck. The backfill is inherently bounded by how far the viewport grew relative to item size (a keyboard hiding frees a few hundred px, not thousands), so the 10,000-item cap is not expected to bind in any real scenario — it's a pure safety net against pathological input, exactly like the walk it now matches.

Added a regression test (`fill_end_gap_backfills_fully_even_when_item_measurement_is_slow`) that forces the *old* code to fail deterministically — two 2ms-sleeping item measurements alone exceed the old 6ms budget — and asserts the new code still backfills to completion regardless. This is the load-bearing artifact in this PR: it is what stops the defect from coming back, independent of anything below. `cranpose-foundation --lib`: 213/213 passing, including this test.

## The thread-local cleanup (separate, does not itself fix the flake)

The audit request was still worth honoring even though its premise was wrong: hidden `thread_local!` test-state-smuggling is bad practice regardless of whether libtest happens to make it dangerous today. Converted every occurrence in `crates/cranpose-ui`'s test files to locally-scoped `Rc<RefCell<Option<T>>>` (or `Rc<Cell<usize>>` for counters) created fresh per test and threaded through composable parameters/closures — the same pattern the file already used successfully for `captured_slots` in one test. Files: `lazy_list_viewport_tests.rs` (the original 27 sites), `lazy_row_tests.rs`, `lazy_list_recompose_tests.rs`, `wear_widget_tests.rs`, `tab_switching_tests.rs`, `primitives_tests.rs` (also deleted a genuinely dead `CounterRow` composable + its two thread-locals, found while auditing), `lazy_recycle_effect_tests.rs`.

**Sibling audit, other crates (not fixed here — different crate, per the task's own instruction):** `crates/cranpose-app-shell/src/tests/app_shell_tests.rs` has ~21 more module-level occurrences of the identical pattern — flagged as a follow-up task. `crates/cranpose-render/wgpu/tests/wear_layer_alpha_pixels.rs` and `crates/cranpose-testing/src/tests/testing_tests.rs` each have one small, single-test-scoped occurrence, low priority. Everything else workspace-wide is either legitimate per-thread runtime state (e.g. `cranpose-core`'s snapshot runtime, explicitly documented as intentionally per-thread) or already function-scoped (safe by construction, since each lexical `thread_local!` site is its own item).

## Duplication-gate follow-up

The `thread_local!`→`Rc` conversion above replaced a one-line `LAST_STATE.with(...)` call, repeated many times per file, with an 11-to-20-line inline capture-and-compose block, also repeated many times per file — more duplicated text than before, correctly flagged by `duplication-gate` (44 clones touching the diff, marked `(new)` on both sides). `#570` (before/after duplication comparison) landed on `main` and now reports 0 violations for this diff too, but that is not why this is fixed: the fix is the same either way, because the duplication was real regardless of what the gate would tolerate.

Extracted one setup helper per composable/test shape instead of inlining it at every call site:
- `lazy_list_viewport_tests.rs`: `compose_with_list_state` / `compose_with_list_state_at` build the composition and hand back a fresh `Rc<RefCell<Option<LazyListState>>>`; `assert_visible_items_stay_ordered` collapses the repeated scroll-then-assert-ordering loop body shared by the three reverse-scroll tests.
- `lazy_list_recompose_tests.rs`: `render_scroll_indicator_lazy_list` and `render_counting_lazy_list_composable` (the latter generic over which `(item_invocations, captured_state)`-shaped composable it renders, since `ReactiveSiblingLazyList` and `StableKeyedCountingLazyList` share the exact same wiring).
- `tab_switching_tests.rs`: `ProgressTabHarness` / `render_progress_tab_host` bundle the composition, render closure, and render/branch-call counters the four `progress_tab`/`summary_tab` switching tests all built by hand.
- `primitives_tests.rs`: `CapturedLazyListSlot` bundles the two `Rc` output slots the `BoxWithConstraints` conditional-branch tests capture (a list state and a node id), so re-threading them through several levels of nested `Row`/`Column` closures is one `.clone()` per level instead of two independent `Rc::clone` calls.

Every helper builds a fresh composition and fresh `Rc`(s) per call — nothing is cached or shared across tests, so the isolation the `thread_local!` removal was for is preserved. `duplication-gate` now reports 31 clones touching the diff, 0 introduced; the remaining 31 are pre-existing duplication the gate's own before/after check exempts (e.g. `LazyColumn`/`LazyRow` parity test pairs that were already near-identical before this PR touched either file, and the generic `Composition::new` + `location_key` + `.render(key, ...)` scaffold used throughout the crate's test suite).

## Verification

- `cargo test -p cranpose-foundation --lib`: 213/213, including the new regression test
- `cargo test -p cranpose-ui --lib`: 1021/1021
- `just fmt-check`, `just clippy` (full workspace, `-D warnings`): clean
- `python3 scripts/ci/duplication_gate.py --base origin/main`: 31 clones touch the diff, 0 introduced
- `just test` (full workspace, `--no-fail-fast`): every crate green except `cranpose-render-wgpu --test pass_timing_report`, which SIGSEGVs on samarch-1 specifically — a pre-existing, documented environmental issue unrelated to this change (it doesn't touch any file this PR modifies)

Built and tested on `ssh samarch-1`, not the local Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
