### PR TITLE
Give the robot runners one place to fail from

### DIFF
--- a/apps/desktop-demo/robot-runners/presented_window_geometry_contract.rs
+++ b/apps/desktop-demo/robot-runners/presented_window_geometry_contract.rs
@@ -56,12 +56,6 @@ impl PixelBounds {
     }
 }
 
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    let _ = robot.exit();
-    std::process::exit(1);
-}
-
 fn color_bounds(image: &RgbaImage, target: [u8; 3]) -> Option<PixelBounds> {
     let mut bounds: Option<PixelBounds> = None;
     for (x, y, pixel) in image.enumerate_pixels() {
@@ -100,7 +94,7 @@ fn require_bounds(
     color: [u8; 3],
 ) -> PixelBounds {
     color_bounds(image, color).unwrap_or_else(|| {
-        fail(
+        crate::robot_exit::fail(
             robot,
             &format!("presented window marker '{name}' was not found"),
         )
@@ -109,7 +103,7 @@ fn require_bounds(
 
 fn assert_close(robot: &cranpose::Robot, name: &str, actual: i32, expected: i32, tolerance: i32) {
     if (actual - expected).abs() > tolerance {
-        fail(
+        crate::robot_exit::fail(
             robot,
             &format!("{name}: actual={actual} expected={expected} tolerance={tolerance}"),
         );
@@ -131,7 +125,7 @@ fn capture_scale(robot: &cranpose::Robot, image: &RgbaImage) -> CaptureScale {
         || scale.y < 0.5
         || (scale.x - scale.y).abs() > SCALE_AXIS_TOLERANCE
     {
-        fail(
+        crate::robot_exit::fail(
             robot,
             &format!(
                 "presented capture has invalid scale: capture={}x{} logical={}x{} scale=({:.3}, {:.3})",
@@ -141,8 +135,7 @@ fn capture_scale(robot: &cranpose::Robot, image: &RgbaImage) -> CaptureScale {
                 WINDOW_HEIGHT,
                 scale.x,
                 scale.y
-            ),
-        );
+            ));
     }
     scale
 }

--- a/apps/desktop-demo/robot-runners/robot_adaptive_frost.rs
+++ b/apps/desktop-demo/robot-runners/robot_adaptive_frost.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::{
     path::PathBuf,
     process::ExitCode,
@@ -96,38 +98,30 @@ fn main() -> ExitCode {
             );
 
             if plain_white - adaptive_white < 8.0 {
-                fail(
-                    &robot,
+                robot_exit::fail_and_await_shutdown(&robot, &FAILED,
                     &format!(
                         "adaptive glass must darken over a bright backdrop: \
                          adaptive {adaptive_white:.1} vs plain {plain_white:.1}"
-                    ),
-                );
+                    ));
             }
             if adaptive_black - plain_black < 8.0 {
-                fail(
-                    &robot,
+                robot_exit::fail_and_await_shutdown(&robot, &FAILED,
                     &format!(
                         "adaptive glass must lighten behind dark foreground on a dark backdrop: \
                          adaptive {adaptive_black:.1} vs plain {plain_black:.1}"
-                    ),
-                );
+                    ));
             }
             if white_text_extrema.1 < 225.0 || black_text_extrema.0 > 30.0 {
-                fail(
-                    &robot,
+                robot_exit::fail_and_await_shutdown(&robot, &FAILED,
                     &format!(
                         "adaptive proof labels did not render at their requested foreground polarity: white {white_text_extrema:?}, black {black_text_extrema:?}"
-                    ),
-                );
+                    ));
             }
             if white_contrast < 4.5 || black_contrast < 4.5 {
-                fail(
-                    &robot,
+                robot_exit::fail_and_await_shutdown(&robot, &FAILED,
                     &format!(
                         "adaptive frost failed foreground contrast: white {white_contrast:.2}:1, black {black_contrast:.2}:1"
-                    ),
-                );
+                    ));
             }
 
             println!("PASS: adaptive frost contract");
@@ -233,19 +227,6 @@ fn main() -> ExitCode {
         ExitCode::FAILURE
     } else {
         ExitCode::SUCCESS
-    }
-}
-
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    FAILED.store(true, Ordering::Relaxed);
-    std::thread::spawn(|| {
-        std::thread::sleep(Duration::from_secs(15));
-        std::process::exit(1);
-    });
-    let _ = robot.exit();
-    loop {
-        std::thread::sleep(Duration::from_secs(60));
     }
 }
 

--- a/apps/desktop-demo/robot-runners/robot_async_progress_after_animations.rs
+++ b/apps/desktop-demo/robot-runners/robot_async_progress_after_animations.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::time::Duration;
 
 use cranpose::AppLauncher;
@@ -9,7 +11,7 @@ use desktop_app::app;
 
 fn click_button(robot: &cranpose::Robot, label: &str) {
     let Some((x, y, w, h)) = find_button_in_semantics(robot, label) else {
-        fail(robot, &format!("button {label:?} not found"));
+        robot_exit::fail(robot, &format!("button {label:?} not found"));
     };
     let cx = x + w / 2.0;
     let cy = y + h / 2.0;
@@ -49,12 +51,6 @@ fn visible_texts(robot: &cranpose::Robot) -> Vec<String> {
     texts
 }
 
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FAIL: {message}");
-    let _ = robot.exit();
-    std::process::exit(1);
-}
-
 fn wait_for_text(robot: &cranpose::Robot, text: &str, timeout: Duration) {
     let deadline = std::time::Instant::now() + timeout;
     while std::time::Instant::now() < deadline {
@@ -63,7 +59,7 @@ fn wait_for_text(robot: &cranpose::Robot, text: &str, timeout: Duration) {
         }
         std::thread::sleep(Duration::from_millis(50));
     }
-    fail(
+    robot_exit::fail(
         robot,
         &format!(
             "timed out waiting for text {text:?}; visible_texts={:?}",
@@ -91,13 +87,12 @@ fn main() {
             wait_for_text(&robot, "Async Runtime Demo", Duration::from_secs(5));
 
             let initial_progress = read_progress_percent(&robot).unwrap_or_else(|| {
-                fail(
+                robot_exit::fail(
                     &robot,
                     &format!(
                         "Async progress text missing after switching from Animations; visible_texts={:?}",
                         visible_texts(&robot)
-                    ),
-                );
+                    ));
             });
 
             println!("Initial async progress after switch: {initial_progress}%");
@@ -116,13 +111,12 @@ fn main() {
             }
 
             if !progressed {
-                fail(
+                robot_exit::fail(
                     &robot,
                     &format!(
                         "Async Runtime progress stayed stuck after Animations -> Async switch; initial={initial_progress}% last={last_progress}% visible_texts={:?}",
                         visible_texts(&robot)
-                    ),
-                );
+                    ));
             }
 
             println!(

--- a/apps/desktop-demo/robot-runners/robot_color_fidelity.rs
+++ b/apps/desktop-demo/robot-runners/robot_color_fidelity.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::time::Duration;
 
 use cranpose::{
@@ -34,7 +36,7 @@ fn main() {
 
             let expect_exact = |label: &str, (x, y): (f32, f32), expected: Color| {
                 let Some(actual) = sample_screenshot_pixel_logical(&screenshot, x, y) else {
-                    fail(&robot, &format!("{label}: sample out of bounds"));
+                    robot_exit::fail(&robot, &format!("{label}: sample out of bounds"));
                 };
                 let expected = [
                     (expected.0 * 255.0).round() as u8,
@@ -47,7 +49,7 @@ fn main() {
                     .zip(expected.iter())
                     .all(|(a, e)| (*a as i16 - *e as i16).abs() <= 1);
                 if !close {
-                    fail(
+                    robot_exit::fail(
                         &robot,
                         &format!("{label}: expected {expected:?}, got {actual:?}"),
                     );
@@ -83,7 +85,7 @@ fn main() {
                 .zip(text_expected.iter())
                 .all(|(a, e)| (*a as i16 - *e as i16).abs() <= 8);
             if !text_ok {
-                fail(
+                robot_exit::fail(
                     &robot,
                     &format!("text core: expected ~{text_expected:?}, darkest {darkest:?}"),
                 );
@@ -94,12 +96,6 @@ fn main() {
             robot.exit().expect("exit");
         })
         .run(content);
-}
-
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    let _ = robot.exit();
-    std::process::exit(1);
 }
 
 fn content() {

--- a/apps/desktop-demo/robot-runners/robot_conditional_infinite_transition_busy.rs
+++ b/apps/desktop-demo/robot-runners/robot_conditional_infinite_transition_busy.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::time::{Duration, Instant};
 
 use cranpose::{AppLauncher, Robot, RobotScreenshot};
@@ -13,16 +15,10 @@ use cranpose_ui::{
     RowSpec, Text, TextStyle,
 };
 
-fn fail(robot: &Robot, message: &str) -> ! {
-    println!("FAIL: {message}");
-    robot.exit().ok();
-    std::process::exit(1);
-}
-
 fn capture(robot: &Robot, label: &str) -> RobotScreenshot {
     robot
         .screenshot()
-        .unwrap_or_else(|err| fail(robot, &format!("{label} screenshot failed: {err}")))
+        .unwrap_or_else(|err| robot_exit::fail(robot, &format!("{label} screenshot failed: {err}")))
 }
 
 fn wait_for_text(robot: &Robot, text: &str, timeout: Duration) -> (f32, f32, f32, f32) {
@@ -33,16 +29,16 @@ fn wait_for_text(robot: &Robot, text: &str, timeout: Duration) -> (f32, f32, f32
         }
         std::thread::sleep(Duration::from_millis(30));
     }
-    fail(robot, &format!("timed out waiting for text {text:?}"));
+    robot_exit::fail(robot, &format!("timed out waiting for text {text:?}"));
 }
 
 fn click_button(robot: &Robot, label: &str) {
     let Some((x, y, w, h)) = find_button_in_semantics(robot, label) else {
-        fail(robot, &format!("button {label:?} not found"));
+        robot_exit::fail(robot, &format!("button {label:?} not found"));
     };
     robot
         .click(x + w * 0.5, y + h * 0.5)
-        .unwrap_or_else(|err| fail(robot, &format!("click {label:?} failed: {err}")));
+        .unwrap_or_else(|err| robot_exit::fail(robot, &format!("click {label:?} failed: {err}")));
 }
 
 fn test_app() {
@@ -140,18 +136,18 @@ fn main() {
                 wait_for_text(&robot, "Busy indicator", Duration::from_secs(5));
             let indicator_region = (text_x - 16.0, text_y - 14.0, 360.0, 52.0);
 
-            robot
-                .pump_frames(2)
-                .unwrap_or_else(|err| fail(&robot, &format!("initial pump failed: {err}")));
+            robot.pump_frames(2).unwrap_or_else(|err| {
+                robot_exit::fail(&robot, &format!("initial pump failed: {err}"))
+            });
             let first = capture(&robot, "first busy frame");
-            robot
-                .pump_frames(16)
-                .unwrap_or_else(|err| fail(&robot, &format!("animation pump failed: {err}")));
+            robot.pump_frames(16).unwrap_or_else(|err| {
+                robot_exit::fail(&robot, &format!("animation pump failed: {err}"))
+            });
             let later = capture(&robot, "later busy frame");
 
             let changed = changed_pixel_count_in_region(&first, &later, indicator_region, 8);
             if changed < 80 {
-                fail(
+                robot_exit::fail(
                     &robot,
                     &format!("busy indicator painted once but did not advance; changed={changed}"),
                 );

--- a/apps/desktop-demo/robot-runners/robot_counter_button_release_external_visual.rs
+++ b/apps/desktop-demo/robot-runners/robot_counter_button_release_external_visual.rs
@@ -1,4 +1,5 @@
 mod output_paths;
+mod robot_exit;
 mod text_showcase_external_helpers;
 
 use std::{path::PathBuf, time::Duration};
@@ -37,7 +38,7 @@ fn main() {
             focus_x11_window(&window_id);
 
             let (x, y, width, height) = find_button_exact_in_semantics(&robot, "Increment")
-                .unwrap_or_else(|| fail(&robot, "Increment button not found"));
+                .unwrap_or_else(|| robot_exit::fail(&robot, "Increment button not found"));
             let center_x = x + width * 0.5;
             let center_y = y + height * 0.5;
             move_x11_mouse_in_window(&window_id, center_x, center_y);
@@ -60,13 +61,12 @@ fn main() {
             let released = capture_x11_window(&window_id, &released_path);
 
             let counter_text = wait_for_counter_text(&robot).unwrap_or_else(|| {
-                fail(&robot, "Counter text missing after Increment button release")
+                robot_exit::fail(&robot, "Counter text missing after Increment button release")
             });
             if !counter_text.contains("1") {
-                fail(
+                robot_exit::fail(
                     &robot,
-                    &format!("Increment click did not update counter: {counter_text}"),
-                );
+                    &format!("Increment click did not update counter: {counter_text}"));
             }
 
             let roi = Roi::around(center_x, center_y);
@@ -100,7 +100,7 @@ fn main() {
             }
 
             if !failures.is_empty() {
-                fail(
+                robot_exit::fail(
                     &robot,
                     &format!(
                         "{}\nscreenshots: baseline={} pressed={} released={}",
@@ -108,8 +108,7 @@ fn main() {
                         baseline_path.display(),
                         pressed_path.display(),
                         released_path.display(),
-                    ),
-                );
+                    ));
             }
 
             robot.exit().expect("exit");
@@ -177,10 +176,4 @@ fn mean_luma_delta(left: &RgbaImage, right: &RgbaImage, roi: Roi) -> f32 {
 
 fn luma(pixel: [u8; 4]) -> f32 {
     pixel[0] as f32 * 0.2126 + pixel[1] as f32 * 0.7152 + pixel[2] as f32 * 0.0722
-}
-
-fn fail(robot: &Robot, message: &str) -> ! {
-    eprintln!("FAIL: {message}");
-    let _ = robot.exit();
-    std::process::exit(1);
 }

--- a/apps/desktop-demo/robot-runners/robot_exit.rs
+++ b/apps/desktop-demo/robot-runners/robot_exit.rs
@@ -1,0 +1,39 @@
+#![allow(dead_code)]
+
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    thread,
+    time::Duration,
+};
+
+use cranpose::Robot;
+
+const SHUTDOWN_WATCHDOG: Duration = Duration::from_secs(15);
+
+pub fn fail(robot: &Robot, message: &str) -> ! {
+    report(message);
+    let _ = robot.exit();
+    std::process::exit(1);
+}
+
+pub fn fail_without_shutdown(message: &str) -> ! {
+    report(message);
+    std::process::exit(1);
+}
+
+pub fn fail_and_await_shutdown(robot: &Robot, failed: &'static AtomicBool, message: &str) -> ! {
+    report(message);
+    failed.store(true, Ordering::Relaxed);
+    thread::spawn(|| {
+        thread::sleep(SHUTDOWN_WATCHDOG);
+        std::process::exit(1);
+    });
+    let _ = robot.exit();
+    loop {
+        thread::sleep(SHUTDOWN_WATCHDOG);
+    }
+}
+
+fn report(message: &str) {
+    println!("FATAL: {message}");
+}

--- a/apps/desktop-demo/robot-runners/robot_fling_edge_cases.rs
+++ b/apps/desktop-demo/robot-runners/robot_fling_edge_cases.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::time::Duration;
 
 use cranpose::{AppLauncher, Robot};
@@ -70,13 +72,10 @@ fn main() {
                 return;
             }
 
-            let mut viewport = match fetch_list_viewport(&robot) {
-                Some(bounds) => bounds,
-                None => {
-                    eprintln!("✗ LazyListViewport is not visible in the viewport");
-                    let _ = robot.exit();
-                    return;
-                }
+            let Some(mut viewport) = fetch_list_viewport(&robot) else {
+                eprintln!("✗ LazyListViewport is not visible in the viewport");
+                let _ = robot.exit();
+                return;
             };
 
             fn find_item_center_y(robot: &Robot, item_text: &str) -> Option<f32> {
@@ -241,12 +240,10 @@ fn main() {
 
             println!("--- Test 7: Simulated Frame Drops ---");
 
-            let (tracked_label, _before_y) = match find_any_item(&robot) {
-                Some(value) => value,
-                None => {
-                    eprintln!("✗ Could not find a visible item before frame drop test");
-                    std::process::exit(1);
-                }
+            let Some((tracked_label, _before_y)) = find_any_item(&robot) else {
+                robot_exit::fail_without_shutdown(
+                    "Could not find a visible item before frame drop test",
+                );
             };
 
             if let Err(err) = robot.reset_last_fling_velocity() {
@@ -281,23 +278,17 @@ fn main() {
                 }
             };
 
-            match (post_release_y, after_fling_y) {
-                (Some(post_y), Some(after_y)) => {
-                    let additional = (post_y - after_y).abs();
-                    if additional < 15.0 && measured_velocity < 50.0 {
-                        eprintln!(
-                            "✗ Frame drop fling too small: {:.1}px (velocity {:.1} px/s)",
-                            additional, measured_velocity
-                        );
-                        std::process::exit(1);
-                    } else if additional < 15.0 {
-                        println!(
-                            "  WARN: Low visual movement ({:.1}px) but fling velocity {:.1} px/s",
-                            additional, measured_velocity
-                        );
-                    }
+            if let (Some(post_y), Some(after_y)) = (post_release_y, after_fling_y) {
+                let additional = (post_y - after_y).abs();
+                if additional < 15.0 && measured_velocity < 50.0 {
+                    robot_exit::fail_without_shutdown(&format!(
+                        "Frame drop fling too small: {additional:.1}px (velocity {measured_velocity:.1} px/s)"
+                    ));
+                } else if additional < 15.0 {
+                    println!(
+                        "  WARN: Low visual movement ({additional:.1}px) but fling velocity {measured_velocity:.1} px/s"
+                    );
                 }
-                _ => {}
             }
 
             println!("  ✓ Frame drops - fling momentum detected\n");

--- a/apps/desktop-demo/robot-runners/robot_gradient_tab_switch.rs
+++ b/apps/desktop-demo/robot-runners/robot_gradient_tab_switch.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::time::Duration;
 
 use cranpose::{AppLauncher, Robot};
@@ -19,12 +21,6 @@ fn wait_for_prefix(
     None
 }
 
-fn fail(robot: &Robot, message: &str) -> ! {
-    eprintln!("✗ {}", message);
-    let _ = robot.exit();
-    std::process::exit(1);
-}
-
 fn dump_semantics(robot: &Robot, label: &str) {
     if let Ok(semantics) = robot.get_semantics() {
         println!("--- Semantics dump ({}) ---", label);
@@ -34,7 +30,7 @@ fn dump_semantics(robot: &Robot, label: &str) {
 
 fn click_tab(robot: &Robot, label: &str) {
     let (x, y, w, h) = find_button_in_semantics(robot, label)
-        .unwrap_or_else(|| fail(robot, &format!("Tab '{}' not found", label)));
+        .unwrap_or_else(|| robot_exit::fail(robot, &format!("Tab '{}' not found", label)));
     robot.click(x + w / 2.0, y + h / 2.0).ok();
     std::thread::sleep(Duration::from_millis(200));
     let _ = robot.wait_for_idle();
@@ -71,7 +67,7 @@ fn main() {
             )
             .is_none()
             {
-                fail(&robot, "CompositionLocal content not visible");
+                robot_exit::fail(&robot, "CompositionLocal content not visible");
             }
 
             click_tab(&robot, "Counter App");
@@ -83,15 +79,15 @@ fn main() {
             )
             .is_none()
             {
-                fail(&robot, "Counter App content not visible");
+                robot_exit::fail(&robot, "Counter App content not visible");
             }
 
             let (x, y, w, h, text_before) =
                 wait_for_prefix(&robot, "Pointer:", 20, Duration::from_millis(100))
-                    .unwrap_or_else(|| fail(&robot, "Pointer text not found"));
+                    .unwrap_or_else(|| robot_exit::fail(&robot, "Pointer text not found"));
 
             let _ = parse_pointer_text(&text_before)
-                .unwrap_or_else(|| fail(&robot, "Failed to parse Pointer text"));
+                .unwrap_or_else(|| robot_exit::fail(&robot, "Failed to parse Pointer text"));
 
             let pos1 = (x + w * 0.2, y + h * 0.5);
             let pos2 = (x + w * 0.8, y + h * 0.5 + 60.0);
@@ -104,11 +100,12 @@ fn main() {
                 wait_for_prefix(&robot, "Pointer:", 10, Duration::from_millis(100)).unwrap_or_else(
                     || {
                         dump_semantics(&robot, "missing pointer after move 1");
-                        fail(&robot, "Pointer text missing after first move")
+                        robot_exit::fail(&robot, "Pointer text missing after first move")
                     },
                 );
-            let coords_1 = parse_pointer_text(&text_after_1)
-                .unwrap_or_else(|| fail(&robot, "Failed to parse Pointer after move 1"));
+            let coords_1 = parse_pointer_text(&text_after_1).unwrap_or_else(|| {
+                robot_exit::fail(&robot, "Failed to parse Pointer after move 1")
+            });
 
             let _ = robot.mouse_move(pos2.0, pos2.1);
             std::thread::sleep(Duration::from_millis(120));
@@ -118,11 +115,12 @@ fn main() {
                 wait_for_prefix(&robot, "Pointer:", 10, Duration::from_millis(100)).unwrap_or_else(
                     || {
                         dump_semantics(&robot, "missing pointer after move 2");
-                        fail(&robot, "Pointer text missing after second move")
+                        robot_exit::fail(&robot, "Pointer text missing after second move")
                     },
                 );
-            let coords_2 = parse_pointer_text(&text_after_2)
-                .unwrap_or_else(|| fail(&robot, "Failed to parse Pointer after move 2"));
+            let coords_2 = parse_pointer_text(&text_after_2).unwrap_or_else(|| {
+                robot_exit::fail(&robot, "Failed to parse Pointer after move 2")
+            });
 
             let dx = coords_2.0 - coords_1.0;
             let dy = coords_2.1 - coords_1.1;

--- a/apps/desktop-demo/robot-runners/robot_increment_bug.rs
+++ b/apps/desktop-demo/robot-runners/robot_increment_bug.rs
@@ -1,13 +1,10 @@
+mod robot_exit;
+
 use std::time::Duration;
 
 use cranpose::AppLauncher;
 use cranpose_testing::find_text_by_prefix_in_semantics;
 use desktop_app::app;
-
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    let _ = robot;
-    panic!("{message}");
-}
 
 fn counter_value(robot: &cranpose::Robot) -> Option<i32> {
     find_text_by_prefix_in_semantics(robot, "Counter:")
@@ -86,7 +83,7 @@ fn main() {
 
             println!("--- Step 1: Verify Initial State ---");
             let initial_counter = counter_value(&robot)
-                .unwrap_or_else(|| fail(&robot, "initial counter value not found"));
+                .unwrap_or_else(|| robot_exit::fail_without_shutdown( "initial counter value not found"));
             println!("  Initial counter value: {}", initial_counter);
 
             println!("\n--- Step 2: Click CompositionLocal Test Tab ---");
@@ -96,14 +93,12 @@ fn main() {
                     x, y
                 );
                 robot.click(x, y).unwrap_or_else(|err| {
-                    fail(
-                        &robot,
-                        &format!("failed to click 'CompositionLocal Test': {err}"),
-                    )
+                    robot_exit::fail_without_shutdown(
+                        &format!("failed to click 'CompositionLocal Test': {err}"))
                 });
                 println!("  ✓ Clicked");
             } else {
-                fail(&robot, "tab 'CompositionLocal Test' not found");
+                robot_exit::fail_without_shutdown( "tab 'CompositionLocal Test' not found");
             }
             std::thread::sleep(Duration::from_millis(300));
 
@@ -112,11 +107,11 @@ fn main() {
             if let Some((x, y)) = counter_app_pos {
                 println!("  Found 'Counter App' tab at ({:.1}, {:.1})", x, y);
                 robot.click(x, y).unwrap_or_else(|err| {
-                    fail(&robot, &format!("failed to click 'Counter App': {err}"))
+                    robot_exit::fail_without_shutdown( &format!("failed to click 'Counter App': {err}"))
                 });
                 println!("  ✓ Clicked");
             } else {
-                fail(&robot, "tab 'Counter App' not found");
+                robot_exit::fail_without_shutdown( "tab 'Counter App' not found");
             }
             std::thread::sleep(Duration::from_millis(300));
 
@@ -135,13 +130,13 @@ fn main() {
                     let x = tab_x + (gradient_x - tab_x) * progress;
                     let y = tab_y + (gradient_y - tab_y) * progress;
                     robot.mouse_move(x, y).unwrap_or_else(|err| {
-                        fail(&robot, &format!("failed to move mouse through gradient area: {err}"))
+                        robot_exit::fail_without_shutdown( &format!("failed to move mouse through gradient area: {err}"))
                     });
                     std::thread::sleep(Duration::from_millis(25));
                 }
                 println!("  ✓ Cursor moved through gradient area (triggering recomposition)");
             } else {
-                fail(&robot, "counter tab position missing before gradient walk");
+                robot_exit::fail_without_shutdown( "counter tab position missing before gradient walk");
             }
             std::thread::sleep(Duration::from_millis(200));
 
@@ -151,16 +146,16 @@ fn main() {
                 println!("  Found 'Increment' button at ({:.1}, {:.1})", x, y);
 
                 robot.mouse_move(x, y).unwrap_or_else(|err| {
-                    fail(&robot, &format!("failed to move mouse to Increment button: {err}"))
+                    robot_exit::fail_without_shutdown( &format!("failed to move mouse to Increment button: {err}"))
                 });
                 std::thread::sleep(Duration::from_millis(100));
 
                 robot.click(x, y).unwrap_or_else(|err| {
-                    fail(&robot, &format!("failed to click Increment button: {err}"))
+                    robot_exit::fail_without_shutdown( &format!("failed to click Increment button: {err}"))
                 });
                 println!("  ✓ Clicked Increment");
             } else {
-                fail(&robot, "Increment button not found after tab roundtrip");
+                robot_exit::fail_without_shutdown( "Increment button not found after tab roundtrip");
             }
             std::thread::sleep(Duration::from_millis(300));
 
@@ -181,15 +176,13 @@ fn main() {
                     initial_counter, final_counter
                 );
             } else {
-                fail(
-                    &robot,
+                robot_exit::fail_without_shutdown(
                     &format!(
                         "counter value mismatch after robot click: expected {}, got {}, all counters {:?}",
                         initial_counter + 1,
                         final_counter,
                         all_counters,
-                    ),
-                );
+                    ));
             }
 
             println!("\nClosing in 1 second...");

--- a/apps/desktop-demo/robot-runners/robot_interactive_anim.rs
+++ b/apps/desktop-demo/robot-runners/robot_interactive_anim.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::time::Duration;
 
 use cranpose::{AppLauncher, Robot, RobotScreenshot};
@@ -6,16 +8,10 @@ use cranpose_testing::{
 };
 use desktop_app::app;
 
-fn fail(robot: &Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    robot.exit().ok();
-    std::process::exit(1);
-}
-
 fn capture(robot: &Robot, label: &str) -> RobotScreenshot {
     robot
         .screenshot()
-        .unwrap_or_else(|err| fail(robot, &format!("{label} screenshot failed: {err}")))
+        .unwrap_or_else(|err| robot_exit::fail(robot, &format!("{label} screenshot failed: {err}")))
 }
 
 fn changed_pixels(
@@ -38,16 +34,16 @@ fn main() {
             std::thread::sleep(Duration::from_millis(500));
             robot
                 .wait_for_idle()
-                .unwrap_or_else(|err| fail(&robot, &format!("initial idle failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("initial idle failed: {err}")));
 
             if find_text_in_semantics(&robot, "Interactive Anim").is_none() {
-                fail(&robot, "Interactive Anim tab content not visible");
+                robot_exit::fail(&robot, "Interactive Anim tab content not visible");
             }
 
             let Some((button_x, button_y, button_w, button_h)) =
                 find_button_in_semantics(&robot, "Tap me")
             else {
-                fail(&robot, "'Tap me' button not found");
+                robot_exit::fail(&robot, "'Tap me' button not found");
             };
             let sample_region = (
                 button_x - 18.0,
@@ -60,75 +56,71 @@ fn main() {
 
             robot
                 .move_to(center_x, center_y)
-                .unwrap_or_else(|err| fail(&robot, &format!("move failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("move failed: {err}")));
             robot
                 .wait_for_idle()
-                .unwrap_or_else(|err| fail(&robot, &format!("pre-press idle failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("pre-press idle failed: {err}")));
             let baseline = capture(&robot, "baseline");
 
             robot
                 .mouse_down()
-                .unwrap_or_else(|err| fail(&robot, &format!("mouse down failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("mouse down failed: {err}")));
             robot
                 .pump_frames(1)
-                .unwrap_or_else(|err| fail(&robot, &format!("down pump failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("down pump failed: {err}")));
             let down_first = capture(&robot, "first pressed");
 
             robot
                 .pump_frames(8)
-                .unwrap_or_else(|err| fail(&robot, &format!("pressed animation pump failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("pressed animation pump failed: {err}")));
             let down_later = capture(&robot, "later pressed");
 
             let press_delta = changed_pixels(&baseline, &down_first, sample_region);
             let held_delta = changed_pixels(&down_first, &down_later, sample_region);
             if press_delta < 120 {
-                fail(
+                robot_exit::fail(
                     &robot,
-                    &format!("press did not produce visible button pixels: {press_delta}"),
-                );
+                    &format!("press did not produce visible button pixels: {press_delta}"));
             }
             if held_delta < 2 {
-                fail(
+                robot_exit::fail(
                     &robot,
-                    &format!("held press animation did not advance: {held_delta}"),
-                );
+                    &format!("held press animation did not advance: {held_delta}"));
             }
 
             robot
                 .mouse_up()
-                .unwrap_or_else(|err| fail(&robot, &format!("mouse up failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("mouse up failed: {err}")));
             robot
                 .pump_frames(6)
-                .unwrap_or_else(|err| fail(&robot, &format!("release pump failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("release pump failed: {err}")));
             let released_first = capture(&robot, "first released");
             robot
                 .pump_frames(14)
-                .unwrap_or_else(|err| fail(&robot, &format!("slow release pump failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("slow release pump failed: {err}")));
             let released_later = capture(&robot, "later released");
             let release_delta = changed_pixels(&down_later, &released_first, sample_region);
             let slow_release_delta =
                 changed_pixels(&released_first, &released_later, sample_region);
             if release_delta < 80 {
-                fail(
+                robot_exit::fail(
                     &robot,
-                    &format!("release did not animate button back up: {release_delta}"),
-                );
+                    &format!("release did not animate button back up: {release_delta}"));
             }
             if slow_release_delta < 20 {
-                fail(
+                robot_exit::fail(
                     &robot,
-                    &format!("release animation did not continue slowly: {slow_release_delta}"),
-                );
+                    &format!("release animation did not continue slowly: {slow_release_delta}"));
             }
 
             if find_text_in_semantics(&robot, "1").is_none() {
-                fail(&robot, "click count did not update after release");
+                robot_exit::fail(&robot, "click count did not update after release");
             }
 
             let Some((reveal_x, reveal_y, reveal_w, reveal_h)) =
                 find_button_in_semantics(&robot, "Reveal")
             else {
-                fail(&robot, "'Reveal' button not found");
+                robot_exit::fail(&robot, "'Reveal' button not found");
             };
             let reveal_region = (
                 reveal_x - 4.0,
@@ -141,24 +133,24 @@ fn main() {
 
             robot
                 .move_to(reveal_center_x, reveal_center_y)
-                .unwrap_or_else(|err| fail(&robot, &format!("reveal move failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("reveal move failed: {err}")));
             robot
                 .wait_for_idle()
-                .unwrap_or_else(|err| fail(&robot, &format!("pre-reveal idle failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("pre-reveal idle failed: {err}")));
             let reveal_baseline = capture(&robot, "reveal baseline");
             robot
                 .mouse_down()
-                .unwrap_or_else(|err| fail(&robot, &format!("reveal mouse down failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("reveal mouse down failed: {err}")));
             robot
                 .mouse_up()
-                .unwrap_or_else(|err| fail(&robot, &format!("reveal mouse up failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("reveal mouse up failed: {err}")));
             robot
                 .pump_frames(4)
-                .unwrap_or_else(|err| fail(&robot, &format!("reveal start pump failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("reveal start pump failed: {err}")));
             let reveal_started = capture(&robot, "reveal started");
             robot
                 .pump_frames(14)
-                .unwrap_or_else(|err| fail(&robot, &format!("reveal progress pump failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("reveal progress pump failed: {err}")));
             let reveal_later = capture(&robot, "reveal later");
 
             let reveal_start_delta =
@@ -168,20 +160,18 @@ fn main() {
             let reveal_total_delta =
                 changed_pixels(&reveal_baseline, &reveal_later, reveal_region);
             if reveal_total_delta < 80 {
-                fail(
+                robot_exit::fail(
                     &robot,
                     &format!(
                         "reveal click did not draw visible circular pixels: start={reveal_start_delta}, total={reveal_total_delta}"
-                    ),
-                );
+                    ));
             }
             if reveal_progress_delta < 30 {
-                fail(
+                robot_exit::fail(
                     &robot,
                     &format!(
                         "reveal animation did not expand over time: {reveal_progress_delta}"
-                    ),
-                );
+                    ));
             }
 
             println!(

--- a/apps/desktop-demo/robot-runners/robot_liquid_backdrop_feedback.rs
+++ b/apps/desktop-demo/robot-runners/robot_liquid_backdrop_feedback.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::{
     process::ExitCode,
     sync::atomic::{AtomicBool, Ordering},
@@ -31,7 +33,7 @@ fn main() -> ExitCode {
             settle(&robot, 900);
 
             let Some(pill) = scroll_to_button(&robot, "Sort filter pill", 260.0) else {
-                fail(&robot, "sort filter stage not found");
+                robot_exit::fail_and_await_shutdown(&robot, &FAILED, "sort filter stage not found");
             };
             let (px, py) = center(pill);
 
@@ -65,16 +67,18 @@ fn main() -> ExitCode {
 
             let Some(first_materialized) = lumas.iter().position(|&l| l >= MATERIALIZED_LUMA_FLOOR)
             else {
-                fail(
+                robot_exit::fail_and_await_shutdown(
                     &robot,
+                    &FAILED,
                     "droplet face never materialized over the pill (probe point missed)",
                 );
             };
             let base = lumas[first_materialized];
             for (index, &later) in lumas.iter().enumerate().skip(first_materialized + 1) {
                 if later - base > MAX_LATER_BRIGHTENING {
-                    fail(
+                    robot_exit::fail_and_await_shutdown(
                         &robot,
+                        &FAILED,
                         &format!(
                             "static glass face brightened after its first composite \
                              (self-feedback): {base:.1} at {}ms -> {later:.1} at {}ms",
@@ -168,17 +172,4 @@ fn sample_rgb(shot: &cranpose::RobotScreenshot, x: f32, y: f32) -> [u8; 3] {
 
 fn luma(rgb: [u8; 3]) -> f32 {
     0.2126 * rgb[0] as f32 + 0.7152 * rgb[1] as f32 + 0.0722 * rgb[2] as f32
-}
-
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    FAILED.store(true, Ordering::Relaxed);
-    std::thread::spawn(|| {
-        std::thread::sleep(Duration::from_secs(15));
-        std::process::exit(1);
-    });
-    let _ = robot.exit();
-    loop {
-        std::thread::sleep(Duration::from_secs(60));
-    }
 }

--- a/apps/desktop-demo/robot-runners/robot_liquid_dropdown_accordion.rs
+++ b/apps/desktop-demo/robot-runners/robot_liquid_dropdown_accordion.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::{
     process::ExitCode,
     sync::atomic::{AtomicBool, Ordering},
@@ -41,8 +43,9 @@ fn main() -> ExitCode {
             settle(&robot, SETTLE_MS);
 
             if visible(&robot, ACCORDION_HEADER) {
-                fail(
+                robot_exit::fail_and_await_shutdown(
                     &robot,
+                    &FAILED,
                     "the dropdown was already open before anything was tapped",
                 );
             }
@@ -50,11 +53,16 @@ fn main() -> ExitCode {
             tap(&robot, TRIGGER_LABEL, "open the dropdown");
             settle(&robot, SETTLE_MS);
             if !visible(&robot, ACCORDION_HEADER) {
-                fail(&robot, "tapping the trigger did not open the dropdown");
+                robot_exit::fail_and_await_shutdown(
+                    &robot,
+                    &FAILED,
+                    "tapping the trigger did not open the dropdown",
+                );
             }
             if visible(&robot, UNFOLDED_ROW) {
-                fail(
+                robot_exit::fail_and_await_shutdown(
                     &robot,
+                    &FAILED,
                     "the accordion was unfolded before its header was tapped",
                 );
             }
@@ -63,16 +71,18 @@ fn main() -> ExitCode {
             settle(&robot, SETTLE_MS);
 
             if !visible(&robot, ACCORDION_HEADER) {
-                fail(
+                robot_exit::fail_and_await_shutdown(
                     &robot,
+                    &FAILED,
                     "tapping a `keeps_open` row dismissed the dropdown. The row asked the \
                      menu to stay open and the menu closed anyway, so an accordion inside a \
                      dropdown can never unfold.",
                 );
             }
             if !visible(&robot, UNFOLDED_ROW) {
-                fail(
+                robot_exit::fail_and_await_shutdown(
                     &robot,
+                    &FAILED,
                     &format!(
                         "the dropdown stayed open but never unfolded: `{UNFOLDED_ROW}` is not \
                          on screen after tapping `{ACCORDION_HEADER}`."
@@ -84,8 +94,9 @@ fn main() -> ExitCode {
             tap(&robot, PLAIN_ROW, "tap an ordinary row");
             settle(&robot, SETTLE_MS);
             if visible(&robot, ACCORDION_HEADER) {
-                fail(
+                robot_exit::fail_and_await_shutdown(
                     &robot,
+                    &FAILED,
                     "tapping an ordinary row left the dropdown open. A row that does not ask \
                      to stay open has to dismiss.",
                 );
@@ -95,8 +106,9 @@ fn main() -> ExitCode {
             tap(&robot, TRIGGER_LABEL, "reopen the dropdown");
             settle(&robot, SETTLE_MS);
             if !visible(&robot, ACCORDION_HEADER) {
-                fail(
+                robot_exit::fail_and_await_shutdown(
                     &robot,
+                    &FAILED,
                     "the dropdown would not reopen after being dismissed",
                 );
             }
@@ -171,21 +183,22 @@ fn tap(robot: &cranpose::Robot, text: &str, what: &str) {
     let bounds = robot
         .find_text_bounds(text)
         .expect("query the screen for text")
-        .unwrap_or_else(|| fail(robot, &format!("cannot {what}: `{text}` is not on screen")));
+        .unwrap_or_else(|| {
+            robot_exit::fail_and_await_shutdown(
+                robot,
+                &FAILED,
+                &format!("cannot {what}: `{text}` is not on screen"),
+            )
+        });
     robot
         .click(bounds.0 + bounds.2 * 0.5, bounds.1 + bounds.3 * 0.5)
-        .unwrap_or_else(|error| fail(robot, &format!("cannot {what}: {error}")));
+        .unwrap_or_else(|error| {
+            robot_exit::fail_and_await_shutdown(robot, &FAILED, &format!("cannot {what}: {error}"))
+        });
 }
 
 fn settle(robot: &cranpose::Robot, millis: u64) {
     let _ = robot.wait_for_idle();
     std::thread::sleep(Duration::from_millis(millis));
     let _ = robot.wait_for_idle();
-}
-
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("\n✗ {message}");
-    FAILED.store(true, Ordering::Relaxed);
-    let _ = robot.exit();
-    std::process::exit(1);
 }

--- a/apps/desktop-demo/robot-runners/robot_liquid_tab_bar_pill_containment.rs
+++ b/apps/desktop-demo/robot-runners/robot_liquid_tab_bar_pill_containment.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::{
     path::{Path, PathBuf},
     process::ExitCode,
@@ -70,10 +72,8 @@ fn main() -> ExitCode {
                 save(&shot, &shot_dir, &format!("1-{name}-end-cell.png"));
 
                 let (first, last) = changed_span(&interior, &shot).unwrap_or_else(|| {
-                    fail(
-                        &robot,
-                        &format!("selecting the {name} end cell changed nothing on screen"),
-                    )
+                    robot_exit::fail_and_await_shutdown(&robot, &FAILED,
+                        &format!("selecting the {name} end cell changed nothing on screen"))
                 });
                 println!("the {name} end bubble occupies columns {first}..={last}");
 
@@ -81,15 +81,13 @@ fn main() -> ExitCode {
                 let past_right = last as f32 - right_edge;
                 if past_left > ESCAPE_BUDGET_PX || past_right > ESCAPE_BUDGET_PX {
                     let escape = past_left.max(past_right) / scale;
-                    fail(
-                        &robot,
+                    robot_exit::fail_and_await_shutdown(&robot, &FAILED,
                         &format!(
                             "the resting bubble on the {name} end cell is drawing outside the \
                              bar: columns {first}..={last} against the {left_edge:.1}..={right_edge:.1} \
                              it was given, about {escape:.1}dp of glass past the pill's rounded \
                              end. Its overhang past its own cell has outgrown the pill's margin."
-                        ),
-                    );
+                        ));
                 }
 
                 click_cell(&robot, 1);
@@ -217,11 +215,4 @@ fn settle(robot: &cranpose::Robot, millis: u64) {
     let _ = robot.wait_for_idle();
     std::thread::sleep(Duration::from_millis(millis));
     let _ = robot.wait_for_idle();
-}
-
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("\n✗ {message}");
-    FAILED.store(true, Ordering::Relaxed);
-    let _ = robot.exit();
-    std::process::exit(1);
 }

--- a/apps/desktop-demo/robot-runners/robot_menu_slide.rs
+++ b/apps/desktop-demo/robot-runners/robot_menu_slide.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::{
     process::ExitCode,
     sync::atomic::{AtomicBool, Ordering},
@@ -61,14 +63,19 @@ fn main() -> ExitCode {
             robot.touch_down(press_x, line_mid).expect("press down");
             std::thread::sleep(Duration::from_millis(250));
             if find_text_in_semantics(&robot, "Copy").is_some() {
-                fail(&robot, "menu appeared before the long-press threshold");
+                robot_exit::fail_and_await_shutdown(
+                    &robot,
+                    &FAILED,
+                    "menu appeared before the long-press threshold",
+                );
             }
             std::thread::sleep(Duration::from_millis(600));
 
             let menu_up_while_down = find_text_in_semantics(&robot, "Copy").is_some();
             if !menu_up_while_down {
-                fail(
+                robot_exit::fail_and_await_shutdown(
                     &robot,
+                    &FAILED,
                     "menu did not materialize during the hold (finger still down)",
                 );
             }
@@ -80,8 +87,9 @@ fn main() -> ExitCode {
             let accent_pixels = count_accentish(&shot, FIELD_X + prefix, FIELD_Y, word, 20.0);
             println!("menu_up_while_down={menu_up_while_down} accent_pixels={accent_pixels}");
             if accent_pixels < 60 {
-                fail(
+                robot_exit::fail_and_await_shutdown(
                     &robot,
+                    &FAILED,
                     &format!("no selection highlight after the long-press ({accent_pixels} px)"),
                 );
             }
@@ -92,8 +100,13 @@ fn main() -> ExitCode {
                 .expect("move mouse to second word");
             robot.mouse_down().expect("mouse long-press down");
             std::thread::sleep(Duration::from_millis(750));
-            let copy = find_text_in_semantics(&robot, "Copy")
-                .unwrap_or_else(|| fail(&robot, "menu absent during the second hold"));
+            let copy = find_text_in_semantics(&robot, "Copy").unwrap_or_else(|| {
+                robot_exit::fail_and_await_shutdown(
+                    &robot,
+                    &FAILED,
+                    "menu absent during the second hold",
+                )
+            });
             let (copy_cx, copy_cy) = (copy.0 + copy.2 * 0.5, copy.1 + copy.3 * 0.5);
             robot
                 .mouse_move((press_x + copy_cx) * 0.5, (line_mid + copy_cy) * 0.5)
@@ -105,8 +118,9 @@ fn main() -> ExitCode {
             std::thread::sleep(Duration::from_millis(300));
             let _ = robot.wait_for_idle();
             if find_text_in_semantics(&robot, "Copy").is_some() {
-                fail(
+                robot_exit::fail_and_await_shutdown(
                     &robot,
+                    &FAILED,
                     "lifting on Copy did not fire it (menu still open after release)",
                 );
             }
@@ -149,19 +163,6 @@ fn main() -> ExitCode {
         ExitCode::FAILURE
     } else {
         ExitCode::SUCCESS
-    }
-}
-
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    FAILED.store(true, Ordering::Relaxed);
-    std::thread::spawn(|| {
-        std::thread::sleep(Duration::from_secs(15));
-        std::process::exit(1);
-    });
-    let _ = robot.exit();
-    loop {
-        std::thread::sleep(Duration::from_secs(60));
     }
 }
 

--- a/apps/desktop-demo/robot-runners/robot_presented_window_geometry.rs
+++ b/apps/desktop-demo/robot-runners/robot_presented_window_geometry.rs
@@ -1,5 +1,6 @@
 mod output_paths;
 mod presented_window_geometry_contract;
+mod robot_exit;
 mod text_showcase_external_helpers;
 
 fn main() {

--- a/apps/desktop-demo/robot-runners/robot_presented_window_hidpi_geometry.rs
+++ b/apps/desktop-demo/robot-runners/robot_presented_window_hidpi_geometry.rs
@@ -1,5 +1,6 @@
 mod output_paths;
 mod presented_window_geometry_contract;
+mod robot_exit;
 mod text_showcase_external_helpers;
 
 fn main() {

--- a/apps/desktop-demo/robot-runners/robot_pressed_state.rs
+++ b/apps/desktop-demo/robot-runners/robot_pressed_state.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::time::Duration;
 
 use cranpose::{AppLauncher, Robot};
@@ -9,12 +11,6 @@ use desktop_app::test_screens::pressed_state_repro::{
 
 const COLOR_TOLERANCE: i32 = 24;
 const SAMPLE_ATTEMPTS: usize = 20;
-
-fn fail(robot: &Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    let _ = robot.exit();
-    std::process::exit(1);
-}
 
 fn physical_scale(screenshot: &cranpose::RobotScreenshot) -> f32 {
     if screenshot.logical_width.is_finite() && screenshot.logical_width > 0.0 {
@@ -72,10 +68,9 @@ fn main() {
             let center_y = SPRITE_OFFSET_Y + SPRITE_HEIGHT * 0.5;
 
             if let Err(actual) = wait_for_sprite_color(&robot, center_x, center_y, NORMAL_RGBA) {
-                fail(
+                robot_exit::fail(
                     &robot,
-                    &format!("sprite should start with the normal color, got {actual:?}"),
-                );
+                    &format!("sprite should start with the normal color, got {actual:?}"));
             }
             println!("Baseline normal sprite confirmed");
 
@@ -85,22 +80,20 @@ fn main() {
 
             if let Err(actual) = wait_for_sprite_color(&robot, center_x, center_y, PRESSED_RGBA) {
                 let _ = robot.mouse_up();
-                fail(
+                robot_exit::fail(
                     &robot,
                     &format!(
                         "sprite must show the pressed color while the pointer is down, got {actual:?}"
-                    ),
-                );
+                    ));
             }
             println!("Pressed sprite confirmed while pointer is down");
 
             robot.mouse_up().expect("mouse up");
 
             if let Err(actual) = wait_for_sprite_color(&robot, center_x, center_y, NORMAL_RGBA) {
-                fail(
+                robot_exit::fail(
                     &robot,
-                    &format!("sprite should return to the normal color after release, got {actual:?}"),
-                );
+                    &format!("sprite should return to the normal color after release, got {actual:?}"));
             }
             println!("Normal sprite restored after release");
 

--- a/apps/desktop-demo/robot-runners/robot_regression_fused_viewport_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_regression_fused_viewport_contract.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::{
     path::{Path, PathBuf},
     time::Duration,
@@ -64,10 +66,9 @@ fn main() {
                         let fully_visible =
                             y > chrome_bottom && y + h < WINDOW_HEIGHT as f32 - 10.0;
                         if fully_visible && ink < 40 {
-                            fail(
+                            robot_exit::fail(
                                 &robot,
-                                &format!("'{label}' missing on the initial frame ({ink} ink pixels)"),
-                            );
+                                &format!("'{label}' missing on the initial frame ({ink} ink pixels)"));
                         }
                     } else {
                         println!("initial '{label}' no semantics");
@@ -89,12 +90,11 @@ fn main() {
                             line.push_str(&format!(" | {label}: y={y:.0} ink={ink}"));
                             if ink < 40 {
                                 save(&shot, &shot_dir, &format!("missing-{step:02}"));
-                                fail(
+                                robot_exit::fail(
                                     &robot,
                                     &format!(
                                         "'{label}' visible in semantics at y={y:.0} but only {ink} ink pixels rendered (step {step})"
-                                    ),
-                                );
+                                    ));
                             }
                         }
                     }
@@ -138,12 +138,11 @@ fn main() {
                     println!("ghost-diff-pixels target={target} scroll={scroll_delta} diff={diff}");
                     if diff > threshold {
                         save(&shot, &shot_dir, &format!("{target}-ghost-{scroll_delta}"));
-                        fail(
+                        robot_exit::fail(
                             &robot,
                             &format!(
                                 "liquid page (scrolled {scroll_delta}) ghosting through {target} tab: {diff} changed pixels"
-                            ),
-                        );
+                            ));
                     }
                     robot
                         .invoke_app_hook("set-tab", "liquid")
@@ -158,12 +157,6 @@ fn main() {
             robot.exit().expect("exit");
         })
         .run(app::combined_app);
-}
-
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    let _ = robot.exit();
-    std::process::exit(1);
 }
 
 fn count_ink(shot: &cranpose::RobotScreenshot, x: f32, y: f32, w: f32, h: f32) -> usize {

--- a/apps/desktop-demo/robot-runners/robot_regression_hn_markdown_visual_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_regression_hn_markdown_visual_contract.rs
@@ -1,5 +1,6 @@
 mod markdown_fixture_client;
 mod output_paths;
+mod robot_exit;
 mod text_showcase_external_helpers;
 mod visual_contract_metrics;
 
@@ -24,11 +25,6 @@ const MIN_HN_TITLE_WIDTH: f32 = 120.0;
 const MAX_MARKDOWN_THUMB_RAIL_RATIO: f64 = 0.88;
 const MIN_MARKDOWN_THUMB_PIXELS: usize = 24;
 
-fn fail(_robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    std::process::exit(1);
-}
-
 fn wait_for_text(robot: &cranpose::Robot, text: &str) {
     for _ in 0..60 {
         if find_text_in_semantics(robot, text).is_some() {
@@ -37,7 +33,7 @@ fn wait_for_text(robot: &cranpose::Robot, text: &str) {
         std::thread::sleep(Duration::from_millis(100));
         let _ = robot.wait_for_idle();
     }
-    fail(robot, &format!("text {text:?} did not appear"));
+    robot_exit::fail_without_shutdown(&format!("text {text:?} did not appear"));
 }
 
 fn main() {
@@ -70,12 +66,10 @@ fn run_hacker_news_crispness() {
             let _ = robot.wait_for_idle();
 
             let bounds = find_text_in_semantics(&robot, target)
-                .unwrap_or_else(|| fail(&robot, "target Hacker News title not in semantics"));
+                .unwrap_or_else(|| robot_exit::fail_without_shutdown( "target Hacker News title not in semantics"));
             if bounds.2 < MIN_HN_TITLE_WIDTH {
-                fail(
-                    &robot,
-                    &format!("target title bounds too narrow for crispness metric: {bounds:?}"),
-                );
+                robot_exit::fail_without_shutdown(
+                    &format!("target title bounds too narrow for crispness metric: {bounds:?}"));
             }
             let logical = robot.screenshot().expect("read logical screenshot size");
             let window_id = find_window_id(HN_WINDOW_TITLE);
@@ -94,19 +88,17 @@ fn run_hacker_news_crispness() {
                 bounds.2 + 4.0,
                 bounds.3 + 4.0,
             )
-            .unwrap_or_else(|| fail(&robot, "failed to crop HN target text"));
+            .unwrap_or_else(|| robot_exit::fail_without_shutdown( "failed to crop HN target text"));
             let edge = edge_energy_screenshot(&crop);
             println!(
                 "hn_text_crispness target={target:?} bounds={bounds:?} edge_energy={edge:.3} screenshot={}",
                 screenshot_path.display()
             );
             if edge < MIN_HN_TITLE_EDGE_ENERGY {
-                fail(
-                    &robot,
+                robot_exit::fail_without_shutdown(
                     &format!(
                         "Hacker News title rendered blurred: edge_energy={edge:.3} threshold={MIN_HN_TITLE_EDGE_ENERGY:.3}"
-                    ),
-                );
+                    ));
             }
 
             println!("PASS: Hacker News target text is crisp enough");
@@ -128,16 +120,16 @@ fn run_markdown_scrollbar() {
             std::thread::sleep(Duration::from_millis(900));
             let _ = robot.wait_for_idle();
             let Some((x, y, w, h)) = find_button_in_semantics(&robot, "Fetch") else {
-                fail(&robot, "Fetch button not found");
+                robot_exit::fail_without_shutdown( "Fetch button not found");
             };
             robot.click(x + w * 0.5, y + h * 0.5).expect("click Fetch");
             wait_for_text(&robot, "Daily leetcode archive");
 
             let rail_bounds = find_text_in_semantics(&robot, "MarkdownScrollbarRail")
-                .unwrap_or_else(|| fail(&robot, "MarkdownScrollbarRail semantics missing"));
+                .unwrap_or_else(|| robot_exit::fail_without_shutdown( "MarkdownScrollbarRail semantics missing"));
             let screenshot = robot.screenshot().expect("capture markdown screenshot");
             let thumb_stats = feature_stats_screenshot(&screenshot, rail_bounds, is_markdown_thumb_pixel)
-                .unwrap_or_else(|| fail(&robot, "Markdown scrollbar thumb pixels not found"));
+                .unwrap_or_else(|| robot_exit::fail_without_shutdown( "Markdown scrollbar thumb pixels not found"));
             let thumb_height = (thumb_stats.max_y - thumb_stats.min_y + 1) as f64;
             let scale_y = screenshot.height as f64 / screenshot.logical_height.max(1.0) as f64;
             let rail_height = rail_bounds.3 as f64 * scale_y;
@@ -146,12 +138,10 @@ fn run_markdown_scrollbar() {
                 "markdown_scrollbar_initial rail={rail_bounds:?} thumb={thumb_stats:?} ratio={ratio:.3}"
             );
             if thumb_stats.count < MIN_MARKDOWN_THUMB_PIXELS || ratio > MAX_MARKDOWN_THUMB_RAIL_RATIO {
-                fail(
-                    &robot,
+                robot_exit::fail_without_shutdown(
                     &format!(
                         "Markdown scrollbar starts visually filled before touch: thumb_height={thumb_height:.1} rail_height={rail_height:.1} ratio={ratio:.3}"
-                    ),
-                );
+                    ));
             }
 
             println!("PASS: Markdown initial scrollbar thumb is proportional");

--- a/apps/desktop-demo/robot-runners/robot_regression_layout_jitter_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_regression_layout_jitter_contract.rs
@@ -1,4 +1,5 @@
 mod output_paths;
+mod robot_exit;
 mod text_showcase_external_helpers;
 mod visual_contract_metrics;
 
@@ -23,24 +24,13 @@ fn center((x, y, w, h): Rect) -> (f32, f32) {
     (x + w * 0.5, y + h * 0.5)
 }
 
-fn fail(_robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    std::process::exit(1);
-}
-
 fn require_prefix(robot: &cranpose::Robot, prefix: &str) -> (Rect, String) {
     find_text_by_prefix_in_semantics(robot, prefix)
         .map(|(x, y, w, h, text)| ((x, y, w, h), text))
         .unwrap_or_else(|| panic!("text prefix {prefix:?} not found"))
 }
 
-fn assert_same_origin(
-    robot: &cranpose::Robot,
-    label: &str,
-    before: Rect,
-    after: Rect,
-    epsilon: f32,
-) {
+fn assert_same_origin(label: &str, before: Rect, after: Rect, epsilon: f32) {
     let dx = after.0 - before.0;
     let dy = after.1 - before.1;
     println!(
@@ -48,20 +38,19 @@ fn assert_same_origin(
         before.0, before.1, after.0, after.1
     );
     if dx.abs() > epsilon || dy.abs() > epsilon {
-        fail(
-            robot,
-            &format!("{label} moved unexpectedly by ({dx:.2},{dy:.2})"),
-        );
+        robot_exit::fail_without_shutdown(&format!(
+            "{label} moved unexpectedly by ({dx:.2},{dy:.2})"
+        ));
     }
 }
 
 fn select_tab(robot: &cranpose::Robot, tab: DemoTab) {
     let Some((x, y, w, h)) = find_button_in_semantics(robot, tab.label()) else {
-        fail(robot, &format!("tab '{}' not found", tab.label()));
+        robot_exit::fail_without_shutdown(&format!("tab '{}' not found", tab.label()));
     };
-    robot
-        .click(x + w * 0.5, y + h * 0.5)
-        .unwrap_or_else(|err| fail(robot, &format!("click tab failed: {err}")));
+    robot.click(x + w * 0.5, y + h * 0.5).unwrap_or_else(|err| {
+        robot_exit::fail_without_shutdown(&format!("click tab failed: {err}"))
+    });
     std::thread::sleep(Duration::from_millis(260));
     let _ = robot.wait_for_idle();
 }
@@ -69,7 +58,7 @@ fn select_tab(robot: &cranpose::Robot, tab: DemoTab) {
 fn assert_animation_jitter(robot: &cranpose::Robot) {
     select_tab(robot, DemoTab::Animations);
     if find_text_in_semantics(robot, "Animations Showcase").is_none() {
-        fail(robot, "Animations Showcase did not load");
+        robot_exit::fail_without_shutdown("Animations Showcase did not load");
     }
 
     let ((initial_alpha_x, initial_alpha_y, _, _), alpha_text) = require_prefix(robot, "Alpha ");
@@ -81,10 +70,9 @@ fn assert_animation_jitter(robot: &cranpose::Robot) {
         let dy = y - initial_alpha_y;
         println!("alpha frame={frame} text={text:?} delta=({dx:.2},{dy:.2})");
         if dx.abs() > 0.75 || dy.abs() > 0.75 {
-            fail(
-                robot,
-                &format!("Pulse Alpha text jumped during animation frame {frame}: delta=({dx:.2},{dy:.2})"),
-            );
+            robot_exit::fail_without_shutdown(&format!(
+                "Pulse Alpha text jumped during animation frame {frame}: delta=({dx:.2},{dy:.2})"
+            ));
         }
     }
 
@@ -93,8 +81,7 @@ fn assert_animation_jitter(robot: &cranpose::Robot) {
     let alpha_bounds = find_text_by_prefix_in_semantics(robot, "Alpha ")
         .map(|(x, y, w, h, _)| (x, y, w, h))
         .unwrap_or_else(|| {
-            fail(
-                robot,
+            robot_exit::fail_without_shutdown(
                 "Alpha row label was not visible for visual stability",
             )
         });
@@ -121,23 +108,20 @@ fn assert_animation_jitter(robot: &cranpose::Robot) {
         let dy = edge_y - base_y;
         println!("alpha visual frame={frame} edge_y={edge_y:.2} delta={dy:.2}");
         if dy.abs() > 1.5 {
-            fail(
-                robot,
-                &format!("Pulse Alpha row jumped vertically in presented pixels: delta={dy:.2}"),
-            );
+            robot_exit::fail_without_shutdown(&format!(
+                "Pulse Alpha row jumped vertically in presented pixels: delta={dy:.2}"
+            ));
         }
     }
     if alpha_base_y.is_none() {
-        fail(
-            robot,
+        robot_exit::fail_without_shutdown(
             "Pulse Alpha row edge never became visible across 12 frames",
         );
     }
 
     let label_bounds = find_text_in_semantics(robot, "Animation sampled inside graphics_layer")
         .unwrap_or_else(|| {
-            fail(
-                robot,
+            robot_exit::fail_without_shutdown(
                 "Scale + Fade label was not visible for orange-box stability check",
             )
         });
@@ -146,8 +130,10 @@ fn assert_animation_jitter(robot: &cranpose::Robot) {
     let crop_region = (crop_left, crop_top, 110, 90);
     let first_path = output_paths::diagnostic_path("layout_jitter_animation_orange_first.png");
     let first = capture_x11_window(&window_id, &first_path);
-    let first_stats = feature_stats_rgba(&first, crop_region, is_orange_box_pixel)
-        .unwrap_or_else(|| fail(robot, "orange animation box pixels not found"));
+    let first_stats =
+        feature_stats_rgba(&first, crop_region, is_orange_box_pixel).unwrap_or_else(|| {
+            robot_exit::fail_without_shutdown("orange animation box pixels not found")
+        });
     let base_y = first_stats.centroid_y();
     println!("orange frame=base stats={first_stats:?} centroid_y={base_y:.2}");
 
@@ -157,15 +143,16 @@ fn assert_animation_jitter(robot: &cranpose::Robot) {
             "layout_jitter_animation_orange_{frame:02}.png"
         ));
         let image = capture_x11_window(&window_id, &path);
-        let stats = feature_stats_rgba(&image, crop_region, is_orange_box_pixel)
-            .unwrap_or_else(|| fail(robot, "orange animation box pixels disappeared"));
+        let stats =
+            feature_stats_rgba(&image, crop_region, is_orange_box_pixel).unwrap_or_else(|| {
+                robot_exit::fail_without_shutdown("orange animation box pixels disappeared")
+            });
         let dy = stats.centroid_y() - base_y;
         println!("orange frame={frame} stats={stats:?} centroid_y_delta={dy:.2}");
         if dy.abs() > 1.5 {
-            fail(
-                robot,
-                &format!("orange Scale + Fade box jumped vertically: delta={dy:.2}"),
-            );
+            robot_exit::fail_without_shutdown(&format!(
+                "orange Scale + Fade box jumped vertically: delta={dy:.2}"
+            ));
         }
     }
 }
@@ -173,7 +160,7 @@ fn assert_animation_jitter(robot: &cranpose::Robot) {
 fn assert_text_input_jitter(robot: &cranpose::Robot) {
     select_tab(robot, DemoTab::TextInput);
     if find_text_in_semantics(robot, "Text Input Demo").is_none() {
-        fail(robot, "Text Input Demo did not load");
+        robot_exit::fail_without_shutdown("Text Input Demo did not load");
     }
 
     let (field_before, _) = require_prefix(robot, "Type here");
@@ -191,15 +178,8 @@ fn assert_text_input_jitter(robot: &cranpose::Robot) {
     let (value_after, value_text_after) = require_prefix(robot, "Current value:");
     let after_screenshot = robot.screenshot().expect("text input after screenshot");
     println!("text input after field={field_text_after:?} value={value_text_after:?}");
+    assert_same_origin("text input field block", field_before, field_after, 1.0);
     assert_same_origin(
-        robot,
-        "text input field block",
-        field_before,
-        field_after,
-        1.0,
-    );
-    assert_same_origin(
-        robot,
         "text input current-value block",
         value_before,
         value_after,
@@ -209,17 +189,16 @@ fn assert_text_input_jitter(robot: &cranpose::Robot) {
     let diff = changed_pixel_count_in_region(&before_screenshot, &after_screenshot, region, 10);
     println!("text input visual diff={diff} region={region:?}");
     if diff > 4_500 {
-        fail(
-            robot,
-            &format!("typing changed too many pixels around the text input block: diff={diff}"),
-        );
+        robot_exit::fail_without_shutdown(&format!(
+            "typing changed too many pixels around the text input block: diff={diff}"
+        ));
     }
 }
 
 fn assert_dynamic_modifier_moves(robot: &cranpose::Robot) {
     select_tab(robot, DemoTab::ModifierShowcase);
     let Some((x, y, w, h)) = find_button_in_semantics(robot, "Dynamic Modifiers") else {
-        fail(robot, "Dynamic Modifiers selector not found");
+        robot_exit::fail_without_shutdown("Dynamic Modifiers selector not found");
     };
     robot
         .click(x + w * 0.5, y + h * 0.5)
@@ -228,12 +207,12 @@ fn assert_dynamic_modifier_moves(robot: &cranpose::Robot) {
     let _ = robot.wait_for_idle();
 
     if scroll_text_into_view(robot, "Move", 12, modifier_scroll_config()).is_none() {
-        fail(robot, "Move box text not visible");
+        robot_exit::fail_without_shutdown("Move box text not visible");
     }
     let move_before = find_text_in_semantics(robot, "Move").expect("Move text visible");
     let frame_before = require_prefix(robot, "Frame:").1;
     let Some((bx, by, bw, bh)) = find_button_in_semantics(robot, "Advance Frame") else {
-        fail(robot, "Advance Frame button not found");
+        robot_exit::fail_without_shutdown("Advance Frame button not found");
     };
     robot
         .click(bx + bw * 0.5, by + bh * 0.5)
@@ -249,13 +228,11 @@ fn assert_dynamic_modifier_moves(robot: &cranpose::Robot) {
         "dynamic modifiers: frame_before={frame_before:?} frame_after={frame_after:?} move_before={move_before:?} move_after={move_after:?} delta=({dx:.2},{dy:.2})"
     );
     if frame_before == frame_after {
-        fail(robot, "Advance Frame did not update the frame text");
+        robot_exit::fail_without_shutdown("Advance Frame did not update the frame text");
     }
     if dx.abs() < 8.0 || dy.abs() > 0.75 {
-        fail(
-            robot,
-            &format!("Advance Frame updated text but did not move the Move box horizontally enough: delta=({dx:.2},{dy:.2})"),
-        );
+        robot_exit::fail_without_shutdown(
+            &format!("Advance Frame updated text but did not move the Move box horizontally enough: delta=({dx:.2},{dy:.2})"));
     }
 }
 

--- a/apps/desktop-demo/robot-runners/robot_regression_shader_visual_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_regression_shader_visual_contract.rs
@@ -1,4 +1,5 @@
 mod output_paths;
+mod robot_exit;
 mod text_showcase_external_helpers;
 mod visual_contract_metrics;
 
@@ -25,11 +26,6 @@ const SHADOW_TITLE: &str = "Robot Shader Shadow Regression Contract";
 const DSTOUT_TITLE: &str = "Robot Shader DstOut Regression Contract";
 const WINDOW_WIDTH: u32 = 1200;
 const WINDOW_HEIGHT: u32 = 900;
-
-fn fail(_robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    std::process::exit(1);
-}
 
 fn center((x, y, w, h): (f32, f32, f32, f32)) -> (f32, f32) {
     (x + w * 0.5, y + h * 0.5)
@@ -86,9 +82,9 @@ fn run_interactive_overlap() {
             wait_for_text(&robot, "Interactive Effects (drag the rects!)");
 
             let blur = find_text_in_semantics(&robot, "Blur")
-                .unwrap_or_else(|| fail(&robot, "Blur label missing"));
+                .unwrap_or_else(|| robot_exit::fail_without_shutdown( "Blur label missing"));
             let glass = find_text_in_semantics(&robot, "Glass")
-                .unwrap_or_else(|| fail(&robot, "Glass label missing"));
+                .unwrap_or_else(|| robot_exit::fail_without_shutdown( "Glass label missing"));
             let (blur_cx, blur_cy) = center(blur);
             let (glass_cx, glass_cy) = center(glass);
             let blur_start = (blur_cx + 16.0, blur_cy + 16.0);
@@ -175,10 +171,8 @@ fn run_interactive_overlap() {
                 || right_blue_blur_pixels < left_blue_blur_pixels.saturating_mul(3)
                 || right_edge < 0.65 * left_edge.max(1.0)
             {
-                fail(
-                    &robot,
-                    "glass/blur overlap lost backdrop detail in the right half of the glass rect",
-                );
+                robot_exit::fail_without_shutdown(
+                    "glass/blur overlap lost backdrop detail in the right half of the glass rect");
             }
 
             println!("PASS: glass/blur overlap keeps visible backdrop detail");
@@ -204,7 +198,7 @@ fn run_shader_scrollbar() {
             select_shaders_tab(&robot);
 
             let before = robot.screenshot().expect("shader before screenshot");
-            assert_no_implicit_scrollbar(&robot, "before scroll", &before);
+            assert_no_implicit_scrollbar("before scroll", &before);
             robot
                 .mouse_move(WINDOW_WIDTH as f32 - 46.0, WINDOW_HEIGHT as f32 * 0.5)
                 .expect("move to shader scrollbar area");
@@ -213,7 +207,7 @@ fn run_shader_scrollbar() {
             let _ = robot.wait_for_idle();
 
             let after = robot.screenshot().expect("shader after screenshot");
-            assert_no_implicit_scrollbar(&robot, "after scroll", &after);
+            assert_no_implicit_scrollbar("after scroll", &after);
 
             println!("PASS: plain shader scroll container draws no implicit scrollbar chrome");
             robot.exit().expect("exit");
@@ -240,7 +234,7 @@ fn run_shadow_showcases() {
             )
             .is_none()
             {
-                fail(&robot, "Shadow Fields section not visible");
+                robot_exit::fail_without_shutdown( "Shadow Fields section not visible");
             }
             let _ = set_slider_fraction(&robot, "shadow_elevation", 1.0, 196.0, 9.0, shader_scroll_config());
             let _ = set_slider_fraction(&robot, "ambient_alpha", 1.0, 196.0, 9.0, shader_scroll_config());
@@ -252,7 +246,7 @@ fn run_shadow_showcases() {
                 12,
                 shader_scroll_config(),
             )
-            .unwrap_or_else(|| fail(&robot, "Shadow preview label not visible"));
+            .unwrap_or_else(|| robot_exit::fail_without_shutdown( "Shadow preview label not visible"));
             let screenshot = robot.screenshot().expect("shadow screenshot");
             let shadow_path = output_paths::diagnostic_path("shader_shadow_fields.png");
             save_robot_screenshot(&shadow_path, &screenshot);
@@ -270,10 +264,8 @@ fn run_shadow_showcases() {
                 shadow_path.display()
             );
             if shadow_pixels < 120 {
-                fail(
-                    &robot,
-                    &format!("Shadow Fields preview is missing shadow pixels: count={shadow_pixels}"),
-                );
+                robot_exit::fail_without_shutdown(
+                    &format!("Shadow Fields preview is missing shadow pixels: count={shadow_pixels}"));
             }
 
             scroll_text_into_view(
@@ -282,12 +274,12 @@ fn run_shadow_showcases() {
                 24,
                 shader_scroll_config(),
             )
-            .unwrap_or_else(|| fail(&robot, "Compose 1.9 Shadow API section not visible"));
+            .unwrap_or_else(|| robot_exit::fail_without_shutdown( "Compose 1.9 Shadow API section not visible"));
             let screenshot = robot.screenshot().expect("compose shadow screenshot");
             let compose_path = output_paths::diagnostic_path("shader_compose_shadow.png");
             save_robot_screenshot(&compose_path, &screenshot);
             let drop_label = find_text_in_semantics(&robot, "drop")
-                .unwrap_or_else(|| fail(&robot, "drop shadow preview label not visible"));
+                .unwrap_or_else(|| robot_exit::fail_without_shutdown( "drop shadow preview label not visible"));
             let drop_box_left = drop_label.0 - 10.0;
             let drop_box_top = drop_label.1 - 50.0;
             let compose_probe = (
@@ -308,10 +300,8 @@ fn run_shadow_showcases() {
                 compose_path.display()
             );
             if compose_shadow_pixels < 300 {
-                fail(
-                    &robot,
-                    &format!("Compose shadow preview is missing shadow pixels: count={compose_shadow_pixels}"),
-                );
+                robot_exit::fail_without_shutdown(
+                    &format!("Compose shadow preview is missing shadow pixels: count={compose_shadow_pixels}"));
             }
 
             println!("PASS: shadow showcases contain visible shadow pixels");
@@ -344,7 +334,7 @@ fn run_dstout_alpha() {
                 830.0,
                 shader_scroll_config(),
             )
-            .unwrap_or_else(|| fail(&robot, "TOP LAYER text not visible in measurement band"));
+            .unwrap_or_else(|| robot_exit::fail_without_shutdown( "TOP LAYER text not visible in measurement band"));
             let screenshot = robot.screenshot().expect("DstOut screenshot");
             let dstout_path = output_paths::diagnostic_path("shader_dstout_alpha.png");
             save_robot_screenshot(&dstout_path, &screenshot);
@@ -355,10 +345,10 @@ fn run_dstout_alpha() {
                 top_layer.2 + 8.0,
                 top_layer.3 + 8.0,
             )
-            .unwrap_or_else(|| fail(&robot, "failed to crop TOP LAYER text"));
+            .unwrap_or_else(|| robot_exit::fail_without_shutdown( "failed to crop TOP LAYER text"));
             let top_edge = edge_energy_screenshot(&top_crop);
             let underlay = find_text_in_semantics(&robot, "UNDERLAY CONTENT")
-                .unwrap_or_else(|| fail(&robot, "UNDERLAY CONTENT text not visible after preview_alpha change"));
+                .unwrap_or_else(|| robot_exit::fail_without_shutdown( "UNDERLAY CONTENT text not visible after preview_alpha change"));
             let underlay_crop = crop_screenshot_logical(
                 &screenshot,
                 (underlay.0 - 4.0).max(0.0),
@@ -366,17 +356,15 @@ fn run_dstout_alpha() {
                 underlay.2 + 8.0,
                 underlay.3 + 8.0,
             )
-            .unwrap_or_else(|| fail(&robot, "failed to crop UNDERLAY CONTENT text"));
+            .unwrap_or_else(|| robot_exit::fail_without_shutdown( "failed to crop UNDERLAY CONTENT text"));
             let underlay_edge = edge_energy_screenshot(&underlay_crop);
             println!(
                 "dstout_alpha top_edge={top_edge:.3} underlay_edge={underlay_edge:.3} top={top_layer:?} underlay={underlay:?} screenshot={}",
                 dstout_path.display()
             );
             if top_edge < 3.5 || underlay_edge < 8.0 {
-                fail(
-                    &robot,
-                    &format!("DstOut preview damaged text after preview_alpha changed: top_edge={top_edge:.3} underlay_edge={underlay_edge:.3}"),
-                );
+                robot_exit::fail_without_shutdown(
+                    &format!("DstOut preview damaged text after preview_alpha changed: top_edge={top_edge:.3} underlay_edge={underlay_edge:.3}"));
             }
 
             println!("PASS: DstOut alpha change keeps preview text visible");
@@ -436,7 +424,7 @@ fn drag_window(window_id: &str, from: (f32, f32), to: (f32, f32)) {
 
 fn select_shaders_tab(robot: &cranpose::Robot) {
     let Some((x, y, w, h)) = find_button_in_semantics(robot, "Shaders") else {
-        fail(robot, "Shaders tab not found");
+        robot_exit::fail_without_shutdown("Shaders tab not found");
     };
     robot
         .click(x + w * 0.5, y + h * 0.5)
@@ -453,7 +441,7 @@ fn wait_for_text(robot: &cranpose::Robot, text: &str) {
         std::thread::sleep(Duration::from_millis(100));
         let _ = robot.wait_for_idle();
     }
-    fail(robot, &format!("text {text:?} did not appear"));
+    robot_exit::fail_without_shutdown(&format!("text {text:?} did not appear"));
 }
 
 fn shader_scroll_config() -> ScrollConfig {
@@ -475,11 +463,7 @@ fn scrollbar_probe_region(screenshot: &cranpose::RobotScreenshot) -> (f32, f32, 
     )
 }
 
-fn assert_no_implicit_scrollbar(
-    robot: &cranpose::Robot,
-    phase: &str,
-    screenshot: &cranpose::RobotScreenshot,
-) {
+fn assert_no_implicit_scrollbar(phase: &str, screenshot: &cranpose::RobotScreenshot) {
     let stats = feature_stats_screenshot(
         screenshot,
         scrollbar_probe_region(screenshot),
@@ -487,10 +471,9 @@ fn assert_no_implicit_scrollbar(
     );
     println!("shader_no_implicit_scrollbar phase={phase} stats={stats:?}");
     if stats.is_some_and(|stats| stats.count > 80) {
-        fail(
-            robot,
-            &format!("plain shader scroll container drew implicit scrollbar chrome {phase}"),
-        );
+        robot_exit::fail_without_shutdown(&format!(
+            "plain shader scroll container drew implicit scrollbar chrome {phase}"
+        ));
     }
 }
 

--- a/apps/desktop-demo/robot-runners/robot_regression_tabbar_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_regression_tabbar_contract.rs
@@ -1,4 +1,5 @@
 mod output_paths;
+mod robot_exit;
 
 use std::{path::Path, time::Duration};
 
@@ -62,11 +63,6 @@ fn tab_row_y(tabs: &[(String, Rect)]) -> f32 {
     ys[ys.len() / 2]
 }
 
-fn fail(_robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    std::process::exit(1);
-}
-
 fn save_screenshot(path: &Path, screenshot: &cranpose::RobotScreenshot) {
     let Some(image) = ImageBuffer::<image::Rgba<u8>, _>::from_raw(
         screenshot.width,
@@ -97,17 +93,17 @@ fn main() {
             let root = root_bounds(&robot).unwrap_or((0.0, 0.0, 900.0, 700.0));
             let initial_tabs = collect_tab_bounds(&robot, &labels);
             if initial_tabs.len() < 4 {
-                fail(&robot, "not enough tab semantics collected");
+                robot_exit::fail_without_shutdown( "not enough tab semantics collected");
             }
             let axis = detect_tab_axis(&initial_tabs).unwrap_or(TabAxis::Horizontal);
             if axis != TabAxis::Horizontal {
-                fail(&robot, "tabbar is expected to be horizontal in the desktop demo");
+                robot_exit::fail_without_shutdown( "tabbar is expected to be horizontal in the desktop demo");
             }
             let Some(span) = bounds_span(&initial_tabs) else {
-                fail(&robot, "missing tab span");
+                robot_exit::fail_without_shutdown( "missing tab span");
             };
             if span.2 - span.0 <= root.2 - 40.0 {
-                fail(&robot, "tabbar does not overflow, so scroll contract cannot run");
+                robot_exit::fail_without_shutdown( "tabbar does not overflow, so scroll contract cannot run");
             }
 
             let initial_y = tab_row_y(&initial_tabs);
@@ -121,10 +117,8 @@ fn main() {
             let wheel_y_delta = after_wheel_y - initial_y;
             println!("after_wheel_y={after_wheel_y:.2} wheel_y_delta={wheel_y_delta:.2}");
             if wheel_y_delta.abs() > 1.0 {
-                fail(
-                    &robot,
-                    &format!("tab row changed Y during wheel scroll: delta={wheel_y_delta:.2}"),
-                );
+                robot_exit::fail_without_shutdown(
+                    &format!("tab row changed Y during wheel scroll: delta={wheel_y_delta:.2}"));
             }
 
             scroll_tab_row_left(&robot, initial_counter, 260.0);
@@ -137,10 +131,8 @@ fn main() {
                 lazy_after_drag.0
             );
             if y_delta.abs() > 1.0 {
-                fail(
-                    &robot,
-                    &format!("tab row changed Y while scrolling: delta={y_delta:.2}"),
-                );
+                robot_exit::fail_without_shutdown(
+                    &format!("tab row changed Y while scrolling: delta={y_delta:.2}"));
             }
 
             for label in [
@@ -187,10 +179,8 @@ fn main() {
             let before_hn = require_tab(&before_click, "Hacker News");
             let before_counter = require_tab(&before_click, "Counter App");
             if !visible_in_root(before_hn, root) {
-                fail(
-                    &robot,
-                    &format!("Hacker News tab is still not visible after tabbar scroll: {before_hn:?}"),
-                );
+                robot_exit::fail_without_shutdown(
+                    &format!("Hacker News tab is still not visible after tabbar scroll: {before_hn:?}"));
             }
             let tab_strip_region = (0.0, (before_hn.1 - 18.0).max(0.0), root.2, before_hn.3 + 36.0);
             let screenshot_before_click = robot.screenshot().expect("tabbar before click screenshot");
@@ -230,13 +220,11 @@ fn main() {
                 || hn_jump.abs() > 12.0
                 || tab_strip_diff > 18_000
             {
-                fail(
-                    &robot,
-                    "clicking Hacker News after tabbar scroll reset or jumped the tab-row scroll position",
-                );
+                robot_exit::fail_without_shutdown(
+                    "clicking Hacker News after tabbar scroll reset or jumped the tab-row scroll position");
             }
             if find_button_exact_in_semantics(&robot, "Hacker News").is_none() {
-                fail(&robot, "Hacker News tab disappeared from button semantics");
+                robot_exit::fail_without_shutdown( "Hacker News tab disappeared from button semantics");
             }
 
             let edge_probe_before = collect_tab_bounds(&robot, &labels);
@@ -255,12 +243,10 @@ fn main() {
             let edge_probe_delta = edge_probe_hn_after.0 - edge_probe_hn_before.0;
             println!("edge_wheel_delta={edge_probe_delta:.2}");
             if edge_probe_delta < 100.0 {
-                fail(
-                    &robot,
+                robot_exit::fail_without_shutdown(
                     &format!(
                         "horizontal wheel inside the tab-row band near the window edge did not reach the row: delta={edge_probe_delta:.2}"
-                    ),
-                );
+                    ));
             }
 
             println!("PASS: tab row keeps Y position and retained scroll offset");

--- a/apps/desktop-demo/robot-runners/robot_render_crispness_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_render_crispness_contract.rs
@@ -1,4 +1,5 @@
 mod output_paths;
+mod robot_exit;
 
 use std::{path::Path, time::Duration};
 
@@ -31,12 +32,6 @@ const SCROLL_COMPARE_TOP: f32 = 1.0;
 const SCROLL_COMPARE_H: f32 = BLOCK_H - 2.0;
 const GRID_COMPARE_TOP: f32 = 26.4;
 const GRID_COMPARE_H: f32 = 20.0;
-
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    let _ = robot.exit();
-    std::process::exit(1);
-}
 
 fn save_png(path: &Path, screenshot: &cranpose::RobotScreenshot) -> Result<(), String> {
     let image: RgbaImage = ImageBuffer::from_raw(
@@ -260,11 +255,11 @@ fn main() {
 
             let screenshot = robot
                 .screenshot_with_scale(CAPTURE_SCALE)
-                .unwrap_or_else(|err| fail(&robot, &format!("failed to capture screenshot: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("failed to capture screenshot: {err}")));
             let output_path =
                 output_paths::diagnostic_path("cranpose_render_crispness_contract.png");
             if let Err(err) = save_png(&output_path, &screenshot) {
-                fail(&robot, &err);
+                robot_exit::fail(&robot, &err);
             }
             println!("SCREENSHOT_PATH={}", output_path.display());
 
@@ -335,7 +330,7 @@ fn main() {
             }
 
             if !failures.is_empty() {
-                fail(&robot, &failures.join("; "));
+                robot_exit::fail(&robot, &failures.join("; "));
             }
 
             println!(

--- a/apps/desktop-demo/robot-runners/robot_renderer_micro_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_renderer_micro_contract.rs
@@ -1,4 +1,5 @@
 mod output_paths;
+mod robot_exit;
 mod text_showcase_external_helpers;
 
 use std::{path::Path, time::Duration};
@@ -124,12 +125,6 @@ fn normalize_micro_contract_logical_size(
     screenshot.logical_width = WINDOW_WIDTH as f32;
     screenshot.logical_height = WINDOW_HEIGHT as f32;
     screenshot
-}
-
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    let _ = robot.exit();
-    std::process::exit(1);
 }
 
 struct MicroContractMetrics {
@@ -532,18 +527,18 @@ fn assert_micro_contract_pixels(
         ),
     ] {
         if let Err(err) = assert_color(screenshot, label, x, y, expected) {
-            fail(robot, &format!("{capture_label} {err}"));
+            robot_exit::fail(robot, &format!("{capture_label} {err}"));
         }
     }
 
     let Some(underline_crop) = crop_screenshot_logical(screenshot, 58.0, 22.0, 90.0, 24.0) else {
-        fail(
+        robot_exit::fail(
             robot,
             &format!("{capture_label} failed to crop underlined text region"),
         );
     };
     let Some(underline_band) = crop_screenshot_logical(screenshot, 58.0, 37.0, 90.0, 4.0) else {
-        fail(
+        robot_exit::fail(
             robot,
             &format!("{capture_label} failed to crop underline band"),
         );
@@ -552,31 +547,29 @@ fn assert_micro_contract_pixels(
     let underline_bright = count_bright_pixels(&underline_crop);
     let underline_band_bright = count_bright_pixels(&underline_band);
     if underline_bright < 150 {
-        fail(
+        robot_exit::fail(
             robot,
             &format!(
                 "{capture_label} underlined text region is too soft or missing: bright_pixels={underline_bright}"
-            ),
-        );
+            ));
     }
     if underline_band_bright < 22 {
-        fail(
+        robot_exit::fail(
             robot,
             &format!(
                 "{capture_label} underline band is too weak or misplaced: bright_pixels={underline_band_bright}"
-            ),
-        );
+            ));
     }
 
     let Some(bitmap_row_text) = crop_screenshot_logical(screenshot, 38.0, 96.0, 134.0, 30.0) else {
-        fail(
+        robot_exit::fail(
             robot,
             &format!("{capture_label} failed to crop bitmap icon text row"),
         );
     };
     let Some(source_row_text) = crop_screenshot_logical(screenshot, 38.0, 126.0, 134.0, 30.0)
     else {
-        fail(
+        robot_exit::fail(
             robot,
             &format!("{capture_label} failed to crop source icon text row"),
         );
@@ -584,45 +577,42 @@ fn assert_micro_contract_pixels(
     let bitmap_green = count_green_text_pixels(&bitmap_row_text);
     let source_green = count_green_text_pixels(&source_row_text);
     let Some(panel_text) = crop_screenshot_logical(screenshot, 100.0, 46.0, 60.0, 22.0) else {
-        fail(
+        robot_exit::fail(
             robot,
             &format!("{capture_label} failed to crop nested panel text"),
         );
     };
     let panel_yellow = count_yellow_text_pixels(&panel_text);
     if bitmap_green < 35 {
-        fail(
+        robot_exit::fail(
             robot,
             &format!(
                 "{capture_label} text after Image(BitmapPainter) is missing or clipped: green_pixels={bitmap_green}"
-            ),
-        );
+            ));
     }
     if source_green < 35 {
-        fail(
+        robot_exit::fail(
             robot,
             &format!(
                 "{capture_label} text after draw_image_src is missing or clipped: green_pixels={source_green}"
-            ),
-        );
+            ));
     }
     if panel_yellow < 20 {
-        fail(
+        robot_exit::fail(
             robot,
             &format!(
                 "{capture_label} nested panel text after image layers is missing or clipped: yellow_pixels={panel_yellow}"
-            ),
-        );
+            ));
     }
 
     let Some(compact_text) = crop_screenshot_logical(screenshot, 36.0, 156.0, 94.0, 34.0) else {
-        fail(
+        robot_exit::fail(
             robot,
             &format!("{capture_label} failed to crop compact text row"),
         );
     };
     let Some(compact_gap) = crop_screenshot_logical(screenshot, 135.0, 158.0, 4.0, 28.0) else {
-        fail(
+        robot_exit::fail(
             robot,
             &format!("{capture_label} failed to crop compact text gap"),
         );
@@ -630,20 +620,18 @@ fn assert_micro_contract_pixels(
     let compact_green = count_green_text_pixels(&compact_text);
     let compact_gap_green = count_green_text_pixels(&compact_gap);
     if compact_green < 18 {
-        fail(
+        robot_exit::fail(
             robot,
             &format!(
                 "{capture_label} scaled compact text is missing or over-clipped: green_pixels={compact_green}"
-            ),
-        );
+            ));
     }
     if compact_gap_green != 0 {
-        fail(
+        robot_exit::fail(
             robot,
             &format!(
                 "{capture_label} scaled compact text drew outside its bounds into badge gap: green_pixels={compact_gap_green}"
-            ),
-        );
+            ));
     }
 
     MicroContractMetrics {
@@ -672,20 +660,19 @@ fn main() {
 
             let screenshot = robot
                 .screenshot_with_scale(1.0)
-                .unwrap_or_else(|err| fail(&robot, &format!("failed to capture screenshot: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("failed to capture screenshot: {err}")));
             if screenshot.width < WINDOW_WIDTH || screenshot.height < WINDOW_HEIGHT {
-                fail(
+                robot_exit::fail(
                     &robot,
                     &format!(
                         "renderer readback scale-1 screenshot is smaller than the requested app surface: expected_at_least={}x{} actual={}x{}",
                         WINDOW_WIDTH, WINDOW_HEIGHT, screenshot.width, screenshot.height
-                    ),
-                );
+                    ));
             }
             let screenshot = normalize_micro_contract_logical_size(screenshot);
             let output_path = output_paths::diagnostic_path("cranpose_renderer_micro_contract.png");
             if let Err(err) = save_png(&output_path, &screenshot) {
-                fail(&robot, &err);
+                robot_exit::fail(&robot, &err);
             }
             println!("SCREENSHOT_PATH={}", output_path.display());
             println!(

--- a/apps/desktop-demo/robot-runners/robot_tab_roundtrip_content.rs
+++ b/apps/desktop-demo/robot-runners/robot_tab_roundtrip_content.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::time::Duration;
 
 use cranpose::AppLauncher;
@@ -24,11 +26,6 @@ fn click_tab(robot: &cranpose::Robot, label: &str) -> bool {
     true
 }
 
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    let _ = robot;
-    panic!("{message}");
-}
-
 fn main() {
     env_logger::init();
     println!("=== Robot Tab Roundtrip Content Test ===");
@@ -52,16 +49,13 @@ fn main() {
             for (tab, marker) in tab_walk {
                 println!("--- Switching to '{}' ---", tab);
                 if !click_tab(&robot, tab) {
-                    fail(&robot, &format!("tab '{}' not found", tab));
+                    robot_exit::fail_without_shutdown(&format!("tab '{}' not found", tab));
                 }
                 if !wait_for_text(&robot, marker, 30, Duration::from_millis(100)) {
-                    fail(
-                        &robot,
-                        &format!(
-                            "marker '{}' did not appear after switching to '{}'",
-                            marker, tab
-                        ),
-                    );
+                    robot_exit::fail_without_shutdown(&format!(
+                        "marker '{}' did not appear after switching to '{}'",
+                        marker, tab
+                    ));
                 }
             }
 

--- a/apps/desktop-demo/robot-runners/robot_text_loupe.rs
+++ b/apps/desktop-demo/robot-runners/robot_text_loupe.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::{
     path::{Path, PathBuf},
     process::ExitCode,
@@ -107,7 +109,7 @@ fn main() -> ExitCode {
                     break;
                 }
                 if attempt == 2 {
-                    fail(&robot, "double-tap selection never armed");
+                    robot_exit::fail_and_await_shutdown(&robot, &FAILED,  "double-tap selection never armed");
                 }
                 robot
                     .drag(melody_center, line1_mid, melody_center, line1_mid)
@@ -149,13 +151,13 @@ fn main() -> ExitCode {
                 save(shot, &shot_dir, name);
             }
             if !region_has_structure(shots.last().expect("settled grow frame"), loupe_region_at(end_x)) {
-                fail(&robot, "the loupe never reached its raised steady pose");
+                robot_exit::fail_and_await_shutdown(&robot, &FAILED,  "the loupe never reached its raised steady pose");
             }
             std::thread::sleep(Duration::from_millis(420));
 
             let held = robot.screenshot_with_scale(3.0).expect("held loupe");
             let held_center = loupe_top_rim_center_x(&held)
-                .unwrap_or_else(|| fail(&robot, "held loupe top rim was not measurable"));
+                .unwrap_or_else(|| robot_exit::fail_and_await_shutdown(&robot, &FAILED,  "held loupe top rim was not measurable"));
             let jump_x = (end_x + 90.0).min(FIELD_X + FIELD_WIDTH - 60.0);
             robot
                 .touch_move(jump_x, line1_mid)
@@ -165,19 +167,17 @@ fn main() -> ExitCode {
                 .expect("immediate jump frame");
             save(&jumped, &shot_dir, "05b-direct-follow");
             let jumped_center = loupe_top_rim_center_x(&jumped)
-                .unwrap_or_else(|| fail(&robot, "jumped loupe top rim was not measurable"));
+                .unwrap_or_else(|| robot_exit::fail_and_await_shutdown(&robot, &FAILED,  "jumped loupe top rim was not measurable"));
             println!(
                 "loupe direct follow held={held_center:.2} pointer={jump_x:.2} frame={jumped_center:.2}"
             );
             let step = jump_x - end_x;
             let moved = jumped_center - held_center;
             if moved < -2.0 || moved > step * 0.75 {
-                fail(
-                    &robot,
+                robot_exit::fail_and_await_shutdown(&robot, &FAILED,
                     &format!(
                         "loupe step response outside the measured follow envelope: held={held_center:.2}, pointer={jump_x:.2}, frame={jumped_center:.2}"
-                    ),
-                );
+                    ));
             }
             std::thread::sleep(Duration::from_millis(350));
             let _ = robot.wait_for_idle();
@@ -186,14 +186,12 @@ fn main() -> ExitCode {
                 .expect("converged follow frame");
             save(&converged, &shot_dir, "05c-follow-converged");
             let converged_center = loupe_top_rim_center_x(&converged)
-                .unwrap_or_else(|| fail(&robot, "converged loupe top rim was not measurable"));
+                .unwrap_or_else(|| robot_exit::fail_and_await_shutdown(&robot, &FAILED,  "converged loupe top rim was not measurable"));
             if (converged_center - jump_x).abs() > 8.0 {
-                fail(
-                    &robot,
+                robot_exit::fail_and_await_shutdown(&robot, &FAILED,
                     &format!(
                         "loupe follow did not converge on the pointer: pointer={jump_x:.2}, settled={converged_center:.2}"
-                    ),
-                );
+                    ));
             }
             robot
                 .touch_move(end_x, line1_mid)
@@ -264,7 +262,7 @@ fn main() -> ExitCode {
                 line1_mid - 14.0,
             );
             if region_has_structure(&shots[5], terminal_region) {
-                fail(&robot, "collapse +270 ms: bubble residue never unmounted");
+                robot_exit::fail_and_await_shutdown(&robot, &FAILED,  "collapse +270 ms: bubble residue never unmounted");
             }
             std::thread::sleep(Duration::from_millis(500));
             let after = robot.screenshot_with_scale(3.0).expect("after");
@@ -283,7 +281,7 @@ fn main() -> ExitCode {
                 line1_mid - 72.0,
             );
             if !region_has_structure(&dot_drag, dot_loupe_region) {
-                fail(&robot, "no loupe rose for a dot grab below the line");
+                robot_exit::fail_and_await_shutdown(&robot, &FAILED,  "no loupe rose for a dot grab below the line");
             }
             robot
                 .touch_move(wrap_boundary_x, dot_y)
@@ -304,10 +302,8 @@ fn main() -> ExitCode {
                 "wrapped boundary byte={first_wrap_boundary} x={wrap_boundary_x:.2} upper-end pixels={upper_end_pixels}"
             );
             if upper_end_pixels < 20 {
-                fail(
-                    &robot,
-                    "end handle at a shared soft-wrap boundary jumped off the upper visual line",
-                );
+                robot_exit::fail_and_await_shutdown(&robot, &FAILED,
+                    "end handle at a shared soft-wrap boundary jumped off the upper visual line");
             }
             robot
                 .touch_up(wrap_boundary_x, dot_y)
@@ -470,17 +466,4 @@ fn count_accent_pixels(shot: &cranpose::RobotScreenshot, region: (f32, f32, f32,
         }
     }
     count
-}
-
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    FAILED.store(true, Ordering::Relaxed);
-    std::thread::spawn(|| {
-        std::thread::sleep(Duration::from_secs(15));
-        std::process::exit(1);
-    });
-    let _ = robot.exit();
-    loop {
-        std::thread::sleep(Duration::from_secs(1));
-    }
 }

--- a/apps/desktop-demo/robot-runners/robot_text_showcase_gradient.rs
+++ b/apps/desktop-demo/robot-runners/robot_text_showcase_gradient.rs
@@ -1,3 +1,5 @@
+mod robot_exit;
+
 use std::time::Duration;
 
 use cranpose::AppLauncher;
@@ -6,12 +8,6 @@ use cranpose_testing::{
     find_in_semantics, find_text,
 };
 use desktop_app::app;
-
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    let _ = robot.exit();
-    std::process::exit(1);
-}
 
 fn main() {
     env_logger::init();
@@ -29,7 +25,7 @@ fn main() {
             let Some((shaders_x, shaders_y, shaders_w, shaders_h)) =
                 find_button_in_semantics(&robot, "Shaders")
             else {
-                fail(&robot, "Shaders tab not found");
+                robot_exit::fail(&robot, "Shaders tab not found");
             };
             robot
                 .click(shaders_x + shaders_w * 0.5, shaders_y + shaders_h * 0.5)
@@ -40,7 +36,7 @@ fn main() {
             let Some((text_x, text_y, text_w, text_h)) =
                 find_button_exact_in_semantics(&robot, "Text")
             else {
-                fail(&robot, "Text tab not found after navigating to right-side tabs");
+                robot_exit::fail(&robot, "Text tab not found after navigating to right-side tabs");
             };
             robot.click(text_x + text_w * 0.5, text_y + text_h * 0.5).ok();
             std::thread::sleep(Duration::from_millis(350));
@@ -51,30 +47,28 @@ fn main() {
             })
             .is_none()
             {
-                fail(&robot, "Text showcase heading not found after tab switch");
+                robot_exit::fail(&robot, "Text showcase heading not found after tab switch");
             }
 
             let Some((_anchor_x, _anchor_y, _anchor_w, _anchor_h)) = find_in_semantics(&robot, |elem| {
                 find_text(elem, "brush + alpha + draw_style + platform_style")
             })
             else {
-                fail(
+                robot_exit::fail(
                     &robot,
-                    "gradient/stroke anchor label not found in Text showcase semantics",
-                );
+                    "gradient/stroke anchor label not found in Text showcase semantics");
             };
             let Some((sample_x, sample_y, sample_w, sample_h)) = find_in_semantics(&robot, |elem| {
                 find_text(elem, "Gradient/alpha/fill/platform")
             }) else {
-                fail(
+                robot_exit::fail(
                     &robot,
-                    "gradient/stroke sample text not found in Text showcase semantics",
-                );
+                    "gradient/stroke sample text not found in Text showcase semantics");
             };
 
             let screenshot = robot
                 .screenshot()
-                .unwrap_or_else(|err| fail(&robot, &format!("screenshot failed: {err}")));
+                .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("screenshot failed: {err}")));
 
             let crop_padding = 8.0;
             let cropped = crop_screenshot_logical(
@@ -84,7 +78,7 @@ fn main() {
                 sample_w + crop_padding * 2.0,
                 sample_h + crop_padding * 2.0,
             )
-                .unwrap_or_else(|| fail(&robot, "failed to crop sample bounds"));
+                .unwrap_or_else(|| robot_exit::fail(&robot, "failed to crop sample bounds"));
 
             let mut colored_pixels = 0usize;
             let mut min_red = 1.0f32;
@@ -109,41 +103,37 @@ fn main() {
             }
 
             if colored_pixels <= 20 {
-                fail(
+                robot_exit::fail(
                     &robot,
                     &format!(
                         "expected visible colored ink in sample, got colored_pixels={colored_pixels}"
-                    ),
-                );
+                    ));
             }
 
             let red_span = max_red - min_red;
             let blue_span = max_blue - min_blue;
             let channel_span = red_span.max(blue_span);
             if channel_span <= 0.12 {
-                fail(
+                robot_exit::fail(
                     &robot,
                     &format!(
                         "expected gradient variation in sample, red_span={red_span:.3}, blue_span={blue_span:.3}"
-                    ),
-                );
+                    ));
             }
 
             let Some((_p_x, _p_y, _p_w, p_h)) = find_in_semantics(&robot, |elem| {
                 find_text(elem, "This paragraph demonstrates textIndent")
             }) else {
-                fail(
+                robot_exit::fail(
                     &robot,
-                    "paragraph sample text not found for multiline-wrap verification",
-                );
+                    "paragraph sample text not found for multiline-wrap verification");
             };
             if p_h <= 40.0 {
-                fail(
+                robot_exit::fail(
                     &robot,
                     &format!(
                         "expected multiline paragraph sample height, got p_h={p_h:.1} (likely wrapped to a single clipped line)"
-                    ),
-                );
+                    ));
             }
 
             println!(

--- a/apps/desktop-demo/robot-runners/robot_text_strikeout_presented.rs
+++ b/apps/desktop-demo/robot-runners/robot_text_strikeout_presented.rs
@@ -1,4 +1,5 @@
 mod output_paths;
+mod robot_exit;
 mod text_showcase_external_helpers;
 
 use std::{path::Path, time::Duration};
@@ -26,12 +27,6 @@ struct StrikeoutMetrics {
     max_dark_gap: u32,
 }
 
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    let _ = robot.exit();
-    std::process::exit(1);
-}
-
 fn main() {
     env_logger::init();
     println!("=== Robot Text Strikeout Presented ===");
@@ -56,7 +51,7 @@ fn main() {
                 .expect("present Text tab before strikeout capture");
             wait_for_text_showcase_heading(&robot);
             let bounds = find_exact_text_in_semantics(&robot, TARGET_TEXT)
-                .unwrap_or_else(|| fail(&robot, "strikeout text semantics bounds not found"));
+                .unwrap_or_else(|| robot_exit::fail(&robot, "strikeout text semantics bounds not found"));
             println!("Target bounds: {bounds:?}");
 
             let window_id = find_window_id(WINDOW_TITLE);
@@ -78,25 +73,24 @@ fn main() {
                 bounds.2 + crop_padding * 2.0,
                 bounds.3 + crop_padding * 2.0,
             )
-            .unwrap_or_else(|| fail(&robot, "failed to crop strikeout text from X11 capture"));
+            .unwrap_or_else(|| robot_exit::fail(&robot, "failed to crop strikeout text from X11 capture"));
             let crop_path = output_dir.join("strikeout_crop.png");
             save_robot_screenshot(&crop, &crop_path);
 
             let metrics = strikeout_metrics(&crop)
-                .unwrap_or_else(|| fail(&robot, "could not locate line-through row in crop"));
+                .unwrap_or_else(|| robot_exit::fail(&robot, "could not locate line-through row in crop"));
             println!(
                 "Strikeout metrics: row={} first_x={} last_x={} coverage={:.3} max_dark_gap={}",
                 metrics.row, metrics.first_x, metrics.last_x, metrics.coverage, metrics.max_dark_gap
             );
 
             if metrics.coverage < 0.86 || metrics.max_dark_gap > 2 {
-                fail(
+                robot_exit::fail(
                     &robot,
                     &format!(
                         "line-through must be continuous in the presented X11 capture; coverage={:.3}, max_dark_gap={}",
                         metrics.coverage, metrics.max_dark_gap
-                    ),
-                );
+                    ));
             }
 
             println!("PASS: Text tab line-through is continuous in presented X11 capture");

--- a/apps/desktop-demo/robot-runners/robot_underline_screenshot.rs
+++ b/apps/desktop-demo/robot-runners/robot_underline_screenshot.rs
@@ -1,4 +1,5 @@
 mod output_paths;
+mod robot_exit;
 mod text_showcase_external_helpers;
 
 use std::{path::Path, time::Duration};
@@ -35,12 +36,6 @@ impl UnderlineMetrics {
     fn span_width(self) -> u32 {
         self.last_x.saturating_sub(self.first_x) + 1
     }
-}
-
-fn fail(robot: &cranpose::Robot, message: &str) -> ! {
-    println!("FATAL: {message}");
-    let _ = robot.exit();
-    std::process::exit(1);
 }
 
 fn main() {
@@ -93,18 +88,17 @@ fn main() {
                     bounds.2 + 24.0,
                     bounds.3 + 24.0,
                 )
-                .unwrap_or_else(|| fail(&robot, "failed to crop underlined text"));
+                .unwrap_or_else(|| robot_exit::fail(&robot, "failed to crop underlined text"));
                 let crop_path = output_dir.join(format!("step_{step:02}_underline_crop.png"));
                 save_robot_screenshot(&crop, &crop_path);
 
                 let metrics = underline_metrics(&crop).unwrap_or_else(|| {
-                    fail(
+                    robot_exit::fail(
                         &robot,
                         &format!(
                             "red underline not found in crop at step {step}: {}",
                             crop_path.display()
-                        ),
-                    )
+                        ))
                 });
                 println!(
                     "  underline step={step}: row={} span={} first_x={} last_x={} coverage={:.3} max_red_gap={} thickness={}",
@@ -142,15 +136,14 @@ fn main() {
 
 fn assert_underline_quality(robot: &cranpose::Robot, step: usize, metrics: UnderlineMetrics) {
     if metrics.coverage < MIN_UNDERLINE_COVERAGE || metrics.max_red_gap > MAX_UNDERLINE_GAP_PX {
-        fail(
+        robot_exit::fail(
             robot,
             &format!(
                 "underline is dashed or broken at step {step}: coverage={:.3} max_red_gap={} span={}",
                 metrics.coverage,
                 metrics.max_red_gap,
                 metrics.span_width()
-            ),
-        );
+            ));
     }
 }
 
@@ -163,12 +156,11 @@ fn assert_underline_stability(
     let thickness_delta = baseline.thickness.abs_diff(current.thickness);
     let span_delta = baseline.span_width().abs_diff(current.span_width());
     if thickness_delta > MAX_THICKNESS_DELTA_PX || span_delta > MAX_SPAN_DELTA_PX {
-        fail(
+        robot_exit::fail(
             robot,
             &format!(
                 "underline changed under scroll at step {step}: baseline={baseline:?} current={current:?} thickness_delta={thickness_delta} span_delta={span_delta}",
-            ),
-        );
+            ));
     }
 }
 


### PR DESCRIPTION
Twenty-seven runners each carried their own `fail`, in thirteen spellings. Only **three** of those differences described different behaviour; the rest were `println!` against `eprintln!`, `FATAL:` against `FAIL:` against `✗`, `let _ = robot.exit()` against `robot.exit().ok()`, and `&cranpose::Robot` against an imported `&Robot`.

This is what #539's duplication gate has been reporting. It fired on #559 (seven clones, 11–21 lines) and #573 (one clone) and was **right both times** — a new runner has only ever been written by copying an existing one, so the eighteenth copy of the preamble is what finally trips it. Both of those pull requests are blocked on this one thing, not on two separate cleanups.

The directory already had the pattern half-built: `output_paths.rs`, `perf_contract.rs`, `perf_robot_stats.rs` and a dozen more sit alongside the runners. The failure exits simply never landed in one.

### The three behaviours

| function | what it does | why it exists |
|---|---|---|
| `fail` | report, ask the robot to shut down, exit non-zero | the default |
| `fail_without_shutdown` | report, exit non-zero, no shutdown | the failure leaves the app in a state the shutdown would not survive |
| `fail_and_await_shutdown` | report, flag, arm a 15s hard exit, ask for shutdown, park | must not race `process::exit` against its own GPU teardown |

Skipping the shutdown is now spelled, rather than implied by an underscore on an unused parameter.

### Two behaviour changes, both deliberate

**`robot_liquid_dropdown_accordion` and `robot_liquid_tab_bar_pill_containment` had a dead flag.** Both set `FAILED` and then called `process::exit(1)` immediately, while their `main` reads that flag *after* the robot loop returns — so the read could never be true. They had copied the flag from the parking variant without the parking. Both now use `fail_and_await_shutdown`, which is what the flag was for. This fixes a latent hard-exit-during-teardown in two runners.

**`robot_increment_bug` and `robot_tab_roundtrip_content` ended in `panic!` behind `let _ = robot;`** — a parameter kept for uniformity and then discarded. Both now use `fail_without_shutdown`, which states the same intent and prints the same message. The backtrace is no loss: it pointed at the `fail` call site, which the message already names.

Two helpers lost a `robot` parameter they held only to reach the old `fail` — `assert_same_origin` in the layout-jitter contract and `assert_no_implicit_scrollbar` in the shader visual contract. Dropped rather than underscored.

`hacker_news_robot_support::fail` stays where it is. It dumps the semantics tree on failure — a diagnostic the HN runners want and the others do not — and it is already shared rather than copied.

### Verification

```
cargo check   -p desktop-app --examples --features robot-app    0 errors, 0 warnings
cargo clippy  -p desktop-app --examples --features robot-app -D warnings   clean
just fmt                                                        clean
just complexity-gate    247 changed line ranges clean
just duplication-gate   1609 clones in the repo, 1 touches the diff, none introduced by it
```

The duplication line is the one that matters: this diff introduces no clone and removes the population that was tripping the gate.

### After this merges

#559 and #573 rebase onto it and drop their copied blocks. Any future runner uses `mod robot_exit;` and picks one of three named behaviours instead of copying whichever neighbour was open.