### PR TITLE
Dedup cranpose-ui: shared measurer/modifier-node/test-fixture abstractions

### DIFF
--- a/crates/cranpose-ui/src/layout/tests/layout_tests.rs
+++ b/crates/cranpose-ui/src/layout/tests/layout_tests.rs
@@ -203,6 +203,67 @@ impl MeasurePolicy for MutableLeafPolicy {
     }
 }
 
+struct DirtyCleanLeaves {
+    applier: MemoryApplier,
+    root_id: NodeId,
+    dirty_child: NodeId,
+    clean_child: NodeId,
+    dirty_size: Rc<Cell<Size>>,
+    dirty_calls: Rc<Cell<usize>>,
+    clean_calls: Rc<Cell<usize>>,
+}
+
+fn measured_dirty_clean_leaves() -> Result<DirtyCleanLeaves, NodeError> {
+    let dirty_size = Rc::new(Cell::new(Size::new(10.0, 10.0)));
+    let dirty_calls = Rc::new(Cell::new(0usize));
+    let clean_size = Rc::new(Cell::new(Size::new(5.0, 5.0)));
+    let clean_calls = Rc::new(Cell::new(0usize));
+
+    let mut applier = MemoryApplier::new();
+    let dirty_child = applier.create(Box::new(LayoutNode::new(
+        Modifier::empty(),
+        Rc::new(MutableLeafPolicy {
+            size: Rc::clone(&dirty_size),
+            calls: Rc::clone(&dirty_calls),
+        }),
+    )));
+    let clean_child = applier.create(Box::new(LayoutNode::new(
+        Modifier::empty(),
+        Rc::new(MutableLeafPolicy {
+            size: clean_size,
+            calls: Rc::clone(&clean_calls),
+        }),
+    )));
+
+    let mut root = LayoutNode::new(Modifier::empty(), Rc::new(VerticalStackPolicy));
+    root.children.push(dirty_child);
+    root.children.push(clean_child);
+    let root_id = applier.create(Box::new(root));
+
+    applier.with_node::<LayoutNode, _>(root_id, |node| node.set_node_id(root_id))?;
+    applier.with_node::<LayoutNode, _>(dirty_child, |node| {
+        node.set_node_id(dirty_child);
+        node.set_parent(root_id);
+    })?;
+    applier.with_node::<LayoutNode, _>(clean_child, |node| {
+        node.set_node_id(clean_child);
+        node.set_parent(root_id);
+    })?;
+
+    let first = measure_layout(&mut applier, root_id, Size::new(100.0, 100.0))?;
+    assert_eq!(first.root_size().height, 15.0);
+
+    Ok(DirtyCleanLeaves {
+        applier,
+        root_id,
+        dirty_child,
+        clean_child,
+        dirty_size,
+        dirty_calls,
+        clean_calls,
+    })
+}
+
 #[derive(Clone)]
 struct RecordingDensityPolicy {
     recorded: Rc<Cell<f32>>,
@@ -983,44 +1044,16 @@ fn scoped_layout_repass_remeasures_only_dirty_subtree() -> Result<(), NodeError>
     let _app_context = crate::render_state::app_context_test_scope();
     let _guard = crate::render_state::render_state_test_guard();
     crate::reset_render_state_for_tests();
-    let dirty_size = Rc::new(Cell::new(Size::new(10.0, 10.0)));
-    let dirty_calls = Rc::new(Cell::new(0usize));
-    let clean_size = Rc::new(Cell::new(Size::new(5.0, 5.0)));
-    let clean_calls = Rc::new(Cell::new(0usize));
+    let DirtyCleanLeaves {
+        mut applier,
+        root_id,
+        dirty_child,
+        clean_child,
+        dirty_size,
+        dirty_calls,
+        clean_calls,
+    } = measured_dirty_clean_leaves()?;
 
-    let mut applier = MemoryApplier::new();
-    let dirty_child = applier.create(Box::new(LayoutNode::new(
-        Modifier::empty(),
-        Rc::new(MutableLeafPolicy {
-            size: Rc::clone(&dirty_size),
-            calls: Rc::clone(&dirty_calls),
-        }),
-    )));
-    let clean_child = applier.create(Box::new(LayoutNode::new(
-        Modifier::empty(),
-        Rc::new(MutableLeafPolicy {
-            size: Rc::clone(&clean_size),
-            calls: Rc::clone(&clean_calls),
-        }),
-    )));
-
-    let mut root = LayoutNode::new(Modifier::empty(), Rc::new(VerticalStackPolicy));
-    root.children.push(dirty_child);
-    root.children.push(clean_child);
-    let root_id = applier.create(Box::new(root));
-
-    applier.with_node::<LayoutNode, _>(root_id, |node| node.set_node_id(root_id))?;
-    applier.with_node::<LayoutNode, _>(dirty_child, |node| {
-        node.set_node_id(dirty_child);
-        node.set_parent(root_id);
-    })?;
-    applier.with_node::<LayoutNode, _>(clean_child, |node| {
-        node.set_node_id(clean_child);
-        node.set_parent(root_id);
-    })?;
-
-    let first = measure_layout(&mut applier, root_id, Size::new(100.0, 100.0))?;
-    assert_eq!(first.root_size().height, 15.0);
     assert_eq!(
         dirty_calls.get(),
         1,
@@ -1213,44 +1246,16 @@ fn measure_layout_consumes_pending_scoped_repass_for_dirty_child() -> Result<(),
     let _guard = crate::render_state::render_state_test_guard();
     crate::reset_render_state_for_tests();
 
-    let dirty_size = Rc::new(Cell::new(Size::new(10.0, 10.0)));
-    let dirty_calls = Rc::new(Cell::new(0usize));
-    let clean_size = Rc::new(Cell::new(Size::new(5.0, 5.0)));
-    let clean_calls = Rc::new(Cell::new(0usize));
+    let DirtyCleanLeaves {
+        mut applier,
+        root_id,
+        dirty_child,
+        dirty_size,
+        dirty_calls,
+        clean_calls,
+        ..
+    } = measured_dirty_clean_leaves()?;
 
-    let mut applier = MemoryApplier::new();
-    let dirty_child = applier.create(Box::new(LayoutNode::new(
-        Modifier::empty(),
-        Rc::new(MutableLeafPolicy {
-            size: Rc::clone(&dirty_size),
-            calls: Rc::clone(&dirty_calls),
-        }),
-    )));
-    let clean_child = applier.create(Box::new(LayoutNode::new(
-        Modifier::empty(),
-        Rc::new(MutableLeafPolicy {
-            size: Rc::clone(&clean_size),
-            calls: Rc::clone(&clean_calls),
-        }),
-    )));
-
-    let mut root = LayoutNode::new(Modifier::empty(), Rc::new(VerticalStackPolicy));
-    root.children.push(dirty_child);
-    root.children.push(clean_child);
-    let root_id = applier.create(Box::new(root));
-
-    applier.with_node::<LayoutNode, _>(root_id, |node| node.set_node_id(root_id))?;
-    applier.with_node::<LayoutNode, _>(dirty_child, |node| {
-        node.set_node_id(dirty_child);
-        node.set_parent(root_id);
-    })?;
-    applier.with_node::<LayoutNode, _>(clean_child, |node| {
-        node.set_node_id(clean_child);
-        node.set_parent(root_id);
-    })?;
-
-    let first = measure_layout(&mut applier, root_id, Size::new(100.0, 100.0))?;
-    assert_eq!(first.root_size().height, 15.0);
     let epoch_before =
         applier.with_node::<LayoutNode, _>(root_id, |node| node.cache_handles().epoch())?;
 

--- a/crates/cranpose-ui/src/modifier_nodes.rs
+++ b/crates/cranpose-ui/src/modifier_nodes.rs
@@ -158,6 +158,163 @@ fn hash_alignment<H: Hasher>(state: &mut H, alignment: Alignment) {
     hash_vertical_alignment(state, alignment.vertical);
 }
 
+macro_rules! impl_layout_modifier_node {
+    ($ty:ty) => {
+        impl ModifierNode for $ty {
+            fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
+                Some(self)
+            }
+
+            fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
+                Some(self)
+            }
+        }
+    };
+    ($ty:ty, invalidate = $invalidation:expr) => {
+        impl ModifierNode for $ty {
+            fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
+                context.invalidate($invalidation);
+            }
+
+            fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
+                Some(self)
+            }
+
+            fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
+                Some(self)
+            }
+        }
+    };
+}
+
+macro_rules! impl_draw_modifier_node {
+    ($ty:ty) => {
+        impl ModifierNode for $ty {
+            fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
+                context.invalidate(InvalidationKind::Draw);
+            }
+
+            fn as_draw_node(&self) -> Option<&dyn DrawModifierNode> {
+                Some(self)
+            }
+
+            fn as_draw_node_mut(&mut self) -> Option<&mut dyn DrawModifierNode> {
+                Some(self)
+            }
+        }
+
+        impl DrawModifierNode for $ty {
+            fn draw(&self, _draw_scope: &mut dyn DrawScope) {}
+        }
+    };
+}
+
+macro_rules! forward_intrinsics_to_child {
+    () => {
+        fn min_intrinsic_width(&self, measurable: &dyn Measurable, height: f32) -> f32 {
+            measurable.min_intrinsic_width(height)
+        }
+
+        fn max_intrinsic_width(&self, measurable: &dyn Measurable, height: f32) -> f32 {
+            measurable.max_intrinsic_width(height)
+        }
+
+        fn min_intrinsic_height(&self, measurable: &dyn Measurable, width: f32) -> f32 {
+            measurable.min_intrinsic_height(width)
+        }
+
+        fn max_intrinsic_height(&self, measurable: &dyn Measurable, width: f32) -> f32 {
+            measurable.max_intrinsic_height(width)
+        }
+    };
+}
+
+macro_rules! impl_sink_reporter_element {
+    ($element:ty, $node:ty) => {
+        impl ModifierNodeElement for $element {
+            type Node = $node;
+
+            fn create(&self) -> Self::Node {
+                <$node>::new(self.sink.clone())
+            }
+
+            fn update(&self, node: &mut Self::Node) {
+                node.sink = self.sink.clone();
+            }
+
+            fn capabilities(&self) -> NodeCapabilities {
+                NodeCapabilities::LAYOUT
+            }
+        }
+    };
+}
+
+fn measure_pass_through(
+    measurable: &dyn Measurable,
+    constraints: Constraints,
+    offset: impl FnOnce(Size) -> (f32, f32),
+) -> cranpose_ui_layout::LayoutModifierMeasureResult {
+    let placeable = measurable.measure(constraints);
+    let size = Size {
+        width: placeable.width(),
+        height: placeable.height(),
+    };
+    let (x, y) = offset(size);
+    cranpose_ui_layout::LayoutModifierMeasureResult::new(size, x, y)
+}
+
+fn attach_draw_observer(
+    node_id_cell: &Cell<Option<NodeId>>,
+    context: &mut dyn ModifierNodeContext,
+) {
+    node_id_cell.set(context.node_id());
+    context.invalidate(InvalidationKind::Draw);
+}
+
+fn detach_draw_observer(node_id_cell: &Cell<Option<NodeId>>) {
+    if let Some(node_id) = node_id_cell.replace(None) {
+        crate::render_state::clear_draw_observations_for_node(node_id);
+    }
+}
+
+enum SizeAxis {
+    Width,
+    Height,
+}
+
+fn size_intrinsic(
+    target: Constraints,
+    axis: SizeAxis,
+    enforce_incoming: bool,
+    cross: f32,
+    intrinsic: impl FnOnce(f32) -> f32,
+) -> f32 {
+    let (target_min, target_max, cross_min, cross_max) = match axis {
+        SizeAxis::Width => (
+            target.min_width,
+            target.max_width,
+            target.min_height,
+            target.max_height,
+        ),
+        SizeAxis::Height => (
+            target.min_height,
+            target.max_height,
+            target.min_width,
+            target.max_width,
+        ),
+    };
+    if target_min == target_max && target_max != f32::INFINITY {
+        target_max
+    } else {
+        let child_cross = if enforce_incoming {
+            cross
+        } else {
+            cross.clamp(cross_min, cross_max)
+        };
+        intrinsic(child_cross).clamp(target_min, target_max)
+    }
+}
+
 /// Node that adds padding around its content.
 #[derive(Debug)]
 pub struct PaddingNode {
@@ -184,19 +341,7 @@ impl DelegatableNode for PaddingNode {
     }
 }
 
