### PR TITLE
Fill animate*AsState family and add updateTransition/Transition<S>

### DIFF
--- a/crates/cranpose-animation/README.md
+++ b/crates/cranpose-animation/README.md
@@ -12,7 +12,8 @@ Use this crate to create smooth, interruptible animations. Unlike traditional ti
 -   **`AnimationSpec`**: Defines the behavior of an animation. Common types include:
     -   **`Spring`**: Physical simulation based on stiffness and damping ratio.
     -   **`Tween`**: Duration-based interpolation with an easing curve.
--   **`animate*AsState`**: Composable functions that subscribe to a target value and return a `State` object representing the current animated value.
+-   **`animate*AsState`**: Composable functions that subscribe to a target value and return a `State` object representing the current animated value. `animateFloatAsState` and `animateColorAsState` are joined by `animateDpAsState`, `animateOffsetAsState`, `animateSizeAsState` and `animateRectAsState`, all built over the generic `animateValueAsState` and the `SpringScalar` vector-converter core -- any type that decomposes into a fixed-size float vector (see `SpringScalar`/`Lerp`) gets a specialization for free.
+-   **`Transition<S>`**: A finite, state-driven animation obtained from `updateTransition`. Multiple child animations (`transition.animateFloat { }`, `.animateDp { }`, `.animateColor { }`, or the generic `.animateValue { }`) each derive their own target from the same state and run in lockstep; `transition.is_running()` is `true` until every child has settled.
 
 ## Example: Interruptible Spring Animation
 
