### PR TITLE
dedup(cranpose-core): nested-mutable-snapshot, subcompose, and state-handle abstractions

### DIFF
--- a/crates/cranpose-core/src/composer.rs
+++ b/crates/cranpose-core/src/composer.rs
@@ -325,6 +325,23 @@ impl ComposerRuntimeState {
         self.clear_host_storage_key(host_key);
     }
 
+    fn deactivate_and_queue_subtrees(
+        &self,
+        retention: RetentionManager,
+        table: &mut SlotTable,
+        lifecycle: &mut crate::slot::SlotLifecycleCoordinator,
+    ) {
+        for subtree in retention.into_subtrees() {
+            for scope_id in subtree.scope_ids() {
+                if let Some(scope) = self.remove_scope(scope_id) {
+                    scope.deactivate();
+                }
+            }
+            table.invalidate_detached_subtree_anchors(&subtree);
+            lifecycle.queue_subtree_disposal(subtree);
+        }
+    }
+
     pub(crate) fn dispose_retained_subtrees_for_host(
         &self,
         host_key: usize,
@@ -349,15 +366,7 @@ impl ComposerRuntimeState {
         let Some(retention) = self.retention_by_host.borrow_mut().remove(&host_key) else {
             return Ok(());
         };
-        for subtree in retention.into_subtrees() {
-            for scope_id in subtree.scope_ids() {
-                if let Some(scope) = self.remove_scope(scope_id) {
-                    scope.deactivate();
-                }
-            }
-            table.invalidate_detached_subtree_anchors(&subtree);
-            lifecycle.queue_subtree_disposal(subtree);
-        }
+        self.deactivate_and_queue_subtrees(retention, table, lifecycle);
         Ok(())
     }
 
@@ -371,15 +380,7 @@ impl ComposerRuntimeState {
             self.clear_host_storage_key(host_key);
             return;
         };
-        for subtree in retention.into_subtrees() {
-            for scope_id in subtree.scope_ids() {
-                if let Some(scope) = self.remove_scope(scope_id) {
-                    scope.deactivate();
-                }
-            }
-            table.invalidate_detached_subtree_anchors(&subtree);
-            lifecycle.queue_subtree_disposal(subtree);
-        }
+        self.deactivate_and_queue_subtrees(retention, table, lifecycle);
         self.clear_host_storage_key(host_key);
     }
 
@@ -510,6 +511,19 @@ fn take_subcompose_frame(core: &ComposerCore, operation: &str) -> SubcomposeFram
         None => {
             log::error!("subcompose stack underflow while finishing {operation}");
             SubcomposeFrame::default()
+        }
+    }
+}
+
+struct SubcomposeStackGuard {
+    core: Rc<ComposerCore>,
+    leaked: bool,
+}
+
+impl Drop for SubcomposeStackGuard {
+    fn drop(&mut self) {
+        if !self.leaked {
+            self.core.subcompose_stack.borrow_mut().pop();
         }
     }
 }
@@ -1541,18 +1555,7 @@ impl Composer {
         }
 
         self.subcompose_stack().push(SubcomposeFrame::default());
