### PR TITLE
Discover robot tests by fn main, not by a hardcoded exclusion

### DIFF
--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -250,8 +250,11 @@ mkdir -p "$(dirname "$LOG_FILE")" "$(dirname "$SUMMARY_FILE")"
 rm -f "$LOG_FILE" "$SUMMARY_FILE"
 
 echo "Cleaning up..."
-# Dynamically discover all robot tests from the robot-runners and examples directories
-# Exclude utility modules (files that don't have a main function)
+# A robot test is a file with a `fn main`. Anything else under robot_*.rs is a
+# module the runners share, and cargo builds no binary for it -- asking for one
+# reports FAIL:missing_binary, which is what a shared module named robot_exit.rs
+# did to the whole suite. The previous predicate was a single hardcoded name,
+# so every future shared module had to be added to it or break the suite.
 EXAMPLES=()
 RUN_EXAMPLES=()
 CAPABILITY_SKIPPED_EXAMPLES=()
@@ -260,13 +263,10 @@ for robot_source_dir in "$ROBOT_DIR" "$ROBOT_EXAMPLES_DIR"; do
         if [ ! -f "$file" ]; then
             continue
         fi
-        # Extract the example name (filename without .rs extension)
-        example=$(basename "$file" .rs)
-        # Skip utility modules (they don't have fn main)
-        if [ "$example" = "robot_test_utils" ]; then
+        if ! grep -qE '^fn main\(' "$file"; then
             continue
         fi
-        EXAMPLES+=("$example")
+        EXAMPLES+=("$(basename "$file" .rs)")
     done
 done
 


### PR DESCRIPTION
`robot e2e` is red on main and this is why:

```
[FAIL] robot_exit (missing_binary)
[FAIL] robot_shot (missing_binary)
[ERROR] 2 tests FAILED
```

`run_robot_test.sh` globs `robot_*.rs` and excludes exactly one name — `robot_test_utils`, which no longer exists in the tree. Everything else matching the glob is assumed to build a binary. #575 and #559 added `robot_exit.rs` and `robot_shot.rs` as **shared modules** in that directory; cargo builds no binary for a module, so the suite demanded one and failed.

**The comment above that loop already stated the right predicate** — *"Exclude utility modules (files that don't have a main function)"* — and the code checked a name instead. The rule was written down and not implemented. Any future shared module would have broken the suite until somebody remembered to add it to the list.

`output_paths.rs`, `perf_contract.rs` and the dozen others have sat in that directory for months without incident purely because they do not match `robot_*`. Naming these two with a `robot_` prefix is what exposed a latent defect, not what caused one.

### The fix

Discovery asks the question the comment asks. Verified against the tree:

| | count |
|---|---|
| files matching `robot_*.rs` | 163 |
| declaring `fn main` | **161** |
| not declaring it | `robot_exit.rs`, `robot_shot.rs` |

The dead `robot_test_utils` special case goes with it.

### Why this reached main

#575 and #559 were verified with `just fmt`, `just clippy-robot`, `cargo check --examples --features robot-app`, `just complexity-gate` and `just duplication-gate`. **All of those pass on a shared module that breaks the suite, because none of them run it.** They were merged without a robot run under the force-merge policy, and this is the class of defect that policy trades away. Worth stating plainly rather than filing as bad luck.

It also means [#582](https://github.com/samoylenkodmitry/Cranpose/pull/582) — which adds five more shared modules under the same directory — must have a real `just robot` run before merging, and would have hit the same wall without this change.