-impl ModifierNode for PaddingNode {
-    fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
-        context.invalidate(cranpose_foundation::InvalidationKind::Layout);
-    }
-
-    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
-        Some(self)
-    }
-
-    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
-        Some(self)
-    }
-}
+impl_layout_modifier_node!(PaddingNode, invalidate = InvalidationKind::Layout);
 
 impl LayoutModifierNode for PaddingNode {
     fn measure(
@@ -331,23 +476,7 @@ impl DelegatableNode for BackgroundNode {
     }
 }
 
-impl ModifierNode for BackgroundNode {
-    fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
-        context.invalidate(cranpose_foundation::InvalidationKind::Draw);
-    }
-
-    fn as_draw_node(&self) -> Option<&dyn DrawModifierNode> {
-        Some(self)
-    }
-
-    fn as_draw_node_mut(&mut self) -> Option<&mut dyn DrawModifierNode> {
-        Some(self)
-    }
-}
-
-impl DrawModifierNode for BackgroundNode {
-    fn draw(&self, _draw_scope: &mut dyn DrawScope) {}
-}
+impl_draw_modifier_node!(BackgroundNode);
 
 /// Element that creates and updates background nodes.
 #[derive(Debug, Clone, PartialEq)]
@@ -414,23 +543,7 @@ impl DelegatableNode for CornerShapeNode {
     }
 }
 
-impl ModifierNode for CornerShapeNode {
-    fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
-        context.invalidate(cranpose_foundation::InvalidationKind::Draw);
-    }
-
-    fn as_draw_node(&self) -> Option<&dyn DrawModifierNode> {
-        Some(self)
-    }
-
-    fn as_draw_node_mut(&mut self) -> Option<&mut dyn DrawModifierNode> {
-        Some(self)
-    }
-}
-
-impl DrawModifierNode for CornerShapeNode {
-    fn draw(&self, _draw_scope: &mut dyn DrawScope) {}
-}
+impl_draw_modifier_node!(CornerShapeNode);
 
 /// Element that creates and updates corner shape nodes.
 #[derive(Debug, Clone, PartialEq)]
@@ -555,14 +668,11 @@ impl DelegatableNode for GraphicsLayerNode {
 
 impl ModifierNode for GraphicsLayerNode {
     fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
-        self.node_id.set(context.node_id());
-        context.invalidate(cranpose_foundation::InvalidationKind::Draw);
+        attach_draw_observer(&self.node_id, context);
     }
 
     fn on_detach(&mut self) {
-        if let Some(node_id) = self.node_id.replace(None) {
-            crate::render_state::clear_draw_observations_for_node(node_id);
-        }
+        detach_draw_observer(&self.node_id);
     }
 }
 
@@ -760,19 +870,7 @@ impl DelegatableNode for SizeNode {
     }
 }
 
-impl ModifierNode for SizeNode {
-    fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
-        context.invalidate(cranpose_foundation::InvalidationKind::Layout);
-    }
-
-    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
-        Some(self)
-    }
-
-    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
-        Some(self)
-    }
-}
+impl_layout_modifier_node!(SizeNode, invalidate = InvalidationKind::Layout);
 
 impl LayoutModifierNode for SizeNode {
     fn measure(
@@ -865,67 +963,43 @@ impl LayoutModifierNode for SizeNode {
     }
 
     fn min_intrinsic_width(&self, measurable: &dyn Measurable, height: f32) -> f32 {
-        let target = self.target_constraints();
-        if target.min_width == target.max_width && target.max_width != f32::INFINITY {
-            target.max_width
-        } else {
-            let child_height = if self.enforce_incoming {
-                height
-            } else {
-                height.clamp(target.min_height, target.max_height)
-            };
-            measurable
-                .min_intrinsic_width(child_height)
-                .clamp(target.min_width, target.max_width)
-        }
+        size_intrinsic(
+            self.target_constraints(),
+            SizeAxis::Width,
+            self.enforce_incoming,
+            height,
+            |h| measurable.min_intrinsic_width(h),
+        )
     }
 
     fn max_intrinsic_width(&self, measurable: &dyn Measurable, height: f32) -> f32 {
-        let target = self.target_constraints();
-        if target.min_width == target.max_width && target.max_width != f32::INFINITY {
-            target.max_width
-        } else {
-            let child_height = if self.enforce_incoming {
-                height
-            } else {
-                height.clamp(target.min_height, target.max_height)
-            };
-            measurable
-                .max_intrinsic_width(child_height)
-                .clamp(target.min_width, target.max_width)
-        }
+        size_intrinsic(
+            self.target_constraints(),
+            SizeAxis::Width,
+            self.enforce_incoming,
+            height,
+            |h| measurable.max_intrinsic_width(h),
+        )
     }
 
     fn min_intrinsic_height(&self, measurable: &dyn Measurable, width: f32) -> f32 {
-        let target = self.target_constraints();
-        if target.min_height == target.max_height && target.max_height != f32::INFINITY {
-            target.max_height
-        } else {
-            let child_width = if self.enforce_incoming {
-                width
-            } else {
-                width.clamp(target.min_width, target.max_width)
-            };
-            measurable
-                .min_intrinsic_height(child_width)
-                .clamp(target.min_height, target.max_height)
-        }
+        size_intrinsic(
+            self.target_constraints(),
+            SizeAxis::Height,
+            self.enforce_incoming,
+            width,
+            |w| measurable.min_intrinsic_height(w),
+        )
     }
 
     fn max_intrinsic_height(&self, measurable: &dyn Measurable, width: f32) -> f32 {
-        let target = self.target_constraints();
-        if target.min_height == target.max_height && target.max_height != f32::INFINITY {
-            target.max_height
-        } else {
-            let child_width = if self.enforce_incoming {
-                width
-            } else {
-                width.clamp(target.min_width, target.max_width)
-            };
-            measurable
-                .max_intrinsic_height(child_width)
-                .clamp(target.min_height, target.max_height)
-        }
+        size_intrinsic(
+            self.target_constraints(),
+            SizeAxis::Height,
+            self.enforce_incoming,
+            width,
+            |w| measurable.max_intrinsic_height(w),
+        )
     }
 }
 
@@ -1259,23 +1333,7 @@ impl DelegatableNode for AlphaNode {
     }
 }
 
