### PR TITLE
Dedup wgpu render paths: shared composite, shape iteration, image batch

### DIFF
--- a/crates/cranpose-render/common/src/hit_graph.rs
+++ b/crates/cranpose-render/common/src/hit_graph.rs
@@ -7,7 +7,7 @@ use cranpose_ui_graphics::{Rect, RoundedCornerShape};
 
 use crate::{
     graph::{LayerNode, ProjectiveTransform, RenderNode, quad_bounds},
-    graph_scene::{HitClip, HitGeometry},
+    graph_scene::{ClickAction, HitClip, HitGeometry, Scene},
     primitive_emit::resolve_clip,
 };
 
@@ -21,6 +21,32 @@ pub trait HitGraphSink {
         click_actions: &[Rc<dyn Fn(Point)>],
         pointer_inputs: &[Rc<dyn Fn(PointerEvent)>],
     );
+}
+
+impl HitGraphSink for Scene {
+    fn push_hit(
+        &mut self,
+        node_id: NodeId,
+        capture_path: &[NodeId],
+        geometry: HitGeometry,
+        shape: Option<RoundedCornerShape>,
+        click_actions: &[Rc<dyn Fn(Point)>],
+        pointer_inputs: &[Rc<dyn Fn(PointerEvent)>],
+    ) {
+        Scene::push_hit(
+            self,
+            node_id,
+            capture_path.to_vec(),
+            geometry,
+            shape,
+            click_actions
+                .iter()
+                .cloned()
+                .map(ClickAction::WithPoint)
+                .collect(),
+            pointer_inputs.to_vec(),
+        );
+    }
 }
 
 pub fn collect_hits_from_graph<S: HitGraphSink>(

--- a/crates/cranpose-render/common/src/scene_builder.rs
+++ b/crates/cranpose-render/common/src/scene_builder.rs
@@ -1807,7 +1807,7 @@ fn pad_clip_rect(rect: Rect) -> Rect {
     }
 }
 