-        struct StackGuard {
-            core: Rc<ComposerCore>,
-            leaked: bool,
-        }
-        impl Drop for StackGuard {
-            fn drop(&mut self) {
-                if !self.leaked {
-                    self.core.subcompose_stack.borrow_mut().pop();
-                }
-            }
-        }
-        let mut guard = StackGuard {
+        let mut guard = SubcomposeStackGuard {
             core: self.clone_core(),
             leaked: false,
         };
@@ -1588,15 +1591,14 @@ impl Composer {
         (result, roots)
     }
 
-    pub fn subcompose_in<R>(
+    fn spin_up_subcompose_core(
         &self,
         slots: &Rc<SlotsHost>,
         root: Option<NodeId>,
-        f: impl FnOnce(&Composer) -> R,
-    ) -> Result<R, NodeError> {
-        let runtime_handle = self.runtime_handle();
+        runtime_handle: &RuntimeHandle,
+        locals: LocalStackSnapshot,
+    ) -> Rc<ComposerCore> {
         let phase = self.phase();
-        let locals = self.current_local_stack();
         let shared_state = slots
             .runtime_state()
             .unwrap_or_else(|| Rc::clone(&self.core.shared_state));
@@ -1611,17 +1613,16 @@ impl Composer {
         ));
         core.phase.set(phase);
         *core.local_stack.borrow_mut() = locals;
-        let composer = Composer::from_core(core);
-        let (result, commands, side_effects, compact_applier) = composer.install(|composer| {
-            let (output, outcome) = composer.try_with_slot_host_pass(
-                Rc::clone(slots),
-                crate::slot::SlotPassMode::Compose,
-                |composer| f(composer),
-            )?;
-            let commands = composer.take_commands();
-            let side_effects = composer.take_side_effects();
-            Ok((output, commands, side_effects, outcome.compacted))
-        })?;
+        core
+    }
+
+    fn flush_subcompose_pass(
+        &self,
+        commands: CommandQueue,
+        runtime_handle: &RuntimeHandle,
+        compact_applier: bool,
+        side_effects: Vec<Box<dyn FnOnce()>>,
+    ) -> Result<(), NodeError> {
         {
             let mut applier = self.borrow_applier();
             commands.apply(&mut *applier)?;
@@ -1638,6 +1639,30 @@ impl Composer {
             effect();
         }
         runtime_handle.drain_ui();
+        Ok(())
+    }
+
+    pub fn subcompose_in<R>(
+        &self,
+        slots: &Rc<SlotsHost>,
+        root: Option<NodeId>,
+        f: impl FnOnce(&Composer) -> R,
+    ) -> Result<R, NodeError> {
+        let runtime_handle = self.runtime_handle();
+        let locals = self.current_local_stack();
+        let core = self.spin_up_subcompose_core(slots, root, &runtime_handle, locals);
+        let composer = Composer::from_core(core);
+        let (result, commands, side_effects, compact_applier) = composer.install(|composer| {
+            let (output, outcome) = composer.try_with_slot_host_pass(
+                Rc::clone(slots),
+                crate::slot::SlotPassMode::Compose,
+                |composer| f(composer),
+            )?;
+            let commands = composer.take_commands();
+            let side_effects = composer.take_side_effects();
+            Ok((output, commands, side_effects, outcome.compacted))
+        })?;
+        self.flush_subcompose_pass(commands, &runtime_handle, compact_applier, side_effects)?;
         Ok(result)
     }
 
@@ -1685,22 +1710,8 @@ impl Composer {
         f: impl FnOnce(&Composer) -> R,
     ) -> Result<(R, Vec<RecomposeScope>), NodeError> {
         let runtime_handle = self.runtime_handle();
-        let phase = self.phase();
         let locals = context.locals.clone();
-        let shared_state = slots
-            .runtime_state()
-            .unwrap_or_else(|| Rc::clone(&self.core.shared_state));
-        let core = Rc::new(ComposerCore::new(
-            shared_state,
-            Rc::clone(slots),
-            Rc::clone(&self.core.applier),
-            runtime_handle.clone(),
-            self.observer(),
-            root,
-            InitialParentFrame::RealParent,
-        ));
-        core.phase.set(phase);
-        *core.local_stack.borrow_mut() = locals;
+        let core = self.spin_up_subcompose_core(slots, root, &runtime_handle, locals);
         *core.subcomposition_owner_scope.borrow_mut() = context
             .owner_scope
             .as_ref()
@@ -1708,18 +1719,7 @@ impl Composer {
             .map(|inner| RecomposeScope { inner });
         let composer = Composer::from_core(core);
         composer.subcompose_stack().push(SubcomposeFrame::default());
-        struct StackGuard {
-            core: Rc<ComposerCore>,
-            leaked: bool,
-        }
-        impl Drop for StackGuard {
-            fn drop(&mut self) {
-                if !self.leaked {
-                    self.core.subcompose_stack.borrow_mut().pop();
-                }
-            }
-        }
-        let mut guard = StackGuard {
+        let mut guard = SubcomposeStackGuard {
             core: composer.clone_core(),
             leaked: false,
         };
@@ -1746,22 +1746,7 @@ impl Composer {
             frame
         };
 
-        {
-            let mut applier = self.borrow_applier();
-            commands.apply(&mut *applier)?;
-            for update in runtime_handle.take_updates() {
-                update.apply(&mut *applier)?;
-            }
-        }
-        if compact_applier {
-            self.core.applier.compact();
-            self.core.applier.borrow_dyn().clear_recycled_nodes();
-        }
-        runtime_handle.drain_ui();
-        for effect in side_effects {
-            effect();
-        }
-        runtime_handle.drain_ui();
+        self.flush_subcompose_pass(commands, &runtime_handle, compact_applier, side_effects)?;
         Ok((result, frame.scopes))
     }
 

--- a/crates/cranpose-core/src/composition_locals.rs
+++ b/crates/cranpose-core/src/composition_locals.rs
@@ -149,15 +149,19 @@ impl<T: Clone + 'static> CompositionLocal<T> {
 }
 
 #[cfg(test)]
-pub(crate) fn malformed_composition_local_for_test<T: Clone + 'static>(
-    local: &CompositionLocal<T>,
-    entry: Rc<dyn Any>,
-) -> ProvidedValue {
-    let key = local.key.clone();
+fn malformed_provided_value_for_test(key: LocalKey, entry: Rc<dyn Any>) -> ProvidedValue {
     ProvidedValue {
         key,
         apply: Box::new(move |_, _| entry.clone()),
     }
+}
+
+#[cfg(test)]
+pub(crate) fn malformed_composition_local_for_test<T: Clone + 'static>(
+    local: &CompositionLocal<T>,
+    entry: Rc<dyn Any>,
+) -> ProvidedValue {
+    malformed_provided_value_for_test(local.key.clone(), entry)
 }
 
 #[allow(non_snake_case)]
@@ -234,11 +238,7 @@ pub(crate) fn malformed_static_composition_local_for_test<T: Clone + 'static>(
     local: &StaticCompositionLocal<T>,
     entry: Rc<dyn Any>,
 ) -> ProvidedValue {
-    let key = local.key.clone();
-    ProvidedValue {
-        key,
-        apply: Box::new(move |_, _| entry.clone()),
-    }
+    malformed_provided_value_for_test(local.key.clone(), entry)
 }
 
 #[allow(non_snake_case)]

--- a/crates/cranpose-core/src/launched_effect.rs
+++ b/crates/cranpose-core/src/launched_effect.rs
@@ -13,6 +13,22 @@ use std::{
 
 use crate::{Key, RuntimeHandle, TaskHandle, effect_key::EffectKey, with_current_composer};
 
+trait EffectKeySlot {
+    fn key(&self) -> &Option<EffectKey>;
+    fn key_mut(&mut self) -> &mut Option<EffectKey>;
+
+    fn should_run(&self, key: &EffectKey) -> bool {
+        match self.key() {
+            Some(current) => key.differs_from(current),
+            None => true,
+        }
+    }
+
+    fn set_key(&mut self, key: EffectKey) {
+        *self.key_mut() = Some(key);
+    }
+}
+
 #[derive(Default)]
 struct LaunchedEffectState {
     key: Option<EffectKey>,
@@ -72,18 +88,17 @@ struct LaunchedEffectAsyncState {
     site: TaskSite,
 }
 
+impl EffectKeySlot for LaunchedEffectState {
+    fn key(&self) -> &Option<EffectKey> {
+        &self.key
+    }
+
+    fn key_mut(&mut self) -> &mut Option<EffectKey> {
+        &mut self.key
+    }
+}
+
 impl LaunchedEffectState {
-    fn should_run(&self, key: &EffectKey) -> bool {
-        match &self.key {
-            Some(current) => key.differs_from(current),
-            None => true,
-        }
-    }
-
-    fn set_key(&mut self, key: EffectKey) {
-        self.key = Some(key);
-    }
-
     fn launch(
         &mut self,
         runtime: RuntimeHandle,
@@ -129,18 +144,17 @@ impl LaunchedEffectCancellation {
     }
 }
 
+impl EffectKeySlot for LaunchedEffectAsyncState {
+    fn key(&self) -> &Option<EffectKey> {
+        &self.key
+    }
+
+    fn key_mut(&mut self) -> &mut Option<EffectKey> {
+        &mut self.key
+    }
+}
+
 impl LaunchedEffectAsyncState {
-    fn should_run(&self, key: &EffectKey) -> bool {
-        match &self.key {
-            Some(current) => key.differs_from(current),
-            None => true,
-        }
-    }
-
-    fn set_key(&mut self, key: EffectKey) {
-        self.key = Some(key);
-    }
-
     fn set_site(&mut self, site: TaskSite) {
         self.site = site;
     }

--- a/crates/cranpose-core/src/snapshot_v2/global.rs
+++ b/crates/cranpose-core/src/snapshot_v2/global.rs
@@ -152,27 +152,19 @@ impl GlobalSnapshot {
         self.nested_count.set(self.nested_count.get() + 1);
         self.state.add_pending_child(new_id);
 
-        let parent_arc = self.root_global();
-        let weak = Arc::downgrade(&parent_arc);
-        drop(parent_arc);
-        child.set_on_dispose({
-            let child_id = new_id;
-            move || {
-                if let Some(parent) = weak.upgrade() {
-                    if parent.nested_count.get() > 0 {
-                        parent
-                            .nested_count
-                            .set(parent.nested_count.get().saturating_sub(1));
-                    }
-                    let mut invalid = parent.state.invalid.borrow_mut();
-                    let new_set = invalid.clone().clear(child_id);
-                    *invalid = new_set;
-                    parent.state.remove_pending_child(child_id);
-                }
-            }
-        });
+        child.set_on_dispose(clear_nested_child_on_dispose(&self.root_global(), new_id));
 
         child
+    }
+}
+
+impl NestedMutableHost for GlobalSnapshot {
+    fn snapshot_state(&self) -> &SnapshotState {
+        &self.state
+    }
+
+    fn nested_count(&self) -> &Cell<usize> {
+        &self.nested_count
     }
 }
 

--- a/crates/cranpose-core/src/snapshot_v2/mod.rs
+++ b/crates/cranpose-core/src/snapshot_v2/mod.rs
@@ -715,16 +715,8 @@ pub(crate) fn optimistic_merges(
     result
 }
 
-/// Merge two read observers into one.
-///
-/// # Thread Safety
-/// The resulting Arc-wrapped closure may capture non-Send closures. This is safe
-/// because observers are only invoked on the UI thread where they were created.
 #[allow(clippy::arc_with_non_send_sync)]
-pub fn merge_read_observers(
-    a: Option<ReadObserver>,
-    b: Option<ReadObserver>,
-) -> Option<ReadObserver> {
+fn merge_observers(a: Option<ReadObserver>, b: Option<ReadObserver>) -> Option<ReadObserver> {
     match (a, b) {
         (None, None) => None,
         (Some(a), None) => Some(a),
@@ -736,25 +728,28 @@ pub fn merge_read_observers(
     }
 }
 
+/// Merge two read observers into one.
+///
+/// # Thread Safety
+/// The resulting Arc-wrapped closure may capture non-Send closures. This is safe
+/// because observers are only invoked on the UI thread where they were created.
+pub fn merge_read_observers(
+    a: Option<ReadObserver>,
+    b: Option<ReadObserver>,
+) -> Option<ReadObserver> {
+    merge_observers(a, b)
+}
+
 /// Merge two write observers into one.
 ///
 /// # Thread Safety
 /// The resulting Arc-wrapped closure may capture non-Send closures. This is safe
 /// because observers are only invoked on the UI thread where they were created.
-#[allow(clippy::arc_with_non_send_sync)]
 pub fn merge_write_observers(
     a: Option<WriteObserver>,
     b: Option<WriteObserver>,
 ) -> Option<WriteObserver> {
-    match (a, b) {
-        (None, None) => None,
-        (Some(a), None) => Some(a),
-        (None, Some(b)) => Some(b),
-        (Some(a), Some(b)) => Some(Arc::new(move |state: &dyn StateObject| {
-            a(state);
-            b(state);
-        })),
-    }
+    merge_observers(a, b)
 }
 
 pub(crate) struct SnapshotState {
@@ -877,8 +872,78 @@ impl SnapshotState {
     }
 }
 
+pub(crate) trait NestedMutableHost {
+    fn snapshot_state(&self) -> &SnapshotState;
+    fn nested_count(&self) -> &Cell<usize>;
+}
+
+pub(crate) fn clear_nested_child_on_dispose<P>(
+    parent: &Arc<P>,
+    child_id: SnapshotId,
+) -> impl FnOnce() + 'static
+where
+    P: NestedMutableHost + 'static,
+{
+    let weak = Arc::downgrade(parent);
+    move || {
+        if let Some(parent) = weak.upgrade() {
+            let nested_count = parent.nested_count();
+            if nested_count.get() > 0 {
+                nested_count.set(nested_count.get().saturating_sub(1));
+            }
+            let state = parent.snapshot_state();
+            let new_invalid = state.invalid.borrow().clone().clear(child_id);
+            state.invalid.replace(new_invalid);
+            state.remove_pending_child(child_id);
+        }
+    }
+}
+
+pub(crate) fn allocate_nested_mutable_snapshot<P>(
+    parent: &Arc<P>,
+    root: Weak<MutableSnapshot>,
+    read_observer: Option<ReadObserver>,
+    write_observer: Option<WriteObserver>,
+) -> Arc<NestedMutableSnapshot>
+where
+    P: NestedMutableHost + 'static,
+{
+    let state = parent.snapshot_state();
+    let merged_read = merge_read_observers(read_observer, state.read_observer.borrow().clone());
+    let merged_write = merge_write_observers(write_observer, state.write_observer.borrow().clone());
+
+    let parent_id = state.id.get();
+    let current_invalid = state.invalid.borrow().clone();
+
+    let (new_id, _runtime_invalid) = allocate_snapshot();
+
+    let parent_invalid_with_child = current_invalid.set(new_id);
+    state.invalid.replace(parent_invalid_with_child);
+
+    let invalid = current_invalid.add_range(parent_id + 1, new_id);
+
+    let nested = NestedMutableSnapshot::new(
+        new_id,
+        invalid,
+        merged_read,
+        merged_write,
+        root,
+        state.id.get(),
+    );
+
+    let nested_count = parent.nested_count();
+    nested_count.set(nested_count.get() + 1);
+    state.add_pending_child(new_id);
+
+    nested.set_on_dispose(clear_nested_child_on_dispose(parent, new_id));
+
+    nested
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
 
     #[test]
@@ -1108,26 +1173,20 @@ mod tests {
         assert_eq!(*call_count.lock().unwrap(), 1);
     }
 
+    fn register_counting_observer(calls: &Arc<Mutex<Vec<i32>>>, tag: i32) -> ObserverHandle {
+        let calls = calls.clone();
+        register_apply_observer(Rc::new(move |_, _| {
+            calls.lock().unwrap().push(tag);
+        }))
+    }
+
     #[test]
     fn test_observer_handle_drop_removes_correct_observer() {
-        use std::sync::Mutex;
-
         let calls = Arc::new(Mutex::new(Vec::new()));
 
-        let calls1 = calls.clone();
-        let handle1 = register_apply_observer(Rc::new(move |_, _| {
-            calls1.lock().unwrap().push(1);
-        }));
-
-        let calls2 = calls.clone();
-        let handle2 = register_apply_observer(Rc::new(move |_, _| {
-            calls2.lock().unwrap().push(2);
-        }));
-
-        let calls3 = calls.clone();
-        let handle3 = register_apply_observer(Rc::new(move |_, _| {
-            calls3.lock().unwrap().push(3);
-        }));
+        let handle1 = register_counting_observer(&calls, 1);
+        let handle2 = register_counting_observer(&calls, 2);
+        let handle3 = register_counting_observer(&calls, 3);
 
         notify_apply_observers(&[], 1);
         let result = calls.lock().unwrap().clone();
@@ -1163,25 +1222,12 @@ mod tests {
 
     #[test]
     fn test_observer_handle_drop_in_different_orders() {
-        use std::sync::Mutex;
-
         {
             let calls = Arc::new(Mutex::new(Vec::new()));
 
-            let calls1 = calls.clone();
-            let h1 = register_apply_observer(Rc::new(move |_, _| {
-                calls1.lock().unwrap().push(1);
-            }));
-
-            let calls2 = calls.clone();
-            let h2 = register_apply_observer(Rc::new(move |_, _| {
-                calls2.lock().unwrap().push(2);
-            }));
-
-            let calls3 = calls.clone();
-            let h3 = register_apply_observer(Rc::new(move |_, _| {
-                calls3.lock().unwrap().push(3);
-            }));
+            let h1 = register_counting_observer(&calls, 1);
+            let h2 = register_counting_observer(&calls, 2);
+            let h3 = register_counting_observer(&calls, 3);
 
             drop(h3);
             notify_apply_observers(&[], 1);
@@ -1204,20 +1250,9 @@ mod tests {
         {
             let calls = Arc::new(Mutex::new(Vec::new()));
 
-            let calls1 = calls.clone();
-            let h1 = register_apply_observer(Rc::new(move |_, _| {
-                calls1.lock().unwrap().push(1);
-            }));
-
-            let calls2 = calls.clone();
-            let h2 = register_apply_observer(Rc::new(move |_, _| {
-                calls2.lock().unwrap().push(2);
-            }));
-
-            let calls3 = calls.clone();
-            let h3 = register_apply_observer(Rc::new(move |_, _| {
-                calls3.lock().unwrap().push(3);
-            }));
+            let h1 = register_counting_observer(&calls, 1);
+            let h2 = register_counting_observer(&calls, 2);
+            let h3 = register_counting_observer(&calls, 3);
 
             drop(h1);
             notify_apply_observers(&[], 1);
@@ -1308,51 +1343,9 @@ mod tests {
 
     #[test]
     fn test_state_object_storage_in_modified_set() {
-        use crate::state::StateObject;
-
-        struct TestState;
-
-        impl StateObject for TestState {
-            fn object_id(&self) -> crate::state::ObjectId {
-                crate::state::ObjectId(12345)
-            }
-
-            fn first_record(&self) -> Rc<crate::state::StateRecord> {
-                unimplemented!("Not needed for this test")
-            }
-
-            fn try_readable_record(
-                &self,
-                _snapshot_id: SnapshotId,
-                _invalid: &SnapshotIdSet,
-            ) -> Option<Rc<crate::state::StateRecord>> {
-                None
-            }
-
-            fn readable_record(
-                &self,
-                _snapshot_id: SnapshotId,
-                _invalid: &SnapshotIdSet,
-            ) -> Rc<crate::state::StateRecord> {
-                unimplemented!("Not needed for this test")
-            }
-
-            fn prepend_state_record(&self, _record: Rc<crate::state::StateRecord>) {
-                unimplemented!("Not needed for this test")
-            }
-
-            fn promote_record(&self, _child_id: SnapshotId) -> Result<(), &'static str> {
-                unimplemented!("Not needed for this test")
-            }
-
-            fn as_any(&self) -> &dyn std::any::Any {
-                self
-            }
-        }
-
         let state = SnapshotState::new(1, SnapshotIdSet::new(), None, None, false);
 
-        let state_obj = Arc::new(TestState) as Arc<dyn StateObject>;
+        let state_obj = TestStateObject::new(12345) as Arc<dyn StateObject>;
 
         state.record_write(state_obj.clone(), 1);
 
@@ -1367,50 +1360,8 @@ mod tests {
 
     #[test]
     fn test_multiple_writes_to_same_state_object() {
-        use crate::state::StateObject;
-
-        struct TestState;
-
-        impl StateObject for TestState {
-            fn object_id(&self) -> crate::state::ObjectId {
-                crate::state::ObjectId(99999)
-            }
-
-            fn first_record(&self) -> Rc<crate::state::StateRecord> {
-                unimplemented!()
-            }
-
-            fn try_readable_record(
-                &self,
-                _snapshot_id: SnapshotId,
-                _invalid: &SnapshotIdSet,
-            ) -> Option<Rc<crate::state::StateRecord>> {
-                None
-            }
-
-            fn readable_record(
-                &self,
-                _snapshot_id: SnapshotId,
-                _invalid: &SnapshotIdSet,
-            ) -> Rc<crate::state::StateRecord> {
-                unimplemented!()
-            }
-
-            fn prepend_state_record(&self, _record: Rc<crate::state::StateRecord>) {
-                unimplemented!()
-            }
-
-            fn promote_record(&self, _child_id: SnapshotId) -> Result<(), &'static str> {
-                unimplemented!()
-            }
-
-            fn as_any(&self) -> &dyn std::any::Any {
-                self
-            }
-        }
-
         let state = SnapshotState::new(1, SnapshotIdSet::new(), None, None, false);
-        let state_obj = Arc::new(TestState) as Arc<dyn StateObject>;
+        let state_obj = TestStateObject::new(99999) as Arc<dyn StateObject>;
 
         state.record_write(state_obj.clone(), 1);
         assert_eq!(state.modified.borrow().len(), 1);

--- a/crates/cranpose-core/src/snapshot_v2/mutable.rs
+++ b/crates/cranpose-core/src/snapshot_v2/mutable.rs
@@ -433,53 +433,7 @@ impl MutableSnapshot {
         self.validate_not_disposed();
         self.validate_not_applied();
 
-        let merged_read =
-            merge_read_observers(read_observer, self.state.read_observer.borrow().clone());
-        let merged_write =
-            merge_write_observers(write_observer, self.state.write_observer.borrow().clone());
-
-        let parent_id = self.state.id.get();
-        let current_invalid = self.state.invalid.borrow().clone();
-
-        let (new_id, _runtime_invalid) = allocate_snapshot();
-
-        let parent_invalid_with_child = current_invalid.set(new_id);
-        self.state.invalid.replace(parent_invalid_with_child);
-
-        let invalid = current_invalid.add_range(parent_id + 1, new_id);
-
-        let self_weak = Arc::downgrade(self);
-        let nested = NestedMutableSnapshot::new(
-            new_id,
-            invalid,
-            merged_read,
-            merged_write,
-            self_weak,
-            self.state.id.get(),
-        );
-
-        self.nested_count.set(self.nested_count.get() + 1);
-        self.state.add_pending_child(new_id);
-
-        let parent_weak = Arc::downgrade(self);
-        nested.set_on_dispose({
-            let child_id = new_id;
-            move || {
-                if let Some(parent) = parent_weak.upgrade() {
-                    if parent.nested_count.get() > 0 {
-                        parent
-                            .nested_count
-                            .set(parent.nested_count.get().saturating_sub(1));
-                    }
-                    let mut invalid = parent.state.invalid.borrow_mut();
-                    let new_set = invalid.clone().clear(child_id);
-                    *invalid = new_set;
-                    parent.state.remove_pending_child(child_id);
-                }
-            }
-        });
-
-        nested
+        allocate_nested_mutable_snapshot(self, Arc::downgrade(self), read_observer, write_observer)
     }
 
     pub(crate) fn merge_child_modifications(
@@ -500,6 +454,16 @@ impl MutableSnapshot {
             parent_mod.entry(*key).or_insert_with(|| value.clone());
         }
         Ok(())
+    }
+}
+
+impl NestedMutableHost for MutableSnapshot {
+    fn snapshot_state(&self) -> &SnapshotState {
+        &self.state
+    }
+
+    fn nested_count(&self) -> &Cell<usize> {
+        &self.nested_count
     }
 }
 

--- a/crates/cranpose-core/src/snapshot_v2/nested.rs
+++ b/crates/cranpose-core/src/snapshot_v2/nested.rs
@@ -260,54 +260,18 @@ impl NestedMutableSnapshot {
         read_observer: Option<ReadObserver>,
         write_observer: Option<WriteObserver>,
     ) -> Arc<NestedMutableSnapshot> {
-        let merged_read =
-            merge_read_observers(read_observer, self.state.read_observer.borrow().clone());
-        let merged_write =
-            merge_write_observers(write_observer, self.state.write_observer.borrow().clone());
+        let root = Arc::downgrade(&self.root_mutable());
+        allocate_nested_mutable_snapshot(self, root, read_observer, write_observer)
+    }
+}
 
-        let parent_id = self.state.id.get();
-        let current_invalid = self.state.invalid.borrow().clone();
+impl NestedMutableHost for NestedMutableSnapshot {
+    fn snapshot_state(&self) -> &SnapshotState {
+        &self.state
+    }
 
-        let (new_id, _runtime_invalid) = allocate_snapshot();
-
-        let parent_invalid_with_child = current_invalid.set(new_id);
-        self.state.invalid.replace(parent_invalid_with_child);
-
-        let invalid = current_invalid.add_range(parent_id + 1, new_id);
-
-        let self_weak = Arc::downgrade(&self.root_mutable());
-
-        let nested = NestedMutableSnapshot::new(
-            new_id,
-            invalid,
-            merged_read,
-            merged_write,
-            self_weak,
-            self.state.id.get(),
-        );
-
-        self.nested_count.set(self.nested_count.get() + 1);
-        self.state.add_pending_child(new_id);
-
-        let parent_self_weak = Arc::downgrade(self);
-        nested.set_on_dispose({
-            let child_id = new_id;
-            move || {
-                if let Some(parent) = parent_self_weak.upgrade() {
-                    if parent.nested_count.get() > 0 {
-                        parent
-                            .nested_count
-                            .set(parent.nested_count.get().saturating_sub(1));
-                    }
-                    let mut invalid = parent.state.invalid.borrow_mut();
-                    let new_set = invalid.clone().clear(child_id);
-                    *invalid = new_set;
-                    parent.state.remove_pending_child(child_id);
-                }
-            }
-        });
-
-        nested
+    fn nested_count(&self) -> &Cell<usize> {
+        &self.nested_count
     }
 }
 

--- a/crates/cranpose-core/src/state.rs
+++ b/crates/cranpose-core/src/state.rs
@@ -627,6 +627,19 @@ impl<T: Clone + 'static> SnapshotMutableState<T> {
         readable_record_for(&head, snapshot_id, invalid)
     }
 
+    fn is_equivalent_to_readable(
+        &self,
+        snapshot_id: SnapshotId,
+        invalid: &SnapshotIdSet,
+        new_value: &T,
+    ) -> bool {
+        self.readable_for(snapshot_id, invalid)
+            .map(|record| {
+                record.with_value(|current: &T| self.policy.equivalent(current, new_value))
+            })
+            .unwrap_or(false)
+    }
+
     fn writable_record(&self, snapshot_id: SnapshotId, invalid: &SnapshotIdSet) -> Rc<StateRecord> {
         let readable = match self.readable_for(snapshot_id, invalid) {
             Some(record) => record,
@@ -843,13 +856,7 @@ impl<T: Clone + 'static> SnapshotMutableState<T> {
         match &snapshot {
             AnySnapshot::Global(global) => {
                 let invalid = snapshot.invalid();
-                let equivalent = self
-                    .readable_for(snapshot_id, &invalid)
-                    .map(|record| {
-                        record.with_value(|current: &T| self.policy.equivalent(current, &new_value))
-                    })
-                    .unwrap_or(false);
-                if equivalent {
+                if self.is_equivalent_to_readable(snapshot_id, &invalid, &new_value) {
                     return false;
                 }
 
@@ -901,13 +908,7 @@ impl<T: Clone + 'static> SnapshotMutableState<T> {
             | AnySnapshot::NestedMutable(_)
             | AnySnapshot::TransparentMutable(_) => {
                 let invalid = snapshot.invalid();
-                let equivalent = self
-                    .readable_for(snapshot_id, &invalid)
-                    .map(|record| {
-                        record.with_value(|current: &T| self.policy.equivalent(current, &new_value))
-                    })
-                    .unwrap_or(false);
-                if equivalent {
+                if self.is_equivalent_to_readable(snapshot_id, &invalid, &new_value) {
                     return false;
                 }
 
@@ -1318,6 +1319,30 @@ fn register_current_state_scope<T: Clone + 'static>(inner: &MutableStateInner<T>
     }
 }
 
+trait StateArenaHandle<T: Clone + 'static> {
+    fn state_id(&self) -> StateId;
+    fn runtime_id(&self) -> runtime::RuntimeId;
+
+    fn runtime_handle(&self) -> RuntimeHandle {
+        runtime::runtime_handle_by_id(self.runtime_id())
+            .unwrap_or_else(|| panic!("runtime {:?} dropped", self.runtime_id()))
+    }
+
+    fn runtime_handle_opt(&self) -> Option<RuntimeHandle> {
+        runtime::runtime_handle_by_id(self.runtime_id())
+    }
+
+    fn with_inner<R>(&self, f: impl FnOnce(&MutableStateInner<T>) -> R) -> R {
+        self.runtime_handle()
+            .with_state_arena(|arena| arena.with_typed::<T, R>(self.state_id(), f))
+    }
+
+    fn try_with_inner<R>(&self, f: impl FnOnce(&MutableStateInner<T>) -> R) -> Option<R> {
+        self.runtime_handle_opt()?
+            .try_with_state_arena(|arena| arena.with_typed_opt::<T, R>(self.state_id(), f))?
+    }
+}
+
 /// Cheap copyable read-only view of a state cell.
 pub struct State<T: Clone + 'static> {
     id: StateId,
@@ -1376,7 +1401,7 @@ impl<T: Clone + 'static> Clone for MutableState<T> {
     }
 }
 
-impl<T: Clone + 'static> State<T> {
+impl<T: Clone + 'static> StateArenaHandle<T> for State<T> {
     fn state_id(&self) -> StateId {
         self.id
     }
@@ -1384,26 +1409,9 @@ impl<T: Clone + 'static> State<T> {
     fn runtime_id(&self) -> runtime::RuntimeId {
         self.runtime_id
     }
+}
 
-    fn runtime_handle(&self) -> RuntimeHandle {
-        runtime::runtime_handle_by_id(self.runtime_id())
-            .unwrap_or_else(|| panic!("runtime {:?} dropped", self.runtime_id()))
-    }
-
-    fn runtime_handle_opt(&self) -> Option<RuntimeHandle> {
-        runtime::runtime_handle_by_id(self.runtime_id())
-    }
-
-    fn with_inner<R>(&self, f: impl FnOnce(&MutableStateInner<T>) -> R) -> R {
-        self.runtime_handle()
-            .with_state_arena(|arena| arena.with_typed::<T, R>(self.state_id(), f))
-    }
-
-    fn try_with_inner<R>(&self, f: impl FnOnce(&MutableStateInner<T>) -> R) -> Option<R> {
-        self.runtime_handle_opt()?
-            .try_with_state_arena(|arena| arena.with_typed_opt::<T, R>(self.state_id(), f))?
-    }
-
+impl<T: Clone + 'static> State<T> {
     fn subscribe_current_scope(&self) {
         self.with_inner(register_current_state_scope::<T>);
     }
@@ -1474,6 +1482,16 @@ pub struct StateSubscriptionHold {
     _lease: Option<Box<dyn Any>>,
 }
 
+impl<T: Clone + 'static> StateArenaHandle<T> for MutableState<T> {
+    fn state_id(&self) -> StateId {
+        self.id
+    }
+
+    fn runtime_id(&self) -> runtime::RuntimeId {
+        self.runtime_id
+    }
+}
+
 impl<T: Clone + 'static> MutableState<T> {
     pub fn with_runtime(value: T, runtime: RuntimeHandle) -> Self {
         runtime.alloc_persistent_state(value)
@@ -1489,33 +1507,6 @@ impl<T: Clone + 'static> MutableState<T> {
 
     pub(crate) fn from_lease(lease: &Rc<runtime::StateHandleLease>) -> Self {
         Self::from_parts(lease.id(), lease.runtime().id())
-    }
-
-    fn state_id(&self) -> StateId {
-        self.id
-    }
-
-    fn runtime_id(&self) -> runtime::RuntimeId {
-        self.runtime_id
-    }
-
-    fn runtime_handle(&self) -> RuntimeHandle {
-        runtime::runtime_handle_by_id(self.runtime_id())
-            .unwrap_or_else(|| panic!("runtime {:?} dropped", self.runtime_id()))
-    }
-
-    fn runtime_handle_opt(&self) -> Option<RuntimeHandle> {
-        runtime::runtime_handle_by_id(self.runtime_id())
-    }
-
-    fn with_inner<R>(&self, f: impl FnOnce(&MutableStateInner<T>) -> R) -> R {
-        self.runtime_handle()
-            .with_state_arena(|arena| arena.with_typed::<T, R>(self.state_id(), f))
-    }
-
-    fn try_with_inner<R>(&self, f: impl FnOnce(&MutableStateInner<T>) -> R) -> Option<R> {
-        self.runtime_handle_opt()?
-            .try_with_state_arena(|arena| arena.with_typed_opt::<T, R>(self.state_id(), f))?
     }
 
     pub fn is_alive(&self) -> bool {
@@ -2384,36 +2375,7 @@ mod tests {
         let rec2 = StateRecord::new(200, 2i32, Some(rec1.clone()));
         let rec3 = StateRecord::new(300, 3i32, Some(rec2.clone()));
 
-        struct TestState {
-            head: Rc<StateRecord>,
-        }
-        impl StateObject for TestState {
-            fn object_id(&self) -> ObjectId {
-                ObjectId(999)
-            }
-            fn first_record(&self) -> Rc<StateRecord> {
-                Rc::clone(&self.head)
-            }
-            fn try_readable_record(
-                &self,
-                _: SnapshotId,
-                _: &SnapshotIdSet,
-            ) -> Option<Rc<StateRecord>> {
-                Some(Rc::clone(&self.head))
-            }
-            fn readable_record(&self, _: SnapshotId, _: &SnapshotIdSet) -> Rc<StateRecord> {
-                Rc::clone(&self.head)
-            }
-            fn prepend_state_record(&self, _: Rc<StateRecord>) {}
-            fn promote_record(&self, _: SnapshotId) -> Result<(), &'static str> {
-                Ok(())
-            }
-            fn as_any(&self) -> &dyn Any {
-                self
-            }
-        }
-
-        let test_state = TestState { head: rec3.clone() };
+        let test_state = ManualState::new(rec3.clone());
 
         let _pin = crate::snapshot_pinning::track_pinning(1000, &SnapshotIdSet::EMPTY);
 


### PR DESCRIPTION
## Summary

Removes duplication from `crates/cranpose-core/src/` by naming five real absent abstractions instead of the hand-copied code that stood in for them. Scope limited to `cranpose-core/src/`.

**Before: 208 clone pairs** (`jscpd --min-lines 10 --min-tokens 50 --format rust crates/cranpose-core`)
**After: 189 clone pairs**

## Abstractions introduced

- **`NestedMutableHost` trait + `clear_nested_child_on_dispose`/`allocate_nested_mutable_snapshot`** (`snapshot_v2/mod.rs`) - `MutableSnapshot`, `NestedMutableSnapshot` and `GlobalSnapshot` each hand-rolled "allocate a child snapshot id, bump `nested_count`, wire a dispose callback that undoes it on the parent." `GlobalSnapshot` keeps its own id allocation (it advances the global snapshot instead of calling `allocate_snapshot`) but now shares the dispose-cleanup closure.
- **`merge_read_observers`/`merge_write_observers` consolidation** - `ReadObserver` and `WriteObserver` are the same type alias, so these were the same function under two names. One now delegates to the other.
- **`SubcomposeStackGuard`, `spin_up_subcompose_core`, `flush_subcompose_pass`, `deactivate_and_queue_subtrees`** (`composer.rs`) - `subcompose()`, `subcompose_in()` and `subcompose_slot_with_context()` each defined their own copy of the subcompose-stack `Drop` guard; `subcompose_in`/`subcompose_slot_with_context` also duplicated the "build an isolated `ComposerCore`" setup and the "apply commands, compact, drain UI, run side effects" teardown. `dispose_retained_subtrees_for_host`/`abandon_retained_subtrees_for_host` shared an identical "deactivate scopes and queue subtree disposal" loop.
- **`StateArenaHandle` trait + `is_equivalent_to_readable`** (`state.rs`) - `State<T>` and `MutableState<T>` are both bare `(StateId, RuntimeId)` handles into the runtime's state arena and had verbatim copies of `state_id`/`runtime_id`/`runtime_handle`/`runtime_handle_opt`/`with_inner`/`try_with_inner`. The public `is_alive`/`try_with`/`try_value` stay duplicated on each type since removing them would need a real public-API change. `SnapshotMutableState::set()` ran the same equivalent-value check under the `Global` and `Mutable/Nested/Transparent` match arms.
- **`EffectKeySlot` trait** (`launched_effect.rs`) - `LaunchedEffectState` and `LaunchedEffectAsyncState` had identical `should_run`/`set_key` bodies.
- **Test-mock reuse** - `snapshot_v2::mod.rs` and `state.rs` each had a reusable `StateObject` mock (`TestStateObject`, `ManualState`) sitting unused next to per-test copies of the same shape; pointed the duplicate tests at the existing mock. Added `register_counting_observer` (three near-identical apply-observer tests) and `malformed_provided_value_for_test` (the `CompositionLocal`/`StaticCompositionLocal` malformed-entry helpers).

## Deliberately left duplicated

- The snapshot_v2 types' one-line accessors (`snapshot_id`/`invalid`/`record_read`/`close`/`is_disposed`) are textually identical across 3-7 types, but they are the only inherent, `pub` methods on published `pub` types - folding them into a trait would force every caller, including downstream crates, to import a new trait just to call `.snapshot_id()`.
- `MutableSnapshot::take_nested_snapshot` tracks `nested_count` and wires a dispose callback on the readonly child it returns; `NestedMutableSnapshot`'s and `TransparentObserverMutableSnapshot`'s equivalents do not. Confirmed by reading, not assumed identical - flagged as a possible pre-existing gap worth its own investigation, not folded together here.
- `NestedMutableSnapshot::take_nested_mutable_snapshot` never calls `validate_not_disposed`/`validate_not_applied` the way `MutableSnapshot`'s does. Same as above: a likely gap, left alone rather than silently patched inside a dedup change.

## Test plan

- [x] `just fmt`
- [x] `cargo clippy -p cranpose-core --all-targets -- -D warnings` - clean
- [x] `cargo test --profile ci -p cranpose-core` - 834 lib + 8 + 1 + 10 + 1 integration tests, all passing (same counts before/after)
- [x] `just test-features` - clean across all feature combinations
- [x] `just test-property` - clean
- [x] `just complexity-gate` - clean
- [x] `just duplication-gate` - clean (0 clones touch the diff)
- [x] No new `//`/`///`/`//!` comments on non-published-pub items

Generated with [Claude Code](https://claude.com/claude-code)