-impl ModifierNode for AlphaNode {
-    fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
-        context.invalidate(cranpose_foundation::InvalidationKind::Draw);
-    }
-
-    fn as_draw_node(&self) -> Option<&dyn DrawModifierNode> {
-        Some(self)
-    }
-
-    fn as_draw_node_mut(&mut self) -> Option<&mut dyn DrawModifierNode> {
-        Some(self)
-    }
-}
-
-impl DrawModifierNode for AlphaNode {
-    fn draw(&self, _draw_scope: &mut dyn DrawScope) {}
-}
+impl_draw_modifier_node!(AlphaNode);
 
 /// Element that creates and updates alpha nodes.
 #[derive(Debug, Clone, PartialEq)]
@@ -1335,23 +1393,7 @@ impl DelegatableNode for ClipToBoundsNode {
     }
 }
 
-impl ModifierNode for ClipToBoundsNode {
-    fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
-        context.invalidate(cranpose_foundation::InvalidationKind::Draw);
-    }
-
-    fn as_draw_node(&self) -> Option<&dyn DrawModifierNode> {
-        Some(self)
-    }
-
-    fn as_draw_node_mut(&mut self) -> Option<&mut dyn DrawModifierNode> {
-        Some(self)
-    }
-}
-
-impl DrawModifierNode for ClipToBoundsNode {
-    fn draw(&self, _draw_scope: &mut dyn DrawScope) {}
-}
+impl_draw_modifier_node!(ClipToBoundsNode);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ClipToBoundsElement;
@@ -1418,15 +1460,7 @@ impl DelegatableNode for WindowRectReporterNode {
     }
 }
 
-impl ModifierNode for WindowRectReporterNode {
-    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
-        Some(self)
-    }
-
-    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
-        Some(self)
-    }
-}
+impl_layout_modifier_node!(WindowRectReporterNode);
 
 impl LayoutModifierNode for WindowRectReporterNode {
     fn measure(
@@ -1435,15 +1469,7 @@ impl LayoutModifierNode for WindowRectReporterNode {
         measurable: &dyn Measurable,
         constraints: Constraints,
     ) -> cranpose_ui_layout::LayoutModifierMeasureResult {
-        let placeable = measurable.measure(constraints);
-        cranpose_ui_layout::LayoutModifierMeasureResult::new(
-            Size {
-                width: placeable.width(),
-                height: placeable.height(),
-            },
-            0.0,
-            0.0,
-        )
+        measure_pass_through(measurable, constraints, |_| (0.0, 0.0))
     }
 }
 
@@ -1484,21 +1510,7 @@ impl Hash for WindowRectReporterElement {
     }
 }
 
-impl ModifierNodeElement for WindowRectReporterElement {
-    type Node = WindowRectReporterNode;
-
-    fn create(&self) -> Self::Node {
-        WindowRectReporterNode::new(self.sink.clone())
-    }
-
-    fn update(&self, node: &mut Self::Node) {
-        node.sink = self.sink.clone();
-    }
-
-    fn capabilities(&self) -> NodeCapabilities {
-        NodeCapabilities::LAYOUT
-    }
-}
+impl_sink_reporter_element!(WindowRectReporterElement, WindowRectReporterNode);
 
 pub trait SizeSink {
     fn set(&self, size: Size);
@@ -1565,15 +1577,7 @@ impl DelegatableNode for SizeReporterNode {
     }
 }
 
-impl ModifierNode for SizeReporterNode {
-    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
-        Some(self)
-    }
-
-    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
-        Some(self)
-    }
-}
+impl_layout_modifier_node!(SizeReporterNode);
 
 impl LayoutModifierNode for SizeReporterNode {
     fn measure(
@@ -1582,15 +1586,12 @@ impl LayoutModifierNode for SizeReporterNode {
         measurable: &dyn Measurable,
         constraints: Constraints,
     ) -> cranpose_ui_layout::LayoutModifierMeasureResult {
-        let placeable = measurable.measure(constraints);
-        let size = Size {
-            width: placeable.width(),
-            height: placeable.height(),
-        };
-        #[cfg(debug_assertions)]
-        self.check_oscillation(size);
-        self.sink.set(size);
-        cranpose_ui_layout::LayoutModifierMeasureResult::new(size, 0.0, 0.0)
+        measure_pass_through(measurable, constraints, |size| {
+            #[cfg(debug_assertions)]
+            self.check_oscillation(size);
+            self.sink.set(size);
+            (0.0, 0.0)
+        })
     }
 }
 
@@ -1629,21 +1630,7 @@ impl Hash for SizeReporterElement {
     }
 }
 
-impl ModifierNodeElement for SizeReporterElement {
-    type Node = SizeReporterNode;
-
-    fn create(&self) -> Self::Node {
-        SizeReporterNode::new(self.sink.clone())
-    }
-
-    fn update(&self, node: &mut Self::Node) {
-        node.sink = self.sink.clone();
-    }
-
-    fn capabilities(&self) -> NodeCapabilities {
-        NodeCapabilities::LAYOUT
-    }
-}
+impl_sink_reporter_element!(SizeReporterElement, SizeReporterNode);
 
 pub struct DrawCommandNode {
     commands: Vec<DrawCommand>,
@@ -1684,14 +1671,11 @@ impl DelegatableNode for DrawCommandNode {
 
 impl ModifierNode for DrawCommandNode {
     fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
-        self.node_id.set(context.node_id());
-        context.invalidate(cranpose_foundation::InvalidationKind::Draw);
+        attach_draw_observer(&self.node_id, context);
     }
 
     fn on_detach(&mut self) {
-        if let Some(node_id) = self.node_id.replace(None) {
-            crate::render_state::clear_draw_observations_for_node(node_id);
-        }
+        detach_draw_observer(&self.node_id);
     }
 
     fn as_draw_node(&self) -> Option<&dyn DrawModifierNode> {
@@ -1853,19 +1837,7 @@ impl DelegatableNode for OffsetNode {
     }
 }
 
-impl ModifierNode for OffsetNode {
-    fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
-        context.invalidate(cranpose_foundation::InvalidationKind::Layout);
-    }
-
-    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
-        Some(self)
-    }
-
-    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
-        Some(self)
-    }
-}
+impl_layout_modifier_node!(OffsetNode, invalidate = InvalidationKind::Layout);
 
 impl LayoutModifierNode for OffsetNode {
     fn measure(
@@ -1874,33 +1846,10 @@ impl LayoutModifierNode for OffsetNode {
         measurable: &dyn Measurable,
         constraints: Constraints,
     ) -> cranpose_ui_layout::LayoutModifierMeasureResult {
-        let placeable = measurable.measure(constraints);
-
-        cranpose_ui_layout::LayoutModifierMeasureResult::new(
-            Size {
-                width: placeable.width(),
-                height: placeable.height(),
-            },
-            self.x,
-            self.y,
-        )
+        measure_pass_through(measurable, constraints, |_| (self.x, self.y))
     }
 
-    fn min_intrinsic_width(&self, measurable: &dyn Measurable, height: f32) -> f32 {
-        measurable.min_intrinsic_width(height)
-    }
-
-    fn max_intrinsic_width(&self, measurable: &dyn Measurable, height: f32) -> f32 {
-        measurable.max_intrinsic_width(height)
-    }
-
-    fn min_intrinsic_height(&self, measurable: &dyn Measurable, width: f32) -> f32 {
-        measurable.min_intrinsic_height(width)
-    }
-
-    fn max_intrinsic_height(&self, measurable: &dyn Measurable, width: f32) -> f32 {
-        measurable.max_intrinsic_height(width)
-    }
+    forward_intrinsics_to_child!();
 }
 
 /// Element that creates and updates offset nodes.
@@ -1988,19 +1937,7 @@ impl DelegatableNode for FractionalOffsetNode {
     }
 }
 
