### PR TITLE
Remove the eight clones the duplication-gate missed today

### DIFF
--- a/apps/desktop-demo/examples/round_glass_probe.rs
+++ b/apps/desktop-demo/examples/round_glass_probe.rs
@@ -14,6 +14,9 @@
 //! cargo run --package desktop-app --example round_glass_probe --features desktop,robot-app
 //! ```
 
+#[path = "../robot-runners/robot_shot.rs"]
+mod robot_shot;
+
 use std::path::PathBuf;
 
 use cranpose::{
@@ -69,13 +72,6 @@ fn ProbeApp() {
     });
 }
 
-fn color_distance(a: (u8, u8, u8), b: (u8, u8, u8)) -> f32 {
-    let dr = a.0 as f32 - b.0 as f32;
-    let dg = a.1 as f32 - b.1 as f32;
-    let db = a.2 as f32 - b.2 as f32;
-    (dr * dr + dg * dg + db * db).sqrt()
-}
-
 fn main() {
     let _ = env_logger::try_init();
     let shot_dir = PathBuf::from(
@@ -91,18 +87,8 @@ fn main() {
         .with_test_driver(move |robot| {
             std::thread::sleep(std::time::Duration::from_millis(700));
             let shot = robot.screenshot().expect("shot");
-            let scale = shot.width as f32 / shot.logical_width;
-            let sample = |lx: f32, ly: f32| -> (u8, u8, u8) {
-                let px = (lx * scale).round().clamp(0.0, shot.width as f32 - 1.0) as u32;
-                let py = (ly * scale).round().clamp(0.0, shot.height as f32 - 1.0) as u32;
-                let idx = ((py * shot.width + px) * 4) as usize;
-                (shot.pixels[idx], shot.pixels[idx + 1], shot.pixels[idx + 2])
-            };
-            let marker_rgb = (
-                (MARKER.r() * 255.0) as u8,
-                (MARKER.g() * 255.0) as u8,
-                (MARKER.b() * 255.0) as u8,
-            );
+            let sample = robot_shot::logical_sampler(&shot);
+            let marker_rgb = robot_shot::to_rgb8(MARKER);
             println!("angle_deg,logical_x,logical_y,r,g,b,dist_to_marker");
             let mut worst = f32::MAX;
             for step in 0..36 {
@@ -110,7 +96,7 @@ fn main() {
                 let lx = CENTER + (CIRCLE_RADIUS - 1.0) * angle.cos();
                 let ly = CENTER + (CIRCLE_RADIUS - 1.0) * angle.sin();
                 let rgb = sample(lx, ly);
-                let dist = color_distance(rgb, marker_rgb);
+                let dist = robot_shot::color_distance(rgb, marker_rgb);
                 worst = worst.min(dist);
                 println!(
                     "{:.1},{:.1},{:.1},{},{},{},{:.1}",
@@ -124,8 +110,8 @@ fn main() {
                 );
             }
             println!("closest_rim_sample_to_marker_color = {worst:.1}");
-            let image =
-                image::RgbaImage::from_raw(shot.width, shot.height, shot.pixels).expect("decode");
+            let image = image::RgbaImage::from_raw(shot.width, shot.height, shot.pixels.clone())
+                .expect("decode");
             image
                 .save(shot_dir.join("round-glass-probe.png"))
                 .expect("save");

--- a/apps/desktop-demo/robot-runners/robot_layout_validation.rs
+++ b/apps/desktop-demo/robot-runners/robot_layout_validation.rs
@@ -3,7 +3,7 @@ mod robot_launch;
 use std::time::Duration;
 
 use cranpose::SemanticElement;
-use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
+use cranpose_testing::{click_button_in_semantics, find_text_in_semantics};
 use desktop_app::app;
 
 const WINDOW_WIDTH: f32 = 1200.0;
@@ -211,22 +211,7 @@ fn main() {
         let mut all_issues: Vec<(String, LayoutIssue)> = Vec::new();
         let window_bounds = (0.0, 0.0, WINDOW_WIDTH, WINDOW_HEIGHT);
 
-        let click_button = |name: &str| -> bool {
-            if let Some((x, y, w, h)) = find_button_in_semantics(&robot, name) {
-                println!(
-                    "  Clicking '{}' at ({:.1}, {:.1})",
-                    name,
-                    x + w / 2.0,
-                    y + h / 2.0
-                );
-                robot.click(x + w / 2.0, y + h / 2.0).ok();
-                std::thread::sleep(Duration::from_millis(200));
-                true
-            } else {
-                println!("  ✗ Button '{}' not found!", name);
-                false
-            }
-        };
+        let click_button = |name: &str| -> bool { click_button_in_semantics(&robot, name) };
 
         println!("\n\n######################################");
         println!("# TEST 1: ASYNC RUNTIME TAB");

--- a/apps/desktop-demo/robot-runners/robot_lazy_list_end_alignment.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_list_end_alignment.rs
@@ -3,7 +3,7 @@ mod robot_launch;
 use std::time::Duration;
 
 use cranpose_testing::{
-    find_button_in_semantics, find_element_by_text_exact, find_in_semantics,
+    click_button_in_semantics, find_element_by_text_exact, find_in_semantics,
     find_text_by_prefix_in_semantics, find_text_exact, print_semantics_with_bounds, union_bounds,
 };
 use desktop_app::app;
@@ -17,17 +17,7 @@ fn main() {
             println!("✓ App launched");
             std::thread::sleep(Duration::from_millis(500));
 
-            let click_button = |name: &str| -> bool {
-                if let Some((x, y, w, h)) = find_button_in_semantics(&robot, name) {
-                    println!("  Found button '{}' at ({:.1}, {:.1})", name, x, y);
-                    robot.click(x + w / 2.0, y + h / 2.0).ok();
-                    std::thread::sleep(Duration::from_millis(200));
-                    true
-                } else {
-                    println!("  ✗ Button '{}' not found!", name);
-                    false
-                }
-            };
+            let click_button = |name: &str| -> bool { click_button_in_semantics(&robot, name) };
 
             println!("\n--- Step 1: Navigate to 'Lazy List' tab ---");
             if !click_button("Lazy List") {

--- a/apps/desktop-demo/robot-runners/robot_lazy_tab_test.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_tab_test.rs
@@ -2,7 +2,7 @@ mod robot_launch;
 
 use std::time::Duration;
 
-use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
+use cranpose_testing::{click_button_in_semantics, find_text_in_semantics};
 use desktop_app::app;
 
 fn main() {
@@ -15,18 +15,15 @@ fn main() {
             std::thread::sleep(Duration::from_millis(500));
 
             let click_button = |name: &str| -> bool {
-                if let Some((x, y, w, h)) = find_button_in_semantics(&robot, name) {
-                    println!("  Found button '{}' at ({:.1}, {:.1})", name, x, y);
-                    robot.click(x + w / 2.0, y + h / 2.0).ok();
-                    std::thread::sleep(Duration::from_millis(200));
+                if click_button_in_semantics(&robot, name) {
                     return true;
-                } else if let Some((x, y, w, h)) = find_text_in_semantics(&robot, name) {
+                }
+                if let Some((x, y, w, h)) = find_text_in_semantics(&robot, name) {
                     println!("  Found text/button '{}' at ({:.1}, {:.1})", name, x, y);
                     robot.click(x + w / 2.0, y + h / 2.0).ok();
                     std::thread::sleep(Duration::from_millis(200));
                     return true;
                 }
-                println!("  ✗ Button '{}' not found!", name);
                 false
             };
 

--- a/apps/desktop-demo/robot-runners/robot_liquid_round_glass_edge_refraction.rs
+++ b/apps/desktop-demo/robot-runners/robot_liquid_round_glass_edge_refraction.rs
@@ -24,6 +24,7 @@
 //! ```
 
 mod robot_exit;
+mod robot_shot;
 
 use std::{
     f32::consts::TAU,
@@ -160,13 +161,6 @@ fn ProbeApp() {
     });
 }
 
-fn color_distance(a: (u8, u8, u8), b: (u8, u8, u8)) -> f32 {
-    let dr = a.0 as f32 - b.0 as f32;
-    let dg = a.1 as f32 - b.1 as f32;
-    let db = a.2 as f32 - b.2 as f32;
-    (dr * dr + dg * dg + db * db).sqrt()
-}
-
 fn main() -> ExitCode {
     let _ = env_logger::try_init();
     let shot_dir = PathBuf::from(
@@ -189,25 +183,15 @@ fn main() -> ExitCode {
             {
                 let _ = image.save(shot_dir.join("round-glass-edge-refraction.png"));
             }
-            let scale = shot.width as f32 / shot.logical_width;
-            let sample = |lx: f32, ly: f32| -> (u8, u8, u8) {
-                let px = (lx * scale).round().clamp(0.0, shot.width as f32 - 1.0) as u32;
-                let py = (ly * scale).round().clamp(0.0, shot.height as f32 - 1.0) as u32;
-                let idx = ((py * shot.width + px) * 4) as usize;
-                (shot.pixels[idx], shot.pixels[idx + 1], shot.pixels[idx + 2])
-            };
-            let marker_rgb = (
-                (MARKER.r() * 255.0) as u8,
-                (MARKER.g() * 255.0) as u8,
-                (MARKER.b() * 255.0) as u8,
-            );
+            let sample = robot_shot::logical_sampler(&shot);
+            let marker_rgb = robot_shot::to_rgb8(MARKER);
 
             for probe in probes() {
                 // Sanity: the marker itself must actually be rendered (a
                 // deep, undistorted lens face is identity-mapped), or the
                 // rim check below would trivially pass by testing nothing.
                 let at_marker = sample(probe.center.0, probe.center.1);
-                let marker_visible = color_distance(at_marker, marker_rgb);
+                let marker_visible = robot_shot::color_distance(at_marker, marker_rgb);
                 if marker_visible > 60.0 {
                     println!(
                         "\n✗ the {}'s own center marker is not visible through the glass \
@@ -228,7 +212,7 @@ fn main() -> ExitCode {
                     let lx = probe.center.0 + axis_shift + (probe.radius - RIM_INSET) * angle.cos();
                     let ly = probe.center.1 + (probe.radius - RIM_INSET) * angle.sin();
                     let rgb = sample(lx, ly);
-                    let dist = color_distance(rgb, marker_rgb);
+                    let dist = robot_shot::color_distance(rgb, marker_rgb);
                     if dist < worst {
                         worst = dist;
                         worst_angle = angle.to_degrees();

--- a/apps/desktop-demo/robot-runners/robot_shot.rs
+++ b/apps/desktop-demo/robot-runners/robot_shot.rs
@@ -2,7 +2,7 @@
 
 use std::{path::Path, time::Duration};
 
-use cranpose::{Robot, RobotScreenshot};
+use cranpose::{Color, Robot, RobotScreenshot};
 
 pub fn save(shot: &RobotScreenshot, directory: &Path, name: &str) {
     if let Some(image) = image::RgbaImage::from_raw(shot.width, shot.height, shot.pixels.clone()) {
@@ -23,4 +23,29 @@ pub fn settle(robot: &Robot, millis: u64) {
     let _ = robot.wait_for_idle();
     std::thread::sleep(Duration::from_millis(millis));
     let _ = robot.wait_for_idle();
+}
+
+pub fn color_distance(a: (u8, u8, u8), b: (u8, u8, u8)) -> f32 {
+    let dr = a.0 as f32 - b.0 as f32;
+    let dg = a.1 as f32 - b.1 as f32;
+    let db = a.2 as f32 - b.2 as f32;
+    (dr * dr + dg * dg + db * db).sqrt()
+}
+
+pub fn to_rgb8(color: Color) -> (u8, u8, u8) {
+    (
+        (color.r() * 255.0) as u8,
+        (color.g() * 255.0) as u8,
+        (color.b() * 255.0) as u8,
+    )
+}
+
+pub fn logical_sampler(shot: &RobotScreenshot) -> impl Fn(f32, f32) -> (u8, u8, u8) + '_ {
+    let scale = shot.width as f32 / shot.logical_width;
+    move |lx: f32, ly: f32| -> (u8, u8, u8) {
+        let px = (lx * scale).round().clamp(0.0, shot.width as f32 - 1.0) as u32;
+        let py = (ly * scale).round().clamp(0.0, shot.height as f32 - 1.0) as u32;
+        let idx = ((py * shot.width + px) * 4) as usize;
+        (shot.pixels[idx], shot.pixels[idx + 1], shot.pixels[idx + 2])
+    }
 }

--- a/apps/desktop-demo/robot-runners/robot_tab_navigation.rs
+++ b/apps/desktop-demo/robot-runners/robot_tab_navigation.rs
@@ -2,7 +2,7 @@ mod robot_launch;
 
 use std::time::Duration;
 
-use cranpose_testing::{find_button_in_semantics, find_text_in_semantics};
+use cranpose_testing::{click_button_in_semantics, find_text_in_semantics};
 use desktop_app::app;
 
 fn main() {
@@ -14,17 +14,7 @@ fn main() {
             println!("✓ App launched\n");
             std::thread::sleep(Duration::from_millis(500));
 
-            let click_button = |name: &str| -> bool {
-                if let Some((x, y, w, h)) = find_button_in_semantics(&robot, name) {
-                    println!("  Found button '{}' at ({:.1}, {:.1})", name, x, y);
-                    robot.click(x + w / 2.0, y + h / 2.0).ok();
-                    std::thread::sleep(Duration::from_millis(100));
-                    true
-                } else {
-                    println!("  ✗ Button '{}' not found!", name);
-                    false
-                }
-            };
+            let click_button = |name: &str| -> bool { click_button_in_semantics(&robot, name) };
 
             let verify_text = |text: &str| -> bool {
                 if let Some((x, y, _, _)) = find_text_in_semantics(&robot, text) {

--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -104,6 +104,25 @@ pub fn optional_device_features(adapter: &wgpu::Adapter) -> wgpu::Features {
     adapter.features() & (wgpu::Features::PIPELINE_CACHE | wgpu::Features::TIMESTAMP_QUERY)
 }
 
+#[doc(hidden)]
+pub fn offscreen_render_target_for_tests(
+    device: &wgpu::Device,
+    width: u32,
+    height: u32,
+    label: &str,
+) -> (wgpu::Texture, wgpu::TextureView) {
+    let texture = offscreen::create_2d_texture(
+        device,
+        wgpu::TextureFormat::Rgba8Unorm,
+        width,
+        height,
+        wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        Some(label),
+    );
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    (texture, view)
+}
+
 pub(crate) fn rect_to_quad(rect: Rect) -> [[f32; 2]; 4] {
     [
         [rect.x, rect.y],

--- a/crates/cranpose-render/wgpu/src/offscreen.rs
+++ b/crates/cranpose-render/wgpu/src/offscreen.rs
@@ -25,6 +25,30 @@ fn resolve_composition_format(requested: Option<&str>, android: bool) -> wgpu::T
     }
 }
 
+pub(crate) fn create_2d_texture(
+    device: &wgpu::Device,
+    format: wgpu::TextureFormat,
+    width: u32,
+    height: u32,
+    usage: wgpu::TextureUsages,
+    label: Option<&str>,
+) -> wgpu::Texture {
+    device.create_texture(&wgpu::TextureDescriptor {
+        label,
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format,
+        usage,
+        view_formats: &[],
+    })
+}
+
 pub(crate) struct OffscreenTarget {
     texture: wgpu::Texture,
     pub view: wgpu::TextureView,
@@ -51,23 +75,17 @@ impl OffscreenTarget {
         height: u32,
         label: &'static str,
     ) -> Self {
-        let texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some(label),
-            size: wgpu::Extent3d {
-                width,
-                height,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
+        let texture = create_2d_texture(
+            device,
             format,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+            width,
+            height,
+            wgpu::TextureUsages::RENDER_ATTACHMENT
                 | wgpu::TextureUsages::TEXTURE_BINDING
                 | wgpu::TextureUsages::COPY_SRC
                 | wgpu::TextureUsages::COPY_DST,
-            view_formats: &[],
-        });
+            Some(label),
+        );
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
         Self {
             texture,

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -8345,20 +8345,14 @@ impl GpuRenderer {
             return Err("Screenshot size must be non-zero".to_string());
         }
 
-        let output_texture = self.device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Screenshot Output Texture"),
-            size: wgpu::Extent3d {
-                width,
-                height,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Rgba8Unorm,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
-            view_formats: &[],
-        });
+        let output_texture = crate::offscreen::create_2d_texture(
+            &self.device,
+            wgpu::TextureFormat::Rgba8Unorm,
+            width,
+            height,
+            wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            Some("Screenshot Output Texture"),
+        );
         let output_view = output_texture.create_view(&wgpu::TextureViewDescriptor::default());
         self.render_internal(
             width,

--- a/crates/cranpose-render/wgpu/tests/device_error_survival.rs
+++ b/crates/cranpose-render/wgpu/tests/device_error_survival.rs
@@ -1,49 +1,16 @@
 mod support;
 
-use cranpose_core::NodeId;
 use cranpose_render_common::{
     Renderer,
     graph::{
-        CachePolicy, DrawPrimitiveNode, IsolationReasons, LayerNode, PrimitiveEntry, PrimitiveNode,
-        PrimitivePhase, ProjectiveTransform, RenderGraph, RenderNode,
+        DrawPrimitiveNode, PrimitiveEntry, PrimitiveNode, PrimitivePhase, RenderGraph, RenderNode,
     },
-    raster_cache::LayerRasterCacheHashes,
 };
 use cranpose_render_wgpu::{CancelReason, PresentOutcome};
-use cranpose_ui_graphics::{Brush, Color, GraphicsLayer, Point, Rect};
+use cranpose_ui_graphics::{Brush, Color, Rect};
 
 const WIDTH: u32 = 128;
 const HEIGHT: u32 = 96;
-
-fn test_layer(node_id: Option<NodeId>, children: Vec<RenderNode>) -> LayerNode {
-    LayerNode {
-        node_id,
-        local_bounds: Rect {
-            x: 0.0,
-            y: 0.0,
-            width: WIDTH as f32,
-            height: HEIGHT as f32,
-        },
-        transform_to_parent: ProjectiveTransform::identity(),
-        motion_context_animated: false,
-        translated_content_context: false,
-        translated_content_offset: Point::default(),
-        content_offset: Point::default(),
-        scene_children_origin: Point::default(),
-        scene_children_layer_translation: Point::default(),
-        graphics_layer: GraphicsLayer::default(),
-        clip_to_bounds: false,
-        shadow_clip: None,
-        hit_test: None,
-        has_hit_targets: false,
-        has_origin_sinks: false,
-        isolation: IsolationReasons::default(),
-        cache_policy: CachePolicy::None,
-        cache_hashes: LayerRasterCacheHashes::default(),
-        cache_hashes_valid: false,
-        children,
-    }
-}
 
 fn rect_primitive(rect: Rect, color: Color) -> RenderNode {
     RenderNode::Primitive(PrimitiveEntry {
@@ -60,8 +27,10 @@ fn rect_primitive(rect: Rect, color: Color) -> RenderNode {
 }
 
 fn direct_graph() -> RenderGraph {
-    RenderGraph::new(test_layer(
+    RenderGraph::new(support::layer_node(
         Some(9_400),
+        WIDTH as f32,
+        HEIGHT as f32,
         vec![rect_primitive(
             Rect {
                 x: 16.0,

--- a/crates/cranpose-render/wgpu/tests/fail_closed_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/fail_closed_contract.rs
@@ -2,15 +2,11 @@ mod support;
 
 use cranpose_render_common::{
     Renderer,
-    graph::{
-        CachePolicy, DrawCommandId, DrawRunNode, IsolationReasons, LayerNode, PrimitivePhase,
-        ProjectiveTransform, RenderGraph, RenderNode,
-    },
-    raster_cache::LayerRasterCacheHashes,
+    graph::{DrawCommandId, DrawRunNode, PrimitivePhase, RenderGraph, RenderNode},
     style_shared::DrawPlacement,
 };
 use cranpose_ui_graphics::{
-    Brush, Color, CommandReplayState, DrawScope, DrawScopeDefault, GraphicsLayer, Point, Rect,
+    Brush, Color, CommandReplayState, DrawScope, DrawScopeDefault, Point, Rect,
 };
 
 const SIZE: u32 = 408;
@@ -90,33 +86,12 @@ fn record_frame(frame: usize) -> DrawScopeDefault {
 }
 
 fn graph_for(children: Vec<RenderNode>) -> RenderGraph {
-    RenderGraph::new(LayerNode {
-        node_id: None,
-        local_bounds: Rect {
-            x: 0.0,
-            y: 0.0,
-            width: SIZE as f32,
-            height: SIZE as f32,
-        },
-        transform_to_parent: ProjectiveTransform::identity(),
-        content_offset: Point::default(),
-        motion_context_animated: false,
-        translated_content_context: false,
-        translated_content_offset: Point::default(),
-        scene_children_origin: Point::default(),
-        scene_children_layer_translation: Point::default(),
-        graphics_layer: GraphicsLayer::default(),
-        clip_to_bounds: false,
-        shadow_clip: None,
-        hit_test: None,
-        has_hit_targets: false,
-        has_origin_sinks: false,
-        isolation: IsolationReasons::default(),
-        cache_policy: CachePolicy::None,
-        cache_hashes: LayerRasterCacheHashes::default(),
-        cache_hashes_valid: false,
+    RenderGraph::new(support::layer_node(
+        None,
+        SIZE as f32,
+        SIZE as f32,
         children,
-    })
+    ))
 }
 
 fn command_for(node_id: usize) -> DrawCommandId {

--- a/crates/cranpose-render/wgpu/tests/initial_present_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/initial_present_contract.rs
@@ -1,6 +1,6 @@
 use std::{sync::mpsc, time::Duration};
 
-use cranpose_render_wgpu::clear_to_default_background;
+use cranpose_render_wgpu::{clear_to_default_background, offscreen_render_target_for_tests};
 
 fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
     let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
@@ -32,21 +32,8 @@ fn clears_every_pixel_to_the_frameworks_default_background() {
 
     const WIDTH: u32 = 4;
     const HEIGHT: u32 = 4;
-    let texture = device.create_texture(&wgpu::TextureDescriptor {
-        label: Some("placeholder-clear-test-target"),
-        size: wgpu::Extent3d {
-            width: WIDTH,
-            height: HEIGHT,
-            depth_or_array_layers: 1,
-        },
-        mip_level_count: 1,
-        sample_count: 1,
-        dimension: wgpu::TextureDimension::D2,
-        format: wgpu::TextureFormat::Rgba8Unorm,
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
-        view_formats: &[],
-    });
-    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    let (texture, view) =
+        offscreen_render_target_for_tests(&device, WIDTH, HEIGHT, "placeholder-clear-test-target");
 
     clear_to_default_background(&device, &queue, &view);
 

--- a/crates/cranpose-render/wgpu/tests/scene_range_cache_exactness.rs
+++ b/crates/cranpose-render/wgpu/tests/scene_range_cache_exactness.rs
@@ -13,12 +13,10 @@ use cranpose_core::NodeId;
 use cranpose_render_common::{
     Renderer,
     graph::{
-        CachePolicy, DrawPrimitiveNode, IsolationReasons, LayerNode, PrimitiveEntry, PrimitiveNode,
-        PrimitivePhase, ProjectiveTransform, RenderGraph, RenderNode,
+        DrawPrimitiveNode, PrimitiveEntry, PrimitiveNode, PrimitivePhase, RenderGraph, RenderNode,
     },
-    raster_cache::LayerRasterCacheHashes,
 };
-use cranpose_ui_graphics::{Brush, Color, CornerRadii, DrawPrimitive, GraphicsLayer, Point, Rect};
+use cranpose_ui_graphics::{Brush, Color, CornerRadii, DrawPrimitive, Rect};
 
 const SIZE: u32 = 600;
 const FRAMES: usize = 3;
@@ -74,33 +72,12 @@ fn layered_graph(node_id: NodeId, region: Rect, frame: usize) -> RenderGraph {
         Color(0.9, 0.55, 0.2, 0.65),
         7.0,
     )));
-    RenderGraph::new(LayerNode {
-        node_id: Some(node_id),
-        local_bounds: Rect {
-            x: 0.0,
-            y: 0.0,
-            width: SIZE as f32,
-            height: SIZE as f32,
-        },
-        transform_to_parent: ProjectiveTransform::identity(),
-        content_offset: Point::default(),
-        motion_context_animated: false,
-        translated_content_context: false,
-        translated_content_offset: Point::default(),
-        scene_children_origin: Point::default(),
-        scene_children_layer_translation: Point::default(),
-        graphics_layer: GraphicsLayer::default(),
-        clip_to_bounds: false,
-        shadow_clip: None,
-        hit_test: None,
-        has_hit_targets: false,
-        has_origin_sinks: false,
-        isolation: IsolationReasons::default(),
-        cache_policy: CachePolicy::None,
-        cache_hashes: LayerRasterCacheHashes::default(),
-        cache_hashes_valid: false,
-        children: primitives,
-    })
+    RenderGraph::new(support::layer_node(
+        Some(node_id),
+        SIZE as f32,
+        SIZE as f32,
+        primitives,
+    ))
 }
 
 /// One pass over the sequence: per-frame pixels plus per-frame

--- a/crates/cranpose-render/wgpu/tests/support.rs
+++ b/crates/cranpose-render/wgpu/tests/support.rs
@@ -5,11 +5,36 @@ use std::{
     sync::{Arc, Mutex, MutexGuard},
 };
 
-use cranpose_render_common::{Renderer, software_text_raster::DEFAULT_SOFTWARE_TEXT_FONT_BYTES};
+use cranpose_core::NodeId;
+use cranpose_render_common::{
+    Renderer,
+    graph::{LayerNode, RenderNode},
+    software_text_raster::DEFAULT_SOFTWARE_TEXT_FONT_BYTES,
+};
 use cranpose_render_wgpu::{CapturedFrame, RenderStatsSnapshot, WgpuRenderer};
 use cranpose_ui::AppContext;
+use cranpose_ui_graphics::Rect;
 
 pub static TEST_FONT: &[u8] = DEFAULT_SOFTWARE_TEXT_FONT_BYTES;
+
+pub fn layer_node(
+    node_id: Option<NodeId>,
+    width: f32,
+    height: f32,
+    children: Vec<RenderNode>,
+) -> LayerNode {
+    LayerNode {
+        node_id,
+        local_bounds: Rect {
+            x: 0.0,
+            y: 0.0,
+            width,
+            height,
+        },
+        children,
+        ..Default::default()
+    }
+}
 
 static GPU_TEST_LOCK: Mutex<()> = Mutex::new(());
 

--- a/crates/cranpose-testing/src/robot_helpers.rs
+++ b/crates/cranpose-testing/src/robot_helpers.rs
@@ -215,6 +215,19 @@ pub fn find_button_exact_in_semantics(
     find_button_in_semantics_by(robot, text, TextMatchMode::Exact)
 }
 
+/// Find a button by semantic text, click its center, and wait for the UI to
+/// settle. Returns whether the button was found.
+pub fn click_button_in_semantics(robot: &cranpose::Robot, name: &str) -> bool {
+    let Some((x, y, w, h)) = find_button_in_semantics(robot, name) else {
+        println!("  ✗ Button '{}' not found!", name);
+        return false;
+    };
+    println!("  Found button '{}' at ({:.1}, {:.1})", name, x, y);
+    robot.click(x + w / 2.0, y + h / 2.0).ok();
+    std::thread::sleep(Duration::from_millis(200));
+    true
+}
+
 fn find_button_in_semantics_by(
     robot: &cranpose::Robot,
     text: &str,


### PR DESCRIPTION
## Summary

A batch of PRs landed on main today via `--admin`, bypassing CI, so `cargo xtask duplication-gate` never ran on them. It flags eight >=10-line clones against base `52e51010`. This PR removes them with real shared abstractions, not mechanical copy-paste deletion.

- **`apps/desktop-demo/robot-runners/robot_shot.rs`** gains `color_distance`/`to_rgb8`/`logical_sampler`, used by `round_glass_probe.rs` and `robot_liquid_round_glass_edge_refraction.rs` — the round-glass rim-color probe was duplicated across the throwaway example and its permanent regression test.
- **`cranpose_testing`** gains `click_button_in_semantics`, replacing four copies of the same find-log-click-settle closure across robot runners (`robot_layout_validation`, `robot_lazy_list_end_alignment`, `robot_tab_navigation`, `robot_lazy_tab_test`).
- **`crates/cranpose-render/wgpu/tests/support.rs`** gains `layer_node()`, a `LayerNode { .., ..Default::default() }` constructor, collapsing three near-identical 25-line struct literals in `fail_closed_contract.rs`, `scene_range_cache_exactness.rs`, and `device_error_survival.rs` (which already had its own local copy of the same thing) down to one call each.
- **`cranpose-render-wgpu`** gains one `create_2d_texture` primitive (`offscreen.rs`), used by `OffscreenTarget`, `GpuRenderer::render_to_rgba_pixels`, and a new `#[doc(hidden)] offscreen_render_target_for_tests`. This replaces three independent copies of the same `wgpu::TextureDescriptor` — production `render.rs` and `offscreen.rs` included. A naive test-only fix would have made the pre-existing production duplication worse (three copies instead of two), so this consolidates all three call sites onto one definition.

One flagged clone is deliberately left as-is: the identical `mod`/`use` header shared by `robot_liquid_tab_bar_pill_containment.rs` and `robot_liquid_tab_flight_dark_scheme_ink_recolor.rs`. Every imported symbol is independently used in both files (verified — none are vestigial), and the files diverge completely past the header (different test purpose, different geometry). Forcing a shared prelude module would only relocate the duplication and couple two unrelated visual-regression tests through an artificial shared import list.

## Verification (run locally, not via CI — see freeze note below)

- `cargo xtask duplication-gate --base 52e51010` — 1 of 8 remaining (the documented false positive above; explained in code review notes)
- `just fmt` — clean, idempotent
- `just clippy` — 0 warnings (`-D warnings`)
- `just clippy-robot` — 0 warnings (`-D warnings`)
- `cargo test --profile ci -p cranpose-render-wgpu --no-fail-fast` — 41 unit tests + all integration test files pass, including the four touched (`device_error_survival`, `fail_closed_contract`, `initial_present_contract`, `scene_range_cache_exactness`)
- `cargo test --profile ci --workspace --no-fail-fast` — run locally, see PR comment for result
- `just test-robot-discovery` — all pass, confirms `robot_shot.rs`'s new cross-directory usage and the four `click_button_in_semantics` call sites don't break example discovery

## Note on the merge freeze

Per instructions, **this PR should not be merged** — main is under a freeze while a robot-suite run (cancelled five times by successive merges) completes. Please hold merging until the freeze lifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)