### PR TITLE
Give agents a wait-for-quiet that can actually finish

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,6 +86,10 @@ jobs:
         # this job is the one that never skips.
         run: just test-ci-filters
 
+      - name: Test the shell helpers
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
+        run: just test-shell-helpers
+
       - name: Check cyclomatic complexity of changed functions
         if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just complexity-gate

--- a/justfile
+++ b/justfile
@@ -175,6 +175,10 @@ test-features:
 test-ci-filters:
     scripts/ci/docs_only_change_test.sh
 
+# The shell helpers agents run by hand, pinned so they cannot rot.
+test-shell-helpers:
+    scripts/wait_until_quiet_test.sh
+
 # The deterministic slot-table model check, at the frame count CI uses.
 test-property:
     cargo test --profile ci -p cranpose-core deterministic_model_render_frames_match_slot_table
@@ -394,7 +398,7 @@ perf-heap *args:
 # Excludes the jobs that need a GPU, an Android SDK or an iOS toolchain.
 
 # What a pull request is gated on. Run this before pushing.
-ci: fmt-check typos versions test clippy clippy-robot doc budgets test-quality-gates complexity-gate duplication-gate
+ci: fmt-check typos versions test clippy clippy-robot doc budgets test-quality-gates test-shell-helpers complexity-gate duplication-gate
 
 # Needs a Linux box with the X11 stack, an Android SDK and (on macOS) Xcode.
 

