### PR TITLE
Make the host-capacity lock paths overridable and test the lock itself

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -189,6 +189,14 @@ jobs:
           command -v just >/dev/null || cargo install just --locked
           scripts/ci/start_sccache.sh
 
+      - name: Run the host capacity lock suite
+        if: steps.changes.outputs.docs_only != 'true'
+        # Here rather than on the mac job: this is the machine the lock exists
+        # to protect, and the only one of the two with flock(1), so it is the
+        # only place the lock cases run at all. Takes no host lock itself --
+        # it drives a private pair of lock files under a scratch directory.
+        run: just test-host-lock
+
       - name: Check architecture budgets
         if: steps.changes.outputs.docs_only != 'true'
         # Featureless and all-features builds, the per-backend winit checks, the

--- a/PLAN.md
+++ b/PLAN.md
@@ -444,8 +444,18 @@ Linux builds that share this host -- the size budget, the wasm build, the
 Android release build -- take the **shared** side for their whole run. The
 robot suite builds without it and takes the **exclusive** side for the timed
 part only, so builds still overlap builds and only a measurement empties the
-machine. Neither side ever refuses to run: after forty-five minutes it starts
-anyway and says on stdout that it did.
+machine. The two sides part ways on what a forty-five-minute wait means: a
+build starts anyway and says on stdout that it did, because a gate that will
+not start is worse than one that starts late, while a measurement fails,
+because measuring beside a build is the exact bug the lock exists to prevent.
+
+Plain `flock` alone cannot deliver that, either: it only ever checks locks
+currently held, never ones merely queued, so a continuous stream of shared
+builds is granted ahead of an already-waiting exclusive measurement for as
+long as the stream lasts. A turnstile in front of the real lock closes that
+gap (`host_capacity_turnstile_*`), and `just test-host-lock` holds it shut --
+it drives both sides against a private pair of lock files, so the suite that
+proves the machine's lock works cannot disturb a job holding it.
 
 That lock covers this fleet. The other nineteen queues on the box are not
 ours to serialise, so the suite also waits for the load average itself

--- a/justfile
+++ b/justfile
@@ -207,6 +207,17 @@ test-robot-discovery:
 test-shell-helpers:
     scripts/wait_until_quiet_test.sh
 
+# Covers the shared/exclusive lock that keeps builds off the machine while a
+# measurement runs, and the turnstile that keeps a stream of builds from
+# starving that measurement. It drives the real scripts against a private
+# lock pair under a scratch directory, so a run here cannot disturb -- or be
+# disturbed by -- a job actually holding the machine's lock. Needs flock(1):
+# on macOS the wrapper runs unlocked, and the lock cases say they skipped.
+
+# The host capacity lock's own suite.
+test-host-lock:
+    scripts/ci/with_host_lock_test.sh
+
 # The deterministic slot-table model check, at the frame count CI uses.
 test-property:
     cargo test --profile ci -p cranpose-core deterministic_model_render_frames_match_slot_table
@@ -429,7 +440,7 @@ perf-heap *args:
 # on it. A gate a pull request is judged by must be runnable before pushing.
 
 # What a pull request is gated on. Run this before pushing.
-ci: fmt-check typos versions test clippy clippy-robot clippy-wasm doc budgets test-quality-gates complexity-gate duplication-gate test-robot-discovery test-shell-helpers
+ci: fmt-check typos versions test clippy clippy-robot clippy-wasm doc budgets test-quality-gates complexity-gate duplication-gate test-robot-discovery test-shell-helpers test-host-lock
 
 # Needs a Linux box with the X11 stack, an Android SDK and (on macOS) Xcode.
 