-impl ModifierNode for FractionalOffsetNode {
-    fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
-        context.invalidate(cranpose_foundation::InvalidationKind::Layout);
-    }
-
-    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
-        Some(self)
-    }
-
-    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
-        Some(self)
-    }
-}
+impl_layout_modifier_node!(FractionalOffsetNode, invalidate = InvalidationKind::Layout);
 
 impl LayoutModifierNode for FractionalOffsetNode {
     fn measure(
@@ -2009,33 +1946,12 @@ impl LayoutModifierNode for FractionalOffsetNode {
         measurable: &dyn Measurable,
         constraints: Constraints,
     ) -> cranpose_ui_layout::LayoutModifierMeasureResult {
-        let placeable = measurable.measure(constraints);
-
-        cranpose_ui_layout::LayoutModifierMeasureResult::new(
-            Size {
-                width: placeable.width(),
-                height: placeable.height(),
-            },
-            self.x_fraction * placeable.width(),
-            self.y_fraction * placeable.height(),
-        )
+        measure_pass_through(measurable, constraints, |size| {
+            (self.x_fraction * size.width, self.y_fraction * size.height)
+        })
     }
 
-    fn min_intrinsic_width(&self, measurable: &dyn Measurable, height: f32) -> f32 {
-        measurable.min_intrinsic_width(height)
-    }
-
-    fn max_intrinsic_width(&self, measurable: &dyn Measurable, height: f32) -> f32 {
-        measurable.max_intrinsic_width(height)
-    }
-
-    fn min_intrinsic_height(&self, measurable: &dyn Measurable, width: f32) -> f32 {
-        measurable.min_intrinsic_height(width)
-    }
-
-    fn max_intrinsic_height(&self, measurable: &dyn Measurable, width: f32) -> f32 {
-        measurable.max_intrinsic_height(width)
-    }
+    forward_intrinsics_to_child!();
 }
 
 /// Element that creates and updates fractional offset nodes.
@@ -2127,19 +2043,7 @@ impl DelegatableNode for FillNode {
     }
 }
 
-impl ModifierNode for FillNode {
-    fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
-        context.invalidate(cranpose_foundation::InvalidationKind::Layout);
-    }
-
-    fn as_layout_node(&self) -> Option<&dyn LayoutModifierNode> {
-        Some(self)
-    }
-
-    fn as_layout_node_mut(&mut self) -> Option<&mut dyn LayoutModifierNode> {
-        Some(self)
-    }
-}
+impl_layout_modifier_node!(FillNode, invalidate = InvalidationKind::Layout);
 
 impl LayoutModifierNode for FillNode {
     fn measure(
@@ -2211,21 +2115,7 @@ impl LayoutModifierNode for FillNode {
         })
     }
 
-    fn min_intrinsic_width(&self, measurable: &dyn Measurable, height: f32) -> f32 {
-        measurable.min_intrinsic_width(height)
-    }
-
-    fn max_intrinsic_width(&self, measurable: &dyn Measurable, height: f32) -> f32 {
-        measurable.max_intrinsic_width(height)
-    }
-
-    fn min_intrinsic_height(&self, measurable: &dyn Measurable, width: f32) -> f32 {
-        measurable.min_intrinsic_height(width)
-    }
-
-    fn max_intrinsic_height(&self, measurable: &dyn Measurable, width: f32) -> f32 {
-        measurable.max_intrinsic_height(width)
-    }
+    forward_intrinsics_to_child!();
 }
 
 /// Element that creates and updates fill nodes.

--- a/crates/cranpose-ui/src/tests/primitives_tests.rs
+++ b/crates/cranpose-ui/src/tests/primitives_tests.rs
@@ -393,6 +393,54 @@ fn PrimitiveScrollReactiveStoriesBranch(list_state: LazyListState, captures: Cap
 }
 
 #[composable]
+fn PrimitiveLazyColumnWithScrollIndicator(
+    list_state: LazyListState,
+    captures: CapturedLazyListSlot,
+) {
+    let captures = captures.clone();
+    Row(
+        Modifier::empty().fill_max_width().weight(1.0),
+        RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
+        move || {
+            let captures = captures.clone();
+            Column(
+                Modifier::empty().weight(1.0).fill_max_height(),
+                ColumnSpec::default(),
+                move || {
+                    let node_id = LazyColumn(
+                        Modifier::empty().fill_max_size(),
+                        list_state,
+                        LazyColumnSpec::default(),
+                        |scope| {
+                            scope.items(40, |index| {
+                                Text(
+                                    format!("Item {}", index),
+                                    Modifier::empty(),
+                                    TextStyle::default(),
+                                );
+                            });
+                        },
+                    );
+                    *captures.state.borrow_mut() = Some(list_state);
+                    *captures.node_id.borrow_mut() = Some(node_id);
+                },
+            );
+            Column(
+                Modifier::empty().width(28.0).fill_max_height(),
+                ColumnSpec::default(),
+                move || {
+                    Text(
+                        format!("At {}", list_state.first_visible_item_index()),
+                        Modifier::empty(),
+                        TextStyle::default(),
+                    );
+                },
+            );
+        },
+    );
+}
+
+#[composable]
 fn PrimitiveStoriesPaneWithIndicator(
     modifier: Modifier,
     list_state: LazyListState,
@@ -404,47 +452,7 @@ fn PrimitiveStoriesPaneWithIndicator(
         move || {
             Text("Top stories", Modifier::empty(), TextStyle::default());
             Text("40 loaded of 40", Modifier::empty(), TextStyle::default());
-            let captures = captures.clone();
-            Row(
-                Modifier::empty().fill_max_width().weight(1.0),
-                RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
-                move || {
-                    let captures = captures.clone();
-                    Column(
-                        Modifier::empty().weight(1.0).fill_max_height(),
-                        ColumnSpec::default(),
-                        move || {
-                            let node_id = LazyColumn(
-                                Modifier::empty().fill_max_size(),
-                                list_state,
-                                LazyColumnSpec::default(),
-                                |scope| {
-                                    scope.items(40, |index| {
-                                        Text(
-                                            format!("Item {}", index),
-                                            Modifier::empty(),
-                                            TextStyle::default(),
-                                        );
-                                    });
-                                },
-                            );
-                            *captures.state.borrow_mut() = Some(list_state);
-                            *captures.node_id.borrow_mut() = Some(node_id);
-                        },
-                    );
-                    Column(
-                        Modifier::empty().width(28.0).fill_max_height(),
-                        ColumnSpec::default(),
-                        move || {
-                            Text(
-                                format!("At {}", list_state.first_visible_item_index()),
-                                Modifier::empty(),
-                                TextStyle::default(),
-                            );
-                        },
-                    );
-                },
-            );
+            PrimitiveLazyColumnWithScrollIndicator(list_state, captures.clone());
         },
     );
 }
@@ -466,49 +474,18 @@ fn PrimitiveStoriesPaneWithDynamicStatus(
                 Modifier::empty(),
                 TextStyle::default(),
             );
-            let captures = captures.clone();
-            Row(
-                Modifier::empty().fill_max_width().weight(1.0),
-                RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
-                move || {
-                    let captures = captures.clone();
-                    Column(
-                        Modifier::empty().weight(1.0).fill_max_height(),
-                        ColumnSpec::default(),
-                        move || {
-                            let node_id = LazyColumn(
-                                Modifier::empty().fill_max_size(),
-                                list_state,
-                                LazyColumnSpec::default(),
-                                |scope| {
-                                    scope.items(40, |index| {
-                                        Text(
-                                            format!("Item {}", index),
-                                            Modifier::empty(),
-                                            TextStyle::default(),
-                                        );
-                                    });
-                                },
-                            );
-                            *captures.state.borrow_mut() = Some(list_state);
-                            *captures.node_id.borrow_mut() = Some(node_id);
-                        },
-                    );
-                    Column(
-                        Modifier::empty().width(28.0).fill_max_height(),
-                        ColumnSpec::default(),
-                        move || {
-                            Text(
-                                format!("At {}", list_state.first_visible_item_index()),
-                                Modifier::empty(),
-                                TextStyle::default(),
-                            );
-                        },
-                    );
-                },
-            );
+            PrimitiveLazyColumnWithScrollIndicator(list_state, captures.clone());
         },
     );
