### PR TITLE
Rename the draw-scope TextStyle so two TextStyles stop sharing a name

### DIFF
--- a/crates/cranpose-render/common/src/primitive_emit.rs
+++ b/crates/cranpose-render/common/src/primitive_emit.rs
@@ -893,9 +893,7 @@ mod tests {
 
     use std::rc::Rc as StdRc;
 
-    use cranpose_ui_graphics::{
-        FontWeight as DrawFontWeight, TextPrimitive, TextStyle as DrawTextStyle,
-    };
+    use cranpose_ui_graphics::{DrawTextStyle, FontWeight as DrawFontWeight, TextPrimitive};
 
     #[derive(Default)]
     struct CollectingTextSink {

--- a/crates/cranpose-render/common/tests/draw_scope_text_raster.rs
+++ b/crates/cranpose-render/common/tests/draw_scope_text_raster.rs
@@ -5,10 +5,8 @@ use cranpose_render_common::software_text_raster::{
     SoftwareTextMeasurer, collect_solid_text_atlas_run,
     software_text_font_set_from_fonts_or_default,
 };
-use cranpose_ui::text::{
-    AnnotatedString, TextMeasurer, TextStyle as UiTextStyle, text_style_for_draw_style,
-};
-use cranpose_ui_graphics::{Color, Rect, TextStyle};
+use cranpose_ui::text::{AnnotatedString, TextMeasurer, TextStyle, text_style_for_draw_style};
+use cranpose_ui_graphics::{Color, DrawTextStyle, Rect};
 
 const GLYPH_CACHE_CAPACITY: usize = 512;
 
@@ -20,7 +18,7 @@ fn measurer() -> SoftwareTextMeasurer {
     SoftwareTextMeasurer::from_font_set(fonts(), 256)
 }
 
-fn measured_block(origin: (f32, f32), text: &str, style: &TextStyle) -> (Rect, UiTextStyle) {
+fn measured_block(origin: (f32, f32), text: &str, style: &DrawTextStyle) -> (Rect, TextStyle) {
     let ui_style = text_style_for_draw_style(style);
     let measurer = measurer();
     let metrics = measurer.measure(&AnnotatedString::from(text), &ui_style);
@@ -40,8 +38,8 @@ fn measured_block(origin: (f32, f32), text: &str, style: &TextStyle) -> (Rect, U
 fn collect(
     rect: Rect,
     text: &str,
-    ui_style: &UiTextStyle,
-    style: &TextStyle,
+    ui_style: &TextStyle,
+    style: &DrawTextStyle,
     cache: &mut SoftwareGlyphRasterCache,
 ) -> Vec<SoftwareGlyphAtlasRunGlyph> {
     let mut run = Vec::new();
@@ -62,7 +60,7 @@ fn collect(
 
 #[test]
 fn every_glyph_lands_inside_the_block_measure_text_reported() {
-    let style = TextStyle::new(24.0);
+    let style = DrawTextStyle::new(24.0);
     let (rect, ui_style) = measured_block((40.0, 60.0), "SCORE 1234", &style);
     let mut cache = SoftwareGlyphRasterCache::with_capacity_at_least_one(GLYPH_CACHE_CAPACITY);
     let run = collect(rect, "SCORE 1234", &ui_style, &style, &mut cache);
@@ -90,7 +88,7 @@ fn every_glyph_lands_inside_the_block_measure_text_reported() {
 
 #[test]
 fn a_wider_string_measures_wider_and_draws_wider() {
-    let style = TextStyle::new(20.0);
+    let style = DrawTextStyle::new(20.0);
     let mut cache = SoftwareGlyphRasterCache::with_capacity_at_least_one(GLYPH_CACHE_CAPACITY);
     let mut ink_right = |text: &str| {
         let (rect, ui_style) = measured_block((0.0, 0.0), text, &style);
@@ -116,7 +114,7 @@ fn a_wider_string_measures_wider_and_draws_wider() {
 
 #[test]
 fn a_stable_string_rasterizes_once_and_is_served_from_the_glyph_cache_after_that() {
-    let style = TextStyle::new(18.0);
+    let style = DrawTextStyle::new(18.0);
     let (rect, ui_style) = measured_block((10.0, 10.0), "FPS 60", &style);
     let mut cache = SoftwareGlyphRasterCache::with_capacity_at_least_one(GLYPH_CACHE_CAPACITY);
 
@@ -147,7 +145,7 @@ fn a_stable_string_rasterizes_once_and_is_served_from_the_glyph_cache_after_that
 
 #[test]
 fn only_the_new_characters_of_a_changing_counter_rasterize() {
-    let style = TextStyle::new(18.0);
+    let style = DrawTextStyle::new(18.0);
     let mut cache = SoftwareGlyphRasterCache::with_capacity_at_least_one(GLYPH_CACHE_CAPACITY);
     for score in 0..10 {
         let text = format!("SCORE {score}");
@@ -164,7 +162,7 @@ fn only_the_new_characters_of_a_changing_counter_rasterize() {
 
 #[test]
 fn an_unknown_font_family_falls_back_to_the_framework_font() {
-    let style = TextStyle::new(20.0).with_font_family("No Such Family At All");
+    let style = DrawTextStyle::new(20.0).with_font_family("No Such Family At All");
     let (rect, ui_style) = measured_block((0.0, 0.0), "AB", &style);
     assert!(
         rect.width > 0.0,
@@ -181,7 +179,7 @@ fn an_unknown_font_family_falls_back_to_the_framework_font() {
 #[test]
 fn characters_the_font_cannot_draw_measure_and_collect_without_panicking() {
     let text = "A\u{E000}\u{10FFFD}B";
-    let style = TextStyle::new(20.0);
+    let style = DrawTextStyle::new(20.0);
     let (rect, ui_style) = measured_block((0.0, 0.0), text, &style);
     assert!(rect.width > 0.0 && rect.height > 0.0);
 
@@ -196,7 +194,7 @@ fn characters_the_font_cannot_draw_measure_and_collect_without_panicking() {
 
 #[test]
 fn multiline_text_stacks_by_the_line_height_it_was_measured_with() {
-    let style = TextStyle::new(16.0);
+    let style = DrawTextStyle::new(16.0);
     let (rect, ui_style) = measured_block((0.0, 0.0), "AB\nCD", &style);
     let measured_line_height = rect.height / 2.0;
 
@@ -215,7 +213,7 @@ fn multiline_text_stacks_by_the_line_height_it_was_measured_with() {
 
 #[test]
 fn the_measured_baseline_is_the_row_glyphs_are_actually_placed_on() {
-    let style = TextStyle::new(32.0);
+    let style = DrawTextStyle::new(32.0);
     let ui_style = text_style_for_draw_style(&style);
     let baseline = measurer()
         .first_baseline(&ui_style)
@@ -237,7 +235,7 @@ fn a_drawn_run_that_names_a_line_height_policy_is_laid_out_by_it() {
     use cranpose_ui::text::{LineHeightAlignment, LineHeightMode, LineHeightStyle, LineHeightTrim};
 
     let asked = 30.0;
-    let plain = TextStyle::new(32.0).with_line_height(asked);
+    let plain = DrawTextStyle::new(32.0).with_line_height(asked);
     let styled = plain.clone().with_line_height_style(LineHeightStyle {
         alignment: LineHeightAlignment::Center,
         trim: LineHeightTrim::None,
@@ -288,10 +286,10 @@ fn a_drawn_run_that_names_a_line_height_policy_is_laid_out_by_it() {
 fn letter_spacing_pads_a_run_with_half_a_space_at_each_edge() {
     const WORD: &str = "ORBIT";
     const TRACKING: f32 = 5.0;
-    let plain = TextStyle::new(20.0);
-    let tracked = TextStyle::new(20.0).with_letter_spacing(TRACKING);
+    let plain = DrawTextStyle::new(20.0);
+    let tracked = DrawTextStyle::new(20.0).with_letter_spacing(TRACKING);
     let mut cache = SoftwareGlyphRasterCache::with_capacity_at_least_one(GLYPH_CACHE_CAPACITY);
-    let mut spans = |style: &TextStyle| {
+    let mut spans = |style: &DrawTextStyle| {
         let (rect, ui_style) = measured_block((0.0, 0.0), WORD, style);
         let run = collect(rect, WORD, &ui_style, style, &mut cache);
         let left = run

--- a/crates/cranpose-render/wgpu/src/pipeline.rs
+++ b/crates/cranpose-render/wgpu/src/pipeline.rs
@@ -4655,7 +4655,7 @@ mod tests {
         DrawPrimitive::Text(Box::new(cranpose_ui_graphics::TextPrimitive {
             rect,
             text: std::rc::Rc::from(text),
-            style: cranpose_ui_graphics::TextStyle::new(16.0),
+            style: cranpose_ui_graphics::DrawTextStyle::new(16.0),
             color: cranpose_ui_graphics::Color::WHITE,
         }))
     }

--- a/crates/cranpose-render/wgpu/src/surface_plan.rs
+++ b/crates/cranpose-render/wgpu/src/surface_plan.rs
@@ -1196,7 +1196,7 @@ mod tests {
                         height: 20.0,
                     },
                     text: std::rc::Rc::from("SCORE"),
-                    style: cranpose_ui_graphics::TextStyle::new(16.0),
+                    style: cranpose_ui_graphics::DrawTextStyle::new(16.0),
                     color: cranpose_ui_graphics::Color::WHITE,
                 })),
                 clip: None,

--- a/crates/cranpose-ui-graphics/src/geometry.rs
+++ b/crates/cranpose-ui-graphics/src/geometry.rs
@@ -6,7 +6,7 @@ use crate::{
     Brush, Color, ColorFilter, ImageBitmap, ImageSampling,
     stroke::{ArcGeometry, Stroke, arc_band},
     typography::{
-        DrawTextMeasurer, TextAlign, TextMeasurement, TextStyle, TextVerticalAlign,
+        DrawTextMeasurer, DrawTextStyle, TextAlign, TextMeasurement, TextVerticalAlign,
         estimate_text_measurement,
     },
 };
@@ -565,7 +565,7 @@ pub enum DrawPrimitive {
 /// A run of text, positioned and ready to rasterize.
 ///
 /// `rect` is *already resolved*: [`DrawScope::draw_text_at`] measures the
-/// string, applies [`TextStyle::align`] / [`TextStyle::vertical_align`] inside
+/// string, applies [`DrawTextStyle::align`] / [`DrawTextStyle::vertical_align`] inside
 /// the requested box, and stores the result here. Renderers therefore lay the
 /// glyphs out from `rect`'s top-left and never re-align — which is what keeps
 /// what [`DrawScope::measure_text`] reported and what lands on screen the same
@@ -578,7 +578,7 @@ pub struct TextPrimitive {
     /// Shared so redrawing an unchanged string each frame clones a pointer
     /// rather than the characters.
     pub text: std::rc::Rc<str>,
-    pub style: TextStyle,
+    pub style: DrawTextStyle,
     /// Text is filled with a single color: the glyph atlas path modulates one
     /// vertex color per glyph. Gradient brushes are resolved to their first
     /// stop by the draw scope, exactly like [`DrawScope::draw_vector_path`].
@@ -863,28 +863,28 @@ pub trait DrawScope {
     /// Free to call repeatedly: the underlying text stack caches metrics on
     /// `(text, style)`, so a game can measure every label every frame to center
     /// it without touching a font file more than once.
-    fn measure_text(&self, text: &str, style: &TextStyle) -> TextMeasurement;
+    fn measure_text(&self, text: &str, style: &DrawTextStyle) -> TextMeasurement;
 
     /// Draws `text` inside the whole scope rect, positioned by
-    /// [`TextStyle::align`] and [`TextStyle::vertical_align`].
-    fn draw_text(&mut self, brush: Brush, text: &str, style: &TextStyle) {
+    /// [`DrawTextStyle::align`] and [`DrawTextStyle::vertical_align`].
+    fn draw_text(&mut self, brush: Brush, text: &str, style: &DrawTextStyle) {
         self.draw_text_at(Rect::from_size(self.size()), brush, text, style);
     }
 
-    /// Draws `text` inside `rect`, positioned by [`TextStyle::align`] and
-    /// [`TextStyle::vertical_align`].
+    /// Draws `text` inside `rect`, positioned by [`DrawTextStyle::align`] and
+    /// [`DrawTextStyle::vertical_align`].
     ///
     /// The glyphs are *not* clipped to `rect` — it is an alignment box, not a
     /// viewport. A `rect` narrower than the measured text overflows in the
     /// direction the alignment implies; clip the layer if that matters.
-    fn draw_text_at(&mut self, rect: Rect, brush: Brush, text: &str, style: &TextStyle);
+    fn draw_text_at(&mut self, rect: Rect, brush: Brush, text: &str, style: &DrawTextStyle);
 
     /// Draws `text` with the top-left corner of its block at `top_left`.
     ///
     /// Alignment is a no-op here because the box is the measurement — this is
     /// the "I already know where it goes" form, and the one to pair with
     /// [`measure_text`](Self::measure_text) for hand-rolled centering.
-    fn draw_text_from(&mut self, top_left: Point, brush: Brush, text: &str, style: &TextStyle) {
+    fn draw_text_from(&mut self, top_left: Point, brush: Brush, text: &str, style: &DrawTextStyle) {
         if text.is_empty() {
             return;
         }
@@ -893,7 +893,7 @@ pub trait DrawScope {
             Rect::from_origin_size(top_left, measurement.size),
             brush,
             text,
-            &TextStyle {
+            &DrawTextStyle {
                 align: TextAlign::Left,
                 vertical_align: TextVerticalAlign::Top,
                 ..style.clone()
@@ -909,7 +909,7 @@ pub trait DrawScope {
 ///
 /// Split out so the placement rule is stated once and can be unit-tested
 /// against the measurement it is derived from.
-pub fn align_text_block(rect: Rect, measurement: TextMeasurement, style: &TextStyle) -> Point {
+pub fn align_text_block(rect: Rect, measurement: TextMeasurement, style: &DrawTextStyle) -> Point {
     let x = match style.align {
         TextAlign::Left => rect.x,
         TextAlign::Center => rect.x + (rect.width - measurement.size.width) * 0.5,
@@ -2121,14 +2121,14 @@ impl DrawScope for DrawScopeDefault {
         });
     }
 
-    fn measure_text(&self, text: &str, style: &TextStyle) -> TextMeasurement {
+    fn measure_text(&self, text: &str, style: &DrawTextStyle) -> TextMeasurement {
         match &self.text_measurer {
             Some(measurer) => measurer.measure_text(text, style),
             None => estimate_text_measurement(text, style),
         }
     }
 
-    fn draw_text_at(&mut self, rect: Rect, brush: Brush, text: &str, style: &TextStyle) {
+    fn draw_text_at(&mut self, rect: Rect, brush: Brush, text: &str, style: &DrawTextStyle) {
         if text.is_empty() {
             return;
         }
@@ -2516,7 +2516,7 @@ mod tests {
             line_count: 1,
         };
         let style = |align, vertical| {
-            TextStyle::default()
+            DrawTextStyle::default()
                 .with_align(align)
                 .with_vertical_align(vertical)
         };
@@ -3290,7 +3290,7 @@ mod tests {
     }
 
     impl DrawTextMeasurer for FixedAdvanceTextMeasurer {
-        fn measure_text(&self, text: &str, _style: &TextStyle) -> TextMeasurement {
+        fn measure_text(&self, text: &str, _style: &DrawTextStyle) -> TextMeasurement {
             self.calls.set(self.calls.get() + 1);
             let lines: Vec<&str> = text.split('\n').collect();
             let width = lines
@@ -3324,7 +3324,7 @@ mod tests {
     #[test]
     fn drawn_text_occupies_exactly_the_box_measure_text_reported() {
         let (mut scope, _) = text_scope(Size::new(200.0, 100.0));
-        let style = TextStyle::new(16.0);
+        let style = DrawTextStyle::new(16.0);
         let measured = scope.measure_text("ABCD", &style);
 
         scope.draw_text_from(
@@ -3366,7 +3366,7 @@ mod tests {
         ];
         for (align, vertical_align, expected_x, expected_y) in cases {
             let (mut scope, _) = text_scope(Size::new(400.0, 400.0));
-            let style = TextStyle::new(16.0)
+            let style = DrawTextStyle::new(16.0)
                 .with_align(align)
                 .with_vertical_align(vertical_align);
             scope.draw_text_at(box_rect, Brush::solid(Color::WHITE), "AB", &style);
@@ -3384,7 +3384,7 @@ mod tests {
     #[test]
     fn baseline_aligned_text_hangs_above_the_box_edge() {
         let (mut scope, _) = text_scope(Size::new(200.0, 200.0));
-        let style = TextStyle::new(16.0).with_vertical_align(TextVerticalAlign::Baseline);
+        let style = DrawTextStyle::new(16.0).with_vertical_align(TextVerticalAlign::Baseline);
         let measured = scope.measure_text("Ag", &style);
         scope.draw_text_at(
             Rect {
@@ -3409,7 +3409,7 @@ mod tests {
     #[test]
     fn draw_text_fills_the_whole_scope_rect() {
         let (mut scope, _) = text_scope(Size::new(120.0, 60.0));
-        let style = TextStyle::new(16.0)
+        let style = DrawTextStyle::new(16.0)
             .with_align(TextAlign::Right)
             .with_vertical_align(TextVerticalAlign::Bottom);
         scope.draw_text(Brush::solid(Color::WHITE), "AB", &style);
@@ -3425,7 +3425,7 @@ mod tests {
     #[test]
     fn draw_text_from_ignores_alignment_and_anchors_the_top_left() {
         let (mut scope, _) = text_scope(Size::new(400.0, 400.0));
-        let style = TextStyle::new(16.0)
+        let style = DrawTextStyle::new(16.0)
             .with_align(TextAlign::Center)
             .with_vertical_align(TextVerticalAlign::Bottom);
         scope.draw_text_from(
@@ -3446,7 +3446,7 @@ mod tests {
     #[test]
     fn multiline_text_measures_the_widest_line_and_stacks_the_lines() {
         let (mut scope, _) = text_scope(Size::new(400.0, 400.0));
-        let style = TextStyle::new(16.0);
+        let style = DrawTextStyle::new(16.0);
         scope.draw_text_from(Point::ZERO, Brush::solid(Color::WHITE), "AB\nABCDE", &style);
         let primitives = scope.into_primitives();
         let text = unwrap_text(&primitives[0]);
@@ -3457,18 +3457,18 @@ mod tests {
     #[test]
     fn empty_text_draws_nothing_and_never_measures() {
         let (mut scope, measurer) = text_scope(Size::new(100.0, 100.0));
-        scope.draw_text(Brush::solid(Color::WHITE), "", &TextStyle::new(16.0));
+        scope.draw_text(Brush::solid(Color::WHITE), "", &DrawTextStyle::new(16.0));
         scope.draw_text_at(
             Rect::from_size(Size::new(10.0, 10.0)),
             Brush::solid(Color::WHITE),
             "",
-            &TextStyle::new(16.0),
+            &DrawTextStyle::new(16.0),
         );
         scope.draw_text_from(
             Point::ZERO,
             Brush::solid(Color::WHITE),
             "",
-            &TextStyle::new(16.0),
+            &DrawTextStyle::new(16.0),
         );
         assert!(scope.into_primitives().is_empty());
         assert_eq!(
@@ -3481,7 +3481,7 @@ mod tests {
     #[test]
     fn invisible_text_draws_nothing() {
         let (mut scope, _) = text_scope(Size::new(100.0, 100.0));
-        let style = TextStyle::new(16.0);
+        let style = DrawTextStyle::new(16.0);
         scope.draw_text(Brush::solid(Color(1.0, 1.0, 1.0, 0.0)), "AB", &style);
         scope.draw_text(
             Brush::LinearGradient {
@@ -3503,7 +3503,7 @@ mod tests {
         scope.draw_text(
             Brush::linear_gradient(vec![Color::RED, Color::BLUE]),
             "AB",
-            &TextStyle::new(16.0),
+            &DrawTextStyle::new(16.0),
         );
         let primitives = scope.into_primitives();
         assert_eq!(unwrap_text(&primitives[0]).color, Color::RED);
@@ -3512,7 +3512,7 @@ mod tests {
     #[test]
     fn a_scope_without_a_measurer_falls_back_to_the_font_free_estimate() {
         let mut scope = DrawScopeDefault::new(Size::new(100.0, 100.0));
-        let style = TextStyle::new(16.0);
+        let style = DrawTextStyle::new(16.0);
         assert_eq!(
             scope.measure_text("ABC", &style),
             crate::estimate_text_measurement("ABC", &style)
@@ -3527,7 +3527,7 @@ mod tests {
     fn degenerate_text_geometry_emits_nothing_and_never_panics() {
         struct DegenerateTextMeasurer;
         impl DrawTextMeasurer for DegenerateTextMeasurer {
-            fn measure_text(&self, _text: &str, _style: &TextStyle) -> TextMeasurement {
+            fn measure_text(&self, _text: &str, _style: &DrawTextStyle) -> TextMeasurement {
                 TextMeasurement {
                     size: Size::new(f32::NAN, 0.0),
                     line_height: f32::NAN,
@@ -3541,7 +3541,7 @@ mod tests {
             Size::new(50.0, 50.0),
             Rc::new(DegenerateTextMeasurer),
         );
-        scope.draw_text(Brush::solid(Color::WHITE), "AB", &TextStyle::new(16.0));
+        scope.draw_text(Brush::solid(Color::WHITE), "AB", &DrawTextStyle::new(16.0));
         scope.draw_text_at(
             Rect {
                 x: f32::NAN,
@@ -3551,7 +3551,7 @@ mod tests {
             },
             Brush::solid(Color::WHITE),
             "AB",
-            &TextStyle::new(16.0),
+            &DrawTextStyle::new(16.0),
         );
         assert!(
             scope.into_primitives().is_empty(),
@@ -3562,7 +3562,7 @@ mod tests {
     #[test]
     fn text_style_survives_lowering_into_the_primitive() {
         let (mut scope, _) = text_scope(Size::new(100.0, 100.0));
-        let style = TextStyle::new(21.0)
+        let style = DrawTextStyle::new(21.0)
             .with_font_family("Fira Sans")
             .with_weight(FontWeight::BOLD)
             .with_style(FontStyle::Italic)

--- a/crates/cranpose-ui-graphics/src/render_hash.rs
+++ b/crates/cranpose-ui-graphics/src/render_hash.rs
@@ -369,7 +369,7 @@ fn hash_draw_primitive<H: Hasher>(primitive: &DrawPrimitive, state: &mut H) {
     }
 }
 
-fn hash_text_style<H: Hasher>(style: &crate::TextStyle, state: &mut H) {
+fn hash_text_style<H: Hasher>(style: &crate::DrawTextStyle, state: &mut H) {
     style.font_family.hash(state);
     hash_f32_bits(style.font_size, state);
     style.font_weight.hash(state);

--- a/crates/cranpose-ui-graphics/src/typography.rs
+++ b/crates/cranpose-ui-graphics/src/typography.rs
@@ -4,7 +4,7 @@
 //! of text that [`crate::DrawScope`] can hand to a renderer. The full typography
 //! model (annotated strings, span/paragraph styles, decorations, hyphenation)
 //! lives in `cranpose-ui`, which is above this crate in the dependency graph —
-//! `cranpose-ui` maps a [`TextStyle`] onto that richer model, and both
+//! `cranpose-ui` maps a [`DrawTextStyle`] onto that richer model, and both
 //! measurement and rasterization go through that one mapping.
 
 use crate::geometry::Size;
@@ -156,7 +156,7 @@ impl Default for LineHeightStyle {
 /// `(text, style)` pair, so a style rebuilt with identical values still hits
 /// the cache.
 #[derive(Clone, Debug, PartialEq)]
-pub struct TextStyle {
+pub struct DrawTextStyle {
     /// Family name to resolve against the fonts the app registered. `None`
     /// asks for the framework's default family.
     ///
@@ -179,7 +179,7 @@ pub struct TextStyle {
     pub vertical_align: TextVerticalAlign,
 }
 
-impl TextStyle {
+impl DrawTextStyle {
     /// The size used when a style carries a non-positive or non-finite one.
     /// Matches the framework-wide text default.
     pub const DEFAULT_FONT_SIZE: f32 = 14.0;
@@ -240,7 +240,7 @@ impl TextStyle {
     }
 
     /// The font size a measurer/rasterizer will actually use. Non-finite and
-    /// non-positive sizes fall back to [`TextStyle::DEFAULT_FONT_SIZE`] instead
+    /// non-positive sizes fall back to [`DrawTextStyle::DEFAULT_FONT_SIZE`] instead
     /// of producing NaN geometry.
     pub fn resolved_font_size(&self) -> f32 {
         if self.font_size.is_finite() && self.font_size > 0.0 {
@@ -269,7 +269,7 @@ impl TextStyle {
     }
 }
 
-impl Default for TextStyle {
+impl Default for DrawTextStyle {
     fn default() -> Self {
         Self {
             font_family: None,
@@ -326,7 +326,7 @@ impl TextMeasurement {
 /// back to [`estimate_text_measurement`], which is good enough for layout
 /// smoke tests and wrong for anything that has to line up with real glyphs.
 pub trait DrawTextMeasurer {
-    fn measure_text(&self, text: &str, style: &TextStyle) -> TextMeasurement;
+    fn measure_text(&self, text: &str, style: &DrawTextStyle) -> TextMeasurement;
 }
 
 /// Font-free estimate used when no [`DrawTextMeasurer`] is installed.
@@ -335,7 +335,7 @@ pub trait DrawTextMeasurer {
 /// split typical of a UI sans face, so the shape of the result (and the
 /// baseline formula) matches what a real font measurer returns even though the
 /// numbers do not.
-pub fn estimate_text_measurement(text: &str, style: &TextStyle) -> TextMeasurement {
+pub fn estimate_text_measurement(text: &str, style: &DrawTextStyle) -> TextMeasurement {
     const CHAR_WIDTH_RATIO: f32 = 0.6;
     const ASCENT_RATIO: f32 = 0.8;
     const NATURAL_LINE_HEIGHT_RATIO: f32 = 1.0;
@@ -372,7 +372,7 @@ mod tests {
 
     #[test]
     fn letter_spacing_resolves_to_something_a_measurer_can_use() {
-        let style = TextStyle::default().with_font_size(18.0);
+        let style = DrawTextStyle::default().with_font_size(18.0);
         assert_eq!(style.font_size, 18.0);
         assert_eq!(style.resolved_font_size(), 18.0);
         assert_eq!(style.resolved_letter_spacing(), 0.0);
@@ -404,10 +404,10 @@ mod tests {
 
         for broken in [0.0, -12.0, f32::NAN, f32::INFINITY] {
             assert_eq!(
-                TextStyle::default()
+                DrawTextStyle::default()
                     .with_font_size(broken)
                     .resolved_font_size(),
-                TextStyle::DEFAULT_FONT_SIZE
+                DrawTextStyle::DEFAULT_FONT_SIZE
             );
         }
     }
@@ -417,17 +417,17 @@ mod tests {
     fn text_style_resolves_degenerate_sizes_to_the_framework_default() {
         for size in [0.0, -12.0, f32::NAN, f32::INFINITY] {
             assert_eq!(
-                TextStyle::new(size).resolved_font_size(),
-                TextStyle::DEFAULT_FONT_SIZE,
+                DrawTextStyle::new(size).resolved_font_size(),
+                DrawTextStyle::DEFAULT_FONT_SIZE,
                 "font size {size} must not reach a font backend"
             );
         }
-        assert_eq!(TextStyle::new(19.0).resolved_font_size(), 19.0);
+        assert_eq!(DrawTextStyle::new(19.0).resolved_font_size(), 19.0);
     }
 
     #[test]
     fn text_style_line_height_falls_back_to_the_natural_one() {
-        let style = TextStyle::new(20.0);
+        let style = DrawTextStyle::new(20.0);
         assert_eq!(style.resolved_line_height(28.0), 28.0);
         assert_eq!(
             style
@@ -444,9 +444,12 @@ mod tests {
 
     #[test]
     fn empty_font_family_name_means_the_default_family() {
-        assert_eq!(TextStyle::new(14.0).with_font_family("").font_family, None);
         assert_eq!(
-            TextStyle::new(14.0)
+            DrawTextStyle::new(14.0).with_font_family("").font_family,
+            None
+        );
+        assert_eq!(
+            DrawTextStyle::new(14.0)
                 .with_font_family("Fira Sans")
                 .font_family,
             Some("Fira Sans".to_string())
@@ -455,7 +458,7 @@ mod tests {
 
     #[test]
     fn estimated_measurement_grows_with_the_longest_line() {
-        let style = TextStyle::new(10.0);
+        let style = DrawTextStyle::new(10.0);
         let one = estimate_text_measurement("AAAA", &style);
         let two = estimate_text_measurement("AAAA\nAAAAAAAA", &style);
         assert_eq!(one.line_count, 1);
@@ -466,7 +469,7 @@ mod tests {
 
     #[test]
     fn estimated_measurement_of_an_empty_string_keeps_one_line_of_metrics() {
-        let measurement = estimate_text_measurement("", &TextStyle::new(16.0));
+        let measurement = estimate_text_measurement("", &DrawTextStyle::new(16.0));
         assert_eq!(measurement.size, Size::ZERO);
         assert_eq!(measurement.line_count, 1);
         assert!(measurement.line_height > 0.0);
@@ -475,7 +478,7 @@ mod tests {
 
     #[test]
     fn estimated_baseline_sits_inside_the_line_slot() {
-        let measurement = estimate_text_measurement("Ag", &TextStyle::new(24.0));
+        let measurement = estimate_text_measurement("Ag", &DrawTextStyle::new(24.0));
         assert!(measurement.first_baseline > 0.0);
         assert!(measurement.first_baseline < measurement.line_height);
     }

--- a/crates/cranpose-ui/src/text/draw_scope_text.rs
+++ b/crates/cranpose-ui/src/text/draw_scope_text.rs
@@ -12,8 +12,8 @@
 use std::rc::Rc;
 
 use cranpose_ui_graphics::{
-    DrawTextMeasurer, FontStyle as DrawFontStyle, Size, TextMeasurement,
-    TextStyle as DrawTextStyle, estimate_text_measurement,
+    DrawTextMeasurer, DrawTextStyle, FontStyle as DrawFontStyle, Size, TextMeasurement,
+    estimate_text_measurement,
 };
 
 use super::{

--- a/crates/cranpose-ui/src/text/line_box.rs
+++ b/crates/cranpose-ui/src/text/line_box.rs
@@ -25,7 +25,7 @@
 //! of text that never asked. The Wear widgets ask for it through
 //! [`WearTextStyle`](crate::widgets::wear::WearTextStyle), and a
 //! [`DrawScope`](cranpose_ui_graphics::DrawScope) run asks for it through
-//! [`TextStyle::with_line_height_style`](cranpose_ui_graphics::TextStyle::with_line_height_style)
+//! [`DrawTextStyle::with_line_height_style`](cranpose_ui_graphics::DrawTextStyle::with_line_height_style)
 //! — which is what lets a canvas and a `Text` on one screen agree.
 
 use crate::text::style::{

--- a/crates/cranpose-ui/src/widgets/canvas.rs
+++ b/crates/cranpose-ui/src/widgets/canvas.rs
@@ -28,7 +28,7 @@ use crate::{composable, layout::policies::LeafMeasurePolicy, modifier::Modifier,
 ///
 /// ```ignore
 /// Canvas(Modifier::empty().fill_max_size(), |scope| {
-///     let style = TextStyle::new(24.0)
+///     let style = DrawTextStyle::new(24.0)
 ///         .with_weight(FontWeight::BOLD)
 ///         .with_align(TextAlign::Center);
 ///     // Centered in the whole canvas.

--- a/crates/cranpose-ui/tests/draw_scope_text_integration.rs
+++ b/crates/cranpose-ui/tests/draw_scope_text_integration.rs
@@ -6,8 +6,8 @@ use cranpose_ui::{
     text::{AnnotatedString, TextLayoutResult},
 };
 use cranpose_ui_graphics::{
-    Brush, Color, DrawPrimitive, DrawScope, Point, Rect, Size, TextAlign,
-    TextStyle as DrawTextStyle, TextVerticalAlign, estimate_text_measurement,
+    Brush, Color, DrawPrimitive, DrawScope, DrawTextStyle, Point, Rect, Size, TextAlign,
+    TextVerticalAlign, estimate_text_measurement,
 };
 
 const CHAR_WIDTH: f32 = 6.0;


### PR DESCRIPTION
## Summary

`docs/compose_api_parity.md` flagged two distinct `TextStyle` structs and left the intent unresolved. This PR does the git-blame/field/call-site dig and acts on the conclusion.

**Finding**: `cranpose-ui-graphics::typography::TextStyle` (2025-10-17, `6878e0aa`) and `cranpose-ui::text::style::TextStyle` (2026-02-06, `27126be3`) are not drift — they are a real architectural split, the way `cranpose-ui-graphics` sits below fonts and the text-layout engine in the dependency graph:

- `cranpose-ui-graphics::TextStyle` is a **resolved, self-positioning draw primitive**: plain `f32` sizes, no theme/inheritance, and it uniquely carries `align`/`vertical_align` because a canvas draw call has no parent layout to position it.
- `cranpose-ui::TextStyle` is an **authored, Compose-parity style** (`TextStyle { span_style, paragraph_style }`, matching `androidx.compose.ui.text.TextStyle`'s own split) consumed by the `Text` composable, with `TextUnit` sizes that only resolve at measure time.

A single documented conversion function (`text_style_for_draw_style`) maps one into the other and is deliberately partial (it does not carry `align` forward, because the draw scope already consumed it to place the primitive's rect before calling in). Not lossy — intentional.

**Verdict: keep two types, rename.** The identical name was already a felt problem, not hypothetical — four files had independently invented `use ... TextStyle as DrawTextStyle` / `as UiTextStyle` local aliases, and one doc intra-link had to fully-qualify itself to disambiguate from the bare `TextStyle` already in scope. This PR formalizes the name those call sites kept reinventing.

## Changes

- Renamed `cranpose-ui-graphics::typography::TextStyle` → `DrawTextStyle` (struct, impls, `Default`, its own unit tests).
- Propagated through every signature in `cranpose-ui-graphics::geometry` that names it (`DrawScope::draw_text`/`measure_text`/`draw_text_at`/`draw_text_from`/`align_text_block`, `DrawTextMeasurer`) and `render_hash.rs`.
- Dropped the now-redundant local aliases in `cranpose-ui/src/text/draw_scope_text.rs`, `cranpose-ui/tests/draw_scope_text_integration.rs`, `cranpose-render/common/src/primitive_emit.rs`, `cranpose-render/common/tests/draw_scope_text_raster.rs` — they now import the real name directly.
- Fixed two fully-qualified `cranpose_ui_graphics::TextStyle::new(...)` call sites in `cranpose-render/wgpu/src/{pipeline.rs,surface_plan.rs}`.
- Fixed a doc intra-link in `cranpose-ui/src/text/line_box.rs` and a doc example in `cranpose-ui/src/widgets/canvas.rs` that used the bare `TextStyle` name to mean the graphics one.
- `cranpose_ui::text::style::TextStyle` is untouched — same name, same fields, matches Compose.

Pure rename: no field added, removed, or reinterpreted; no change to how any text size is stored or typed (`DrawTextStyle.font_size` stays plain `f32`, `TextStyle.span_style.font_size` stays `TextUnit`). Diff is 11 files, 81 insertions / 82 deletions, all mechanical.

**Not touched**: `docs/compose_api_parity.md` (left for the coordinating pass — row `TextStyle`, `AnnotatedString` in the curated table and the "Two `TextStyle` types" section both need updating to reflect this resolution).

## Test plan

Run on the branch, in the branch's own worktree, after rebasing onto latest `main` (`7d0ea478`):

- [x] `just fmt` (nightly) — clean, no diff
- [x] `just clippy` — clean
- [x] `just clippy-robot` — clean
- [x] `just clippy-wasm` — clean
- [x] `just clippy-svg`, `just clippy-hyphenation`, `just clippy-optional-backends` — clean (extra coverage since this touches shared text plumbing)
- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test --profile ci --workspace --no-fail-fast` — 161 test-result blocks, all `ok`, zero failures
- [x] `just robot-build` — 125 robot examples compile and link

## Merge freeze

Per instructions: opening for review, **not merging** — merge freeze is on for the v0.1.107 release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)