### PR TITLE
Remove duplication in cranpose-render-common and cranpose-app-shell

### DIFF
--- a/crates/cranpose-app-shell/src/shell_frame.rs
+++ b/crates/cranpose-app-shell/src/shell_frame.rs
@@ -108,6 +108,40 @@ fn log_render_phase_dirty_diagnostics(diagnostics: RenderPhaseDirtyDiagnostics<'
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn log_dirty_diagnostics_for_path(
+    render_dirty: bool,
+    pointer_dirty: bool,
+    scene_dirty: bool,
+    draw_repass_pending: bool,
+    draw_dirty_nodes: &[NodeId],
+    layout_dirty_nodes: &[NodeId],
+    structural_parents: &[NodeId],
+    partial_dirty_nodes: &[NodeId],
+    render_only_dirty: bool,
+    recomposed_this_frame: bool,
+    path: &str,
+) {
+    log_render_phase_dirty_diagnostics(RenderPhaseDirtyDiagnostics {
+        render_dirty,
+        pointer_dirty,
+        scene_dirty,
+        draw_repass_pending,
+        draw_dirty_nodes: draw_dirty_nodes.len(),
+        layout_dirty_nodes: layout_dirty_nodes.len(),
+        structural_dirty_nodes: structural_parents.len(),
+        partial_dirty_nodes: partial_dirty_nodes.len(),
+        dirty_node_ids: render_phase_dirty_diagnostics_enabled().then(|| {
+            format!(
+                "draw={draw_dirty_nodes:?} layout={layout_dirty_nodes:?} structural={structural_parents:?} partial={partial_dirty_nodes:?}",
+            )
+        }),
+        render_only_dirty,
+        recomposed_this_frame,
+        path,
+    });
+}
+
 impl<R> AppShell<R>
 where
     R: Renderer,
@@ -503,10 +537,6 @@ where
         partial_dirty_nodes.extend(structural_parents.iter().copied());
         partial_dirty_nodes.sort_unstable();
         partial_dirty_nodes.dedup();
-        let draw_dirty_node_count = draw_dirty_nodes.len();
-        let layout_dirty_node_count = layout_dirty_nodes.len();
-        let structural_dirty_node_count = structural_parents.len();
-        let partial_dirty_node_count = partial_dirty_nodes.len();
         let _ = cranpose_ui::has_focused_field();
 
         let render_only_dirty = render_dirty
@@ -529,32 +559,23 @@ where
             || structural_dirty;
 
         if !needs_scene_rebuild {
-            log_render_phase_dirty_diagnostics(RenderPhaseDirtyDiagnostics {
+            log_dirty_diagnostics_for_path(
                 render_dirty,
                 pointer_dirty,
                 scene_dirty,
                 draw_repass_pending,
-                draw_dirty_nodes: draw_dirty_node_count,
-                layout_dirty_nodes: layout_dirty_node_count,
-                structural_dirty_nodes: structural_dirty_node_count,
-                partial_dirty_nodes: partial_dirty_node_count,
-                dirty_node_ids: render_phase_dirty_diagnostics_enabled().then(|| {
-                    format!(
-                        "draw={:?} layout={:?} structural={:?} partial={:?}",
-                        draw_dirty_nodes,
-                        layout_dirty_nodes,
-                        structural_parents,
-                        partial_dirty_nodes
-                    )
-                }),
+                &draw_dirty_nodes,
+                &layout_dirty_nodes,
+                &structural_parents,
+                &partial_dirty_nodes,
                 render_only_dirty,
                 recomposed_this_frame,
-                path: if render_only_dirty {
+                if render_only_dirty {
                     "present-retained"
                 } else {
                     "skip"
                 },
-            });
+            );
             self.scoped_layout_scene_nodes = layout_dirty_nodes;
             if render_only_dirty && self.dev_options.fps_counter {
                 let viewport_size = Size {
@@ -584,34 +605,25 @@ where
             let use_partial_update =
                 !partial_dirty_nodes.is_empty() && !render_only_dirty && !full_scene_dirty;
             let use_visual_update = use_partial_update && draw_only_partial_dirty;
-            log_render_phase_dirty_diagnostics(RenderPhaseDirtyDiagnostics {
+            log_dirty_diagnostics_for_path(
                 render_dirty,
                 pointer_dirty,
                 scene_dirty,
                 draw_repass_pending,
-                draw_dirty_nodes: draw_dirty_node_count,
-                layout_dirty_nodes: layout_dirty_node_count,
-                structural_dirty_nodes: structural_dirty_node_count,
-                partial_dirty_nodes: partial_dirty_node_count,
-                dirty_node_ids: render_phase_dirty_diagnostics_enabled().then(|| {
-                    format!(
-                        "draw={:?} layout={:?} structural={:?} partial={:?}",
-                        draw_dirty_nodes,
-                        layout_dirty_nodes,
-                        structural_parents,
-                        partial_dirty_nodes
-                    )
-                }),
+                &draw_dirty_nodes,
+                &layout_dirty_nodes,
+                &structural_parents,
+                &partial_dirty_nodes,
                 render_only_dirty,
                 recomposed_this_frame,
-                path: if use_visual_update {
+                if use_visual_update {
                     "visual-update"
                 } else if use_partial_update {
                     "update"
                 } else {
                     "rebuild"
                 },
-            });
+            );
             let rebuild_result = if use_visual_update {
                 self.renderer.update_visual_scene_from_applier(
                     &mut applier,

--- a/crates/cranpose-app-shell/src/shell_input.rs
+++ b/crates/cranpose-app-shell/src/shell_input.rs
@@ -70,6 +70,25 @@ where
         event.finish_post_dispatch();
     }
 
+    fn dispatch_to_hits(
+        &mut self,
+        hits: &[<<R as Renderer>::Scene as RenderScene>::HitTarget],
+        event: PointerEvent,
+    ) -> bool {
+        let capture_paths = hits
+            .iter()
+            .map(|hit| hit.capture_path())
+            .collect::<Vec<_>>();
+        let targets = crate::hit_path_tracker::dispatch_order_for_paths(&capture_paths)
+            .into_iter()
+            .filter_map(|node_id| self.renderer.scene().find_target(node_id))
+            .collect::<Vec<_>>();
+
+        self.dispatch_targets(targets, event.clone(), true);
+
+        event.is_consumed()
+    }
+
     /// Sets the device source (touch/mouse/stylus) of the pointer sample that
     /// the platform is about to dispatch. Call this before `set_cursor` /
     /// `pointer_pressed` / `pointer_released` so the resulting `PointerEvent`s
@@ -550,18 +569,7 @@ where
             .with_zoom_delta(zoom_factor)
             .with_source(self.pointer_source);
 
-        let capture_paths = hits
-            .iter()
-            .map(|hit| hit.capture_path())
-            .collect::<Vec<_>>();
-        let targets = crate::hit_path_tracker::dispatch_order_for_paths(&capture_paths)
-            .into_iter()
-            .filter_map(|node_id| self.renderer.scene().find_target(node_id))
-            .collect::<Vec<_>>();
-
-        self.dispatch_targets(targets, event.clone(), true);
-
-        event.is_consumed()
+        self.dispatch_to_hits(&hits, event)
     }
 
     /// Dispatches one mouse-wheel / trackpad sample through the whole wheel
@@ -675,18 +683,7 @@ where
             })
             .with_source(self.pointer_source);
 
-        let capture_paths = hits
-            .iter()
-            .map(|hit| hit.capture_path())
-            .collect::<Vec<_>>();
-        let targets = crate::hit_path_tracker::dispatch_order_for_paths(&capture_paths)
-            .into_iter()
-            .filter_map(|node_id| self.renderer.scene().find_target(node_id))
-            .collect::<Vec<_>>();
-
-        self.dispatch_targets(targets, event.clone(), true);
-
-        event.is_consumed()
+        self.dispatch_to_hits(&hits, event)
     }
 
     /// Installs the window-level rotary (Wear OS crown / rotating bezel)

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -652,6 +652,39 @@ impl RenderScene for AppContextProbeScene {
     }
 }
 
+macro_rules! renderer_scene_accessors {
+    () => {
+        fn scene(&self) -> &Self::Scene {
+            &self.scene
+        }
+
+        fn scene_mut(&mut self) -> &mut Self::Scene {
+            &mut self.scene
+        }
+    };
+}
+
+macro_rules! renderer_noop_rebuild {
+    () => {
+        fn rebuild_scene(
+            &mut self,
+            _layout_tree: &LayoutTree,
+            _viewport: Size,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn rebuild_scene_from_applier(
+            &mut self,
+            _applier: &mut cranpose_core::MemoryApplier,
+            _root: cranpose_core::NodeId,
+            _viewport: Size,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    };
+}
+
 struct AppContextProbeRenderer {
     scene: AppContextProbeScene,
 }
@@ -660,30 +693,8 @@ impl Renderer for AppContextProbeRenderer {
     type Scene = AppContextProbeScene;
     type Error = ();
 
-    fn scene(&self) -> &Self::Scene {
-        &self.scene
-    }
-
-    fn scene_mut(&mut self) -> &mut Self::Scene {
-        &mut self.scene
-    }
-
-    fn rebuild_scene(
-        &mut self,
-        _layout_tree: &LayoutTree,
-        _viewport: Size,
-    ) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn rebuild_scene_from_applier(
-        &mut self,
-        _applier: &mut cranpose_core::MemoryApplier,
-        _root: cranpose_core::NodeId,
-        _viewport: Size,
-    ) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    renderer_scene_accessors!();
+    renderer_noop_rebuild!();
 }
 
 #[derive(Clone)]
@@ -853,30 +864,8 @@ impl Renderer for TestRenderer {
         }
     }
 
-    fn scene(&self) -> &Self::Scene {
-        &self.scene
-    }
-
-    fn scene_mut(&mut self) -> &mut Self::Scene {
-        &mut self.scene
-    }
-
-    fn rebuild_scene(
-        &mut self,
-        _layout_tree: &LayoutTree,
-        _viewport: Size,
-    ) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn rebuild_scene_from_applier(
-        &mut self,
-        _applier: &mut cranpose_core::MemoryApplier,
-        _root: cranpose_core::NodeId,
-        _viewport: Size,
-    ) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    renderer_scene_accessors!();
+    renderer_noop_rebuild!();
 }
 
 struct WarmupRenderer {
@@ -888,30 +877,8 @@ impl Renderer for WarmupRenderer {
     type Scene = TestScene;
     type Error = ();
 
-    fn scene(&self) -> &Self::Scene {
-        &self.scene
-    }
-
-    fn scene_mut(&mut self) -> &mut Self::Scene {
-        &mut self.scene
-    }
-
-    fn rebuild_scene(
-        &mut self,
-        _layout_tree: &LayoutTree,
-        _viewport: Size,
-    ) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn rebuild_scene_from_applier(
-        &mut self,
-        _applier: &mut cranpose_core::MemoryApplier,
-        _root: cranpose_core::NodeId,
-        _viewport: Size,
-    ) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    renderer_scene_accessors!();
+    renderer_noop_rebuild!();
 
     fn needs_frame_warmup(&self) -> bool {
         self.needs_warmup.get()
@@ -1379,60 +1346,16 @@ impl Renderer for MutableRecordingRenderer {
     type Scene = MutableRecordingScene;
     type Error = ();
 
-    fn scene(&self) -> &Self::Scene {
-        &self.scene
-    }
-
-    fn scene_mut(&mut self) -> &mut Self::Scene {
-        &mut self.scene
-    }
-
-    fn rebuild_scene(
-        &mut self,
-        _layout_tree: &LayoutTree,
-        _viewport: Size,
-    ) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn rebuild_scene_from_applier(
-        &mut self,
-        _applier: &mut cranpose_core::MemoryApplier,
-        _root: cranpose_core::NodeId,
-        _viewport: Size,
-    ) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    renderer_scene_accessors!();
+    renderer_noop_rebuild!();
 }
 
 impl Renderer for ScrollDispatchRenderer {
     type Scene = RecordingScene;
     type Error = ();
 
-    fn scene(&self) -> &Self::Scene {
-        &self.scene
-    }
-
-    fn scene_mut(&mut self) -> &mut Self::Scene {
-        &mut self.scene
-    }
-
-    fn rebuild_scene(
-        &mut self,
-        _layout_tree: &LayoutTree,
-        _viewport: Size,
-    ) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn rebuild_scene_from_applier(
-        &mut self,
-        _applier: &mut cranpose_core::MemoryApplier,
-        _root: cranpose_core::NodeId,
-        _viewport: Size,
-    ) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    renderer_scene_accessors!();
+    renderer_noop_rebuild!();
 }
 
 #[derive(Default)]
@@ -1445,13 +1368,7 @@ impl Renderer for RecordingRenderer {
     type Scene = TestScene;
     type Error = ();
 
-    fn scene(&self) -> &Self::Scene {
-        &self.scene
-    }
-
-    fn scene_mut(&mut self) -> &mut Self::Scene {
-        &mut self.scene
-    }
+    renderer_scene_accessors!();
 
     fn rebuild_scene(
         &mut self,
@@ -1502,13 +1419,7 @@ impl Renderer for CountingRenderer {
     type Scene = TestScene;
     type Error = ();
 
-    fn scene(&self) -> &Self::Scene {
-        &self.scene
-    }
-
-    fn scene_mut(&mut self) -> &mut Self::Scene {
-        &mut self.scene
-    }
+    renderer_scene_accessors!();
 
     fn rebuild_scene(
         &mut self,
@@ -1571,13 +1482,7 @@ impl Renderer for ScopedUpdateCountingRenderer {
     type Scene = cranpose_render_common::graph_scene::Scene;
     type Error = ();
 
-    fn scene(&self) -> &Self::Scene {
-        &self.scene
-    }
-
-    fn scene_mut(&mut self) -> &mut Self::Scene {
-        &mut self.scene
-    }
+    renderer_scene_accessors!();
 
     fn rebuild_scene(
         &mut self,
@@ -1722,13 +1627,7 @@ impl Renderer for HitGraphRenderer {
     type Scene = cranpose_render_common::graph_scene::Scene;
     type Error = ();
 
-    fn scene(&self) -> &Self::Scene {
-        &self.scene
-    }
-
-    fn scene_mut(&mut self) -> &mut Self::Scene {
-        &mut self.scene
-    }
+    renderer_scene_accessors!();
 
     fn rebuild_scene(
         &mut self,

--- a/crates/cranpose-render/common/src/brush_sampling.rs
+++ b/crates/cranpose-render/common/src/brush_sampling.rs
@@ -84,6 +84,24 @@ fn dither_gradient(rgba: [f32; 4], x: f32, y: f32) -> [f32; 4] {
     ]
 }
 
+fn sample_tiled_gradient_rgba(
+    t: f32,
+    tile_mode: TileMode,
+    colors: &[Color],
+    stops: Option<&[f32]>,
+    x: f32,
+    y: f32,
+) -> [f32; 4] {
+    match normalize_gradient_t(t, tile_mode) {
+        Some(sample_t) => dither_gradient(
+            color_to_rgba(interpolate_colors(colors, stops, sample_t)),
+            x,
+            y,
+        ),
+        None => color_to_rgba(TRANSPARENT),
+    }
+}
+
 #[doc(hidden)]
 pub fn sample_brush_rgba(brush: &Brush, rect: Rect, x: f32, y: f32) -> [f32; 4] {
     match brush {
@@ -103,14 +121,7 @@ pub fn sample_brush_rgba(brush: &Brush, rect: Rect, x: f32, y: f32) -> [f32; 4] 
             let dy = ey - sy;
             let denom = (dx * dx + dy * dy).max(f32::EPSILON);
             let t = ((x - sx) * dx + (y - sy) * dy) / denom;
-            match normalize_gradient_t(t, *tile_mode) {
-                Some(sample_t) => dither_gradient(
-                    color_to_rgba(interpolate_colors(colors, stops.as_deref(), sample_t)),
-                    x,
-                    y,
-                ),
-                None => color_to_rgba(TRANSPARENT),
-            }
+            sample_tiled_gradient_rgba(t, *tile_mode, colors, stops.as_deref(), x, y)
         }
         Brush::RadialGradient {
             colors,
@@ -126,14 +137,7 @@ pub fn sample_brush_rgba(brush: &Brush, rect: Rect, x: f32, y: f32) -> [f32; 4] 
             let dy = y - cy;
             let distance = (dx * dx + dy * dy).sqrt();
             let t = distance / radius;
-            match normalize_gradient_t(t, *tile_mode) {
-                Some(sample_t) => dither_gradient(
-                    color_to_rgba(interpolate_colors(colors, stops.as_deref(), sample_t)),
-                    x,
-                    y,
-                ),
-                None => color_to_rgba(TRANSPARENT),
-            }
+            sample_tiled_gradient_rgba(t, *tile_mode, colors, stops.as_deref(), x, y)
         }
         Brush::SweepGradient {
             colors,

--- a/crates/cranpose-render/common/src/dev_overlay.rs
+++ b/crates/cranpose-render/common/src/dev_overlay.rs
@@ -1,16 +1,11 @@
 //! Renderer-drawn dev overlay (fps counter): one shared graph builder so
 //! every backend draws the identical overlay without composition impact.
 
-use cranpose_ui_graphics::{
-    Brush, Color, CornerRadii, DrawPrimitive, GraphicsLayer, Point, Rect, Size,
-};
+use cranpose_ui_graphics::{Brush, Color, CornerRadii, DrawPrimitive, Rect, Size};
 
-use crate::{
-    graph::{
-        CachePolicy, DrawPrimitiveNode, IsolationReasons, LayerNode, PrimitiveEntry, PrimitiveNode,
-        PrimitivePhase, ProjectiveTransform, RenderGraph, RenderNode, TextPrimitiveNode,
-    },
-    raster_cache::LayerRasterCacheHashes,
+use crate::graph::{
+    DrawPrimitiveNode, LayerNode, PrimitiveEntry, PrimitiveNode, PrimitivePhase,
+    ProjectiveTransform, RenderGraph, RenderNode, TextPrimitiveNode,
 };
 
 /// Cache key for the last-built overlay; rebuilding only on change keeps the
@@ -57,22 +52,6 @@ pub fn build_dev_overlay_graph(
             height: text_height + padding / 2.0,
         },
         transform_to_parent: ProjectiveTransform::translation(x, y),
-        content_offset: Point::default(),
-        motion_context_animated: false,
-        translated_content_context: false,
-        translated_content_offset: Point::default(),
-        scene_children_origin: Point::default(),
-        scene_children_layer_translation: Point::default(),
-        graphics_layer: GraphicsLayer::default(),
-        clip_to_bounds: false,
-        shadow_clip: None,
-        hit_test: None,
-        has_hit_targets: false,
-        has_origin_sinks: false,
-        isolation: IsolationReasons::default(),
-        cache_policy: CachePolicy::None,
-        cache_hashes: LayerRasterCacheHashes::default(),
-        cache_hashes_valid: false,
         children: vec![
             RenderNode::Primitive(PrimitiveEntry {
                 phase: PrimitivePhase::BeforeChildren,
@@ -109,30 +88,14 @@ pub fn build_dev_overlay_graph(
                 })),
             }),
         ],
+        ..Default::default()
     };
     overlay_layer.recompute_raster_cache_hashes();
 
     let mut graph = RenderGraph::new(LayerNode {
-        node_id: None,
         local_bounds: Rect::from_size(viewport),
-        transform_to_parent: ProjectiveTransform::identity(),
-        content_offset: Point::default(),
-        motion_context_animated: false,
-        translated_content_context: false,
-        translated_content_offset: Point::default(),
-        scene_children_origin: Point::default(),
-        scene_children_layer_translation: Point::default(),
-        graphics_layer: GraphicsLayer::default(),
-        clip_to_bounds: false,
-        shadow_clip: None,
-        hit_test: None,
-        has_hit_targets: false,
-        has_origin_sinks: false,
-        isolation: IsolationReasons::default(),
-        cache_policy: CachePolicy::None,
-        cache_hashes: LayerRasterCacheHashes::default(),
-        cache_hashes_valid: false,
         children: vec![RenderNode::Layer(Box::new(overlay_layer))],
+        ..Default::default()
     });
     graph.root.recompute_raster_cache_hashes();
     graph

--- a/crates/cranpose-render/common/src/font_source.rs
+++ b/crates/cranpose-render/common/src/font_source.rs
@@ -81,6 +81,28 @@ pub struct SoftwareTextFontRegistry {
     system_faces: Vec<(FontFamilyKey, FontWeight, FontStyle)>,
 }
 
+#[derive(Default)]
+struct TolerantLoad {
+    first_error: Option<FontLoadError>,
+    loaded: usize,
+}
+
+impl TolerantLoad {
+    fn record(&mut self, result: Result<(), FontLoadError>) {
+        match result {
+            Ok(()) => self.loaded += 1,
+            Err(error) => self.first_error = self.first_error.take().or(Some(error)),
+        }
+    }
+
+    fn finish(self) -> Result<(), FontLoadError> {
+        match self.first_error {
+            Some(error) if self.loaded == 0 => Err(error),
+            _ => Ok(()),
+        }
+    }
+}
+
 impl SoftwareTextFontRegistry {
     pub fn new() -> Self {
         Self::default()
@@ -102,25 +124,17 @@ impl SoftwareTextFontRegistry {
         }
 
         let mut reads = FontFileReads::default();
-        let mut first_error = None;
-        let mut loaded = 0usize;
+        let mut load = TolerantLoad::default();
         for file in &files {
-            match self.register_read_face(
+            load.record(self.register_read_face(
                 &mut reads,
                 family,
                 file.weight,
                 file.style,
                 Path::new(&file.path),
-            ) {
-                Ok(()) => loaded += 1,
-                Err(error) => first_error = first_error.or(Some(error)),
-            }
+            ));
         }
-
-        match first_error {
-            Some(error) if loaded == 0 => Err(error),
-            _ => Ok(()),
-        }
+        load.finish()
     }
 
     fn register_read_face(
@@ -216,25 +230,17 @@ impl SoftwareTextFontRegistry {
     ) -> Result<(), FontLoadError> {
         let directory = directory.as_ref();
         let mut reads = FontFileReads::default();
-        let mut first_error = None;
-        let mut loaded = 0usize;
+        let mut load = TolerantLoad::default();
         for weight in weights {
-            match self.register_read_system_face(
+            load.record(self.register_read_system_face(
                 &mut reads,
                 directory,
                 family,
                 *weight,
                 FontStyle::Normal,
-            ) {
-                Ok(()) => loaded += 1,
-                Err(error) => first_error = first_error.or(Some(error)),
-            }
+            ));
         }
-
-        match first_error {
-            Some(error) if loaded == 0 => Err(error),
-            _ => Ok(()),
-        }
+        load.finish()
     }
 
     /// Register one weight/style of a generic family alias from the platform's

--- a/crates/cranpose-render/common/src/graph.rs
+++ b/crates/cranpose-render/common/src/graph.rs
@@ -308,6 +308,38 @@ pub struct LayerNode {
     pub children: Vec<RenderNode>,
 }
 
+impl Default for LayerNode {
+    fn default() -> Self {
+        Self {
+            node_id: None,
+            local_bounds: Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 0.0,
+                height: 0.0,
+            },
+            transform_to_parent: ProjectiveTransform::identity(),
+            content_offset: Point::default(),
+            motion_context_animated: false,
+            translated_content_context: false,
+            translated_content_offset: Point::default(),
+            scene_children_origin: Point::default(),
+            scene_children_layer_translation: Point::default(),
+            graphics_layer: GraphicsLayer::default(),
+            clip_to_bounds: false,
+            shadow_clip: None,
+            hit_test: None,
+            has_hit_targets: false,
+            has_origin_sinks: false,
+            isolation: IsolationReasons::default(),
+            cache_policy: CachePolicy::None,
+            cache_hashes: LayerRasterCacheHashes::default(),
+            cache_hashes_valid: false,
+            children: Vec::new(),
+        }
+    }
+}
+
 impl LayerNode {
     pub fn clip_rect(&self) -> Option<Rect> {
         (self.clip_to_bounds || self.graphics_layer.clip).then_some(self.local_bounds)
@@ -775,30 +807,12 @@ mod tests {
     use cranpose_ui_graphics::{Brush, Color, DrawPrimitive};
 
     use super::*;
-    use crate::raster_cache::LayerRasterCacheHashes;
 
     fn test_layer(local_bounds: Rect, children: Vec<RenderNode>) -> LayerNode {
         LayerNode {
-            node_id: None,
             local_bounds,
-            transform_to_parent: ProjectiveTransform::identity(),
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            translated_content_offset: Point::default(),
-            scene_children_origin: Point::default(),
-            scene_children_layer_translation: Point::default(),
-            graphics_layer: GraphicsLayer::default(),
-            clip_to_bounds: false,
-            shadow_clip: None,
-            hit_test: None,
-            has_hit_targets: false,
-            has_origin_sinks: false,
-            isolation: IsolationReasons::default(),
-            cache_policy: CachePolicy::None,
-            cache_hashes: LayerRasterCacheHashes::default(),
-            cache_hashes_valid: false,
             children,
+            ..Default::default()
         }
     }
 

--- a/crates/cranpose-render/common/src/graph_scene.rs
+++ b/crates/cranpose-render/common/src/graph_scene.rs
@@ -110,6 +110,38 @@ struct HitRegionInit {
     diagnostics: Rc<RenderDiagnostics>,
 }
 
+impl Default for HitRegionInit {
+    fn default() -> Self {
+        Self {
+            node_id: 0,
+            capture_path: Vec::new(),
+            geometry: HitGeometry {
+                rect: Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 0.0,
+                    height: 0.0,
+                },
+                quad: [[0.0, 0.0]; 4],
+                local_bounds: Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 0.0,
+                    height: 0.0,
+                },
+                world_to_local: ProjectiveTransform::identity(),
+                hit_clip_bounds: None,
+                hit_clips: Vec::new(),
+            },
+            shape: None,
+            click_actions: Vec::new(),
+            pointer_inputs: Vec::new(),
+            z_index: 0,
+            diagnostics: Rc::new(RenderDiagnostics::new()),
+        }
+    }
+}
+
 impl HitRegion {
     fn with_diagnostics(init: HitRegionInit) -> Self {
         let HitRegionInit {
@@ -615,14 +647,11 @@ mod tests {
                 width: 50.0,
                 height: 50.0,
             }),
-            shape: None,
-            click_actions: Vec::new(),
             pointer_inputs: vec![
                 make_handler(count_first.clone(), true),
                 make_handler(count_second.clone(), false),
             ],
-            z_index: 0,
-            diagnostics: test_diagnostics(),
+            ..Default::default()
         });
 
         let event = PointerEvent::new(
@@ -650,14 +679,11 @@ mod tests {
                 width: 50.0,
                 height: 50.0,
             }),
-            shape: None,
-            click_actions: Vec::new(),
             pointer_inputs: vec![
                 make_handler(count_first.clone(), true),
                 make_handler(count_second.clone(), false),
             ],
-            z_index: 0,
-            diagnostics: test_diagnostics(),
+            ..Default::default()
         });
 
         for kind in [PointerEventKind::Up, PointerEventKind::Cancel] {
@@ -684,11 +710,9 @@ mod tests {
                 width: 20.0,
                 height: 20.0,
             }),
-            shape: None,
-            click_actions: Vec::new(),
             pointer_inputs: vec![make_handler(child_count.clone(), true)],
             z_index: 1,
-            diagnostics: test_diagnostics(),
+            ..Default::default()
         });
         let parent_hit = HitRegion::with_diagnostics(HitRegionInit {
             node_id: 1,
@@ -699,11 +723,8 @@ mod tests {
                 width: 50.0,
                 height: 50.0,
             }),
-            shape: None,
-            click_actions: Vec::new(),
             pointer_inputs: vec![make_handler(parent_count.clone(), false)],
-            z_index: 0,
-            diagnostics: test_diagnostics(),
+            ..Default::default()
         });
 
         let event = PointerEvent::new(
@@ -735,11 +756,8 @@ mod tests {
                 width: 50.0,
                 height: 50.0,
             }),
-            shape: None,
             click_actions: vec![click_action],
-            pointer_inputs: Vec::new(),
-            z_index: 0,
-            diagnostics: test_diagnostics(),
+            ..Default::default()
         });
 
         hit.dispatch(PointerEvent::new(
@@ -773,11 +791,8 @@ mod tests {
                 width: 50.0,
                 height: 50.0,
             }),
-            shape: None,
             click_actions: vec![click_action],
-            pointer_inputs: Vec::new(),
-            z_index: 0,
-            diagnostics: test_diagnostics(),
+            ..Default::default()
         });
 
         hit.dispatch(PointerEvent::new(
@@ -806,11 +821,9 @@ mod tests {
                 width: 50.0,
                 height: 50.0,
             }),
-            shape: None,
             click_actions: vec![click_action],
             pointer_inputs: vec![Rc::new(|event: PointerEvent| event.consume())],
-            z_index: 0,
-            diagnostics: test_diagnostics(),
+            ..Default::default()
         });
 
         hit.dispatch(PointerEvent::new(
@@ -896,11 +909,8 @@ mod tests {
                 hit_clip_bounds: None,
                 hit_clips: Vec::new(),
             },
-            shape: None,
             click_actions: vec![click_action],
-            pointer_inputs: Vec::new(),
-            z_index: 0,
-            diagnostics: test_diagnostics(),
+            ..Default::default()
         });
 
         hit.dispatch(PointerEvent::new(
@@ -926,13 +936,11 @@ mod tests {
                 width: 50.0,
                 height: 50.0,
             }),
-            shape: None,
-            click_actions: Vec::new(),
             pointer_inputs: vec![Rc::new(move |_event: PointerEvent| {
                 handler_calls_for_handler.set(handler_calls_for_handler.get() + 1);
             })],
-            z_index: 0,
             diagnostics: Rc::clone(&diagnostics),
+            ..Default::default()
         });
         let misses_before = diagnostics.live_modifier_slice_lookup_miss_count();
         let mut applier = MemoryApplier::new();

--- a/crates/cranpose-render/common/src/hit_graph.rs
+++ b/crates/cranpose-render/common/src/hit_graph.rs
@@ -138,10 +138,7 @@ fn collect_hits_from_graph_inner<S: HitGraphSink>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        graph::{CachePolicy, HitTestNode, IsolationReasons},
-        raster_cache::LayerRasterCacheHashes,
-    };
+    use crate::graph::HitTestNode;
 
     type RecordedHit = (
         NodeId,
@@ -188,15 +185,7 @@ mod tests {
                 height: 18.0,
             },
             transform_to_parent,
-            content_offset: cranpose_ui_graphics::Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            translated_content_offset: cranpose_ui_graphics::Point::default(),
-            scene_children_origin: cranpose_ui_graphics::Point::default(),
-            scene_children_layer_translation: cranpose_ui_graphics::Point::default(),
-            graphics_layer: cranpose_ui_graphics::GraphicsLayer::default(),
             clip_to_bounds: true,
-            shadow_clip: None,
             hit_test: Some(HitTestNode {
                 shape: None,
                 click_actions: vec![Rc::new(|_point| {})],
@@ -204,12 +193,7 @@ mod tests {
                 clip: None,
             }),
             has_hit_targets: true,
-            has_origin_sinks: false,
-            isolation: IsolationReasons::default(),
-            cache_policy: CachePolicy::None,
-            cache_hashes: LayerRasterCacheHashes::default(),
-            cache_hashes_valid: false,
-            children: vec![],
+            ..Default::default()
         }
     }
 

--- a/crates/cranpose-render/common/src/primitive_emit.rs
+++ b/crates/cranpose-render/common/src/primitive_emit.rs
@@ -927,6 +927,19 @@ mod tests {
         }))
     }
 