--- a/scripts/ci/with_host_lock_test.sh
+++ b/scripts/ci/with_host_lock_test.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test for with_host_lock.sh and the host capacity lock it
+# applies (scripts/dev_build_common.sh owns the lock itself).
+#
+# scripts/dev_build_common.sh owns the reader/writer lock that keeps builds
+# off the machine while a measurement runs, and the turnstile that keeps a
+# stream of builds from starving that measurement forever. Both were verified
+# by hand against the machine's real lock files while real CI jobs held them,
+# which is not a thing to repeat: this suite drives the same code through
+# CRANPOSE_HOST_LOCK_FILE / CRANPOSE_HOST_LOCK_TURNSTILE_FILE against a
+# private pair under a scratch directory, so nothing here can touch a running
+# job's lock and nothing a running job does can perturb a result here.
+#
+# The timing cases assert generous bounds, not tight ones, because this is a
+# test of who gets the lock and not of how fast the machine is. Each bound
+# sits between two outcomes that are far apart by construction: a fair writer
+# waits for the readers already in flight (measured at 1-2s), a starved one
+# waits out the entire 15s stream, and the bound is 6s.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly REPO_ROOT
+readonly COMMON_SH="$REPO_ROOT/scripts/dev_build_common.sh"
+readonly WITH_HOST_LOCK="$REPO_ROOT/scripts/ci/with_host_lock.sh"
+
+# The defaults this suite must never write to, spelled out here on purpose:
+# if someone changes them in dev_build_common.sh, the first case fails and
+# says so rather than silently testing whatever the new value is.
+readonly DEFAULT_LOCK_FILE="/tmp/cranpose-host-capacity.lock"
+readonly DEFAULT_TURNSTILE_FILE="/tmp/cranpose-host-capacity.turnstile.lock"
+
+# sccache has nothing to do with locking, and starting its daemon here would
+# add seconds of noise to every case. A short lock wait keeps a regression
+# failing in seconds instead of parking a CI job for the 45-minute default.
+export CRANPOSE_USE_SCCACHE=0
+export CRANPOSE_HOST_LOCK_MAX_WAIT_SECS=30
+unset RUSTC_WRAPPER
+
+# mktemp here rather than dev_build_common.sh's create_local_temp_dir: that
+# file is what this suite tests, and sourcing it would fix its two lock
+# constants -- they are readonly -- at the defaults inside the harness itself.
+# Every case reaches the code under test through a child process instead, the
+# same way CI does.
+tmp_root="${TMPDIR:-/tmp}"
+SCRATCH_DIR="$(mktemp -d "${tmp_root%/}/cranpose-host-lock-test.XXXXXX")"
+readonly SCRATCH_DIR
+export CRANPOSE_HOST_LOCK_FILE="$SCRATCH_DIR/host-capacity.lock"
+export CRANPOSE_HOST_LOCK_TURNSTILE_FILE="$SCRATCH_DIR/host-capacity.turnstile.lock"
+
+failures=0
+cases_run=0
+cases_skipped=0
+
+cleanup() {
+    # Kill anything still holding a scratch lock before the directory goes,
+    # so a failed case cannot leave a background reader running.
+    local pid
+    for pid in $(jobs -pr); do
+        kill "$pid" 2>/dev/null || true
+    done
+    wait 2>/dev/null || true
+    if [ -d "$SCRATCH_DIR" ]; then
+        rm -r -- "$SCRATCH_DIR" || true
+    fi
+}
+trap cleanup EXIT
+
+pass() {
+    cases_run=$((cases_run + 1))
+    echo "ok   - $1"
+}
+
+fail() {
+    cases_run=$((cases_run + 1))
+    failures=$((failures + 1))
+    echo "FAIL - $1" >&2
+    shift
+    local line
+    for line in "$@"; do
+        echo "       $line" >&2
+    done
+}
+
+skip() {
+    cases_skipped=$((cases_skipped + 1))
+    echo "skip - $1: $2"
+}
+
+expect_equal() {
+    local name="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        pass "$name"
+    else
+        fail "$name" "expected: $expected" "actual:   $actual"
+    fi
+}
+
+# Sources dev_build_common.sh in a clean child and prints the two lock paths
+# it resolved, one per line. Any leading arguments run as a wrapper around
+# that child, which is how the defaults are read back with the overrides off.
+resolved_lock_paths() {
+    "$@" bash -c '. "$1"; printf "%s\n%s\n" "$HOST_CAPACITY_LOCK_FILE" "$HOST_CAPACITY_TURNSTILE_FILE"' \
+        _ "$COMMON_SH"
+}
+
+# --- the paths themselves --------------------------------------------------
+
+case_default_paths() {
+    local resolved
+    resolved="$(resolved_lock_paths env -u CRANPOSE_HOST_LOCK_FILE -u CRANPOSE_HOST_LOCK_TURNSTILE_FILE)"
+    expect_equal "unset overrides resolve to the host-wide defaults" \
+        "$DEFAULT_LOCK_FILE
+$DEFAULT_TURNSTILE_FILE" "$resolved"
+}
+
+case_overridden_paths() {
+    local resolved
+    resolved="$(resolved_lock_paths)"
+    expect_equal "the overrides replace both paths" \
+        "$CRANPOSE_HOST_LOCK_FILE
+$CRANPOSE_HOST_LOCK_TURNSTILE_FILE" "$resolved"
+}
+
+# --- the lock, through the overrides ---------------------------------------
+#
+# Everything below needs flock(1). macOS has none, which is why
+# host_capacity_lock_available exists at all: there the wrapper runs its
+# command unlocked, and there is no lock behaviour left to assert.
+
+# Runs $@ under the wrapper in $mode, with its narration in the case log.
+with_lock() {
+    local mode="$1"
+    shift
+    "$WITH_HOST_LOCK" "$mode" "$@" >>"$SCRATCH_DIR/wrapper.log" 2>&1
+}
+
+# Inode, mode, size and mtime, or the fact that there is no such file. Enough
+# to catch a run creating, truncating or replacing a path it was told not to
+# touch, on a host where that path exists already and on one where it does not.
+file_fingerprint() {
+    if [ -e "$1" ]; then
+        ls -ldi -- "$1"
+    else
+        echo "absent"
+    fi
+}
+
+case_lock_lands_on_the_overridden_file() {
+    local default_before default_after
+    default_before="$(file_fingerprint "$DEFAULT_LOCK_FILE")"
+
+    # `flock -n -x` from outside the wrapper is the only honest way to ask
+    # whether the wrapper really holds the lock: the file existing proves
+    # nothing, and the wrapper closes its own fds in the child.
+    if with_lock --exclusive \
+        bash -c '! flock -n -x "$CRANPOSE_HOST_LOCK_FILE" true'; then
+        pass "the exclusive side holds the overridden lock file"
+    else
+        fail "the exclusive side holds the overridden lock file" \
+            "$CRANPOSE_HOST_LOCK_FILE was lockable from outside the wrapper," \
+            "or the wrapper never took it at all -- see the wrapper output below"
+    fi
+
+    default_after="$(file_fingerprint "$DEFAULT_LOCK_FILE")"
+    expect_equal "an overridden run leaves the host-wide lock file alone" \
+        "$default_before" "$default_after"
+}
+
+case_exclusive_waits_for_a_shared_holder() {
+    local hold_secs=3 elapsed
+
+    with_lock --shared sleep "$hold_secs" &
+    local reader_pid=$!
+    # Long enough for that reader to be holding the lock, not merely spawned.
+    sleep 1
+
+    local started=$SECONDS
+    with_lock --exclusive true
+    elapsed=$((SECONDS - started))
+    wait "$reader_pid"
+
+    # The reader holds for 3s and had 1s of it before the timer started, so a
+    # working lock costs the writer ~2s. A broken one costs it none.
+    if [ "$elapsed" -ge 1 ]; then
+        pass "the exclusive side waits out a shared holder (waited ${elapsed}s)"
+    else
+        fail "the exclusive side waits out a shared holder" \
+            "exclusive acquire returned in ${elapsed}s while a shared holder was still running"
+    fi
+}
+
+# The regression this whole override exists for. flock(2) only ever checks
+# locks currently held, never ones merely queued, so without the turnstile a
+# continuous stream of shared acquirers is granted ahead of an already-waiting
+# exclusive one for as long as the stream lasts -- fifteen seconds of stream
+# kept a writer out for the full fifteen when this was measured. With the
+# turnstile the writer's wait is bounded by the readers already in flight.
+case_writer_is_not_starved_by_a_reader_stream() {
+    local stream_secs=15 reader_hold=2 reader_gap=1 max_wait_secs=6 elapsed
+
+    (
+        stream_end=$((SECONDS + stream_secs))
+        while [ "$SECONDS" -lt "$stream_end" ]; do
+            with_lock --shared sleep "$reader_hold" &
+            sleep "$reader_gap"
+        done
+        wait
+    ) &
+    local stream_pid=$!
+
+    # Join mid-stream, so the writer is queueing against readers that are
+    # already holding the lock and against new ones still arriving.
+    sleep 3
+
+    local started=$SECONDS
+    local acquired=1
+    with_lock --exclusive true || acquired=0
+    elapsed=$((SECONDS - started))
+
+    wait "$stream_pid" || true
+
+    if [ "$acquired" = 0 ]; then
+        fail "a reader stream does not starve the exclusive side" \
+            "the exclusive acquire timed out entirely after ${elapsed}s"
+    elif [ "$elapsed" -le "$max_wait_secs" ]; then
+        pass "a reader stream does not starve the exclusive side (waited ${elapsed}s)"
+    else
+        fail "a reader stream does not starve the exclusive side" \
+            "waited ${elapsed}s, over the ${max_wait_secs}s bound" \
+            "a starved writer waits out the whole ${stream_secs}s stream; a fair one waits for the readers in flight"
+    fi
+}
+
+# --- run -------------------------------------------------------------------
+
+echo "host lock suite: locks under $SCRATCH_DIR"
+
+case_default_paths
+case_overridden_paths
+
+if command -v flock >/dev/null 2>&1; then
+    case_lock_lands_on_the_overridden_file
+    case_exclusive_waits_for_a_shared_holder
+    case_writer_is_not_starved_by_a_reader_stream
+else
+    skip "the lock cases" "no flock(1) on this host, so the wrapper runs unlocked here"
+fi
+
+echo "host lock suite: $cases_run run, $failures failed, $cases_skipped skipped"
+
+if [ "$failures" -ne 0 ]; then
+    echo "--- wrapper output ---" >&2
+    cat "$SCRATCH_DIR/wrapper.log" >&2 2>/dev/null || true
+    exit 1
+fi

