### PR TITLE
Pin the demo's tab-swipe row to the new motion-stable default

### DIFF
--- a/apps/desktop-demo/src/app/liquid_ui.rs
+++ b/apps/desktop-demo/src/app/liquid_ui.rs
@@ -2445,7 +2445,7 @@ mod tests {
         let glass = tab_swipe_reference_glass();
         assert_eq!(glass.variant, GlassVariant::Regular);
         assert!(glass.shadow);
-        assert_eq!(glass.refraction_depth, 0.34);
+        assert_eq!(glass.refraction_depth, 0.0);
         assert!(glass.blur_radius.is_none());
         assert!(glass.tint.is_none());
     }


### PR DESCRIPTION
main is red on `fmt + tests + clippy (mac)`. One test, `app::liquid_ui::tests::tab_swipe_reference_row_is_physical_glass`, `left: 0.0, right: 0.34`.

**Cause:** #573 (`bc033c8f`) changed `Glass::regular()` from `refraction_depth: 0.34` to `0.0` — its rustdoc now reads "a motion-stable frosted surface without optical displacement" — and updated the assertion in `cranpose-liquid`'s own tests. It missed the other assertion of the same default, in `apps/desktop-demo`.

**Why this is the right fix rather than restoring 0.34:** `tab_swipe_reference_glass()` is `Glass::regular()`, and the demo renders the tab-swipe row with it at `liquid_ui.rs:619`. Before #573 that row got optical displacement *implicitly*. Implicit displacement on a surface that moves is exactly the artifact #573 exists to remove, so the row inheriting the new default is the intended outcome. If the reference row is later found to need displacement, `.refraction_depth(0.34)` at the call site makes it a decision instead of an inheritance.

**Verified:** `cargo test --profile ci -p desktop-app --lib` — 101 passed, 0 failed.

Two notes on how this got to main, since both are about the tooling rather than the change:

- #573's own run never executed the workspace tests. Its `checks` job failed at the duplication gate, and before #574 a failed step stopped the job, so `Run workspace tests` reported `skipped`. #574 has since landed and main's run reported all seventeen steps — one failure and sixteen passes, including the new `clippy-robot` — which is how this was a two-minute diagnosis instead of a bisect.
- `--no-fail-fast` from #576 confirmed this is the *only* failure in the workspace rather than the first one.