### PR TITLE
Dedup robot-runners: shared launch, exit-timeout, and pixel-probe helpers

### DIFF
--- a/apps/desktop-demo/robot-runners/markdown_scroll_drag.rs
+++ b/apps/desktop-demo/robot-runners/markdown_scroll_drag.rs
@@ -1,0 +1,109 @@
+#![allow(dead_code)]
+
+use std::time::Duration;
+
+use cranpose_testing::{
+    find_button_in_semantics, find_in_semantics, find_text, print_semantics_with_bounds,
+};
+
+pub fn center(bounds: (f32, f32, f32, f32)) -> (f32, f32) {
+    (bounds.0 + bounds.2 * 0.5, bounds.1 + bounds.3 * 0.5)
+}
+
+pub fn wait_for_text_bounds(
+    robot: &cranpose::Robot,
+    text: &str,
+    timeout_ms: u64,
+) -> Option<(f32, f32, f32, f32)> {
+    let attempts = (timeout_ms / 100).max(1);
+    for _ in 0..attempts {
+        if let Some(bounds) = find_in_semantics(robot, |elem| find_text(elem, text)) {
+            return Some(bounds);
+        }
+        std::thread::sleep(Duration::from_millis(100));
+        let _ = robot.wait_for_idle();
+    }
+    None
+}
+
+pub fn fail_and_exit(robot: &cranpose::Robot, message: &str) -> ! {
+    eprintln!("FATAL: {message}");
+    if let Ok(semantics) = robot.get_semantics() {
+        print_semantics_with_bounds(&semantics, 0);
+    }
+    let _ = robot.exit();
+    std::process::exit(1);
+}
+
+pub fn click_button(robot: &cranpose::Robot, label: &str, settle_ms: u64) {
+    let Some(bounds) = find_button_in_semantics(robot, label) else {
+        fail_and_exit(robot, &format!("button '{label}' not found"));
+    };
+    let (x, y) = center(bounds);
+    robot
+        .click(x, y)
+        .unwrap_or_else(|err| fail_and_exit(robot, &format!("click '{label}' failed: {err}")));
+    std::thread::sleep(Duration::from_millis(settle_ms));
+    let _ = robot.wait_for_idle();
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn drag_scrollbar(
+    robot: &cranpose::Robot,
+    rail_bounds: (f32, f32, f32, f32),
+    from_frac: f32,
+    to_frac: f32,
+    step_delay_ms: u64,
+    wait_for_idle: bool,
+) {
+    let x = rail_bounds.0 + rail_bounds.2 * 0.5;
+    let y0 = rail_bounds.1 + rail_bounds.3 * from_frac;
+    let y1 = rail_bounds.1 + rail_bounds.3 * to_frac;
+    let steps = 30;
+
+    let _ = robot.mouse_move(x, y0);
+    let _ = robot.mouse_down();
+    for step in 0..=steps {
+        let t = step as f32 / steps as f32;
+        let y = y0 + (y1 - y0) * t;
+        let _ = robot.mouse_move(x, y);
+        std::thread::sleep(Duration::from_millis(step_delay_ms));
+    }
+    let _ = robot.mouse_up();
+    std::thread::sleep(Duration::from_millis(120));
+    if wait_for_idle {
+        let _ = robot.wait_for_idle();
+    }
+}
+
+pub struct DragViewportConfig {
+    pub from_frac: f32,
+    pub to_frac: f32,
+    pub steps: u32,
+    pub step_delay_ms: u64,
+    pub settle_delay_ms: u64,
+    pub wait_for_idle: bool,
+}
+
+pub fn drag_viewport(
+    robot: &cranpose::Robot,
+    viewport_bounds: (f32, f32, f32, f32),
+    config: DragViewportConfig,
+) {
+    let x = viewport_bounds.0 + viewport_bounds.2 * 0.5;
+    let y0 = viewport_bounds.1 + viewport_bounds.3 * config.from_frac;
+    let y1 = viewport_bounds.1 + viewport_bounds.3 * config.to_frac;
+    let _ = robot.mouse_move(x, y0);
+    let _ = robot.mouse_down();
+    for step in 0..=config.steps {
+        let t = step as f32 / config.steps as f32;
+        let y = y0 + (y1 - y0) * t;
+        let _ = robot.mouse_move(x, y);
+        std::thread::sleep(Duration::from_millis(config.step_delay_ms));
+    }
+    let _ = robot.mouse_up();
+    std::thread::sleep(Duration::from_millis(config.settle_delay_ms));
+    if config.wait_for_idle {
+        let _ = robot.wait_for_idle();
+    }
+}

--- a/apps/desktop-demo/robot-runners/robot_advance_frame_bug.rs
+++ b/apps/desktop-demo/robot-runners/robot_advance_frame_bug.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button, find_button_in_semantics, find_in_semantics, find_text};
 use desktop_app::app;
 
@@ -11,16 +14,9 @@ fn main() {
 
     const TEST_TIMEOUT_SECS: u64 = 60;
 
-    AppLauncher::new()
-        .with_title("Robot Advance Frame Bug Test")
-        .with_size(900, 700)
-        .with_headless(true)
+    robot_launch::launch("Robot Advance Frame Bug Test", 900, 700)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(TEST_TIMEOUT_SECS));
-                println!("✗ Test timed out after {} seconds", TEST_TIMEOUT_SECS);
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(TEST_TIMEOUT_SECS);
 
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_android_resume.rs
+++ b/apps/desktop-demo/robot-runners/robot_android_resume.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::{cell::RefCell, path::Path};
 
-use cranpose::AppLauncher;
 use cranpose_core::{rememberMutableStateOf, MutableState};
 use cranpose_ui::{composable, Column, ColumnSpec, LinearArrangement, Modifier, Text, TextStyle};
 