+}
+
+fn find_layout(node: &LayoutBox, target: NodeId) -> Option<&LayoutBox> {
+    if node.node_id == target {
+        return Some(node);
+    }
+    node.children
+        .iter()
+        .find_map(|child| find_layout(child, target))
 }
 
 fn captured_conditional_lazy_list_state(captured_state: &CapturedLazyListState) -> LazyListState {
@@ -536,6 +513,82 @@ fn settle_scroll_recomposition(
         measure_root(composition, root, size);
     }
     measure_root(composition, root, size);
+}
+
+fn assert_lazy_list_host_survives_one_scroll(
+    composition: &mut Composition<MemoryApplier>,
+    root: NodeId,
+    size: Size,
+    list_state: LazyListState,
+    captures: &CapturedLazyListSlot,
+    message: &str,
+) {
+    let fresh_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
+    let fresh_generation = node_generation(composition, fresh_node_id);
+
+    list_state.dispatch_scroll_delta(-120.0);
+    settle_scroll_recomposition(composition, root, size);
+
+    let fresh_after_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
+    let fresh_after_generation = node_generation(composition, fresh_after_node_id);
+    assert_eq!(
+        (fresh_after_node_id, fresh_after_generation),
+        (fresh_node_id, fresh_generation),
+        "{message}"
+    );
+}
+
+fn assert_branch_round_trip_preserves_lazy_list_host(
+    composition: &mut Composition<MemoryApplier>,
+    root: NodeId,
+    size: Size,
+    selected_story: cranpose_core::MutableState<Option<u64>>,
+) {
+    selected_story.set_value(Some(1));
+    while composition
+        .process_invalid_scopes()
+        .expect("switch to thread branch")
+    {
+        settle_scroll_recomposition(composition, root, size);
+    }
+    settle_scroll_recomposition(composition, root, size);
+
+    selected_story.set_value(None);
+    while composition
+        .process_invalid_scopes()
+        .expect("restore stories branch")
+    {
+        settle_scroll_recomposition(composition, root, size);
+    }
+    settle_scroll_recomposition(composition, root, size);
+}
+
+fn assert_lazy_list_host_stable_across_scrolls(
+    composition: &mut Composition<MemoryApplier>,
+    root: NodeId,
+    size: Size,
+    list_state: LazyListState,
+    captures: &CapturedLazyListSlot,
+    scroll_count: usize,
+    message: &str,
+) {
+    let restored_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
+    let restored_generation = node_generation(composition, restored_node_id);
+
+    let mut seen = Vec::new();
+    for _ in 0..scroll_count {
+        list_state.dispatch_scroll_delta(-120.0);
+        settle_scroll_recomposition(composition, root, size);
+        let node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
+        let generation = node_generation(composition, node_id);
+        seen.push((node_id, generation));
+    }
+
+    assert_eq!(
+        seen,
+        vec![(restored_node_id, restored_generation); seen.len()],
+        "{message}; restored=({restored_node_id}, {restored_generation}) seen={seen:?}",
+    );
 }
 
 #[test]
@@ -997,54 +1050,25 @@ fn box_with_constraints_restored_lazy_list_branch_keeps_host_generation_during_s
     settle_scroll_recomposition(&mut composition, root, size);
 
     let list_state = captured_conditional_lazy_list_state(&captures.state);