-fn expand_text_bounds_for_baseline_shift(
+pub fn expand_text_bounds_for_baseline_shift(
     text_bounds: Rect,
     text_style: &TextStyle,
     font_size: f32,

--- a/crates/cranpose-render/pixels/src/pipeline.rs
+++ b/crates/cranpose-render/pixels/src/pipeline.rs
@@ -8,7 +8,7 @@ use cranpose_render_common::{
         RenderNode, TextPrimitiveNode,
     },
     graph_scene::RenderDiagnostics,
-    hit_graph::{HitGraphSink, collect_hits_from_graph as collect_common_hits},
+    hit_graph::collect_hits_from_graph,
     layer_composition::local_content_layer,
     layer_shadow::layer_shadow_geometry,
     layer_transform::{apply_layer_affine_to_rect, apply_layer_to_rect, layer_uniform_scale},
@@ -33,22 +33,9 @@ use cranpose_ui_graphics::{
 };
 
 use crate::{
-    scene::{ClickAction, RasterScene, Scene},
+    scene::{RasterScene, Scene},
     style::{apply_layer_to_brush, apply_layer_to_color, combine_layers, scale_corner_radii},
 };
-
-#[cfg(test)]
-const TEXT_CLIP_PAD: f32 = 1.0;
-
-#[cfg(test)]
-fn pad_clip_rect(rect: Rect) -> Rect {
-    Rect {
-        x: rect.x - TEXT_CLIP_PAD,
-        y: rect.y - TEXT_CLIP_PAD,
-        width: (rect.width + TEXT_CLIP_PAD * 2.0).max(0.0),
-        height: (rect.height + TEXT_CLIP_PAD * 2.0).max(0.0),
-    }
-}
 
 fn graphics_layer_supports_rigid_snap(layer: &GraphicsLayer) -> bool {
     (layer.scale - 1.0).abs() <= f32::EPSILON
@@ -403,51 +390,6 @@ pub(crate) fn render_layout_tree(root: &LayoutBox, scene: &mut Scene) {
     scene.replace_graph(graph);
 }
 
-#[cfg(test)]
-fn resolve_text_clip(
-    overflow: TextOverflow,
-    visual_clip: Option<Rect>,
-    transformed_text_bounds: Rect,
-) -> Option<Option<Rect>> {
-    if overflow == TextOverflow::Visible {
-        return Some(visual_clip);
-    }
-    resolve_clip(visual_clip, Some(pad_clip_rect(transformed_text_bounds))).map(Some)
-}
-
-#[cfg(test)]
-fn expand_text_bounds_for_baseline_shift(
-    text_bounds: Rect,
-    text_style: &TextStyle,
-    font_size: f32,
-) -> Rect {
-    let baseline_shift_px = text_style
-        .span_style
-        .baseline_shift
-        .filter(|shift| shift.is_specified())
-        .map(|shift| -(shift.0 * font_size))
-        .unwrap_or(0.0);
-    if baseline_shift_px == 0.0 {
-        return text_bounds;
-    }
-
-    if baseline_shift_px < 0.0 {
-        Rect {
-            x: text_bounds.x,
-            y: text_bounds.y + baseline_shift_px,
-            width: text_bounds.width,
-            height: (text_bounds.height - baseline_shift_px).max(0.0),
-        }
-    } else {
-        Rect {
-            x: text_bounds.x,
-            y: text_bounds.y,
-            width: text_bounds.width,
-            height: (text_bounds.height + baseline_shift_px).max(0.0),
-        }
-    }
-}
-
 fn resolve_text_color_without_gradient_fallback(text_style: &TextStyle, default: Color) -> Color {
     let mut color = text_style
         .span_style
@@ -681,7 +623,9 @@ fn text_decoration_rect(x: f32, y: f32, width: f32, thickness: f32) -> Rect {
 }
 
 #[cfg(test)]
-use cranpose_render_common::scene_builder::resolve_text_measure_width;
+use cranpose_render_common::scene_builder::{
+    expand_text_bounds_for_baseline_shift, resolve_text_measure_width,
+};
 
 #[cfg(test)]
 fn resolve_text_horizontal_offset(
@@ -723,45 +667,6 @@ pub(crate) fn render_from_applier(applier: &mut MemoryApplier, root: NodeId, sce
     };
     collect_hits_from_graph(&graph.root, ProjectiveTransform::identity(), scene, None);
     scene.replace_graph(graph);
-}
-
-fn collect_hits_from_graph(
-    layer: &LayerNode,
-    parent_transform: ProjectiveTransform,
-    scene: &mut Scene,
-    parent_hit_clip: Option<Rect>,
-) {
-    struct SceneHitSink<'a> {
-        scene: &'a mut Scene,
-    }
-
-    impl HitGraphSink for SceneHitSink<'_> {
-        fn push_hit(
-            &mut self,
-            node_id: NodeId,
-            capture_path: &[NodeId],
-            geometry: cranpose_render_common::graph_scene::HitGeometry,
-            shape: Option<RoundedCornerShape>,
-            click_actions: &[Rc<dyn Fn(Point)>],
-            pointer_inputs: &[Rc<dyn Fn(cranpose_foundation::PointerEvent)>],
-        ) {
-            self.scene.push_hit(
-                node_id,
-                capture_path.to_vec(),
-                geometry,
-                shape,
-                click_actions
-                    .iter()
-                    .cloned()
-                    .map(ClickAction::WithPoint)
-                    .collect(),
-                pointer_inputs.to_vec(),
-            );
-        }
-    }
-
-    let mut sink = SceneHitSink { scene };
-    collect_common_hits(layer, parent_transform, &mut sink, parent_hit_clip);
 }
 
 pub(crate) fn build_raster_scene(
@@ -1812,40 +1717,6 @@ mod tests {
                 width: 20.0,
                 height: 20.0,
             }
-        );
-    }
-
-    #[test]
-    fn resolve_text_clip_skips_when_intersection_is_empty() {
-        let visual_clip = Some(Rect {
-            x: 0.0,
-            y: 0.0,
-            width: 10.0,
-            height: 10.0,
-        });
-        let text_bounds = Rect {
-            x: 20.0,
-            y: 20.0,
-            width: 5.0,
-            height: 5.0,
-        };
-        assert_eq!(
-            resolve_text_clip(TextOverflow::Clip, visual_clip, text_bounds),
-            None
-        );
-    }
-
-    #[test]
-    fn resolve_text_clip_visible_keeps_unbounded_draw() {
-        let text_bounds = Rect {
-            x: 20.0,
-            y: 20.0,
-            width: 5.0,
-            height: 5.0,
-        };
-        assert_eq!(
-            resolve_text_clip(TextOverflow::Visible, None, text_bounds),
-            Some(None)
         );
     }
 

--- a/crates/cranpose-render/wgpu/src/pipeline.rs
+++ b/crates/cranpose-render/wgpu/src/pipeline.rs
@@ -6,7 +6,7 @@ use cranpose_render_common::primitive_emit::resolve_clip;
 use cranpose_render_common::{
     Brush, RenderScene,
     geometry::{expand_blurred_rect, union_rect},
-    hit_graph::{HitGraphSink, collect_hits_from_graph as collect_common_hits},
+    hit_graph::collect_hits_from_graph,
     layer_shadow::layer_shadow_geometry,
     layer_transform::{apply_layer_to_rect, layer_uniform_scale},
     primitive_emit::{
@@ -29,21 +29,21 @@ use cranpose_ui::{
     text::{TextDecoration, TextDrawStyle, TextStyle},
     text_layout_result::TextLayoutResult,
 };
+#[cfg(test)]
+use cranpose_ui_graphics::Point;
 use cranpose_ui_graphics::{
-    BlendMode, Color, DrawPrimitive, GraphicsLayer, LayerShape, Point, Rect, RenderEffect,
+    BlendMode, Color, DrawPrimitive, GraphicsLayer, LayerShape, Rect, RenderEffect,
     RoundedCornerShape, RuntimeShader, TileMode,
 };
 
 use crate::{
-    scene::{ClickAction, CompositorScene, DrawShape, Scene, ShadowDraw, TextDraw},
+    scene::{CompositorScene, DrawShape, Scene, ShadowDraw, TextDraw},
     surface_requirements::{SurfaceRequirement, SurfaceRequirementSet},
 };
 
 mod style;
 use style::{apply_layer_to_brush, apply_layer_to_color, scale_corner_radii};
 
-#[cfg(test)]
-const TEXT_CLIP_PAD: f32 = 1.0;
 const GPU_TEXT_BRUSH_EFFECT_MAX_STOPS: usize = 16;
 const GPU_TEXT_BRUSH_EFFECT_FIRST_STOP_SLOT: usize = 8;
 const DECORATION_SEGMENT_MERGE_EPSILON: f32 = 0.75;
@@ -69,16 +69,6 @@ impl TextLayoutResolver for UiTextLayoutResolver {
         style: &TextStyle,
     ) -> TextLayoutResult {
         layout_text(text, style)
-    }
-}
-
-#[cfg(test)]
-fn pad_clip_rect(rect: Rect) -> Rect {
-    Rect {
-        x: rect.x - TEXT_CLIP_PAD,
-        y: rect.y - TEXT_CLIP_PAD,
-        width: (rect.width + TEXT_CLIP_PAD * 2.0).max(0.0),
-        height: (rect.height + TEXT_CLIP_PAD * 2.0).max(0.0),
     }
 }
 
@@ -212,51 +202,6 @@ pub(crate) fn render_layout_tree_with_scale(root: &LayoutBox, scene: &mut Scene,
         None,
     );
     scene.replace_graph(graph);
-}
-
-#[cfg(test)]
-fn resolve_text_clip(
-    overflow: TextOverflow,
-    visual_clip: Option<Rect>,
-    transformed_text_bounds: Rect,
-) -> Option<Option<Rect>> {
-    if overflow == TextOverflow::Visible {
-        return Some(visual_clip);
-    }
-    resolve_clip(visual_clip, Some(pad_clip_rect(transformed_text_bounds))).map(Some)
-}
-
-#[cfg(test)]
-fn expand_text_bounds_for_baseline_shift(
-    text_bounds: Rect,
-    text_style: &TextStyle,
-    font_size: f32,
-) -> Rect {
-    let baseline_shift_px = text_style
-        .span_style
-        .baseline_shift
-        .filter(|shift| shift.is_specified())
-        .map(|shift| -(shift.0 * font_size))
-        .unwrap_or(0.0);
-    if baseline_shift_px == 0.0 {
-        return text_bounds;
-    }
-
-    if baseline_shift_px < 0.0 {
-        Rect {
-            x: text_bounds.x,
-            y: text_bounds.y + baseline_shift_px,
-            width: text_bounds.width,
-            height: (text_bounds.height - baseline_shift_px).max(0.0),
-        }
-    } else {
-        Rect {
-            x: text_bounds.x,
-            y: text_bounds.y,
-            width: text_bounds.width,
-            height: (text_bounds.height + baseline_shift_px).max(0.0),
-        }
-    }
 }
 
 fn resolve_text_color_without_gradient_fallback(text_style: &TextStyle, default: Color) -> Color {
@@ -1908,7 +1853,9 @@ fn decoration_brush_for_span(
 }
 
 #[cfg(test)]
-use cranpose_render_common::scene_builder::resolve_text_measure_width;
+use cranpose_render_common::scene_builder::{
+    expand_text_bounds_for_baseline_shift, resolve_text_measure_width,
+};
 
 #[cfg(test)]
 fn resolve_text_horizontal_offset(
@@ -2051,45 +1998,6 @@ pub(crate) fn update_from_applier(
     );
     scene.replace_graph(graph);
     SceneUpdateOutcome::Patched
-}
-
-fn collect_hits_from_graph(
-    layer: &cranpose_render_common::graph::LayerNode,
-    parent_transform: cranpose_render_common::graph::ProjectiveTransform,
-    scene: &mut Scene,
-    parent_hit_clip: Option<Rect>,
-) {
-    struct SceneHitSink<'a> {
-        scene: &'a mut Scene,
-    }
-
-    impl HitGraphSink for SceneHitSink<'_> {
-        fn push_hit(
-            &mut self,
-            node_id: NodeId,
-            capture_path: &[NodeId],
-            geometry: cranpose_render_common::graph_scene::HitGeometry,
-            shape: Option<RoundedCornerShape>,
-            click_actions: &[Rc<dyn Fn(Point)>],
-            pointer_inputs: &[Rc<dyn Fn(cranpose_foundation::PointerEvent)>],
-        ) {
-            self.scene.push_hit(
-                node_id,
-                capture_path.to_vec(),
-                geometry,
-                shape,
-                click_actions
-                    .iter()
-                    .cloned()
-                    .map(ClickAction::WithPoint)
-                    .collect(),
-                pointer_inputs.to_vec(),
-            );
-        }
-    }
-
-    let mut sink = SceneHitSink { scene };
-    collect_common_hits(layer, parent_transform, &mut sink, parent_hit_clip);
 }
 
 const DRAW_PRIMITIVE_TEXT_NODE_ID: cranpose_core::NodeId = 0;