@@ -68,10 +69,7 @@ fn android_resume_contract_is_fixed() {
 }
 
 fn main() {
-    AppLauncher::new()
-        .with_title("Android Resume")
-        .with_size(640, 480)
-        .with_headless(true)
+    robot_launch::launch("Android Resume", 640, 480)
         .with_robot_app_hook(lifecycle_hook)
         .with_test_driver(|robot| {
             robot.wait_for_idle().expect("initial frame");

--- a/apps/desktop-demo/robot-runners/robot_animation_showcase.rs
+++ b/apps/desktop-demo/robot-runners/robot_animation_showcase.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
     find_button_in_semantics, find_text_by_prefix_in_semantics, find_text_in_semantics,
 };
@@ -33,10 +34,7 @@ fn main() {
     env_logger::init();
     println!("=== Robot Animation Showcase Test ===");
 
-    AppLauncher::new()
-        .with_title("Robot Animation Showcase Test")
-        .with_size(1200, 800)
-        .with_headless(true)
+    robot_launch::launch("Robot Animation Showcase Test", 1200, 800)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_async_pause.rs
+++ b/apps/desktop-demo/robot-runners/robot_async_pause.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::find_text_center;
 use desktop_app::app;
 
@@ -11,16 +14,9 @@ fn main() {
 
     const TEST_TIMEOUT_SECS: u64 = 60;
 
-    AppLauncher::new()
-        .with_title("Robot Async Pause Button Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Robot Async Pause Button Test", 800, 600)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(TEST_TIMEOUT_SECS));
-                println!("✗ Test TIMEOUT after {} seconds", TEST_TIMEOUT_SECS);
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(TEST_TIMEOUT_SECS);
 
             println!("\n✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_async_progress_after_animations.rs
+++ b/apps/desktop-demo/robot-runners/robot_async_progress_after_animations.rs
@@ -1,8 +1,9 @@
+mod robot_launch;
+
 mod robot_exit;
 
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
     exit_with_timeout, find_button_in_semantics, find_text_by_prefix_in_semantics,
     find_text_in_semantics,
@@ -72,11 +73,7 @@ fn main() {
     env_logger::init();
     println!("=== Robot Async Progress After Animations Test ===");
 
-    AppLauncher::new()
-        .with_title("Robot Async Progress After Animations Test")
-        .with_size(1200, 800)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Robot Async Progress After Animations Test", 1200, 800).with_test_driver(|robot| {
             println!("✓ App launched");
             wait_for_text(&robot, "Counter App", Duration::from_secs(5));
 

--- a/apps/desktop-demo/robot-runners/robot_async_tab_bug.rs
+++ b/apps/desktop-demo/robot-runners/robot_async_tab_bug.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::find_text_center;
 use desktop_app::app;
 
@@ -10,19 +13,9 @@ fn main() {
 
     const TEST_TIMEOUT_SECS: u64 = 60;
 
-    AppLauncher::new()
-        .with_title("Robot Async Tab Bug Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Robot Async Tab Bug Test", 800, 600)
         .with_test_driver(|robot| {
-            std::thread::spawn(move || {
-                std::thread::sleep(std::time::Duration::from_secs(TEST_TIMEOUT_SECS));
-                println!(
-                    "Test finished (timeout after {} seconds)",
-                    TEST_TIMEOUT_SECS
-                );
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(TEST_TIMEOUT_SECS);
 
             println!("\n✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_click_drag.rs
+++ b/apps/desktop-demo/robot-runners/robot_click_drag.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button, find_button_in_semantics, find_in_semantics, find_text};
 use desktop_app::app;
 
@@ -11,16 +14,8 @@ fn main() {
 
     const TEST_TIMEOUT_SECS: u64 = 60;
 
-    AppLauncher::new()
-        .with_title("Robot Click Drag Test")
-        .with_size(800, 600)
-        .with_headless(true)
-        .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(TEST_TIMEOUT_SECS));
-                println!("✗ Test timed out after {} seconds", TEST_TIMEOUT_SECS);
-                std::process::exit(1);
-            });
+    robot_launch::launch("Robot Click Drag Test", 800, 600).with_test_driver(|robot| {
+            robot_exit::arm_timeout(TEST_TIMEOUT_SECS);
 
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_composition_local_disappear.rs
+++ b/apps/desktop-demo/robot-runners/robot_composition_local_disappear.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button, find_button_in_semantics, find_in_semantics, find_text};
 use desktop_app::app;
 
@@ -11,16 +14,9 @@ fn main() {
 
     const TEST_TIMEOUT_SECS: u64 = 60;
 
-    AppLauncher::new()
-        .with_title("Robot CompositionLocal Bug Test")
-        .with_size(900, 700)
-        .with_headless(true)
+    robot_launch::launch("Robot CompositionLocal Bug Test", 900, 700)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(TEST_TIMEOUT_SECS));
-                println!("✗ Test timed out after {} seconds", TEST_TIMEOUT_SECS);
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(TEST_TIMEOUT_SECS);
 
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_conditional_infinite_transition_busy.rs
+++ b/apps/desktop-demo/robot-runners/robot_conditional_infinite_transition_busy.rs
@@ -1,8 +1,10 @@
+mod robot_launch;
+
 mod robot_exit;
 
 use std::time::{Duration, Instant};
 
-use cranpose::{AppLauncher, Robot, RobotScreenshot};
+use cranpose::{Robot, RobotScreenshot};
 use cranpose_animation::{
     infiniteRepeatable, rememberInfiniteTransition, AnimationSpec, Easing, RepeatMode, StartOffset,
 };
@@ -121,10 +123,7 @@ fn main() {
     env_logger::init();
     println!("=== Conditional Infinite Transition Busy Robot Test ===");
 
-    AppLauncher::new()
-        .with_title("Conditional Infinite Transition Busy")
-        .with_size(800, 500)
-        .with_headless(true)
+    robot_launch::launch("Conditional Infinite Transition Busy", 800, 500)
         .with_test_driver(|robot| {
             wait_for_text(
                 &robot,

--- a/apps/desktop-demo/robot-runners/robot_content_type_reuse.rs
+++ b/apps/desktop-demo/robot-runners/robot_content_type_reuse.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::find_text_in_semantics;
 
 const MAX_NEW_COMPOSES_DURING_SCROLL: usize = 200;
@@ -10,11 +11,7 @@ fn main() {
     env_logger::init();
     println!("=== Content-Type Reuse Robot Test ===");
 
-    AppLauncher::new()
-        .with_title("Content-Type Reuse Test")
-        .with_size(900, 700)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Content-Type Reuse Test", 900, 700).with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(200));
 

--- a/apps/desktop-demo/robot-runners/robot_copy_paste.rs
+++ b/apps/desktop-demo/robot-runners/robot_copy_paste.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button, find_button_in_semantics, find_in_semantics, find_text};
 use desktop_app::app;
 
@@ -9,16 +12,9 @@ fn main() {
     println!("=== Robot Copy-Paste Test ===");
     println!("Testing text selection, copy, and paste functionality\n");
 
-    AppLauncher::new()
-        .with_title("Robot Copy-Paste Test")
-        .with_size(900, 700)
-        .with_headless(true)
+    robot_launch::launch("Robot Copy-Paste Test", 900, 700)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(30));
-                println!("✗ Test timed out after 30 seconds");
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(30);
 
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_counter_conditional_text_top.rs
+++ b/apps/desktop-demo/robot-runners/robot_counter_conditional_text_top.rs
@@ -1,8 +1,9 @@
+mod robot_launch;
+
 mod regression_robot_support;
 
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{capture_screenshot, sample_screenshot_pixel_logical};
 use desktop_app::app;
 use regression_robot_support::{
@@ -54,11 +55,7 @@ fn main() {
     env_logger::init();
     println!("=== Robot Counter Conditional Text Top Test ===");
 
-    AppLauncher::new()
-        .with_title("Robot Counter Conditional Text Top Test")
-        .with_size(1024, 768)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Robot Counter Conditional Text Top Test", 1024, 768).with_test_driver(|robot| {
             spawn_timeout(30, "robot_counter_conditional_text_top");
 
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_demo.rs
+++ b/apps/desktop-demo/robot-runners/robot_demo.rs
@@ -1,6 +1,8 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, Robot};
+use cranpose::Robot;
 use desktop_app::app;
 
 fn wait_for_content(robot: &Robot, expected: &str, attempts: usize, delay: Duration) -> bool {
@@ -16,10 +18,7 @@ fn wait_for_content(robot: &Robot, expected: &str, attempts: usize, delay: Durat
 fn main() {
     println!("Launching app with robot control...");
 
-    AppLauncher::new()
-        .with_title("Robot Demo")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Robot Demo", 800, 600)
         .with_test_driver(|robot| {
             println!("App launched! Starting robot interactions in 1 second...");
             std::thread::sleep(Duration::from_secs(1));

--- a/apps/desktop-demo/robot-runners/robot_double_click.rs
+++ b/apps/desktop-demo/robot-runners/robot_double_click.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button, find_in_semantics, find_text};
 use desktop_app::app;
 
@@ -10,16 +13,9 @@ fn main() {
     env_logger::init();
     println!("=== Double-Click / Triple-Click Selection Test ===\n");
 
-    AppLauncher::new()
-        .with_title("Double-Click Test")
-        .with_size(600, 400)
-        .with_headless(true)
+    robot_launch::launch("Double-Click Test", 600, 400)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(60));
-                println!("\n✗ Test timed out");
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(60);
 
             std::thread::sleep(Duration::from_millis(300));
             println!("✓ App ready\n");

--- a/apps/desktop-demo/robot-runners/robot_drag_selection.rs
+++ b/apps/desktop-demo/robot-runners/robot_drag_selection.rs
@@ -1,14 +1,17 @@
+mod robot_launch;
+
 use std::{
     path::{Path, PathBuf},
     time::Duration,
 };
 
-use cranpose::{AppLauncher, RobotScreenshot, SemanticElement};
+use cranpose::{RobotScreenshot, SemanticElement};
 use cranpose_testing::{find_button, find_in_semantics, find_text};
 use desktop_app::app;
 use image::RgbaImage;
 
 mod robot_exit;
+mod robot_handle_probe;
 mod text_input_robot_helpers;
 
 type SelectedEditable = ((f32, f32, f32, f32), (usize, usize));
@@ -21,11 +24,7 @@ fn main() {
     );
     std::fs::create_dir_all(&shot_dir).expect("create screenshot directory");
 
-    AppLauncher::new()
-        .with_title("Drag Selection Test")
-        .with_size(600, 400)
-        .with_headless(true)
-        .with_test_driver(move |robot| {
+    robot_launch::launch("Drag Selection Test", 600, 400).with_test_driver(move |robot| {
             robot_exit::arm_timeout(60);
 
             std::thread::sleep(Duration::from_millis(300));
@@ -210,34 +209,16 @@ fn lower_handle_center(shot: &RobotScreenshot, rect: (f32, f32, f32, f32)) -> Op
     let right = (((x + width) * sx) as usize).min(shot.width as usize);
     let top = (((y + height * 0.5) * sy) as usize).min(shot.height as usize);
     let bottom = (((y + height + 8.0) * sy) as usize).min(shot.height as usize);
-
-    let is_blue = |px: usize, py: usize| {
-        let i = (py * shot.width as usize + px) * 4;
-        let (r, g, b) = (shot.pixels[i], shot.pixels[i + 1], shot.pixels[i + 2]);
-        b > 170 && b.saturating_sub(r) > 55 && b.saturating_sub(g) > 25
-    };
-    let max_y = (top..bottom)
-        .rev()
-        .find(|&py| (left..right).any(|px| is_blue(px, py)))?;
-    let band_top = max_y.saturating_sub((4.0 * sy).ceil() as usize);
-    let mut sum_x = 0usize;
-    let mut sum_y = 0usize;
-    let mut count = 0usize;
-    for py in band_top..=max_y {
-        for px in left..right {
-            if is_blue(px, py) {
-                sum_x += px;
-                sum_y += py;
-                count += 1;
-            }
-        }
-    }
-    (count > 0).then(|| {
-        (
-            sum_x as f32 / count as f32 / sx,
-            sum_y as f32 / count as f32 / sy,
-        )
-    })
+    robot_handle_probe::lower_band_center(
+        shot,
+        sx,
+        sy,
+        left,
+        right,
+        top,
+        bottom,
+        robot_handle_probe::is_blue_handle,
+    )
 }
 
 fn selected_editable(elements: &[SemanticElement]) -> Option<SelectedEditable> {
@@ -269,22 +250,16 @@ fn count_blue_handle_bands(shot: &RobotScreenshot, rect: (f32, f32, f32, f32)) -
     let bottom = (((y + height) * sy) as usize).min(shot.height as usize);
     let upper_end = ((y + height * 0.45) * sy) as usize;
     let lower_start = ((y + height * 0.55) * sy) as usize;
-    let mut upper = 0;
-    let mut lower = 0;
-    for py in top..bottom {
-        for px in left..right {
-            let i = (py * shot.width as usize + px) * 4;
-            let (r, g, b) = (shot.pixels[i], shot.pixels[i + 1], shot.pixels[i + 2]);
-            if b > 170 && b.saturating_sub(r) > 55 && b.saturating_sub(g) > 25 {
-                if py < upper_end {
-                    upper += 1;
-                } else if py >= lower_start {
-                    lower += 1;
-                }
-            }
-        }
-    }
-    (upper, lower)
+    robot_handle_probe::count_upper_lower_bands(
+        shot,
+        left,
+        right,
+        top,
+        bottom,
+        upper_end,
+        lower_start,
+        robot_handle_probe::is_blue_handle,
+    )
 }
 
 fn save(shot: &RobotScreenshot, dir: &Path, name: &str) {

--- a/apps/desktop-demo/robot-runners/robot_draw_only_transition_work.rs
+++ b/apps/desktop-demo/robot-runners/robot_draw_only_transition_work.rs
@@ -1,9 +1,10 @@
+mod robot_launch;
+
 use std::{
     sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
 
-use cranpose::AppLauncher;
 use cranpose_core::rememberMutableStateOf;
 use cranpose_testing::find_button_in_semantics;
 use cranpose_ui::{
@@ -18,10 +19,7 @@ static ROOT_COMPOSITIONS: AtomicUsize = AtomicUsize::new(0);
 
 fn main() {
     env_logger::init();
-    AppLauncher::new()
-        .with_title("Draw-only Transition Work")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Draw-only Transition Work", 800, 600)
         .with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(500));
             let (x, y, width, height) = find_button_in_semantics(&robot, "Activate")

--- a/apps/desktop-demo/robot-runners/robot_fling.rs
+++ b/apps/desktop-demo/robot-runners/robot_fling.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
     find_bounds_by_text, find_button_in_semantics, find_in_semantics, find_text,
     visible_bounds_in_viewport,
@@ -14,16 +17,9 @@ fn main() {
 
     const TEST_TIMEOUT_SECS: u64 = 60;
 
-    AppLauncher::new()
-        .with_title("Robot Fling Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Robot Fling Test", 800, 600)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(TEST_TIMEOUT_SECS));
-                println!("✗ Test timed out after {} seconds", TEST_TIMEOUT_SECS);
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(TEST_TIMEOUT_SECS);
 
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_fling_edge_cases.rs
+++ b/apps/desktop-demo/robot-runners/robot_fling_edge_cases.rs
@@ -1,8 +1,10 @@
+mod robot_launch;
+
 mod robot_exit;
 
 use std::time::Duration;
 
-use cranpose::{AppLauncher, Robot};
+use cranpose::Robot;
 use cranpose_testing::{
     find_bounds_by_text, find_button_in_semantics, find_in_semantics, find_text,
     visible_bounds_in_viewport,
@@ -45,16 +47,8 @@ fn main() {
 
     const TEST_TIMEOUT_SECS: u64 = 180;
 
-    AppLauncher::new()
-        .with_title("Fling Edge Cases")
-        .with_size(800, 600)
-        .with_headless(true)
-        .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(TEST_TIMEOUT_SECS));
-                eprintln!("✗ Test timed out");
-                std::process::exit(1);
-            });
+    robot_launch::launch("Fling Edge Cases", 800, 600).with_test_driver(|robot| {
+            robot_exit::arm_timeout(TEST_TIMEOUT_SECS);
 
             std::thread::sleep(Duration::from_millis(500));
             let _ = robot.wait_for_idle();

--- a/apps/desktop-demo/robot-runners/robot_fling_interrupt.rs
+++ b/apps/desktop-demo/robot-runners/robot_fling_interrupt.rs
@@ -1,16 +1,14 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{exit_with_timeout, find_button_in_semantics, find_text_in_semantics};
 use desktop_app::app;
 
 fn main() {
     println!("=== Robot Fling Interrupt Test ===\n");
 
-    AppLauncher::new()
-        .with_title("Robot Fling Interrupt Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Robot Fling Interrupt Test", 800, 600)
         .with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(500));
             let _ = robot.wait_for_idle();

--- a/apps/desktop-demo/robot-runners/robot_fling_precise.rs
+++ b/apps/desktop-demo/robot-runners/robot_fling_precise.rs
@@ -1,6 +1,10 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, Robot};
+use cranpose::Robot;
 use cranpose_testing::{
     exit_with_timeout, find_bounds_by_text, find_button_in_semantics, find_in_semantics, find_text,
     visible_bounds_in_viewport,
@@ -13,16 +17,9 @@ fn main() {
 
     const TEST_TIMEOUT_SECS: u64 = 120;
 
-    AppLauncher::new()
-        .with_title("Precise Fling Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Precise Fling Test", 800, 600)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(TEST_TIMEOUT_SECS));
-                eprintln!("✗ Test timed out after {} seconds", TEST_TIMEOUT_SECS);
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(TEST_TIMEOUT_SECS);
 
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_gradient_tab_switch.rs
+++ b/apps/desktop-demo/robot-runners/robot_gradient_tab_switch.rs
@@ -1,8 +1,10 @@
+mod robot_launch;
+
 mod robot_exit;
 
 use std::time::Duration;
 
-use cranpose::{AppLauncher, Robot};
+use cranpose::Robot;
 use cranpose_testing::{find_button_in_semantics, find_text_by_prefix_in_semantics};
 use desktop_app::app;
 
@@ -50,10 +52,7 @@ fn main() {
     env_logger::init();
     println!("=== Robot Gradient Tab Switch ===");
 
-    AppLauncher::new()
-        .with_title("Gradient Tab Switch Test")
-        .with_size(1024, 768)
-        .with_headless(true)
+    robot_launch::launch("Gradient Tab Switch Test", 1024, 768)
         .with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(500));
             let _ = robot.wait_for_idle();

--- a/apps/desktop-demo/robot-runners/robot_hacker_news_back_drag_scroll.rs
+++ b/apps/desktop-demo/robot-runners/robot_hacker_news_back_drag_scroll.rs
@@ -1,8 +1,9 @@
+mod robot_launch;
+
 pub mod hacker_news_robot_support;
 
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_core::CompositionLocalProvider;
 use cranpose_services::local_http_client;
 use cranpose_testing::{find_in_semantics, find_text_exact};
@@ -152,11 +153,7 @@ fn rewind_story_list_to_top(robot: &cranpose::Robot, list_bounds: (f32, f32, f32
 fn main() {
     env_logger::init();
     println!("=== Hacker News Back Drag Scroll Robot Test ===");
-    AppLauncher::new()
-        .with_title("Hacker News Back Drag Scroll Robot Test")
-        .with_size(390, 844)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Hacker News Back Drag Scroll Robot Test", 390, 844).with_test_driver(|robot| {
             println!("  • opening Hacker News startup");
             let list_bounds = open_hacker_news_tab(&robot);
             println!("  • measuring fresh drag baseline");

--- a/apps/desktop-demo/robot-runners/robot_hacker_news_scroll.rs
+++ b/apps/desktop-demo/robot-runners/robot_hacker_news_scroll.rs
@@ -1,8 +1,10 @@
+mod robot_launch;
+
 pub mod hacker_news_robot_support;
 
 use std::time::Duration;
 
-use cranpose::{AppLauncher, Robot};
+use cranpose::Robot;
 use cranpose_core::CompositionLocalProvider;
 use cranpose_services::local_http_client;
 use cranpose_testing::{find_in_semantics, find_text_exact, root_bounds};
@@ -84,11 +86,7 @@ fn main() {
     env_logger::init();
     println!("=== Hacker News Single Pane Scroll Robot Test ===");
 
-    AppLauncher::new()
-        .with_title("Hacker News Single Pane Scroll Test")
-        .with_size(390, 844)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Hacker News Single Pane Scroll Test", 390, 844).with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(500));
             let _ = robot.wait_for_idle();
 

--- a/apps/desktop-demo/robot-runners/robot_handle_probe.rs
+++ b/apps/desktop-demo/robot-runners/robot_handle_probe.rs
@@ -1,0 +1,76 @@
+#![allow(dead_code)]
+
+use cranpose::RobotScreenshot;
+
+pub fn is_blue_handle(r: u8, g: u8, b: u8) -> bool {
+    b > 170 && b.saturating_sub(r) > 55 && b.saturating_sub(g) > 25
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn lower_band_center(
+    shot: &RobotScreenshot,
+    sx: f32,
+    sy: f32,
+    left: usize,
+    right: usize,
+    top: usize,
+    bottom: usize,
+    matches: impl Fn(u8, u8, u8) -> bool,
+) -> Option<(f32, f32)> {
+    let is_match = |px: usize, py: usize| {
+        let i = (py * shot.width as usize + px) * 4;
+        let (r, g, b) = (shot.pixels[i], shot.pixels[i + 1], shot.pixels[i + 2]);
+        matches(r, g, b)
+    };
+    let max_y = (top..bottom)
+        .rev()
+        .find(|&py| (left..right).any(|px| is_match(px, py)))?;
+    let band_top = max_y.saturating_sub((4.0 * sy).ceil() as usize);
+    let mut sum_x = 0usize;
+    let mut sum_y = 0usize;
+    let mut count = 0usize;
+    for py in band_top..=max_y {
+        for px in left..right {
+            if is_match(px, py) {
+                sum_x += px;
+                sum_y += py;
+                count += 1;
+            }
+        }
+    }
+    (count > 0).then(|| {
+        (
+            sum_x as f32 / count as f32 / sx,
+            sum_y as f32 / count as f32 / sy,
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn count_upper_lower_bands(
+    shot: &RobotScreenshot,
+    left: usize,
+    right: usize,
+    top: usize,
+    bottom: usize,
+    upper_end: usize,
+    lower_start: usize,
+    matches: impl Fn(u8, u8, u8) -> bool,
+) -> (usize, usize) {
+    let mut upper = 0usize;
+    let mut lower = 0usize;
+    for py in top..bottom {
+        for px in left..right {
+            let i = (py * shot.width as usize + px) * 4;
+            let (r, g, b) = (shot.pixels[i], shot.pixels[i + 1], shot.pixels[i + 2]);
+            if matches(r, g, b) {
+                if py < upper_end {
+                    upper += 1;
+                } else if py >= lower_start {
+                    lower += 1;
+                }
+            }
+        }
+    }
+    (upper, lower)
+}

--- a/apps/desktop-demo/robot-runners/robot_idle_transition_work.rs
+++ b/apps/desktop-demo/robot-runners/robot_idle_transition_work.rs
@@ -1,9 +1,10 @@
+mod robot_launch;
+
 use std::{
     sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
 
-use cranpose::AppLauncher;
 use cranpose_animation::{
     infiniteRepeatable, rememberInfiniteTransition, AnimationSpec, Easing, RepeatMode, StartOffset,
 };
@@ -34,11 +35,7 @@ fn click_mode(robot: &cranpose::Robot, label: &str) {
 
 fn main() {
     env_logger::init();
-    AppLauncher::new()
-        .with_title("Idle Transition Work")
-        .with_size(800, 600)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Idle Transition Work", 800, 600).with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(500));
             robot.screenshot().expect("capture baseline frame");
             let baseline_render = robot

--- a/apps/desktop-demo/robot-runners/robot_image_chessboard.rs
+++ b/apps/desktop-demo/robot-runners/robot_image_chessboard.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
     find_button_in_semantics, find_in_semantics, find_text, sample_screenshot_pixel_logical,
 };
@@ -21,11 +22,7 @@ fn main() {
     env_logger::init();
     println!("=== Robot Image Chessboard Screenshot Test ===");
 
-    AppLauncher::new()
-        .with_title("Robot Image Chessboard")
-        .with_size(1200, 800)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Robot Image Chessboard", 1200, 800).with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(600));
             let _ = robot.wait_for_idle();
 

--- a/apps/desktop-demo/robot-runners/robot_increment_bug.rs
+++ b/apps/desktop-demo/robot-runners/robot_increment_bug.rs
@@ -1,8 +1,9 @@
+mod robot_launch;
+
 mod robot_exit;
 
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::find_text_by_prefix_in_semantics;
 use desktop_app::app;
 
@@ -60,11 +61,7 @@ fn main() {
     println!("=== Robot Increment Button Bug Test ===");
     println!("Testing if Increment button works after tab switch + cursor movement\n");
 
-    AppLauncher::new()
-        .with_title("Robot Increment Bug Test")
-        .with_size(800, 600)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Robot Increment Bug Test", 800, 600).with_test_driver(|robot| {
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));
 

--- a/apps/desktop-demo/robot-runners/robot_interactive.rs
+++ b/apps/desktop-demo/robot-runners/robot_interactive.rs
@@ -1,6 +1,8 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, Robot};
+use cranpose::Robot;
 use desktop_app::app;
 
 fn wait_for_content(robot: &Robot, expected: &str, attempts: usize, delay: Duration) -> bool {
@@ -17,10 +19,7 @@ fn main() {
     println!("=== Robot Interactive Demo (Semantic API) ===");
     println!("This demo uses semantic tree queries instead of hardcoded coordinates.\n");
 
-    AppLauncher::new()
-        .with_title("Robot Interactive Demo - Semantic API")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Robot Interactive Demo - Semantic API", 800, 600)
         .with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(500));
             println!("✓ App launched\n");

--- a/apps/desktop-demo/robot-runners/robot_interactive_anim.rs
+++ b/apps/desktop-demo/robot-runners/robot_interactive_anim.rs
@@ -1,8 +1,10 @@
+mod robot_launch;
+
 mod robot_exit;
 
 use std::time::Duration;
 
-use cranpose::{AppLauncher, Robot, RobotScreenshot};
+use cranpose::{Robot, RobotScreenshot};
 use cranpose_testing::{
     changed_pixel_count_in_region, find_button_in_semantics, find_text_in_semantics,
 };
@@ -26,11 +28,7 @@ fn main() {
     env_logger::init();
     println!("=== Robot Interactive Anim Test ===");
 
-    AppLauncher::new()
-        .with_title("Robot Interactive Anim Test")
-        .with_size(1200, 760)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Robot Interactive Anim Test", 1200, 760).with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(500));
             robot
                 .wait_for_idle()

--- a/apps/desktop-demo/robot-runners/robot_launch.rs
+++ b/apps/desktop-demo/robot-runners/robot_launch.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code)]
+
+use cranpose::AppLauncher;
+
+pub fn launch(title: &str, width: u32, height: u32) -> AppLauncher {
+    AppLauncher::new()
+        .with_title(title)
+        .with_size(width, height)
+        .with_headless(true)
+}

--- a/apps/desktop-demo/robot-runners/robot_layout_validation.rs
+++ b/apps/desktop-demo/robot-runners/robot_layout_validation.rs
@@ -1,6 +1,8 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, SemanticElement};
+use cranpose::SemanticElement;
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
 use desktop_app::app;
 
@@ -197,155 +199,155 @@ fn main() {
     println!("=== Comprehensive Layout Validation Robot Test ===");
     println!("Window size: {}x{}", WINDOW_WIDTH, WINDOW_HEIGHT);
 
-    AppLauncher::new()
-        .with_title("Layout Validation Test")
-        .with_size(WINDOW_WIDTH as u32, WINDOW_HEIGHT as u32)
-        .with_headless(true)
-        .with_test_driver(|robot| {
-            println!("✓ App launched");
+    robot_launch::launch(
+        "Layout Validation Test",
+        WINDOW_WIDTH as u32,
+        WINDOW_HEIGHT as u32,
+    )
+    .with_test_driver(|robot| {
+        println!("✓ App launched");
+        std::thread::sleep(Duration::from_millis(500));
+
+        let mut all_issues: Vec<(String, LayoutIssue)> = Vec::new();
+        let window_bounds = (0.0, 0.0, WINDOW_WIDTH, WINDOW_HEIGHT);
+
+        let click_button = |name: &str| -> bool {
+            if let Some((x, y, w, h)) = find_button_in_semantics(&robot, name) {
+                println!(
+                    "  Clicking '{}' at ({:.1}, {:.1})",
+                    name,
+                    x + w / 2.0,
+                    y + h / 2.0
+                );
+                robot.click(x + w / 2.0, y + h / 2.0).ok();
+                std::thread::sleep(Duration::from_millis(200));
+                true
+            } else {
+                println!("  ✗ Button '{}' not found!", name);
+                false
+            }
+        };
+
+        println!("\n\n######################################");
+        println!("# TEST 1: ASYNC RUNTIME TAB");
+        println!("######################################");
+
+        if click_button("Async Runtime") {
             std::thread::sleep(Duration::from_millis(500));
 
-            let mut all_issues: Vec<(String, LayoutIssue)> = Vec::new();
-            let window_bounds = (0.0, 0.0, WINDOW_WIDTH, WINDOW_HEIGHT);
+            if find_text_in_semantics(&robot, "Async Runtime Demo").is_some() {
+                println!("✓ Navigated to Async Runtime tab");
 
-            let click_button = |name: &str| -> bool {
-                if let Some((x, y, w, h)) = find_button_in_semantics(&robot, name) {
-                    println!(
-                        "  Clicking '{}' at ({:.1}, {:.1})",
-                        name,
-                        x + w / 2.0,
-                        y + h / 2.0
-                    );
-                    robot.click(x + w / 2.0, y + h / 2.0).ok();
-                    std::thread::sleep(Duration::from_millis(200));
-                    true
-                } else {
-                    println!("  ✗ Button '{}' not found!", name);
-                    false
-                }
-            };
-
-            println!("\n\n######################################");
-            println!("# TEST 1: ASYNC RUNTIME TAB");
-            println!("######################################");
-
-            if click_button("Async Runtime") {
-                std::thread::sleep(Duration::from_millis(500));
-
-                if find_text_in_semantics(&robot, "Async Runtime Demo").is_some() {
-                    println!("✓ Navigated to Async Runtime tab");
-
-                    if let Ok(semantics) = robot.get_semantics() {
-                        println!("\n--- Full Semantics Tree ---");
-                        for elem in &semantics {
-                            print_semantics_tree(elem, 0);
-                        }
-
-                        let issues =
-                            validate_bounds(&semantics, "Async Runtime", window_bounds, false);
-                        for issue in issues {
-                            all_issues.push(("Async Runtime".to_string(), issue));
-                        }
+                if let Ok(semantics) = robot.get_semantics() {
+                    println!("\n--- Full Semantics Tree ---");
+                    for elem in &semantics {
+                        print_semantics_tree(elem, 0);
                     }
-                } else {
-                    println!("✗ Failed to verify Async Runtime tab content");
-                }
-            } else {
-                println!("✗ Could not find Async Runtime tab button");
-            }
 
-            println!("\n\n######################################");
-            println!("# TEST 2: RECURSIVE LAYOUT TAB");
-            println!("######################################");
-
-            if click_button("Recursive Layout") {
-                std::thread::sleep(Duration::from_millis(500));
-
-                if find_text_in_semantics(&robot, "Recursive Layout Playground").is_some() {
-                    println!("✓ Navigated to Recursive Layout tab");
-
-                    if let Ok(semantics) = robot.get_semantics() {
-                        println!("\n--- Full Semantics Tree ---");
-                        for elem in &semantics {
-                            print_semantics_tree(elem, 0);
-                        }
-
-                        let issues =
-                            validate_bounds(&semantics, "Recursive Layout", window_bounds, true);
-                        for issue in issues {
-                            all_issues.push(("Recursive Layout".to_string(), issue));
-                        }
-                    }
-                } else {
-                    println!("✗ Failed to verify Recursive Layout tab content");
-                }
-
-                println!("\n--- Testing after state changes ---");
-                if click_button("Increase depth") {
-                    std::thread::sleep(Duration::from_millis(300));
-                    if let Ok(semantics) = robot.get_semantics() {
-                        let issues = validate_bounds(
-                            &semantics,
-                            "Recursive Layout (depth+1)",
-                            window_bounds,
-                            true,
-                        );
-                        for issue in issues {
-                            all_issues.push(("Recursive Layout (depth+1)".to_string(), issue));
-                        }
-                    }
-                }
-
-                if click_button("Increase depth") {
-                    std::thread::sleep(Duration::from_millis(300));
-                    if let Ok(semantics) = robot.get_semantics() {
-                        let issues = validate_bounds(
-                            &semantics,
-                            "Recursive Layout (depth+2)",
-                            window_bounds,
-                            true,
-                        );
-                        for issue in issues {
-                            all_issues.push(("Recursive Layout (depth+2)".to_string(), issue));
-                        }
+                    let issues = validate_bounds(&semantics, "Async Runtime", window_bounds, false);
+                    for issue in issues {
+                        all_issues.push(("Async Runtime".to_string(), issue));
                     }
                 }
             } else {
-                println!("✗ Could not find Recursive Layout tab button");
+                println!("✗ Failed to verify Async Runtime tab content");
             }
+        } else {
+            println!("✗ Could not find Async Runtime tab button");
+        }
 
-            println!("\n\n######################################");
-            println!("# LAYOUT VALIDATION REPORT");
-            println!("######################################\n");
+        println!("\n\n######################################");
+        println!("# TEST 2: RECURSIVE LAYOUT TAB");
+        println!("######################################");
 
-            if all_issues.is_empty() {
-                println!("✓ NO LAYOUT ISSUES FOUND");
-                println!("\nAll elements have valid bounds:");
-                println!("  - No NaN/Infinity values");
-                println!("  - No zero/negative sizes");
-                println!("  - No elements far outside window");
-                println!("  - No negative positions");
-            } else {
-                println!("✗ FOUND {} LAYOUT ISSUES:\n", all_issues.len());
-                for (i, (tab, issue)) in all_issues.iter().enumerate() {
-                    println!("Issue #{}: [{}]", i + 1, tab);
-                    println!(
-                        "  Element: [{}] \"{}\"",
-                        issue.element_role, issue.element_text
-                    );
-                    println!("  Problem: {}", issue.issue);
-                    println!(
-                        "  Bounds: ({:.1}, {:.1}, {:.1}, {:.1})\n",
-                        issue.bounds.0, issue.bounds.1, issue.bounds.2, issue.bounds.3
-                    );
+        if click_button("Recursive Layout") {
+            std::thread::sleep(Duration::from_millis(500));
+
+            if find_text_in_semantics(&robot, "Recursive Layout Playground").is_some() {
+                println!("✓ Navigated to Recursive Layout tab");
+
+                if let Ok(semantics) = robot.get_semantics() {
+                    println!("\n--- Full Semantics Tree ---");
+                    for elem in &semantics {
+                        print_semantics_tree(elem, 0);
+                    }
+
+                    let issues =
+                        validate_bounds(&semantics, "Recursive Layout", window_bounds, true);
+                    for issue in issues {
+                        all_issues.push(("Recursive Layout".to_string(), issue));
+                    }
                 }
-                println!("\n=== TEST FAILED ===");
-                robot.exit().ok();
-                std::process::exit(1);
+            } else {
+                println!("✗ Failed to verify Recursive Layout tab content");
             }
 
-            println!("\n=== Layout Validation Complete ===");
+            println!("\n--- Testing after state changes ---");
+            if click_button("Increase depth") {
+                std::thread::sleep(Duration::from_millis(300));
+                if let Ok(semantics) = robot.get_semantics() {
+                    let issues = validate_bounds(
+                        &semantics,
+                        "Recursive Layout (depth+1)",
+                        window_bounds,
+                        true,
+                    );
+                    for issue in issues {
+                        all_issues.push(("Recursive Layout (depth+1)".to_string(), issue));
+                    }
+                }
+            }
+
+            if click_button("Increase depth") {
+                std::thread::sleep(Duration::from_millis(300));
+                if let Ok(semantics) = robot.get_semantics() {
+                    let issues = validate_bounds(
+                        &semantics,
+                        "Recursive Layout (depth+2)",
+                        window_bounds,
+                        true,
+                    );
+                    for issue in issues {
+                        all_issues.push(("Recursive Layout (depth+2)".to_string(), issue));
+                    }
+                }
+            }
+        } else {
+            println!("✗ Could not find Recursive Layout tab button");
+        }
+
+        println!("\n\n######################################");
+        println!("# LAYOUT VALIDATION REPORT");
+        println!("######################################\n");
+
+        if all_issues.is_empty() {
+            println!("✓ NO LAYOUT ISSUES FOUND");
+            println!("\nAll elements have valid bounds:");
+            println!("  - No NaN/Infinity values");
+            println!("  - No zero/negative sizes");
+            println!("  - No elements far outside window");
+            println!("  - No negative positions");
+        } else {
+            println!("✗ FOUND {} LAYOUT ISSUES:\n", all_issues.len());
+            for (i, (tab, issue)) in all_issues.iter().enumerate() {
+                println!("Issue #{}: [{}]", i + 1, tab);
+                println!(
+                    "  Element: [{}] \"{}\"",
+                    issue.element_role, issue.element_text
+                );
+                println!("  Problem: {}", issue.issue);
+                println!(
+                    "  Bounds: ({:.1}, {:.1}, {:.1}, {:.1})\n",
+                    issue.bounds.0, issue.bounds.1, issue.bounds.2, issue.bounds.3
+                );
+            }
+            println!("\n=== TEST FAILED ===");
             robot.exit().ok();
-        })
-        .run(app::combined_app);
+            std::process::exit(1);
+        }
+
+        println!("\n=== Layout Validation Complete ===");
+        robot.exit().ok();
+    })
+    .run(app::combined_app);
 }

--- a/apps/desktop-demo/robot-runners/robot_lazy_complex_scroll.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_complex_scroll.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope};
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
 use cranpose_ui::{
@@ -14,10 +15,7 @@ use cranpose_ui::{
 fn main() {
     env_logger::init();
 
-    AppLauncher::new()
-        .with_title("Lazy Complex Scroll Test")
-        .with_size(400, 800)
-        .with_headless(true)
+    robot_launch::launch("Lazy Complex Scroll Test", 400, 800)
         .with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(500));
 

--- a/apps/desktop-demo/robot-runners/robot_lazy_duplication_bug.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_duplication_bug.rs
@@ -1,6 +1,8 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, SemanticElement};
+use cranpose::SemanticElement;
 use cranpose_testing::find_button_in_semantics;
 use desktop_app::app;
 
@@ -8,10 +10,7 @@ fn main() {
     env_logger::init();
     println!("=== Lazy Duplication Bug Reproduction Test ===");
 
-    AppLauncher::new()
-        .with_title("Lazy Duplication Test")
-        .with_size(1200, 800)
-        .with_headless(true)
+    robot_launch::launch("Lazy Duplication Test", 1200, 800)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_lazy_extreme_nav.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_extreme_nav.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::find_text_in_semantics;
 
 fn main() {
@@ -8,10 +9,7 @@ fn main() {
     println!("=== LazyList Extreme Navigation Robot Test ===");
     println!("Tests: Set usize::MAX → Jump Mid → Jump End");
 
-    AppLauncher::new()
-        .with_title("Extreme Navigation Test")
-        .with_size(900, 700)
-        .with_headless(true)
+    robot_launch::launch("Extreme Navigation Test", 900, 700)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(200));

--- a/apps/desktop-demo/robot-runners/robot_lazy_fixes.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_fixes.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
 use desktop_app::app;
 
@@ -9,10 +10,7 @@ fn main() {
     println!("=== LazyList P1 Fixes Validation Test ===");
     println!("Testing: DEFAULT_ITEM_SIZE_ESTIMATE, dead code removal, slot tracking");
 
-    AppLauncher::new()
-        .with_title("LazyList Fixes Test")
-        .with_size(1200, 800)
-        .with_headless(true)
+    robot_launch::launch("LazyList Fixes Test", 1200, 800)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_lazy_infinite_scroll.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_infinite_scroll.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope};
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
 use cranpose_ui::{
@@ -14,11 +15,7 @@ use cranpose_ui::{
 fn main() {
     env_logger::init();
 
-    AppLauncher::new()
-        .with_title("Lazy Infinite Scroll Test")
-        .with_size(400, 600)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Lazy Infinite Scroll Test", 400, 600).with_test_driver(|robot| {
              std::thread::sleep(Duration::from_millis(500));
 
              println!("--- Phase 1: Initial Layout ---");

--- a/apps/desktop-demo/robot-runners/robot_lazy_items_provider.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_items_provider.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::{rc::Rc, time::Duration};
 
-use cranpose::AppLauncher;
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScopeExt, LazyListState};
 use cranpose_macros::composable;
 use cranpose_testing::find_text_in_semantics;
@@ -178,10 +179,7 @@ fn main() {
     env_logger::init();
     println!("=== LazyList Provider Items Robot Test ===");
 
-    AppLauncher::new()
-        .with_title("Provider Items Test")
-        .with_size(800, 800)
-        .with_headless(true)
+    robot_launch::launch("Provider Items Test", 800, 800)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(300));

--- a/apps/desktop-demo/robot-runners/robot_lazy_items_rc.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_items_rc.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::{rc::Rc, time::Duration};
 
-use cranpose::AppLauncher;
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScopeExt, LazyListState};
 use cranpose_macros::composable;
 use cranpose_testing::find_text_in_semantics;
@@ -164,10 +165,7 @@ fn main() {
     env_logger::init();
     println!("=== LazyList Rc Items Robot Test ===");
 
-    AppLauncher::new()
-        .with_title("Rc Items Test")
-        .with_size(800, 800)
-        .with_headless(true)
+    robot_launch::launch("Rc Items Test", 800, 800)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(300));

--- a/apps/desktop-demo/robot-runners/robot_lazy_lifecycle.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_lifecycle.rs
@@ -1,6 +1,8 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, LazyItems};
+use cranpose::LazyItems;
 use cranpose_core::{DisposableEffect, DisposableEffectResult, MutableState};
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope, LazyListState};
 use cranpose_macros::composable;
@@ -143,10 +145,7 @@ fn main() {
     env_logger::init();
     println!("=== LazyList Lifecycle Robot Test ===");
 
-    AppLauncher::new()
-        .with_title("Lifecycle Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Lifecycle Test", 800, 600)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(100));

--- a/apps/desktop-demo/robot-runners/robot_lazy_list.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_list.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
     find_button_in_semantics, find_element_by_text_exact, find_text_by_prefix_in_semantics,
     find_text_in_semantics, print_semantics_with_bounds, root_bounds, union_bounds,
@@ -11,11 +12,7 @@ fn main() {
     env_logger::init();
     println!("=== LazyList Robot Test (with bounds validation) ===");
 
-    AppLauncher::new()
-        .with_title("LazyList Test")
-        .with_size(1200, 800)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("LazyList Test", 1200, 800).with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));
             let _ = robot.wait_for_idle();

--- a/apps/desktop-demo/robot-runners/robot_lazy_list_after_modifiers.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_list_after_modifiers.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
     find_button_in_semantics, find_element_by_text_exact, find_in_subtree_by_text,
     find_text_in_semantics, print_semantics_with_bounds,
@@ -11,10 +12,7 @@ fn main() {
     env_logger::init();
     println!("=== LazyList After Modifiers (rect validation) ===");
 
-    AppLauncher::new()
-        .with_title("LazyList After Modifiers")
-        .with_size(1200, 800)
-        .with_headless(true)
+    robot_launch::launch("LazyList After Modifiers", 1200, 800)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_lazy_list_end_alignment.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_list_end_alignment.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
     find_button_in_semantics, find_element_by_text_exact, find_in_semantics,
     find_text_by_prefix_in_semantics, find_text_exact, print_semantics_with_bounds, union_bounds,
@@ -11,10 +12,7 @@ fn main() {
     env_logger::init();
     println!("=== LazyList End Alignment Test ===");
 
-    AppLauncher::new()
-        .with_title("LazyList End Alignment Test")
-        .with_size(1200, 800)
-        .with_headless(true)
+    robot_launch::launch("LazyList End Alignment Test", 1200, 800)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_lazy_list_end_start_dup.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_list_end_start_dup.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
     count_text_in_tree, find_button_in_semantics, find_element_by_text_exact,
     print_semantics_with_bounds,
@@ -11,10 +12,7 @@ fn main() {
     env_logger::init();
     println!("=== LazyList End/Start Duplication Test ===");
 
-    AppLauncher::new()
-        .with_title("LazyList End/Start Dup Test")
-        .with_size(1200, 800)
-        .with_headless(true)
+    robot_launch::launch("LazyList End/Start Dup Test", 1200, 800)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_lazy_list_order_bug.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_list_order_bug.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button_in_semantics, find_in_semantics, find_text};
 use desktop_app::app;
 
@@ -11,16 +14,9 @@ fn main() {
 
     const TEST_TIMEOUT_SECS: u64 = 60;
 
-    AppLauncher::new()
-        .with_title("Robot LazyList Order Bug Test")
-        .with_size(900, 700)
-        .with_headless(true)
+    robot_launch::launch("Robot LazyList Order Bug Test", 900, 700)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(TEST_TIMEOUT_SECS));
-                println!("✗ Test timed out after {} seconds", TEST_TIMEOUT_SECS);
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(TEST_TIMEOUT_SECS);
 
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_lazy_list_remove_dup.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_list_remove_dup.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::{collections::HashMap, time::Duration};
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
     collect_by_text_exact, collect_text_prefix_counts, find_button_in_semantics,
     find_text_in_semantics, print_semantics_with_bounds,
@@ -11,10 +12,7 @@ fn main() {
     env_logger::init();
     println!("=== LazyList Remove 10 Duplication Test ===");
 
-    AppLauncher::new()
-        .with_title("LazyList Remove 10 Dup Test")
-        .with_size(1200, 800)
-        .with_headless(true)
+    robot_launch::launch("LazyList Remove 10 Dup Test", 1200, 800)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_lazy_list_state_reactivity.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_list_state_reactivity.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button_in_semantics, find_text_by_prefix_in_semantics};
 use desktop_app::app;
 
@@ -9,16 +12,9 @@ fn main() {
     println!("=== LazyListState Reactivity Test ===");
     println!("Testing that first_visible_item_index() triggers recomposition\n");
 
-    AppLauncher::new()
-        .with_title("LazyListState Reactivity Test")
-        .with_size(1200, 800)
-        .with_headless(true)
+    robot_launch::launch("LazyListState Reactivity Test", 1200, 800)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(30));
-                eprintln!("TIMEOUT: Test exceeded 30 seconds");
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(30);
 
             std::thread::sleep(Duration::from_millis(500));
             let _ = robot.wait_for_idle();

--- a/apps/desktop-demo/robot-runners/robot_lazy_max_demo.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_max_demo.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
     find_button_in_semantics, find_text_by_prefix_in_semantics, find_text_in_semantics,
 };
@@ -9,10 +10,7 @@ use desktop_app::app::lazy_list::lazy_list_example;
 fn main() {
     println!("=== LazyColumn usize::MAX Demo Test (ACTUAL APP) ===\n");
 
-    AppLauncher::new()
-        .with_title("LazyMax Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("LazyMax Test", 800, 600)
         .with_test_driver(|robot| {
             use std::time::Instant;
 

--- a/apps/desktop-demo/robot-runners/robot_lazy_max_jump.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_max_jump.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope};
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
 use cranpose_ui::{
@@ -14,10 +15,7 @@ use cranpose_ui::{
 fn main() {
     env_logger::init();
 
-    AppLauncher::new()
-        .with_title("LazyList usize::MAX Jump Middle Test")
-        .with_size(500, 700)
-        .with_headless(true)
+    robot_launch::launch("LazyList usize::MAX Jump Middle Test", 500, 700)
         .with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(500));
 

--- a/apps/desktop-demo/robot-runners/robot_lazy_perf.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_perf.rs
@@ -1,6 +1,8 @@
+mod robot_launch;
+
 use std::time::{Duration, Instant};
 
-use cranpose::{AppLauncher, LazyItems};
+use cranpose::LazyItems;
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope};
 use cranpose_testing::find_text_in_semantics;
 use cranpose_ui::{widgets::*, Color, LinearArrangement, Modifier, TextStyle};
@@ -117,10 +119,7 @@ fn main() {
         format_large_number(ITEM_COUNT)
     );
 
-    AppLauncher::new()
-        .with_title("LazyColumn Perf Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("LazyColumn Perf Test", 800, 600)
         .with_test_driver(|robot| {
             println!("✓ App launched");
 

--- a/apps/desktop-demo/robot-runners/robot_lazy_perf_validation.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_perf_validation.rs
@@ -1,17 +1,14 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::find_text_in_semantics;
 
 fn main() {
     env_logger::init();
     println!("=== LazyList Performance Validation ===");
 
-    AppLauncher::new()
-        .with_title("Performance Validation")
-        .with_size(900, 700)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Performance Validation", 900, 700).with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(200));
 

--- a/apps/desktop-demo/robot-runners/robot_lazy_recursive_composition.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_recursive_composition.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
     find_button_in_semantics, find_element_by_text_exact, find_in_semantics, find_text_exact,
 };
@@ -10,11 +11,7 @@ fn main() {
     env_logger::init();
     println!("=== LazyList Recursive Composition Bug Test ===");
 
-    AppLauncher::new()
-        .with_title("LazyList Recursive Composition Test")
-        .with_size(1200, 800)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("LazyList Recursive Composition Test", 1200, 800).with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));
 

--- a/apps/desktop-demo/robot-runners/robot_lazy_scroll_edge_cases.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_scroll_edge_cases.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope};
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
 use cranpose_ui::{
@@ -15,10 +16,7 @@ fn main() {
     env_logger::init();
     println!("=== Lazy Scroll Edge Cases Robot Test ===");
 
-    AppLauncher::new()
-        .with_title("Lazy Scroll Edge Cases")
-        .with_size(400, 600)
-        .with_headless(true)
+    robot_launch::launch("Lazy Scroll Edge Cases", 400, 600)
         .with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(500));
             let _ = robot.wait_for_idle();

--- a/apps/desktop-demo/robot-runners/robot_lazy_stats.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_stats.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button_in_semantics, find_text_by_prefix_in_semantics};
 use desktop_app::app;
 
@@ -8,10 +9,7 @@ fn main() {
     env_logger::init();
     println!("=== Lazy Stats Validation Test ===");
 
-    AppLauncher::new()
-        .with_title("LazyStats Test")
-        .with_size(1200, 800)
-        .with_headless(true)
+    robot_launch::launch("LazyStats Test", 1200, 800)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_lazy_tab_test.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_tab_test.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
 use desktop_app::app;
 
@@ -8,10 +9,7 @@ fn main() {
     env_logger::init();
     println!("=== Comprehensive LazyList Tab Robot Test ===\n");
 
-    AppLauncher::new()
-        .with_title("LazyList Tab Test")
-        .with_size(1024, 768)
-        .with_headless(true)
+    robot_launch::launch("LazyList Tab Test", 1024, 768)
         .with_test_driver(|robot| {
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_lazy_varheight_lifecycle.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_varheight_lifecycle.rs
@@ -1,6 +1,8 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, LazyItems};
+use cranpose::LazyItems;
 use cranpose_core::{DisposableEffect, DisposableEffectResult, MutableState};
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope, LazyListState};
 use cranpose_macros::composable;
@@ -148,10 +150,7 @@ fn main() {
     env_logger::init();
     println!("=== Variable Height Lifecycle Robot Test ===");
 
-    AppLauncher::new()
-        .with_title("VarHeight Lifecycle Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("VarHeight Lifecycle Test", 800, 600)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(100));

--- a/apps/desktop-demo/robot-runners/robot_lazy_variable_height.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_variable_height.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope};
 use cranpose_testing::find_text_in_semantics;
 use cranpose_ui::{
@@ -11,11 +12,7 @@ use cranpose_ui::{
 fn main() {
     env_logger::init();
 
-    AppLauncher::new()
-        .with_title("Lazy Variable Height Test")
-        .with_size(400, 600)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Lazy Variable Height Test", 400, 600).with_test_driver(|robot| {
              std::thread::sleep(Duration::from_millis(500));
 
              let check_item = |name: &str, expected_y: f32, _expected_height: f32| {

--- a/apps/desktop-demo/robot-runners/robot_lazy_wheel_backtrack.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_wheel_backtrack.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::{cmp::Ordering, time::Duration};
 
-use cranpose::AppLauncher;
 use cranpose_foundation::{
     lazy::{rememberLazyListState, LazyListScope},
     SemanticsConfiguration,
@@ -151,10 +152,7 @@ fn main() {
     env_logger::init();
     println!("=== Lazy Wheel Backtrack Test ===");
 
-    AppLauncher::new()
-        .with_title("Lazy Wheel Backtrack")
-        .with_size(640, 800)
-        .with_headless(true)
+    robot_launch::launch("Lazy Wheel Backtrack", 640, 800)
         .with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(600));
             let _ = robot.wait_for_idle();

--- a/apps/desktop-demo/robot-runners/robot_lazylist_redraw_bug.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazylist_redraw_bug.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
     find_button_in_semantics, find_text_by_prefix_in_semantics, find_text_in_semantics,
 };
@@ -11,10 +12,7 @@ fn main() {
     println!("=== Lazy List Redraw Bug Test ===");
     println!("Testing: Set MAX → Jump to Middle should update UI immediately");
 
-    AppLauncher::new()
-        .with_title("LazyList Redraw Bug Test")
-        .with_size(1200, 800)
-        .with_headless(true)
+    robot_launch::launch("LazyList Redraw Bug Test", 1200, 800)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_leetcodedaily_full_layout_scroll_stability.rs
+++ b/apps/desktop-demo/robot-runners/robot_leetcodedaily_full_layout_scroll_stability.rs
@@ -11,7 +11,7 @@ mod text_showcase_external_helpers;
 use std::{
     cell::RefCell,
     collections::{BTreeMap, HashMap, HashSet},
-    path::{Path, PathBuf},
+    path::PathBuf,
     time::{Duration, Instant},
 };
 
@@ -32,7 +32,7 @@ use cranpose_ui::{
     Point, Rect, RoundedCornerShape, Row, RowSpec, ScrollState, Size, Spacer, SpanStyle, Text,
     TextOverflow, TextStyle, VerticalAlignment,
 };
-use image::{imageops::FilterType, ImageBuffer, RgbaImage};
+use image::{imageops::FilterType, RgbaImage};
 use perf_robot_stats::{print_render_summary, RenderStatsAccumulator};
 use scroll_stability_external_helpers::{run_scroll_stability_capture, ScrollStabilityConfig};
 use text_showcase_external_helpers::{find_window_id, take_x11_screenshot};
@@ -6791,7 +6791,7 @@ fn capture_bottom_clear_stability_sample(robot: &cranpose::Robot) -> BottomClear
     .unwrap_or_else(|| {
         let dir = bottom_clear_capture_dir();
         let full_path = dir.join("missing-visual-clear-full-window.png");
-        save_robot_screenshot_png(&full_path, &screenshot);
+        scroll_stability_external_helpers::save_robot_screenshot(&full_path, &screenshot);
         fail_with_robot(
             robot,
             &format!(
@@ -6825,7 +6825,7 @@ fn capture_bottom_clear_stability_sample(robot: &cranpose::Robot) -> BottomClear
     let red_profile = red_icon_horizontal_profile(&clear_crop).unwrap_or_else(|| {
         let dir = bottom_clear_capture_dir();
         let clear_path = dir.join("missing-red-profile-clear-button.png");
-        save_robot_screenshot_png(&clear_path, &clear_crop);
+        scroll_stability_external_helpers::save_robot_screenshot(&clear_path, &clear_crop);
         fail_with_robot(
             robot,
             &format!(
@@ -7973,8 +7973,8 @@ fn save_row_micro_failure(
     let dir = leetcodedaily_diagnostic_dir("cranpose-leetcodedaily-row-micro-stability");
     let before_path = dir.join(format!("step{step:02}_before.png"));
     let after_path = dir.join(format!("step{step:02}_after.png"));
-    save_robot_screenshot_png(&before_path, before);
-    save_robot_screenshot_png(&after_path, after);
+    scroll_stability_external_helpers::save_robot_screenshot(&before_path, before);
+    scroll_stability_external_helpers::save_robot_screenshot(&after_path, after);
     eprintln!(
         "row_micro_failure_paths step={step} before={} after={}",
         before_path.display(),
@@ -7999,8 +7999,8 @@ fn save_workspace_strip_failure(
     let dir = leetcodedaily_diagnostic_dir("cranpose-leetcodedaily-workspace-strip-stability");
     let before_path = dir.join(format!("step{step:02}_before.png"));
     let after_path = dir.join(format!("step{step:02}_after.png"));
-    save_robot_screenshot_png(&before_path, &before);
-    save_robot_screenshot_png(&after_path, &after);
+    scroll_stability_external_helpers::save_robot_screenshot(&before_path, &before);
+    scroll_stability_external_helpers::save_robot_screenshot(&after_path, &after);
     eprintln!(
         "workspace_strip_failure_paths step={step} before={} after={}",
         before_path.display(),
@@ -8025,8 +8025,8 @@ fn save_workspace_top_band_failure(
     let dir = leetcodedaily_diagnostic_dir("cranpose-leetcodedaily-workspace-top-band-stability");
     let before_path = dir.join(format!("step{step:02}_before.png"));
     let after_path = dir.join(format!("step{step:02}_after.png"));
-    save_robot_screenshot_png(&before_path, &before);
-    save_robot_screenshot_png(&after_path, &after);
+    scroll_stability_external_helpers::save_robot_screenshot(&before_path, &before);
+    scroll_stability_external_helpers::save_robot_screenshot(&after_path, &after);
     eprintln!(
         "workspace_top_band_failure_paths step={step} before={} after={}",
         before_path.display(),
@@ -8054,8 +8054,8 @@ fn save_workspace_top_band_sample_if_requested(
     let dir = leetcodedaily_diagnostic_dir("cranpose-leetcodedaily-workspace-top-band-samples");
     let full_path = dir.join(format!("step{step:02}_full.png"));
     let band_path = dir.join(format!("step{step:02}_band.png"));
-    save_robot_screenshot_png(&full_path, &full);
-    save_robot_screenshot_png(&band_path, &band);
+    scroll_stability_external_helpers::save_robot_screenshot(&full_path, &full);
+    scroll_stability_external_helpers::save_robot_screenshot(&band_path, &band);
     eprintln!(
         "workspace_top_band_sample_paths step={step} full={} band={}",
         full_path.display(),
@@ -8093,8 +8093,8 @@ fn save_row_micro_feature_failure(
     let dir = leetcodedaily_diagnostic_dir("cranpose-leetcodedaily-row-micro-stability");
     let before_path = dir.join(format!("step{step:02}_{label}_before.png"));
     let after_path = dir.join(format!("step{step:02}_{label}_after.png"));
-    save_robot_screenshot_png(&before_path, &before);
-    save_robot_screenshot_png(&after_path, &after);
+    scroll_stability_external_helpers::save_robot_screenshot(&before_path, &before);
+    scroll_stability_external_helpers::save_robot_screenshot(&after_path, &after);
     eprintln!(
         "row_micro_feature_failure_paths step={step} label={label} before={} after={}",
         before_path.display(),
@@ -8113,8 +8113,8 @@ fn save_bottom_clear_sample_if_requested(step: usize, sample: &BottomClearStabil
     let dir = bottom_clear_capture_dir();
     let fixed_path = dir.join(format!("step{step:02}_fixed-bottom.png"));
     let clear_path = dir.join(format!("step{step:02}_clear-button.png"));
-    save_robot_screenshot_png(&fixed_path, &sample.fixed_crop);
-    save_robot_screenshot_png(&clear_path, &sample.clear_crop);
+    scroll_stability_external_helpers::save_robot_screenshot(&fixed_path, &sample.fixed_crop);
+    scroll_stability_external_helpers::save_robot_screenshot(&clear_path, &sample.clear_crop);
     println!(
         "bottom_clear_capture step={step} fixed={} clear={}",
         fixed_path.display(),
@@ -8132,10 +8132,22 @@ fn save_bottom_clear_failure(
     let current_fixed_path = dir.join(format!("step{step:02}_current_fixed-bottom.png"));
     let previous_clear_path = dir.join(format!("step{step:02}_previous_clear-button.png"));
     let current_clear_path = dir.join(format!("step{step:02}_current_clear-button.png"));
-    save_robot_screenshot_png(&previous_fixed_path, &previous.fixed_crop);
-    save_robot_screenshot_png(&current_fixed_path, &current.fixed_crop);
-    save_robot_screenshot_png(&previous_clear_path, &previous.clear_crop);
-    save_robot_screenshot_png(&current_clear_path, &current.clear_crop);
+    scroll_stability_external_helpers::save_robot_screenshot(
+        &previous_fixed_path,
+        &previous.fixed_crop,
+    );
+    scroll_stability_external_helpers::save_robot_screenshot(
+        &current_fixed_path,
+        &current.fixed_crop,
+    );
+    scroll_stability_external_helpers::save_robot_screenshot(
+        &previous_clear_path,
+        &previous.clear_crop,
+    );
+    scroll_stability_external_helpers::save_robot_screenshot(
+        &current_clear_path,
+        &current.clear_crop,
+    );
     eprintln!(
         "bottom_clear_failure_paths step={step} previous_fixed={} current_fixed={} previous_clear={} current_clear={}",
         previous_fixed_path.display(),
@@ -8803,7 +8815,7 @@ fn save_full_frame_color_health_failure(
 ) -> PathBuf {
     let dir = leetcodedaily_diagnostic_dir("cranpose-leetcodedaily-full-frame-color-health");
     let path = dir.join(format!("{}.png", sanitize_capture_name(label)));
-    save_robot_screenshot_png(&path, screenshot);
+    scroll_stability_external_helpers::save_robot_screenshot(&path, screenshot);
     path
 }
 
@@ -8822,7 +8834,7 @@ fn save_button_reference_crop(
         sanitize_capture_name(phase),
         sanitize_capture_name(tag)
     ));
-    save_robot_screenshot_png(&path, screenshot);
+    scroll_stability_external_helpers::save_robot_screenshot(&path, screenshot);
     path
 }
 
@@ -8862,7 +8874,7 @@ fn save_button_quality_crop_if_requested(
         sanitize_capture_name(label),
         sanitize_capture_name(phase)
     ));
-    save_robot_screenshot_png(&path, screenshot);
+    scroll_stability_external_helpers::save_robot_screenshot(&path, screenshot);
     Some(path)
 }
 
@@ -8903,18 +8915,6 @@ fn sanitize_capture_name(input: &str) -> String {
             }
         })
         .collect()
-}
-
-fn save_robot_screenshot_png(path: &Path, screenshot: &cranpose::RobotScreenshot) {
-    let image: RgbaImage = ImageBuffer::from_raw(
-        screenshot.width,
-        screenshot.height,
-        screenshot.pixels.clone(),
-    )
-    .expect("valid screenshot dimensions");
-    image
-        .save(path)
-        .unwrap_or_else(|err| panic!("failed to save {}: {err}", path.display()));
 }
 
 fn fail_with_robot(robot: &cranpose::Robot, message: &str) -> ! {

--- a/apps/desktop-demo/robot-runners/robot_liquid_tab_bar_pill_containment.rs
+++ b/apps/desktop-demo/robot-runners/robot_liquid_tab_bar_pill_containment.rs
@@ -1,5 +1,6 @@
 mod robot_exit;
 mod robot_shot;
+mod robot_tab_fixture;
 
 use std::{path::PathBuf, process::ExitCode, sync::atomic::AtomicBool, time::Duration};
 
@@ -130,11 +131,7 @@ fn main() -> ExitCode {
                             LiquidTabBarSpec::new(WIDE_TAB),
                             selected.get(),
                             move |index| selected.set(index),
-                            |scope| {
-                                for (icon, label) in TABS {
-                                    scope.tab(icon, label);
-                                }
-                            },
+                            robot_tab_fixture::tabs(&TABS),
                         );
                     },
                 );

--- a/apps/desktop-demo/robot-runners/robot_liquid_tab_flight_dark_scheme_ink_recolor.rs
+++ b/apps/desktop-demo/robot-runners/robot_liquid_tab_flight_dark_scheme_ink_recolor.rs
@@ -26,6 +26,7 @@
 
 mod robot_exit;
 mod robot_shot;
+mod robot_tab_fixture;
 
 use std::{path::PathBuf, process::ExitCode, sync::atomic::AtomicBool, time::Duration};
 
@@ -183,11 +184,7 @@ fn main() -> ExitCode {
                                 LiquidTabBarSpec::new(TAB_WIDTH),
                                 selected.get(),
                                 move |index| selected.set(index),
-                                |scope| {
-                                    for (icon, label) in TABS {
-                                        scope.tab(icon, label);
-                                    }
-                                },
+                                robot_tab_fixture::tabs(&TABS),
                             );
                         },
                     );

--- a/apps/desktop-demo/robot-runners/robot_markdown_end_drag_up.rs
+++ b/apps/desktop-demo/robot-runners/robot_markdown_end_drag_up.rs
@@ -1,11 +1,11 @@
+mod markdown_scroll_drag;
+
 use std::{cmp::Ordering, fs, sync::Arc, time::Duration};
 
 use cranpose::AppLauncher;
 use cranpose_core::CompositionLocalProvider;
 use cranpose_services::{local_http_client, HttpClientRef, StubHttpClient};
-use cranpose_testing::{
-    find_button_in_semantics, find_in_semantics, find_text, print_semantics_with_bounds,
-};
+use cranpose_testing::{find_in_semantics, find_text};
 use desktop_app::app;
 
 const VIEWPORT_TAG: &str = "MarkdownListViewport";
@@ -24,10 +24,6 @@ const DEFAULT_REVERSE_ATTEMPTS: u32 = 3;
 struct FixtureData {
     body: String,
     bottom_probe: String,
-}
-
-fn center(bounds: (f32, f32, f32, f32)) -> (f32, f32) {
-    (bounds.0 + bounds.2 * 0.5, bounds.1 + bounds.3 * 0.5)
 }
 
 fn parse_bool_env(name: &str, default: bool) -> bool {
@@ -49,102 +45,6 @@ fn parse_u32_env(name: &str, default: u32) -> u32 {
         .ok()
         .and_then(|value| value.parse::<u32>().ok())
         .unwrap_or(default)
-}
-
-fn wait_for_text_bounds(
-    robot: &cranpose::Robot,
-    text: &str,
-    timeout_ms: u64,
-) -> Option<(f32, f32, f32, f32)> {
-    let attempts = (timeout_ms / 100).max(1);
-    for _ in 0..attempts {
-        if let Some(bounds) = find_in_semantics(robot, |elem| find_text(elem, text)) {
-            return Some(bounds);
-        }
-        std::thread::sleep(Duration::from_millis(100));
-        let _ = robot.wait_for_idle();
-    }
-    None
-}
-
-fn fail_and_exit(robot: &cranpose::Robot, message: &str) -> ! {
-    eprintln!("FATAL: {message}");
-    if let Ok(semantics) = robot.get_semantics() {
-        print_semantics_with_bounds(&semantics, 0);
-    }
-    let _ = robot.exit();
-    std::process::exit(1);
-}
-
-fn click_button(robot: &cranpose::Robot, label: &str) {
-    let Some(bounds) = find_button_in_semantics(robot, label) else {
-        fail_and_exit(robot, &format!("button '{label}' not found"));
-    };
-    let (x, y) = center(bounds);
-    robot
-        .click(x, y)
-        .unwrap_or_else(|err| fail_and_exit(robot, &format!("click '{label}' failed: {err}")));
-    std::thread::sleep(Duration::from_millis(220));
-    let _ = robot.wait_for_idle();
-}
-
-struct DragViewportConfig {
-    from_frac: f32,
-    to_frac: f32,
-    steps: u32,
-    step_delay_ms: u64,
-    settle_delay_ms: u64,
-    wait_for_idle: bool,
-}
-
-fn drag_viewport(
-    robot: &cranpose::Robot,
-    viewport_bounds: (f32, f32, f32, f32),
-    config: DragViewportConfig,
-) {
-    let x = viewport_bounds.0 + viewport_bounds.2 * 0.5;
-    let y0 = viewport_bounds.1 + viewport_bounds.3 * config.from_frac;
-    let y1 = viewport_bounds.1 + viewport_bounds.3 * config.to_frac;
-    let _ = robot.mouse_move(x, y0);
-    let _ = robot.mouse_down();
-    for step in 0..=config.steps {
-        let t = step as f32 / config.steps as f32;
-        let y = y0 + (y1 - y0) * t;
-        let _ = robot.mouse_move(x, y);
-        std::thread::sleep(Duration::from_millis(config.step_delay_ms));
-    }
-    let _ = robot.mouse_up();
-    std::thread::sleep(Duration::from_millis(config.settle_delay_ms));
-    if config.wait_for_idle {
-        let _ = robot.wait_for_idle();
-    }
-}
-
-fn drag_scrollbar(
-    robot: &cranpose::Robot,
-    rail_bounds: (f32, f32, f32, f32),
-    from_frac: f32,
-    to_frac: f32,
-    wait_for_idle: bool,
-) {
-    let x = rail_bounds.0 + rail_bounds.2 * 0.5;
-    let y0 = rail_bounds.1 + rail_bounds.3 * from_frac;
-    let y1 = rail_bounds.1 + rail_bounds.3 * to_frac;
-    let steps = 30;
-
-    let _ = robot.mouse_move(x, y0);
-    let _ = robot.mouse_down();
-    for step in 0..=steps {
-        let t = step as f32 / steps as f32;
-        let y = y0 + (y1 - y0) * t;
-        let _ = robot.mouse_move(x, y);
-        std::thread::sleep(Duration::from_millis(8));
-    }
-    let _ = robot.mouse_up();
-    std::thread::sleep(Duration::from_millis(120));
-    if wait_for_idle {
-        let _ = robot.wait_for_idle();
-    }
 }
 
 fn sentinel_bounds(robot: &cranpose::Robot, text: &str) -> Option<(f32, f32, f32, f32)> {
@@ -269,10 +169,10 @@ fn drag_down_until_stalled(
     let mut previous_sig = viewport_signature(robot, viewport_bounds);
 
     for loop_idx in 1..=down_drag_loops {
-        drag_viewport(
+        markdown_scroll_drag::drag_viewport(
             robot,
             viewport_bounds,
-            DragViewportConfig {
+            markdown_scroll_drag::DragViewportConfig {
                 from_frac: down_drag_from_frac,
                 to_frac: down_drag_to_frac,
                 steps: 7,
@@ -316,8 +216,8 @@ fn force_absolute_bottom_with_scrollbar(
     let mut last_probe_y = sentinel_bounds(robot, bottom_probe).map(|b| b.1);
 
     for pass in 1..=scrollbar_max_passes {
-        drag_scrollbar(robot, rail_bounds, 0.20, 0.995, false);
-        drag_scrollbar(robot, rail_bounds, 0.88, 0.995, false);
+        markdown_scroll_drag::drag_scrollbar(robot, rail_bounds, 0.20, 0.995, 8, false);
+        markdown_scroll_drag::drag_scrollbar(robot, rail_bounds, 0.88, 0.995, 8, false);
         let probe_y = sentinel_bounds(robot, bottom_probe).map(|b| b.1);
 
         let stable_by_probe = match (last_probe_y, probe_y) {
@@ -376,11 +276,12 @@ fn reverse_drag_moves_content(
         let _ = robot.mouse_up();
         std::thread::sleep(Duration::from_millis(8));
 
-        drag_scrollbar(
+        markdown_scroll_drag::drag_scrollbar(
             robot,
             rail_bounds,
             reverse_drag_to_frac,
             reverse_drag_from_frac,
+            8,
             false,
         );
         std::thread::sleep(Duration::from_millis(140));
@@ -524,10 +425,10 @@ fn main() {
             std::thread::sleep(Duration::from_millis(500));
             let _ = robot.wait_for_idle();
 
-            click_button(&robot, "Fetch");
+            markdown_scroll_drag::click_button(&robot, "Fetch", 220);
 
             if !top_sentinel.is_empty()
-                && wait_for_text_bounds(&robot, &top_sentinel, 10_000).is_none()
+                && markdown_scroll_drag::wait_for_text_bounds(&robot, &top_sentinel, 10_000).is_none()
             {
                 eprintln!(
                     "NOTE: top sentinel {:?} not found within timeout; continuing",
@@ -535,11 +436,11 @@ fn main() {
                 );
             }
 
-            let Some(viewport_bounds) = wait_for_text_bounds(&robot, VIEWPORT_TAG, 4_000) else {
-                fail_and_exit(&robot, "markdown viewport semantics not found");
+            let Some(viewport_bounds) = markdown_scroll_drag::wait_for_text_bounds(&robot, VIEWPORT_TAG, 4_000) else {
+                markdown_scroll_drag::fail_and_exit(&robot, "markdown viewport semantics not found");
             };
-            let Some(rail_bounds) = wait_for_text_bounds(&robot, SCROLLBAR_TAG, 4_000) else {
-                fail_and_exit(&robot, "markdown scrollbar semantics not found");
+            let Some(rail_bounds) = markdown_scroll_drag::wait_for_text_bounds(&robot, SCROLLBAR_TAG, 4_000) else {
+                markdown_scroll_drag::fail_and_exit(&robot, "markdown scrollbar semantics not found");
             };
 
             println!(
@@ -560,17 +461,17 @@ fn main() {
             );
             robot
                 .mouse_move(viewport_center.0, viewport_center.1)
-                .unwrap_or_else(|err| fail_and_exit(&robot, &format!("mouse move failed: {err}")));
+                .unwrap_or_else(|err| markdown_scroll_drag::fail_and_exit(&robot, &format!("mouse move failed: {err}")));
 
             let mut down_history = Vec::new();
             for step in 0..6 {
                 robot.mouse_scroll(0.0, -120.0).unwrap_or_else(|err| {
-                    fail_and_exit(&robot, &format!("forward wheel step {step} failed: {err}"))
+                    markdown_scroll_drag::fail_and_exit(&robot, &format!("forward wheel step {step} failed: {err}"))
                 });
                 std::thread::sleep(Duration::from_millis(120));
                 let _ = robot.wait_for_idle();
                 let top_line = top_visible_markdown_line(&robot, viewport_bounds).unwrap_or_else(|| {
-                    fail_and_exit(&robot, "failed to capture top visible markdown line after forward wheel");
+                    markdown_scroll_drag::fail_and_exit(&robot, "failed to capture top visible markdown line after forward wheel");
                 });
                 down_history.push(top_line);
                 println!("wheel_down step={step} top_line={top_line}");
@@ -578,19 +479,19 @@ fn main() {
 
             let mut previous_top_line = *down_history
                 .last()
-                .unwrap_or_else(|| fail_and_exit(&robot, "missing wheel down history"));
+                .unwrap_or_else(|| markdown_scroll_drag::fail_and_exit(&robot, "missing wheel down history"));
             for step in 0..6 {
                 robot.mouse_scroll(0.0, 120.0).unwrap_or_else(|err| {
-                    fail_and_exit(&robot, &format!("reverse wheel step {step} failed: {err}"))
+                    markdown_scroll_drag::fail_and_exit(&robot, &format!("reverse wheel step {step} failed: {err}"))
                 });
                 std::thread::sleep(Duration::from_millis(120));
                 let _ = robot.wait_for_idle();
                 let top_line = top_visible_markdown_line(&robot, viewport_bounds).unwrap_or_else(|| {
-                    fail_and_exit(&robot, "failed to capture top visible markdown line after reverse wheel");
+                    markdown_scroll_drag::fail_and_exit(&robot, "failed to capture top visible markdown line after reverse wheel");
                 });
                 println!("wheel_up step={step} top_line={top_line}");
                 if top_line > previous_top_line {
-                    fail_and_exit(
+                    markdown_scroll_drag::fail_and_exit(
                         &robot,
                         &format!(
                             "reverse wheel backtracked from top line {previous_top_line} to {top_line}"
@@ -628,7 +529,7 @@ fn main() {
                 reverse_drag_to_frac,
                 reverse_attempts,
             ) {
-                fail_and_exit(
+                markdown_scroll_drag::fail_and_exit(
                     &robot,
                     "BUG REPRODUCED: reverse drag after drag-down+scrollbar-bottom did not move markdown content",
                 );

--- a/apps/desktop-demo/robot-runners/robot_markdown_scrollbar.rs
+++ b/apps/desktop-demo/robot-runners/robot_markdown_scrollbar.rs
@@ -1,11 +1,11 @@
+mod markdown_scroll_drag;
+
 use std::{fs, sync::Arc, time::Duration};
 
 use cranpose::AppLauncher;
 use cranpose_core::CompositionLocalProvider;
 use cranpose_services::{local_http_client, HttpClientRef, StubHttpClient};
-use cranpose_testing::{
-    find_button_in_semantics, find_in_semantics, find_text, print_semantics_with_bounds,
-};
+use cranpose_testing::{find_in_semantics, find_text};
 use desktop_app::app;
 
 const VIEWPORT_TAG: &str = "MarkdownListViewport";
@@ -34,101 +34,6 @@ impl MarkdownFixture {
             body.push_str(&format!("- Line {i:03}\n"));
         }
         Self { body }
-    }
-}
-
-fn center(bounds: (f32, f32, f32, f32)) -> (f32, f32) {
-    (bounds.0 + bounds.2 * 0.5, bounds.1 + bounds.3 * 0.5)
-}
-
-fn wait_for_text_bounds(
-    robot: &cranpose::Robot,
-    text: &str,
-    timeout_ms: u64,
-) -> Option<(f32, f32, f32, f32)> {
-    let attempts = (timeout_ms / 100).max(1);
-    for _ in 0..attempts {
-        if let Some(bounds) = find_in_semantics(robot, |elem| find_text(elem, text)) {
-            return Some(bounds);
-        }
-        std::thread::sleep(Duration::from_millis(100));
-        let _ = robot.wait_for_idle();
-    }
-    None
-}
-
-fn fail_and_exit(robot: &cranpose::Robot, message: &str) -> ! {
-    eprintln!("FATAL: {message}");
-    if let Ok(semantics) = robot.get_semantics() {
-        print_semantics_with_bounds(&semantics, 0);
-    }
-    let _ = robot.exit();
-    std::process::exit(1);
-}
-
-fn click_button(robot: &cranpose::Robot, label: &str) {
-    let Some(bounds) = find_button_in_semantics(robot, label) else {
-        fail_and_exit(robot, &format!("button '{label}' not found"));
-    };
-    let (x, y) = center(bounds);
-    robot
-        .click(x, y)
-        .unwrap_or_else(|err| fail_and_exit(robot, &format!("click '{label}' failed: {err}")));
-    std::thread::sleep(Duration::from_millis(150));
-    let _ = robot.wait_for_idle();
-}
-
-fn drag_scrollbar(
-    robot: &cranpose::Robot,
-    rail_bounds: (f32, f32, f32, f32),
-    from_frac: f32,
-    to_frac: f32,
-    wait_for_idle: bool,
-) {
-    let x = rail_bounds.0 + rail_bounds.2 * 0.5;
-    let y0 = rail_bounds.1 + rail_bounds.3 * from_frac;
-    let y1 = rail_bounds.1 + rail_bounds.3 * to_frac;
-    let steps = 30;
-
-    let _ = robot.mouse_move(x, y0);
-    let _ = robot.mouse_down();
-    for step in 0..=steps {
-        let t = step as f32 / steps as f32;
-        let y = y0 + (y1 - y0) * t;
-        let _ = robot.mouse_move(x, y);
-        std::thread::sleep(Duration::from_millis(12));
-    }
-    let _ = robot.mouse_up();
-    std::thread::sleep(Duration::from_millis(120));
-    if wait_for_idle {
-        let _ = robot.wait_for_idle();
-    }
-}
-
-fn drag_viewport(
-    robot: &cranpose::Robot,
-    viewport_bounds: (f32, f32, f32, f32),
-    from_frac: f32,
-    to_frac: f32,
-    wait_for_idle: bool,
-) {
-    let x = viewport_bounds.0 + viewport_bounds.2 * 0.5;
-    let y0 = viewport_bounds.1 + viewport_bounds.3 * from_frac;
-    let y1 = viewport_bounds.1 + viewport_bounds.3 * to_frac;
-    let steps = 36;
-
-    let _ = robot.mouse_move(x, y0);
-    let _ = robot.mouse_down();
-    for step in 0..=steps {
-        let t = step as f32 / steps as f32;
-        let y = y0 + (y1 - y0) * t;
-        let _ = robot.mouse_move(x, y);
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    let _ = robot.mouse_up();
-    std::thread::sleep(Duration::from_millis(120));
-    if wait_for_idle {
-        let _ = robot.wait_for_idle();
     }
 }
 
@@ -254,10 +159,10 @@ fn main() {
             std::thread::sleep(Duration::from_millis(500));
             let _ = robot.wait_for_idle();
 
-            click_button(&robot, "Fetch");
+            markdown_scroll_drag::click_button(&robot, "Fetch", 150);
 
             if !top_sentinel.is_empty()
-                && wait_for_text_bounds(&robot, &top_sentinel, 10_000).is_none()
+                && markdown_scroll_drag::wait_for_text_bounds(&robot, &top_sentinel, 10_000).is_none()
             {
                 eprintln!(
                     "WARN: top sentinel {:?} not found within timeout; continuing",
@@ -265,11 +170,11 @@ fn main() {
                 );
             }
 
-            let Some(viewport_bounds) = wait_for_text_bounds(&robot, VIEWPORT_TAG, 2_000) else {
-                fail_and_exit(&robot, "markdown viewport semantics not found");
+            let Some(viewport_bounds) = markdown_scroll_drag::wait_for_text_bounds(&robot, VIEWPORT_TAG, 2_000) else {
+                markdown_scroll_drag::fail_and_exit(&robot, "markdown viewport semantics not found");
             };
-            let Some(rail_bounds) = wait_for_text_bounds(&robot, SCROLLBAR_TAG, 2_000) else {
-                fail_and_exit(&robot, "markdown scrollbar semantics not found");
+            let Some(rail_bounds) = markdown_scroll_drag::wait_for_text_bounds(&robot, SCROLLBAR_TAG, 2_000) else {
+                markdown_scroll_drag::fail_and_exit(&robot, "markdown scrollbar semantics not found");
             };
 
             println!(
@@ -297,9 +202,9 @@ fn main() {
             let mut after_bottom_visible = false;
             for loop_idx in 0..drag_loops {
                 if loop_idx % 2 == 0 {
-                    drag_scrollbar(&robot, rail_bounds, 0.10, 0.90, wait_for_idle_after_drag);
+                    markdown_scroll_drag::drag_scrollbar(&robot, rail_bounds, 0.10, 0.90, 12, wait_for_idle_after_drag);
                 } else {
-                    drag_scrollbar(&robot, rail_bounds, 0.90, 0.15, wait_for_idle_after_drag);
+                    markdown_scroll_drag::drag_scrollbar(&robot, rail_bounds, 0.90, 0.15, 12, wait_for_idle_after_drag);
                 }
                 if !deep_sentinel.is_empty() {
                     after_bottom_visible =
@@ -321,7 +226,7 @@ fn main() {
             };
 
             if drag_loops > 0 && !after_bottom_visible && !moved_forward {
-                fail_and_exit(
+                markdown_scroll_drag::fail_and_exit(
                     &robot,
                     "scrollbar drag did not move viewport forward enough",
                 );
@@ -338,12 +243,17 @@ fn main() {
 
                 let mut down_drags_executed = 0u32;
                 for _ in 0..viewport_drag_down_loops {
-                    drag_viewport(
+                    markdown_scroll_drag::drag_viewport(
                         &robot,
                         viewport_bounds,
-                        viewport_drag_from_frac,
-                        viewport_drag_to_frac,
-                        wait_for_idle_after_drag,
+                        markdown_scroll_drag::DragViewportConfig {
+                            from_frac: viewport_drag_from_frac,
+                            to_frac: viewport_drag_to_frac,
+                            steps: 36,
+                            step_delay_ms: 10,
+                            settle_delay_ms: 120,
+                            wait_for_idle: wait_for_idle_after_drag,
+                        },
                     );
                     down_drags_executed += 1;
                     if viewport_drag_stop_on_deep
@@ -366,12 +276,17 @@ fn main() {
                 );
 
                 for _ in 0..viewport_drag_up_loops {
-                    drag_viewport(
+                    markdown_scroll_drag::drag_viewport(
                         &robot,
                         viewport_bounds,
-                        viewport_drag_to_frac,
-                        viewport_drag_from_frac,
-                        wait_for_idle_after_drag,
+                        markdown_scroll_drag::DragViewportConfig {
+                            from_frac: viewport_drag_to_frac,
+                            to_frac: viewport_drag_from_frac,
+                            steps: 36,
+                            step_delay_ms: 10,
+                            settle_delay_ms: 120,
+                            wait_for_idle: wait_for_idle_after_drag,
+                        },
                     );
                 }
 

--- a/apps/desktop-demo/robot-runners/robot_memory_leak.rs
+++ b/apps/desktop-demo/robot-runners/robot_memory_leak.rs
@@ -1,8 +1,9 @@
+mod robot_launch;
+
 #[cfg(target_os = "linux")]
 use std::collections::HashMap;
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::find_text_by_prefix_in_semantics;
 use desktop_app::app;
 
@@ -369,11 +370,7 @@ fn main() {
         SPIKE_DEPTH, MEASURE_CYCLES,
     );
 
-    AppLauncher::new()
-        .with_title("Robot Memory Leak Test")
-        .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
-        .with_headless(true)
-        .with_robot_app_hook(|name, argument| match name.as_str() {
+    robot_launch::launch("Robot Memory Leak Test", WINDOW_WIDTH, WINDOW_HEIGHT).with_robot_app_hook(|name, argument| match name.as_str() {
             SET_RECURSIVE_LAYOUT_DEPTH_HOOK => {
                 let depth = argument
                     .parse::<usize>()

--- a/apps/desktop-demo/robot-runners/robot_menu_slide.rs
+++ b/apps/desktop-demo/robot-runners/robot_menu_slide.rs
@@ -1,36 +1,22 @@
 mod robot_exit;
+mod text_fixture_style;
 
 use std::{process::ExitCode, sync::atomic::AtomicBool, time::Duration};
 
 use cranpose::{
     widgets::{BasicTextFieldOptions, BasicTextFieldWithOptions, Box as CBox, BoxSpec},
-    AppLauncher, Color, Modifier, Size,
+    AppLauncher, Modifier, Size,
 };
 use cranpose_foundation::text::TextFieldState;
 use cranpose_testing::find_text_in_semantics;
-use cranpose_ui::text::{AnnotatedString, TextStyle, TextUnit};
-
-const WINDOW_WIDTH: u32 = 460;
-const WINDOW_HEIGHT: u32 = 340;
-const BACKDROP: Color = Color(0.149, 0.129, 0.125, 1.0);
-const TEXT_COLOR: Color = Color(0.94, 0.92, 0.90, 1.0);
-const ACCENT: Color = Color(0.965, 0.208, 0.557, 1.0);
-
-const FIELD_X: f32 = 20.0;
-const FIELD_Y: f32 = 170.0;
-const FIELD_WIDTH: f32 = 420.0;
+use cranpose_ui::text::AnnotatedString;
+use text_fixture_style::{
+    text_style, ACCENT, BACKDROP, FIELD_WIDTH, FIELD_X, FIELD_Y, WINDOW_HEIGHT, WINDOW_WIDTH,
+};
 
 const TEXT: &str = "Silence. Melody. Then beats.";
 
 static FAILED: AtomicBool = AtomicBool::new(false);
-
-fn text_style() -> TextStyle {
-    let mut style = TextStyle::default();
-    style.span_style.color = Some(TEXT_COLOR);
-    style.span_style.font_size = TextUnit::Sp(16.0);
-    style.paragraph_style.line_height = TextUnit::Sp(24.0);
-    style
-}
 
 fn main() -> ExitCode {
     let _ = env_logger::try_init();

--- a/apps/desktop-demo/robot-runners/robot_multiline_click.rs
+++ b/apps/desktop-demo/robot-runners/robot_multiline_click.rs
@@ -1,6 +1,10 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, Robot};
+use cranpose::Robot;
 use cranpose_testing::{find_in_semantics, find_text_exact};
 use cranpose_ui::TextStyle;
 use desktop_app::app;
@@ -11,16 +15,9 @@ fn main() {
     env_logger::init();
     println!("=== Multiline Click Positioning Test ===\n");
 
-    AppLauncher::new()
-        .with_title("Multiline Click Test")
-        .with_size(600, 600)
-        .with_headless(true)
+    robot_launch::launch("Multiline Click Test", 600, 600)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(60));
-                println!("\n✗ Test timed out");
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(60);
 
             std::thread::sleep(Duration::from_millis(300));
             println!("✓ App ready\n");

--- a/apps/desktop-demo/robot-runners/robot_multiline_nav.rs
+++ b/apps/desktop-demo/robot-runners/robot_multiline_nav.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_in_semantics, find_text, find_text_exact};
 use desktop_app::app;
 
@@ -10,16 +13,9 @@ fn main() {
     env_logger::init();
     println!("=== Multiline Navigation Test ===\n");
 
-    AppLauncher::new()
-        .with_title("Multiline Nav Test")
-        .with_size(600, 600)
-        .with_headless(true)
+    robot_launch::launch("Multiline Nav Test", 600, 600)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(60));
-                println!("\n✗ Test timed out");
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(60);
 
             std::thread::sleep(Duration::from_millis(300));
             println!("✓ App ready\n");

--- a/apps/desktop-demo/robot-runners/robot_offscreen_draw_transition.rs
+++ b/apps/desktop-demo/robot-runners/robot_offscreen_draw_transition.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope};
 use cranpose_testing::find_button_in_semantics;
 use cranpose_ui::{
@@ -14,10 +15,7 @@ use cranpose_ui::{
 
 fn main() {
     env_logger::init();
-    AppLauncher::new()
-        .with_title("Offscreen Draw Transition")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Offscreen Draw Transition", 800, 600)
         .with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(500));
             let initial = robot

--- a/apps/desktop-demo/robot-runners/robot_offset_test.rs
+++ b/apps/desktop-demo/robot-runners/robot_offset_test.rs
@@ -1,6 +1,8 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, SemanticElement};
+use cranpose::SemanticElement;
 use cranpose_testing::{find_button_in_semantics, find_by_text_recursive, find_text_exact};
 use desktop_app::app;
 
@@ -32,10 +34,7 @@ fn main() {
     println!("Robot Offset Test - Combined App");
     println!("=================================\n");
 
-    AppLauncher::new()
-        .with_title("Robot Offset Test")
-        .with_size(900, 700)
-        .with_headless(true)
+    robot_launch::launch("Robot Offset Test", 900, 700)
         .with_test_driver(|robot| {
             println!("App launched! Waiting for initial render...");
             std::thread::sleep(Duration::from_secs(1));

--- a/apps/desktop-demo/robot-runners/robot_overscroll_bounce.rs
+++ b/apps/desktop-demo/robot-runners/robot_overscroll_bounce.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_core::remember;
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope};
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
@@ -117,11 +118,7 @@ fn overscroll_reproduction() {
 }
 
 fn main() {
-    AppLauncher::new()
-        .with_title("Overscroll Bounce Reproduction")
-        .with_size(600, 600)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Overscroll Bounce Reproduction", 600, 600).with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(500));
             let _ = robot.wait_for_idle();
 

--- a/apps/desktop-demo/robot-runners/robot_positioned_boxes_after_lazy_list.rs
+++ b/apps/desktop-demo/robot-runners/robot_positioned_boxes_after_lazy_list.rs
@@ -1,6 +1,8 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, SemanticElement};
+use cranpose::SemanticElement;
 use cranpose_testing::find_button_in_semantics;
 use desktop_app::app;
 
@@ -38,10 +40,7 @@ fn main() {
     env_logger::init();
     println!("=== Positioned Boxes After LazyList (dup check) ===");
 
-    AppLauncher::new()
-        .with_title("Positioned Boxes After LazyList")
-        .with_size(1200, 800)
-        .with_headless(true)
+    robot_launch::launch("Positioned Boxes After LazyList", 1200, 800)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_pressed_state.rs
+++ b/apps/desktop-demo/robot-runners/robot_pressed_state.rs
@@ -1,8 +1,10 @@
+mod robot_launch;
+
 mod robot_exit;
 
 use std::time::Duration;
 
-use cranpose::{AppLauncher, Robot};
+use cranpose::Robot;
 use cranpose_testing::capture_screenshot;
 use desktop_app::test_screens::pressed_state_repro::{
     PressedStateReproScreen, NORMAL_RGBA, PRESSED_RGBA, SPRITE_HEIGHT, SPRITE_OFFSET_X,
@@ -56,11 +58,7 @@ fn main() {
     env_logger::init();
     println!("=== Robot Pressed State Test ===");
 
-    AppLauncher::new()
-        .with_title("Robot Pressed State Test")
-        .with_size(800, 600)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Robot Pressed State Test", 800, 600).with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(500));
             let _ = robot.wait_for_idle();
 

--- a/apps/desktop-demo/robot-runners/robot_progress_bar.rs
+++ b/apps/desktop-demo/robot-runners/robot_progress_bar.rs
@@ -1,6 +1,8 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, SemanticElement};
+use cranpose::SemanticElement;
 use cranpose_testing::find_button_in_semantics;
 use cranpose_ui::{
     Button, ButtonSpec, Column, ColumnSpec, Modifier, Size, Spacer, Text, TextStyle,
@@ -166,120 +168,121 @@ fn main() {
     println!("=== Async Runtime Progress Bar Layout Test ===");
     println!("Window size: {}x{}", WINDOW_WIDTH, WINDOW_HEIGHT);
 
-    AppLauncher::new()
-        .with_title("Async Progress Layout")
-        .with_size(WINDOW_WIDTH as u32, WINDOW_HEIGHT as u32)
-        .with_headless(true)
-        .with_test_driver(|robot| {
-            std::thread::sleep(Duration::from_millis(400));
+    robot_launch::launch(
+        "Async Progress Layout",
+        WINDOW_WIDTH as u32,
+        WINDOW_HEIGHT as u32,
+    )
+    .with_test_driver(|robot| {
+        std::thread::sleep(Duration::from_millis(400));
 
-            let mut issues = Vec::new();
-            for (index, percent) in TEST_PCTS.iter().enumerate() {
-                robot.wait_for_idle().ok();
-                std::thread::sleep(Duration::from_millis(200));
+        let mut issues = Vec::new();
+        for (index, percent) in TEST_PCTS.iter().enumerate() {
+            robot.wait_for_idle().ok();
+            std::thread::sleep(Duration::from_millis(200));
 
-                if let Ok(semantics) = robot.get_semantics() {
+            if let Ok(semantics) = robot.get_semantics() {
+                for elem in &semantics {
+                    collect_semantic_issues(
+                        elem,
+                        (0.0, 0.0, WINDOW_WIDTH, WINDOW_HEIGHT),
+                        &mut issues,
+                    );
+                }
+                validate_progress_bar(&semantics, *percent, &mut issues);
+
+                if !issues.is_empty() {
+                    println!("\n--- Semantics Tree ({}%) ---", percent);
                     for elem in &semantics {
-                        collect_semantic_issues(
-                            elem,
-                            (0.0, 0.0, WINDOW_WIDTH, WINDOW_HEIGHT),
-                            &mut issues,
-                        );
-                    }
-                    validate_progress_bar(&semantics, *percent, &mut issues);
-
-                    if !issues.is_empty() {
-                        println!("\n--- Semantics Tree ({}%) ---", percent);
-                        for elem in &semantics {
-                            print_tree(elem, 0);
-                        }
-                    } else {
-                        println!("✓ Layout rects + progress sizing OK for {}%", percent);
+                        print_tree(elem, 0);
                     }
                 } else {
-                    issues.push("Failed to fetch semantics".to_string());
+                    println!("✓ Layout rects + progress sizing OK for {}%", percent);
                 }
-
-                if index + 1 < TEST_PCTS.len() {
-                    if let Some((x, y, w, h)) = find_button_in_semantics(&robot, "Next") {
-                        robot.click(x + w / 2.0, y + h / 2.0).ok();
-                        robot.wait_for_idle().ok();
-                        std::thread::sleep(Duration::from_millis(200));
-                    } else {
-                        issues.push("Next button not found".to_string());
-                    }
-                }
+            } else {
+                issues.push("Failed to fetch semantics".to_string());
             }
 
-            if !issues.is_empty() {
-                println!("\n=== FAILURE ===");
-                for issue in &issues {
-                    println!("✗ {issue}");
+            if index + 1 < TEST_PCTS.len() {
+                if let Some((x, y, w, h)) = find_button_in_semantics(&robot, "Next") {
+                    robot.click(x + w / 2.0, y + h / 2.0).ok();
+                    robot.wait_for_idle().ok();
+                    std::thread::sleep(Duration::from_millis(200));
+                } else {
+                    issues.push("Next button not found".to_string());
                 }
-                robot.exit().ok();
-                std::process::exit(1);
             }
+        }
 
-            println!("\n=== SUCCESS ===");
-            println!("✓ Async Runtime progress layout validated");
+        if !issues.is_empty() {
+            println!("\n=== FAILURE ===");
+            for issue in &issues {
+                println!("✗ {issue}");
+            }
             robot.exit().ok();
-        })
-        .run(|| {
-            let step_state = cranpose_core::rememberMutableStateOf(|| 0usize);
-            let initial_step = step_state.get();
-            let percent = TEST_PCTS[initial_step];
-            let progress = (percent as f32 / 100.0).clamp(0.0, 1.0);
-            let animation = cranpose_core::rememberMutableStateOf(|| AnimationState {
-                progress,
-                direction: 1.0,
-            });
-            let stats = cranpose_core::rememberMutableStateOf(|| FrameStats {
-                frames: 120,
-                last_frame_ms: 16.0,
-            });
-            let is_running = cranpose_core::rememberMutableStateOf(|| false);
-            let reset_signal = cranpose_core::rememberMutableStateOf(|| 0u64);
+            std::process::exit(1);
+        }
 
-            Column(
-                Modifier::empty().fill_max_size(),
-                ColumnSpec::default(),
-                move || {
-                    let step = step_state.get();
-                    Text(
-                        format!("Test percent: {}%", TEST_PCTS[step]),
-                        Modifier::empty().padding(6.0),
-                        TextStyle::default(),
-                    );
-                    Button(
-                        Modifier::empty().padding(6.0),
-                        ButtonSpec::default(),
-                        move || {
-                            let last = TEST_PCTS.len().saturating_sub(1);
-                            let next = (step_state.get() + 1).min(last);
-                            if next != step_state.get() {
-                                step_state.set(next);
-                                let pct = TEST_PCTS[next];
-                                let progress_value = (pct as f32 / 100.0).clamp(0.0, 1.0);
-                                animation.set(AnimationState {
-                                    progress: progress_value,
-                                    direction: 1.0,
-                                });
-                                stats.set(FrameStats {
-                                    frames: 120,
-                                    last_frame_ms: 16.0,
-                                });
-                            }
-                        },
-                        || {
-                            Text("Next", Modifier::empty().padding(4.0), TextStyle::default());
-                        },
-                    );
-                    Spacer(Size {
-                        width: 0.0,
-                        height: 8.0,
-                    });
-                    AsyncRuntimeTabContent(animation, stats, is_running, reset_signal);
-                },
-            );
+        println!("\n=== SUCCESS ===");
+        println!("✓ Async Runtime progress layout validated");
+        robot.exit().ok();
+    })
+    .run(|| {
+        let step_state = cranpose_core::rememberMutableStateOf(|| 0usize);
+        let initial_step = step_state.get();
+        let percent = TEST_PCTS[initial_step];
+        let progress = (percent as f32 / 100.0).clamp(0.0, 1.0);
+        let animation = cranpose_core::rememberMutableStateOf(|| AnimationState {
+            progress,
+            direction: 1.0,
         });
+        let stats = cranpose_core::rememberMutableStateOf(|| FrameStats {
+            frames: 120,
+            last_frame_ms: 16.0,
+        });
+        let is_running = cranpose_core::rememberMutableStateOf(|| false);
+        let reset_signal = cranpose_core::rememberMutableStateOf(|| 0u64);
+
+        Column(
+            Modifier::empty().fill_max_size(),
+            ColumnSpec::default(),
+            move || {
+                let step = step_state.get();
+                Text(
+                    format!("Test percent: {}%", TEST_PCTS[step]),
+                    Modifier::empty().padding(6.0),
+                    TextStyle::default(),
+                );
+                Button(
+                    Modifier::empty().padding(6.0),
+                    ButtonSpec::default(),
+                    move || {
+                        let last = TEST_PCTS.len().saturating_sub(1);
+                        let next = (step_state.get() + 1).min(last);
+                        if next != step_state.get() {
+                            step_state.set(next);
+                            let pct = TEST_PCTS[next];
+                            let progress_value = (pct as f32 / 100.0).clamp(0.0, 1.0);
+                            animation.set(AnimationState {
+                                progress: progress_value,
+                                direction: 1.0,
+                            });
+                            stats.set(FrameStats {
+                                frames: 120,
+                                last_frame_ms: 16.0,
+                            });
+                        }
+                    },
+                    || {
+                        Text("Next", Modifier::empty().padding(4.0), TextStyle::default());
+                    },
+                );
+                Spacer(Size {
+                    width: 0.0,
+                    height: 8.0,
+                });
+                AsyncRuntimeTabContent(animation, stats, is_running, reset_signal);
+            },
+        );
+    });
 }

--- a/apps/desktop-demo/robot-runners/robot_reactive_handle_copy.rs
+++ b/apps/desktop-demo/robot-runners/robot_reactive_handle_copy.rs
@@ -1,4 +1,5 @@
-use cranpose::AppLauncher;
+mod robot_launch;
+
 use cranpose_core::remember;
 use cranpose_foundation::text::TextFieldState;
 use cranpose_ui::{
@@ -57,10 +58,7 @@ fn reactive_handle_copy_screen() {
 }
 
 fn main() {
-    AppLauncher::new()
-        .with_title("Reactive Handle Copy")
-        .with_size(640, 240)
-        .with_headless(true)
+    robot_launch::launch("Reactive Handle Copy", 640, 240)
         .with_test_driver(|robot| {
             std::thread::sleep(std::time::Duration::from_millis(500));
             robot.validate_content("left").expect("left content");

--- a/apps/desktop-demo/robot-runners/robot_reactive_state.rs
+++ b/apps/desktop-demo/robot-runners/robot_reactive_state.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button, find_in_semantics, find_text};
 use desktop_app::app;
 
@@ -9,16 +12,9 @@ fn main() {
     println!("=== Robot Reactive State Test ===");
     println!("Verifying TextFieldState snapshot integration\n");
 
-    AppLauncher::new()
-        .with_title("Robot Reactive State Test")
-        .with_size(900, 700)
-        .with_headless(true)
+    robot_launch::launch("Robot Reactive State Test", 900, 700)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(20));
-                eprintln!("TIMEOUT: Test exceeded 20 seconds");
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(20);
 
             std::thread::sleep(Duration::from_millis(500));
             println!("✓ App launched and ready\n");

--- a/apps/desktop-demo/robot-runners/robot_recomposition_lab.rs
+++ b/apps/desktop-demo/robot-runners/robot_recomposition_lab.rs
@@ -1,8 +1,9 @@
+mod robot_launch;
+
 mod regression_robot_support;
 
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use desktop_app::app;
 use regression_robot_support::{
     click_button, semantics_dump, spawn_timeout, wait_for_text, wait_for_text_prefix,
@@ -46,11 +47,7 @@ fn main() {
     env_logger::init();
     println!("=== Robot Recomposition Lab Test ===");
 
-    AppLauncher::new()
-        .with_title("Robot Recomposition Lab Test")
-        .with_size(1100, 1500)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Robot Recomposition Lab Test", 1100, 1500).with_test_driver(|robot| {
             spawn_timeout(90, "robot_recomposition_lab");
 
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_recursive_layout.rs
+++ b/apps/desktop-demo/robot-runners/robot_recursive_layout.rs
@@ -1,6 +1,8 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, SemanticElement};
+use cranpose::SemanticElement;
 use cranpose_testing::{
     find_button_in_semantics, find_text_by_prefix_in_semantics, find_text_in_semantics,
 };
@@ -143,71 +145,72 @@ fn main() {
     env_logger::init();
     println!("=== Recursive Layout Robot Test (rect validation) ===");
 
-    AppLauncher::new()
-        .with_title("Recursive Layout Test")
-        .with_size(WINDOW_WIDTH as u32, WINDOW_HEIGHT as u32)
-        .with_headless(true)
-        .with_test_driver(|robot| {
-            println!("✓ App launched");
-            std::thread::sleep(Duration::from_millis(400));
+    robot_launch::launch(
+        "Recursive Layout Test",
+        WINDOW_WIDTH as u32,
+        WINDOW_HEIGHT as u32,
+    )
+    .with_test_driver(|robot| {
+        println!("✓ App launched");
+        std::thread::sleep(Duration::from_millis(400));
 
-            let click_button = |name: &str| -> bool {
-                if let Some((x, y, w, h)) = find_button_in_semantics(&robot, name) {
-                    println!("  Found button '{}' at ({:.1}, {:.1})", name, x, y);
-                    robot.click(x + w / 2.0, y + h / 2.0).ok();
-                    std::thread::sleep(Duration::from_millis(150));
-                    true
-                } else {
-                    println!("  ✗ Button '{}' not found!", name);
-                    false
-                }
-            };
-
-            println!("\n--- Step 1: Navigate to 'Recursive Layout' tab ---");
-            if !click_button("Recursive Layout") {
-                println!("FATAL: Could not find 'Recursive Layout' tab button");
-                robot.exit().ok();
-                std::process::exit(1);
+        let click_button = |name: &str| -> bool {
+            if let Some((x, y, w, h)) = find_button_in_semantics(&robot, name) {
+                println!("  Found button '{}' at ({:.1}, {:.1})", name, x, y);
+                robot.click(x + w / 2.0, y + h / 2.0).ok();
+                std::thread::sleep(Duration::from_millis(150));
+                true
+            } else {
+                println!("  ✗ Button '{}' not found!", name);
+                false
             }
-            std::thread::sleep(Duration::from_millis(400));
+        };
 
-            println!("\n--- Step 2: Verify Recursive Layout header + controls ---");
-            if find_text_in_semantics(&robot, "Recursive Layout Playground").is_none() {
-                println!("  ✗ Missing Recursive Layout header");
-                robot.exit().ok();
-                std::process::exit(1);
-            }
-
-            let mut issues = Vec::new();
-            if find_button_in_semantics(&robot, "Increase depth").is_none() {
-                issues.push("Missing Increase depth button".to_string());
-            }
-            if find_button_in_semantics(&robot, "Decrease depth").is_none() {
-                issues.push("Missing Decrease depth button".to_string());
-            }
-            if find_text_by_prefix_in_semantics(&robot, "Current depth:").is_none() {
-                issues.push("Missing Current depth label".to_string());
-            }
-
-            println!("\n--- Step 3: Increase depth to 5 ---");
-            click_button("Increase depth");
-            click_button("Increase depth");
-            std::thread::sleep(Duration::from_millis(250));
-
-            issues.extend(validate_recursive_layout(&robot, "Depth 5"));
-
-            if !issues.is_empty() {
-                println!("\n=== FAILURE ===");
-                for issue in &issues {
-                    println!("✗ {issue}");
-                }
-                robot.exit().ok();
-                std::process::exit(1);
-            }
-
-            println!("\n=== SUCCESS ===");
-            println!("✓ Recursive Layout rects are within viewport");
+        println!("\n--- Step 1: Navigate to 'Recursive Layout' tab ---");
+        if !click_button("Recursive Layout") {
+            println!("FATAL: Could not find 'Recursive Layout' tab button");
             robot.exit().ok();
-        })
-        .run(app::combined_app);
+            std::process::exit(1);
+        }
+        std::thread::sleep(Duration::from_millis(400));
+
+        println!("\n--- Step 2: Verify Recursive Layout header + controls ---");
+        if find_text_in_semantics(&robot, "Recursive Layout Playground").is_none() {
+            println!("  ✗ Missing Recursive Layout header");
+            robot.exit().ok();
+            std::process::exit(1);
+        }
+
+        let mut issues = Vec::new();
+        if find_button_in_semantics(&robot, "Increase depth").is_none() {
+            issues.push("Missing Increase depth button".to_string());
+        }
+        if find_button_in_semantics(&robot, "Decrease depth").is_none() {
+            issues.push("Missing Decrease depth button".to_string());
+        }
+        if find_text_by_prefix_in_semantics(&robot, "Current depth:").is_none() {
+            issues.push("Missing Current depth label".to_string());
+        }
+
+        println!("\n--- Step 3: Increase depth to 5 ---");
+        click_button("Increase depth");
+        click_button("Increase depth");
+        std::thread::sleep(Duration::from_millis(250));
+
+        issues.extend(validate_recursive_layout(&robot, "Depth 5"));
+
+        if !issues.is_empty() {
+            println!("\n=== FAILURE ===");
+            for issue in &issues {
+                println!("✗ {issue}");
+            }
+            robot.exit().ok();
+            std::process::exit(1);
+        }
+
+        println!("\n=== SUCCESS ===");
+        println!("✓ Recursive Layout rects are within viewport");
+        robot.exit().ok();
+    })
+    .run(app::combined_app);
 }

--- a/apps/desktop-demo/robot-runners/robot_recursive_layout_depth_six.rs
+++ b/apps/desktop-demo/robot-runners/robot_recursive_layout_depth_six.rs
@@ -1,8 +1,9 @@
+mod robot_launch;
+
 mod regression_robot_support;
 
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use desktop_app::app;
 use regression_robot_support::{
     click_button, semantics_dump, spawn_timeout, wait_for_text, wait_for_text_prefix,
@@ -12,10 +13,7 @@ fn main() {
     env_logger::init();
     println!("=== Robot Recursive Layout Depth Six Test ===");
 
-    AppLauncher::new()
-        .with_title("Robot Recursive Layout Depth Six Test")
-        .with_size(1024, 768)
-        .with_headless(true)
+    robot_launch::launch("Robot Recursive Layout Depth Six Test", 1024, 768)
         .with_test_driver(|robot| {
             spawn_timeout(30, "robot_recursive_layout_depth_six");
 

--- a/apps/desktop-demo/robot-runners/robot_render_crispness_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_render_crispness_contract.rs
@@ -1,7 +1,8 @@
 mod output_paths;
 mod robot_exit;
+mod robot_shot;
 
-use std::{path::Path, time::Duration};
+use std::time::Duration;
 
 use cranpose::AppLauncher;
 use cranpose_testing::crop_screenshot_logical;
@@ -12,7 +13,6 @@ use cranpose_ui::{
     Text, TextStyle,
 };
 use cranpose_ui_graphics::DrawScope;
-use image::{ImageBuffer, RgbaImage};
 
 const WINDOW_WIDTH: u32 = 320;
 const WINDOW_HEIGHT: u32 = 170;
@@ -32,18 +32,6 @@ const SCROLL_COMPARE_TOP: f32 = 1.0;
 const SCROLL_COMPARE_H: f32 = BLOCK_H - 2.0;
 const GRID_COMPARE_TOP: f32 = 26.4;
 const GRID_COMPARE_H: f32 = 20.0;
-
-fn save_png(path: &Path, screenshot: &cranpose::RobotScreenshot) -> Result<(), String> {
-    let image: RgbaImage = ImageBuffer::from_raw(
-        screenshot.width,
-        screenshot.height,
-        screenshot.pixels.clone(),
-    )
-    .ok_or_else(|| "invalid screenshot dimensions".to_string())?;
-    image
-        .save(path)
-        .map_err(|err| format!("failed to save {}: {}", path.display(), err))
-}
 
 fn atlas_bitmap() -> ImageBitmap {
     const WIDTH: u32 = 24;
@@ -258,7 +246,7 @@ fn main() {
                 .unwrap_or_else(|err| robot_exit::fail(&robot, &format!("failed to capture screenshot: {err}")));
             let output_path =
                 output_paths::diagnostic_path("cranpose_render_crispness_contract.png");
-            if let Err(err) = save_png(&output_path, &screenshot) {
+            if let Err(err) = robot_shot::save_checked(&output_path, &screenshot) {
                 robot_exit::fail(&robot, &err);
             }
             println!("SCREENSHOT_PATH={}", output_path.display());

--- a/apps/desktop-demo/robot-runners/robot_render_translation_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_render_translation_contract.rs
@@ -1,13 +1,14 @@
+mod robot_launch;
+
 mod output_paths;
+mod text_showcase_external_helpers;
 
 use std::{path::Path, time::Duration};
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
-    capture_screenshot, find_bounds_by_text, find_button_exact_in_semantics,
-    find_button_in_semantics, find_in_semantics, find_text_exact, find_text_in_semantics,
-    normalize_screenshot_region, root_bounds, screenshot_difference_stats, scroll_down, scroll_up,
-    y_is_visible,
+    capture_screenshot, find_bounds_by_text, find_button_in_semantics, find_in_semantics,
+    find_text_exact, normalize_screenshot_region, root_bounds, screenshot_difference_stats,
+    scroll_down, scroll_up, y_is_visible,
 };
 use desktop_app::app;
 use image::{ImageBuffer, RgbaImage};
@@ -34,23 +35,24 @@ fn main() {
     env_logger::init();
     println!("=== Robot Render Translation Contract ===");
 
-    AppLauncher::new()
-        .with_title("Robot Render Translation Contract")
-        .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
-        .with_headless(true)
-        .with_test_driver(|robot| {
-            std::thread::sleep(Duration::from_millis(600));
-            let _ = robot.wait_for_idle();
+    robot_launch::launch(
+        "Robot Render Translation Contract",
+        WINDOW_WIDTH,
+        WINDOW_HEIGHT,
+    )
+    .with_test_driver(|robot| {
+        std::thread::sleep(Duration::from_millis(600));
+        let _ = robot.wait_for_idle();
 
-            verify_text_drag_release_contract(&robot);
-            verify_lazy_list_drag_release_contract(&robot);
-            verify_lazy_list_translation_contract(&robot);
+        verify_text_drag_release_contract(&robot);
+        verify_lazy_list_drag_release_contract(&robot);
+        verify_lazy_list_translation_contract(&robot);
 
-            println!("\n=== Test Summary ===");
-            println!("✓ rigid subtree motion preserved in desktop demo surfaces");
-            robot.exit().expect("exit");
-        })
-        .run(app::combined_app);
+        println!("\n=== Test Summary ===");
+        println!("✓ rigid subtree motion preserved in desktop demo surfaces");
+        robot.exit().expect("exit");
+    })
+    .run(app::combined_app);
 }
 
 fn verify_text_drag_release_contract(robot: &cranpose::Robot) {
@@ -301,7 +303,9 @@ fn click_tab(robot: &cranpose::Robot, label: &str) {
 fn open_text_tab(robot: &cranpose::Robot) {
     for _ in 0..3 {
         click_tab(robot, "Shaders");
-        let Some((x, y, w, h)) = wait_for_exact_button(robot, "Text", 20) else {
+        let Some((x, y, w, h)) =
+            text_showcase_external_helpers::wait_for_exact_button_in_semantics(robot, "Text", 20)
+        else {
             continue;
         };
         robot
@@ -309,38 +313,16 @@ fn open_text_tab(robot: &cranpose::Robot) {
             .expect("click text tab");
         std::thread::sleep(Duration::from_millis(350));
         let _ = robot.wait_for_idle();
-        if wait_for_semantic_text(robot, "Text Rendering Feature Showcase", 30) {
+        if text_showcase_external_helpers::wait_for_text_in_semantics(
+            robot,
+            "Text Rendering Feature Showcase",
+            30,
+        ) {
             return;
         }
     }
 
     panic!("Text showcase heading not found after tab switch");
-}
-
-fn wait_for_exact_button(
-    robot: &cranpose::Robot,
-    text: &str,
-    attempts: usize,
-) -> Option<(f32, f32, f32, f32)> {
-    for _ in 0..attempts {
-        if let Some(bounds) = find_button_exact_in_semantics(robot, text) {
-            return Some(bounds);
-        }
-        std::thread::sleep(Duration::from_millis(100));
-        let _ = robot.wait_for_idle();
-    }
-    None
-}
-
-fn wait_for_semantic_text(robot: &cranpose::Robot, text: &str, attempts: usize) -> bool {
-    for _ in 0..attempts {
-        if find_text_in_semantics(robot, text).is_some() {
-            return true;
-        }
-        std::thread::sleep(Duration::from_millis(100));
-        let _ = robot.wait_for_idle();
-    }
-    false
 }
 
 fn wait_for_text(robot: &cranpose::Robot, text: &str) {

--- a/apps/desktop-demo/robot-runners/robot_renderer_micro_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_renderer_micro_contract.rs
@@ -1,8 +1,9 @@
 mod output_paths;
 mod robot_exit;
+mod robot_shot;
 mod text_showcase_external_helpers;
 
-use std::{path::Path, time::Duration};
+use std::time::Duration;
 
 use cranpose::AppLauncher;
 use cranpose_testing::{crop_screenshot_logical, sample_screenshot_pixel_logical};
@@ -13,7 +14,6 @@ use cranpose_ui::{
     Modifier, Rect, Row, RowSpec, Size, Spacer, Text, TextOptions, TextOverflow, TextStyle,
     TextWithOptions,
 };
-use image::{ImageBuffer, RgbaImage};
 use text_showcase_external_helpers::{capture_x11_window_screenshot, find_window_id};
 
 const WINDOW_TITLE: &str = "Robot Renderer Micro Contract";
@@ -105,18 +105,6 @@ fn count_yellow_text_pixels(screenshot: &cranpose::RobotScreenshot) -> usize {
                 && rgba[1] > rgba[2].saturating_add(12)
         })
         .count()
-}
-
-fn save_png(path: &Path, screenshot: &cranpose::RobotScreenshot) -> Result<(), String> {
-    let image: RgbaImage = ImageBuffer::from_raw(
-        screenshot.width,
-        screenshot.height,
-        screenshot.pixels.clone(),
-    )
-    .ok_or_else(|| "invalid screenshot dimensions".to_string())?;
-    image
-        .save(path)
-        .map_err(|err| format!("failed to save {}: {}", path.display(), err))
 }
 
 fn normalize_micro_contract_logical_size(
@@ -671,7 +659,7 @@ fn main() {
             }
             let screenshot = normalize_micro_contract_logical_size(screenshot);
             let output_path = output_paths::diagnostic_path("cranpose_renderer_micro_contract.png");
-            if let Err(err) = save_png(&output_path, &screenshot) {
+            if let Err(err) = robot_shot::save_checked(&output_path, &screenshot) {
                 robot_exit::fail(&robot, &err);
             }
             println!("SCREENSHOT_PATH={}", output_path.display());

--- a/apps/desktop-demo/robot-runners/robot_renderer_pixel_precision.rs
+++ b/apps/desktop-demo/robot-runners/robot_renderer_pixel_precision.rs
@@ -1,6 +1,8 @@
+mod robot_launch;
+
 use cranpose::{
     widgets::{Box, BoxSpec, Row, RowSpec},
-    AppLauncher, Color, LazyItems, Modifier, Size,
+    Color, LazyItems, Modifier, Size,
 };
 use cranpose_testing::sample_screenshot_pixel_logical;
 use cranpose_ui::{
@@ -22,10 +24,7 @@ fn pixel(screenshot: &cranpose::RobotScreenshot, x: f32, y: f32) -> [u8; 3] {
 }
 
 fn main() {
-    AppLauncher::new()
-        .with_title("Renderer Pixel Precision")
-        .with_size(WIDTH, HEIGHT)
-        .with_headless(true)
+    robot_launch::launch("Renderer Pixel Precision", WIDTH, HEIGHT)
         .with_test_driver(|robot| {
             std::thread::sleep(std::time::Duration::from_millis(900));
             let screenshot = robot.screenshot().expect("screenshot");

--- a/apps/desktop-demo/robot-runners/robot_scroll_bug.rs
+++ b/apps/desktop-demo/robot-runners/robot_scroll_bug.rs
@@ -1,6 +1,8 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, Robot};
+use cranpose::Robot;
 use cranpose_testing::{find_in_semantics, find_text_exact};
 use desktop_app::test_screens::scroll_repro::ScrollReproScreen;
 
@@ -17,10 +19,7 @@ fn wait_for_content(robot: &Robot, expected: &str, attempts: usize, delay: Durat
 fn main() {
     println!("Launching app with robot control for Scroll Bug Reproduction...");
 
-    AppLauncher::new()
-        .with_title("Scroll Bug Reproduction")
-        .with_size(1024, 768)
-        .with_headless(true)
+    robot_launch::launch("Scroll Bug Reproduction", 1024, 768)
         .with_test_driver(|robot| {
             println!("App launched! Starting test...");
             std::thread::sleep(Duration::from_secs(1));

--- a/apps/desktop-demo/robot-runners/robot_scroll_decoration_invariance.rs
+++ b/apps/desktop-demo/robot-runners/robot_scroll_decoration_invariance.rs
@@ -1,8 +1,10 @@
+mod robot_launch;
+
 mod output_paths;
 
 use std::{path::Path, time::Duration};
 
-use cranpose::{AppLauncher, RobotScreenshot, SemanticElement};
+use cranpose::{RobotScreenshot, SemanticElement};
 use cranpose_testing::{
     find_button_exact_in_semantics, find_button_in_semantics, find_text_in_semantics,
     normalize_screenshot_region, screenshot_difference_stats,
@@ -25,25 +27,26 @@ fn main() {
     env_logger::init();
     println!("=== Robot Scroll Decoration Invariance ===");
 
-    AppLauncher::new()
-        .with_title("Robot Scroll Decoration Invariance")
-        .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
-        .with_headless(true)
-        .with_test_driver(|robot| {
-            std::thread::sleep(Duration::from_millis(600));
-            let _ = robot.wait_for_idle();
+    robot_launch::launch(
+        "Robot Scroll Decoration Invariance",
+        WINDOW_WIDTH,
+        WINDOW_HEIGHT,
+    )
+    .with_test_driver(|robot| {
+        std::thread::sleep(Duration::from_millis(600));
+        let _ = robot.wait_for_idle();
 
-            open_text_tab(&robot);
-            scroll_text_into_view(&robot, TARGET_TEXT, 20);
+        open_text_tab(&robot);
+        scroll_text_into_view(&robot, TARGET_TEXT, 20);
 
-            verify_underline_row_tracks_fractional_scroll(&robot);
-            verify_scroll_decoration_invariance(&robot);
+        verify_underline_row_tracks_fractional_scroll(&robot);
+        verify_scroll_decoration_invariance(&robot);
 
-            println!("\n=== Test Summary ===");
-            println!("PASS: text decoration rendering is scroll-position-invariant");
-            robot.exit().expect("exit");
-        })
-        .run(app::combined_app);
+        println!("\n=== Test Summary ===");
+        println!("PASS: text decoration rendering is scroll-position-invariant");
+        robot.exit().expect("exit");
+    })
+    .run(app::combined_app);
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/apps/desktop-demo/robot-runners/robot_scroll_jump.rs
+++ b/apps/desktop-demo/robot-runners/robot_scroll_jump.rs
@@ -1,6 +1,10 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, Robot};
+use cranpose::Robot;
 use cranpose_testing::{find_button_in_semantics, find_in_semantics, find_text};
 use desktop_app::app;
 
@@ -8,16 +12,9 @@ fn main() {
     env_logger::init();
     println!("=== Lazy List Scroll Bug Test ===\n");
 
-    AppLauncher::new()
-        .with_title("Lazy List Scroll Bug")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Lazy List Scroll Bug", 800, 600)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(120));
-                eprintln!("✗ Test timed out");
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(120);
 
             std::thread::sleep(Duration::from_millis(800));
             let _ = robot.wait_for_idle();

--- a/apps/desktop-demo/robot-runners/robot_scroll_persistence.rs
+++ b/apps/desktop-demo/robot-runners/robot_scroll_persistence.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button_in_semantics, find_in_semantics, find_text};
 use desktop_app::app;
 
@@ -11,16 +14,9 @@ fn main() {
 
     const TEST_TIMEOUT_SECS: u64 = 60;
 
-    AppLauncher::new()
-        .with_title("Robot Scroll Persistence Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Robot Scroll Persistence Test", 800, 600)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(TEST_TIMEOUT_SECS));
-                println!("✗ Test timed out after {} seconds", TEST_TIMEOUT_SECS);
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(TEST_TIMEOUT_SECS);
 
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_scroll_to_item_redraw.rs
+++ b/apps/desktop-demo/robot-runners/robot_scroll_to_item_redraw.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope};
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
 use cranpose_ui::{
@@ -14,10 +15,7 @@ use cranpose_ui::{
 fn main() {
     env_logger::init();
 
-    AppLauncher::new()
-        .with_title("scroll_to_item Redraw Test")
-        .with_size(400, 600)
-        .with_headless(true)
+    robot_launch::launch("scroll_to_item Redraw Test", 400, 600)
         .with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(300));
 

--- a/apps/desktop-demo/robot-runners/robot_scroll_visual.rs
+++ b/apps/desktop-demo/robot-runners/robot_scroll_visual.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
     exit_with_timeout, find_button_in_semantics, find_text_by_prefix_in_semantics,
 };
@@ -21,10 +22,7 @@ fn main() {
     println!("=== Robot Scroll Visual Test ===");
     println!("Verifying that scroll actually moves content visually\n");
 
-    AppLauncher::new()
-        .with_title("Robot Scroll Visual Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Robot Scroll Visual Test", 800, 600)
         .with_test_driver(|robot| {
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_selection_vertical_grab.rs
+++ b/apps/desktop-demo/robot-runners/robot_selection_vertical_grab.rs
@@ -1,3 +1,5 @@
+mod robot_handle_probe;
+
 use std::{
     path::{Path, PathBuf},
     process::ExitCode,
@@ -203,32 +205,8 @@ fn lower_handle_center(shot: &RobotScreenshot, rect: (f32, f32, f32, f32)) -> Op
     let right = (((x + width) * sx) as usize).min(shot.width as usize);
     let top = (y.max(0.0) * sy) as usize;
     let bottom = (((y + height + 10.0) * sy) as usize).min(shot.height as usize);
-    let is_accent = |px: usize, py: usize| {
-        let i = (py * shot.width as usize + px) * 4;
-        let (r, g, b) = (shot.pixels[i], shot.pixels[i + 1], shot.pixels[i + 2]);
+    robot_handle_probe::lower_band_center(shot, sx, sy, left, right, top, bottom, |r, g, b| {
         r > 180 && r.saturating_sub(g) > 70 && b.saturating_sub(g) > 25
-    };
-    let max_y = (top..bottom)
-        .rev()
-        .find(|&py| (left..right).any(|px| is_accent(px, py)))?;
-    let band_top = max_y.saturating_sub((4.0 * sy).ceil() as usize);
-    let mut sum_x = 0usize;
-    let mut sum_y = 0usize;
-    let mut count = 0usize;
-    for py in band_top..=max_y {
-        for px in left..right {
-            if is_accent(px, py) {
-                sum_x += px;
-                sum_y += py;
-                count += 1;
-            }
-        }
-    }
-    (count > 0).then(|| {
-        (
-            sum_x as f32 / count as f32 / sx,
-            sum_y as f32 / count as f32 / sy,
-        )
     })
 }
 

--- a/apps/desktop-demo/robot-runners/robot_shadow_fields.rs
+++ b/apps/desktop-demo/robot-runners/robot_shadow_fields.rs
@@ -1,8 +1,9 @@
+mod robot_launch;
+
 mod output_paths;
 
 use std::{fs, path::Path, time::Duration};
 
-use cranpose::AppLauncher;
 use cranpose_testing::{
     capture_screenshot, changed_pixel_count, changed_pixel_count_in_region,
     find_button_in_semantics, logical_region_to_pixel_bounds, scroll_prefix_into_view,
@@ -183,11 +184,7 @@ fn main() {
     env_logger::init();
     println!("=== Robot Shadow Fields Visual Test ===");
 
-    AppLauncher::new()
-        .with_title("Robot Shadow Fields Visual Test")
-        .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Robot Shadow Fields Visual Test", WINDOW_WIDTH, WINDOW_HEIGHT).with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(900));
             let _ = robot.wait_for_idle();
 

--- a/apps/desktop-demo/robot-runners/robot_shot.rs
+++ b/apps/desktop-demo/robot-runners/robot_shot.rs
@@ -10,6 +10,15 @@ pub fn save(shot: &RobotScreenshot, directory: &Path, name: &str) {
     }
 }
 
+pub fn save_checked(path: &Path, shot: &RobotScreenshot) -> Result<(), String> {
+    let image: image::RgbaImage =
+        image::ImageBuffer::from_raw(shot.width, shot.height, shot.pixels.clone())
+            .ok_or_else(|| "invalid screenshot dimensions".to_string())?;
+    image
+        .save(path)
+        .map_err(|err| format!("failed to save {}: {}", path.display(), err))
+}
+
 pub fn settle(robot: &Robot, millis: u64) {
     let _ = robot.wait_for_idle();
     std::thread::sleep(Duration::from_millis(millis));

--- a/apps/desktop-demo/robot-runners/robot_subcompose_invalidation.rs
+++ b/apps/desktop-demo/robot-runners/robot_subcompose_invalidation.rs
@@ -1,6 +1,10 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, LazyItems};
+use cranpose::LazyItems;
 use cranpose_core::rememberMutableStateOf;
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope};
 use cranpose_testing::{find_button, find_in_semantics, find_text_in_semantics};
@@ -109,16 +113,9 @@ fn main() {
     println!("=== SubcomposeLayout Invalidation Routing Test ===");
     println!("Testing that modifier changes in LazyColumn items trigger re-renders\n");
 
-    AppLauncher::new()
-        .with_title("SubcomposeLayout Invalidation Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("SubcomposeLayout Invalidation Test", 800, 600)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(30));
-                eprintln!("TIMEOUT: Test exceeded 30 seconds");
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(30);
 
             std::thread::sleep(Duration::from_millis(500));
             println!("✓ App launched and ready\n");

--- a/apps/desktop-demo/robot-runners/robot_subcompose_lazy.rs
+++ b/apps/desktop-demo/robot-runners/robot_subcompose_lazy.rs
@@ -1,6 +1,8 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::{AppLauncher, LazyItems};
+use cranpose::LazyItems;
 use cranpose_foundation::lazy::{rememberLazyListState, LazyListScope};
 use cranpose_testing::find_text_in_semantics;
 use cranpose_ui::{widgets::*, Modifier, TextStyle};
@@ -85,11 +87,7 @@ fn main() {
     env_logger::init();
     println!("=== SubcomposeLayout & LazyColumn Comprehensive Test ===\n");
 
-    AppLauncher::new()
-        .with_title("SubcomposeLayout Test")
-        .with_size(800, 600)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("SubcomposeLayout Test", 800, 600).with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));
 

--- a/apps/desktop-demo/robot-runners/robot_tab_fixture.rs
+++ b/apps/desktop-demo/robot-runners/robot_tab_fixture.rs
@@ -1,0 +1,13 @@
+#![allow(dead_code)]
+
+use cranpose::liquid::prelude::LiquidTabBarScope;
+
+pub fn tabs(
+    entries: &'static [(&'static str, &'static str)],
+) -> impl Fn(&LiquidTabBarScope) + 'static {
+    move |scope: &LiquidTabBarScope| {
+        for &(icon, label) in entries {
+            scope.tab(icon, label);
+        }
+    }
+}

--- a/apps/desktop-demo/robot-runners/robot_tab_navigation.rs
+++ b/apps/desktop-demo/robot-runners/robot_tab_navigation.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
 use desktop_app::app;
 
@@ -8,10 +9,7 @@ fn main() {
     env_logger::init();
     println!("=== Robot Tab Navigation Stress Test ===");
 
-    AppLauncher::new()
-        .with_title("Robot Tab Navigation Test")
-        .with_size(1024, 768)
-        .with_headless(true)
+    robot_launch::launch("Robot Tab Navigation Test", 1024, 768)
         .with_test_driver(|robot| {
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_tab_roundtrip_content.rs
+++ b/apps/desktop-demo/robot-runners/robot_tab_roundtrip_content.rs
@@ -1,8 +1,9 @@
+mod robot_launch;
+
 mod robot_exit;
 
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
 use desktop_app::app;
 
@@ -30,10 +31,7 @@ fn main() {
     env_logger::init();
     println!("=== Robot Tab Roundtrip Content Test ===");
 
-    AppLauncher::new()
-        .with_title("Robot Tab Roundtrip Content Test")
-        .with_size(1024, 768)
-        .with_headless(true)
+    robot_launch::launch("Robot Tab Roundtrip Content Test", 1024, 768)
         .with_test_driver(|robot| {
             std::thread::sleep(Duration::from_millis(500));
             let _ = robot.wait_for_idle();

--- a/apps/desktop-demo/robot-runners/robot_tab_scroll.rs
+++ b/apps/desktop-demo/robot-runners/robot_tab_scroll.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::find_button_in_semantics;
 use desktop_app::app;
 
@@ -9,10 +10,7 @@ fn main() {
     println!("=== Robot Tab Scroll Test ===");
     println!("Testing that clicking tabs doesn't cause scroll following cursor\n");
 
-    AppLauncher::new()
-        .with_title("Robot Tab Scroll Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Robot Tab Scroll Test", 800, 600)
         .with_test_driver(|robot| {
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_tab_selection.rs
+++ b/apps/desktop-demo/robot-runners/robot_tab_selection.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
 use desktop_app::{app, app::DemoTab};
 
@@ -13,10 +14,7 @@ fn main() {
     println!("=== Robot Tab Selection Test ===");
     println!("Testing that tab selection state visually changes\n");
 
-    AppLauncher::new()
-        .with_title("Robot Tab Selection Test")
-        .with_size(1200, 800)
-        .with_headless(true)
+    robot_launch::launch("Robot Tab Selection Test", 1200, 800)
         .with_test_driver(|robot| {
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_tabbar_drag.rs
+++ b/apps/desktop-demo/robot-runners/robot_tabbar_drag.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{bounds_span, collect_tab_bounds, detect_tab_axis, root_bounds, TabAxis};
 use desktop_app::app;
 
@@ -8,16 +11,9 @@ fn main() {
     env_logger::init();
     println!("=== Robot Tabbar Drag Test ===\n");
 
-    AppLauncher::new()
-        .with_title("Robot Tabbar Drag Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Robot Tabbar Drag Test", 800, 600)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(30));
-                println!("✗ Test timed out");
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(30);
 
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_tabs_scroll.rs
+++ b/apps/desktop-demo/robot-runners/robot_tabs_scroll.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{bounds_span, collect_tab_bounds, detect_tab_axis, root_bounds, TabAxis};
 use desktop_app::app;
 
@@ -9,11 +10,7 @@ fn main() {
     println!("=== Robot Tabs Scroll Test ===");
     println!("Testing tabs row scrolling and click behavior\n");
 
-    AppLauncher::new()
-        .with_title("Robot Tabs Scroll Test")
-        .with_size(800, 600)
-        .with_headless(true)
-        .with_test_driver(|robot| {
+    robot_launch::launch("Robot Tabs Scroll Test", 800, 600).with_test_driver(|robot| {
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));
 

--- a/apps/desktop-demo/robot-runners/robot_test_recorder.rs
+++ b/apps/desktop-demo/robot-runners/robot_test_recorder.rs
@@ -1,8 +1,9 @@
+mod robot_launch;
+
 mod output_paths;
 
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use desktop_app::app;
 
 fn main() {
@@ -11,10 +12,7 @@ fn main() {
     println!("=== Robot Recorder Test ===");
     println!("Recording to: {:?}\n", recording_path);
 
-    AppLauncher::new()
-        .with_title("Robot Recorder Test")
-        .with_size(800, 600)
-        .with_headless(true)
+    robot_launch::launch("Robot Recorder Test", 800, 600)
         .with_recording(&recording_path)
         .with_test_driver(move |robot| {
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_text_handle_cycle_stability.rs
+++ b/apps/desktop-demo/robot-runners/robot_text_handle_cycle_stability.rs
@@ -1,10 +1,13 @@
+mod robot_launch;
+
 mod robot_exit;
+mod robot_handle_probe;
 
 use std::time::Duration;
 
 use cranpose::{
     widgets::{BasicTextField, Box as CBox, BoxSpec},
-    AppLauncher, Color, Modifier, Robot, RobotScreenshot, Size,
+    Color, Modifier, Robot, RobotScreenshot, Size,
 };
 use cranpose_foundation::text::TextFieldState;
 use cranpose_ui::text::TextStyle;
@@ -55,11 +58,7 @@ fn main() {
     env_logger::init();
     println!("=== Text Handle Cycle Stability ===\n");
 
-    AppLauncher::new()
-        .with_title("Handle Cycle Stability")
-        .with_size(600, 400)
-        .with_headless(true)
-        .with_test_driver(move |robot| {
+    robot_launch::launch("Handle Cycle Stability", 600, 400).with_test_driver(move |robot| {
             robot_exit::arm_timeout(400);
 
             std::thread::sleep(Duration::from_millis(300));
@@ -361,32 +360,14 @@ fn lower_handle_center(shot: &RobotScreenshot, band: (f32, f32, f32)) -> Option<
     let right = (((x + width) * sx) as usize).min(shot.width as usize);
     let top = ((line_y * sy) as usize).min(shot.height as usize);
     let bottom = (((line_y + 40.0) * sy) as usize).min(shot.height as usize);
-
-    let is_blue = |px: usize, py: usize| {
-        let i = (py * shot.width as usize + px) * 4;
-        let (r, g, b) = (shot.pixels[i], shot.pixels[i + 1], shot.pixels[i + 2]);
-        b > 170 && b.saturating_sub(r) > 55 && b.saturating_sub(g) > 25
-    };
-    let max_y = (top..bottom)
-        .rev()
-        .find(|&py| (left..right).any(|px| is_blue(px, py)))?;
-    let band_top = max_y.saturating_sub((4.0 * sy).ceil() as usize);
-    let mut sum_x = 0usize;
-    let mut sum_y = 0usize;
-    let mut count = 0usize;
-    for py in band_top..=max_y {
-        for px in left..right {
-            if is_blue(px, py) {
-                sum_x += px;
-                sum_y += py;
-                count += 1;
-            }
-        }
-    }
-    (count > 0).then(|| {
-        (
-            sum_x as f32 / count as f32 / sx,
-            sum_y as f32 / count as f32 / sy,
-        )
-    })
+    robot_handle_probe::lower_band_center(
+        shot,
+        sx,
+        sy,
+        left,
+        right,
+        top,
+        bottom,
+        robot_handle_probe::is_blue_handle,
+    )
 }

--- a/apps/desktop-demo/robot-runners/robot_text_handle_survives_tab_switch.rs
+++ b/apps/desktop-demo/robot-runners/robot_text_handle_survives_tab_switch.rs
@@ -1,8 +1,11 @@
+mod robot_launch;
+
 mod robot_exit;
+mod robot_handle_probe;
 
 use std::time::Duration;
 
-use cranpose::{AppLauncher, RobotScreenshot, SemanticElement};
+use cranpose::{RobotScreenshot, SemanticElement};
 use cranpose_testing::{find_button, find_button_in_semantics, find_in_semantics, find_text};
 use desktop_app::app;
 
@@ -22,10 +25,7 @@ fn main() {
     env_logger::init();
     println!("=== Text Handle Survives Tab Switch ===\n");
 
-    AppLauncher::new()
-        .with_title("Text Handle Survives Tab Switch")
-        .with_size(900, 700)
-        .with_headless(true)
+    robot_launch::launch("Text Handle Survives Tab Switch", 900, 700)
         .with_test_driver(move |robot| {
             robot_exit::arm_timeout(90);
 
@@ -356,22 +356,16 @@ fn count_handle_bands_in(
     let bottom = (((y + height) * sy) as usize).min(shot.height as usize);
     let upper_end = ((y + height * 0.45) * sy) as usize;
     let lower_start = ((y + height * 0.55) * sy) as usize;
-    let mut upper = 0;
-    let mut lower = 0;
-    for py in top..bottom {
-        for px in left..right {
-            let i = (py * shot.width as usize + px) * 4;
-            let (r, g, b) = (shot.pixels[i], shot.pixels[i + 1], shot.pixels[i + 2]);
-            if matches_accent(r, g, b, target) {
-                if py < upper_end {
-                    upper += 1;
-                } else if py >= lower_start {
-                    lower += 1;
-                }
-            }
-        }
-    }
-    (upper, lower)
+    robot_handle_probe::count_upper_lower_bands(
+        shot,
+        left,
+        right,
+        top,
+        bottom,
+        upper_end,
+        lower_start,
+        |r, g, b| matches_accent(r, g, b, target),
+    )
 }
 
 fn count_pixels_in(

--- a/apps/desktop-demo/robot-runners/robot_text_input.rs
+++ b/apps/desktop-demo/robot-runners/robot_text_input.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button, find_button_in_semantics, find_in_semantics, find_text};
 use desktop_app::app;
 
@@ -11,16 +14,8 @@ fn main() {
 
     const TEST_TIMEOUT_SECS: u64 = 120;
 
-    AppLauncher::new()
-        .with_title("Robot Text Input Test")
-        .with_size(900, 700)
-        .with_headless(true)
-        .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(TEST_TIMEOUT_SECS));
-                println!("✗ Test timed out after {} seconds", TEST_TIMEOUT_SECS);
-                std::process::exit(1);
-            });
+    robot_launch::launch("Robot Text Input Test", 900, 700).with_test_driver(|robot| {
+            robot_exit::arm_timeout(TEST_TIMEOUT_SECS);
 
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_text_input_value_disappear.rs
+++ b/apps/desktop-demo/robot-runners/robot_text_input_value_disappear.rs
@@ -1,6 +1,9 @@
+mod robot_launch;
+
+mod robot_exit;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_testing::{find_button_in_semantics, find_in_semantics, find_text};
 use desktop_app::app;
 
@@ -13,16 +16,9 @@ fn main() {
 
     const TEST_TIMEOUT_SECS: u64 = 60;
 
-    AppLauncher::new()
-        .with_title("Robot Text Input Value Disappear Bug Test")
-        .with_size(900, 700)
-        .with_headless(true)
+    robot_launch::launch("Robot Text Input Value Disappear Bug Test", 900, 700)
         .with_test_driver(|robot| {
-            std::thread::spawn(|| {
-                std::thread::sleep(Duration::from_secs(TEST_TIMEOUT_SECS));
-                println!("✗ Test timed out after {} seconds", TEST_TIMEOUT_SECS);
-                std::process::exit(1);
-            });
+            robot_exit::arm_timeout(TEST_TIMEOUT_SECS);
 
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_text_loupe.rs
+++ b/apps/desktop-demo/robot-runners/robot_text_loupe.rs
@@ -1,4 +1,5 @@
 mod robot_exit;
+mod text_fixture_style;
 
 use std::{
     path::{Path, PathBuf},
@@ -14,30 +15,14 @@ use cranpose::{
 use cranpose_foundation::text::TextFieldState;
 use cranpose_ui::text::{AnnotatedString, TextStyle, TextUnit};
 use image::RgbaImage;
-
-const WINDOW_WIDTH: u32 = 460;
-const WINDOW_HEIGHT: u32 = 340;
-
-const BACKDROP: Color = Color(0.149, 0.129, 0.125, 1.0);
-const TEXT_COLOR: Color = Color(0.94, 0.92, 0.90, 1.0);
-const ACCENT: Color = Color(0.965, 0.208, 0.557, 1.0);
-
-const FIELD_X: f32 = 20.0;
-const FIELD_Y: f32 = 170.0;
-const FIELD_WIDTH: f32 = 420.0;
+use text_fixture_style::{
+    text_style, ACCENT, BACKDROP, FIELD_WIDTH, FIELD_X, FIELD_Y, WINDOW_HEIGHT, WINDOW_WIDTH,
+};
 
 const TEXT: &str =
     "Silence. Melody. Then beats. Subtle electronic beats goaantra trance pp ulsy catching melody";
 
 static FAILED: AtomicBool = AtomicBool::new(false);
-
-fn text_style() -> TextStyle {
-    let mut style = TextStyle::default();
-    style.span_style.color = Some(TEXT_COLOR);
-    style.span_style.font_size = TextUnit::Sp(16.0);
-    style.paragraph_style.line_height = TextUnit::Sp(24.0);
-    style
-}
 
 fn main() -> ExitCode {
     let _ = env_logger::try_init();

--- a/apps/desktop-demo/robot-runners/robot_ui_breakage.rs
+++ b/apps/desktop-demo/robot-runners/robot_ui_breakage.rs
@@ -1,6 +1,7 @@
+mod robot_launch;
+
 use std::time::Duration;
 
-use cranpose::AppLauncher;
 use cranpose_core::rememberMutableStateOf;
 use cranpose_testing::find_text_in_semantics;
 use cranpose_ui::{
@@ -38,10 +39,7 @@ fn main() {
     env_logger::init();
     println!("=== Robot UI Breakage Reproduction ===");
 
-    AppLauncher::new()
-        .with_title("UI Breakage Repro")
-        .with_size(400, 300)
-        .with_headless(true)
+    robot_launch::launch("UI Breakage Repro", 400, 300)
         .with_test_driver(|robot| {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));

--- a/apps/desktop-demo/robot-runners/robot_winamp_native_window_geometry.rs
+++ b/apps/desktop-demo/robot-runners/robot_winamp_native_window_geometry.rs
@@ -694,7 +694,7 @@ fn drag_main_and_assert_offsets(label: &str, windows: WinampWindows) {
     drag_and_assert_offsets(label, windows, windows.main, true);
 }
 
-fn drag_main_one_pixel_trace_and_assert_continuity(label: &str, windows: WinampWindows) {
+fn begin_main_drag(label: &str, windows: WinampWindows) -> WinampGeometries {
     let initial = assert_attached_offsets(label, windows.geometries());
     let (start_x, start_y) = drag_start_for_window(windows, windows.main);
 
@@ -703,6 +703,12 @@ fn drag_main_one_pixel_trace_and_assert_continuity(label: &str, windows: WinampW
     std::thread::sleep(Duration::from_millis(100));
     xdotool(["mousedown", "1"]);
     std::thread::sleep(Duration::from_millis(60));
+
+    initial
+}
+
+fn drag_main_one_pixel_trace_and_assert_continuity(label: &str, windows: WinampWindows) {
+    let initial = begin_main_drag(label, windows);
 
     let mut trace = Vec::with_capacity(PIXEL_TRACE_STEPS + 1);
     trace.push(DragTraceSample {
@@ -726,14 +732,7 @@ fn drag_main_one_pixel_trace_and_assert_continuity(label: &str, windows: WinampW
 }
 
 fn drag_main_fast_and_assert_offsets(label: &str, windows: WinampWindows) {
-    let initial = assert_attached_offsets(label, windows.geometries());
-    let (start_x, start_y) = drag_start_for_window(windows, windows.main);
-
-    activate_window(windows.main);
-    mousemove_in_window_exact(label, windows.main, start_x, start_y);
-    std::thread::sleep(Duration::from_millis(100));
-    xdotool(["mousedown", "1"]);
-    std::thread::sleep(Duration::from_millis(60));
+    let initial = begin_main_drag(label, windows);
 
     let mut previous_main = initial.main;
     for step in 1..=FAST_MOVE_STEPS {
@@ -764,14 +763,7 @@ fn drag_main_fast_and_assert_offsets(label: &str, windows: WinampWindows) {
 }
 
 fn drag_main_long_continuous_trace_and_assert_sync(label: &str, windows: WinampWindows) {
-    let initial = assert_attached_offsets(label, windows.geometries());
-    let (start_x, start_y) = drag_start_for_window(windows, windows.main);
-
-    activate_window(windows.main);
-    mousemove_in_window_exact(label, windows.main, start_x, start_y);
-    std::thread::sleep(Duration::from_millis(100));
-    xdotool(["mousedown", "1"]);
-    std::thread::sleep(Duration::from_millis(60));
+    let initial = begin_main_drag(label, windows);
 
     let origin_pointer = pointer_location();
     let started = Instant::now();

--- a/apps/desktop-demo/robot-runners/scroll_stability_external_helpers.rs
+++ b/apps/desktop-demo/robot-runners/scroll_stability_external_helpers.rs
@@ -967,7 +967,7 @@ fn cleanup_capture_paths(capture_paths: &[PathBuf]) {
     }
 }
 
-fn save_robot_screenshot(path: &Path, screenshot: &cranpose::RobotScreenshot) {
+pub fn save_robot_screenshot(path: &Path, screenshot: &cranpose::RobotScreenshot) {
     let image: RgbaImage = ImageBuffer::from_raw(
         screenshot.width,
         screenshot.height,

--- a/apps/desktop-demo/robot-runners/text_fixture_style.rs
+++ b/apps/desktop-demo/robot-runners/text_fixture_style.rs
@@ -1,0 +1,21 @@
+#![allow(dead_code)]
+
+use cranpose::Color;
+use cranpose_ui::text::{TextStyle, TextUnit};
+
+pub const WINDOW_WIDTH: u32 = 460;
+pub const WINDOW_HEIGHT: u32 = 340;
+pub const BACKDROP: Color = Color(0.149, 0.129, 0.125, 1.0);
+pub const TEXT_COLOR: Color = Color(0.94, 0.92, 0.90, 1.0);
+pub const ACCENT: Color = Color(0.965, 0.208, 0.557, 1.0);
+pub const FIELD_X: f32 = 20.0;
+pub const FIELD_Y: f32 = 170.0;
+pub const FIELD_WIDTH: f32 = 420.0;
+
+pub fn text_style() -> TextStyle {
+    let mut style = TextStyle::default();
+    style.span_style.color = Some(TEXT_COLOR);
+    style.span_style.font_size = TextUnit::Sp(16.0);
+    style.paragraph_style.line_height = TextUnit::Sp(24.0);
+    style
+}

--- a/apps/desktop-demo/robot-runners/text_showcase_external_helpers.rs
+++ b/apps/desktop-demo/robot-runners/text_showcase_external_helpers.rs
@@ -311,7 +311,7 @@ fn wait_for_button_in_semantics(
     None
 }
 
-fn wait_for_exact_button_in_semantics(
+pub fn wait_for_exact_button_in_semantics(
     robot: &cranpose::Robot,
     text: &str,
     attempts: usize,
@@ -326,7 +326,7 @@ fn wait_for_exact_button_in_semantics(
     None
 }
 
-fn wait_for_text_in_semantics(robot: &cranpose::Robot, text: &str, attempts: usize) -> bool {
+pub fn wait_for_text_in_semantics(robot: &cranpose::Robot, text: &str, attempts: usize) -> bool {
     for _ in 0..attempts {
         if find_text_in_semantics(robot, text).is_some() {
             return true;


### PR DESCRIPTION
## Summary

`apps/desktop-demo/robot-runners/` and `apps/desktop-demo/examples/` had 179 jscpd clone pairs (2907 duplicated lines) even after the earlier `robot_exit`/`robot_shot` extraction (#575, #559), because most of the ~155 runners had never adopted those helpers, and several more copy-paste shapes had never been named. This PR adds the next layer.

**Before → after (jscpd `--min-lines 10 --min-tokens 50` on the two directories):** 179 clone pairs / 2907 duplicated lines → **163 clone pairs / 2419 duplicated lines**.

### Abstractions introduced

- **`robot_launch::launch(title, w, h)`** — replaces the `.with_title(...).with_size(...).with_headless(true)` chain in **93 runners** that all built it identically. Runners with a non-boolean `headless` expression (env-var driven) or a `.with_fonts(...)` call were left alone since that isn't the same chain.
- **`robot_exit::arm_timeout` adoption** — **21 runners** had hand-rolled the exact timeout-thread-spawn block (`thread::spawn(|| { sleep; println!; process::exit(1); })`) that `robot_exit::arm_timeout` already provides. Switched them to call it.
- **`robot_handle_probe.rs`** — generalizes the "scan a rect bottom-up / count upper-lower band pixels for an accent color" loops duplicated across `robot_drag_selection.rs`, `robot_selection_vertical_grab.rs`, `robot_text_handle_cycle_stability.rs`, and `robot_text_handle_survives_tab_switch.rs`. These four callers use **three different color predicates** (a loose blue heuristic, a red/orange heuristic, and an exact-target-with-tolerance match) — the shared functions take the predicate as a closure so each caller keeps its own detection behavior; only the scan/average shape is shared.
- **`markdown_scroll_drag.rs`** — shares `click_button`/`drag_scrollbar`/`drag_viewport`/`wait_for_text_bounds`/`fail_and_exit` between `robot_markdown_end_drag_up.rs` and `robot_markdown_scrollbar.rs`. These had been copy-pasted with **one silent divergence**: the scrollbar drag step delay was `8ms` in one file and `12ms` in the other. Fixed by making the delay a parameter instead of collapsing to one value — behavior of both runners is unchanged.
- **`robot_tab_fixture.rs`** — shares the `LiquidTabBar` "spec + populate scope from a TABS array" shape between the two liquid tab-bar runners; the `TABS` content itself stays per-runner (per the brief: the fixture is the shape, not the data).
- **`text_fixture_style.rs`** — shares the window/text-field constants and `text_style()` between `robot_menu_slide.rs` and `robot_text_loupe.rs`.
- **`robot_shot::save_checked`** — the `Result`-returning screenshot save that `robot_render_crispness_contract.rs` and `robot_renderer_micro_contract.rs` had each defined locally as `save_png`, duplicating the existing `robot_shot::save`'s sibling.
- **Adoption fixes for existing shared modules**: `robot_leetcodedaily_full_layout_scroll_stability.rs` had its own private copy of `scroll_stability_external_helpers`'s screenshot saver even though it already `mod`s that file (made the helper `pub`, repointed 21 call sites); `robot_render_translation_contract.rs` had its own copies of `text_showcase_external_helpers`'s `wait_for_exact_button_in_semantics`/`wait_for_text_in_semantics` (adopted the shared ones).
- **`begin_main_drag` in `robot_winamp_native_window_geometry.rs`** — the same 7-line "attach window, move to drag start, mouse down" sequence was called identically from three functions in the same file.

### Runners converted

93 (`robot_launch`) + 21 (`robot_exit::arm_timeout`) + 4 (`robot_handle_probe`) + 2 (`markdown_scroll_drag`) + 2 (`robot_tab_fixture`) + 2 (`text_fixture_style`) + 2 (`robot_shot::save_checked`) + 1 (leetcodedaily → `scroll_stability_external_helpers`) + 1 (`robot_render_translation_contract` → `text_showcase_external_helpers`) + 1 (winamp self-dedup) — 112 files touched total in the diff, including the 5 new shared modules.

### Deliberately left as clones, with reasons

- **`use` blocks** — jscpd still flags repeated import lists as clones. Each runner is its own `[[example]]` binary target; Rust has no mechanism for one binary to borrow another's `use` statements, so this class is unfixable without a shared library crate (out of scope here).
- **`robot_lazy_items_provider.rs` / `robot_lazy_items_rc.rs`** — structurally parallel (same window/layout shape) but exercise two genuinely different LazyList APIs (callback-based `items_with_provider` vs zero-copy `items_slice_rc`), with different data types and different widget content per item. Forcing a shared abstraction would obscure which API each test is actually exercising.
- **`robot_lazy_lifecycle.rs` / `robot_lazy_varheight_lifecycle.rs`** — same reasoning: fixed-height vs variable-height lifecycle tests track composition differently (`remember`-based counter vs `SideEffect`), so the per-item bodies aren't actually the same logic.
- **External-x11 shader perf-report clusters** (`robot_shader_external_x11_drag.rs` / `robot_shader_rect_external_animation.rs` / `robot_shader_full_demo_external_perf.rs`) and the **internal repeats inside `robot_leetcodedaily_full_layout_scroll_stability.rs`** (9200+ lines, ~19 internal clone pairs) — real duplication, but with per-test thresholds/labels that would need to be verified against a live X11 display this sandbox doesn't have. Left for a follow-up rather than risking a silent threshold swap like the drag-delay one caught above.

### Verification

    just fmt                 # clean, no diff
    just clippy-robot        # 0 warnings (this is the only lint that reaches these files)
    cargo check -p desktop-app --examples --features robot-app   # 0 warnings
    just complexity-gate     # 346 changed line ranges clean
    just duplication-gate    # 1632 clones repo-wide, 37 touch the diff, none introduced by it

`git diff origin/main..HEAD -- apps/desktop-demo/robot-runners apps/desktop-demo/examples | grep -cE "^\+\s*(//|///|//!)"` → **0** (no comments added; `desktop-app` is not a published crate).

No bug found matching the "FAILED flag set then `process::exit(1)` immediately, so the flag can never be read" shape from the last pass — checked all 8 files using a `static FAILED: AtomicBool` and none exit before reaching `robot_exit::exit_code(&FAILED)`.

## Test plan

- [x] `just fmt`
- [x] `just clippy-robot`
- [x] `cargo check -p desktop-app --examples --features robot-app`
- [x] `just complexity-gate`
- [x] `just duplication-gate`
- [ ] `just robot` (full GUI robot suite — not run in this sandbox; no X11/display available here. Recommend running on samarch-1 before merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
