### PR TITLE
shape_indices is native-only, and clippy-wasm must gate a pull request

### DIFF
--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -14802,6 +14802,9 @@ impl SegmentDrawChunkPlan {
         self.batches.iter().copied()
     }
 
+    // Both callers -- the fused native partition path and the fusion budget --
+    // are `not(target_arch = "wasm32")`, so on wasm this has no callers at all.
+    #[cfg(not(target_arch = "wasm32"))]
     fn shape_indices<'a>(
         &'a self,
         ordered_items: &'a [(usize, SegmentDrawItem)],

--- a/justfile
+++ b/justfile
@@ -61,6 +61,7 @@ clippy:
 
 # Lint the exact package and feature set the web demo ships.
 clippy-wasm:
+    rustup target add wasm32-unknown-unknown
     scripts/ci/with_host_lock.sh --shared \
       cargo clippy --target wasm32-unknown-unknown -p desktop-app-platform --no-default-features --features web,renderer-wgpu -- -D warnings
 
@@ -423,11 +424,14 @@ perf-heap *args:
 # --- aggregates ------------------------------------------------------------
 
 # Excludes the jobs that need a GPU, an Android SDK or an iOS toolchain.
+# clippy-wasm is in here because it needs none of those -- only the wasm32
+# target, which the recipe installs itself -- and CI gates every pull request
+# on it. A gate a pull request is judged by must be runnable before pushing.
 
 # What a pull request is gated on. Run this before pushing.
-ci: fmt-check typos versions test clippy clippy-robot doc budgets test-quality-gates complexity-gate duplication-gate test-robot-discovery test-shell-helpers
+ci: fmt-check typos versions test clippy clippy-robot clippy-wasm doc budgets test-quality-gates complexity-gate duplication-gate test-robot-discovery test-shell-helpers
 
 # Needs a Linux box with the X11 stack, an Android SDK and (on macOS) Xcode.
 
 # Every gate, including the platform builds and the robot suite.
-ci-full: ci clippy-wasm clippy-ios clippy-android web android robot
+ci-full: ci clippy-ios clippy-android web android robot


### PR DESCRIPTION
**main is red on `wasm build`** — at `6ea6a176` and at `5f5e9f48` before it.

```
error: method `shape_indices` is never used
  --> crates/cranpose-render/wgpu/src/render.rs:14805:8
```

#583 factored a shape-iteration loop into `SegmentDrawChunkPlan::shape_indices`. Both of its callers — `render_segment_draw_chunk_fused_native_partition` (gated at render.rs:9018) and `native_segment_fusion_budget` (gated at render.rs:14955) — are `#[cfg(not(target_arch = "wasm32"))]`. On wasm the method therefore has no callers at all. Gated with the same cfg its callers carry; `#[allow(dead_code)]` would have hidden the next genuinely dead method here.

## The gate is the actual defect

The justfile calls `ci` "What a pull request is gated on. Run this before pushing." That was false. CI gates every PR on `wasm build`, but `clippy-wasm` lived in `ci-full`, whose comment scopes it to "a Linux box with the X11 stack, an Android SDK and (on macOS) Xcode".

`clippy-wasm` needs none of those. rust.yml says so in its own words — *"A wasm32 build and lint do not depend on the host"* — and provisions it with a single `rustup target add`. So the one cheap gate that catches wasm-only breakage was shelved next to the ones needing an Android SDK, and nobody ran it before pushing.

- `clippy-wasm` moves into `ci`, and installs its own target the way rust.yml does.
- `ci-full` keeps the gates that genuinely need hardware.
- The comments now say something true.

Cost: 30s on a warm tree.

## Verified locally

| command | result |
|---|---|
| `cargo clippy --target wasm32-unknown-unknown -p desktop-app-platform --no-default-features --features web,renderer-wgpu -- -D warnings` | clean |
| `cargo clippy -p cranpose-render-wgpu --all-targets -- -D warnings` | clean (native still reaches the method) |
| `just clippy-wasm` | clean end to end, target provisioning included |

🤖 Generated with [Claude Code](https://claude.com/claude-code)