--- a/scripts/wait_until_quiet.sh
+++ b/scripts/wait_until_quiet.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Wait until nothing on this host matches any of the given patterns.
+#
+# Hand-rolled `until ! pgrep -f "$pat"; do sleep; done` loops do not work, and
+# the way they fail is silent. `pgrep -f` matches against full command lines,
+# and the command line of the shell running the loop contains the pattern --
+# so the loop matches itself, the condition never goes false, and it waits
+# forever while looking exactly like patience. Four of these were found alive
+# on one build host in a single day, from three separate callers; the oldest
+# had been spinning for twenty hours and four minutes, orphaned to init, with
+# nothing left to read the output it was never going to produce.
+#
+# Two things here make that impossible rather than merely documented. Each
+# pattern is bracketed before use, so it cannot match its own literal text.
+# And the wait is bounded: it always ends, and a timeout exits non-zero with
+# the survivors named, so a caller cannot mistake "gave up" for "quiet".
+set -euo pipefail
+
+timeout_seconds=1800
+interval_seconds=15
+patterns=()
+
+usage() {
+    cat >&2 <<'USAGE'
+usage: wait_until_quiet.sh [--timeout SECONDS] [--interval SECONDS] PATTERN...
+
+Waits until no process matches any PATTERN, then exits 0. Exits 2 if the
+timeout passes while something still matches, naming what survived.
+
+Patterns are matched against full command lines, like `pgrep -f`.
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --timeout) timeout_seconds="${2:?--timeout needs a value}"; shift 2 ;;
+        --interval) interval_seconds="${2:?--interval needs a value}"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        --) shift; while [ $# -gt 0 ]; do patterns+=("$1"); shift; done ;;
+        -*) echo "unknown option: $1" >&2; usage; exit 64 ;;
+        *) patterns+=("$1"); shift ;;
+    esac
+done
+
+if [ "${#patterns[@]}" -eq 0 ]; then
+    usage
+    exit 64
+fi
+
+# The bracket trick alone is NOT enough here, and the reason is worth stating.
+# `[c]argo build` stops a pattern matching its own literal text, which is what
+# saves an inline `until ! pgrep -f "cargo build"` loop. But this script takes
+# the pattern as an ARGUMENT, so its own argv holds the unbracketed string --
+# and `[c]argo build` matches `cargo build` perfectly. Every subshell this
+# script forks inherits that argv and answers the pgrep. So the bracket stays,
+# because it costs nothing and helps callers who inline a literal, and the
+# thing actually doing the work is the ancestry filter below.
+self_excluding() {
+    local pattern="$1" i char
+    for (( i = 0; i < ${#pattern}; i++ )); do
+        char="${pattern:i:1}"
+        case "$char" in
+            [A-Za-z0-9_])
+                printf '%s[%s]%s\n' "${pattern:0:i}" "$char" "${pattern:i+1}"
+                return 0
+                ;;
+        esac
+    done
+    printf '%s\n' "$pattern"
+}
+
+# True when pid is this script or anything it forked. Walks the parent chain
+# rather than comparing process groups: a caller that backgrounds the process
+# being waited for shares this script's group, so a group filter would discard
+# the very thing the wait is for.
+own_descendant() {
+    local pid="$1" hops=0
+    while [ -n "$pid" ] && [ "$pid" != "1" ] && [ "$hops" -lt 40 ]; do
+        [ "$pid" = "$$" ] && return 0
+        pid="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')"
+        hops=$(( hops + 1 ))
+    done
+    return 1
+}
+
+# A pid pgrep reports is not necessarily a process still doing something. An
+# exited child whose parent has not reaped it keeps its full command line until
+# the wait(2), so a waiter that trusts pgrep can block on a process that
+# finished minutes ago.
+alive() {
+    local pid state
+    while read -r pid; do
+        if [ -z "$pid" ] || own_descendant "$pid"; then
+            continue
+        fi
+        state="$(ps -o state= -p "$pid" 2>/dev/null || true)"
+        case "${state// /}" in
+            ''|Z*) continue ;;
+        esac
+        printf '%s\n' "$pid"
+    done
+}
+
+survivors() {
+    local pattern matches out=""
+    for pattern in "${patterns[@]}"; do
+        matches="$(pgrep -f "$(self_excluding "$pattern")" 2>/dev/null | alive || true)"
+        if [ -n "${matches//[[:space:]]/}" ]; then
+            out+="  $pattern: $(printf '%s' "$matches" | tr '\n' ' ')"$'\n'
+        fi
+    done
+    printf '%s' "$out"
+}
+
+deadline=$(( SECONDS + timeout_seconds ))
+while :; do
+    still="$(survivors)"
+    if [ -z "$still" ]; then
+        echo "quiet: nothing matches ${patterns[*]}"
+        exit 0
+    fi
+    if [ "$SECONDS" -ge "$deadline" ]; then
+        echo "timed out after ${timeout_seconds}s; still running:" >&2
+        printf '%s' "$still" >&2
+        exit 2
+    fi
+    sleep "$interval_seconds"
+done

--- a/scripts/wait_until_quiet_test.sh
+++ b/scripts/wait_until_quiet_test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Regression test for wait_until_quiet.sh.
+#
+# The case that matters is the second one. A wait loop written with a bare
+# `pgrep -f` matches the command line that carries the pattern, so it waits
+# for itself and never finishes. That failure has no symptom: the process
+# sits at almost no CPU, prints nothing, and is indistinguishable from a wait
+# that is merely long. It is only visible if something asserts that a wait on
+# a quiet host returns, which is what this file does.
+#
+# Every case is bounded. A test for a hang that can itself hang would be the
+# same defect one level up.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+waiter="$script_dir/wait_until_quiet.sh"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+failures=0
+
+check() {
+    local name="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "ok   $name"
+    else
+        echo "FAIL $name: expected exit $expected, got $actual"
+        failures=$(( failures + 1 ))
+    fi
+}
+
+# 1. Nothing matches: returns at once.
+set +e
+"$waiter" --timeout 5 --interval 1 "cranpose-no-such-process-aardvark" >/dev/null 2>&1
+check "quiet host returns 0" 0 "$?"
+set -e
+
+# 2. The pattern appears in the waiter's own command line. A bare
+#    `pgrep -f` loop matches itself here and waits forever; this must not.
+#    The short timeout is the assertion: a self-match cannot finish inside it.
+set +e
+"$waiter" --timeout 5 --interval 1 "wait_until_quiet_marker_xyzzy" >/dev/null 2>&1
+check "pattern in own argv does not match itself" 0 "$?"
+set -e
+
+# The sleeper is given a name nothing else on the host can carry. `sleep 3` was
+# the obvious choice and it is wrong twice over: the string appears in the
+# waiter's own argument list, and it is a prefix of `sleep 30`, so case 4 below
+# would answer case 3's question.
+sleeper="$workdir/quiet-test-sleeper-$$"
+mkdir -p "$workdir"
+printf '#!/bin/sh\nsleep "$1"\n' > "$sleeper"
+chmod +x "$sleeper"
+
+# 3. A real match blocks, then clears when the process ends.
+"$sleeper" 3 &
+sleep_pid=$!
+start=$SECONDS
+set +e
+"$waiter" --timeout 20 --interval 1 "$(basename "$sleeper") 3" >/dev/null 2>&1
+rc=$?
+set -e
+wait "$sleep_pid" 2>/dev/null || true
+check "waits for a real match" 0 "$rc"
+elapsed=$(( SECONDS - start ))
+if [ "$elapsed" -lt 2 ] || [ "$elapsed" -ge 19 ]; then
+    echo "FAIL waited for a real match: returned in ${elapsed}s (want 2..18)"
+    failures=$(( failures + 1 ))
+else
+    echo "ok   waited for a real match (blocked ${elapsed}s)"
+fi
+
+# 4. A match that outlives the timeout exits 2 and names the survivor.
+"$sleeper" 45 &
+long_pid=$!
+set +e
+out="$("$waiter" --timeout 2 --interval 1 "$(basename "$sleeper") 45" 2>&1)"
+rc=$?
+set -e
+kill "$long_pid" 2>/dev/null || true
+wait "$long_pid" 2>/dev/null || true
+check "timeout exits 2" 2 "$rc"
+case "$out" in
+    *"$(basename "$sleeper") 45"*) echo "ok   timeout names the survivor" ;;
+    *) echo "FAIL timeout names the survivor: got $out"; failures=$(( failures + 1 )) ;;
+esac
+
+# 5. No pattern is a usage error, not a wait on everything.
+set +e
+"$waiter" >/dev/null 2>&1
+check "no pattern exits 64" 64 "$?"
+set -e
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures failure(s)"
+    exit 1
+fi
+echo "wait_until_quiet: all cases pass"