+    fn sample_text_primitive() -> DrawPrimitive {
+        text_primitive(
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 30.0,
+                height: 14.0,
+            },
+            "AB",
+            DrawTextStyle::new(10.0),
+        )
+    }
+
     fn lower_text(primitive: DrawPrimitive, layer: &GraphicsLayer) -> Vec<TextDrawParams> {
         let mut sink = CollectingTextSink::default();
         emit_draw_primitive(
@@ -979,19 +992,7 @@ mod tests {
             transform_origin: cranpose_ui_graphics::TransformOrigin::new(0.0, 0.0),
             ..Default::default()
         };
-        let params = lower_text(
-            text_primitive(
-                Rect {
-                    x: 0.0,
-                    y: 0.0,
-                    width: 30.0,
-                    height: 14.0,
-                },
-                "AB",
-                DrawTextStyle::new(10.0),
-            ),
-            &layer,
-        );
+        let params = lower_text(sample_text_primitive(), &layer);
         assert_eq!(params[0].scale, 2.0, "glyphs rasterize at the layer scale");
         assert!(approx(params[0].rect.width, 60.0), "{:?}", params[0].rect);
     }
@@ -1002,19 +1003,7 @@ mod tests {
             alpha: 0.5,
             ..Default::default()
         };
-        let params = lower_text(
-            text_primitive(
-                Rect {
-                    x: 0.0,
-                    y: 0.0,
-                    width: 30.0,
-                    height: 14.0,
-                },
-                "AB",
-                DrawTextStyle::new(10.0),
-            ),
-            &layer,
-        );
+        let params = lower_text(sample_text_primitive(), &layer);
         assert!(approx(params[0].color.3, 0.5));
     }
 