-    let fresh_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
-    let fresh_generation = node_generation(&mut composition, fresh_node_id);
-
-    list_state.dispatch_scroll_delta(-120.0);
-    settle_scroll_recomposition(&mut composition, root, size);
-
-    let fresh_after_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
-    let fresh_after_generation = node_generation(&mut composition, fresh_after_node_id);
-    assert_eq!(
-        (fresh_after_node_id, fresh_after_generation),
-        (fresh_node_id, fresh_generation),
-        "fresh scroll should not recreate the lazy list host"
+    assert_lazy_list_host_survives_one_scroll(
+        &mut composition,
+        root,
+        size,
+        list_state,
+        &captures,
+        "fresh scroll should not recreate the lazy list host",
     );
 
-    selected_story.set_value(Some(1));
-    while composition
-        .process_invalid_scopes()
-        .expect("switch to thread branch")
-    {
-        settle_scroll_recomposition(&mut composition, root, size);
-    }
-    settle_scroll_recomposition(&mut composition, root, size);
+    assert_branch_round_trip_preserves_lazy_list_host(&mut composition, root, size, selected_story);
 
-    selected_story.set_value(None);
-    while composition
-        .process_invalid_scopes()
-        .expect("restore stories branch")
-    {
-        settle_scroll_recomposition(&mut composition, root, size);
-    }
-    settle_scroll_recomposition(&mut composition, root, size);
-
-    let restored_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
-    let restored_generation = node_generation(&mut composition, restored_node_id);
-
-    let mut seen = Vec::new();
-    for _ in 0..4 {
-        list_state.dispatch_scroll_delta(-120.0);
-        settle_scroll_recomposition(&mut composition, root, size);
-        let node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
-        let generation = node_generation(&mut composition, node_id);
-        seen.push((node_id, generation));
-    }
-
-    assert_eq!(
-        seen,
-        vec![(restored_node_id, restored_generation); seen.len()],
-        "restored lazy-list host changed across scroll-driven recompositions; restored=({restored_node_id}, {restored_generation}) seen={seen:?}",
+    assert_lazy_list_host_stable_across_scrolls(
+        &mut composition,
+        root,
+        size,
+        list_state,
+        &captures,
+        4,
+        "restored lazy-list host changed across scroll-driven recompositions",
     );
 }
 
@@ -1101,54 +1125,25 @@ fn box_with_constraints_restored_weighted_lazy_list_branch_keeps_host_generation
     settle_scroll_recomposition(&mut composition, root, size);
 
     let list_state = captured_conditional_lazy_list_state(&captures.state);
-    let fresh_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
-    let fresh_generation = node_generation(&mut composition, fresh_node_id);
-
-    list_state.dispatch_scroll_delta(-120.0);
-    settle_scroll_recomposition(&mut composition, root, size);
-
-    let fresh_after_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
-    let fresh_after_generation = node_generation(&mut composition, fresh_after_node_id);
-    assert_eq!(
-        (fresh_after_node_id, fresh_after_generation),
-        (fresh_node_id, fresh_generation),
-        "fresh weighted scroll should not recreate the lazy list host"
+    assert_lazy_list_host_survives_one_scroll(
+        &mut composition,
+        root,
+        size,
+        list_state,
+        &captures,
+        "fresh weighted scroll should not recreate the lazy list host",
     );
 
-    selected_story.set_value(Some(1));
-    while composition
-        .process_invalid_scopes()
-        .expect("switch to thread branch")
-    {
-        settle_scroll_recomposition(&mut composition, root, size);
-    }
-    settle_scroll_recomposition(&mut composition, root, size);
+    assert_branch_round_trip_preserves_lazy_list_host(&mut composition, root, size, selected_story);
 
-    selected_story.set_value(None);
-    while composition
-        .process_invalid_scopes()
-        .expect("restore stories branch")
-    {
-        settle_scroll_recomposition(&mut composition, root, size);
-    }
-    settle_scroll_recomposition(&mut composition, root, size);
-
-    let restored_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
-    let restored_generation = node_generation(&mut composition, restored_node_id);
-
-    let mut seen = Vec::new();
-    for _ in 0..4 {
-        list_state.dispatch_scroll_delta(-120.0);
-        settle_scroll_recomposition(&mut composition, root, size);
-        let node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
-        let generation = node_generation(&mut composition, node_id);
-        seen.push((node_id, generation));
-    }
-
-    assert_eq!(
-        seen,
-        vec![(restored_node_id, restored_generation); seen.len()],
-        "restored weighted lazy-list host changed across scroll-driven recompositions; restored=({restored_node_id}, {restored_generation}) seen={seen:?}",
+    assert_lazy_list_host_stable_across_scrolls(
+        &mut composition,
+        root,
+        size,
+        list_state,
+        &captures,
+        4,
+        "restored weighted lazy-list host changed across scroll-driven recompositions",
     );
 }
 
@@ -1206,23 +1201,7 @@ fn box_with_constraints_restored_weighted_lazy_list_branch_keeps_host_during_sta
     };
     settle_scroll_recomposition(&mut composition, root, size);
 
-    selected_story.set_value(Some(1));
-    while composition
-        .process_invalid_scopes()
-        .expect("switch to thread branch")
-    {
-        settle_scroll_recomposition(&mut composition, root, size);
-    }
-    settle_scroll_recomposition(&mut composition, root, size);
-
-    selected_story.set_value(None);
-    while composition
-        .process_invalid_scopes()
-        .expect("restore stories branch")
-    {
-        settle_scroll_recomposition(&mut composition, root, size);
-    }
-    settle_scroll_recomposition(&mut composition, root, size);
+    assert_branch_round_trip_preserves_lazy_list_host(&mut composition, root, size, selected_story);
 
     let restored_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
     let restored_generation = node_generation(&mut composition, restored_node_id);
@@ -1293,57 +1272,25 @@ fn box_with_constraints_restored_weighted_branch_after_header_toggle_keeps_host_
     settle_scroll_recomposition(&mut composition, root, size);
 
     let list_state = captured_conditional_lazy_list_state(&captures.state);
-    let fresh_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
-    let fresh_generation = node_generation(&mut composition, fresh_node_id);
-
-    list_state.dispatch_scroll_delta(-120.0);
-    settle_scroll_recomposition(&mut composition, root, size);
-    assert_eq!(
-        (
-            captured_conditional_lazy_list_node_id(&captures.node_id),
-            node_generation(
-                &mut composition,
-                captured_conditional_lazy_list_node_id(&captures.node_id)
-            )
-        ),
-        (fresh_node_id, fresh_generation),
+    assert_lazy_list_host_survives_one_scroll(
+        &mut composition,
+        root,
+        size,
+        list_state,
+        &captures,
         "fresh scroll should not recreate the lazy list host",
     );
 
-    selected_story.set_value(Some(1));
-    while composition
-        .process_invalid_scopes()
-        .expect("switch to thread branch")
-    {
-        settle_scroll_recomposition(&mut composition, root, size);
-    }
-    settle_scroll_recomposition(&mut composition, root, size);
+    assert_branch_round_trip_preserves_lazy_list_host(&mut composition, root, size, selected_story);
 
-    selected_story.set_value(None);
-    while composition
-        .process_invalid_scopes()
-        .expect("restore stories branch")
-    {
-        settle_scroll_recomposition(&mut composition, root, size);
-    }
-    settle_scroll_recomposition(&mut composition, root, size);
-
-    let restored_node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
-    let restored_generation = node_generation(&mut composition, restored_node_id);
-
-    let mut seen = Vec::new();
-    for _ in 0..4 {
-        list_state.dispatch_scroll_delta(-120.0);
-        settle_scroll_recomposition(&mut composition, root, size);
-        let node_id = captured_conditional_lazy_list_node_id(&captures.node_id);
-        let generation = node_generation(&mut composition, node_id);
-        seen.push((node_id, generation));
-    }
-
-    assert_eq!(
-        seen,
-        vec![(restored_node_id, restored_generation); seen.len()],
-        "restored weighted branch after header toggle changed host across scroll-driven recompositions; restored=({restored_node_id}, {restored_generation}) seen={seen:?}",
+    assert_lazy_list_host_stable_across_scrolls(
+        &mut composition,
+        root,
+        size,
+        list_state,
+        &captures,
+        4,
+        "restored weighted branch after header toggle changed host across scroll-driven recompositions",
     );
 }
 
@@ -1435,15 +1382,6 @@ fn test_fill_max_width_respects_parent_bounds() {
         .expect("compute layout");
 
     let root_layout = layout_tree.root();
-
-    fn find_layout(node: &LayoutBox, target: NodeId) -> Option<&LayoutBox> {
-        if node.node_id == target {
-            return Some(node);
-        }
-        node.children
-            .iter()
-            .find_map(|child| find_layout(child, target))
-    }
 
     let column_node_id = column_id
         .borrow()
@@ -1578,15 +1516,6 @@ fn test_fill_max_width_with_background_and_double_padding() {
 
     let root_layout = layout_tree.root();
 
-    fn find_layout(node: &LayoutBox, target: NodeId) -> Option<&LayoutBox> {
-        if node.node_id == target {
-            return Some(node);
-        }
-        node.children
-            .iter()
-            .find_map(|child| find_layout(child, target))
-    }
-
     let outer_column_node = outer_column_id
         .borrow()
         .as_ref()
@@ -1718,15 +1647,6 @@ fn fill_max_width_tracks_bounded_parent_width() {
 
     let root_layout = layout_tree.root();
 
-    fn find_layout(node: &LayoutBox, target: NodeId) -> Option<&LayoutBox> {
-        if node.node_id == target {
-            return Some(node);
-        }
-        node.children
-            .iter()
-            .find_map(|child| find_layout(child, target))
-    }
-
     let outer_node = outer_column_id.borrow().as_ref().copied().expect("outer");
     let inner_node = inner_column_id.borrow().as_ref().copied().expect("inner");
     let row_node = row_id.borrow().as_ref().copied().expect("row");
@@ -1828,15 +1748,6 @@ fn wrap_column_with_fill_child_uses_bounded_width() {
             },
         )
         .expect("compute layout");
-
-    fn find_layout(node: &LayoutBox, target: NodeId) -> Option<&LayoutBox> {
-        if node.node_id == target {
-            return Some(node);
-        }
-        node.children
-            .iter()
-            .find_map(|child| find_layout(child, target))
-    }
 
     let root_layout = layout_tree.root();
     let column_layout = find_layout(
@@ -1952,15 +1863,6 @@ fn fill_child_respects_explicit_parent_width() {
         )
         .expect("compute layout");
 
-    fn find_layout(node: &LayoutBox, target: NodeId) -> Option<&LayoutBox> {
-        if node.node_id == target {
-            return Some(node);
-        }
-        node.children
-            .iter()
-            .find_map(|child| find_layout(child, target))
-    }
-
     let root_layout = layout_tree.root();
     let column_layout = find_layout(
         root_layout,
@@ -2046,15 +1948,6 @@ fn fill_max_height_child_clamps_to_parent() {
             },
         )
         .expect("compute layout");
-
-    fn find_layout(node: &LayoutBox, target: NodeId) -> Option<&LayoutBox> {
-        if node.node_id == target {
-            return Some(node);
-        }
-        node.children
-            .iter()
-            .find_map(|child| find_layout(child, target))
-    }
 
     let root_layout = layout_tree.root();
     let row_layout = find_layout(

--- a/crates/cranpose-ui/src/text/measure.rs
+++ b/crates/cranpose-ui/src/text/measure.rs
@@ -2085,28 +2085,45 @@ fn apply_line_overflow<M: TextMeasurer + ?Sized>(
     }
 }
 
+fn measured_width<M: TextMeasurer + ?Sized>(measurer: &M, text: &str, style: &TextStyle) -> f32 {
+    measurer
+        .measure(&crate::text::AnnotatedString::from(text), style)
+        .width
+}
+
+enum EllipsisTruncation {
+    NotNeeded,
+    ImpossibleFit,
+    Truncate(Vec<usize>),
+}
+
+fn ellipsis_truncation<M: TextMeasurer + ?Sized>(
+    measurer: &M,
+    line: &str,
+    style: &TextStyle,
+    max_width: f32,
+) -> EllipsisTruncation {
+    if measured_width(measurer, line, style) <= max_width + WRAP_EPSILON {
+        return EllipsisTruncation::NotNeeded;
+    }
+    if measured_width(measurer, ELLIPSIS, style) > max_width + WRAP_EPSILON {
+        return EllipsisTruncation::ImpossibleFit;
+    }
+    EllipsisTruncation::Truncate(char_boundaries(line))
+}
+
 fn fit_end_ellipsis<M: TextMeasurer + ?Sized>(
     measurer: &M,
     line: &str,
     style: &TextStyle,
     max_width: f32,
 ) -> String {
-    if measurer
-        .measure(&crate::text::AnnotatedString::from(line), style)
-        .width
-        <= max_width + WRAP_EPSILON
-    {
-        return line.to_string();
-    }
+    let boundaries = match ellipsis_truncation(measurer, line, style, max_width) {
+        EllipsisTruncation::NotNeeded => return line.to_string(),
+        EllipsisTruncation::ImpossibleFit => return String::new(),
+        EllipsisTruncation::Truncate(boundaries) => boundaries,
+    };
 
-    let ellipsis_width = measurer
-        .measure(&crate::text::AnnotatedString::from(ELLIPSIS), style)
-        .width;
-    if ellipsis_width > max_width + WRAP_EPSILON {
-        return String::new();
-    }
-
-    let boundaries = char_boundaries(line);
     let mut low = 0usize;
     let mut high = boundaries.len() - 1;
     let mut best = 0usize;
@@ -2115,13 +2132,7 @@ fn fit_end_ellipsis<M: TextMeasurer + ?Sized>(
         let mid = (low + high) / 2;
         let prefix = &line[..boundaries[mid]];
         let candidate = format!("{prefix}{ELLIPSIS}");
-        let width = measurer
-            .measure(
-                &crate::text::AnnotatedString::from(candidate.as_str()),
-                style,
-            )
-            .width;
-        if width <= max_width + WRAP_EPSILON {
+        if measured_width(measurer, &candidate, style) <= max_width + WRAP_EPSILON {
             best = mid;
             low = mid + 1;
         } else if mid == 0 {
@@ -2140,22 +2151,12 @@ fn fit_start_ellipsis<M: TextMeasurer + ?Sized>(
     style: &TextStyle,
     max_width: f32,
 ) -> String {
-    if measurer
-        .measure(&crate::text::AnnotatedString::from(line), style)
-        .width
-        <= max_width + WRAP_EPSILON
-    {
-        return line.to_string();
-    }
+    let boundaries = match ellipsis_truncation(measurer, line, style, max_width) {
+        EllipsisTruncation::NotNeeded => return line.to_string(),
+        EllipsisTruncation::ImpossibleFit => return String::new(),
+        EllipsisTruncation::Truncate(boundaries) => boundaries,
+    };
 
-    let ellipsis_width = measurer
-        .measure(&crate::text::AnnotatedString::from(ELLIPSIS), style)
-        .width;
-    if ellipsis_width > max_width + WRAP_EPSILON {
-        return String::new();
-    }
-
-    let boundaries = char_boundaries(line);
     let mut low = 0usize;
     let mut high = boundaries.len() - 1;
     let mut best = boundaries.len() - 1;
@@ -2164,13 +2165,7 @@ fn fit_start_ellipsis<M: TextMeasurer + ?Sized>(
         let mid = (low + high) / 2;
         let suffix = &line[boundaries[mid]..];
         let candidate = format!("{ELLIPSIS}{suffix}");
-        let width = measurer
-            .measure(
-                &crate::text::AnnotatedString::from(candidate.as_str()),
-                style,
-            )
-            .width;
-        if width <= max_width + WRAP_EPSILON {
+        if measured_width(measurer, &candidate, style) <= max_width + WRAP_EPSILON {
             best = mid;
             if mid == 0 {
                 break;
@@ -2190,22 +2185,12 @@ fn fit_middle_ellipsis<M: TextMeasurer + ?Sized>(
     style: &TextStyle,
     max_width: f32,
 ) -> String {
-    if measurer
-        .measure(&crate::text::AnnotatedString::from(line), style)
-        .width
-        <= max_width + WRAP_EPSILON
-    {
-        return line.to_string();
-    }
+    let boundaries = match ellipsis_truncation(measurer, line, style, max_width) {
+        EllipsisTruncation::NotNeeded => return line.to_string(),
+        EllipsisTruncation::ImpossibleFit => return String::new(),
+        EllipsisTruncation::Truncate(boundaries) => boundaries,
+    };
 
-    let ellipsis_width = measurer
-        .measure(&crate::text::AnnotatedString::from(ELLIPSIS), style)
-        .width;
-    if ellipsis_width > max_width + WRAP_EPSILON {
-        return String::new();
-    }
-
-    let boundaries = char_boundaries(line);
     let total_chars = boundaries.len().saturating_sub(1);
     for keep in (0..=total_chars).rev() {
         let keep_start = keep.div_ceil(2);
@@ -2214,14 +2199,7 @@ fn fit_middle_ellipsis<M: TextMeasurer + ?Sized>(
         let end_start = boundaries[total_chars.saturating_sub(keep_end)];
         let end = &line[end_start..];
         let candidate = format!("{start}{ELLIPSIS}{end}");
-        if measurer
-            .measure(
-                &crate::text::AnnotatedString::from(candidate.as_str()),
-                style,
-            )
-            .width
-            <= max_width + WRAP_EPSILON
-        {
+        if measured_width(measurer, &candidate, style) <= max_width + WRAP_EPSILON {
             return candidate;
         }
     }
@@ -2455,6 +2433,34 @@ mod tests {
         }
     }
 
+    fn monospaced_measure(text: &crate::text::AnnotatedString, style: &TextStyle) -> TextMetrics {
+        MonospacedTextMeasurer.measure(text, style)
+    }
+
+    fn monospaced_offset_for_position(
+        text: &crate::text::AnnotatedString,
+        style: &TextStyle,
+        x: f32,
+        y: f32,
+    ) -> usize {
+        MonospacedTextMeasurer.get_offset_for_position(text, style, x, y)
+    }
+
+    fn monospaced_cursor_x_for_offset(
+        text: &crate::text::AnnotatedString,
+        style: &TextStyle,
+        offset: usize,
+    ) -> f32 {
+        MonospacedTextMeasurer.get_cursor_x_for_offset(text, style, offset)
+    }
+
+    fn monospaced_layout(
+        text: &crate::text::AnnotatedString,
+        style: &TextStyle,
+    ) -> TextLayoutResult {
+        MonospacedTextMeasurer.layout(text, style)
+    }
+
     struct CountingTextMeasurer {
         measure_calls: Rc<Cell<usize>>,
         layout_calls: Rc<Cell<usize>>,
@@ -2472,7 +2478,7 @@ mod tests {
     impl TextMeasurer for CountingTextMeasurer {
         fn measure(&self, text: &crate::text::AnnotatedString, style: &TextStyle) -> TextMetrics {
             self.measure_calls.set(self.measure_calls.get() + 1);
-            MonospacedTextMeasurer.measure(text, style)
+            monospaced_measure(text, style)
         }
 
         fn get_offset_for_position(
@@ -2482,7 +2488,7 @@ mod tests {
             x: f32,
             y: f32,
         ) -> usize {
-            MonospacedTextMeasurer.get_offset_for_position(text, style, x, y)
+            monospaced_offset_for_position(text, style, x, y)
         }
 
         fn get_cursor_x_for_offset(
@@ -2491,7 +2497,7 @@ mod tests {
             style: &TextStyle,
             offset: usize,
         ) -> f32 {
-            MonospacedTextMeasurer.get_cursor_x_for_offset(text, style, offset)
+            monospaced_cursor_x_for_offset(text, style, offset)
         }
 
         fn layout(
@@ -2500,7 +2506,7 @@ mod tests {
             style: &TextStyle,
         ) -> TextLayoutResult {
             self.layout_calls.set(self.layout_calls.get() + 1);
-            MonospacedTextMeasurer.layout(text, style)
+            monospaced_layout(text, style)
         }
     }
 
@@ -2530,7 +2536,7 @@ mod tests {
 
     impl TextMeasurer for PrefixWidthCountingMeasurer {
         fn measure(&self, text: &crate::text::AnnotatedString, style: &TextStyle) -> TextMetrics {
-            MonospacedTextMeasurer.measure(text, style)
+            monospaced_measure(text, style)
         }
 
         fn measure_subsequence(
@@ -2560,7 +2566,7 @@ mod tests {
             x: f32,
             y: f32,
         ) -> usize {
-            MonospacedTextMeasurer.get_offset_for_position(text, style, x, y)
+            monospaced_offset_for_position(text, style, x, y)
         }
 
         fn get_cursor_x_for_offset(
@@ -2569,7 +2575,7 @@ mod tests {
             style: &TextStyle,
             offset: usize,
         ) -> f32 {
-            MonospacedTextMeasurer.get_cursor_x_for_offset(text, style, offset)
+            monospaced_cursor_x_for_offset(text, style, offset)
         }
 
         fn layout(
@@ -2577,7 +2583,7 @@ mod tests {
             text: &crate::text::AnnotatedString,
             style: &TextStyle,
         ) -> TextLayoutResult {
-            MonospacedTextMeasurer.layout(text, style)
+            monospaced_layout(text, style)
         }
     }
 
@@ -2612,7 +2618,7 @@ mod tests {
     impl TextMeasurer for LineHeightCountingMeasurer {
         fn measure(&self, text: &crate::text::AnnotatedString, style: &TextStyle) -> TextMetrics {
             self.measure_calls.set(self.measure_calls.get() + 1);
-            MonospacedTextMeasurer.measure(text, style)
+            monospaced_measure(text, style)
         }
 
         fn measure_line_prefix_widths(
@@ -2636,7 +2642,7 @@ mod tests {
             x: f32,
             y: f32,
         ) -> usize {
-            MonospacedTextMeasurer.get_offset_for_position(text, style, x, y)
+            monospaced_offset_for_position(text, style, x, y)
         }
 
         fn get_cursor_x_for_offset(
@@ -2645,7 +2651,7 @@ mod tests {
             style: &TextStyle,
             offset: usize,
         ) -> f32 {
-            MonospacedTextMeasurer.get_cursor_x_for_offset(text, style, offset)
+            monospaced_cursor_x_for_offset(text, style, offset)
         }
 
         fn layout(
@@ -2653,13 +2659,13 @@ mod tests {
             text: &crate::text::AnnotatedString,
             style: &TextStyle,
         ) -> TextLayoutResult {
-            MonospacedTextMeasurer.layout(text, style)
+            monospaced_layout(text, style)
         }
     }
 
     impl TextMeasurer for FitProbeCountingMeasurer {
         fn measure(&self, text: &crate::text::AnnotatedString, style: &TextStyle) -> TextMetrics {
-            MonospacedTextMeasurer.measure(text, style)
+            monospaced_measure(text, style)
         }
 
         fn measure_line_width(
@@ -2689,7 +2695,7 @@ mod tests {
             x: f32,
             y: f32,
         ) -> usize {
-            MonospacedTextMeasurer.get_offset_for_position(text, style, x, y)
+            monospaced_offset_for_position(text, style, x, y)
         }
 
         fn get_cursor_x_for_offset(
@@ -2698,7 +2704,7 @@ mod tests {
             style: &TextStyle,
             offset: usize,
         ) -> f32 {
-            MonospacedTextMeasurer.get_cursor_x_for_offset(text, style, offset)
+            monospaced_cursor_x_for_offset(text, style, offset)
         }
 
         fn layout(
@@ -2706,13 +2712,13 @@ mod tests {
             text: &crate::text::AnnotatedString,
             style: &TextStyle,
         ) -> TextLayoutResult {
-            MonospacedTextMeasurer.layout(text, style)
+            monospaced_layout(text, style)
         }
     }
 
     impl TextMeasurer for CountingPreparedTextMeasurer {
         fn measure(&self, text: &crate::text::AnnotatedString, style: &TextStyle) -> TextMetrics {
-            MonospacedTextMeasurer.measure(text, style)
+            monospaced_measure(text, style)
         }
 
         fn prepare_with_options_for_node(
@@ -2734,7 +2740,7 @@ mod tests {
             x: f32,
             y: f32,
         ) -> usize {
-            MonospacedTextMeasurer.get_offset_for_position(text, style, x, y)
+            monospaced_offset_for_position(text, style, x, y)
         }
 
         fn get_cursor_x_for_offset(
@@ -2743,7 +2749,7 @@ mod tests {
             style: &TextStyle,
             offset: usize,
         ) -> f32 {
-            MonospacedTextMeasurer.get_cursor_x_for_offset(text, style, offset)
+            monospaced_cursor_x_for_offset(text, style, offset)
         }
 
         fn layout(
@@ -2751,7 +2757,7 @@ mod tests {
             text: &crate::text::AnnotatedString,
             style: &TextStyle,
         ) -> TextLayoutResult {
-            MonospacedTextMeasurer.layout(text, style)
+            monospaced_layout(text, style)
         }
     }
 


### PR DESCRIPTION
## Summary

Targeted `crates/cranpose-ui/src/` for the dedup pass. Measured with:
`jscpd --min-lines 10 --min-tokens 50 --reporters json --format rust crates/cranpose-ui`

- **Before: 299 clone pairs**
- **After: 274 clone pairs**

## Abstractions introduced

**`text/measure.rs`** (production code)
- `monospaced_measure` / `monospaced_offset_for_position` / `monospaced_cursor_x_for_offset` / `monospaced_layout` — the identical uncounted passthrough bodies shared by the five inline-test `TextMeasurer` wrappers (`CountingTextMeasurer`, `CountingPreparedTextMeasurer`, `PrefixWidthCountingMeasurer`, `LineHeightCountingMeasurer`, `FitProbeCountingMeasurer`). Kept the five types distinct — see "left alone" note below for why a single generic wrapper is wrong here.
- `measured_width()` + `EllipsisTruncation` (`NotNeeded` / `ImpossibleFit` / `Truncate(boundaries)`) — the shared "does it already fit, is the ellipsis itself too wide" preamble duplicated across `fit_end_ellipsis`/`fit_start_ellipsis`/`fit_middle_ellipsis`.

**`modifier_nodes.rs`** (production code)
- `impl_layout_modifier_node!` / `impl_draw_modifier_node!` macros for the `ModifierNode` on_attach+as_X_node(_mut) boilerplate repeated across 11 node types.
- `forward_intrinsics_to_child!()` for the four intrinsic-passthrough methods byte-identical across `OffsetNode`, `FractionalOffsetNode`, `FillNode` (the trait default is `0.0`, not a passthrough, so these aren't no-ops).
- `measure_pass_through()` for "measure the child, place it at an offset derived from the resulting size" (`WindowRectReporterNode`, `OffsetNode`, `FractionalOffsetNode`, `SizeReporterNode`).
- `attach_draw_observer()` / `detach_draw_observer()` for the node-id-tracking on_attach/on_detach pair shared by `GraphicsLayerNode` and `DrawCommandNode`.
- `impl_sink_reporter_element!()` for the `ModifierNodeElement` create/update/capabilities boilerplate shared by the two sink-reporter elements.
- `size_intrinsic()` / `SizeAxis` for `SizeNode`'s own four intrinsic methods, which differed only in which axis/measurable-method to use.

**`tests/primitives_tests.rs`** (test scaffolding)
- Hoisted six byte-identical nested `fn find_layout` out of six tests into one module-level fn of the same name (zero call-site changes needed).
- `PrimitiveLazyColumnWithScrollIndicator(list_state, captures)` — the identical Row/LazyColumn/indicator subtree shared by two composables that otherwise only differ in their status-line `Text`, which stays inline at each call site.
- `assert_lazy_list_host_survives_one_scroll` / `assert_branch_round_trip_preserves_lazy_list_host` / `assert_lazy_list_host_stable_across_scrolls` — three independently-composable helpers extracted from a repeated three-part test tail (one test only needed the middle piece).

**`layout/tests/layout_tests.rs`** (test scaffolding)
- `measured_dirty_clean_leaves() -> DirtyCleanLeaves` — the identical two-child (dirty+clean) `LayoutNode` tree setup shared by two tests, destructured back into the same local names so nothing past setup needed to change.

## Deliberately left alone

- **`SizeNode::new` / `SizeElement::with_constraints`** (`modifier_nodes.rs`) — same field list, but this is the `ModifierNodeElement` Node/Element split by design (retained state with `NodeState` vs. a `Clone+PartialEq+Hash` diffing descriptor), not accidental duplication.
- **Subcompose-child pair** in `layout_tests.rs` (`scoped_layout_repass_remeasures_dirty_subcompose_child` / `measure_layout_consumes_pending_scoped_repass_for_subcompose_child`) — their shared setup creates a throwaway `Composition` purely to mint a `RuntimeHandle`, and `RuntimeHandle` holds `Weak<RuntimeInner>` internally. A helper that returns before the caller finishes would drop that `Composition` and leave the handle stored on the `applier` dangling mid-test. Confirming that's safe needs more digging into `subcompose_layout`'s runtime usage than this pass budgeted for, so I left the two tests duplicated rather than risk a silent behavior change.
- A single first attempt at collapsing all five `TextMeasurer` counting wrappers into one generic `CountingMeasurer<M>` (forwarding every optional trait method to the inner measurer) broke two tests: their whole point is that a measurer lacking `measure_line_width`/`measure_line_prefix_widths` forces a different wrap-algorithm code path, and the generic wrapper made every optional method universally "supported," erasing that distinction. Reverted to five distinct wrapper types sharing only the genuinely identical bodies.

## Test plan

- [x] `cargo clippy -p cranpose-ui --all-targets -- -D warnings` — clean
- [x] `cargo test --profile ci -p cranpose-ui` — 1021/1021 lib tests passing (same count as main), all integration + doc tests pass
- [x] `just fmt` — no-op
- [x] `just complexity-gate` — clean
- [x] `just duplication-gate` — clean (0 new clones introduced)
- [x] `cargo build --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)