@@ -64,6 +65,35 @@ fn PulsingDot() {
             .width(24.0)
             .height(24.0)
             .background(Color(0.2, 0.5, 0.9, alpha.value())),
+        BoxSpec::default(),
+        || {},
+    );
+}
+```
+
+## Example: Finite, State-Driven Transition
+
+```rust
+use cranpose_animation::{updateTransition, AnimationSpec, AnimationType, Easing};
+use cranpose_ui_graphics::Color;
+
+#[composable]
+fn ExpandingCard(expanded: bool) {
+    let transition = updateTransition(expanded, "card");
+    let tween = AnimationType::Tween(AnimationSpec::tween(240, Easing::FastOutSlowInEasing));
+
+    let height = transition.animateFloat(if expanded { 320.0 } else { 96.0 }, tween, "height");
+    let tint = transition.animateColor(
+        if expanded { Color(0.1, 0.1, 0.15, 1.0) } else { Color(0.9, 0.9, 0.95, 1.0) },
+        tween,
+        "tint",
+    );
+
+    // transition.is_running() stays true until both children have settled,
+    // and flipping `expanded` again mid-animation retargets in place rather
+    // than snapping.
+    Box(
+        Modifier::empty().height(height.value()).background(tint.value()),
         BoxSpec::default(),
         || {},
     );

--- a/crates/cranpose-animation/src/animation.rs
+++ b/crates/cranpose-animation/src/animation.rs
@@ -825,6 +825,26 @@ struct AnimatableInner<T: SpringScalar + 'static> {
 impl<T: SpringScalar + 'static> Animatable<T> {
     /// Create a new animatable with the given initial value.
     pub fn new(initial: T, runtime: RuntimeHandle) -> Self {
+        Self::new_with_animation(initial, AnimationType::default(), runtime)
+    }
+
+    /// Create a new animatable already at rest at `initial`, recording
+    /// `animation` as the spec currently driving it without scheduling a
+    /// frame.
+    ///
+    /// Building blocks like [`crate::animateValueAsState`] use this instead
+    /// of [`Animatable::new`] so that a call site's first render, which
+    /// starts already at its target, does not spuriously detect the
+    /// caller's spec as "changed" the moment [`Animatable::animation_type`]
+    /// is first compared against it (a fresh [`Animatable::new`] always
+    /// reports [`AnimationType::default`], regardless of what the call site
+    /// actually asked for) and schedule a pointless one-frame animation to
+    /// nowhere.
+    pub fn new_with_animation(
+        initial: T,
+        animation: AnimationType,
+        runtime: RuntimeHandle,
+    ) -> Self {
         let inner = AnimatableInner {
             state: OwnedMutableState::with_runtime(initial.clone(), runtime.clone()),
             runtime,
@@ -832,7 +852,7 @@ impl<T: SpringScalar + 'static> Animatable<T> {
             velocity: [0.0; SPRING_MAX_DIMENSIONS],
             start: initial.clone(),
             target: initial,
-            animation_type: AnimationType::default(),
+            animation_type: animation,
             start_time_nanos: None,
             last_frame_nanos: None,
             registration: None,
@@ -934,6 +954,21 @@ impl<T: SpringScalar + 'static> Animatable<T> {
     /// Return the animation spec currently driving this animatable.
     pub fn animation_type(&self) -> AnimationType {
         self.inner.borrow().animation_type
+    }
+
+    /// Whether a frame callback is currently scheduled: `true` while the
+    /// value is mid-flight toward its target, `false` once it has settled.
+    /// Mirrors Jetpack Compose's `Animatable.isRunning`.
+    pub fn is_running(&self) -> bool {
+        self.inner.borrow().registration.is_some()
+    }
+
+    /// Pointer identity of the shared inner state, stable across clones of
+    /// the same [`Animatable`]. Used to key registration into a parent
+    /// collection (e.g. [`crate::transition::Transition`]'s children) by
+    /// object identity rather than value equality.
+    pub(crate) fn identity(&self) -> usize {
+        Rc::as_ptr(&self.inner) as usize
     }
 
     /// Get the current state.
@@ -1104,24 +1139,42 @@ pub fn animate_float_as_state_with_initial(
     })
 }
 
-#[allow(non_snake_case)]
+/// Generic building block for the whole `animate*AsState` family: any type
+/// that implements [`SpringScalar`] (the vector-converter core -- equality
+/// plus a fixed-size float decomposition, mirroring Compose's
+/// `TwoWayConverter`/`AnimationVector`) gets a fire-and-forget animation for
+/// free. [`animateFloatAsState`], [`crate::animateColorAsState`] and the
+/// `Dp`/`Offset`/`Size`/`Rect` specializations in
+/// [`crate::unit_animation`]/[`crate::geometry_animation`] are all thin
+/// wrappers over this one function.
 #[track_caller]
-pub fn animateFloatAsState(target: f32, animation: AnimationType, label: &str) -> State<f32> {
+pub fn animateValueAsState<T: SpringScalar + PartialEq + 'static>(
+    target: T,
+    animation: AnimationType,
+    label: &str,
+) -> State<T> {
     let _ = label;
     let caller = cranpose_core::caller_location_key();
     with_current_composer(|composer| {
         let runtime = composer.runtime_handle();
-        let anim: Owned<Animatable<f32>> =
-            composer.remember_at(caller, || Animatable::new(target, runtime));
+        let anim: Owned<Animatable<T>> = composer.remember_at(caller, || {
+            Animatable::new_with_animation(target.clone(), animation, runtime)
+        });
         anim.update(|animatable| {
-            let is_new_target = (animatable.target() - target).abs() > f32::EPSILON;
+            let is_new_target = animatable.target() != target;
             let is_new_animation = animatable.animation_type() != animation;
             if is_new_target || is_new_animation {
-                animatable.animateTo(target, animation);
+                animatable.animateTo(target.clone(), animation);
             }
         });
         anim.with(|animatable| animatable.state())
     })
+}
+
+#[allow(non_snake_case)]
+#[track_caller]
+pub fn animateFloatAsState(target: f32, animation: AnimationType, label: &str) -> State<f32> {
+    animateValueAsState(target, animation, label)
 }
 
 impl<T: SpringScalar + 'static> Clone for Animatable<T> {

--- a/crates/cranpose-animation/src/color.rs
+++ b/crates/cranpose-animation/src/color.rs
@@ -2,17 +2,17 @@
 //!
 //! Mirrors Jetpack Compose's `animateColorAsState` from
 //! `androidx.compose.animation.SingleValueAnimation` by layering a [`Lerp`]
-//! implementation for [`Color`] over the generic [`Animatable`] machinery.
+//! implementation for [`Color`] over the generic [`crate::Animatable`] machinery.
 //!
 //! Note: This module uses camelCase for function names to maintain 1:1 API
 //! parity with Jetpack Compose.
 
 #![allow(non_snake_case)]
 
-use cranpose_core::{Owned, State, with_current_composer};
+use cranpose_core::State;
 use cranpose_ui_graphics::Color;
 
-use crate::animation::{Animatable, AnimationType, Lerp, SpringScalar};
+use crate::animation::{AnimationType, Lerp, SpringScalar, animateValueAsState};
 
 impl Lerp for Color {
     fn lerp(&self, target: &Self, fraction: f32) -> Self {
@@ -62,21 +62,7 @@ impl SpringScalar for Color {
 /// [`Lerp`] for [`Color`] for how this relates to Compose's Oklab lerp).
 #[track_caller]
 pub fn animateColorAsState(target: Color, animation: AnimationType, label: &str) -> State<Color> {
-    let _ = label;
-    let caller = cranpose_core::caller_location_key();
-    with_current_composer(|composer| {
-        let runtime = composer.runtime_handle();
-        let anim: Owned<Animatable<Color>> =
-            composer.remember_at(caller, || Animatable::new(target, runtime));
-        anim.update(|animatable| {
-            let is_new_target = animatable.target() != target;
-            let is_new_animation = animatable.animation_type() != animation;
-            if is_new_target || is_new_animation {
-                animatable.animateTo(target, animation);
-            }
-        });
-        anim.with(|animatable| animatable.state())
-    })
+    animateValueAsState(target, animation, label)
 }
 
 #[cfg(test)]

--- a/crates/cranpose-animation/src/geometry_animation.rs
+++ b/crates/cranpose-animation/src/geometry_animation.rs
@@ -1,0 +1,126 @@
+//! Animation over Cranpose's 2D geometry types.
+//!
+//! Layers [`Lerp`] and [`SpringScalar`] onto [`Point`], [`Size`] and [`Rect`]
+//! so they plug into the same generic [`animateValueAsState`] core as
+//! [`animateFloatAsState`](crate::animateFloatAsState) and
+//! [`animateColorAsState`](crate::animateColorAsState).
+//!
+//! Note: This module uses camelCase for function names to maintain 1:1 API
+//! parity with Jetpack Compose.
+
+#![allow(non_snake_case)]
+
+use cranpose_core::State;
+use cranpose_ui_graphics::{Point, Rect, Size};
+
+use crate::animation::{AnimationType, Lerp, SpringScalar, animateValueAsState};
+
+impl Lerp for Point {
+    fn lerp(&self, target: &Self, fraction: f32) -> Self {
+        Point::new(
+            self.x.lerp(&target.x, fraction),
+            self.y.lerp(&target.y, fraction),
+        )
+    }
+}
+
+impl SpringScalar for Point {
+    const DIMENSIONS: usize = 2;
+
+    fn dimension(&self, index: usize) -> f32 {
+        match index {
+            0 => self.x,
+            _ => self.y,
+        }
+    }
+
+    fn from_dimensions(dimensions: [f32; crate::animation::SPRING_MAX_DIMENSIONS]) -> Self {
+        Point::new(dimensions[0], dimensions[1])
+    }
+}
+
+impl Lerp for Size {
+    fn lerp(&self, target: &Self, fraction: f32) -> Self {
+        Size::new(
+            self.width.lerp(&target.width, fraction),
+            self.height.lerp(&target.height, fraction),
+        )
+    }
+}
+
+impl SpringScalar for Size {
+    const DIMENSIONS: usize = 2;
+
+    fn dimension(&self, index: usize) -> f32 {
+        match index {
+            0 => self.width,
+            _ => self.height,
+        }
+    }
+
+    fn from_dimensions(dimensions: [f32; crate::animation::SPRING_MAX_DIMENSIONS]) -> Self {
+        Size::new(dimensions[0], dimensions[1])
+    }
+}
+
+impl Lerp for Rect {
+    fn lerp(&self, target: &Self, fraction: f32) -> Self {
+        Rect {
+            x: self.x.lerp(&target.x, fraction),
+            y: self.y.lerp(&target.y, fraction),
+            width: self.width.lerp(&target.width, fraction),
+            height: self.height.lerp(&target.height, fraction),
+        }
+    }
+}
+
+impl SpringScalar for Rect {
+    const DIMENSIONS: usize = 4;
+
+    fn dimension(&self, index: usize) -> f32 {
+        match index {
+            0 => self.x,
+            1 => self.y,
+            2 => self.width,
+            _ => self.height,
+        }
+    }
+
+    fn from_dimensions(dimensions: [f32; crate::animation::SPRING_MAX_DIMENSIONS]) -> Self {
+        Rect {
+            x: dimensions[0],
+            y: dimensions[1],
+            width: dimensions[2],
+            height: dimensions[3],
+        }
+    }
+}
+
+/// Fire-and-forget animation of a 2D position.
+///
+/// Mirrors Jetpack Compose: `animateOffsetAsState(targetValue, animationSpec, label)`,
+/// using Cranpose's own [`Point`] in place of Compose's `Offset`.
+#[track_caller]
+pub fn animateOffsetAsState(target: Point, animation: AnimationType, label: &str) -> State<Point> {
+    animateValueAsState(target, animation, label)
+}
+
+/// Fire-and-forget animation of a 2D extent.
+///
+/// Mirrors Jetpack Compose: `animateSizeAsState(targetValue, animationSpec, label)`.
+#[track_caller]
+pub fn animateSizeAsState(target: Size, animation: AnimationType, label: &str) -> State<Size> {
+    animateValueAsState(target, animation, label)
+}
+
+/// Fire-and-forget animation of a rectangle.
+///
+/// Mirrors Jetpack Compose: `animateRectAsState(targetValue, animationSpec, label)`.
+#[track_caller]
+pub fn animateRectAsState(target: Rect, animation: AnimationType, label: &str) -> State<Rect> {
+    animateValueAsState(target, animation, label)
+}
+
+#[cfg(test)]
+#[path = "tests/geometry_animation_tests.rs"]
+mod tests;

--- a/crates/cranpose-animation/src/lib.rs
+++ b/crates/cranpose-animation/src/lib.rs
@@ -7,6 +7,11 @@
 pub mod animation;
 pub mod color;
 pub mod decay_spec;
+pub mod geometry_animation;
+#[cfg(test)]
+pub(crate) mod test_support;
+pub mod transition;
+pub mod unit_animation;
 
 pub use animation::*;
 pub use color::animateColorAsState;
@@ -14,15 +19,22 @@ pub use decay_spec::{
     ExponentialDecaySpec, FloatDecayAnimationSpec, IOS_DECELERATION_RATE_FAST,
     IOS_DECELERATION_RATE_NORMAL,
 };
+pub use geometry_animation::{animateOffsetAsState, animateRectAsState, animateSizeAsState};
+pub use transition::{Transition, updateTransition};
+pub use unit_animation::animateDpAsState;
 
 pub mod prelude {
     pub use crate::{
         animation::{
             Animatable, AnimationSpec, AnimationType, Easing, InfiniteRepeatableSpec,
             InfiniteTransition, Lerp, RepeatMode, Spring, SpringSpec, StartOffset, StartOffsetType,
-            animateFloatAsState, infiniteRepeatable, rememberInfiniteTransition, spring, tween,
+            animateFloatAsState, animateValueAsState, infiniteRepeatable,
+            rememberInfiniteTransition, spring, tween,
         },
         color::animateColorAsState,
         decay_spec::{ExponentialDecaySpec, FloatDecayAnimationSpec},
+        geometry_animation::{animateOffsetAsState, animateRectAsState, animateSizeAsState},
+        transition::{Transition, updateTransition},
+        unit_animation::animateDpAsState,
     };
 }

--- a/crates/cranpose-animation/src/test_support.rs
+++ b/crates/cranpose-animation/src/test_support.rs
@@ -1,0 +1,205 @@
+//! Shared composition-driving harness for animation tests.
+//!
+//! Every `animate*AsState` specialization (Gap 1) and every `Transition`
+//! child accessor (Gap 2) is exercised the same way: render once, change
+//! what the call site asks for, then step a frame clock and observe the
+//! committed value. Factoring that loop out here keeps each type's test
+//! module down to the handful of lines that are actually specific to it.
+
+use std::{cell::RefCell, rc::Rc};
+
+use cranpose_core::{Composition, Key, MemoryApplier, State, location_key};
+
+use crate::animation::SpringScalar;
+
+const FRAME_NANOS: u64 = 16_666_667;
+
+pub(crate) struct AnimationHarness<T: Clone + 'static> {
+    composition: Composition<MemoryApplier>,
+    root_key: Key,
+    state_slot: Rc<RefCell<Option<State<T>>>>,
+    current_target: Rc<RefCell<T>>,
+    pass: Box<dyn FnMut()>,
+    frame_time_nanos: u64,
+}
+
+impl<T: Clone + 'static> AnimationHarness<T> {
+    pub(crate) fn new<R>(initial_target: T, render_at: R) -> Self
+    where
+        R: FnMut(T) -> State<T> + 'static,
+    {
+        let composition = Composition::new(MemoryApplier::new());
+        let root_key = location_key(file!(), line!(), column!());
+        let state_slot: Rc<RefCell<Option<State<T>>>> = Rc::new(RefCell::new(None));
+        let current_target = Rc::new(RefCell::new(initial_target));
+
+        let pass: Box<dyn FnMut()> = {
+            let state_slot = Rc::clone(&state_slot);
+            let current_target = Rc::clone(&current_target);
+            let mut render_at = render_at;
+            Box::new(move || {
+                let target = current_target.borrow().clone();
+                let state = render_at(target);
+                state_slot.borrow_mut().replace(state);
+            })
+        };
+
+        let mut harness = Self {
+            composition,
+            root_key,
+            state_slot,
+            current_target,
+            pass,
+            frame_time_nanos: 0,
+        };
+        harness.render();
+        harness
+    }
+
+    fn render(&mut self) {
+        self.composition
+            .render(self.root_key, &mut self.pass)
+            .expect("render succeeds");
+    }
+
+    pub(crate) fn value(&self) -> T {
+        self.state_slot
+            .borrow()
+            .as_ref()
+            .expect("state available after render")
+            .get()
+    }
+
+    /// Changes what the call site passes as its target and re-renders --
+    /// this is a target change mid-composition, not a fresh animation.
+    pub(crate) fn retarget(&mut self, target: T) -> T {
+        *self.current_target.borrow_mut() = target;
+        self.render();
+        self.value()
+    }
+
+    /// Advances the frame clock by one vsync and drains it, returning the
+    /// value the animation committed for that frame.
+    pub(crate) fn advance_frame(&mut self) -> T {
+        self.frame_time_nanos += FRAME_NANOS;
+        let runtime = self.composition.runtime_handle();
+        runtime.drain_frame_callbacks(self.frame_time_nanos);
+        let _ = self.composition.process_invalid_scopes();
+        self.value()
+    }
+
+    pub(crate) fn advance_frames(&mut self, count: usize) -> T {
+        let mut last = self.value();
+        for _ in 0..count {
+            last = self.advance_frame();
+        }
+        last
+    }
+}
+
+/// Confirms the [`SpringScalar`] contract for a type: linear interpolation
+/// matches a per-dimension average, and decomposing then rebuilding a value
+/// round-trips exactly. Every new `animate*AsState` specialization in this
+/// crate is exercised through this one check.
+pub(crate) fn assert_spring_scalar_round_trips<T>(low: T, high: T)
+where
+    T: SpringScalar + PartialEq + std::fmt::Debug,
+{
+    use crate::animation::SPRING_MAX_DIMENSIONS;
+
+    let mid = low.lerp(&high, 0.5);
+    for index in 0..T::DIMENSIONS {
+        let expected = (low.dimension(index) + high.dimension(index)) / 2.0;
+        assert!(
+            (mid.dimension(index) - expected).abs() < 1e-4,
+            "dimension {index} of the midpoint should average its endpoints, \
+             got {} expected {expected}",
+            mid.dimension(index)
+        );
+    }
+
+    let mut dimensions = [0.0f32; SPRING_MAX_DIMENSIONS];
+    for (index, slot) in dimensions.iter_mut().enumerate().take(T::DIMENSIONS) {
+        *slot = low.dimension(index);
+    }
+    assert_eq!(
+        T::from_dimensions(dimensions),
+        low,
+        "decomposing then rebuilding a value must round-trip"
+    );
+}
+
+/// Drives a call site from `low` to `high` and back to a fresh render,
+/// checking the shape every `animate*AsState` specialization must share:
+/// the first frame holds the old value, an intermediate value is observed
+/// while animating, and it settles exactly at the target.
+pub(crate) fn assert_interpolates_to_target<T, R>(low: T, high: T, render_at: R)
+where
+    T: SpringScalar + PartialEq + std::fmt::Debug + 'static,
+    R: FnMut(T) -> State<T> + 'static,
+{
+    let mut harness = AnimationHarness::new(low.clone(), render_at);
+    assert_eq!(harness.value(), low);
+
+    harness.retarget(high.clone());
+    assert_eq!(
+        harness.value(),
+        low,
+        "should not jump before a frame elapses"
+    );
+
+    let mut saw_intermediate = false;
+    let mut last = low.clone();
+    for _ in 0..40 {
+        last = harness.advance_frame();
+        if last != low && last != high {
+            saw_intermediate = true;
+        }
+    }
+    assert!(
+        saw_intermediate,
+        "should observe an intermediate value, last was {last:?}"
+    );
+    assert_eq!(last, high, "should settle exactly at the target");
+}
+
+/// Drives a call site partway to `first_target`, then switches to
+/// `second_target` mid-flight, and confirms the value carries over exactly
+/// rather than snapping, then goes on to settle at the new target -- the
+/// property every retargetable animation in this crate (`Animatable`, the
+/// `animate*AsState` family, `Transition` children) is required to have.
+pub(crate) fn assert_retargets_mid_flight_without_snapping<T, R>(
+    start: T,
+    first_target: T,
+    settle_frames: usize,
+    second_target: T,
+    render_at: R,
+) where
+    T: SpringScalar + PartialEq + std::fmt::Debug + 'static,
+    R: FnMut(T) -> State<T> + 'static,
+{
+    let mut harness = AnimationHarness::new(start.clone(), render_at);
+    harness.retarget(first_target.clone());
+    let mid_flight = harness.advance_frames(settle_frames);
+    assert_ne!(
+        mid_flight, start,
+        "should have moved off the start before retargeting"
+    );
+    assert_ne!(
+        mid_flight, first_target,
+        "should still be mid-flight before retargeting"
+    );
+
+    let value_at_retarget = harness.retarget(second_target.clone());
+    assert_eq!(
+        value_at_retarget, mid_flight,
+        "retargeting must not change the value before the next frame elapses \
+         (this is the \"not restarting from zero\" contract)"
+    );
+
+    let settled = harness.advance_frames(80);
+    assert_eq!(
+        settled, second_target,
+        "should go on to settle at the new target"
+    );
+}

--- a/crates/cranpose-animation/src/tests/color_tests.rs
+++ b/crates/cranpose-animation/src/tests/color_tests.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use cranpose_core::{Composition, MemoryApplier, State, location_key, with_current_composer};
 
 use super::*;
-use crate::animation::{AnimationSpec, AnimationType, Lerp, SpringSpec};
+use crate::animation::{Animatable, AnimationSpec, AnimationType, Lerp, SpringSpec};
 
 fn assert_color_near(actual: Color, expected: Color, tolerance: f32) {
     let channels = [

--- a/crates/cranpose-animation/src/tests/geometry_animation_tests.rs
+++ b/crates/cranpose-animation/src/tests/geometry_animation_tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+use crate::{
+    animation::AnimationSpec,
+    test_support::{
+        assert_interpolates_to_target, assert_retargets_mid_flight_without_snapping,
+        assert_spring_scalar_round_trips,
+    },
+};
+
+#[test]
+fn point_size_and_rect_satisfy_the_spring_scalar_contract() {
+    assert_spring_scalar_round_trips(Point::ZERO, Point::new(10.0, -20.0));
+    assert_spring_scalar_round_trips(Size::ZERO, Size::new(30.0, 40.0));
+    assert_spring_scalar_round_trips(
+        Rect::from_size(Size::ZERO),
+        Rect {
+            x: 5.0,
+            y: -5.0,
+            width: 50.0,
+            height: 60.0,
+        },
+    );
+}
+
+#[test]
+fn animate_offset_as_state_interpolates_from_the_previous_value_to_the_target() {
+    assert_interpolates_to_target(Point::ZERO, Point::new(100.0, -40.0), |target| {
+        animateOffsetAsState(
+            target,
+            AnimationType::Tween(AnimationSpec::linear(160)),
+            "offset",
+        )
+    });
+}
+
+#[test]
+fn animate_size_as_state_interpolates_from_the_previous_value_to_the_target() {
+    assert_interpolates_to_target(Size::ZERO, Size::new(200.0, 80.0), |target| {
+        animateSizeAsState(
+            target,
+            AnimationType::Tween(AnimationSpec::linear(160)),
+            "size",
+        )
+    });
+}
+
+#[test]
+fn animate_rect_as_state_interpolates_from_the_previous_value_to_the_target() {
+    let start = Rect::from_size(Size::ZERO);
+    let end = Rect {
+        x: 10.0,
+        y: 20.0,
+        width: 300.0,
+        height: 150.0,
+    };
+    assert_interpolates_to_target(start, end, |target| {
+        animateRectAsState(
+            target,
+            AnimationType::Tween(AnimationSpec::linear(160)),
+            "rect",
+        )
+    });
+}
+
+#[test]
+fn animate_offset_as_state_retargets_mid_flight_instead_of_restarting() {
+    assert_retargets_mid_flight_without_snapping(
+        Point::ZERO,
+        Point::new(100.0, 100.0),
+        6,
+        Point::new(-30.0, 10.0),
+        |target| {
+            animateOffsetAsState(
+                target,
+                AnimationType::Tween(AnimationSpec::linear(400)),
+                "offset",
+            )
+        },
+    );
+}
+
+#[test]
+fn animate_rect_as_state_retargets_mid_flight_instead_of_restarting() {
+    let start = Rect::from_size(Size::ZERO);
+    let first_target = Rect {
+        x: 0.0,
+        y: 0.0,
+        width: 200.0,
+        height: 200.0,
+    };
+    let second_target = Rect {
+        x: 40.0,
+        y: 40.0,
+        width: 20.0,
+        height: 20.0,
+    };
+    assert_retargets_mid_flight_without_snapping(start, first_target, 6, second_target, |target| {
+        animateRectAsState(
+            target,
+            AnimationType::Tween(AnimationSpec::linear(400)),
+            "rect",
+        )
+    });
+}

--- a/crates/cranpose-animation/src/tests/transition_tests.rs
+++ b/crates/cranpose-animation/src/tests/transition_tests.rs
@@ -1,0 +1,165 @@
+use std::{cell::RefCell, rc::Rc};
+
+use cranpose_core::{Composition, MemoryApplier, State, location_key, with_current_composer};
+
+use super::*;
+use crate::animation::AnimationSpec;
+
+fn drain_frames(
+    composition: &mut Composition<MemoryApplier>,
+    frame_time: &mut u64,
+    until_nanos: u64,
+) {
+    let runtime = composition.runtime_handle();
+    while *frame_time < until_nanos {
+        *frame_time += 16_666_667;
+        runtime.drain_frame_callbacks(*frame_time);
+        let _ = composition.process_invalid_scopes();
+    }
+}
+
+#[test]
+fn transition_with_three_children_reports_running_until_the_last_settles() {
+    let mut composition = Composition::new(MemoryApplier::new());
+    let root_key = location_key(file!(), line!(), column!());
+    let group_key = location_key(file!(), line!(), column!());
+    let transition_slot = Rc::new(RefCell::new(None::<Transition<bool>>));
+    let visible = Rc::new(RefCell::new(false));
+
+    let mut pass = {
+        let transition_slot = Rc::clone(&transition_slot);
+        let visible = Rc::clone(&visible);
+        move || {
+            let transition_slot = Rc::clone(&transition_slot);
+            let target = if *visible.borrow() { 1.0 } else { 0.0 };
+            with_current_composer(|composer| {
+                composer.with_group(group_key, |_| {
+                    let transition = updateTransition(target > 0.0, "visibility");
+                    let _fast = transition.animateFloat(
+                        target,
+                        AnimationType::Tween(AnimationSpec::linear(100)),
+                        "fast",
+                    );
+                    let _medium = transition.animateFloat(
+                        target,
+                        AnimationType::Tween(AnimationSpec::linear(300)),
+                        "medium",
+                    );
+                    let _slow = transition.animateFloat(
+                        target,
+                        AnimationType::Tween(AnimationSpec::linear(500)),
+                        "slow",
+                    );
+                    transition_slot.borrow_mut().replace(transition);
+                });
+            });
+        }
+    };
+
+    composition
+        .render(root_key, &mut pass)
+        .expect("initial render succeeds");
+    let is_running = || {
+        transition_slot
+            .borrow()
+            .as_ref()
+            .expect("transition available")
+            .is_running()
+    };
+    assert!(
+        !is_running(),
+        "a freshly created transition with no target change yet should not be running"
+    );
+
+    *visible.borrow_mut() = true;
+    composition
+        .render(root_key, &mut pass)
+        .expect("target change render succeeds");
+    assert!(
+        is_running(),
+        "changing the target state should start every child animating"
+    );
+
+    let mut frame_time = 0u64;
+    drain_frames(&mut composition, &mut frame_time, 150_000_000);
+    assert!(
+        is_running(),
+        "should still report running while the slower children are mid-flight"
+    );
+
+    drain_frames(&mut composition, &mut frame_time, 600_000_000);
+    assert!(
+        !is_running(),
+        "should stop running only once every child has settled"
+    );
+}
+
+#[test]
+fn transition_retargets_mid_flight_instead_of_snapping() {
+    let mut composition = Composition::new(MemoryApplier::new());
+    let root_key = location_key(file!(), line!(), column!());
+    let group_key = location_key(file!(), line!(), column!());
+    let state_slot = Rc::new(RefCell::new(None::<State<f32>>));
+    let stage = Rc::new(RefCell::new(0u8));
+
+    let mut pass = {
+        let state_slot = Rc::clone(&state_slot);
+        let stage = Rc::clone(&stage);
+        move || {
+            let state_slot = Rc::clone(&state_slot);
+            let stage_value = *stage.borrow();
+            with_current_composer(|composer| {
+                composer.with_group(group_key, |_| {
+                    let transition = updateTransition(stage_value, "stage");
+                    let target = match stage_value {
+                        0 => 0.0,
+                        1 => 100.0,
+                        _ => -60.0,
+                    };
+                    let state = transition.animateFloat(
+                        target,
+                        AnimationType::Tween(AnimationSpec::linear(400)),
+                        "value",
+                    );
+                    state_slot.borrow_mut().replace(state);
+                });
+            });
+        }
+    };
+
+    composition
+        .render(root_key, &mut pass)
+        .expect("initial render succeeds");
+    let value = || state_slot.borrow().as_ref().expect("state available").get();
+    assert_eq!(value(), 0.0);
+
+    *stage.borrow_mut() = 1;
+    composition
+        .render(root_key, &mut pass)
+        .expect("first target render succeeds");
+
+    let mut frame_time = 0u64;
+    drain_frames(&mut composition, &mut frame_time, 100_000_000);
+    let mid_flight = value();
+    assert!(
+        mid_flight > 0.0 && mid_flight < 100.0,
+        "should be mid-flight before retargeting, got {mid_flight}"
+    );
+
+    *stage.borrow_mut() = 2;
+    composition
+        .render(root_key, &mut pass)
+        .expect("retarget render succeeds");
+    assert_eq!(
+        value(),
+        mid_flight,
+        "changing the transition's target state mid-flight must not snap the child's value"
+    );
+
+    drain_frames(&mut composition, &mut frame_time, 600_000_000);
+    assert_eq!(
+        value(),
+        -60.0,
+        "should go on to settle at the new target state's value"
+    );
+}

--- a/crates/cranpose-animation/src/tests/unit_animation_tests.rs
+++ b/crates/cranpose-animation/src/tests/unit_animation_tests.rs
@@ -1,0 +1,36 @@
+use super::*;
+use crate::{
+    animation::AnimationSpec,
+    test_support::{
+        assert_interpolates_to_target, assert_retargets_mid_flight_without_snapping,
+        assert_spring_scalar_round_trips,
+    },
+};
+
+#[test]
+fn dp_and_sp_satisfy_the_spring_scalar_contract() {
+    assert_spring_scalar_round_trips(Dp(0.0), Dp(100.0));
+    assert_spring_scalar_round_trips(Sp(10.0), Sp(24.0));
+}
+
+#[test]
+fn animate_dp_as_state_interpolates_from_the_previous_value_to_the_target() {
+    assert_interpolates_to_target(Dp(0.0), Dp(100.0), |target| {
+        animateDpAsState(
+            target,
+            AnimationType::Tween(AnimationSpec::linear(160)),
+            "dp",
+        )
+    });
+}
+
+#[test]
+fn animate_dp_as_state_retargets_mid_flight_instead_of_restarting() {
+    assert_retargets_mid_flight_without_snapping(Dp(0.0), Dp(100.0), 6, Dp(-60.0), |target| {
+        animateDpAsState(
+            target,
+            AnimationType::Tween(AnimationSpec::linear(400)),
+            "dp",
+        )
+    });
+}

--- a/crates/cranpose-animation/src/transition.rs
+++ b/crates/cranpose-animation/src/transition.rs
@@ -1,0 +1,207 @@
+//! Finite, state-driven, multi-property animation.
+//!
+//! Mirrors Jetpack Compose's `updateTransition`/`Transition<S>`: a
+//! [`Transition`] holds a target state, and each child animation (created
+//! with [`Transition::animateValue`] or one of the typed accessors) derives
+//! its own target value from that state and animates toward it in lockstep
+//! with its siblings. The transition is [`Transition::is_running`] only
+//! while at least one child is still mid-flight, so it settles exactly when
+//! every child has.
+//!
+//! Children reuse the same [`Animatable`]/[`SpringScalar`] machinery as
+//! [`animateFloatAsState`](crate::animateFloatAsState): each call site
+//! remembers its own `Animatable`, so retargeting mid-flight (the target
+//! state changing before the previous one finished) continues from the
+//! current value instead of snapping back to a start point, exactly like
+//! the single-value `animate*AsState` family already does.
+//!
+//! Note: This module uses camelCase for function/method names to maintain
+//! 1:1 API parity with Jetpack Compose.
+
+#![allow(non_snake_case)]
+
+use std::{cell::RefCell, rc::Rc};
+
+use cranpose_core::{DisposableEffectResult, Owned, State, with_current_composer};
+use cranpose_ui_graphics::{Color, Dp};
+
+use crate::animation::{Animatable, AnimationType, SpringScalar};
+
+trait TransitionChild {
+    fn is_running(&self) -> bool;
+}
+
+impl<T: SpringScalar + 'static> TransitionChild for Animatable<T> {
+    fn is_running(&self) -> bool {
+        Animatable::is_running(self)
+    }
+}
+
+struct TransitionInner<S> {
+    target_state: RefCell<S>,
+    children: RefCell<Vec<Rc<dyn TransitionChild>>>,
+}
+
+impl<S> TransitionInner<S> {
+    fn add_child(&self, child: Rc<dyn TransitionChild>) {
+        self.children.borrow_mut().push(child);
+    }
+
+    fn remove_child(&self, child: &Rc<dyn TransitionChild>) {
+        let mut children = self.children.borrow_mut();
+        if let Some(index) = children
+            .iter()
+            .position(|existing| Rc::ptr_eq(existing, child))
+        {
+            children.remove(index);
+        }
+    }
+
+    fn is_running(&self) -> bool {
+        self.children
+            .borrow()
+            .iter()
+            .any(|child| child.is_running())
+    }
+}
+
+/// A finite, multi-property animation driven by a target state `S`.
+///
+/// Obtained from [`updateTransition`]; see the module docs for the overall
+/// model.
+pub struct Transition<S: 'static> {
+    inner: Rc<TransitionInner<S>>,
+}
+
+impl<S> Clone for Transition<S> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Rc::clone(&self.inner),
+        }
+    }
+}
+
+impl<S: Clone + 'static> Transition<S> {
+    fn new(target_state: S) -> Self {
+        Self {
+            inner: Rc::new(TransitionInner {
+                target_state: RefCell::new(target_state),
+                children: RefCell::new(Vec::new()),
+            }),
+        }
+    }
+
+    fn set_target_state(&self, target_state: S) {
+        *self.inner.target_state.borrow_mut() = target_state;
+    }
+
+    /// The state this transition is currently animating towards.
+    pub fn target_state(&self) -> S {
+        self.inner.target_state.borrow().clone()
+    }
+
+    /// `true` while any child animation is still mid-flight. A transition
+    /// with no children yet, or whose children have all settled, reports
+    /// `false` -- it is finished only when every child is.
+    pub fn is_running(&self) -> bool {
+        self.inner.is_running()
+    }
+
+    /// Generic child animation, built on the same [`SpringScalar`]
+    /// vector-converter core as [`crate::animateValueAsState`]. `target_value`
+    /// is the value this child should hold once the transition settles for
+    /// the current [`Transition::target_state`] -- recomputed by the caller
+    /// on every call, exactly like the standalone `animate*AsState` family.
+    #[track_caller]
+    pub fn animateValue<T: SpringScalar + PartialEq + 'static>(
+        &self,
+        target_value: T,
+        animation: AnimationType,
+        label: &str,
+    ) -> State<T> {
+        let _ = label;
+        let caller = cranpose_core::caller_location_key();
+        with_current_composer(|composer| {
+            let runtime = composer.runtime_handle();
+            let anim: Owned<Animatable<T>> = composer.remember_at(caller, || {
+                Animatable::new_with_animation(target_value.clone(), animation, runtime)
+            });
+            anim.update(|animatable| {
+                let is_new_target = animatable.target() != target_value;
+                let is_new_animation = animatable.animation_type() != animation;
+                if is_new_target || is_new_animation {
+                    animatable.animateTo(target_value.clone(), animation);
+                }
+            });
+
+            let animatable_clone = anim.with(|animatable| animatable.clone());
+            let identity = animatable_clone.identity();
+            let transition_inner = Rc::clone(&self.inner);
+            cranpose_core::__disposable_effect_impl(
+                caller ^ cranpose_core::location_key(file!(), line!(), column!()),
+                identity,
+                move |_scope| {
+                    let child: Rc<dyn TransitionChild> = Rc::new(animatable_clone);
+                    transition_inner.add_child(Rc::clone(&child));
+                    let transition_inner = Rc::clone(&transition_inner);
+                    DisposableEffectResult::new(move || {
+                        transition_inner.remove_child(&child);
+                    })
+                },
+            );
+
+            anim.with(|animatable| animatable.state())
+        })
+    }
+
+    /// Child float animation. Mirrors Jetpack Compose's `Transition.animateFloat`.
+    #[track_caller]
+    pub fn animateFloat(
+        &self,
+        target_value: f32,
+        animation: AnimationType,
+        label: &str,
+    ) -> State<f32> {
+        self.animateValue(target_value, animation, label)
+    }
+
+    /// Child density-independent-length animation. Mirrors Jetpack Compose's
+    /// `Transition.animateDp`.
+    #[track_caller]
+    pub fn animateDp(&self, target_value: Dp, animation: AnimationType, label: &str) -> State<Dp> {
+        self.animateValue(target_value, animation, label)
+    }
+
+    /// Child color animation. Mirrors Jetpack Compose's `Transition.animateColor`.
+    #[track_caller]
+    pub fn animateColor(
+        &self,
+        target_value: Color,
+        animation: AnimationType,
+        label: &str,
+    ) -> State<Color> {
+        self.animateValue(target_value, animation, label)
+    }
+}
+
+/// Creates or updates a [`Transition`] targeting `target_state`. Every child
+/// animation added with [`Transition::animateValue`] (or a typed accessor)
+/// retargets when `target_state` changes, continuing from its current value
+/// rather than snapping.
+///
+/// Mirrors Jetpack Compose: `updateTransition(targetState, label)`.
+#[track_caller]
+pub fn updateTransition<S: Clone + 'static>(target_state: S, label: &str) -> Transition<S> {
+    let _ = label;
+    let caller = cranpose_core::caller_location_key();
+    with_current_composer(|composer| {
+        let transition: Owned<Transition<S>> =
+            composer.remember_at(caller, || Transition::new(target_state.clone()));
+        transition.with(|transition| transition.set_target_state(target_state.clone()));
+        transition.with(|transition| transition.clone())
+    })
+}
+
+#[cfg(test)]
+#[path = "tests/transition_tests.rs"]
+mod tests;

