### PR TITLE
Close silent CI skips: guard independent steps, lint svg/hyphenation/audio backends

### DIFF
--- a/.github/workflows/heavy-selfhosted.yml
+++ b/.github/workflows/heavy-selfhosted.yml
@@ -164,6 +164,7 @@ jobs:
         run: scripts/ci/docs_only_change.sh
 
       - name: Provision iOS Rust targets
+        id: provision
         if: steps.changes.outputs.docs_only != 'true'
         run: |
           # Resolve the account's real home rather than trusting $HOME:
@@ -189,15 +190,15 @@ jobs:
             aarch64-apple-ios
 
       - name: Clippy iOS simulator
-        if: steps.changes.outputs.docs_only != 'true'
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' && steps.changes.outputs.docs_only != 'true' }}
         run: just clippy-ios
 
       - name: Build iOS device binary
-        if: steps.changes.outputs.docs_only != 'true'
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' && steps.changes.outputs.docs_only != 'true' }}
         run: just ios-device
 
       - name: Assemble simulator app bundle
-        if: steps.changes.outputs.docs_only != 'true'
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' && steps.changes.outputs.docs_only != 'true' }}
         run: just ios-sim
 
   android-release:
@@ -253,6 +254,7 @@ jobs:
           echo "$sdk_root/platform-tools" >> "$GITHUB_PATH"
 
       - name: Provision toolchains and start sccache
+        id: provision
         if: steps.changes.outputs.docs_only != 'true'
         run: |
           # rust-toolchain.toml owns the version; the targets land on it.
@@ -273,14 +275,14 @@ jobs:
           test -f "$ANDROID_NDK_HOME/source.properties"
 
       - name: Clippy Android ABIs
-        if: steps.changes.outputs.docs_only != 'true'
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' && steps.changes.outputs.docs_only != 'true' }}
         # Gradle does not deny warnings, so the APK build below cannot be the
         # zero-warning gate for this target. Runs first: a lint failure should
         # not wait behind a full release APK.
         run: just clippy-android
 
       - name: Build Android release APK
-        if: steps.changes.outputs.docs_only != 'true'
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' && steps.changes.outputs.docs_only != 'true' }}
         # --no-daemon: never attach to a shared/foreign Gradle daemon on this
         # self-hosted box. Reused daemons started by other builds on the runner
         # can carry a PATH without ~/.cargo/bin, which makes the cargo-ndk check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -196,6 +196,7 @@ jobs:
           cargo xtask wait-for-crates-io "$TAG_NAME"
 
       - name: Point the isolated demo at the release
+        id: point
         run: |
           set -euo pipefail
           version="${TAG_NAME#v}"
@@ -245,6 +246,7 @@ jobs:
       # be built this way is broken for every application that is not this
       # repository, and nothing else in the pipeline would notice.
       - name: Build the isolated demo against the release
+        if: ${{ !cancelled() && steps.point.conclusion == 'success' }}
         run: |
           set -euo pipefail
           cargo build --manifest-path apps/isolated-demo/Cargo.toml \
@@ -257,6 +259,7 @@ jobs:
       # only place a release is proven to build for the browser the way an
       # application builds it.
       - name: Build the isolated demo for the web
+        if: ${{ !cancelled() && steps.point.conclusion == 'success' }}
         run: |
           set -euo pipefail
           rustup target add wasm32-unknown-unknown
@@ -271,6 +274,7 @@ jobs:
       # own environment; setting it here would override a working one with an
       # empty string.
       - name: Build the isolated demo's Android release
+        if: ${{ !cancelled() && steps.point.conclusion == 'success' }}
         run: |
           set -euo pipefail
           ./apps/isolated-demo/android/gradlew \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,9 +102,17 @@ jobs:
         if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just clippy
 
-      - name: Run clippy on the macOS camera backend
+      - name: Run clippy on the optional desktop backends
         if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
-        run: just clippy-camera-desktop
+        run: just clippy-optional-backends
+
+      - name: Run clippy on the SVG image painter
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
+        run: just clippy-svg
+
+      - name: Run clippy on the embedded hyphenation dictionary
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
+        run: just clippy-hyphenation
 
       - name: Run clippy on the robot runners
         if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
@@ -115,7 +123,7 @@ jobs:
         # A broken intra-doc link is a broken published page.
         run: just doc
 