@@ -2580,40 +2488,6 @@ mod tests {
 
         assert_eq!(scene.hits.len(), 1);
         assert!(scene.graph.is_none());
-    }
-
-    #[test]
-    fn resolve_text_clip_skips_when_intersection_is_empty() {
-        let visual_clip = Some(Rect {
-            x: 0.0,
-            y: 0.0,
-            width: 10.0,
-            height: 10.0,
-        });
-        let text_bounds = Rect {
-            x: 20.0,
-            y: 20.0,
-            width: 5.0,
-            height: 5.0,
-        };
-        assert_eq!(
-            resolve_text_clip(TextOverflow::Clip, visual_clip, text_bounds),
-            None
-        );
-    }
-
-    #[test]
-    fn resolve_text_clip_visible_keeps_unbounded_draw() {
-        let text_bounds = Rect {
-            x: 20.0,
-            y: 20.0,
-            width: 5.0,
-            height: 5.0,
-        };
-        assert_eq!(
-            resolve_text_clip(TextOverflow::Visible, None, text_bounds),
-            Some(None)
-        );
     }
 
     #[test]

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -9069,18 +9069,8 @@ impl GpuRenderer {
                 &mut glyph_cmds,
             )?;
             let mut shape_refs = Vec::with_capacity(budget.shape_count);
-            for batch in chunk.iter() {
-                let SegmentBatchPlan::Shape { start, end, .. } = batch else {
-                    continue;
-                };
-                for (_, item) in &ordered_items[start..end] {
-                    let SegmentDrawItem::Shape(shape_index) = item else {
-                        return Err(format!(
-                            "shape batch contains non-shape draw item: {item:?}"
-                        ));
-                    };
-                    shape_refs.push(&shapes[*shape_index]);
-                }
+            for shape_index in chunk.shape_indices(ordered_items) {
+                shape_refs.push(&shapes[shape_index?]);
             }
             let after_shape_refs = Instant::now();
 
@@ -13035,36 +13025,26 @@ impl GpuRenderer {
         );
     }
 
