### PR TITLE
Fix the glass edge stack: post-blur shadow cutout, resting frost transmission, pixel-resolvable rim bands

### DIFF
--- a/crates/cranpose-liquid/src/theme.rs
+++ b/crates/cranpose-liquid/src/theme.rs
@@ -39,6 +39,9 @@ pub struct LiquidColors {
     pub fill: Color,
     /// Lighter fill for nested controls.
     pub secondary_fill: Color,
+    /// Resting tint of a glass surface pane (cards, planks): the surface
+    /// role at pane translucency, so the backdrop transmits through it.
+    pub surface_glass: Color,
     /// Window background (grouped style).
     pub background: Color,
     /// Elevated surface (cards, list sections).
@@ -75,6 +78,7 @@ impl LiquidColors {
             separator: Color::from_rgba_u8(60, 60, 67, 56),
             fill: Color::from_rgba_u8(120, 120, 128, 40),
             secondary_fill: Color::from_rgba_u8(120, 120, 128, 28),
+            surface_glass: Color::from_rgba_u8(255, 255, 255, 191),
             background: Color::from_rgb_u8(242, 242, 247),
             surface: Color::WHITE,
             surface_pressed: Color::from_rgb_u8(226, 226, 231),
@@ -99,6 +103,7 @@ impl LiquidColors {
             separator: Color::from_rgba_u8(84, 84, 88, 130),
             fill: Color::from_rgba_u8(120, 120, 128, 70),
             secondary_fill: Color::from_rgba_u8(120, 120, 128, 50),
+            surface_glass: Color::from_rgba_u8(28, 28, 30, 184),
             background: Color::from_rgb_u8(10, 10, 12),
             surface: Color::from_rgb_u8(28, 28, 30),
             surface_pressed: Color::from_rgb_u8(44, 44, 46),

--- a/crates/cranpose-liquid/src/widgets/card.rs
+++ b/crates/cranpose-liquid/src/widgets/card.rs
@@ -7,9 +7,10 @@ use cranpose_ui::{
     text::{SpanStyle, TextStyle},
     widgets::{Box, BoxSpec, Column, ColumnSpec, Text},
 };
-use cranpose_ui_graphics::{Brush, Color, CornerRadii};
+use cranpose_ui_graphics::{Brush, CornerRadii};
 
 use crate::{
+    material::{Glass, GlassDynamics, LiquidModifierExt, LiquidShape},
     motion::LiquidMotion,
     theme::{liquid_colors, liquid_typography},
 };
@@ -39,28 +40,21 @@ pub fn Card(modifier: Modifier, content: impl FnMut() + 'static) {
     LiquidCard(modifier, content);
 }
 
-/// An elevated surface with the grouped-inset card look.
+/// An elevated glass pane with the grouped-inset card look: a resting pane
+/// that transmits its backdrop through the translucent surface wash.
 #[composable]
 #[allow(non_snake_case)]
 pub fn LiquidCard(modifier: Modifier, content: impl FnMut() + 'static) {
     let colors = liquid_colors();
-    let surface = colors.surface;
-    let shadow_alpha = if colors.is_dark { 0.35 } else { 0.07 };
-    let base = Modifier::empty()
-        .drop_shadow(
-            cranpose_ui_graphics::LayerShape::Rounded(
-                cranpose_ui_graphics::RoundedCornerShape::uniform(CARD_RADIUS),
-            ),
-            move |scope| {
-                scope.radius = 14.0;
-                scope.offset.y = 3.0;
-                scope.color = Color::BLACK.with_alpha(shadow_alpha);
-            },
-        )
-        .rounded_corners(CARD_RADIUS)
-        .draw_behind(move |scope| {
-            scope.draw_round_rect(Brush::solid(surface), CornerRadii::uniform(CARD_RADIUS));
-        });
+    let surface_glass = colors.surface_glass;
+    let base = Modifier::empty().glass_effect_with(
+        Glass::regular().shape(LiquidShape::RoundedRect(CARD_RADIUS)),
+        move || GlassDynamics {
+            activity: Some(0.0),
+            resting_tint: Some(surface_glass),
+            ..Default::default()
+        },
+    );
     Box(base.then(modifier), BoxSpec::default(), content);
 }
 

--- a/crates/cranpose-liquid/src/widgets/chip.rs
+++ b/crates/cranpose-liquid/src/widgets/chip.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, rc::Rc};
 
-use cranpose_animation::animateColorAsState;
+use cranpose_animation::{animateColorAsState, animateFloatAsState};
 use cranpose_macros::composable;
 use cranpose_services::{HapticFeedback, default_haptics};
 use cranpose_ui::{
@@ -8,17 +8,18 @@ use cranpose_ui::{
     text::{FontWeight, SpanStyle, TextStyle},
     widgets::{Box, BoxSpec, Text},
 };
-use cranpose_ui_graphics::{Brush, CornerRadii};
 use cranpose_ui_layout::Alignment;
 
 use crate::{
-    material::{Glass, LiquidModifierExt},
+    material::{Glass, GlassDynamics, LiquidModifierExt},
     motion::{LiquidMotion, liquid_press_scale},
     theme::{liquid_colors, liquid_typography},
 };
 
-/// A selectable filter pill (the Library "All / Receipts" chips). Selected
-/// chips render on glass; unselected ones sit on the fill color.
+/// A selectable filter pill (the Library "All / Receipts" chips). One
+/// persistent glass pane: selection raises its optical activity, and an
+/// unselected chip rests as a fill-washed pane that still transmits its
+/// backdrop.
 #[composable]
 #[allow(non_snake_case)]
 pub fn LiquidChip(
@@ -43,15 +44,20 @@ pub fn LiquidChip(
         "chip-label",
     );
 
-    let mut base = Modifier::empty();
-    if selected {
-        base = base.glass_effect(Glass::regular().adaptive_frost(colors.accent, 0.65));
-    } else {
-        let fill = colors.fill;
-        base = base.clip_to_bounds().draw_behind(move |scope| {
-            scope.draw_round_rect(Brush::solid(fill), CornerRadii::uniform(999.0));
-        });
-    }
+    let activity = animateFloatAsState(
+        if selected { 1.0 } else { 0.0 },
+        LiquidMotion::smooth(),
+        "chip-activity",
+    );
+    let fill = colors.fill;
+    let base = Modifier::empty().glass_effect_with(
+        Glass::regular().adaptive_frost(colors.accent, 0.65),
+        move || GlassDynamics {
+            activity: Some(activity.get()),
+            resting_tint: Some(fill),
+            ..Default::default()
+        },
+    );
 
     let on_click = Rc::new(RefCell::new(on_click));
     let base = base

--- a/crates/cranpose-render/wgpu/src/pipeline.rs
+++ b/crates/cranpose-render/wgpu/src/pipeline.rs
@@ -160,6 +160,7 @@ pub(crate) fn push_layer_shadow(
         );
         scene.push_shadow_draw(ShadowDraw {
             shapes: vec![shadow_shape(ambient_pass.rect, ambient, resolved_shape)],
+            post_blur_cutouts: vec![],
             brushes: vec![],
             texts: vec![],
             blur_radius: ambient_pass.blur_radius,
@@ -178,6 +179,7 @@ pub(crate) fn push_layer_shadow(
         );
         scene.push_shadow_draw(ShadowDraw {
             shapes: vec![shadow_shape(spot_pass.rect, spot, resolved_shape)],
+            post_blur_cutouts: vec![],
             brushes: vec![],
             texts: vec![],
             blur_radius: spot_pass.blur_radius,
@@ -796,6 +798,7 @@ impl TextStyleDrawSink for CompositorScene {
     ) {
         self.push_shadow_draw(ShadowDraw {
             shapes: vec![],
+            post_blur_cutouts: vec![],
             brushes: vec![],
             texts: vec![TextDraw {
                 node_id,
@@ -2131,7 +2134,7 @@ fn push_shadow_primitive(
             else {
                 return;
             };
-            let mut shapes = vec![shape_pair];
+            let mut post_blur_cutouts = Vec::new();
             if let Some(cutout) = cutout {
                 let Some(cutout_pair) = shape_pair_for_primitive(
                     *cutout,
@@ -2142,10 +2145,11 @@ fn push_shadow_primitive(
                 ) else {
                     return;
                 };
-                shapes.push(cutout_pair);
+                post_blur_cutouts.push(cutout_pair);
             }
             scene.push_shadow_draw(ShadowDraw {
-                shapes,
+                shapes: vec![shape_pair],
+                post_blur_cutouts,
                 brushes,
                 texts: vec![],
                 blur_radius,
@@ -2185,6 +2189,7 @@ fn push_shadow_primitive(
             let transformed_clip = apply_layer_to_rect(abs_clip, layer_bounds, layer);
             scene.push_shadow_draw(ShadowDraw {
                 shapes: vec![fill_pair, cutout_pair],
+                post_blur_cutouts: vec![],
                 brushes,
                 texts: vec![],
                 blur_radius,

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -1290,6 +1290,7 @@ fn hash_shape_shadow_item<H: Hasher>(
 
 fn shape_shadow_content_hash(
     shapes: &[(DrawShape, BlendMode)],
+    post_blur_cutouts: &[(DrawShape, BlendMode)],
     brushes: &[Brush],
     root_scale: f32,
 ) -> u64 {
@@ -1302,7 +1303,7 @@ fn shape_shadow_content_hash(
     });
 
     shapes.len().hash(&mut hasher);
-    for (shape, blend_mode) in shapes {
+    for (shape, blend_mode) in shapes.iter().chain(post_blur_cutouts) {
         hash_shape_shadow_item(
             shape,
             brushes,
@@ -1318,13 +1319,14 @@ fn shape_shadow_content_hash(
 
 fn shape_shadow_surface_cache_key(
     shapes: &[(DrawShape, BlendMode)],
+    post_blur_cutouts: &[(DrawShape, BlendMode)],
     brushes: &[Brush],
     device_bounds: DevicePixelBounds,
     pixel_radius: f32,
     root_scale: f32,
 ) -> Option<ShadowSurfaceCacheKey> {
     (root_scale.is_finite() && root_scale > 0.0).then(|| ShadowSurfaceCacheKey {
-        content_hash: shape_shadow_content_hash(shapes, brushes, root_scale),
+        content_hash: shape_shadow_content_hash(shapes, post_blur_cutouts, brushes, root_scale),
         pixel_size: [device_bounds.width, device_bounds.height],
         root_scale_bits: root_scale.to_bits(),
         blur_radius_bits: pixel_radius.to_bits(),
@@ -6413,6 +6415,7 @@ impl GpuRenderer {
         )?;
         let key = shape_shadow_surface_cache_key(
             &shadow.shapes,
+            &shadow.post_blur_cutouts,
             &shadow.brushes,
             plan.source_device_bounds,
             plan.pixel_radius,
@@ -10843,6 +10846,15 @@ impl GpuRenderer {
             );
         }
         frame_encoder.record_passes(2);
+        self.encode_post_blur_cutout_passes(
+            frame_encoder,
+            &source.view,
+            shadow,
+            bounds_w,
+            bounds_h,
+            viewport_offset,
+            root_scale,
+        );
 
         let clip_scissor = shadow
             .clip
@@ -10880,6 +10892,35 @@ impl GpuRenderer {
         self.effect_renderer.record_composite_pass();
         frame_encoder.release_transient_offscreen(scratch_descriptor, scratch);
         frame_encoder.release_transient_offscreen(source_descriptor, source);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn encode_post_blur_cutout_passes<C: FrameCommandRecorder>(
+        &mut self,
+        frame_encoder: &mut C,
+        source_view: &wgpu::TextureView,
+        shadow: &ShadowDraw,
+        width: u32,
+        height: u32,
+        viewport_offset: [f32; 2],
+        root_scale: f32,
+    ) {
+        if shadow.post_blur_cutouts.is_empty() {
+            return;
+        }
+        let mut load_op = wgpu::LoadOp::Load;
+        let outcome = self.encode_shadow_shape_source_passes(
+            frame_encoder,
+            source_view,
+            &shadow.post_blur_cutouts,
+            &shadow.brushes,
+            width,
+            height,
+            viewport_offset,
+            root_scale,
+            &mut load_op,
+        );
+        frame_encoder.record_passes(outcome.pass_count);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -11009,6 +11050,7 @@ impl GpuRenderer {
         let viewport_offset = [device_bounds.x, device_bounds.y];
         let cache_key = shape_shadow_surface_cache_key(
             &shadow.shapes,
+            &shadow.post_blur_cutouts,
             &shadow.brushes,
             device_bounds,
             pixel_radius,
@@ -11136,6 +11178,15 @@ impl GpuRenderer {
             );
         }
         frame_encoder.record_passes(2);
+        self.encode_post_blur_cutout_passes(
+            frame_encoder,
+            &source.view,
+            shadow,
+            bounds_w,
+            bounds_h,
+            viewport_offset,
+            root_scale,
+        );
 
         let clip_scissor = shadow
             .clip
@@ -16712,14 +16763,14 @@ mod tests {
             (translated_cutout, BlendMode::DstOut),
         ];
 
-        let first_hash = shape_shadow_content_hash(&first_shapes, &[], root_scale);
-        let translated_hash = shape_shadow_content_hash(&translated_shapes, &[], root_scale);
+        let first_hash = shape_shadow_content_hash(&first_shapes, &[], &[], root_scale);
+        let translated_hash = shape_shadow_content_hash(&translated_shapes, &[], &[], root_scale);
 
         assert_eq!(first_hash, translated_hash);
 
         let mut changed_shapes = translated_shapes;
         changed_shapes[0].0.rect.width += 1.0;
-        let changed_hash = shape_shadow_content_hash(&changed_shapes, &[], root_scale);
+        let changed_hash = shape_shadow_content_hash(&changed_shapes, &[], &[], root_scale);
 
         assert_ne!(first_hash, changed_hash);
     }
@@ -16751,6 +16802,7 @@ mod tests {
                     .expect("surface plan");
             shape_shadow_surface_cache_key(
                 &shapes,
+                &[],
                 &[],
                 plan.source_device_bounds,
                 pixel_radius,
@@ -16808,6 +16860,7 @@ mod tests {
             shape_shadow_surface_cache_key(
                 &shapes,
                 &[],
+                &[],
                 plan.source_device_bounds,
                 plan.pixel_radius,
                 root_scale,
@@ -16863,6 +16916,7 @@ mod tests {
     fn test_shadow_draw(shapes: Vec<(DrawShape, BlendMode)>) -> ShadowDraw {
         ShadowDraw {
             shapes,
+            post_blur_cutouts: vec![],
             brushes: vec![],
             texts: vec![],
             blur_radius: 8.0,
@@ -20849,6 +20903,7 @@ mod tests {
         };
         let shadow_draws = vec![ShadowDraw {
             shapes: vec![(shadow_shape, BlendMode::SrcOver)],
+            post_blur_cutouts: vec![],
             brushes: vec![],
             texts: Vec::new(),
             blur_radius: 8.0,
@@ -20901,6 +20956,7 @@ mod tests {
         };
         let shadow_draws = vec![ShadowDraw {
             shapes: vec![(shadow_shape, BlendMode::SrcOver)],
+            post_blur_cutouts: vec![],
             brushes: vec![],
             texts: Vec::new(),
             blur_radius: 8.0,

--- a/crates/cranpose-render/wgpu/src/scene.rs
+++ b/crates/cranpose-render/wgpu/src/scene.rs
@@ -245,6 +245,7 @@ pub(crate) struct DrawOp {
 #[derive(Clone)]
 pub(crate) struct ShadowDraw {
     pub shapes: Vec<(DrawShape, BlendMode)>,
+    pub post_blur_cutouts: Vec<(DrawShape, BlendMode)>,
     pub brushes: Vec<Brush>,
     pub texts: Vec<TextDraw>,
     pub blur_radius: f32,

--- a/crates/cranpose-render/wgpu/tests/effect_semantics.rs
+++ b/crates/cranpose-render/wgpu/tests/effect_semantics.rs
@@ -2062,6 +2062,267 @@ fn opaque_row_with_glass_fixture(animated_color: Color) -> RenderGraph {
 }
 
 #[test]
+fn a_resting_glass_pane_washes_its_backdrop_with_the_resting_tint() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!(
+                "skipping resting glass tint assertions because headless WGPU init failed: {}",
+                err
+            );
+            return;
+        }
+    };
+
+    let mut tail =
+        cranpose_ui_graphics::RuntimeShader::new(cranpose_ui_graphics::LIQUID_GLASS_WGSL);
+    tail.set_float2(0, 0.0, 0.0);
+    tail.set_float(6, 10.0);
+    tail.set_float(111, 0.0);
+    tail.set_float4(113, 0.5, 0.5, 0.6, 0.5);
+    let glass = layer(
+        Rect {
+            x: 16.0,
+            y: 32.0,
+            width: 96.0,
+            height: 28.0,
+        },
+        ProjectiveTransform::identity(),
+        GraphicsLayer {
+            backdrop_effect: Some(
+                RenderEffect::blur(6.0)
+                    .then(cranpose_ui_graphics::RenderEffect::runtime_shader(tail)),
+            ),
+            ..GraphicsLayer::default()
+        },
+        vec![],
+    );
+
+    renderer.scene_mut().graph = Some(RenderGraph::new(layer(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: FRAME_WIDTH as f32,
+            height: FRAME_HEIGHT as f32,
+        },
+        ProjectiveTransform::identity(),
+        GraphicsLayer::default(),
+        vec![
+            solid_rect(
+                Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: FRAME_WIDTH as f32,
+                    height: FRAME_HEIGHT as f32,
+                },
+                Color::BLACK,
+            ),
+            RenderNode::Layer(Box::new(glass)),
+        ],
+    )));
+
+    let frame = renderer
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("resting glass tint capture should succeed");
+
+    // A resting pane is frost, not vacuum: its interior carries the resting
+    // tint wash over the transmitted backdrop. A resting path that returns
+    // the raw backdrop sample makes the pane vanish entirely — the invisible
+    // pill regression this pins down.
+    let interior = rgba(&frame, 64, 46);
+    let outside = rgba(&frame, 8, 8);
+    let interior_luma = interior[0] as i32 + interior[1] as i32 + interior[2] as i32;
+    let outside_luma = outside[0] as i32 + outside[1] as i32 + outside[2] as i32;
+    assert!(
+        interior_luma >= 100,
+        "a resting pane must wash its interior with the resting tint: interior \
+         luma {interior_luma} over a black backdrop (tint 0.5/0.5/0.6 at alpha \
+         0.5 washes to ~200 summed; a raw-backdrop pass-through reads 0)"
+    );
+    assert!(
+        outside_luma < 30,
+        "the resting wash must stop at the pane's coverage: outside luma \
+         {outside_luma} should stay near the black backdrop"
+    );
+}
+
+#[test]
+fn a_resting_glass_pane_transmits_the_blurred_backdrop() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!(
+                "skipping resting glass transmission assertions because headless WGPU init failed: {}",
+                err
+            );
+            return;
+        }
+    };
+
+    let star = Rect {
+        x: 38.0,
+        y: 42.0,
+        width: 8.0,
+        height: 8.0,
+    };
+    let mut tail =
+        cranpose_ui_graphics::RuntimeShader::new(cranpose_ui_graphics::LIQUID_GLASS_WGSL);
+    tail.set_float2(0, 0.0, 0.0);
+    tail.set_float(6, 10.0);
+    tail.set_float(111, 0.0);
+    tail.set_float4(113, 0.05, 0.05, 0.08, 0.35);
+    let glass = layer(
+        Rect {
+            x: 16.0,
+            y: 32.0,
+            width: 96.0,
+            height: 28.0,
+        },
+        ProjectiveTransform::identity(),
+        GraphicsLayer {
+            backdrop_effect: Some(
+                RenderEffect::blur(6.0)
+                    .then(cranpose_ui_graphics::RenderEffect::runtime_shader(tail)),
+            ),
+            ..GraphicsLayer::default()
+        },
+        vec![],
+    );
+
+    renderer.scene_mut().graph = Some(RenderGraph::new(layer(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: FRAME_WIDTH as f32,
+            height: FRAME_HEIGHT as f32,
+        },
+        ProjectiveTransform::identity(),
+        GraphicsLayer::default(),
+        vec![
+            solid_rect(
+                Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: FRAME_WIDTH as f32,
+                    height: FRAME_HEIGHT as f32,
+                },
+                Color::BLACK,
+            ),
+            solid_rect(star, Color::WHITE),
+            RenderNode::Layer(Box::new(glass)),
+        ],
+    )));
+
+    let frame = renderer
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("resting glass capture should succeed");
+
+    // A frosted pane spreads the star's light: a pixel a few texels BESIDE
+    // the star, under the glass, carries blurred starlight. A resting path
+    // that discards the backdrop (or leaks it sharply) leaves that pixel as
+    // dark as the pane's far interior.
+    let beside = rgba(&frame, 48, 46);
+    let far = rgba(&frame, 100, 46);
+    let beside_luma = beside[0] as i32 + beside[1] as i32 + beside[2] as i32;
+    let far_luma = far[0] as i32 + far[1] as i32 + far[2] as i32;
+    assert!(
+        beside_luma >= far_luma + 40,
+        "a resting glass pane must transmit the BLURRED backdrop: beside-star \
+         luma {beside_luma} vs far-interior luma {far_luma} (blur radius 6 puts \
+         spread starlight at the beside pixel only when the frost transmits — a \
+         tint-only resting path leaves it as dark as the far interior, and a \
+         sharp leak lights only the star itself)"
+    );
+}
+
+#[test]
+fn a_cutout_drop_shadow_keeps_its_penumbra_outside_and_none_inside() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!(
+                "skipping cutout drop shadow assertions because headless WGPU init failed: {}",
+                err
+            );
+            return;
+        }
+    };
+
+    let element = Rect {
+        x: 24.0,
+        y: 24.0,
+        width: 64.0,
+        height: 32.0,
+    };
+    let shadow_shape = Rect {
+        x: 24.0,
+        y: 30.0,
+        width: 64.0,
+        height: 32.0,
+    };
+    let radii = cranpose_ui_graphics::CornerRadii::uniform(10.0);
+    let shadow = RenderNode::Primitive(PrimitiveEntry {
+        phase: PrimitivePhase::BeforeChildren,
+        node: PrimitiveNode::Draw(DrawPrimitiveNode {
+            primitive: DrawPrimitive::Shadow(ShadowPrimitive::Drop {
+                shape: Box::new(DrawPrimitive::RoundRect {
+                    rect: shadow_shape,
+                    brush: Brush::solid(Color(0.0, 0.0, 0.0, 0.6)),
+                    radii,
+                    stroke: None,
+                }),
+                cutout: Some(Box::new(DrawPrimitive::RoundRect {
+                    rect: element,
+                    brush: Brush::solid(Color::BLACK),
+                    radii,
+                    stroke: None,
+                })),
+                blur_radius: 8.0,
+                blend_mode: BlendMode::SrcOver,
+            }),
+            clip: None,
+        }),
+    });
+
+    renderer.scene_mut().graph = Some(graph(vec![solid_rect(frame_rect(), Color::WHITE), shadow]));
+
+    let frame = renderer
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("cutout drop shadow capture should succeed");
+
+    // The cutout exists so a translucent element never sits over its own
+    // shadow: the element's footprint must stay clean all the way to its
+    // edge, while the penumbra survives OUTSIDE the silhouette. A cutout
+    // applied before the blur bleeds shadow back into the footprint (the
+    // dark ring hugging every glass rim), and misreading the cutout as an
+    // inner-shadow mask discards the outer penumbra entirely.
+    let interior_center = rgba(&frame, 56, 40);
+    let interior_bottom = rgba(&frame, 56, 52);
+    let outside_below = rgba(&frame, 56, 66);
+    let center_luma =
+        interior_center[0] as i32 + interior_center[1] as i32 + interior_center[2] as i32;
+    let bottom_luma =
+        interior_bottom[0] as i32 + interior_bottom[1] as i32 + interior_bottom[2] as i32;
+    let outside_luma = outside_below[0] as i32 + outside_below[1] as i32 + outside_below[2] as i32;
+    assert!(
+        outside_luma <= 720,
+        "the drop shadow's penumbra below the element must survive: outside \
+         luma {outside_luma} over white should be visibly darkened (a shadow \
+         composite masked to its own silhouette discards it)"
+    );
+    assert!(
+        bottom_luma >= 740,
+        "no shadow may bleed inside the element footprint: near-bottom \
+         interior luma {bottom_luma} should stay white (a cutout applied \
+         before the blur lets the blur smear shadow back in)"
+    );
+    assert!(
+        center_luma >= 750,
+        "the element center must stay untouched by its own shadow: luma {center_luma}"
+    );
+}
+
+#[test]
 fn a_row_whose_glass_reads_only_its_own_draws_keeps_its_raster() {
     let mut renderer = match support::headless_renderer() {
         Ok(renderer) => renderer,

--- a/crates/cranpose-render/wgpu/tests/glass_rim_continuity.rs
+++ b/crates/cranpose-render/wgpu/tests/glass_rim_continuity.rs
@@ -1,0 +1,165 @@
+mod support;
+
+#[path = "../src/test_support.rs"]
+mod shared_test_support;
+
+use cranpose_render_common::{
+    Renderer,
+    graph::{
+        DrawPrimitiveNode, PrimitiveEntry, PrimitiveNode, PrimitivePhase, ProjectiveTransform,
+        RenderGraph, RenderNode,
+    },
+};
+use cranpose_render_wgpu::CapturedFrame;
+use cranpose_ui_graphics::{
+    Brush, Color, DrawPrimitive, GraphicsLayer, Rect, RenderEffect, RuntimeShader,
+};
+
+const FRAME_WIDTH: u32 = 128;
+const FRAME_HEIGHT: u32 = 96;
+
+const PANE: Rect = Rect {
+    x: 16.0,
+    y: 16.0,
+    width: 96.0,
+    height: 64.0,
+};
+
+fn solid_rect(rect: Rect, color: Color) -> RenderNode {
+    RenderNode::Primitive(PrimitiveEntry {
+        phase: PrimitivePhase::BeforeChildren,
+        node: PrimitiveNode::Draw(DrawPrimitiveNode {
+            primitive: DrawPrimitive::Rect {
+                rect,
+                brush: Brush::solid(color),
+                stroke: None,
+            },
+            clip: None,
+        }),
+    })
+}
+
+fn regular_capsule_glass_scene() -> RenderGraph {
+    let mut tail = RuntimeShader::new(cranpose_ui_graphics::LIQUID_GLASS_WGSL);
+    tail.set_float2(0, 0.0, 0.0);
+    tail.set_float(6, -1.0);
+    tail.set_float(11, 0.9);
+    tail.set_float4(14, 1.0, 1.0, 1.0, 0.07);
+    tail.set_float(18, 1.5);
+    tail.set_float(20, 0.42);
+    tail.set_float(24, 1.0);
+    tail.set_float(100, 1.0);
+    tail.set_float(111, 1.0);
+    tail.set_float(121, 1.0);
+    let glass = shared_test_support::layer_node(
+        PANE,
+        ProjectiveTransform::identity(),
+        GraphicsLayer {
+            backdrop_effect: Some(RenderEffect::blur(6.0).then(RenderEffect::runtime_shader(tail))),
+            ..GraphicsLayer::default()
+        },
+        vec![],
+    );
+    RenderGraph::new(shared_test_support::layer_node(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: FRAME_WIDTH as f32,
+            height: FRAME_HEIGHT as f32,
+        },
+        ProjectiveTransform::identity(),
+        GraphicsLayer::default(),
+        vec![
+            solid_rect(
+                Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: FRAME_WIDTH as f32,
+                    height: FRAME_HEIGHT as f32,
+                },
+                Color(0.45, 0.45, 0.47, 1.0),
+            ),
+            RenderNode::Layer(Box::new(glass)),
+        ],
+    ))
+}
+
+fn luma(frame: &CapturedFrame, x: i32, y: i32) -> i32 {
+    if x < 0 || y < 0 || x >= frame.width as i32 || y >= frame.height as i32 {
+        return 0;
+    }
+    let index = ((y as usize) * (frame.width as usize) + (x as usize)) * 4;
+    frame.pixels[index] as i32 + frame.pixels[index + 1] as i32 + frame.pixels[index + 2] as i32
+}
+
+fn rim_peak_at_angle(frame: &CapturedFrame, cx: f32, cy: f32, radius: f32, theta: f32) -> i32 {
+    let mut peak = 0;
+    let mut r = radius - 3.0;
+    while r <= radius + 1.5 {
+        let x = (cx + r * theta.cos()).round() as i32;
+        let y = (cy + r * theta.sin()).round() as i32;
+        peak = peak.max(luma(frame, x, y));
+        r += 0.5;
+    }
+    peak
+}
+
+// The capsule's specular rim must read as one continuous line: a band
+// narrower than the pixel grid renders as bright dashes with dropouts
+// between them (the "staircase" rim), so along the cap arc the per-angle
+// rim peak collapses at the angles that fall between pixel rows.
+#[test]
+fn a_capsule_rim_reads_as_a_continuous_line_around_its_cap() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!(
+                "skipping rim continuity assertions because headless WGPU init failed: {}",
+                err
+            );
+            return;
+        }
+    };
+
+    renderer.scene_mut().graph = Some(regular_capsule_glass_scene());
+    let frame = renderer
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("rim continuity capture should succeed");
+
+    let inradius = PANE.height * 0.5;
+    let cap_center_x = PANE.x + inradius;
+    let cap_center_y = PANE.y + inradius;
+    let interior = luma(&frame, cap_center_x as i32 + 8, cap_center_y as i32);
+
+    let mut peaks = Vec::new();
+    let mut deg = 100.0_f32;
+    while deg <= 260.0 {
+        let theta = deg.to_radians();
+        let rim = rim_peak_at_angle(&frame, cap_center_x, cap_center_y, inradius, theta);
+        peaks.push(((rim - interior).max(0), deg));
+        deg += 4.0;
+    }
+
+    let brightest = peaks.iter().map(|(value, _)| *value).max().unwrap_or(0);
+    assert!(
+        brightest >= 40,
+        "the rim line must exist at all around the cap: brightest rim excess \
+         {brightest} over interior {interior}"
+    );
+    let mut dashes = Vec::new();
+    for pair in peaks.windows(2) {
+        let (a, angle_a) = pair[0];
+        let (b, angle_b) = pair[1];
+        let top = a.max(b);
+        if top >= 25 && a.min(b) * 5 < top * 2 {
+            dashes.push((angle_a, angle_b, a, b));
+        }
+    }
+    assert!(
+        dashes.is_empty(),
+        "the rim's brightness must vary smoothly along the cap arc — material \
+         lighting is low-frequency, a collapse between neighboring angles is a \
+         sampling dropout: {dashes:?} (angle, angle, peak, peak) — a sub-pixel \
+         rim band renders as disconnected sparkles instead of a line"
+    );
+}

--- a/crates/cranpose-ui-graphics/shaders/liquid_glass.wgsl
+++ b/crates/cranpose-ui-graphics/shaders/liquid_glass.wgsl
@@ -57,7 +57,8 @@ const WCKSRD_EDGE_EXTENT_DP: f32 = 0.33333334;
 // fixed screen scale where its constants were safe; this port derives
 // band widths from material and density, and each can go sub-pixel
 // independently.
-const MIN_BAND_WIDTH_PX: f32 = 0.75;
+const MIN_BAND_WIDTH_PX: f32 = 1.0;
+const MIN_LINE_WIDTH_PX: f32 = 1.4;
 
 fn floored_band_width(width_px: f32) -> f32 {
     return max(width_px, MIN_BAND_WIDTH_PX);
@@ -274,10 +275,18 @@ fn wcksrd_optics(
     let inradius = max(min(half_size.x, half_size.y), 1.0);
     let lens_refraction = max(inradius * refraction_depth, 0.001);
     let interior = clamp(-distance / lens_refraction, 0.0, 1.0);
-    // The border line's ramp spans lens_refraction/edge_sharpness px.
-    let border_ramp = floored_band_width(lens_refraction / max(edge_sharpness, 1.0));
-    let border = clamp(-(distance - edge_extent) / border_ramp, 0.0, 1.0)
-        - clamp(-distance / border_ramp, 0.0, 1.0);
+    // The border line's ramp spans lens_refraction/edge_sharpness px. The
+    // drawn line must stay resolvable by the pixel grid: a sub-pixel band
+    // point-sampled at pixel centers renders as disconnected sparkles along
+    // a curved rim. Widening the band below the floor conserves its energy
+    // exactly — the profile's integral along the normal equals its extent,
+    // so the gain ratio keeps the line's total light unchanged.
+    let border_extent = max(edge_extent, MIN_LINE_WIDTH_PX);
+    let border_gain = edge_extent / border_extent;
+    let border_ramp = max(lens_refraction / max(edge_sharpness, 1.0), MIN_LINE_WIDTH_PX);
+    let border = (clamp(-(distance - edge_extent) / border_ramp, 0.0, 1.0)
+        - clamp(-(distance + border_extent - edge_extent) / border_ramp, 0.0, 1.0))
+        * border_gain;
     let gradient_band = wcksrd_meniscus(
         distance,
         lens_refraction,
@@ -632,13 +641,15 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
             * material_activity;
     }
     let resting_tint = get_vec4(113u);
-    let resting_alpha = resting_tint.a
-        * (1.0 - material_activity)
-        * coverage;
-    let resting_output = vec4<f32>(
-        resting_tint.rgb * resting_alpha,
-        resting_alpha,
-    );
+    // A drained lens is FROSTED glass, not paint: the pane still transmits
+    // the blurred backdrop it samples, washed with the resting tint. A
+    // tint-only resting output reads as an opaque plank — stars behind a
+    // resting bar simply vanished instead of glowing through the frost.
+    let resting_weight = (1.0 - material_activity) * coverage;
+    let frost_sample = textureSample(input_texture, input_sampler, input.uv);
+    let resting_frost = frost_sample * (1.0 - resting_tint.a)
+        + vec4<f32>(resting_tint.rgb * resting_tint.a, resting_tint.a);
+    let resting_output = resting_frost * resting_weight;
     if material_activity <= 0.0 {
         return resting_output;
     }


### PR DESCRIPTION
Three device-verified defects in how a glass pane's edge and body render, each pinned by a red-first test:

**Inverted drop shadows on every clipped glass surface.** The Drop shadow's cutout was knocked out of the silhouette BEFORE the blur, so the blur smeared shadow back under the pane and its backdrop capture sampled it as a dark ring hugging the rim. On top of that, the composite treated any DstOut-carrying shadow as an inner shadow and clipped the result inside the silhouette rect — deleting the outer penumbra entirely. Net effect: dark inner ring, no outer shadow (the "cracked edge" on light backdrops). `ShadowDraw` now carries Drop cutouts as `post_blur_cutouts`, erased from the blurred surface, and the inner-composite mask only fires for true Inner shadows. Red-proof: outside-penumbra luma was 765 (pure white — no shadow at all).

**Resting panes vanished.** The shader's resting path returned the raw backdrop sample instead of the frost blend, so a drained pane (resting bars, chips, cards) was invisible. Now the resting output is the transmitted backdrop washed with the resting tint, scaled by coverage. Red-proof: interior luma 0 over black with a 0.5-alpha tint.

**Staircase rims.** The specular border band could go sub-pixel (0.33 dp extent, 0.75 px floor); point-sampled at pixel centers it rendered as disconnected sparkles along curved caps, with adjacent-angle rim peaks collapsing 187 → 6. The band now widens inward to a resolvable width with its energy conserved exactly, and the shared band floor rises to a full pixel. A new rim-continuity test sweeps the cap arc and bounds adjacent-angle collapse.

**Chips and cards become glass panes** (user direction: everything in a liquid app is glass): `LiquidChip` is one persistent glass node whose activity animates with selection; `LiquidCard` is a resting pane washed with the new `surface_glass` theme role. Resting panes cost no blur chain — one tail pass each. Verified on the Huawei Mate 20 X: stars transmit through chips and list planks.

Known remaining work (next change, in progress): the Regular-glass edge still renders more contour apparatus (outer optical band, structural bevel) than the recorded reference sheets show on light backdrops — being decomposed term-by-term against `liquid_cheatsheets/cases/tab_swipe` with a headless AppShell harness before any further shader change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)