### PR TITLE
Harden the gates: silent skips, robot discovery, and a bounded wait

### DIFF
--- a/.github/workflows/heavy-selfhosted.yml
+++ b/.github/workflows/heavy-selfhosted.yml
@@ -164,6 +164,7 @@ jobs:
         run: scripts/ci/docs_only_change.sh
 
       - name: Provision iOS Rust targets
+        id: provision
         if: steps.changes.outputs.docs_only != 'true'
         run: |
           # Resolve the account's real home rather than trusting $HOME:
@@ -189,15 +190,15 @@ jobs:
             aarch64-apple-ios
 
       - name: Clippy iOS simulator
-        if: steps.changes.outputs.docs_only != 'true'
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' && steps.changes.outputs.docs_only != 'true' }}
         run: just clippy-ios
 
       - name: Build iOS device binary
-        if: steps.changes.outputs.docs_only != 'true'
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' && steps.changes.outputs.docs_only != 'true' }}
         run: just ios-device
 
       - name: Assemble simulator app bundle
-        if: steps.changes.outputs.docs_only != 'true'
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' && steps.changes.outputs.docs_only != 'true' }}
         run: just ios-sim
 
   android-release:
@@ -253,6 +254,7 @@ jobs:
           echo "$sdk_root/platform-tools" >> "$GITHUB_PATH"
 
       - name: Provision toolchains and start sccache
+        id: provision
         if: steps.changes.outputs.docs_only != 'true'
         run: |
           # rust-toolchain.toml owns the version; the targets land on it.
@@ -273,14 +275,14 @@ jobs:
           test -f "$ANDROID_NDK_HOME/source.properties"
 
       - name: Clippy Android ABIs
-        if: steps.changes.outputs.docs_only != 'true'
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' && steps.changes.outputs.docs_only != 'true' }}
         # Gradle does not deny warnings, so the APK build below cannot be the
         # zero-warning gate for this target. Runs first: a lint failure should
         # not wait behind a full release APK.
         run: just clippy-android
 
       - name: Build Android release APK
-        if: steps.changes.outputs.docs_only != 'true'
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' && steps.changes.outputs.docs_only != 'true' }}
         # --no-daemon: never attach to a shared/foreign Gradle daemon on this
         # self-hosted box. Reused daemons started by other builds on the runner
         # can carry a PATH without ~/.cargo/bin, which makes the cargo-ndk check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -196,6 +196,7 @@ jobs:
           cargo xtask wait-for-crates-io "$TAG_NAME"
 
       - name: Point the isolated demo at the release
+        id: point
         run: |
           set -euo pipefail
           version="${TAG_NAME#v}"
@@ -245,6 +246,7 @@ jobs:
       # be built this way is broken for every application that is not this
       # repository, and nothing else in the pipeline would notice.
       - name: Build the isolated demo against the release
+        if: ${{ !cancelled() && steps.point.conclusion == 'success' }}
         run: |
           set -euo pipefail
           cargo build --manifest-path apps/isolated-demo/Cargo.toml \
@@ -257,6 +259,7 @@ jobs:
       # only place a release is proven to build for the browser the way an
       # application builds it.
       - name: Build the isolated demo for the web
+        if: ${{ !cancelled() && steps.point.conclusion == 'success' }}
         run: |
           set -euo pipefail
           rustup target add wasm32-unknown-unknown
@@ -271,6 +274,7 @@ jobs:
       # own environment; setting it here would override a working one with an
       # empty string.
       - name: Build the isolated demo's Android release
+        if: ${{ !cancelled() && steps.point.conclusion == 'success' }}
         run: |
           set -euo pipefail
           ./apps/isolated-demo/android/gradlew \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,6 +86,17 @@ jobs:
         # this job is the one that never skips.
         run: just test-ci-filters
 
+      - name: Check robot test discovery
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
+        # The predicate the robot suite discovers its examples by. It runs in
+        # this job, not the robot suite's own, so a bad predicate is pinned
+        # before the heavy job ever spends a build on it.
+        run: just test-robot-discovery
+
+      - name: Test the shell helpers
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
+        run: just test-shell-helpers
+
       - name: Check cyclomatic complexity of changed functions
         if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just complexity-gate
@@ -102,9 +113,17 @@ jobs:
         if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just clippy
 