-    fn prepare_image_draw_cmds<'a, I>(
-        &mut self,
-        layer_images: I,
-        viewport: ViewportUniformParams,
-        root_scale: f32,
-        staged_uploads: &mut StagedBufferUploads,
-    ) -> Result<PreparedImageBatch, String>
-    where
-        I: Iterator<Item = &'a ImageDraw>,
-    {
-        #[cfg(target_arch = "wasm32")]
-        let _ = staged_uploads;
-
+    fn take_scratch_image_buffers(&mut self) -> (Vec<Vertex>, Vec<u32>, Vec<ImageDrawCmd>) {
         let mut image_vertices = std::mem::take(&mut self.scratch_image_vertices);
         let mut image_indices = std::mem::take(&mut self.scratch_image_indices);
         let mut image_cmds = std::mem::take(&mut self.scratch_image_cmds);
         image_vertices.clear();
         image_indices.clear();
         image_cmds.clear();
+        (image_vertices, image_indices, image_cmds)
+    }
 
-        for image_draw in layer_images {
-            self.append_image_draw_cmd(
-                image_draw,
-                viewport,
-                root_scale,
-                &mut image_vertices,
-                &mut image_indices,
-                &mut image_cmds,
-            )?;
-        }
+    fn finish_image_batch(
+        &mut self,
+        viewport: ViewportUniformParams,
+        staged_uploads: &mut StagedBufferUploads,
+        image_vertices: Vec<Vertex>,
+        image_indices: Vec<u32>,
+        image_cmds: Vec<ImageDrawCmd>,
+    ) -> PreparedImageBatch {
+        #[cfg(target_arch = "wasm32")]
+        let _ = staged_uploads;
 
         #[cfg(not(target_arch = "wasm32"))]
         if !image_cmds.is_empty() {
@@ -13103,13 +13083,46 @@ impl GpuRenderer {
 
         self.scratch_image_vertices = image_vertices;
         self.scratch_image_indices = image_indices;
-        Ok(PreparedImageBatch {
+        PreparedImageBatch {
             cmds: image_cmds,
             #[cfg(target_arch = "wasm32")]
             image_slot,
             #[cfg(target_arch = "wasm32")]
             uniform_slot,
-        })
+        }
+    }
+
+    fn prepare_image_draw_cmds<'a, I>(
+        &mut self,
+        layer_images: I,
+        viewport: ViewportUniformParams,
+        root_scale: f32,
+        staged_uploads: &mut StagedBufferUploads,
+    ) -> Result<PreparedImageBatch, String>
+    where
+        I: Iterator<Item = &'a ImageDraw>,
+    {
+        let (mut image_vertices, mut image_indices, mut image_cmds) =
+            self.take_scratch_image_buffers();
+
+        for image_draw in layer_images {
+            self.append_image_draw_cmd(
+                image_draw,
+                viewport,
+                root_scale,
+                &mut image_vertices,
+                &mut image_indices,
+                &mut image_cmds,
+            )?;
+        }
+
+        Ok(self.finish_image_batch(
+            viewport,
+            staged_uploads,
+            image_vertices,
+            image_indices,
+            image_cmds,
+        ))
     }
 
     fn glyph_atlas_entry_for(
@@ -14180,15 +14193,8 @@ impl GpuRenderer {
     where
         I: Iterator<Item = &'a TextDraw>,
     {
-        #[cfg(target_arch = "wasm32")]
-        let _ = staged_uploads;
-
-        let mut image_vertices = std::mem::take(&mut self.scratch_image_vertices);
-        let mut image_indices = std::mem::take(&mut self.scratch_image_indices);
-        let mut image_cmds = std::mem::take(&mut self.scratch_image_cmds);
-        image_vertices.clear();
-        image_indices.clear();
-        image_cmds.clear();
+        let (mut image_vertices, mut image_indices, mut image_cmds) =
+            self.take_scratch_image_buffers();
 
         self.append_text_image_draw_cmds(
             layer_texts,
@@ -14199,50 +14205,13 @@ impl GpuRenderer {
             &mut image_cmds,
         )?;
 
-        #[cfg(not(target_arch = "wasm32"))]
-        if !image_cmds.is_empty() {
-            self.stage_native_image_buffers(
-                staged_uploads,
-                viewport,
-                &image_vertices,
-                &image_indices,
-            );
-        }
-
-        #[cfg(target_arch = "wasm32")]
-        let image_slot = if image_cmds.is_empty() {
-            0
-        } else {
-            let slot = self.claim_wasm_image_batch();
-            {
-                let buffers = &mut self.wasm_image_batches[slot];
-                buffers.ensure_capacity(&self.device, image_vertices.len(), image_indices.len());
-            }
-            let buffers = &self.wasm_image_batches[slot];
-            self.write_wasm_buffer(
-                &buffers.vertex_buffer,
-                bytemuck::cast_slice(&image_vertices),
-            );
-            self.write_wasm_buffer(&buffers.index_buffer, bytemuck::cast_slice(&image_indices));
-            slot
-        };
-
-        #[cfg(target_arch = "wasm32")]
-        let uniform_slot = if image_cmds.is_empty() {
-            0
-        } else {
-            self.prepare_wasm_viewport_uniforms(viewport)
-        };
-
-        self.scratch_image_vertices = image_vertices;
-        self.scratch_image_indices = image_indices;
-        Ok(PreparedImageBatch {
-            cmds: image_cmds,
-            #[cfg(target_arch = "wasm32")]
-            image_slot,
-            #[cfg(target_arch = "wasm32")]
-            uniform_slot,
-        })
+        Ok(self.finish_image_batch(
+            viewport,
+            staged_uploads,
+            image_vertices,
+            image_indices,
+            image_cmds,
+        ))
     }
 
     fn text_raster_geometry(
@@ -14832,6 +14801,24 @@ impl SegmentDrawChunkPlan {
     fn iter(&self) -> impl Iterator<Item = SegmentBatchPlan> + '_ {
         self.batches.iter().copied()
     }
+
+    fn shape_indices<'a>(
+        &'a self,
+        ordered_items: &'a [(usize, SegmentDrawItem)],
+    ) -> impl Iterator<Item = Result<usize, String>> + 'a {
+        self.iter().flat_map(move |batch| {
+            let range = match batch {
+                SegmentBatchPlan::Shape { start, end, .. } => start..end,
+                _ => 0..0,
+            };
+            ordered_items[range].iter().map(|(_, item)| match item {
+                SegmentDrawItem::Shape(shape_index) => Ok(*shape_index),
+                other => Err(format!(
+                    "shape batch contains non-shape draw item: {other:?}"
+                )),
+            })
+        })
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -14976,21 +14963,11 @@ fn native_segment_fusion_budget(
     let mut shape_count = 0usize;
     let mut gradient_stop_count = 0usize;
 
-    for batch in chunk.iter() {
-        let SegmentBatchPlan::Shape { start, end, .. } = batch else {
-            continue;
-        };
-        for (_, item) in &ordered_items[start..end] {
-            let SegmentDrawItem::Shape(shape_index) = item else {
-                return Err(format!(
-                    "shape batch contains non-shape draw item: {item:?}"
-                ));
-            };
-            let shape = &shapes[*shape_index];
-            shape_count = shape_count.saturating_add(1);
-            gradient_stop_count =
-                gradient_stop_count.saturating_add(gradient_stop_count_for_shape(shape, brushes));
-        }
+    for shape_index in chunk.shape_indices(ordered_items) {
+        let shape = &shapes[shape_index?];
+        shape_count = shape_count.saturating_add(1);
+        gradient_stop_count =
+            gradient_stop_count.saturating_add(gradient_stop_count_for_shape(shape, brushes));
     }
 
     if shape_count > batch_limits.max_shapes_per_batch

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -1650,6 +1650,127 @@ pub(crate) fn root_direct_scene_events_are_supported(
 }
 
 #[allow(clippy::too_many_arguments)]
+fn composite_captured_effect_layer<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    source: &OffscreenTarget,
+    target_view: &wgpu::TextureView,
+    layer: &EffectLayer,
+    dest_quad: [[f32; 2]; 4],
+    scissor: (u32, u32, u32, u32),
+    capture_rect: Rect,
+    effect_width: u32,
+    effect_height: u32,
+    width: u32,
+    height: u32,
+    sample_mode: CompositeSampleMode,
+) -> Result<(), String> {
+    let composite_plain = |backend: &mut B| {
+        composite_surface_to_view(
+            backend,
+            source,
+            target_view,
+            (width, height),
+            dest_quad,
+            layer.composite_alpha,
+            wgpu::LoadOp::Load,
+            Some(scissor),
+            layer.blend_mode,
+            sample_mode,
+        )
+    };
+    let Some(effect) = &layer.effect else {
+        return composite_plain(backend);
+    };
+    if !backend.is_render_effect_supported(effect) {
+        backend.warn_unsupported_effect_once();
+        return composite_plain(backend);
+    }
+
+    let pixel_rect =
+        content_effect_pixel_rect(Some(layer.rect), capture_rect, effect_width, effect_height);
+    if let Some(dest_rect) = axis_aligned_quad_rect(dest_quad) {
+        let dest_viewport = Some(composite_dest_viewport(
+            dest_rect,
+            effect_width,
+            effect_height,
+            sample_mode,
+        ));
+        if let RenderEffect::Shader { shader } = effect {
+            backend.apply_shader_and_composite_to_view(
+                source,
+                shader,
+                pixel_rect,
+                target_view,
+                layer.composite_alpha,
+                wgpu::LoadOp::Load,
+                Some(scissor),
+                layer.blend_mode,
+                dest_viewport,
+                sample_mode,
+            );
+            Ok(())
+        } else {
+            backend.apply_effect_and_composite_to_view(
+                source,
+                effect,
+                pixel_rect,
+                target_view,
+                layer.composite_alpha,
+                wgpu::LoadOp::Load,
+                Some(scissor),
+                layer.blend_mode,
+                dest_viewport,
+                sample_mode,
+            )
+        }
+    } else {
+        let source_rect = Rect {
+            x: 0.0,
+            y: 0.0,
+            width: effect_width as f32,
+            height: effect_height as f32,
+        };
+        let inverse = ProjectiveTransform::from_rect_to_quad(source_rect, dest_quad)
+            .inverse()
+            .ok_or_else(|| "effect layer transform is not invertible".to_string())?;
+        if let RenderEffect::Shader { shader } = effect {
+            backend.apply_shader_and_composite_to_view_projective(
+                source,
+                shader,
+                pixel_rect,
+                target_view,
+                (width, height),
+                (source_rect.width, source_rect.height),
+                inverse.matrix(),
+                dest_quad,
+                layer.composite_alpha,
+                wgpu::LoadOp::Load,
+                Some(scissor),
+                layer.blend_mode,
+                sample_mode,
+            );
+            Ok(())
+        } else {
+            backend.apply_effect_and_composite_to_view_projective(
+                source,
+                effect,
+                pixel_rect,
+                target_view,
+                (width, height),
+                (source_rect.width, source_rect.height),
+                inverse.matrix(),
+                dest_quad,
+                layer.composite_alpha,
+                wgpu::LoadOp::Load,
+                Some(scissor),
+                layer.blend_mode,
+                sample_mode,
+            )
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn render_effect_layer_to_view<B: SurfaceExecutionBackend>(
     backend: &mut B,
     target_view: &wgpu::TextureView,
@@ -1764,139 +1885,20 @@ fn render_effect_layer_to_view<B: SurfaceExecutionBackend>(
         root_scale,
         sample_mode,
     );
-    let composite_result = if layer.effect.is_none() {
-        composite_surface_to_view(
-            backend,
-            &source,
-            target_view,
-            (width, height),
-            dest_quad,
-            layer.composite_alpha,
-            wgpu::LoadOp::Load,
-            Some(scissor),
-            layer.blend_mode,
-            sample_mode,
-        )
-    } else if let Some(effect) = &layer.effect {
-        if backend.is_render_effect_supported(effect) {
-            if let Some(dest_rect) = axis_aligned_quad_rect(dest_quad) {
-                let dest_viewport = Some(composite_dest_viewport(
-                    dest_rect,
-                    effect_width,
-                    effect_height,
-                    sample_mode,
-                ));
-                if let RenderEffect::Shader { shader } = effect {
-                    backend.apply_shader_and_composite_to_view(
-                        &source,
-                        shader,
-                        content_effect_pixel_rect(
-                            Some(layer.rect),
-                            capture_rect,
-                            effect_width,
-                            effect_height,
-                        ),
-                        target_view,
-                        layer.composite_alpha,
-                        wgpu::LoadOp::Load,
-                        Some(scissor),
-                        layer.blend_mode,
-                        dest_viewport,
-                        sample_mode,
-                    );
-                    Ok(())
-                } else {
-                    backend.apply_effect_and_composite_to_view(
-                        &source,
-                        effect,
-                        content_effect_pixel_rect(
-                            Some(layer.rect),
-                            capture_rect,
-                            effect_width,
-                            effect_height,
-                        ),
-                        target_view,
-                        layer.composite_alpha,
-                        wgpu::LoadOp::Load,
-                        Some(scissor),
-                        layer.blend_mode,
-                        dest_viewport,
-                        sample_mode,
-                    )
-                }
-            } else {
-                let source_rect = Rect {
-                    x: 0.0,
-                    y: 0.0,
-                    width: effect_width as f32,
-                    height: effect_height as f32,
-                };
-                let inverse = ProjectiveTransform::from_rect_to_quad(source_rect, dest_quad)
-                    .inverse()
-                    .ok_or_else(|| "effect layer transform is not invertible".to_string())?;
-                if let RenderEffect::Shader { shader } = effect {
-                    backend.apply_shader_and_composite_to_view_projective(
-                        &source,
-                        shader,
-                        content_effect_pixel_rect(
-                            Some(layer.rect),
-                            capture_rect,
-                            effect_width,
-                            effect_height,
-                        ),
-                        target_view,
-                        (width, height),
-                        (source_rect.width, source_rect.height),
-                        inverse.matrix(),
-                        dest_quad,
-                        layer.composite_alpha,
-                        wgpu::LoadOp::Load,
-                        Some(scissor),
-                        layer.blend_mode,
-                        sample_mode,
-                    );
-                    Ok(())
-                } else {
-                    backend.apply_effect_and_composite_to_view_projective(
-                        &source,
-                        effect,
-                        content_effect_pixel_rect(
-                            Some(layer.rect),
-                            capture_rect,
-                            effect_width,
-                            effect_height,
-                        ),
-                        target_view,
-                        (width, height),
-                        (source_rect.width, source_rect.height),
-                        inverse.matrix(),
-                        dest_quad,
-                        layer.composite_alpha,
-                        wgpu::LoadOp::Load,
-                        Some(scissor),
-                        layer.blend_mode,
-                        sample_mode,
-                    )
-                }
-            }
-        } else {
-            backend.warn_unsupported_effect_once();
-            composite_surface_to_view(
-                backend,
-                &source,
-                target_view,
-                (width, height),
-                dest_quad,
-                layer.composite_alpha,
-                wgpu::LoadOp::Load,
-                Some(scissor),
-                layer.blend_mode,
-                sample_mode,
-            )
-        }
-    } else {
-        Err("effect layer destination requested without render effect".to_string())
-    };
+    let composite_result = composite_captured_effect_layer(
+        backend,
+        &source,
+        target_view,
+        &layer,
+        dest_quad,
+        scissor,
+        capture_rect,
+        effect_width,
+        effect_height,
+        width,
+        height,
+        sample_mode,
+    );
     backend.release_frame_surface(source);
     composite_result
 }
@@ -5749,121 +5751,22 @@ pub(crate) fn render_effect_layer_to_target<B: SurfaceExecutionBackend>(
         root_scale,
         sample_mode,
     );
-    if layer.effect.is_none() {
-        let composite_result = composite_surface_to_view(
-            backend,
-            &source,
-            &target.view,
-            (width, height),
-            dest_quad,
-            layer.composite_alpha,
-            wgpu::LoadOp::Load,
-            Some(scissor),
-            layer.blend_mode,
-            sample_mode,
-        );
-        backend.release_frame_surface(source);
-        return composite_result;
-    }
-
-    let Some(effect) = &layer.effect else {
-        backend.release_frame_surface(source);
-        return Err("effect layer destination requested without render effect".to_string());
-    };
-    if backend.is_render_effect_supported(effect) {
-        if let Some(dest_rect) = axis_aligned_quad_rect(dest_quad) {
-            let dest_viewport = Some(composite_dest_viewport(
-                dest_rect,
-                effect_width,
-                effect_height,
-                sample_mode,
-            ));
-            if let RenderEffect::Shader { shader } = effect {
-                backend.apply_shader_and_composite_to_view(
-                    &source,
-                    shader,
-                    content_effect_pixel_rect(
-                        Some(layer.rect),
-                        capture_rect,
-                        effect_width,
-                        effect_height,
-                    ),
-                    &target.view,
-                    layer.composite_alpha,
-                    wgpu::LoadOp::Load,
-                    Some(scissor),
-                    layer.blend_mode,
-                    dest_viewport,
-                    sample_mode,
-                );
-            } else {
-                backend.apply_effect_and_composite_to_view(
-                    &source,
-                    effect,
-                    content_effect_pixel_rect(
-                        Some(layer.rect),
-                        capture_rect,
-                        effect_width,
-                        effect_height,
-                    ),
-                    &target.view,
-                    layer.composite_alpha,
-                    wgpu::LoadOp::Load,
-                    Some(scissor),
-                    layer.blend_mode,
-                    dest_viewport,
-                    sample_mode,
-                )?;
-            }
-        } else {
-            let source_rect = Rect {
-                x: 0.0,
-                y: 0.0,
-                width: effect_width as f32,
-                height: effect_height as f32,
-            };
-            let inverse = ProjectiveTransform::from_rect_to_quad(source_rect, dest_quad)
-                .inverse()
-                .ok_or_else(|| "effect layer transform is not invertible".to_string())?;
-            backend.apply_effect_and_composite_to_view_projective(
-                &source,
-                effect,
-                content_effect_pixel_rect(
-                    Some(layer.rect),
-                    capture_rect,
-                    effect_width,
-                    effect_height,
-                ),
-                &target.view,
-                (width, height),
-                (source_rect.width, source_rect.height),
-                inverse.matrix(),
-                dest_quad,
-                layer.composite_alpha,
-                wgpu::LoadOp::Load,
-                Some(scissor),
-                layer.blend_mode,
-                sample_mode,
-            )?;
-        }
-    } else {
-        backend.warn_unsupported_effect_once();
-        composite_surface_to_view(
-            backend,
-            &source,
-            &target.view,
-            (width, height),
-            dest_quad,
-            layer.composite_alpha,
-            wgpu::LoadOp::Load,
-            Some(scissor),
-            layer.blend_mode,
-            sample_mode,
-        )?;
-    }
-
+    let composite_result = composite_captured_effect_layer(
+        backend,
+        &source,
+        &target.view,
+        &layer,
+        dest_quad,
+        scissor,
+        capture_rect,
+        effect_width,
+        effect_height,
+        width,
+        height,
+        sample_mode,
+    );
     backend.release_frame_surface(source);
-    Ok(())
+    composite_result
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/cranpose-render/wgpu/tests/render_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/render_contract.rs
@@ -851,26 +851,24 @@ fn transformed_effect_layer_records_effect_and_projective_composite_together() {
     let surface_backend_source =
         std::fs::read_to_string(crate_dir.join("src/surface_executor/backend.rs"))
             .expect("failed to read surface backend source");
-    let start = surface_executor_source
-        .find("pub(crate) fn render_effect_layer_to_target")
-        .expect("effect layer renderer must exist");
-    let end = surface_executor_source[start..]
-        .find("pub(crate) fn apply_backdrop_layer_to_target")
-        .map(|offset| start + offset)
-        .expect("backdrop layer renderer must follow effect layer renderer");
-    let body = &surface_executor_source[start..end];
+    assert!(
+        surface_executor_source.contains("pub(crate) fn render_effect_layer_to_target")
+            && surface_executor_source.contains("pub(crate) fn apply_backdrop_layer_to_target"),
+        "effect layer renderer must exist alongside the backdrop layer renderer"
+    );
 
     assert!(
         surface_backend_source.contains("fn apply_effect_and_composite_to_view_projective("),
         "surface backends must expose a combined transformed effect composite path"
     );
     assert!(
-        body.contains("backend.apply_effect_and_composite_to_view_projective("),
+        surface_executor_source.contains("backend.apply_effect_and_composite_to_view_projective("),
         "transformed render-effect layers must record effect and projective composite together"
     );
     assert!(
-        !body.contains("let effect_dest = backend.acquire_offscreen(effect_width, effect_height);")
-            && !body.contains(
+        !surface_executor_source
+            .contains("let effect_dest = backend.acquire_offscreen(effect_width, effect_height);")
+            && !surface_executor_source.contains(
                 "let fallback_dest = backend.acquire_offscreen(effect_width, effect_height);"
             ),
         "transformed render-effect layers must not allocate caller-owned intermediate targets"
@@ -1055,10 +1053,11 @@ fn surface_executor_allocations_are_semantic() {
     assert!(
         !surface_executor_source
             .contains("effect-free layers return before allocating a destination surface")
-            && surface_executor_source
-                .contains("effect layer destination requested without render effect")
+            && surface_executor_source.contains("fn composite_captured_effect_layer")
+            && surface_executor_source.contains("effect layer transform is not invertible")
             && surface_executor_source.contains("backend.release_frame_surface(source);"),
-        "effect-layer destination failures must release frame surfaces and return renderer errors"
+        "effect-layer destination composites must share one path that returns renderer errors \
+         to the caller, which unconditionally releases the frame surface"
     );
     assert!(
         render_source.contains("fn acquire_retained_surface(&mut self, width: u32, height: u32)")


### PR DESCRIPTION
## Summary

Deduplication pass scoped to `crates/cranpose-render/wgpu/`, touching `pixels/` and `common/` only where a clone pair spanned wgpu and one of them.

**Before/after** (`jscpd --min-lines 10 --min-tokens 50 --format rust crates/cranpose-render`): **491 -> 481** total clone pairs; **363 -> 355** pairs touching `crates/cranpose-render/wgpu`.

## Abstractions extracted

1. **`composite_captured_effect_layer`** (`wgpu/src/surface_executor/render_paths.rs`) — `render_effect_layer_to_view` and `render_effect_layer_to_target` each carried their own ~120-line copy of "apply the layer's render effect (or a plain composite) to a destination view, handling the axis-aligned and projective cases and the Shader-vs-other-effect split." Extracted into one function parameterized on the destination `&wgpu::TextureView` and the already-resolved geometry (`dest_quad`, `scissor`, `capture_rect`, etc). Both callers now just build their geometry, call the helper, and release the frame surface.

2. **`take_scratch_image_buffers` / `finish_image_batch`** (`wgpu/src/render.rs`) — `prepare_image_draw_cmds` and `prepare_text_image_draw_cmds` shared an identical ~45-line tail (stage native buffers, or claim a wasm batch slot and viewport-uniform slot, and build `PreparedImageBatch`). Split into acquire+clear and stage+return halves; each caller keeps only its own population loop.

3. **`SegmentDrawChunkPlan::shape_indices`** (`wgpu/src/render.rs`) — two call sites hand-walked a chunk's `Shape` batches to read out shape indices, one collecting `&DrawShape` refs and one summing a native-fusion budget. Added an iterator method on `SegmentDrawChunkPlan` that yields `Result<usize, String>` per shape (erroring on a malformed batch); both sites now just consume it.

4. **Dead test scaffolding removed, `expand_text_bounds_for_baseline_shift` unified** (`wgpu/src/pipeline.rs`, `pixels/src/pipeline.rs`, `common/src/scene_builder.rs`) — both backend crates carried a private, `cfg(test)`-only `resolve_text_clip`/`pad_clip_rect`/`TEXT_CLIP_PAD`, byte-identical between the two crates and with zero production callers in either (confirmed by grep — `common`'s scene builder resolves text clips a different way entirely). Deleted from both crates along with its two tests. Both crates also had their own private, byte-identical copy of `expand_text_bounds_for_baseline_shift`, even though `common::scene_builder` already has the real (production) implementation. Made that one `pub` and repointed both crates' tests to import it, matching the precedent already set for `resolve_text_measure_width` (see the doc comment on that function).

5. **`impl HitGraphSink for Scene`** (`common/src/hit_graph.rs`) — both `wgpu` and `pixels` defined a private `collect_hits_from_graph` wrapping a local `SceneHitSink` adapter struct whose only job was bridging `common`'s generic `HitGraphSink` trait to `common`'s own `Scene` type (both crates re-export `Scene`/`ClickAction` from `common::graph_scene` rather than defining their own). Implemented the trait for `Scene` directly in `common`, deleted both crates' adapters, and pointed their call sites at `common`'s `collect_hits_from_graph`.

## Test fallout from #1

Extracting the composite logic out of `render_effect_layer_to_target`'s own body broke two source-text contract tests in `wgpu/tests/render_contract.rs` that grepped that function's body specifically:

- `transformed_effect_layer_records_effect_and_projective_composite_together` checked that the function's body contained the `apply_effect_and_composite_to_view_projective(` call. Widened to check the whole surface-executor module (the call still happens, just from the now-shared helper called by both `_to_view` and `_to_target`).
- `surface_executor_allocations_are_semantic` checked for the literal string `"effect layer destination requested without render effect"`. That branch was structurally unreachable in both original functions (a defensive `else`/`let-else` arm after an exhaustive `Option` check that had already handled the `None` case) and the refactor correctly dropped it. Repointed the assertion at the real surviving invariant: `composite_captured_effect_layer` is the one path that raises `"effect layer transform is not invertible"`, and its callers unconditionally release the frame surface after calling it.

Both were confirmed passing after the fix; full `cargo test --profile ci -p cranpose-render-wgpu` (all 500+ lib tests plus every integration test file), `-p cranpose-render-pixels`, and `-p cranpose-render-common` are green, as are `cargo clippy --all-targets -- -D warnings` for all three crates, `just complexity-gate`, and `just duplication-gate` (0 new clones introduced by the diff).

## Deliberately left alone

- **`render_effect_layer_to_view` / `render_effect_layer_to_target` setup preambles** still duplicate ~100 lines (layer/visible-rect/capture-rect/window-scene setup). `_to_target` additionally supports compositing against a `backdrop_underlay` (acquiring/copying/releasing an extra offscreen surface) that `_to_view` explicitly rejects with an error — a real capability difference, not copy-paste. Unifying further would need a destination enum/trait threaded through the whole setup for a comparatively small payoff; flagging as a candidate rather than forcing it.
- **`resolve_text_measure_width` and `resolve_clip` contract tests**, duplicated near-verbatim between `wgpu/src/pipeline.rs` and `pixels/src/pipeline.rs` (the biggest remaining single cluster, ~180 lines). Both functions already have exactly one production implementation in `common`; the doc comment on `resolve_text_measure_width` explains these per-crate tests are intentional — kept so each downstream crate guards its own wiring to the shared function, not merely so the codebase has more tests. Left in place.
- **`record_effect_composite` / `record_effect_projective_composite`** in `render.rs` (~40-line duplicate, GPU pass-recording code with scratch/recorder acquire-release lifetimes) is the same axis-aligned-vs-projective shape as #1 above, one layer lower in the stack. Did not attempt it in this pass — correctness here is harder to verify by inspection alone and it deserves its own focused pass rather than a rushed mechanical extraction.

## Test plan

- [x] `just fmt` (no diff)
- [x] `cargo check -p cranpose-render-wgpu --all-targets`
- [x] `cargo clippy -p cranpose-render-wgpu -p cranpose-render-pixels -p cranpose-render-common --all-targets -- -D warnings`
- [x] `cargo test --profile ci -p cranpose-render-wgpu` (all integration test binaries, including `pass_timing_report` — no SIGSEGV on this host)
- [x] `cargo test --profile ci -p cranpose-render-pixels` / `-p cranpose-render-common`
- [x] `cargo check --workspace --all-targets`
- [x] `just complexity-gate` / `just duplication-gate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)