--- a/crates/cranpose-animation/src/unit_animation.rs
+++ b/crates/cranpose-animation/src/unit_animation.rs
@@ -1,0 +1,64 @@
+//! Animation over Cranpose's density/scale unit types.
+//!
+//! Layers [`Lerp`] and [`SpringScalar`] onto [`Dp`] and [`Sp`] so they plug
+//! into the same generic [`animateValueAsState`] core that
+//! [`animateFloatAsState`](crate::animateFloatAsState) and
+//! [`animateColorAsState`](crate::animateColorAsState) already use.
+//!
+//! Note: This module uses camelCase for function names to maintain 1:1 API
+//! parity with Jetpack Compose.
+
+#![allow(non_snake_case)]
+
+use cranpose_core::State;
+use cranpose_ui_graphics::{Dp, Sp};
+
+use crate::animation::{AnimationType, Lerp, SpringScalar, animateValueAsState};
+
+impl Lerp for Dp {
+    fn lerp(&self, target: &Self, fraction: f32) -> Self {
+        Dp(self.0.lerp(&target.0, fraction))
+    }
+}
+
+impl SpringScalar for Dp {
+    const DIMENSIONS: usize = 1;
+
+    fn dimension(&self, _index: usize) -> f32 {
+        self.0
+    }
+
+    fn from_dimensions(dimensions: [f32; crate::animation::SPRING_MAX_DIMENSIONS]) -> Self {
+        Dp(dimensions[0])
+    }
+}
+
+impl Lerp for Sp {
+    fn lerp(&self, target: &Self, fraction: f32) -> Self {
+        Sp(self.0.lerp(&target.0, fraction))
+    }
+}
+
+impl SpringScalar for Sp {
+    const DIMENSIONS: usize = 1;
+
+    fn dimension(&self, _index: usize) -> f32 {
+        self.0
+    }
+
+    fn from_dimensions(dimensions: [f32; crate::animation::SPRING_MAX_DIMENSIONS]) -> Self {
+        Sp(dimensions[0])
+    }
+}
+
+/// Fire-and-forget animation of a density-independent length.
+///
+/// Mirrors Jetpack Compose: `animateDpAsState(targetValue, animationSpec, label)`.
+#[track_caller]
+pub fn animateDpAsState(target: Dp, animation: AnimationType, label: &str) -> State<Dp> {
+    animateValueAsState(target, animation, label)
+}
+
+#[cfg(test)]
+#[path = "tests/unit_animation_tests.rs"]
+mod tests;