-      - name: Run clippy on the macOS camera backend
+      - name: Run clippy on the optional desktop backends
         if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
-        run: just clippy-camera-desktop
+        run: just clippy-optional-backends
+
+      - name: Run clippy on the SVG image painter
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
+        run: just clippy-svg
+
+      - name: Run clippy on the embedded hyphenation dictionary
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
+        run: just clippy-hyphenation
 
       - name: Run clippy on the robot runners
         if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
@@ -115,7 +134,7 @@ jobs:
         # A broken intra-doc link is a broken published page.
         run: just doc
 
-      - name: Run cranpose-core feature permutations
+      - name: Run feature permutations the default build skips
         if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just test-features
 

--- a/crates/cranpose-render/common/src/text_hyphenation.rs
+++ b/crates/cranpose-render/common/src/text_hyphenation.rs
@@ -89,10 +89,10 @@ impl HyphenationDictionaryStore {
     }
 
     fn get_dictionary(&self, language: Language) -> Option<Standard> {
-        if let Ok(read_guard) = self.dictionaries.read() {
-            if let Some(dict) = read_guard.get(&language) {
-                return Some(dict.clone());
-            }
+        if let Ok(read_guard) = self.dictionaries.read()
+            && let Some(dict) = read_guard.get(&language)
+        {
+            return Some(dict.clone());
         }
 
         #[cfg(feature = "text-hyphenation-embedded")]

--- a/crates/cranpose-ui/src/widgets/image_svg.rs
+++ b/crates/cranpose-ui/src/widgets/image_svg.rs
@@ -151,18 +151,18 @@ impl SvgDocument {
 }
 
 fn draw_rect(pixmap: &mut tiny_skia::PixmapMut<'_>, rect: &SvgRect, transform: Transform) {
-    if let Some(fill) = rect.fill {
-        if let Some(skia_rect) = SkiaRect::from_xywh(rect.x, rect.y, rect.width, rect.height) {
-            let mut paint = Paint::default();
-            fill.apply_to(&mut paint);
-            pixmap.fill_rect(skia_rect, &paint, transform, None);
-        }
+    if let Some(fill) = rect.fill
+        && let Some(skia_rect) = SkiaRect::from_xywh(rect.x, rect.y, rect.width, rect.height)
+    {
+        let mut paint = Paint::default();
+        fill.apply_to(&mut paint);
+        pixmap.fill_rect(skia_rect, &paint, transform, None);
     }
 
-    if let Some(stroke) = &rect.stroke {
-        if let Some(path) = rect_path(rect) {
-            stroke_path(pixmap, &path, stroke, transform);
-        }
+    if let Some(stroke) = &rect.stroke
+        && let Some(path) = rect_path(rect)
+    {
+        stroke_path(pixmap, &path, stroke, transform);
     }
 }
 
@@ -315,10 +315,11 @@ fn parse_attributes(source: &str) -> Result<Vec<(String, String)>, SvgPainterErr
 }
 
 fn parse_intrinsic_size(tag: &SvgTag) -> Result<Size, SvgPainterError> {
-    if let (Some(width), Some(height)) = (number_attr(tag, "width")?, number_attr(tag, "height")?) {
-        if width > 0.0 && height > 0.0 {
-            return Ok(Size::new(width, height));
-        }
+    if let (Some(width), Some(height)) = (number_attr(tag, "width")?, number_attr(tag, "height")?)
+        && width > 0.0
+        && height > 0.0
+    {
+        return Ok(Size::new(width, height));
     }
 
     let view_box = attr(tag, "viewbox")

--- a/justfile
+++ b/justfile
@@ -68,19 +68,35 @@ clippy-wasm:
 clippy-ios:
     cargo clippy -p desktop-app --bin cranpose-ios --target aarch64-apple-ios-sim --no-default-features --features ios -- -D warnings
 
-# Lint the macOS desktop camera backend.
+# Lint the desktop-only backends that ship off by default: the macOS camera
+# capture path, the cpal audio output device, the in-process media backend
+# and the StoreKit purchase bridge.
 #
-# `just clippy` builds default features, and `camera-desktop` is off by
-# default, so the macOS half of `apple_camera.rs` would reach main unlinted
-# without this. That is the same shape of hole `clippy-android` was added to
-# close. Runs on any host: off a Mac the backend compiles away and this only
-# proves the feature still resolves.
+# `just clippy` builds default features, and none of these are on by
+# default, so their code would reach main unlinted without this. That is the
+# same shape of hole `clippy-android` was added to close. Runs on any host:
+# off a Mac the Apple-only backends compile away and this only proves the
+# features still resolve.
 #
 # `robot` rides along because the desktop shell's screenshot helpers are only
 # called from robot code: without it those three functions are dead and the
-# recipe fails on them instead of on the camera.
-clippy-camera-desktop:
-    cargo clippy -p cranpose --no-default-features --features desktop,renderer-wgpu,camera-desktop,robot --all-targets -- -D warnings
+# recipe fails on them instead of on the backends above. `playbilling` rides
+# along too: it is Android-only and compiles away on every other target, so
+# there is no per-target recipe for it to join instead.
+clippy-optional-backends:
+    cargo clippy -p cranpose --no-default-features --features desktop,renderer-wgpu,camera-desktop,robot,audio-desktop,media,storekit,playbilling --all-targets -- -D warnings
+
+# Lint the SVG image painter. `svg` is off by default and no crate in the
+# workspace ever turns it on, so `just clippy` never builds `image_svg.rs`
+# and `svg_painter_integration.rs` never compiles either.
+clippy-svg:
+    cargo clippy -p cranpose-ui --features svg --all-targets -- -D warnings
+
+# Lint the embedded hyphenation dictionary. `text-hyphenation-embedded` is
+# off by default and no crate in the workspace ever turns it on, so
+# `just clippy` never builds `text_hyphenation.rs`'s dictionary-backed path.
+clippy-hyphenation:
+    cargo clippy -p cranpose-render-common --features text-hyphenation-embedded --all-targets -- -D warnings
 
 # Lint the robot runners, which `just clippy` cannot reach.
 #
@@ -164,16 +180,31 @@ duplication-gate base="origin/main":
 test:
     cargo test --profile ci --workspace --no-fail-fast
 
-# Feature permutations of the core crate that the default build does not cover.
+# Feature permutations that the default build does not cover.
 test-features:
     cargo test --profile ci -p cranpose-core --features std-hash
     cargo test --profile ci -p cranpose-core --features internal
+    cargo test --profile ci -p cranpose-ui --features svg
+    cargo test --profile ci -p cranpose-render-common --features text-hyphenation-embedded
+    cargo test --profile ci -p cranpose --no-default-features --features desktop,renderer-wgpu,camera-desktop,robot,audio-desktop,media,storekit,playbilling
 
 # The docs-only trigger filter that lets the heavy jobs skip a prose diff.
 # A wrong answer there disables the robot suite silently, so the predicate is
 # pinned by the same gate that runs everywhere else.
 test-ci-filters:
     scripts/ci/docs_only_change_test.sh
+
+# run_robot_test.sh's example discovery: which robot_*.rs files it asks
+# cargo to build. A wrong answer there either drops a robot test silently or
+# demands a binary cargo never builds and fails the whole suite -- see
+# scripts/ci/robot_test_discovery_test.sh for the outage that predicate once
+# caused.
+test-robot-discovery:
+    scripts/ci/robot_test_discovery_test.sh
+
+# The shell helpers agents run by hand, pinned so they cannot rot.
+test-shell-helpers:
+    scripts/wait_until_quiet_test.sh
 
 # The deterministic slot-table model check, at the frame count CI uses.
 test-property:
@@ -394,7 +425,7 @@ perf-heap *args:
 # Excludes the jobs that need a GPU, an Android SDK or an iOS toolchain.
 
 # What a pull request is gated on. Run this before pushing.
-ci: fmt-check typos versions test clippy clippy-robot doc budgets test-quality-gates complexity-gate duplication-gate
+ci: fmt-check typos versions test clippy clippy-robot doc budgets test-quality-gates complexity-gate duplication-gate test-robot-discovery test-shell-helpers
 
 # Needs a Linux box with the X11 stack, an Android SDK and (on macOS) Xcode.
 

--- a/scripts/ci/robot_test_discovery_test.sh
+++ b/scripts/ci/robot_test_discovery_test.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Regression test for run_robot_test.sh's robot example discovery.
+#
+# A robot test is a file matching robot_*.rs under apps/desktop-demo/
+# robot-runners/ or apps/desktop-demo/examples/ that defines `fn main`.
+# Everything else matching that glob is a module the runners share, and
+# cargo builds no binary for it. Before this predicate existed, discovery
+# hardcoded a single excluded filename; a second shared module named
+# robot_exit.rs was not on that list, cargo built no binary for it, and the
+# suite asked for one anyway and reported FAIL:missing_binary across the
+# whole board the day a release was being cut. This file pins the predicate
+# that replaced the hardcoded name, so a future shared module cannot repeat
+# that outage.
+#
+# The predicate has two independent halves -- the robot_*.rs glob and the
+# `fn main` grep -- and either one failing open reopens a different way to
+# break the suite. Asserting "not discovered" proves nothing by itself: a
+# discovery loop that finds nothing at all would pass every negative
+# trivially. So every negative case here is replayed against a mutant with
+# the relevant half of the predicate inverted, and must flip to "discovered".
+# A case that does not flip is not exercising the half of the predicate it
+# claims to. Positives are excluded from that replay: they already report
+# success, so they cannot flip.
+#
+# This test never runs a real cargo build. It stubs the build tool
+# run_robot_test.sh calls (CARGO_RUNNER) and stops at --build-only, which
+# covers discovery, selection and skipping -- the whole surface this test
+# exists to pin -- before the suite would spend minutes compiling or need a
+# display.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+subject="$repo_root/run_robot_test.sh"
+dev_build_common="$repo_root/scripts/dev_build_common.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+fixture="$workdir/fixture"
+failures=0
+
+# --- fixtures ----------------------------------------------------------
+
+# Every combination the predicate has to tell apart, in both directories it
+# reads: right prefix with `fn main` (discovered), right prefix without it
+# (the robot_exit.rs shape), and wrong prefix with and without `fn main`
+# (never discovered, regardless of content).
+mkdir -p "$fixture/apps/desktop-demo/robot-runners" \
+         "$fixture/apps/desktop-demo/examples" \
+         "$fixture/scripts"
+
+runners="$fixture/apps/desktop-demo/robot-runners"
+examples="$fixture/apps/desktop-demo/examples"
+
+printf 'fn main() {}\n' > "$runners/robot_alpha_fixture.rs"
+printf 'pub fn helper() {}\n' > "$runners/robot_exit_fixture.rs"
+printf 'fn main() {}\n' > "$runners/not_robot_launcher_fixture.rs"
+printf 'pub fn helper() {}\n' > "$runners/not_robot_helper_fixture.rs"
+
+printf 'fn main() {}\n' > "$examples/robot_beta_fixture.rs"
+printf 'pub fn helper() {}\n' > "$examples/robot_helper_fixture.rs"
+
+# Stands in for a real `cargo build`. It echoes what it was asked to build,
+# so a selection down to a single example is verifiable by name and not
+# just by count.
+cat > "$fixture/cargo-dev.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "STUB_BUILD_ARGS: $*"
+exit 0
+STUB
+chmod +x "$fixture/cargo-dev.sh"
+
+# The real helper library, not a copy: symlinked so this test always runs
+# against whatever host-lock and sccache logic the subject currently
+# sources, rather than a snapshot that can drift from it.
+ln -s "$dev_build_common" "$fixture/scripts/dev_build_common.sh"
+
+# A fresh copy of the subject, taken new on every run, so this test always
+# exercises whatever run_robot_test.sh currently does. It resolves
+# ROBOT_DIR/ROBOT_EXAMPLES_DIR relative to the working directory and its own
+# script directory relative to its invocation path, so it must be invoked
+# with the fixture as both cwd and its own directory for those to line up
+# with the stub cargo-dev.sh and the symlinked helper library above.
+cp -p "$subject" "$fixture/run_robot_test.sh"
+
+# --- harness -------------------------------------------------------------
+
+run() {
+    local script="$1"
+    shift
+    set +e
+    last_output="$(cd "$fixture" && CI=1 \
+        CRANPOSE_ROBOT_LOG_FILE="$workdir/run.log" \
+        CRANPOSE_ROBOT_SUMMARY_FILE="$workdir/run.summary" \
+        bash "$script" --build-only "$@" 2>&1)"
+    last_status=$?
+    set -e
+}
+
+check() {
+    local label="$1" want_status="$2" needle="$3"
+    if [[ "$last_status" -eq "$want_status" ]] && [[ "$last_output" == *"$needle"* ]]; then
+        printf 'ok    %-58s status=%s\n' "$label" "$last_status"
+    else
+        printf 'FAIL  %-58s status=%s (want %s), needle %s\n' \
+            "$label" "$last_status" "$want_status" \
+            "$([[ "$last_output" == *"$needle"* ]] && echo found || echo MISSING)"
+        printf '%s\n' "$last_output" | sed 's/^/      | /'
+        failures=$((failures + 1))
+    fi
+}
+
+# --- pass 1: discovery, selection and skip ---------------------------------
+echo "-- discovery --"
+
+run "$fixture/run_robot_test.sh" --example robot_alpha_fixture
+check "robot_*.rs with fn main is discovered (robot-runners/)" 0 "--example robot_alpha_fixture"
+
+run "$fixture/run_robot_test.sh" --example robot_beta_fixture
+check "robot_*.rs with fn main is discovered (examples/)" 0 "--example robot_beta_fixture"
+
+run "$fixture/run_robot_test.sh" --example robot_exit_fixture
+check "robot_*.rs without fn main is NOT discovered (robot-runners/, the robot_exit.rs shape)" \
+    1 "Unknown robot example: robot_exit_fixture"
+
+run "$fixture/run_robot_test.sh" --example robot_helper_fixture
+check "robot_*.rs without fn main is NOT discovered (examples/)" \
+    1 "Unknown robot example: robot_helper_fixture"
+
+run "$fixture/run_robot_test.sh" --example not_robot_launcher_fixture
+check "non-robot_-prefixed file with fn main is NOT discovered" \
+    1 "Unknown robot example: not_robot_launcher_fixture"
+
+run "$fixture/run_robot_test.sh" --example not_robot_helper_fixture
+check "non-robot_-prefixed file without fn main is NOT discovered either" \
+    1 "Unknown robot example: not_robot_helper_fixture"
+
+run "$fixture/run_robot_test.sh"
+check "default discovery spans both directories (2 valid of 4 robot_*.rs candidates)" \
+    0 "Build-only robot gate completed for 2 examples."
+
+run "$fixture/run_robot_test.sh" --skip robot_alpha_fixture
+check "--skip excludes the named example" 0 "Skipping robot example: robot_alpha_fixture"
+check "--skip leaves the rest selected for build" 0 "--example robot_beta_fixture"
+
+# --- pass 2: the predicate halves must each be load-bearing -----------------
+#
+# mutant_a inverts the fn-main check alone: files without `fn main` are kept
+# and files with it are dropped. mutant_b broadens the glob alone: every
+# .rs file in the directory is considered, not just robot_*.rs. mutant_c
+# applies both, which is the only way to also flip the double negative --
+# wrong prefix and no `fn main` -- since inverting either half alone still
+# leaves the other excluding it.
+mutant_a="$fixture/run_robot_test.mutant_a.sh"
+sed -E 's/^([[:space:]]*)if ! grep -qE/\1if grep -qE/' "$fixture/run_robot_test.sh" > "$mutant_a"
+if cmp -s "$fixture/run_robot_test.sh" "$mutant_a"; then
+    echo "FAIL  mutant_a did not apply -- the fn-main check moved, update this test" >&2
+    exit 1
+fi
+
+mutant_b="$fixture/run_robot_test.mutant_b.sh"
+sed 's|"\$robot_source_dir"/robot_\*\.rs|"$robot_source_dir"/*.rs|' "$fixture/run_robot_test.sh" > "$mutant_b"
+if cmp -s "$fixture/run_robot_test.sh" "$mutant_b"; then
+    echo "FAIL  mutant_b did not apply -- the robot_*.rs glob moved, update this test" >&2
+    exit 1
+fi
+
+mutant_c="$fixture/run_robot_test.mutant_c.sh"
+sed -E 's/^([[:space:]]*)if ! grep -qE/\1if grep -qE/' "$mutant_b" > "$mutant_c"
+if cmp -s "$mutant_b" "$mutant_c"; then
+    echo "FAIL  mutant_c did not apply on top of mutant_b -- update this test" >&2
+    exit 1
+fi
+
+echo "-- mutation: each half must be load-bearing --"
+
+mutation_check() {
+    local label="$1" script="$2"
+    shift 2
+    run "$script" "$@"
+    if [[ "$last_status" -eq 0 ]]; then
+        printf 'ok    %-58s flips under mutation\n' "$label"
+    else
+        printf 'FAIL  %-58s did NOT flip (status=%s): assertion is not load-bearing\n' \
+            "$label" "$last_status"
+        failures=$((failures + 1))
+    fi
+}
+
+mutation_check "robot_exit_fixture flips when the fn-main check is inverted" \
+    "$mutant_a" --example robot_exit_fixture
+mutation_check "robot_helper_fixture flips when the fn-main check is inverted" \
+    "$mutant_a" --example robot_helper_fixture
+mutation_check "not_robot_launcher_fixture flips when the robot_*.rs glob is broadened" \
+    "$mutant_b" --example not_robot_launcher_fixture
+mutation_check "not_robot_helper_fixture flips only once both halves are broadened" \
+    "$mutant_c" --example not_robot_helper_fixture
+
+if [[ "$failures" -ne 0 ]]; then
+    printf '\n%d case(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf '\nall robot-discovery cases pass, and every negative assertion is load-bearing\n'

--- a/scripts/wait_until_quiet.sh
+++ b/scripts/wait_until_quiet.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Wait until nothing on this host matches any of the given patterns.
+#
+# Hand-rolled `until ! pgrep -f "$pat"; do sleep; done` loops do not work, and
+# the way they fail is silent. `pgrep -f` matches against full command lines,
+# and the command line of the shell running the loop contains the pattern --
+# so the loop matches itself, the condition never goes false, and it waits
+# forever while looking exactly like patience. Four of these were found alive
+# on one build host in a single day, from three separate callers; the oldest
+# had been spinning for twenty hours and four minutes, orphaned to init, with
+# nothing left to read the output it was never going to produce.
+#
+# Two things here make that impossible rather than merely documented. Each
+# pattern is bracketed before use, so it cannot match its own literal text.
+# And the wait is bounded: it always ends, and a timeout exits non-zero with
+# the survivors named, so a caller cannot mistake "gave up" for "quiet".
+set -euo pipefail
+
+timeout_seconds=1800
+interval_seconds=15
+patterns=()
+
+usage() {
+    cat >&2 <<'USAGE'
+usage: wait_until_quiet.sh [--timeout SECONDS] [--interval SECONDS] PATTERN...
+
+Waits until no process matches any PATTERN, then exits 0. Exits 2 if the
+timeout passes while something still matches, naming what survived.
+
+Patterns are matched against full command lines, like `pgrep -f`.
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --timeout) timeout_seconds="${2:?--timeout needs a value}"; shift 2 ;;
+        --interval) interval_seconds="${2:?--interval needs a value}"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        --) shift; while [ $# -gt 0 ]; do patterns+=("$1"); shift; done ;;
+        -*) echo "unknown option: $1" >&2; usage; exit 64 ;;
+        *) patterns+=("$1"); shift ;;
+    esac
+done
+
+if [ "${#patterns[@]}" -eq 0 ]; then
+    usage
+    exit 64
+fi
+
+# The bracket trick alone is NOT enough here, and the reason is worth stating.
+# `[c]argo build` stops a pattern matching its own literal text, which is what
+# saves an inline `until ! pgrep -f "cargo build"` loop. But this script takes
+# the pattern as an ARGUMENT, so its own argv holds the unbracketed string --
+# and `[c]argo build` matches `cargo build` perfectly. Every subshell this
+# script forks inherits that argv and answers the pgrep. So the bracket stays,
+# because it costs nothing and helps callers who inline a literal, and the
+# thing actually doing the work is the ancestry filter below.
+self_excluding() {
+    local pattern="$1" i char
+    for (( i = 0; i < ${#pattern}; i++ )); do
+        char="${pattern:i:1}"
+        case "$char" in
+            [A-Za-z0-9_])
+                printf '%s[%s]%s\n' "${pattern:0:i}" "$char" "${pattern:i+1}"
+                return 0
+                ;;
+        esac
+    done
+    printf '%s\n' "$pattern"
+}
+
+# True when pid is this script or anything it forked. Walks the parent chain
+# rather than comparing process groups: a caller that backgrounds the process
+# being waited for shares this script's group, so a group filter would discard
+# the very thing the wait is for.
+own_descendant() {
+    local pid="$1" hops=0
+    while [ -n "$pid" ] && [ "$pid" != "1" ] && [ "$hops" -lt 40 ]; do
+        [ "$pid" = "$$" ] && return 0
+        pid="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')"
+        hops=$(( hops + 1 ))
+    done
+    return 1
+}
+
+# A pid pgrep reports is not necessarily a process still doing something. An
+# exited child whose parent has not reaped it keeps its full command line until
+# the wait(2), so a waiter that trusts pgrep can block on a process that
+# finished minutes ago.
+alive() {
+    local pid state
+    while read -r pid; do
+        if [ -z "$pid" ] || own_descendant "$pid"; then
+            continue
+        fi
+        state="$(ps -o state= -p "$pid" 2>/dev/null || true)"
+        case "${state// /}" in
+            ''|Z*) continue ;;
+        esac
+        printf '%s\n' "$pid"
+    done
+}
+
+survivors() {
+    local pattern matches out=""
+    for pattern in "${patterns[@]}"; do
+        matches="$(pgrep -f "$(self_excluding "$pattern")" 2>/dev/null | alive || true)"
+        if [ -n "${matches//[[:space:]]/}" ]; then
+            out+="  $pattern: $(printf '%s' "$matches" | tr '\n' ' ')"$'\n'
+        fi
+    done
+    printf '%s' "$out"
+}
+
+deadline=$(( SECONDS + timeout_seconds ))
+while :; do
+    still="$(survivors)"
+    if [ -z "$still" ]; then
+        echo "quiet: nothing matches ${patterns[*]}"
+        exit 0
+    fi
+    if [ "$SECONDS" -ge "$deadline" ]; then
+        echo "timed out after ${timeout_seconds}s; still running:" >&2
+        printf '%s' "$still" >&2
+        exit 2
+    fi
+    sleep "$interval_seconds"
+done

--- a/scripts/wait_until_quiet_test.sh
+++ b/scripts/wait_until_quiet_test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Regression test for wait_until_quiet.sh.
+#
+# The case that matters is the second one. A wait loop written with a bare
+# `pgrep -f` matches the command line that carries the pattern, so it waits
+# for itself and never finishes. That failure has no symptom: the process
+# sits at almost no CPU, prints nothing, and is indistinguishable from a wait
+# that is merely long. It is only visible if something asserts that a wait on
+# a quiet host returns, which is what this file does.
+#
+# Every case is bounded. A test for a hang that can itself hang would be the
+# same defect one level up.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+waiter="$script_dir/wait_until_quiet.sh"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+failures=0
+
+check() {
+    local name="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "ok   $name"
+    else
+        echo "FAIL $name: expected exit $expected, got $actual"
+        failures=$(( failures + 1 ))
+    fi
+}
+
+# 1. Nothing matches: returns at once.
+set +e
+"$waiter" --timeout 5 --interval 1 "cranpose-no-such-process-aardvark" >/dev/null 2>&1
+check "quiet host returns 0" 0 "$?"
+set -e
+
+# 2. The pattern appears in the waiter's own command line. A bare
+#    `pgrep -f` loop matches itself here and waits forever; this must not.
+#    The short timeout is the assertion: a self-match cannot finish inside it.
+set +e
+"$waiter" --timeout 5 --interval 1 "wait_until_quiet_marker_xyzzy" >/dev/null 2>&1
+check "pattern in own argv does not match itself" 0 "$?"
+set -e
+
+# The sleeper is given a name nothing else on the host can carry. `sleep 3` was
+# the obvious choice and it is wrong twice over: the string appears in the
+# waiter's own argument list, and it is a prefix of `sleep 30`, so case 4 below
+# would answer case 3's question.
+sleeper="$workdir/quiet-test-sleeper-$$"
+mkdir -p "$workdir"
+printf '#!/bin/sh\nsleep "$1"\n' > "$sleeper"
+chmod +x "$sleeper"
+
+# 3. A real match blocks, then clears when the process ends.
+"$sleeper" 3 &
+sleep_pid=$!
+start=$SECONDS
+set +e
+"$waiter" --timeout 20 --interval 1 "$(basename "$sleeper") 3" >/dev/null 2>&1
+rc=$?
+set -e
+wait "$sleep_pid" 2>/dev/null || true
+check "waits for a real match" 0 "$rc"
+elapsed=$(( SECONDS - start ))
+if [ "$elapsed" -lt 2 ] || [ "$elapsed" -ge 19 ]; then
+    echo "FAIL waited for a real match: returned in ${elapsed}s (want 2..18)"
+    failures=$(( failures + 1 ))
+else
+    echo "ok   waited for a real match (blocked ${elapsed}s)"
+fi
+
+# 4. A match that outlives the timeout exits 2 and names the survivor.
+"$sleeper" 45 &
+long_pid=$!
+set +e
+out="$("$waiter" --timeout 2 --interval 1 "$(basename "$sleeper") 45" 2>&1)"
+rc=$?
+set -e
+kill "$long_pid" 2>/dev/null || true
+wait "$long_pid" 2>/dev/null || true
+check "timeout exits 2" 2 "$rc"
+case "$out" in
+    *"$(basename "$sleeper") 45"*) echo "ok   timeout names the survivor" ;;
+    *) echo "FAIL timeout names the survivor: got $out"; failures=$(( failures + 1 )) ;;
+esac
+
+# 5. No pattern is a usage error, not a wait on everything.
+set +e
+"$waiter" >/dev/null 2>&1
+check "no pattern exits 64" 64 "$?"
+set -e
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures failure(s)"
+    exit 1
+fi
+echo "wait_until_quiet: all cases pass"


### PR DESCRIPTION
Collapses #587, #588 and #580. They conflicted only because each added a step to `checks` and a recipe to the `ci` aggregate — verified once together rather than rebased three times.

### Close the silent skips (#588)

#574 guarded `rust.yml`'s two jobs and nothing audited the rest. `heavy-selfhosted.yml` had three independent iOS compiles chained on implicit `success()`, and — worse — **`Clippy Android ABIs` sitting ahead of `Build Android release APK`**, so a lint finding meant the release artifact never got built while the job reported one problem. On the release path.

Separately: **whole feature clusters had never been compiled by any gate.** `--all-targets` skips a target whose `required-features` are unmet, and `svg`, `text-hyphenation`, `text-hyphenation-embedded`, `audio-desktop`, `media`, `storekit` and `playbilling` were activated by nothing at all. Turning them on surfaced **dozens of dead unit tests** — all passing, which is luck rather than evidence, since nothing had been stopping them rot. The four `collapsible_if` lints the new coverage found are fixed, not allowed.

### Pin the robot discovery (#587)

`run_robot_test.sh` gates the most expensive job in the pipeline and nothing tested it; its predicate took the whole suite down today. The test runs the **real script byte-for-byte** against a fixture rather than a copy, and proves its negatives with **three mutants** — discovery has two independent predicate halves, so the wrong-prefix-and-no-`fn main` case cannot flip under either mutation alone. Each mutant asserts via `cmp -s` that it actually changed the file, so a future line move fails loudly instead of silently becoming a no-op.

### Bound the wait (#580)

Five `until ! pgrep -f` loops were alive across four callers, the oldest spinning **21h36m** orphaned to init. `TIME_WASTERS.md` has documented that trap since before any of them were written and prevented none — hence a script rather than more prose.

The correction that matters: **the bracket trick is not sufficient for a script.** `[c]argo build` stops a pattern matching its own literal text, which saves an inline loop. A script takes its pattern as an *argument*, so its argv holds the unbracketed string and `[c]argo build` matches it perfectly. Ancestry filtering is what actually works.

### Verified together

| check | result |
|---|---|
| `actionlint` × 3 workflows | findings **byte-identical** to `origin/main` (2, 6, 0 pre-existing) |
| clippy `-D warnings` incl. new features | clean |
| `just test-robot-discovery` | all cases pass, every negative load-bearing |
| `just test-shell-helpers` | all cases pass |
| complexity / duplication gates | clean, none introduced |

The `actionlint` comparison is against `origin/main`'s files extracted to a scratch tree. My first attempt stashed instead, the stash failed on unmerged paths, and both runs linted the same bytes — a "no new findings" that compared nothing. Redone properly.