--- a/crates/cranpose-render/common/src/raster_cache.rs
+++ b/crates/cranpose-render/common/src/raster_cache.rs
@@ -65,6 +65,15 @@ pub struct LayerRasterCacheKey {
     scale_bucket: ScaleBucket,
 }
 
+fn local_bounds_bits(local_bounds: Rect) -> [u32; 4] {
+    [
+        local_bounds.x.to_bits(),
+        local_bounds.y.to_bits(),
+        local_bounds.width.to_bits(),
+        local_bounds.height.to_bits(),
+    ]
+}
+
 impl LayerRasterCacheKey {
     pub fn new(
         stable_id: Option<NodeId>,
@@ -79,12 +88,7 @@ impl LayerRasterCacheKey {
             stable_id,
             content_hash,
             effect_hash,
-            local_bounds_bits: [
-                local_bounds.x.to_bits(),
-                local_bounds.y.to_bits(),
-                local_bounds.width.to_bits(),
-                local_bounds.height.to_bits(),
-            ],
+            local_bounds_bits: local_bounds_bits(local_bounds),
             pixel_size: [pixel_size.0, pixel_size.1],
             scale_bucket,
         }
@@ -102,12 +106,7 @@ impl LayerRasterCacheKey {
             stable_id,
             content_hash,
             effect_hash: 0,
-            local_bounds_bits: [
-                local_bounds.x.to_bits(),
-                local_bounds.y.to_bits(),
-                local_bounds.width.to_bits(),
-                local_bounds.height.to_bits(),
-            ],
+            local_bounds_bits: local_bounds_bits(local_bounds),
             pixel_size: [pixel_size.0, pixel_size.1],
             scale_bucket,
         }
@@ -126,12 +125,7 @@ impl LayerRasterCacheKey {
             stable_id,
             content_hash: input_hash,
             effect_hash,
-            local_bounds_bits: [
-                local_bounds.x.to_bits(),
-                local_bounds.y.to_bits(),
-                local_bounds.width.to_bits(),
-                local_bounds.height.to_bits(),
-            ],
+            local_bounds_bits: local_bounds_bits(local_bounds),
             pixel_size: [pixel_size.0, pixel_size.1],
             scale_bucket,
         }
@@ -148,12 +142,7 @@ impl LayerRasterCacheKey {
             stable_id: None,
             content_hash,
             effect_hash: 0,
-            local_bounds_bits: [
-                local_bounds.x.to_bits(),
-                local_bounds.y.to_bits(),
-                local_bounds.width.to_bits(),
-                local_bounds.height.to_bits(),
-            ],
+            local_bounds_bits: local_bounds_bits(local_bounds),
             pixel_size: [pixel_size.0, pixel_size.1],
             scale_bucket,
         }
@@ -176,12 +165,7 @@ impl LayerRasterCacheKey {
             stable_id: None,
             content_hash,
             effect_hash: prefix_len,
-            local_bounds_bits: [
-                local_bounds.x.to_bits(),
-                local_bounds.y.to_bits(),
-                local_bounds.width.to_bits(),
-                local_bounds.height.to_bits(),
-            ],
+            local_bounds_bits: local_bounds_bits(local_bounds),
             pixel_size: [pixel_size.0, pixel_size.1],
             scale_bucket,
         }

--- a/crates/cranpose-render/common/src/render_contract.rs
+++ b/crates/cranpose-render/common/src/render_contract.rs
@@ -3,19 +3,16 @@ use cranpose_ui::{
     TextLayoutOptions, TextStyle,
     text::{AnnotatedString, Shadow, SpanStyle, TextDecoration},
 };
-use cranpose_ui_graphics::{
-    Brush, Color, CornerRadii, DrawPrimitive, GraphicsLayer, Point, Rect, Stroke,
-};
+use cranpose_ui_graphics::{Brush, Color, CornerRadii, DrawPrimitive, Point, Rect, Stroke};
 
 use crate::{
     graph::{
-        CachePolicy, DrawPrimitiveNode, IsolationReasons, LayerNode, PrimitiveEntry, PrimitiveNode,
-        PrimitivePhase, ProjectiveTransform, RenderGraph, RenderNode, TextPrimitiveNode,
+        DrawPrimitiveNode, LayerNode, PrimitiveEntry, PrimitiveNode, PrimitivePhase,
+        ProjectiveTransform, RenderGraph, RenderNode, TextPrimitiveNode,
     },
     image_compare::{
         image_difference_stats, normalize_rgba_region, pixel_difference, sample_pixel,
     },
-    raster_cache::LayerRasterCacheHashes,
 };
 
 const BACKGROUND_COLOR: Color = Color(18.0 / 255.0, 18.0 / 255.0, 24.0 / 255.0, 1.0);
@@ -487,26 +484,10 @@ fn graph_layer(
     children: Vec<RenderNode>,
 ) -> LayerNode {
     LayerNode {
-        node_id: None,
         local_bounds,
         transform_to_parent,
-        content_offset: Point::default(),
-        motion_context_animated: false,
-        translated_content_context: false,
-        translated_content_offset: Point::default(),
-        scene_children_origin: Point::default(),
-        scene_children_layer_translation: Point::default(),
-        graphics_layer: GraphicsLayer::default(),
-        clip_to_bounds: false,
-        shadow_clip: None,
-        hit_test: None,
-        has_hit_targets: false,
-        has_origin_sinks: false,
-        isolation: IsolationReasons::default(),
-        cache_policy: CachePolicy::None,
-        cache_hashes: LayerRasterCacheHashes::default(),
-        cache_hashes_valid: false,
         children,
+        ..Default::default()
     }
 }
 

--- a/crates/cranpose-render/common/src/scene_builder.rs
+++ b/crates/cranpose-render/common/src/scene_builder.rs
@@ -25,7 +25,7 @@ use crate::{
 const TEXT_CLIP_PAD: f32 = 1.0;
 const ROUNDED_CLIP_EDGE_FEATHER: f32 = 1.0;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 struct BuildNodeSnapshot {
     node_id: NodeId,
     placement: Point,
@@ -1934,8 +1934,8 @@ mod tests {
     use cranpose_foundation::lazy::{LazyListScope, LazyListState, rememberLazyListState};
     use cranpose_ui::{
         Color, Column, ColumnSpec, DrawCommand, LayoutEngine, LazyColumn, LazyColumnSpec,
-        LinearArrangement, Modifier, Point, Rect, ResolvedModifiers, RoundedCornerShape,
-        ScrollState, Size, Spacer, Text, TextStyle,
+        LinearArrangement, Modifier, Point, Rect, RoundedCornerShape, ScrollState, Size, Spacer,
+        Text, TextStyle,
         text::{AnnotatedString, BaselineShift, SpanStyle, TextAlign, TextDirection, TextMotion},
     };
     use cranpose_ui_graphics::{
@@ -2102,50 +2102,22 @@ mod tests {
                 width: 40.0,
                 height: 20.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
             draw_commands: vec![child_command],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
-            children: vec![],
+            ..Default::default()
         };
 
         BuildNodeSnapshot {
             node_id: 1,
-            placement: Point::default(),
             size: Size {
                 width: 80.0,
                 height: 50.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
             graphics_layer: Some(GraphicsLayer {
                 translation_x: tx,
                 ..GraphicsLayer::default()
             }),
             children: vec![child],
+            ..Default::default()
         }
     }
 
@@ -2200,47 +2172,18 @@ mod tests {
                 width: 40.0,
                 height: 20.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
-            children: vec![],
+            ..Default::default()
         };
 
         let parent = BuildNodeSnapshot {
             node_id: 1,
-            placement: Point::default(),
             size: Size {
                 width: 80.0,
                 height: 50.0,
             },
             content_offset: Point { x: 13.0, y: -9.0 },
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
             children: vec![child],
+            ..Default::default()
         };
 
         let graph = build_layer_node_for_test(parent, 1.0, false);
@@ -2275,27 +2218,12 @@ mod tests {
                     width: 40.0,
                     height: 20.0,
                 },
-                content_offset: Point::default(),
-                motion_context_animated: false,
-                translated_content_context: false,
-                has_own_origin_sinks: false,
-                measured_max_width: None,
-                resolved_modifiers: ResolvedModifiers::default(),
                 draw_commands: vec![child_command],
-                click_actions: vec![],
-                pointer_inputs: vec![],
-                clip_to_bounds: false,
-                annotated_text: None,
-                text_style: None,
-                text_layout_options: None,
-                text_pan: None,
-                graphics_layer: None,
-                children: vec![],
+                ..Default::default()
             };
 
             BuildNodeSnapshot {
                 node_id: 1,
-                placement: Point::default(),
                 size: Size {
                     width: 80.0,
                     height: 50.0,
@@ -2303,19 +2231,8 @@ mod tests {
                 content_offset: offset,
                 motion_context_animated,
                 translated_content_context: true,
-                has_own_origin_sinks: false,
-                measured_max_width: None,
-                resolved_modifiers: ResolvedModifiers::default(),
-                draw_commands: vec![],
-                click_actions: vec![],
-                pointer_inputs: vec![],
-                clip_to_bounds: false,
-                annotated_text: None,
-                text_style: None,
-                text_layout_options: None,
-                text_pan: None,
-                graphics_layer: None,
                 children: vec![child],
+                ..Default::default()
             }
         }
 
@@ -3899,22 +3816,7 @@ mod tests {
                 width: 20.0,
                 height: 10.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
-            children: vec![],
+            ..Default::default()
         };
         let behind = DrawCommand::Behind(Rc::new(|scope: &mut DrawScopeDefault| {
             scope.push_recorded(vec![cranpose_ui_graphics::DrawPrimitive::Rect {
@@ -3943,27 +3845,13 @@ mod tests {
 
         let parent = BuildNodeSnapshot {
             node_id: 1,
-            placement: Point::default(),
             size: Size {
                 width: 80.0,
                 height: 50.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
             draw_commands: vec![behind, overlay],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
             children: vec![child],
+            ..Default::default()
         };
 
         let graph = build_layer_node_for_test(parent, 1.0, false);
@@ -3985,17 +3873,10 @@ mod tests {
     fn command_recordings_reuse_buffers_across_rebuilds() {
         let snapshot = || BuildNodeSnapshot {
             node_id: 7001,
-            placement: Point::default(),
             size: Size {
                 width: 40.0,
                 height: 20.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
             draw_commands: vec![DrawCommand::Behind(Rc::new(
                 |scope: &mut DrawScopeDefault| {
                     scope.draw_rect_at(
@@ -4009,15 +3890,7 @@ mod tests {
                     );
                 },
             ))],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
-            children: vec![],
+            ..Default::default()
         };
         fn run_of(layer: &LayerNode) -> &DrawRunNode {
             let RenderNode::DrawRun(run) = &layer.children[0] else {
@@ -4066,49 +3939,19 @@ mod tests {
                 width: 20.0,
                 height: 10.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
-            children: vec![],
+            ..Default::default()
         };
         let mut moved_child = child.clone();
         moved_child.placement.x += 7.0;
 
         let parent = BuildNodeSnapshot {
             node_id: 1,
-            placement: Point::default(),
             size: Size {
                 width: 80.0,
                 height: 50.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
             children: vec![child],
+            ..Default::default()
         };
         let moved_parent = BuildNodeSnapshot {
             children: vec![moved_child],
@@ -4129,27 +3972,11 @@ mod tests {
     fn stored_effect_hash_tracks_local_effect_only() {
         let base = BuildNodeSnapshot {
             node_id: 1,
-            placement: Point::default(),
             size: Size {
                 width: 80.0,
                 height: 50.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
-            children: vec![],
+            ..Default::default()
         };
         let mut effected = base.clone();
         effected.graphics_layer = Some(GraphicsLayer {
@@ -4177,30 +4004,18 @@ mod tests {
 
         let snapshot = BuildNodeSnapshot {
             node_id: 1,
-            placement: Point::default(),
             size: Size {
                 width: 180.0,
                 height: 48.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
             measured_max_width: Some(180.0),
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
             annotated_text: Some(AnnotatedString::from("rtl")),
             text_style: Some(text_style),
             text_layout_options: Some(cranpose_ui::TextLayoutOptions {
                 overflow: cranpose_ui::TextOverflow::Clip,
                 ..Default::default()
             }),
-            text_pan: None,
-            graphics_layer: None,
-            children: vec![],
+            ..Default::default()
         };
 
         let graph = build_layer_node_for_test(snapshot, 1.0, false);
@@ -4232,30 +4047,18 @@ mod tests {
     fn clipped_text_node_raster_bounds_use_measured_text_width_not_full_box() {
         let snapshot = BuildNodeSnapshot {
             node_id: 1,
-            placement: Point::default(),
             size: Size {
                 width: 320.0,
                 height: 48.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
             measured_max_width: Some(320.0),
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
             annotated_text: Some(AnnotatedString::from("short")),
             text_style: Some(TextStyle::default()),
             text_layout_options: Some(cranpose_ui::TextLayoutOptions {
                 overflow: cranpose_ui::TextOverflow::Clip,
                 ..Default::default()
             }),
-            text_pan: None,
-            graphics_layer: None,
-            children: vec![],
+            ..Default::default()
         };
 
         let graph = build_layer_node_for_test(snapshot, 1.0, false);
@@ -4285,29 +4088,18 @@ mod tests {
         let viewports = resolved_viewports.clone();
         let make_snapshot = |text_pan: Option<cranpose_ui::TextPanResolver>| BuildNodeSnapshot {
             node_id: 1,
-            placement: Point::default(),
             size: Size {
                 width: field_width,
                 height: 24.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
             measured_max_width: Some(field_width),
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
             annotated_text: Some(AnnotatedString::from(
                 "a very long single line of text that cannot fit",
             )),
             text_style: Some(TextStyle::default()),
             text_layout_options: Some(cranpose_ui::TextLayoutOptions::default()),
             text_pan,
-            graphics_layer: None,
-            children: vec![],
+            ..Default::default()
         };
 
         let text_node = |snapshot: BuildNodeSnapshot| {
@@ -4367,46 +4159,21 @@ mod tests {
                 width: 120.0,
                 height: 32.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
             measured_max_width: Some(120.0),
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
             annotated_text: Some(AnnotatedString::from("scrolling")),
             text_style: Some(TextStyle::default()),
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
-            children: vec![],
+            ..Default::default()
         };
         let parent = BuildNodeSnapshot {
             node_id: 1,
-            placement: Point::default(),
             size: Size {
                 width: 160.0,
                 height: 64.0,
             },
             content_offset: Point { x: 0.0, y: -18.5 },
-            motion_context_animated: false,
             translated_content_context: true,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
             children: vec![child],
+            ..Default::default()
         };
 
         let graph = build_layer_node_for_test(parent, 1.0, false);
@@ -4433,46 +4200,20 @@ mod tests {
                 width: 120.0,
                 height: 32.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
             measured_max_width: Some(120.0),
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
             annotated_text: Some(AnnotatedString::from("scrolling")),
             text_style: Some(TextStyle::default()),
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
-            children: vec![],
+            ..Default::default()
         };
         let parent = BuildNodeSnapshot {
             node_id: 1,
-            placement: Point::default(),
             size: Size {
                 width: 160.0,
                 height: 64.0,
             },
             content_offset: Point { x: 0.0, y: -18.0 },
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
             children: vec![child],
+            ..Default::default()
         };
 
         let graph = build_layer_node_for_test(parent, 1.0, false);
@@ -4502,16 +4243,7 @@ mod tests {
                 width: 120.0,
                 height: 32.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
             measured_max_width: Some(120.0),
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
             annotated_text: Some(AnnotatedString::from("shadow")),
             text_style: Some(TextStyle::from_span_style(SpanStyle {
                 shadow: Some(cranpose_ui::text::Shadow {
@@ -4521,34 +4253,18 @@ mod tests {
                 }),
                 ..SpanStyle::default()
             })),
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
-            children: vec![],
+            ..Default::default()
         };
         let parent = BuildNodeSnapshot {
             node_id: 1,
-            placement: Point::default(),
             size: Size {
                 width: 160.0,
                 height: 64.0,
             },
             content_offset: Point { x: 0.0, y: -18.5 },
-            motion_context_animated: false,
             translated_content_context: true,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
             children: vec![child],
+            ..Default::default()
         };
 
         let graph = build_layer_node_for_test(parent, 1.0, false);
@@ -4574,46 +4290,20 @@ mod tests {
                 width: 120.0,
                 height: 32.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
             measured_max_width: Some(120.0),
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
             annotated_text: Some(AnnotatedString::from("lazy")),
             text_style: Some(TextStyle::default()),
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
-            children: vec![],
+            ..Default::default()
         };
         let parent = BuildNodeSnapshot {
             node_id: 1,
-            placement: Point::default(),
             size: Size {
                 width: 160.0,
                 height: 64.0,
             },
-            content_offset: Point::default(),
             motion_context_animated: true,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
             children: vec![child],
+            ..Default::default()
         };
 
         let graph = build_layer_node_for_test(parent, 1.0, false);
@@ -4893,16 +4583,7 @@ mod tests {
                 width: 120.0,
                 height: 32.0,
             },
-            content_offset: Point::default(),
-            motion_context_animated: false,
-            translated_content_context: false,
-            has_own_origin_sinks: false,
             measured_max_width: Some(120.0),
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
             annotated_text: Some(AnnotatedString::from("static")),
             text_style: Some(TextStyle::from_paragraph_style(
                 cranpose_ui::text::ParagraphStyle {
@@ -4910,34 +4591,18 @@ mod tests {
                     ..Default::default()
                 },
             )),
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
-            children: vec![],
+            ..Default::default()
         };
         let parent = BuildNodeSnapshot {
             node_id: 1,
-            placement: Point::default(),
             size: Size {
                 width: 160.0,
                 height: 64.0,
             },
             content_offset: Point { x: 0.0, y: -18.5 },
-            motion_context_animated: false,
             translated_content_context: true,
-            has_own_origin_sinks: false,
-            measured_max_width: None,
-            resolved_modifiers: ResolvedModifiers::default(),
-            draw_commands: vec![],
-            click_actions: vec![],
-            pointer_inputs: vec![],
-            clip_to_bounds: false,
-            annotated_text: None,
-            text_style: None,
-            text_layout_options: None,
-            text_pan: None,
-            graphics_layer: None,
             children: vec![child],
+            ..Default::default()
         };
 
         let graph = build_layer_node_for_test(parent, 1.0, false);

--- a/crates/cranpose-render/common/src/software_text_raster.rs
+++ b/crates/cranpose-render/common/src/software_text_raster.rs
@@ -178,6 +178,15 @@ impl SoftwareTextFont {
     pub fn content_hash(&self) -> u64 {
         self.content_hash
     }
+
+    fn raster_ref(&self) -> RasterFontRef<'_, KernedFont> {
+        RasterFontRef {
+            font: &self.font,
+            ab_glyph_scale_factor: self.metadata.ab_glyph_scale_factor,
+            weight: self.weight(),
+            style: self.style(),
+        }
+    }
 }
 
 pub fn try_default_software_text_font() -> Result<SoftwareTextFont, SoftwareTextFontError> {
@@ -1347,12 +1356,7 @@ pub fn rasterize_text_to_image(
             font_size,
             scale,
         },
-        RasterFontRef {
-            font: &font.font,
-            ab_glyph_scale_factor: font.metadata.ab_glyph_scale_factor,
-            weight: font.weight(),
-            style: font.style(),
-        },
+        font.raster_ref(),
         font.content_hash(),
         None,
     )
@@ -1378,12 +1382,7 @@ pub fn rasterize_text_to_image_with_glyph_cache(
             font_size,
             scale,
         },
-        RasterFontRef {
-            font: &font.font,
-            ab_glyph_scale_factor: font.metadata.ab_glyph_scale_factor,
-            weight: font.weight(),
-            style: font.style(),
-        },
+        font.raster_ref(),
         font.content_hash(),
         Some(glyph_cache),
     )
@@ -1522,6 +1521,72 @@ fn segment_advance_px(
     caret.max(0.0)
 }
 
+fn text_render_request_is_degenerate(
+    text_is_empty: bool,
+    rect: Rect,
+    font_size: f32,
+    scale: f32,
+) -> bool {
+    text_is_empty
+        || rect.width <= 0.0
+        || rect.height <= 0.0
+        || !font_size.is_finite()
+        || font_size <= 0.0
+        || !scale.is_finite()
+        || scale <= 0.0
+}
+
+#[derive(Clone, Copy)]
+struct TextSegmentMetrics {
+    font_px_size: f32,
+    letter_spacing: f32,
+    align_fraction: f32,
+    weight_synthesis: TextWeightSynthesis,
+    style_synthesis: TextStyleSynthesis,
+    line_height: f32,
+    first_baseline_y: f32,
+}
+
+fn text_segment_metrics(
+    text: &str,
+    local_rect: Rect,
+    style: &TextStyle,
+    font_size: f32,
+    scale: f32,
+    font: &SoftwareTextFont,
+) -> TextSegmentMetrics {
+    let font_px_size = font.ab_glyph_px_size(font_size) * scale;
+    let letter_spacing = resolve_letter_spacing(style, font_size) * scale;
+    let align_fraction = crate::scene_builder::text_align_fraction(style, text);
+    let weight_synthesis = TextWeightSynthesis::for_style(style, font.weight(), font_size, scale);
+    let style_synthesis = TextStyleSynthesis::for_style(style, font.style(), font_size, scale);
+    let metrics = vertical_metrics(&font.font, font_px_size);
+    let line_box = line_box_for(
+        style,
+        metrics,
+        (style.resolve_line_height(14.0, font_size * 1.4) * scale).max(1.0),
+        1.0,
+    );
+    TextSegmentMetrics {
+        font_px_size,
+        letter_spacing,
+        align_fraction,
+        weight_synthesis,
+        style_synthesis,
+        line_height: line_box.height,
+        first_baseline_y: local_rect.y + line_box.baseline,
+    }
+}
+
+fn text_segment_supports_solid_atlas(style: &TextStyle) -> bool {
+    style_can_atlas_solid_fill(style)
+        && style
+            .paragraph_style
+            .text_motion
+            .unwrap_or(TextMotion::Static)
+            == TextMotion::Static
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn rasterize_annotated_text_to_image_with_glyph_cache<'a>(
     text: impl Into<StyledTextRef<'a>>,
@@ -1547,14 +1612,7 @@ pub fn rasterize_annotated_text_to_image_with_glyph_cache<'a>(
             glyph_cache,
         );
     }
-    if text.is_empty()
-        || rect.width <= 0.0
-        || rect.height <= 0.0
-        || !font_size.is_finite()
-        || font_size <= 0.0
-        || !scale.is_finite()
-        || scale <= 0.0
-    {
+    if text_render_request_is_degenerate(text.is_empty(), rect, font_size, scale) {
         return None;
     }
 
@@ -1645,8 +1703,8 @@ pub fn rasterize_annotated_text_to_image_with_glyph_cache<'a>(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn collect_solid_text_atlas_glyphs(
-    text: &AnnotatedString,
+fn walk_solid_text_atlas_segments<'a, T>(
+    text: impl Into<StyledTextRef<'a>>,
     rect: Rect,
     style: &TextStyle,
     fallback_color: Color,
@@ -1654,43 +1712,33 @@ pub fn collect_solid_text_atlas_glyphs(
     scale: f32,
     fonts: &SoftwareTextFontSet,
     glyph_cache: &mut SoftwareGlyphRasterCache,
-    out: &mut Vec<SoftwareGlyphAtlasGlyph>,
+    out: &mut Vec<T>,
+    mut collect_segment: impl FnMut(
+        &str,
+        Rect,
+        &TextStyle,
+        Color,
+        f32,
+        f32,
+        &SoftwareTextFont,
+        &mut SoftwareGlyphRasterCache,
+        &mut Vec<T>,
+    ) -> Option<f32>,
 ) -> Option<()> {
-    if text.is_empty()
-        || rect.width <= 0.0
-        || rect.height <= 0.0
-        || !font_size.is_finite()
-        || font_size <= 0.0
-        || !scale.is_finite()
-        || scale <= 0.0
-    {
+    let text: StyledTextRef<'a> = text.into();
+    if text_render_request_is_degenerate(text.is_empty(), rect, font_size, scale) {
         return Some(());
     }
 
     let base_line_height = line_height_for_render_style(style, font_size);
     let mut current_line_height = base_line_height;
-    let line_offsets = annotated_line_alignment_offsets(
-        &StyledTextRef::from(text),
-        style,
-        font_size,
-        scale,
-        fonts,
-    );
+    let line_offsets = annotated_line_alignment_offsets(&text, style, font_size, scale, fonts);
     let mut line_idx = 0usize;
     let mut cursor_x = rect.x + line_offset(&line_offsets, 0);
     let mut cursor_y = rect.y;
     let initial_len = out.len();
 
-    let mut boundaries = text.span_boundaries();
-    for (offset, ch) in text.text.char_indices() {
-        if ch == '\n' {
-            boundaries.push(offset);
-            boundaries.push(offset + ch.len_utf8());
-        }
-    }
-    boundaries.sort_unstable();
-    boundaries.dedup();
-    boundaries.retain(|offset| *offset <= text.text.len() && text.text.is_char_boundary(*offset));
+    let boundaries = annotated_segment_boundaries(&text);
 
     for range in boundaries.windows(2) {
         let start = range[0];
@@ -1698,17 +1746,8 @@ pub fn collect_solid_text_atlas_glyphs(
         if start == end {
             continue;
         }
-        let segment_style = effective_style_for_range(&text.span_styles, style, start, end);
-        if !style_can_atlas_solid_fill(&segment_style) {
-            out.truncate(initial_len);
-            return None;
-        }
-        let static_text_motion = segment_style
-            .paragraph_style
-            .text_motion
-            .unwrap_or(TextMotion::Static)
-            == TextMotion::Static;
-        if !static_text_motion {
+        let segment_style = effective_style_for_range(text.span_styles, style, start, end);
+        if !text_segment_supports_solid_atlas(&segment_style) {
             out.truncate(initial_len);
             return None;
         }
@@ -1735,7 +1774,7 @@ pub fn collect_solid_text_atlas_glyphs(
                     height: rect.height,
                 };
                 let color = segment_style.resolve_text_color(fallback_color);
-                let advance_px = collect_text_segment_solid_atlas_glyphs(
+                let Some(advance_px) = collect_segment(
                     content,
                     local_rect,
                     &segment_style,
@@ -1745,7 +1784,10 @@ pub fn collect_solid_text_atlas_glyphs(
                     font,
                     glyph_cache,
                     out,
-                )?;
+                ) else {
+                    out.truncate(initial_len);
+                    return None;
+                };
                 cursor_x += advance_px;
                 current_line_height = current_line_height.max(line_height_for_render_style(
                     &segment_style,
@@ -1763,6 +1805,32 @@ pub fn collect_solid_text_atlas_glyphs(
     }
 
     Some(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn collect_solid_text_atlas_glyphs(
+    text: &AnnotatedString,
+    rect: Rect,
+    style: &TextStyle,
+    fallback_color: Color,
+    font_size: f32,
+    scale: f32,
+    fonts: &SoftwareTextFontSet,
+    glyph_cache: &mut SoftwareGlyphRasterCache,
+    out: &mut Vec<SoftwareGlyphAtlasGlyph>,
+) -> Option<()> {
+    walk_solid_text_atlas_segments(
+        text,
+        rect,
+        style,
+        fallback_color,
+        font_size,
+        scale,
+        fonts,
+        glyph_cache,
+        out,
+        collect_text_segment_solid_atlas_glyphs,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1777,113 +1845,18 @@ pub fn collect_cached_solid_text_atlas_placements(
     glyph_cache: &mut SoftwareGlyphRasterCache,
     out: &mut Vec<SoftwareGlyphAtlasPlacement>,
 ) -> Option<()> {
-    if text.is_empty()
-        || rect.width <= 0.0
-        || rect.height <= 0.0
-        || !font_size.is_finite()
-        || font_size <= 0.0
-        || !scale.is_finite()
-        || scale <= 0.0
-    {
-        return Some(());
-    }
-
-    let base_line_height = line_height_for_render_style(style, font_size);
-    let mut current_line_height = base_line_height;
-    let line_offsets = annotated_line_alignment_offsets(
-        &StyledTextRef::from(text),
+    walk_solid_text_atlas_segments(
+        text,
+        rect,
         style,
+        fallback_color,
         font_size,
         scale,
         fonts,
-    );
-    let mut line_idx = 0usize;
-    let mut cursor_x = rect.x + line_offset(&line_offsets, 0);
-    let mut cursor_y = rect.y;
-    let initial_len = out.len();
-
-    let mut boundaries = text.span_boundaries();
-    for (offset, ch) in text.text.char_indices() {
-        if ch == '\n' {
-            boundaries.push(offset);
-            boundaries.push(offset + ch.len_utf8());
-        }
-    }
-    boundaries.sort_unstable();
-    boundaries.dedup();
-    boundaries.retain(|offset| *offset <= text.text.len() && text.text.is_char_boundary(*offset));
-
-    for range in boundaries.windows(2) {
-        let start = range[0];
-        let end = range[1];
-        if start == end {
-            continue;
-        }
-        let segment_style = effective_style_for_range(&text.span_styles, style, start, end);
-        if !style_can_atlas_solid_fill(&segment_style) {
-            out.truncate(initial_len);
-            return None;
-        }
-        let static_text_motion = segment_style
-            .paragraph_style
-            .text_motion
-            .unwrap_or(TextMotion::Static)
-            == TextMotion::Static;
-        if !static_text_motion {
-            out.truncate(initial_len);
-            return None;
-        }
-
-        let segment = &text.text[start..end];
-        for part in segment.split_inclusive('\n') {
-            let has_newline = part.ends_with('\n');
-            let content = if has_newline {
-                &part[..part.len().saturating_sub(1)]
-            } else {
-                part
-            };
-
-            if !content.is_empty() {
-                let segment_font_size = segment_style.resolve_font_size(font_size);
-                let Some(font) = fonts.resolve(&segment_style) else {
-                    out.truncate(initial_len);
-                    return None;
-                };
-                let local_rect = Rect {
-                    x: (cursor_x - rect.x).round(),
-                    y: (cursor_y - rect.y).round(),
-                    width: rect.width,
-                    height: rect.height,
-                };
-                let color = segment_style.resolve_text_color(fallback_color);
-                let advance_px = collect_text_segment_cached_solid_atlas_placements(
-                    content,
-                    local_rect,
-                    &segment_style,
-                    color,
-                    segment_font_size,
-                    scale,
-                    font,
-                    glyph_cache,
-                    out,
-                )?;
-                cursor_x += advance_px;
-                current_line_height = current_line_height.max(line_height_for_render_style(
-                    &segment_style,
-                    segment_font_size,
-                ));
-            }
-
-            if has_newline {
-                line_idx += 1;
-                cursor_x = rect.x + line_offset(&line_offsets, line_idx);
-                cursor_y += current_line_height * scale;
-                current_line_height = base_line_height;
-            }
-        }
-    }
-
-    Some(())
+        glyph_cache,
+        out,
+        collect_text_segment_cached_solid_atlas_placements,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1898,108 +1871,18 @@ pub fn collect_solid_text_atlas_run<'a>(
     glyph_cache: &mut SoftwareGlyphRasterCache,
     out: &mut Vec<SoftwareGlyphAtlasRunGlyph>,
 ) -> Option<()> {
-    let text: StyledTextRef<'a> = text.into();
-    if text.is_empty()
-        || rect.width <= 0.0
-        || rect.height <= 0.0
-        || !font_size.is_finite()
-        || font_size <= 0.0
-        || !scale.is_finite()
-        || scale <= 0.0
-    {
-        return Some(());
-    }
-
-    let base_line_height = line_height_for_render_style(style, font_size);
-    let mut current_line_height = base_line_height;
-    let line_offsets = annotated_line_alignment_offsets(&text, style, font_size, scale, fonts);
-    let mut line_idx = 0usize;
-    let mut cursor_x = rect.x + line_offset(&line_offsets, 0);
-    let mut cursor_y = rect.y;
-    let initial_len = out.len();
-
-    let mut boundaries = text.span_boundaries();
-    for (offset, ch) in text.text.char_indices() {
-        if ch == '\n' {
-            boundaries.push(offset);
-            boundaries.push(offset + ch.len_utf8());
-        }
-    }
-    boundaries.sort_unstable();
-    boundaries.dedup();
-    boundaries.retain(|offset| *offset <= text.text.len() && text.text.is_char_boundary(*offset));
-
-    for range in boundaries.windows(2) {
-        let start = range[0];
-        let end = range[1];
-        if start == end {
-            continue;
-        }
-        let segment_style = effective_style_for_range(text.span_styles, style, start, end);
-        if !style_can_atlas_solid_fill(&segment_style) {
-            out.truncate(initial_len);
-            return None;
-        }
-        let static_text_motion = segment_style
-            .paragraph_style
-            .text_motion
-            .unwrap_or(TextMotion::Static)
-            == TextMotion::Static;
-        if !static_text_motion {
-            out.truncate(initial_len);
-            return None;
-        }
-
-        let segment = &text.text[start..end];
-        for part in segment.split_inclusive('\n') {
-            let has_newline = part.ends_with('\n');
-            let content = if has_newline {
-                &part[..part.len().saturating_sub(1)]
-            } else {
-                part
-            };
-
-            if !content.is_empty() {
-                let segment_font_size = segment_style.resolve_font_size(font_size);
-                let Some(font) = fonts.resolve(&segment_style) else {
-                    out.truncate(initial_len);
-                    return None;
-                };
-                let local_rect = Rect {
-                    x: (cursor_x - rect.x).round(),
-                    y: (cursor_y - rect.y).round(),
-                    width: rect.width,
-                    height: rect.height,
-                };
-                let color = segment_style.resolve_text_color(fallback_color);
-                let advance_px = collect_text_segment_solid_atlas_run(
-                    content,
-                    local_rect,
-                    &segment_style,
-                    color,
-                    segment_font_size,
-                    scale,
-                    font,
-                    glyph_cache,
-                    out,
-                )?;
-                cursor_x += advance_px;
-                current_line_height = current_line_height.max(line_height_for_render_style(
-                    &segment_style,
-                    segment_font_size,
-                ));
-            }
-
-            if has_newline {
-                line_idx += 1;
-                cursor_x = rect.x + line_offset(&line_offsets, line_idx);
-                cursor_y += current_line_height * scale;
-                current_line_height = base_line_height;
-            }
-        }
-    }
-
-    Some(())
+    walk_solid_text_atlas_segments(
+        text,
+        rect,
+        style,
+        fallback_color,
+        font_size,
+        scale,
+        fonts,
+        glyph_cache,
+        out,
+        collect_text_segment_solid_atlas_run,
+    )
 }
 
 pub fn measure_text_with_font(
@@ -2350,14 +2233,7 @@ fn rasterize_text_to_image_impl(
         scale,
     } = request;
 
-    if text.is_empty()
-        || rect.width <= 0.0
-        || rect.height <= 0.0
-        || !font_size.is_finite()
-        || font_size <= 0.0
-        || !scale.is_finite()
-        || scale <= 0.0
-    {
+    if text_render_request_is_degenerate(text.is_empty(), rect, font_size, scale) {
         return None;
     }
 
@@ -2523,17 +2399,7 @@ fn style_can_rasterize_direct_solid(style: &TextStyle) -> bool {
 }
 
 fn style_can_atlas_solid_fill(style: &TextStyle) -> bool {
-    if style
-        .span_style
-        .shadow
-        .is_some_and(|shadow| shadow.color.3 > 0.0)
-    {
-        return false;
-    }
-    if !matches!(
-        style.span_style.brush.as_ref(),
-        None | Some(Brush::Solid(_))
-    ) {
+    if !style_can_rasterize_direct_solid(style) {
         return false;
     }
     match style.span_style.draw_style.unwrap_or(TextDrawStyle::Fill) {
@@ -2556,14 +2422,7 @@ fn draw_text_segment_solid_to_rgba(
     font: &SoftwareTextFont,
     glyph_cache: &mut SoftwareGlyphRasterCache,
 ) -> f32 {
-    if text.is_empty()
-        || local_rect.width <= 0.0
-        || local_rect.height <= 0.0
-        || !font_size.is_finite()
-        || font_size <= 0.0
-        || !scale.is_finite()
-        || scale <= 0.0
-    {
+    if text_render_request_is_degenerate(text.is_empty(), local_rect, font_size, scale) {
         return 0.0;
     }
 
@@ -2584,20 +2443,7 @@ fn draw_text_segment_solid_to_rgba(
         .text_motion
         .unwrap_or(TextMotion::Static)
         == TextMotion::Static;
-    let font_px_size = font.ab_glyph_px_size(font_size) * scale;
-    let letter_spacing = resolve_letter_spacing(style, font_size) * scale;
-    let align_fraction = crate::scene_builder::text_align_fraction(style, text);
-    let weight_synthesis = TextWeightSynthesis::for_style(style, font.weight(), font_size, scale);
-    let style_synthesis = TextStyleSynthesis::for_style(style, font.style(), font_size, scale);
-    let metrics = vertical_metrics(&font.font, font_px_size);
-    let line_box = line_box_for(
-        style,
-        metrics,
-        (style.resolve_line_height(14.0, font_size * 1.4) * scale).max(1.0),
-        1.0,
-    );
-    let line_height = line_box.height;
-    let first_baseline_y = local_rect.y + line_box.baseline;
+    let m = text_segment_metrics(text, local_rect, style, font_size, scale, font);
     let origin_x = if text_motion_static {
         local_rect.x.round()
     } else {
@@ -2609,17 +2455,17 @@ fn draw_text_segment_solid_to_rgba(
         text,
         &font.font,
         font.content_hash(),
-        font_px_size,
-        line_height,
-        first_baseline_y,
+        m.font_px_size,
+        m.line_height,
+        m.first_baseline_y,
         origin_x,
         0.0,
-        letter_spacing,
-        align_fraction,
+        m.letter_spacing,
+        m.align_fraction,
         text_motion_static,
         raster_style,
-        weight_synthesis,
-        style_synthesis,
+        m.weight_synthesis,
+        m.style_synthesis,
         Some(glyph_cache),
         |mask| draw_mask_glyph_solid_u8(canvas, canvas_width, canvas_height, mask, color, 1.0),
     )
@@ -2637,43 +2483,14 @@ fn collect_text_segment_solid_atlas_glyphs(
     glyph_cache: &mut SoftwareGlyphRasterCache,
     out: &mut Vec<SoftwareGlyphAtlasGlyph>,
 ) -> Option<f32> {
-    if text.is_empty()
-        || local_rect.width <= 0.0
-        || local_rect.height <= 0.0
-        || !font_size.is_finite()
-        || font_size <= 0.0
-        || !scale.is_finite()
-        || scale <= 0.0
-    {
+    if text_render_request_is_degenerate(text.is_empty(), local_rect, font_size, scale) {
         return Some(0.0);
     }
-    if !style_can_atlas_solid_fill(style) {
+    if !text_segment_supports_solid_atlas(style) {
         return None;
     }
 
-    let text_motion_static = style
-        .paragraph_style
-        .text_motion
-        .unwrap_or(TextMotion::Static)
-        == TextMotion::Static;
-    if !text_motion_static {
-        return None;
-    }
-
-    let font_px_size = font.ab_glyph_px_size(font_size) * scale;
-    let letter_spacing = resolve_letter_spacing(style, font_size) * scale;
-    let align_fraction = crate::scene_builder::text_align_fraction(style, text);
-    let weight_synthesis = TextWeightSynthesis::for_style(style, font.weight(), font_size, scale);
-    let style_synthesis = TextStyleSynthesis::for_style(style, font.style(), font_size, scale);
-    let metrics = vertical_metrics(&font.font, font_px_size);
-    let line_box = line_box_for(
-        style,
-        metrics,
-        (style.resolve_line_height(14.0, font_size * 1.4) * scale).max(1.0),
-        1.0,
-    );
-    let line_height = line_box.height;
-    let first_baseline_y = local_rect.y + line_box.baseline;
+    let m = text_segment_metrics(text, local_rect, style, font_size, scale, font);
     let origin_x = local_rect.x.round();
     let initial_len = out.len();
 
@@ -2681,17 +2498,17 @@ fn collect_text_segment_solid_atlas_glyphs(
         text,
         &font.font,
         font.content_hash(),
-        font_px_size,
-        line_height,
-        first_baseline_y,
+        m.font_px_size,
+        m.line_height,
+        m.first_baseline_y,
         origin_x,
         0.0,
-        letter_spacing,
-        align_fraction,
+        m.letter_spacing,
+        m.align_fraction,
         true,
         GlyphRasterStyle::Fill,
-        weight_synthesis,
-        style_synthesis,
+        m.weight_synthesis,
+        m.style_synthesis,
         Some(glyph_cache),
         |key, mask| {
             if mask.width == 0 || mask.height == 0 {
@@ -2731,43 +2548,14 @@ fn collect_text_segment_cached_solid_atlas_placements(
     glyph_cache: &mut SoftwareGlyphRasterCache,
     out: &mut Vec<SoftwareGlyphAtlasPlacement>,
 ) -> Option<f32> {
-    if text.is_empty()
-        || local_rect.width <= 0.0
-        || local_rect.height <= 0.0
-        || !font_size.is_finite()
-        || font_size <= 0.0
-        || !scale.is_finite()
-        || scale <= 0.0
-    {
+    if text_render_request_is_degenerate(text.is_empty(), local_rect, font_size, scale) {
         return Some(0.0);
     }
-    if !style_can_atlas_solid_fill(style) {
+    if !text_segment_supports_solid_atlas(style) {
         return None;
     }
 
-    let text_motion_static = style
-        .paragraph_style
-        .text_motion
-        .unwrap_or(TextMotion::Static)
-        == TextMotion::Static;
-    if !text_motion_static {
-        return None;
-    }
-
-    let font_px_size = font.ab_glyph_px_size(font_size) * scale;
-    let letter_spacing = resolve_letter_spacing(style, font_size) * scale;
-    let align_fraction = crate::scene_builder::text_align_fraction(style, text);
-    let weight_synthesis = TextWeightSynthesis::for_style(style, font.weight(), font_size, scale);
-    let style_synthesis = TextStyleSynthesis::for_style(style, font.style(), font_size, scale);
-    let metrics = vertical_metrics(&font.font, font_px_size);
-    let line_box = line_box_for(
-        style,
-        metrics,
-        (style.resolve_line_height(14.0, font_size * 1.4) * scale).max(1.0),
-        1.0,
-    );
-    let line_height = line_box.height;
-    let first_baseline_y = local_rect.y + line_box.baseline;
+    let m = text_segment_metrics(text, local_rect, style, font_size, scale, font);
     let origin_x = local_rect.x.round();
     let initial_len = out.len();
 
@@ -2775,16 +2563,16 @@ fn collect_text_segment_cached_solid_atlas_placements(
         text,
         &font.font,
         font.content_hash(),
-        font_px_size,
-        line_height,
-        first_baseline_y,
+        m.font_px_size,
+        m.line_height,
+        m.first_baseline_y,
         origin_x,
         0.0,
-        letter_spacing,
-        align_fraction,
+        m.letter_spacing,
+        m.align_fraction,
         GlyphRasterStyle::Fill,
-        weight_synthesis,
-        style_synthesis,
+        m.weight_synthesis,
+        m.style_synthesis,
         glyph_cache,
         |placement| {
             if placement.width == 0 || placement.height == 0 {
@@ -2814,43 +2602,14 @@ fn collect_text_segment_solid_atlas_run(
     glyph_cache: &mut SoftwareGlyphRasterCache,
     out: &mut Vec<SoftwareGlyphAtlasRunGlyph>,
 ) -> Option<f32> {
-    if text.is_empty()
-        || local_rect.width <= 0.0
-        || local_rect.height <= 0.0
-        || !font_size.is_finite()
-        || font_size <= 0.0
-        || !scale.is_finite()
-        || scale <= 0.0
-    {
+    if text_render_request_is_degenerate(text.is_empty(), local_rect, font_size, scale) {
         return Some(0.0);
     }
-    if !style_can_atlas_solid_fill(style) {
+    if !text_segment_supports_solid_atlas(style) {
         return None;
     }
 
-    let text_motion_static = style
-        .paragraph_style
-        .text_motion
-        .unwrap_or(TextMotion::Static)
-        == TextMotion::Static;
-    if !text_motion_static {
-        return None;
-    }
-
-    let font_px_size = font.ab_glyph_px_size(font_size) * scale;
-    let letter_spacing = resolve_letter_spacing(style, font_size) * scale;
-    let align_fraction = crate::scene_builder::text_align_fraction(style, text);
-    let weight_synthesis = TextWeightSynthesis::for_style(style, font.weight(), font_size, scale);
-    let style_synthesis = TextStyleSynthesis::for_style(style, font.style(), font_size, scale);
-    let metrics = vertical_metrics(&font.font, font_px_size);
-    let line_box = line_box_for(
-        style,
-        metrics,
-        (style.resolve_line_height(14.0, font_size * 1.4) * scale).max(1.0),
-        1.0,
-    );
-    let line_height = line_box.height;
-    let first_baseline_y = local_rect.y + line_box.baseline;
+    let m = text_segment_metrics(text, local_rect, style, font_size, scale, font);
     let origin_x = local_rect.x.round();
     let initial_len = out.len();
 
@@ -2858,16 +2617,16 @@ fn collect_text_segment_solid_atlas_run(
         text,
         &font.font,
         font.content_hash(),
-        font_px_size,
-        line_height,
-        first_baseline_y,
+        m.font_px_size,
+        m.line_height,
+        m.first_baseline_y,
         origin_x,
         0.0,
-        letter_spacing,
-        align_fraction,
+        m.letter_spacing,
+        m.align_fraction,
         GlyphRasterStyle::Fill,
-        weight_synthesis,
-        style_synthesis,
+        m.weight_synthesis,
+        m.style_synthesis,
         glyph_cache,
         |run_glyph| {
             let run_glyph = match run_glyph {


### PR DESCRIPTION
## Summary

Deduplication pass scoped to `crates/cranpose-render/common/` and
`crates/cranpose-app-shell/src/`, per the multi-agent dedup effort
(other agents own `render/wgpu`, `render/pixels`, `cranpose-core`,
`cranpose-ui`, and the robot runners in parallel branches).

Measured with `jscpd --min-lines 10 --min-tokens 50 --format rust`.

**Before/after clone-pair counts:**
- `cranpose-render-common`: 108 -> 71
- `cranpose-app-shell`: 107 -> 98 (all but 3 pairs live inside
  `src/tests/app_shell_tests.rs`)

## Abstractions introduced

**cranpose-render-common**
- `Default` impls for `BuildNodeSnapshot` (scene_builder.rs, test-only),
  `LayerNode` (graph.rs, pub production type), and `HitRegionInit`
  (graph_scene.rs, private). All three were being constructed with
  every field spelled out even when 15+ of them were always the same
  boilerplate value; this is what killed the largest single cluster
  (scene_builder.rs's test module, 54 pairs) and a cross-file one where
  dev_overlay.rs, graph.rs (test), hit_graph.rs (test) and
  render_contract.rs were all separately reinventing the same
  all-defaults `LayerNode` literal.
- `text_render_request_is_degenerate` (software_text_raster.rs): the
  `text.is_empty() || rect.width <= 0.0 || ...` guard repeated
  byte-for-byte at 9 call sites.
- `TextSegmentMetrics` / `text_segment_metrics`: the font-size/letter-
  spacing/line-box computation shared by the draw path and all three
  atlas-collect paths.
- `text_segment_supports_solid_atlas`: folds
  `style_can_atlas_solid_fill` + the text-motion-is-static check that
  were always used together.
- `walk_solid_text_atlas_segments`: the outer text-boundary-walk/line-
  wrap loop that `collect_solid_text_atlas_glyphs`,
  `collect_cached_solid_text_atlas_placements` and
  `collect_solid_text_atlas_run` each reimplemented verbatim (~300
  lines -> one generic driver + 3 thin wrappers), parameterized over
  the per-segment callback.
- `style_can_atlas_solid_fill` now composes
  `style_can_rasterize_direct_solid` instead of repeating its shadow/
  brush checks.
- `SoftwareTextFont::raster_ref()`: the `RasterFontRef` literal built
  identically by `rasterize_text_to_image` and
  `rasterize_text_to_image_with_glyph_cache`.
- `local_bounds_bits` (raster_cache.rs): the bit-cast block repeated in
  all five `LayerRasterCacheKey` constructors.
- `sample_tiled_gradient_rgba` (brush_sampling.rs): what
  `LinearGradient` and `RadialGradient` both did after computing `t`
  differently.
- `TolerantLoad` (font_source.rs): names the "keep going on individual
  failures, fail only if nothing loaded" accumulator both
  `register_family` and `register_system_family` hand-rolled.
- `sample_text_primitive` (primitive_emit.rs, test-only): a text
  fixture two tests built identically.

**cranpose-app-shell**
- `renderer_scene_accessors!` / `renderer_noop_rebuild!` macros
  (app_shell_tests.rs): nine fake `Renderer` impls repeated the same
  `scene()`/`scene_mut()` field-passthrough pair, and five of them also
  repeated the same no-op `rebuild_scene`/`rebuild_scene_from_applier`
  pair. Every impl block still lists its own trait methods; some
  bodies now come from a one-line macro call instead of a 4-8 line
  repeat.
- `log_dirty_diagnostics_for_path` (shell_frame.rs): the two
  `RenderPhaseDirtyDiagnostics` construction sites were identical
  except for the `path` value.
- `AppShell::dispatch_to_hits` (shell_input.rs): the
  capture-paths/dispatch-order/dispatch_targets/is_consumed tail shared
  by `pointer_zoomed_inner` and the scroll dispatch path.

## Left alone, on purpose

- `click_text` vs `click_text_like_robot` (app_shell_tests.rs): the
  only difference is whether `shell.update()` runs between
  `set_cursor` and `pointer_pressed()` -- that gap is the entire point
  of the "robot" variant, so merging them would erase the thing under
  test.
- `graph_layer` (render_contract.rs, kept, just slimmed): a private
  constructor already existed here; it now uses `..Default::default()`
  too, same shape as the other three call sites.
- The bulk of what's left in `app_shell_tests.rs` (98 pairs, ~all in
  that one file) is individual `#[test]` functions that share setup
  *shape* but assert different behavior, or that each need their own
  `AppShell::new(.., location_key(file!(), line!(), column!()), ..)`
  call -- hoisting that into a shared helper would collapse every
  caller onto the identical composition key, which is a correctness
  risk (composition identity), not a style nit.
- `layer_composition.rs`'s two `GraphicsLayer` test-case arrays overlap
  by ~13 lines but back two independent tests; sharing the array would
  couple tests that should be free to diverge.
- `rect_shape_params` / `round_rect_shape_params` / `arc_shape_params`
  (primitive_emit.rs) share a `ShapeDrawParams` struct-literal tail but
  differ in `local_rect`/`shape`/`stroke`/`arc` computation per
  primitive kind; a shared constructor would just relocate the
  complexity into a 10-argument helper.

## Verification

All run from this crate pair's scope:
```
just fmt                                                          # clean
cargo clippy -p cranpose-render-common -p cranpose-app-shell \
    --all-targets -- -D warnings                                  # clean
cargo test --profile ci -p cranpose-render-common \
    -p cranpose-app-shell                                         # 224 + 156 lib tests, unchanged counts
just complexity-gate                                               # 129 changed line ranges clean
just duplication-gate                                               # none introduced by the diff
```

No `unsafe`, no new comments (checked with
`git diff origin/main..HEAD | grep -E "^\+\s*(//|///|//!)"` --
empty), nothing touched outside the two assigned crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
