### PR TITLE
Give a scroll a way to decline the pointer gesture again

### DIFF
--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -468,3 +468,25 @@ Signature → cause → what to do. One lesson per line, no incident history.
   question than the one asked. When a sampled instrument and a totals
   instrument disagree, believe the totals; better, never average from one
   sample.
+
+- **"No caller in this repo" is not evidence an API is dead, and the check
+  that says so silently excludes first-party consumers** — `9af4604b`
+  deleted `Modifier::horizontal_scroll_guarded`/`vertical_scroll_guarded`
+  as dead code on that reasoning. leetcodedaily called the horizontal one,
+  passing `|| false` to stop the row's built-in drag from competing with
+  its own drag-reorder `pointer_input`; migrating it to 0.1.106 forced
+  `.horizontal_scroll(...)` just to compile, and the two gestures have
+  been fighting since. The same commit added 280 lines of
+  `draggable_guarded` tests, so `draggable_guarded` survived the identical
+  pass — the asymmetry is the tell that the scope, not the judgement, was
+  wrong. Note the implementation never died: `scroll_impl` still took the
+  guard, still threaded it into `DragGesture`, still evaluated it per
+  event. Only the public entry points went, leaving a live mechanism
+  pinned to `None`, which is why nothing failed to compile.
+  Same class as `just clippy` never linting the ~165 `[[example]]` targets
+  behind `required-features = ["robot-app"]`: a check whose scope silently
+  excludes the thing it is supposed to cover, reporting clean because it
+  looked nowhere. Before deleting a public API, grep the downstream
+  consumers too (`/Users/s/develop/consumer-bumps/`), and prefer a test
+  that calls it — a test is an in-repo caller, and it is what kept
+  `draggable_guarded` alive.

--- a/crates/cranpose-ui/src/modifier/scroll.rs
+++ b/crates/cranpose-ui/src/modifier/scroll.rs
@@ -1367,6 +1367,41 @@ impl Modifier {
     pub fn vertical_scroll(self, state: ScrollState, reverse_scrolling: bool) -> Self {
         self.then(scroll_impl(state, true, reverse_scrolling, None))
     }
+
+    /// A horizontal scroll that never claims a pointer gesture.
+    ///
+    /// The position still moves through [`ScrollState`], but drags and wheel
+    /// events pass straight through, so an owner can run its own
+    /// `pointer_input` on the same row -- a drag-to-reorder list, say --
+    /// without the two competing for the gesture.
+    pub fn horizontal_scroll_without_gestures(
+        self,
+        state: ScrollState,
+        reverse_scrolling: bool,
+    ) -> Self {
+        self.then(scroll_impl(
+            state,
+            false,
+            reverse_scrolling,
+            Some(Rc::new(|| false)),
+        ))
+    }
+
+    /// A vertical scroll that never claims a pointer gesture.
+    ///
+    /// The vertical counterpart of [`Modifier::horizontal_scroll_without_gestures`].
+    pub fn vertical_scroll_without_gestures(
+        self,
+        state: ScrollState,
+        reverse_scrolling: bool,
+    ) -> Self {
+        self.then(scroll_impl(
+            state,
+            true,
+            reverse_scrolling,
+            Some(Rc::new(|| false)),
+        ))
+    }
 }
 
 fn scroll_impl(

--- a/crates/cranpose-ui/src/tests/scroll_tests.rs
+++ b/crates/cranpose-ui/src/tests/scroll_tests.rs
@@ -1577,3 +1577,76 @@ fn wheel_overscroll_rearms_after_interrupted_settle() {
     }
     assert!(context.overscroll().offset().abs() <= 0.001);
 }
