### PR TITLE
Carry the text-field and state-collection vocabulary in the prelude

### DIFF
--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -62,6 +62,7 @@ pub use cranpose_foundation::{
         LazyItems, LazyListItemInfo, LazyListLayoutInfo, LazyListScope, LazyListState,
         rememberLazyListState, rememberLazyListStateWithPosition,
     },
+    text::{TextFieldBuffer, TextFieldLineLimits, TextFieldState, TextFieldValue, TextRange},
 };
 pub use cranpose_ui_graphics::{BlurredEdgeTreatment, ColorFilter, Dp, ImageBitmap, ImageSampling};
 pub use cranpose_ui_layout::IntrinsicSize;

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -155,8 +155,9 @@ pub use cranpose_audio::{AudioEngine, install as install_audio};
 /// Core runtime helpers commonly used by applications.
 pub use cranpose_core::{
     CoroutineScope, MutableState, SnapshotStateList, SnapshotStateMap, State, delay, interval,
-    launchBlocking, mutableStateOf, produceState, remember, rememberCoroutineScope,
-    rememberMutableStateOf, rememberMutableStateOfNeverEqual, rememberUpdatedState,
+    launchBlocking, mutableStateList, mutableStateListOf, mutableStateMap, mutableStateMapOf,
+    mutableStateOf, produceState, remember, rememberCoroutineScope, rememberMutableStateOf,
+    rememberMutableStateOfNeverEqual, rememberUpdatedState,
 };
 /// Liquid UI — the first-party glass component library
 /// (`use cranpose::liquid::prelude::*;`).
@@ -362,6 +363,7 @@ pub mod _docs;
 pub mod prelude {
     pub use cranpose_core::{
         CoroutineScope, MutableState, SnapshotStateList, SnapshotStateMap, State, delay, interval,
+        launchBlocking, mutableStateList, mutableStateListOf, mutableStateMap, mutableStateMapOf,
         mutableStateOf, produceState, remember, rememberCoroutineScope, rememberMutableStateOf,
         rememberMutableStateOfNeverEqual, rememberUpdatedState,
     };

--- a/crates/cranpose/tests/prelude_surface.rs
+++ b/crates/cranpose/tests/prelude_surface.rs
@@ -1,0 +1,75 @@
+use cranpose::prelude::*;
+
+#[test]
+fn a_text_field_composes_from_the_prelude_alone() {
+    run_test_composition(|| {
+        let state = TextFieldState::new("hello\nworld");
+        state.set_selection(TextRange::new(0, 5));
+        BasicTextFieldWithOptions(
+            state,
+            Modifier::empty(),
+            BasicTextFieldOptions {
+                line_limits: TextFieldLineLimits::MultiLine {
+                    min_lines: 1,
+                    max_lines: 3,
+                },
+                ..BasicTextFieldOptions::default()
+            },
+        );
+
+        state.edit(|buffer: &mut TextFieldBuffer| buffer.place_cursor_at_end());
+        let value: TextFieldValue = state.value();
+        assert_eq!(value.text, "hello\nworld");
+        assert_eq!(value.selection, TextRange::cursor("hello\nworld".len()));
+    });
+}
+
+#[test]
+fn app_owned_list_data_composes_from_the_prelude_alone() {
+    run_test_composition(|| {
+        let items: SnapshotStateList<String> =
+            mutableStateListOf(["one".to_string(), "two".to_string()]);
+        items.push("three".to_string());
+        assert_eq!(items.len(), 3);
+
+        let empty: SnapshotStateList<u32> = mutableStateList();
+        assert!(empty.is_empty(), "a fresh state list arrived with contents");
+
+        let state = rememberLazyListState();
+        LazyColumn(
+            Modifier::empty(),
+            state,
+            LazyColumnSpec::default(),
+            move |scope| {
+                scope.items(items.len(), move |index| {
+                    let _label = items.get(index);
+                    Spacer(Size::new(50.0, 20.0));
+                });
+            },
+        );
+    });
+}
+
+#[test]
+fn app_owned_map_data_composes_from_the_prelude_alone() {
+    run_test_composition(|| {
+        let counts: SnapshotStateMap<String, u32> = mutableStateMapOf([("one".to_string(), 1u32)]);
+        counts.insert("two".to_string(), 2);
+        assert_eq!(counts.len(), 2);
+
+        let empty: SnapshotStateMap<String, u32> = mutableStateMap();
+        assert!(empty.is_empty(), "a fresh state map arrived with entries");
+    });
+}
+
+#[test]
+fn blocking_work_starts_from_the_prelude_alone() {
+    let result = std::rc::Rc::new(std::cell::Cell::new(0u32));
+    let sink = std::rc::Rc::clone(&result);
+    launchBlocking(|| 2 + 2, move |sum| sink.set(sum));
+    assert_eq!(
+        result.get(),
+        4,
+        "with no runtime the work runs inline, so the result is already here"
+    );
+}


### PR DESCRIPTION
`cranpose::prelude` re-exported `BasicTextField` but not `TextFieldState`, the type its first parameter takes. An app composing a text field against the facade had to add cranpose-foundation as a second direct dependency and import `cranpose_foundation::text::{TextFieldState, TextFieldLineLimits}` itself — the reaching-past the facade exists to prevent, and the same gap `rememberLazyListState` was re-exported to close for `LazyColumn`. It surfaced while building a starter-template app that needed a text field.

## What moves

- **cranpose-ui** — `TextFieldState`, `TextFieldLineLimits`, plus `TextRange`, `TextFieldBuffer` and `TextFieldValue`, into the existing merged `pub use cranpose_foundation::{…}`. The last three come along because `TextFieldState`'s own signatures name them: `set_selection` takes a range, `edit` hands out a buffer, `value` returns a value. Exporting the state alone buys an app one line before it reaches past the facade again to place a cursor.
- **cranpose** — `mutableStateListOf`/`mutableStateList` and `mutableStateMapOf`/`mutableStateMap`. `SnapshotStateList` and `SnapshotStateMap` were already exported as types with no constructor, so anything backing a `LazyColumn` with app-owned data went to cranpose-core to build one.
- **cranpose** — `launchBlocking` into the prelude, which the crate root's core list had and the prelude's copy of it did not. The two lists are one curated set stated twice, and that duplication is the mechanism behind all three gaps. They now match.

## The test is the point

`crates/cranpose/tests/prelude_surface.rs` imports `cranpose::prelude::*` and nothing else, then composes a text field, a `LazyColumn` over a state list, a state map and a blocking call. Before this change it failed to compile with ten `cannot find` errors.

It turns "the prelude is missing something" from a recurring downstream discovery into a property the workspace checks. Five consumers now track this crate, so a gap costs five apps rather than one — and this is the general answer to that class, including the `horizontal_scroll_guarded` shape where an item is judged unused from inside the repo while a downstream app calls it.

## No comments on the re-exports

#540 stripped that genre repo-wide and merged the cranpose-foundation statements into one, so a comment here would both violate the rule and re-fragment the block that `imports_granularity = "Crate"` just consolidated. The invariant lives in the test's names.

## Verification

`just ci` green locally on this rebase (6436b61c) — fmt-check, typos, versions, test, clippy, clippy-robot, clippy-wasm, doc, budgets, test-quality-gates, complexity-gate, duplication-gate, test-robot-discovery, test-shell-helpers. Exit 0, zero test failures. `clippy-wasm` specifically: a prelude change moves what the facade re-exports and the wasm build takes a different feature path through it, which is the shape that goes wasm-only red with every native gate green.

Merging without waiting on CI is deliberate: this is going into a single integration that will be verified as a whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)