### PR TITLE
Report every gate, not only the ones before the first failure

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Provision PATH and sccache
+        id: provision
         run: |
           # Both, and in this order. `GITHUB_PATH` only reaches LATER steps,
           # and the `cargo install` on the next line runs in THIS one -- so on
@@ -64,48 +65,62 @@ jobs:
           scripts/ci/start_sccache.sh
 
       - name: Check formatting
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just fmt-check
 
       - name: Check Cranpose package versions
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just versions
 
       - name: Spell check
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just typos
 
       - name: Test the quality gates' diff-scoping logic
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just test-quality-gates
 
       - name: Check the docs-only trigger filter
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         # The predicate the heavy jobs skip on. It runs in this job because
         # this job is the one that never skips.
         run: just test-ci-filters
 
       - name: Check cyclomatic complexity of changed functions
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just complexity-gate
 
       - name: Check for duplicated code in the diff
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just duplication-gate
 
       - name: Run workspace tests
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just test
 
       - name: Run workspace clippy
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just clippy
 
       - name: Run clippy on the macOS camera backend
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just clippy-camera-desktop
 
       - name: Build documentation
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         # A broken intra-doc link is a broken published page.
         run: just doc
 
       - name: Run cranpose-core feature permutations
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just test-features
 
       - name: Run the deterministic slot-table model check
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just test-property
 
       - name: Run the slot-table Criterion smoke
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just bench-smoke
 
   architecture-budget:
@@ -179,6 +194,7 @@ jobs:
         run: scripts/ci/docs_only_change.sh
 
       - name: Provision PATH and sccache
+        id: provision
         if: steps.changes.outputs.docs_only != 'true'
         run: |
           # Both, and in this order. `GITHUB_PATH` only reaches LATER steps,
@@ -210,7 +226,7 @@ jobs:
           wasm-opt --version || echo "no system binaryen; wasm-pack supplies its own"
 
       - name: Run wasm clippy
-        if: steps.changes.outputs.docs_only != 'true'
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' && steps.changes.outputs.docs_only != 'true' }}
         # A build alone (below) does not lint: `Arc<dyn Trait>` values that are
         # not `Send + Sync` on the single-threaded wasm target compile fine but
         # pay for synchronisation the target cannot use. Only clippy catches
@@ -218,5 +234,5 @@ jobs:
         run: just clippy-wasm
 
       - name: Build web demo
-        if: steps.changes.outputs.docs_only != 'true'
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' && steps.changes.outputs.docs_only != 'true' }}
         run: just web


### PR DESCRIPTION
A failing gate in `checks` stopped the job, so every later gate reported `skipped`. That is not a pass, but it reads like one — and it means the author fixes one problem, pushes, and spends another full board to discover a second problem the first run already had the evidence for.

### What it cost today

| PR | first failing step | gates lost after it |
|---|---|---|
| #559 | duplication gate | 7 |
| #551 | workspace tests | 6 |
| #573 | duplication gate | 7 |
| #566 | complexity gate | 8 |
| #566 | wasm clippy | 1 |

Twenty-nine gate executions across four pull requests. On a code diff a full board is roughly forty-five minutes of runner time, and the robot suites serialise on one exclusive host lock, so each avoidable round trip lands on the scarcest resource in the pool.

#566 is the sharpest case: it carries a rewritten renderer mechanism, and `clippy`, `doc`, the feature permutations, the slot-table model check and the Criterion smoke are all currently **unverified** on that head.

### The change

`if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}` on the fourteen gate steps in `checks`, and the same conjoined with the existing docs-only term on `wasm-build`'s two.

- **Why the provisioning term.** The gates are independent of each other — `just clippy` does not need `just test` to have passed, `just doc` needs neither — but all of them need a toolchain. Without that term a failed `cargo install just` would turn one clear error into fourteen copies of `just: command not found`.
- **Why `!cancelled()` and not `always()`.** A cancelled run should stop. Naming a status function is also what removes the implicit `success()`, which is the entire mechanism.
- **`architecture-budget` is untouched** — one gate step, nothing after it to report.
- **Gate definitions stay in the justfile.** This changes only which steps a failure stops, which is orchestration the justfile does not express.

### Pre-registered expectation

Stated before the run so it can be scored rather than admired:

1. This PR's own `checks` job runs the pre-change workflow — a run replays the workflow file as of run creation — so it proves nothing about the change. Only a run created after merge does.
2. On the first post-merge pull request with a failing `checks` gate, the steps after the failing one report `success` or `failure`, **not** `skipped`.
3. The job still concludes `failure`. A failed step marks the job regardless of what runs after it.
4. Skipped-step counts on a prose-only pull request are **unchanged** — provisioning is skipped there, which makes the provisioning term false and skips the gates for a second, equivalent reason.

Point 4 matters because #572 is measuring exactly those counts. Its runs were created before this branch existed, so they replay the old workflow and are unaffected either way.

### Verification

`actionlint` reports the same two findings before and after — both pre-existing warnings about the custom `cranpose-heavy` runner label. No new finding.