### PR DESCRIPTION
## Summary

Closes two Compose-parity gaps in `crates/cranpose-animation` (see `docs/compose_api_parity.md`'s Animation table — rows to update noted below). MERGE FREEZE is in effect; **do not merge**.

**Gap 1 — the `animate*AsState` family.** Cranpose only had `animateFloatAsState`/`animateColorAsState`. Added `animateDpAsState`, `animateOffsetAsState`, `animateSizeAsState`, `animateRectAsState`, all built on one generic `animateValueAsState<T: SpringScalar + PartialEq>` rather than copy-pasted per type. `SpringScalar` already existed as Cranpose's `AnimationVector`/`TwoWayConverter` equivalent (fixed-size float decomposition + rebuild, `Color` was already implemented this way) — extended it to `Dp`, `Point`, `Size`, `Rect` instead of inventing a parallel mechanism. `Int`/`IntOffset`/`IntSize` were **not** added: Cranpose has no such types, and inventing them just to complete the name list would be exactly the kind of unused surface AGENTS.md warns against.

**Gap 2 — `updateTransition`/`Transition<S>`.** Was completely absent. Added `Transition<S>` with `animateValue`/`animateFloat`/`animateDp`/`animateColor` child accessors, all sharing the same `Animatable`/`SpringScalar` core as Gap 1. Each child remembers its own `Animatable` and reports settled/running via a new `Animatable::is_running()` (mirrors Compose's `Animatable.isRunning`); `Transition::is_running()` is true until every child is.

**Bug found and fixed along the way.** Writing the failing test for "a transition with three children reports running until the last settles" caught a pre-existing latent bug shared by `animateFloatAsState`/`animateColorAsState` too: a fresh `Animatable::new` always seeds `animation_type: AnimationType::default()`, so the very first render spuriously detects "spec changed" whenever the caller's spec differs from the default, scheduling a pointless one-frame animation even though the value is already at its target. Confirmed by a standalone probe test before fixing (removed after confirming), then fixed with `Animatable::new_with_animation(initial, animation, runtime)`, used by `animateValueAsState` and `Transition::animateValue`. No existing test asserted the old (buggy) behavior, so nothing regressed.

## Architecture

- `SpringScalar` (dimension decomposition + rebuild) and `Lerp` (linear interpolation) are the vector-converter core, already present for `f32`/`f64`/`Color`. New `impl`s for `Dp`, `Sp`, `Point`, `Size`, `Rect` in `unit_animation.rs`/`geometry_animation.rs` (`Sp` gets the trait impls since it's real Cranpose vocabulary — text sizing — but no dedicated `animate*AsState` wrapper, matching the existing precedent of `f64` having the impls without one).
- `animateValueAsState` in `animation.rs` is the single generic entry point; `animateFloatAsState`/`animateColorAsState` were refactored to delegate to it instead of duplicating the body.
- `Transition<S>` reuses the exact same disposable-effect registration pattern `InfiniteTransition` already uses (remember once, register/unregister a child by pointer identity via `__disposable_effect_impl`), rather than a new mechanism.
- Test helpers (`test_support.rs`) factor the "drive a composition, retarget, step frames" boilerplate into one generic harness (`AnimationHarness<T>`) plus two generic assertions (`assert_interpolates_to_target`, `assert_retargets_mid_flight_without_snapping`) reused across every new type and by `Transition`, specifically to avoid tripping the duplication gate with near-identical per-type tests.

## Doc table rows to update (not touched here per instructions)

- `animateDpAsState`, `animateOffsetAsState`, `animateIntAsState`, ... → now: **Implemented** for Dp/Offset(Point)/Size/Rect via generic `animateValueAsState`; Int variants intentionally not added (no Cranpose analog).
- `updateTransition(targetState)` / `Transition<S>` / `transition.animateFloat { }` → now: **Implemented**, same-name, built on the same `Animatable`/`SpringScalar` core; per-child running/settled semantics rather than Compose's shared total-duration play-time model (documented in `transition.rs`).

## Verification (all run locally, not just CI)

- `just fmt` — clean (nightly toolchain, as required)
- `just clippy` — full workspace, `-D warnings`, clean
- `just clippy-wasm` — clean
- `cargo test --profile ci --workspace --no-fail-fast` — 161 test binaries, 0 failed (cranpose-animation: 48 unit + 5 integration tests, all passing)
- `cargo xtask duplication-gate --base origin/main` — 0 clones introduced by this diff
- `cargo doc --no-deps -p cranpose-animation` with `-D warnings` — clean (fixed two broken intra-doc links surfaced by the refactor)

## Test plan

- [x] Failing tests written first for: retargeting mid-flight continues rather than restarts from zero (per new type); a transition with three children stays running until the slowest settles; changing target state mid-transition retargets rather than snaps
- [x] All tests deterministic — driven via explicit frame-clock stepping (`runtime.drain_frame_callbacks`), no sleeping
- [x] Full verification suite above, run locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)