### PR TITLE
Let the test gate report every crate, not just the first to fail

### DIFF
--- a/justfile
+++ b/justfile
@@ -142,8 +142,16 @@ duplication-gate base="origin/main":
 # backtrace from a failing gate is readable.
 
 # The workspace test suite.
+#
+# `--no-fail-fast` because cargo otherwise stops at the first test binary that
+# fails, and the ~129 remaining binaries report nothing. On samarch-1 that is
+# not hypothetical: `cranpose-render-wgpu --test pass_timing_report` segfaults
+# from an environmental GPU fault, and every crate after it in the run
+# silently never executes while the gate reports one failure. The same shape
+# as a step that stops its job -- one problem hides the rest, and the fix
+# costs a full second run to find the second one.
 test:
-    cargo test --profile ci --workspace
+    cargo test --profile ci --workspace --no-fail-fast
 
 # Feature permutations of the core crate that the default build does not cover.
 test-features:


### PR DESCRIPTION
The crate-list half of the truncation problem #574 fixed at the workflow level.

`just test` is `cargo test --profile ci --workspace`. Cargo stops at the first test binary that fails, so the ~129 binaries after it never run — and the gate reports one failure as though it were the only one.

**On samarch-1 this is not hypothetical.** `cranpose-render-wgpu --test pass_timing_report` segfaults there from an environmental GPU fault: the NVIDIA kernel module is not always loaded, wgpu falls back to software, and the crash has nothing to do with the change under review. Every crate ordered after it silently never executes. A reviewer reading that output sees one red test and no sign that two thirds of the workspace was skipped.

Same shape as the problem #574 solved one level up:

| level | before | after |
|---|---|---|
| workflow step | first failing gate stops the job; 14 gates report `skipped` | every gate reports |
| test binary | first failing crate stops the run; ~129 binaries never execute | every crate reports |

In both cases one problem hides the rest, and finding the second one costs a complete second run of the most contended resource in the pool.

`--no-fail-fast` is cargo's own flag for exactly this. It changes nothing about which tests run or how they are judged — the gate still fails when any test fails. It just says how many.

The gate stays in the justfile and CI keeps calling the same recipe, so `just test` means the same thing locally and in CI.