### PR TITLE
Lint the robot runners, which no gate has ever reached

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -106,6 +106,10 @@ jobs:
         if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just clippy-camera-desktop
 
+      - name: Run clippy on the robot runners
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
+        run: just clippy-robot
+
       - name: Build documentation
         if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         # A broken intra-doc link is a broken published page.

--- a/justfile
+++ b/justfile
@@ -82,6 +82,17 @@ clippy-ios:
 clippy-camera-desktop:
     cargo clippy -p cranpose --no-default-features --features desktop,renderer-wgpu,camera-desktop,robot --all-targets -- -D warnings
 
+# Lint the robot runners, which `just clippy` cannot reach.
+#
+# `cargo clippy --workspace --all-targets` silently SKIPS a target whose
+# `required-features` are not enabled, and all ~165 `[[example]]` entries in
+# apps/desktop-demo carry `required-features = ["robot-app"]`. Skipping is not
+# an error, so the omission never surfaced: `cargo check -p desktop-app
+# --examples` finishes in a fraction of a second having compiled nothing. The
+# runners went unlinted from the day the feature gate was added until #575.
+clippy-robot:
+    cargo clippy -p desktop-app --examples --features robot-app -- -D warnings
+
 # Lint the exact package, features and ABIs the Android build ships.
 #
 # `just android` runs Gradle, which does not deny warnings, so Android was the
@@ -383,7 +394,7 @@ perf-heap *args:
 # Excludes the jobs that need a GPU, an Android SDK or an iOS toolchain.
 
 # What a pull request is gated on. Run this before pushing.
-ci: fmt-check typos versions test clippy doc budgets test-quality-gates complexity-gate duplication-gate
+ci: fmt-check typos versions test clippy clippy-robot doc budgets test-quality-gates complexity-gate duplication-gate
 
 # Needs a Linux box with the X11 stack, an Android SDK and (on macOS) Xcode.
 


### PR DESCRIPTION
`just clippy` is `cargo clippy --workspace --all-targets -- -D warnings`. **`--all-targets` silently skips a target whose `required-features` are not enabled**, and every `[[example]]` in `apps/desktop-demo` carries `required-features = ["robot-app"]` — not a default feature. So all ~165 robot runners have gone unlinted since the day that gate was added.

Skipping is not an error, which is exactly why nothing surfaced it:

```
cargo check -p desktop-app --examples                     0.18s, compiles nothing
cargo check -p desktop-app --examples --features robot-app  22s, a real compile
cargo clippy -p desktop-app --example robot_fling_edge_cases
  error: target requires the features: `robot-app`      <- naming one errors
```

Naming a gated example complains. `--all-targets` just walks past it.

### It has already cost something

#540 deleted a comment from a `_ =>` arm in `robot_fling_edge_cases.rs`. Clippy's `single_match` skips an arm that contains a comment, so removing the comment made the lint fire. **That PR merged 7/7 green with the error in it, and no gate could have caught it.** Confirmed by running clippy on each commit directly — clean at `e4ea985c`, one error at `d0569834`.

### Why now

Because the count is zero. #575 fixed that error while extracting the shared runner module, so `just clippy-robot` passes on this commit with nothing to work through.

A gate introduced at zero stays at zero. A gate introduced against a backlog gets an allow list, and then it is not a gate.

### Verification

```
just clippy-robot     clean (0 errors, 0 warnings, -D warnings)
actionlint            no new findings; the two pre-existing custom-runner-label
                      warnings are unchanged
```

The step carries the same `if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}` guard #574 gave the rest of the job, so a failure ahead of it will not hide its result. The recipe lives in the justfile and CI calls it, so `just clippy-robot` means the same thing locally and in CI, and it joins the `ci` aggregate alongside `clippy`.