### PR DESCRIPTION
Hand-rolled `until ! pgrep -f "$pat"; do sleep; done` loops do not work, and the way they fail is silent: `pgrep -f` matches full command lines, the shell running the loop has the pattern in its own command line, so the loop matches itself and waits forever while looking exactly like patience.

**Five were alive on samarch-1 in one day, from four separate callers.** The oldest had spun for **21 hours 36 minutes**, orphaned to init, with nothing left to read the output it was never going to produce. One carried the fault twice — its `break` could not fire for that reason, and the marker file its outer condition read was never written by anything, so each fault hid the other.

`TIME_WASTERS.md` has documented this trap since before any of those five were written, with the bracket fix and the ssh caveat. **It prevented none of them.** That is why this is a script and not another line of prose.

### Two properties make the failure impossible rather than discouraged

**The wait is bounded.** It always ends, and a timeout exits `2` with the survivors named, so a caller cannot mistake "gave up" for "quiet". That alone turns a 21-hour silent hang into a 30-minute loud failure.

**The self-match is filtered by ancestry, not by the bracket trick** — and this is the part I got wrong first, so it is worth stating plainly:

> `[c]argo build` stops a pattern matching its own literal text. That saves an inline loop, where the pattern and the searched text are the same string. **It does not save a script that takes the pattern as an argument**: the script's own argv holds the *unbracketed* string, and `[c]argo build` matches `cargo build` perfectly. Every subshell it forks inherits that argv and answers the pgrep.

The bracket is kept, because it costs nothing and helps callers who inline a literal. The ancestry walk is what actually works. It beats a process-group filter because a caller that backgrounds the process being waited for shares this script's group, so a group filter would discard the very thing the wait is for.

**Zombies are dropped.** An exited child whose parent has not reaped it keeps its full command line until the `wait(2)`, so a waiter that trusts `pgrep` can block on a process that finished minutes ago. That cost one debugging round on the test itself.

### The test

Seven cases, all bounded — a test for a hang that can itself hang is the same defect one level up. The case that matters most is that a wait on a quiet host **returns**; that failure has no symptom, since the process sits at no CPU and prints nothing, indistinguishable from a wait that is merely long.

Its sleeper gets a name nothing else on the host can carry. `sleep 3` was the obvious choice and is wrong twice: it appears in the waiter's own argument list, and it is a prefix of `sleep 30`, so case 4 would have answered case 3's question.

### Gate

`just test-shell-helpers`, wired into the `checks` job with the same `if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}` guard as the rest, and into the `ci` aggregate. Verified: all seven cases pass both standalone and under `just`, `actionlint` reports no new findings.