+
+// The guarded scroll variants were removed in 9af4604b as dead code because
+// nothing in this repository called them -- a first-party downstream app did,
+// and lost its drag-reorder gesture to the row's own scroll. These tests are
+// that missing caller as much as they are a regression guard.
+
+#[test]
+fn a_scroll_without_gestures_leaves_the_drag_for_its_owner() {
+    let _app_context = crate::render_state::app_context_test_scope();
+    with_test_runtime(|| {
+        let state = ScrollState::new(0.0);
+        state.set_max_value(100.0);
+        let (handler, _chain) =
+            pointer_handler_for(Modifier::empty().vertical_scroll_without_gestures(state, false));
+
+        handler(scroll_pointer_event(PointerEventKind::Down, 0.0, 100.0));
+        let move_event = scroll_pointer_event(PointerEventKind::Move, 0.0, 160.0);
+        handler(move_event.clone());
+        move_event.finish_post_dispatch();
+
+        assert!(
+            !move_event.is_consumed(),
+            "an unconsumed drag is the whole point: the owner's own pointer_input \
+             only sees the event if this scroll declines it"
+        );
+        assert_eq!(
+            state.value(),
+            0.0,
+            "a scroll that declines the gesture must not move on a drag"
+        );
+    });
+}
+
+#[test]
+fn a_scroll_without_gestures_still_moves_programmatically() {
+    let _app_context = crate::render_state::app_context_test_scope();
+    with_test_runtime(|| {
+        let state = ScrollState::new(0.0);
+        state.set_max_value(100.0);
+        let (_handler, _chain) =
+            pointer_handler_for(Modifier::empty().horizontal_scroll_without_gestures(state, false));
+
+        state.scroll_to(40.0);
+
+        assert!(
+            (state.value() - 40.0).abs() < 0.001,
+            "declining pointer gestures must not disable ScrollState itself, got {}",
+            state.value()
+        );
+    });
+}
+
+#[test]
+fn an_ordinary_scroll_still_claims_the_drag() {
+    let _app_context = crate::render_state::app_context_test_scope();
+    with_test_runtime(|| {
+        let state = ScrollState::new(0.0);
+        state.set_max_value(100.0);
+        let (handler, _chain) =
+            pointer_handler_for(Modifier::empty().vertical_scroll(state, false));
+
+        handler(scroll_pointer_event(PointerEventKind::Down, 0.0, 100.0));
+        let move_event = scroll_pointer_event(PointerEventKind::Move, 0.0, 160.0);
+        handler(move_event.clone());
+        move_event.finish_post_dispatch();
+
+        assert!(
+            move_event.is_consumed(),
+            "the control for the two tests above: without this, they would pass \
+             even if the scroll gesture had stopped working entirely"
+        );
+    });
+}


### PR DESCRIPTION
## The defect

`9af4604b` ("Framework ownership: applications stop recreating platform contracts") removed `Modifier::horizontal_scroll_guarded` and `vertical_scroll_guarded` as dead code, on the reasoning that nothing in this repository called them. A first-party downstream app did.

leetcodedaily used the horizontal one on its session-queue row:

```rust
.horizontal_scroll_guarded(scroll_state.clone(), false, || false)
```

`|| false` stopped the row's built-in drag from competing with the app's own drag-reorder `pointer_input`. Migrating that app to 0.1.106 forced `.horizontal_scroll(...)` just to compile, and the two gestures have been fighting since.

**The asymmetry is the tell.** `draggable_guarded` survived the identical dead-code pass — because the same commit added 280 lines of `draggable_tests.rs`, giving it an in-repo caller. The scroll twins had none, so they went.

**The implementation never died.** `scroll_impl` still takes the guard, threads it into `DragGesture`, and evaluates it per event *before* the detector sees anything — a declining guard `continue`s, so the scroll never consumes and the event reaches whoever else wants it. Only the public entry points went, leaving a live mechanism permanently pinned to `None`. That is why nothing failed to compile and nothing went red.

## The fix

Not the old spelling. The one real caller passed a **constant**, and a per-event `Rc<dyn Fn() -> bool>` that only ever answers "no" is exactly what looked like dead weight the first time. The capability is named instead:

```rust
Modifier::horizontal_scroll_without_gestures(state, reverse_scrolling)
Modifier::vertical_scroll_without_gestures(state, reverse_scrolling)
```

Position still moves through `ScrollState`; drags and wheel events pass straight through. `draggable_guarded` keeps its closure — that one is genuinely dynamic, and its tests flip the guard mid-gesture. No plumbing changed.

## The tests are the point

More important than the two functions: they are the in-repo caller whose absence caused the deletion.

- `a_scroll_without_gestures_leaves_the_drag_for_its_owner` — drag unconsumed, offset unmoved
- `a_scroll_without_gestures_still_moves_programmatically` — `ScrollState` is not disabled
- `an_ordinary_scroll_still_claims_the_drag` — the control; without it the first two would pass against a scroll that had stopped working entirely

Confirmed they **fail** when the new variants are pointed back at an unguarded `scroll_impl`, so they catch the regression rather than merely describing it.

## Verification

`just fmt-check`, `just clippy`, `just typos` clean. Workspace `just test`: **5038 passed, 0 failed**. cranpose-ui suite: 1142 passed.

Landing without waiting for CI per the batch-merge window; I own whatever the collective run finds in scroll or gesture arbitration.

## Not fixed here

leetcodedaily consumes cranpose from crates.io, so its call site can only move once a release carries this. The change there is one line — `.horizontal_scroll(scroll_state.clone(), false)` back to `.horizontal_scroll_without_gestures(scroll_state.clone(), false)`.

`TIME_WASTERS.md` records the systemic half: "no caller in this repo" is not evidence an API is dead, and it is the same class as `just clippy` never linting the ~165 `[[example]]` targets behind `required-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)