--- a/scripts/dev_build_common.sh
+++ b/scripts/dev_build_common.sh
@@ -417,8 +417,17 @@ wait_for_host_capacity() {
 # mid-stream exclusive waiter in within ~2.7s of joining, an order of
 # magnitude under the stream's own length -- so the turnstile needs no
 # turnstile of its own.
-readonly HOST_CAPACITY_LOCK_FILE="/tmp/cranpose-host-capacity.lock"
-readonly HOST_CAPACITY_TURNSTILE_FILE="/tmp/cranpose-host-capacity.turnstile.lock"
+#
+# One pair of paths per machine is the whole point: every job on the box has
+# to meet on the same two files or the lock guards nothing. That also means a
+# test of this logic cannot use them -- proving the turnstile above works
+# takes creating, deleting and locking these exact files while real CI jobs on
+# the same machine are holding them, which is how the fix was verified and is
+# not a thing to repeat. The two overrides point a test at a private pair
+# instead; scripts/ci/with_host_lock_test.sh is the only caller that sets them,
+# so every real build and measurement still meets on the defaults.
+readonly HOST_CAPACITY_LOCK_FILE="${CRANPOSE_HOST_LOCK_FILE:-/tmp/cranpose-host-capacity.lock}"
+readonly HOST_CAPACITY_TURNSTILE_FILE="${CRANPOSE_HOST_LOCK_TURNSTILE_FILE:-/tmp/cranpose-host-capacity.turnstile.lock}"
 
 host_capacity_lock_available() {
     command -v flock >/dev/null 2>&1 \


### PR DESCRIPTION
The two host-capacity lock files are hardcoded and host-global, which is the
point — every job on the machine has to meet on the same pair or the lock
guards nothing. It also meant the lock logic could not be tested: proving
#552's turnstile fix worked took creating, deleting and locking those exact
files on samarch-1 while real CI jobs were holding them. No missed exclusion
resulted, but the window for one existed and could not be ruled out.

`CRANPOSE_HOST_LOCK_FILE` and `CRANPOSE_HOST_LOCK_TURNSTILE_FILE` point a test
at a private pair instead. Defaults unchanged, so every real build and
measurement still meets on `/tmp/cranpose-host-capacity.lock`. Both call sites
already read the globals and needed no change.

`scripts/ci/with_host_lock_test.sh` is the caller and the reason the override
exists — six cases:

- unset overrides resolve to the host-wide defaults
- both overrides replace both paths
- the wrapper's exclusive side really holds the *overridden* file (`flock -n -x`
  from outside must fail)
- an overridden run leaves the host-wide lock file untouched (inode/mode/size/
  mtime fingerprint, or "absent")
- the exclusive side waits out a shared holder
- **a continuous reader stream does not starve the writer** — the #552
  regression, which had no test until now

Verified on samarch-1 at 6/6, three sequential and three concurrent runs at the
same timings. Against a copy of `dev_build_common.sh` with the three turnstile
bodies replaced by `:`, the starvation case fails at `waited 13s, over the 6s
bound` versus 1s with the turnstile — so it is not vacuous.

macOS has no `flock(1)`, so the three lock cases report `skip` there while the
two path cases still run. The CI step sits on the Linux job for that reason
rather than beside the other shell-test gates on the mac job.

`PLAN.md` claimed neither side of the lock ever refuses to run, which stopped
being true when the exclusive side started failing on timeout.

Gates run after rebasing onto `6436b61c`: `test-host-lock` (6/6 Linux, 2 run /
3 skip macOS), `fmt-check`, `typos`, `versions`, `test-ci-filters`,
`test-robot-discovery`, `test-shell-helpers`, `test-quality-gates`,
`complexity-gate`, `duplication-gate`. The last two pass vacuously — both are
Rust-only and this diff has no Rust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)