-      - name: Run cranpose-core feature permutations
+      - name: Run feature permutations the default build skips
         if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just test-features
 

--- a/crates/cranpose-render/common/src/text_hyphenation.rs
+++ b/crates/cranpose-render/common/src/text_hyphenation.rs
@@ -89,10 +89,10 @@ impl HyphenationDictionaryStore {
     }
 
     fn get_dictionary(&self, language: Language) -> Option<Standard> {
-        if let Ok(read_guard) = self.dictionaries.read() {
-            if let Some(dict) = read_guard.get(&language) {
-                return Some(dict.clone());
-            }
+        if let Ok(read_guard) = self.dictionaries.read()
+            && let Some(dict) = read_guard.get(&language)
+        {
+            return Some(dict.clone());
         }
 
         #[cfg(feature = "text-hyphenation-embedded")]

--- a/crates/cranpose-ui/src/widgets/image_svg.rs
+++ b/crates/cranpose-ui/src/widgets/image_svg.rs
@@ -151,18 +151,18 @@ impl SvgDocument {
 }
 
 fn draw_rect(pixmap: &mut tiny_skia::PixmapMut<'_>, rect: &SvgRect, transform: Transform) {
-    if let Some(fill) = rect.fill {
-        if let Some(skia_rect) = SkiaRect::from_xywh(rect.x, rect.y, rect.width, rect.height) {
-            let mut paint = Paint::default();
-            fill.apply_to(&mut paint);
-            pixmap.fill_rect(skia_rect, &paint, transform, None);
-        }
+    if let Some(fill) = rect.fill
+        && let Some(skia_rect) = SkiaRect::from_xywh(rect.x, rect.y, rect.width, rect.height)
+    {
+        let mut paint = Paint::default();
+        fill.apply_to(&mut paint);
+        pixmap.fill_rect(skia_rect, &paint, transform, None);
     }
 
-    if let Some(stroke) = &rect.stroke {
-        if let Some(path) = rect_path(rect) {
-            stroke_path(pixmap, &path, stroke, transform);
-        }
+    if let Some(stroke) = &rect.stroke
+        && let Some(path) = rect_path(rect)
+    {
+        stroke_path(pixmap, &path, stroke, transform);
     }
 }
 
@@ -315,10 +315,11 @@ fn parse_attributes(source: &str) -> Result<Vec<(String, String)>, SvgPainterErr
 }
 
 fn parse_intrinsic_size(tag: &SvgTag) -> Result<Size, SvgPainterError> {
-    if let (Some(width), Some(height)) = (number_attr(tag, "width")?, number_attr(tag, "height")?) {
-        if width > 0.0 && height > 0.0 {
-            return Ok(Size::new(width, height));
-        }
+    if let (Some(width), Some(height)) = (number_attr(tag, "width")?, number_attr(tag, "height")?)
+        && width > 0.0
+        && height > 0.0
+    {
+        return Ok(Size::new(width, height));
     }
 
     let view_box = attr(tag, "viewbox")

--- a/justfile
+++ b/justfile
@@ -68,19 +68,35 @@ clippy-wasm:
 clippy-ios:
     cargo clippy -p desktop-app --bin cranpose-ios --target aarch64-apple-ios-sim --no-default-features --features ios -- -D warnings
 
-# Lint the macOS desktop camera backend.
+# Lint the desktop-only backends that ship off by default: the macOS camera
+# capture path, the cpal audio output device, the in-process media backend
+# and the StoreKit purchase bridge.
 #
-# `just clippy` builds default features, and `camera-desktop` is off by
-# default, so the macOS half of `apple_camera.rs` would reach main unlinted
-# without this. That is the same shape of hole `clippy-android` was added to
-# close. Runs on any host: off a Mac the backend compiles away and this only
-# proves the feature still resolves.
+# `just clippy` builds default features, and none of these are on by
+# default, so their code would reach main unlinted without this. That is the
+# same shape of hole `clippy-android` was added to close. Runs on any host:
+# off a Mac the Apple-only backends compile away and this only proves the
+# features still resolve.
 #
 # `robot` rides along because the desktop shell's screenshot helpers are only
 # called from robot code: without it those three functions are dead and the
-# recipe fails on them instead of on the camera.
-clippy-camera-desktop:
-    cargo clippy -p cranpose --no-default-features --features desktop,renderer-wgpu,camera-desktop,robot --all-targets -- -D warnings
+# recipe fails on them instead of on the backends above. `playbilling` rides
+# along too: it is Android-only and compiles away on every other target, so
+# there is no per-target recipe for it to join instead.
+clippy-optional-backends:
+    cargo clippy -p cranpose --no-default-features --features desktop,renderer-wgpu,camera-desktop,robot,audio-desktop,media,storekit,playbilling --all-targets -- -D warnings
+
+# Lint the SVG image painter. `svg` is off by default and no crate in the
+# workspace ever turns it on, so `just clippy` never builds `image_svg.rs`
+# and `svg_painter_integration.rs` never compiles either.
+clippy-svg:
+    cargo clippy -p cranpose-ui --features svg --all-targets -- -D warnings
+
+# Lint the embedded hyphenation dictionary. `text-hyphenation-embedded` is
+# off by default and no crate in the workspace ever turns it on, so
+# `just clippy` never builds `text_hyphenation.rs`'s dictionary-backed path.
+clippy-hyphenation:
+    cargo clippy -p cranpose-render-common --features text-hyphenation-embedded --all-targets -- -D warnings
 
 # Lint the robot runners, which `just clippy` cannot reach.
 #
@@ -164,10 +180,13 @@ duplication-gate base="origin/main":
 test:
     cargo test --profile ci --workspace --no-fail-fast
 
-# Feature permutations of the core crate that the default build does not cover.
+# Feature permutations that the default build does not cover.
 test-features:
     cargo test --profile ci -p cranpose-core --features std-hash
     cargo test --profile ci -p cranpose-core --features internal
+    cargo test --profile ci -p cranpose-ui --features svg
+    cargo test --profile ci -p cranpose-render-common --features text-hyphenation-embedded
+    cargo test --profile ci -p cranpose --no-default-features --features desktop,renderer-wgpu,camera-desktop,robot,audio-desktop,media,storekit,playbilling
 
 # The docs-only trigger filter that lets the heavy jobs skip a prose diff.
 # A wrong answer there disables the robot suite silently, so the predicate is


### PR DESCRIPTION
## Summary

Audited every workflow in `.github/workflows/` for the two defect classes from today. **DO NOT MERGE** — a release is being cut and `publish.yml` refuses a tag that is not at main's HEAD.

### Class 1 — a failing step silently suppresses the steps after it

Fixed two more jobs with the same shape PR #574 fixed in `rust.yml`. Every other job was audited and left fail-fast on purpose (see table).

- `heavy-selfhosted.yml` / `ios-build`: `Clippy iOS simulator`, `Build iOS device binary` and `Assemble simulator app bundle` are three independent compiles (different target triples / outputs). A lint failure was hiding whether the device build or the sim bundle would also fail.
- `heavy-selfhosted.yml` / `android-release`: `Clippy Android ABIs` and `Build Android release APK` are independent; a lint failure was skipping the entire release APK build.
- `publish.yml` / `bump_isolated_demo`: `Build the isolated demo against the release` / `...for the web` / `...'s Android release` only need `Point the isolated demo at the release`'s file edits, not `Land the bump on the default branch`'s git push. A push failure (e.g. a race with another commit) was hiding whether the release even builds for any of the three targets.

Each precondition step that had no `id:` got one (`provision` / `point`), and the guarded steps got the standard `if: ${{ !cancelled() && steps.X.conclusion == 'success' }}`.

### Class 2 — a target silently skipped rather than checked

Enumerated every workspace target with `required-features` via `cargo metadata --no-deps --format-version 1`. Beyond the ~165 robot examples PR #578 already fixed, found `cranpose-ui`'s `svg_painter_integration` test (`required-features = ["svg"]`) — skipped by both `cargo clippy --workspace --all-targets` and `cargo test --workspace`, since nothing in the workspace ever turns `svg` on.

Going further (feature-gated code with no `required-features` marker at all, so `cargo metadata` doesn't surface it as a skipped *target* — it just never gets *compiled*): `cranpose-render-common`'s `text-hyphenation`/`text-hyphenation-embedded` and `cranpose`'s `audio-desktop`, `media`, `storekit`, `playbilling` are non-default features that no crate in the workspace ever activates. All of it — a hyphenation-dictionary module with its own gated unit tests, and the audio/media/purchase backends with substantial existing-but-never-run tests — was unlinted and untested. Verified each combination clean (0 clippy findings after fixing 4 pre-existing `collapsible_if` lints it surfaced, all tests pass) before wiring it in.

Added: `clippy-svg`, `clippy-hyphenation`, broadened `clippy-camera-desktop` → `clippy-optional-backends` (camera-desktop + audio-desktop + media + storekit + playbilling, all verified clean together), and extended `test-features` with all of the above. No backlog was hidden behind an allow-list — everything added here is zero-warnings clean today.

**`cargo test --workspace`'s blind spot**: identical to clippy's — the only required-features test target in the whole workspace was `svg_painter_integration`, now fixed by the same feature list in `test-features`.

**android/ios/wasm clippy-recipe parity** (do they cover what the real builds ship?):
- `clippy-wasm` and `build-web.sh` both build `desktop-app-platform --features web,renderer-wgpu --no-default-features` — exact match.
- `clippy-android` and `CranposeAndroidPlugin`'s default `cranpose.features` convention both use `android,renderer-wgpu`, `defaultFeatures=false` — exact match for what the demo app ships.
- `clippy-ios` only cross-compiles/lints the **simulator** triple (`aarch64-apple-ios-sim`); `just ios-device` builds the **device** triple (`aarch64-apple-ios`) with the identical feature set but is never clippy'd. Verified there is no `target_abi`-conditional code anywhere in the tree (`grep -rn target_abi` is empty), so today this produces zero missed findings — noted, not fixed, since adding iOS-device clippy infra to close a gap that currently hides nothing isn't worth it.
- `playbilling`'s one Android-only call site (`crates/cranpose/src/android_services.rs`) is never linted on a real Android ABI cross-compile — only proven to "compile away" on host via `clippy-optional-backends`. This sandbox has no Android SDK/NDK to verify a `clippy-android` feature-list change safely (per the repo rule against inventing untested feature subsets), so it's left as a follow-up for a machine with the toolchain (samarch-1/macm3), not guessed at here.

**Also verified, not gaps**: `cranpose-testing`'s `desktop-robot` and `cranpose-ui`/`cranpose-core`'s `test-helpers` looked like the same "never independently linted" pattern, but `cargo clippy -v` confirms `RUSTC_WORKSPACE_WRAPPER` (clippy) applies to *every* workspace-member crate compiled in a single invocation, not just the `-p`-selected package — so `just clippy` and `clippy-robot` already fully lint them via existing dev-dependency edges. No gate added; verified by running `just clippy` clean with all-targets after confirming the isolated `-p cranpose-testing --features desktop-robot` invocation is an invalid feature subset (it doesn't compile alone, by design — the crate is renderer/shell-agnostic and needs a consuming app's `desktop-shell` feature too).

## Audit table

| Workflow | Job | Step | Verdict |
|---|---|---|---|
| rust.yml | checks | checkout, Provision PATH and sccache (`id: provision`) | Fail-fast preconditions — unchanged |
| rust.yml | checks | Check formatting … Run the slot-table Criterion smoke (15 steps) | Already guarded independently by #574 — unchanged, confirmed |
| rust.yml | checks | Run clippy on the optional desktop backends | Renamed from "macOS camera backend" (recipe broadened); guard unchanged |
| rust.yml | checks | Run clippy on the SVG image painter | **New step**, guarded |
| rust.yml | checks | Run clippy on the embedded hyphenation dictionary | **New step**, guarded |
| rust.yml | checks | Run feature permutations the default build skips | Renamed from "cranpose-core feature permutations" (recipe broadened); guard unchanged |
| rust.yml | architecture-budget | checkout, Detect a docs-only change (`id: changes`), Provision PATH and sccache | Fail-fast preconditions — unchanged |
| rust.yml | architecture-budget | Check architecture budgets | Only step after provisioning — nothing to suppress; unchanged |
| rust.yml | wasm-build | checkout, Detect a docs-only change (`id: changes`), Provision PATH/sccache/wasm (`id: provision`) | Fail-fast preconditions — unchanged |
| rust.yml | wasm-build | Run wasm clippy, Build web demo | Already guarded independently by #574 — unchanged, confirmed |
| build-one.yml | build | checkout, Provision the pinned toolchain and just | Fail-fast precondition — unchanged |
| build-one.yml | build | Desktop / Web / Android / iOS / Robot example | Mutually exclusive via `inputs.target ==` dispatch choice, not sequential independent checks — nothing for a failure to suppress; unchanged |
| build-one.yml | build | Upload robot artifacts | Already `always()` — unchanged |
| deploy-pages.yml | build | Checkout … Upload artifact (8 steps) | Genuine sequential build pipeline (toolchain → binaryen → wasm-pack → build → package → gtar → upload), each step's output feeds the next — correctly fail-fast; unchanged |
| deploy-pages.yml | deploy | Deploy to GitHub Pages | Single step; unchanged |
| heavy-selfhosted.yml | robot-e2e-gpu | checkout, Detect a docs-only change, Configure machine-local knobs, Start sccache | Fail-fast preconditions (env/PATH/`just` needed downstream) — unchanged |
| heavy-selfhosted.yml | robot-e2e-gpu | Run the robot suite on the GPU | Only substantive step after setup — nothing to suppress; unchanged |
| heavy-selfhosted.yml | robot-e2e-gpu | sccache stats | Already `always()` — unchanged |
| heavy-selfhosted.yml | robot-capture-software | (same shape as robot-e2e-gpu) | Same verdict — unchanged |
| heavy-selfhosted.yml | ios-build | checkout, Detect a docs-only change, Provision iOS Rust targets | Fail-fast preconditions; **added `id: provision`** |
| heavy-selfhosted.yml | ios-build | Clippy iOS simulator, Build iOS device binary, Assemble simulator app bundle | **Fixed** — three independent compiles, now guarded so one failing doesn't hide the others |
| heavy-selfhosted.yml | android-release | checkout, Detect a docs-only change, Configure machine-local SDK/cache paths, Provision toolchains and start sccache | Fail-fast preconditions; **added `id: provision`** to the last one |
| heavy-selfhosted.yml | android-release | Clippy Android ABIs, Build Android release APK | **Fixed** — independent; a lint failure no longer hides an APK build failure |
| heavy-selfhosted.yml | android-release | sccache stats | Already `always()` — unchanged |
| publish.yml | sync_versions | checkout, Provision the pinned Rust toolchain, Sync Cargo versions with tag (`id: sync`) | Single substantive step, genuine precondition (does the real tag/bump work) — unchanged |
| publish.yml | publish | checkout, Provision toolchain, Verify tag and workspace versions, Publish crates | Strictly sequential precondition → action — correctly fail-fast; unchanged |
| publish.yml | bump_isolated_demo | checkout, Provision toolchain, Wait for crates.io to serve the release | Fail-fast preconditions — unchanged |
| publish.yml | bump_isolated_demo | Point the isolated demo at the release | **Added `id: point`** |
| publish.yml | bump_isolated_demo | Land the bump on the default branch | Genuine dependency of nothing else in this job (only the git push); kept fail-fast on its own preconditions — unchanged |
| publish.yml | bump_isolated_demo | Build the isolated demo against the release / for the web / 's Android release | **Fixed** — three independent builds that only need `point`'s file edits, now guarded so a `Land the bump` push failure doesn't hide a build failure |
| release.yml | create-release | Create release | Single step; unchanged |
| release.yml | build (matrix) | checkout … Attach to release | Genuine sequential release pipeline (provision → build → package → attach); package step is OS-conditional but still a real dependency on the build step's output — correctly fail-fast; unchanged |
| release.yml | build-windows | checkout … Attach to release | Same shape — unchanged |
| release.yml | build-android | checkout … Attach to release | Same shape — unchanged |

## Verification

- `just fmt` / `just fmt-check` — clean
- `just clippy`, `just clippy-svg`, `just clippy-hyphenation`, `just clippy-optional-backends`, `just clippy-robot` — all clean (0 warnings)
- `just test-features` — all new lines pass, including the previously-never-run `svg_painter_integration`, hyphenation dictionary tests, and the audio/media/storekit/playbilling unit tests
- `just test` (full workspace) — 0 failures
- `actionlint` on every workflow touched, diffed before/after: **zero new findings** (only the pre-existing `cranpose-heavy` runner-label warnings and pre-existing shellcheck SC2129 style notes in `heavy-selfhosted.yml`, byte-for-byte identical before and after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
