### PR TITLE
Add FocusRequester and Modifier::focusable() for imperative focus

### DIFF
--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -253,6 +253,11 @@ path = "robot-runners/robot_text_input.rs"
 required-features = ["robot-app"]
 
 [[example]]
+name = "robot_focus_requester"
+path = "robot-runners/robot_focus_requester.rs"
+required-features = ["robot-app"]
+
+[[example]]
 name = "robot_reactive_state"
 path = "robot-runners/robot_reactive_state.rs"
 required-features = ["robot-app"]

--- a/apps/desktop-demo/robot-runners/robot_focus_requester.rs
+++ b/apps/desktop-demo/robot-runners/robot_focus_requester.rs
@@ -1,0 +1,105 @@
+mod robot_launch;
+
+mod robot_exit;
+
+mod text_input_robot_helpers;
+
+use std::time::Duration;
+
+use cranpose_testing::find_button_in_semantics;
+use desktop_app::app;
+
+/// Proves `FocusRequester` end to end on a live window: clicking "Focus Field
+/// 2" never touches the text field itself, only the button next to it, yet
+/// the keystrokes typed right after land in that field. If the field never
+/// received real focus, `text_field_focus` would have nothing to dispatch the
+/// keys to and this would fail.
+fn main() {
+    env_logger::init();
+    println!("=== Robot Focus Requester Test ===");
+    println!("Testing Modifier::focus_requester() moving keyboard focus without a tap\n");
+
+    const TEST_TIMEOUT_SECS: u64 = 60;
+
+    robot_launch::launch("Robot Focus Requester Test", 900, 700)
+        .with_test_driver(|robot| {
+            robot_exit::arm_timeout(TEST_TIMEOUT_SECS);
+
+            std::thread::sleep(Duration::from_millis(300));
+            println!("✓ App launched\n");
+
+            let mut all_passed = true;
+
+            println!("--- Step 1: Open Text Input tab ---");
+            if text_input_robot_helpers::open_text_input_tab(&robot) {
+                println!("✓ Text Input tab visible\n");
+            } else {
+                println!("✗ FAIL: Could not open the Text Input tab");
+                let _ = robot.exit();
+                return;
+            }
+
+            println!("--- Step 2: Field 2 starts empty and unfocused ---");
+            match text_input_robot_helpers::wait_for_in_semantics(&robot, |robot| {
+                cranpose_testing::find_text_in_semantics(robot, "Field 2 value: \"\"")
+            }) {
+                Some(_) => println!("✓ PASS: Field 2 starts empty\n"),
+                None => {
+                    println!("✗ FAIL: Could not find the empty 'Field 2 value' readout\n");
+                    all_passed = false;
+                }
+            }
+
+            println!("--- Step 3: Click 'Focus Field 2' (never touches the field) ---");
+            match text_input_robot_helpers::wait_for_in_semantics(&robot, |robot| {
+                find_button_in_semantics(robot, "Focus Field 2")
+            }) {
+                Some(bounds) => {
+                    if text_input_robot_helpers::click_bounds(&robot, bounds).is_ok() {
+                        println!("✓ Clicked 'Focus Field 2'\n");
+                    } else {
+                        println!("✗ FAIL: Could not click 'Focus Field 2'\n");
+                        all_passed = false;
+                    }
+                }
+                None => {
+                    println!("✗ FAIL: Could not find the 'Focus Field 2' button\n");
+                    all_passed = false;
+                }
+            }
+
+            println!("--- Step 4: Type without ever tapping the field ---");
+            for ch in ["h", "i"] {
+                let _ = robot.send_key(ch);
+                std::thread::sleep(Duration::from_millis(30));
+            }
+            let _ = robot.wait_for_idle();
+            std::thread::sleep(Duration::from_millis(200));
+
+            match text_input_robot_helpers::wait_for_in_semantics(&robot, |robot| {
+                cranpose_testing::find_text_in_semantics(robot, "Field 2 value: \"hi\"")
+            }) {
+                Some(_) => println!("✓ PASS: Field 2 received the typed keys via FocusRequester\n"),
+                None => {
+                    println!(
+                        "✗ FAIL: Field 2 did not pick up the typed keys — FocusRequester did not \
+                     move real keyboard focus\n"
+                    );
+                    all_passed = false;
+                }
+            }
+
+            println!(
+                "=== Result: {} ===",
+                if all_passed { "PASS" } else { "FAIL" }
+            );
+            let _ = robot.exit();
+
+            if !all_passed {
+                std::process::exit(1);
+            }
+        })
+        .run(|| {
+            app::combined_app();
+        });
+}

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -16,9 +16,9 @@ use cranpose_foundation::{
 };
 use cranpose_ui::{
     composable, BasicTextField, BasicTextFieldOptions, BasicTextFieldWithOptions, BoxSpec, Brush,
-    Button, ButtonSpec, Color, Column, ColumnSpec, CornerRadii, GraphicsLayer, IntrinsicSize,
-    LinearArrangement, Modifier, Point, PointerInputScope, RoundedCornerShape, Row, RowSpec,
-    ScrollState, Size, Spacer, Text, TextStyle, VerticalAlignment,
+    Button, ButtonSpec, Color, Column, ColumnSpec, CornerRadii, FocusRequester, GraphicsLayer,
+    IntrinsicSize, LinearArrangement, Modifier, Point, PointerInputScope, RoundedCornerShape, Row,
+    RowSpec, ScrollState, Size, Spacer, Text, TextStyle, VerticalAlignment,
 };
 
 mod animations;
@@ -849,6 +849,7 @@ fn text_input_example() {
     let text_state1 =
         cranpose_core::remember(|| TextFieldState::new("Type here...")).with(|state| *state);
     let text_state2 = cranpose_core::remember(|| TextFieldState::new("")).with(|state| *state);
+    let field2_focus = cranpose_core::remember(FocusRequester::new).with(Clone::clone);
 
     Column(
         Modifier::empty()
@@ -932,9 +933,22 @@ fn text_input_example() {
                     .fill_max_width()
                     .padding(12.0)
                     .background(Color(0.18, 0.15, 0.22, 1.0))
-                    .rounded_corners(8.0),
+                    .rounded_corners(8.0)
+                    .focus_requester(&field2_focus),
                 TextStyle::default(),
             );
+
+            {
+                let field2_text = text_state2.text();
+                Text(
+                    format!("Field 2 value: \"{}\"", field2_text),
+                    Modifier::empty()
+                        .padding(8.0)
+                        .background(Color(0.12, 0.16, 0.28, 0.8))
+                        .rounded_corners(8.0),
+                    TextStyle::default(),
+                );
+            }
 
             Spacer(Size {
                 width: 0.0,
@@ -956,6 +970,7 @@ fn text_input_example() {
                 Modifier::empty().fill_max_width(),
                 RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(8.0)),
                 {
+                    let field2_focus = field2_focus.clone();
                     move || {
                         {
                             Button(
@@ -1029,6 +1044,32 @@ fn text_input_example() {
                                 || {
                                     Text(
                                         "Copy ↓",
+                                        Modifier::empty().padding(4.0),
+                                        TextStyle::default(),
+                                    );
+                                },
+                            );
+                        }
+
+                        {
+                            let field2_focus = field2_focus.clone();
+                            Button(
+                                Modifier::empty()
+                                    .rounded_corners(8.0)
+                                    .draw_behind(|scope| {
+                                        scope.draw_round_rect(
+                                            Brush::solid(Color(0.5, 0.3, 0.6, 1.0)),
+                                            CornerRadii::uniform(8.0),
+                                        );
+                                    })
+                                    .padding(10.0),
+                                ButtonSpec::default(),
+                                move || {
+                                    let _ = field2_focus.request_focus();
+                                },
+                                || {
+                                    Text(
+                                        "Focus Field 2",
                                         Modifier::empty().padding(4.0),
                                         TextStyle::default(),
                                     );

--- a/crates/cranpose-ui/src/focus_dispatch.rs
+++ b/crates/cranpose-ui/src/focus_dispatch.rs
@@ -1,11 +1,23 @@
-use std::{cell::RefCell, collections::HashSet};
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet, VecDeque},
+    rc::Rc,
+};
 
 use cranpose_core::NodeId;
+use cranpose_foundation::FocusState;
+
+pub(crate) trait FocusTargetHandle {
+    fn set_focus_state(&self, state: FocusState);
+}
 
 struct FocusInvalidationManager {
     dirty_nodes: HashSet<NodeId>,
     is_processing: bool,
     active_focus_target: Option<NodeId>,
+    focus_targets: HashMap<NodeId, Vec<Rc<dyn FocusTargetHandle>>>,
+    pending_focus_requests: VecDeque<NodeId>,
+    dispatching_focus: bool,
 }
 
 impl FocusInvalidationManager {
@@ -14,6 +26,9 @@ impl FocusInvalidationManager {
             dirty_nodes: HashSet::new(),
             is_processing: false,
             active_focus_target: None,
+            focus_targets: HashMap::new(),
+            pending_focus_requests: VecDeque::new(),
+            dispatching_focus: false,
         }
     }
 
@@ -31,6 +46,58 @@ impl FocusInvalidationManager {
 
     fn active_focus_target(&self) -> Option<NodeId> {
         self.active_focus_target
+    }
+
+    fn register_focus_target(&mut self, node_id: NodeId, handle: Rc<dyn FocusTargetHandle>) {
+        self.focus_targets.entry(node_id).or_default().push(handle);
+    }
+
+    fn unregister_focus_target(&mut self, node_id: NodeId, handle: &Rc<dyn FocusTargetHandle>) {
+        let Some(handles) = self.focus_targets.get_mut(&node_id) else {
+            return;
+        };
+        handles.retain(|existing| !Rc::ptr_eq(existing, handle));
+        if handles.is_empty() {
+            self.focus_targets.remove(&node_id);
+            if self.active_focus_target == Some(node_id) {
+                self.active_focus_target = None;
+            }
+        }
+    }
+
+    fn has_focus_target(&self, node_id: NodeId) -> bool {
+        self.focus_targets.contains_key(&node_id)
+    }
+
+    fn focus_target_handles(&self, node_id: NodeId) -> Vec<Rc<dyn FocusTargetHandle>> {
+        self.focus_targets
+            .get(&node_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn swap_active_focus_target(&mut self, node_id: NodeId) -> Option<NodeId> {
+        if self.active_focus_target == Some(node_id) {
+            return None;
+        }
+        self.active_focus_target.replace(node_id)
+    }
+
+    fn take_first_focus_request_if_idle(&mut self) -> Option<NodeId> {
+        if self.dispatching_focus {
+            return None;
+        }
+        let next = self.pending_focus_requests.pop_front()?;
+        self.dispatching_focus = true;
+        Some(next)
+    }
+
+    fn take_next_focus_request(&mut self) -> Option<NodeId> {
+        self.pending_focus_requests.pop_front()
+    }
+
+    fn finish_focus_dispatch(&mut self) {
+        self.dispatching_focus = false;
     }
 
     fn take_pending_for_processing(&mut self) -> Option<Vec<NodeId>> {
@@ -80,6 +147,73 @@ impl FocusInvalidationState {
 
     fn active_focus_target(&self) -> Option<NodeId> {
         self.manager.borrow().active_focus_target()
+    }
+
+    fn register_focus_target(&self, node_id: NodeId, handle: Rc<dyn FocusTargetHandle>) {
+        self.manager
+            .borrow_mut()
+            .register_focus_target(node_id, handle);
+    }
+
+    fn unregister_focus_target(&self, node_id: NodeId, handle: &Rc<dyn FocusTargetHandle>) {
+        self.manager
+            .borrow_mut()
+            .unregister_focus_target(node_id, handle);
+    }
+
+    pub(crate) fn request_focus(&self, node_id: NodeId) -> bool {
+        let accepted = {
+            let mut manager = self.manager.borrow_mut();
+            if !manager.has_focus_target(node_id) {
+                false
+            } else {
+                manager.pending_focus_requests.push_back(node_id);
+                true
+            }
+        };
+        if accepted {
+            self.drain_focus_requests();
+        }
+        accepted
+    }
+
+    fn drain_focus_requests(&self) {
+        let Some(first) = self.manager.borrow_mut().take_first_focus_request_if_idle() else {
+            return;
+        };
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut current = first;
+            loop {
+                self.apply_focus_change(current);
+                match self.manager.borrow_mut().take_next_focus_request() {
+                    Some(next) => current = next,
+                    None => break,
+                }
+            }
+        }));
+
+        self.manager.borrow_mut().finish_focus_dispatch();
+
+        if let Err(payload) = result {
+            std::panic::resume_unwind(payload);
+        }
+    }
+
+    fn apply_focus_change(&self, node_id: NodeId) {
+        let previous = self.manager.borrow_mut().swap_active_focus_target(node_id);
+
+        if let Some(previous) = previous {
+            let losing_handles = self.manager.borrow().focus_target_handles(previous);
+            for handle in losing_handles {
+                handle.set_focus_state(FocusState::Inactive);
+            }
+        }
+
+        let gaining_handles = self.manager.borrow().focus_target_handles(node_id);
+        for handle in gaining_handles {
+            handle.set_focus_state(FocusState::Active);
+        }
     }
 
     fn process_invalidations<F>(&self, processor: F)
@@ -140,6 +274,30 @@ pub fn set_active_focus_target(node_id: Option<NodeId>) {
 /// Returns the currently active focus target, if any.
 pub fn active_focus_target() -> Option<NodeId> {
     crate::render_state::with_focus_dispatch(|state| state.active_focus_target())
+}
+
+pub(crate) fn register_focus_target(node_id: NodeId, handle: Rc<dyn FocusTargetHandle>) {
+    crate::render_state::with_focus_dispatch(|state| state.register_focus_target(node_id, handle));
+}
+
+pub(crate) fn unregister_focus_target(node_id: NodeId, handle: &Rc<dyn FocusTargetHandle>) {
+    crate::render_state::with_focus_dispatch(|state| {
+        state.unregister_focus_target(node_id, handle)
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn request_focus(node_id: NodeId) -> bool {
+    crate::render_state::with_focus_dispatch(|state| state.request_focus(node_id))
+}
+
+pub(crate) fn request_focus_for(
+    app_context: crate::render_state::AppContextId,
+    node_id: NodeId,
+) -> Option<bool> {
+    crate::render_state::with_focus_dispatch_by_app_context(app_context, |state| {
+        state.request_focus(node_id)
+    })
 }
 
 /// Processes all pending focus invalidations.
@@ -298,5 +456,152 @@ mod tests {
             assert_eq!(processed, vec![9]);
             assert_eq!(active_focus_target(), Some(19));
         });
+    }
+
+    struct RecordingTarget {
+        states: RefCell<Vec<FocusState>>,
+        on_active: RefCell<Option<Box<dyn Fn()>>>,
+    }
+
+    impl RecordingTarget {
+        fn new() -> Rc<Self> {
+            Rc::new(Self {
+                states: RefCell::new(Vec::new()),
+                on_active: RefCell::new(None),
+            })
+        }
+
+        fn states(&self) -> Vec<FocusState> {
+            self.states.borrow().clone()
+        }
+    }
+
+    impl FocusTargetHandle for RecordingTarget {
+        fn set_focus_state(&self, state: FocusState) {
+            self.states.borrow_mut().push(state);
+            if state == FocusState::Active
+                && let Some(callback) = self.on_active.borrow_mut().take()
+            {
+                callback();
+            }
+        }
+    }
+
+    fn as_handle(target: &Rc<RecordingTarget>) -> Rc<dyn FocusTargetHandle> {
+        Rc::clone(target) as Rc<dyn FocusTargetHandle>
+    }
+
+    #[test]
+    fn request_focus_moves_focus_between_two_registered_targets() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        clear_focus_invalidations();
+        set_active_focus_target(None);
+
+        let a = RecordingTarget::new();
+        let b = RecordingTarget::new();
+        register_focus_target(1, as_handle(&a));
+        register_focus_target(2, as_handle(&b));
+
+        assert!(request_focus(1));
+        assert_eq!(a.states(), vec![FocusState::Active]);
+        assert_eq!(active_focus_target(), Some(1));
+
+        assert!(request_focus(2));
+        assert_eq!(a.states(), vec![FocusState::Active, FocusState::Inactive]);
+        assert_eq!(b.states(), vec![FocusState::Active]);
+        assert_eq!(active_focus_target(), Some(2));
+    }
+
+    #[test]
+    fn request_focus_on_an_unregistered_node_fails_without_changing_anything() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        clear_focus_invalidations();
+        set_active_focus_target(None);
+
+        assert!(!request_focus(99));
+        assert_eq!(active_focus_target(), None);
+    }
+
+    #[test]
+    fn unregistering_the_active_targets_last_handle_clears_active_focus() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        clear_focus_invalidations();
+        set_active_focus_target(None);
+
+        let a = RecordingTarget::new();
+        let handle = as_handle(&a);
+        register_focus_target(1, Rc::clone(&handle));
+        assert!(request_focus(1));
+        assert_eq!(active_focus_target(), Some(1));
+
+        unregister_focus_target(1, &handle);
+        assert_eq!(active_focus_target(), None);
+        assert!(!request_focus(1));
+    }
+
+    #[test]
+    fn request_focus_from_inside_a_callback_does_not_double_borrow_or_recurse() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        clear_focus_invalidations();
+        set_active_focus_target(None);
+
+        let a = RecordingTarget::new();
+        let b = RecordingTarget::new();
+        register_focus_target(1, as_handle(&a));
+        register_focus_target(2, as_handle(&b));
+
+        *a.on_active.borrow_mut() = Some(Box::new({
+            let bounced_back = RefCell::new(false);
+            move || {
+                if !*bounced_back.borrow() {
+                    *bounced_back.borrow_mut() = true;
+                    assert!(request_focus(2));
+                }
+            }
+        }));
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            assert!(request_focus(1));
+        }));
+        assert!(
+            result.is_ok(),
+            "a request_focus call from inside a callback must not panic or overflow the stack"
+        );
+
+        assert_eq!(a.states(), vec![FocusState::Active, FocusState::Inactive]);
+        assert_eq!(b.states(), vec![FocusState::Active]);
+        assert_eq!(active_focus_target(), Some(2));
+    }
+
+    #[test]
+    fn a_panicking_callback_still_releases_the_dispatch_lock() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        clear_focus_invalidations();
+        set_active_focus_target(None);
+
+        struct PanicsOnActivate;
+        impl FocusTargetHandle for PanicsOnActivate {
+            fn set_focus_state(&self, state: FocusState) {
+                if state == FocusState::Active {
+                    panic!("focus target panicked while activating");
+                }
+            }
+        }
+
+        register_focus_target(1, Rc::new(PanicsOnActivate) as Rc<dyn FocusTargetHandle>);
+        let b = RecordingTarget::new();
+        register_focus_target(2, as_handle(&b));
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            request_focus(1);
+        }));
+        assert!(result.is_err());
+
+        assert!(request_focus(2));
+        assert_eq!(
+            b.states(),
+            vec![FocusState::Active],
+            "the dispatch lock must be released after a callback panic so later requests proceed"
+        );
     }
 }

--- a/crates/cranpose-ui/src/lib.rs
+++ b/crates/cranpose-ui/src/lib.rs
@@ -113,12 +113,13 @@ pub use modal::{
 };
 pub use modifier::{
     BlendMode, Brush, Color, CompositingStrategy, CornerRadii, DpOffset, EdgeInsets,
-    FocusDirection, GlassMaterial, GraphicsLayer, LayerShape, Modifier, ModifierLocalKey,
-    ModifierLocalReadScope, ModifierNodeSlices, ModifierNodeSlicesDebugStats, Point, PointerEvent,
-    PointerEventKind, PointerInputScope, PointerSource, Rect, RenderEffect, ResolvedBackground,
-    ResolvedModifiers, RotaryInputModifierNode, RotaryScrollEvent, RoundedCornerShape,
-    RuntimeShader, SemanticsRequester, Shadow, ShadowScope, Size, TransformOrigin,
-    collect_modifier_slices, collect_semantics_from_modifier, collect_slices_from_modifier,
+    FocusDirection, FocusRequestError, FocusRequester, GlassMaterial, GraphicsLayer, LayerShape,
+    Modifier, ModifierLocalKey, ModifierLocalReadScope, ModifierNodeSlices,
+    ModifierNodeSlicesDebugStats, Point, PointerEvent, PointerEventKind, PointerInputScope,
+    PointerSource, Rect, RenderEffect, ResolvedBackground, ResolvedModifiers,
+    RotaryInputModifierNode, RotaryScrollEvent, RoundedCornerShape, RuntimeShader,
+    SemanticsRequester, Shadow, ShadowScope, Size, TransformOrigin, collect_modifier_slices,
+    collect_semantics_from_modifier, collect_slices_from_modifier,
 };
 #[cfg(feature = "test-helpers")]
 pub use modifier::{last_fling_velocity, reset_last_fling_velocity};

--- a/crates/cranpose-ui/src/modifier/focus.rs
+++ b/crates/cranpose-ui/src/modifier/focus.rs
@@ -1,13 +1,16 @@
 use std::{
-    cell::Cell,
+    cell::{Cell, RefCell},
     hash::{Hash, Hasher},
     rc::Rc,
 };
 
+use cranpose_core::NodeId;
 use cranpose_foundation::{
     DelegatableNode, FocusNode, FocusState, ModifierNode, ModifierNodeContext, ModifierNodeElement,
     NodeCapabilities, NodeState, impl_focus_node,
 };
+
+use crate::{focus_dispatch, render_state::AppContextId};
 
 /// Focus direction for navigation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -30,44 +33,79 @@ pub enum FocusDirection {
     Right,
 }
 
+type FocusChangedCallback = Rc<dyn Fn(FocusState)>;
+
+struct FocusTargetShared {
+    focus_state: Cell<FocusState>,
+    on_focus_changed: RefCell<Option<FocusChangedCallback>>,
+}
+
+impl FocusTargetShared {
+    fn new(on_focus_changed: Option<FocusChangedCallback>) -> Self {
+        Self {
+            focus_state: Cell::new(FocusState::Inactive),
+            on_focus_changed: RefCell::new(on_focus_changed),
+        }
+    }
+
+    fn set_focus_state(&self, state: FocusState) {
+        let old_state = self.focus_state.get();
+        if old_state != state {
+            self.focus_state.set(state);
+            let callback = self.on_focus_changed.borrow().clone();
+            if let Some(callback) = callback {
+                callback(state);
+            }
+        }
+    }
+}
+
+impl focus_dispatch::FocusTargetHandle for FocusTargetShared {
+    fn set_focus_state(&self, state: FocusState) {
+        FocusTargetShared::set_focus_state(self, state);
+    }
+}
+
 pub struct FocusTargetNode {
     state: NodeState,
-    focus_state: Cell<FocusState>,
-    on_focus_changed: Option<Rc<dyn Fn(FocusState)>>,
+    shared: Rc<FocusTargetShared>,
+    handle: Rc<dyn focus_dispatch::FocusTargetHandle>,
+    registered_node_id: Cell<Option<NodeId>>,
 }
 
 impl FocusTargetNode {
     pub fn new() -> Self {
-        Self {
-            state: NodeState::new(),
-            focus_state: Cell::new(FocusState::Inactive),
-            on_focus_changed: None,
-        }
+        Self::from_callback(None)
     }
 
     pub fn with_callback<F>(callback: F) -> Self
     where
         F: Fn(FocusState) + 'static,
     {
+        Self::from_callback(Some(Rc::new(callback) as FocusChangedCallback))
+    }
+
+    fn from_callback(on_focus_changed: Option<FocusChangedCallback>) -> Self {
+        let shared = Rc::new(FocusTargetShared::new(on_focus_changed));
+        let handle: Rc<dyn focus_dispatch::FocusTargetHandle> = shared.clone();
         Self {
             state: NodeState::new(),
-            focus_state: Cell::new(FocusState::Inactive),
-            on_focus_changed: Some(Rc::new(callback)),
+            shared,
+            handle,
+            registered_node_id: Cell::new(None),
         }
     }
 
     pub fn set_focus_state(&self, state: FocusState) {
-        let old_state = self.focus_state.get();
-        if old_state != state {
-            self.focus_state.set(state);
-            if let Some(callback) = &self.on_focus_changed {
-                callback(state);
-            }
-        }
+        self.shared.set_focus_state(state);
     }
 
     pub fn clear_focus(&self) {
         self.set_focus_state(FocusState::Inactive);
+    }
+
+    fn set_callback(&self, callback: Option<FocusChangedCallback>) {
+        *self.shared.on_focus_changed.borrow_mut() = callback;
     }
 }
 
@@ -84,12 +122,19 @@ impl DelegatableNode for FocusTargetNode {
 }
 
 impl ModifierNode for FocusTargetNode {
-    fn on_attach(&mut self, _context: &mut dyn ModifierNodeContext) {
+    fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
         self.state.set_attached(true);
+        if let Some(node_id) = context.node_id() {
+            self.registered_node_id.set(Some(node_id));
+            focus_dispatch::register_focus_target(node_id, Rc::clone(&self.handle));
+        }
     }
 
     fn on_detach(&mut self) {
         self.state.set_attached(false);
+        if let Some(node_id) = self.registered_node_id.take() {
+            focus_dispatch::unregister_focus_target(node_id, &self.handle);
+        }
         self.clear_focus();
     }
 
@@ -98,7 +143,7 @@ impl ModifierNode for FocusTargetNode {
 
 impl FocusNode for FocusTargetNode {
     fn focus_state(&self) -> FocusState {
-        self.focus_state.get()
+        self.shared.focus_state.get()
     }
 
     fn on_focus_changed(&mut self, _context: &mut dyn ModifierNodeContext, state: FocusState) {
@@ -108,7 +153,7 @@ impl FocusNode for FocusTargetNode {
 
 #[derive(Clone)]
 pub struct FocusTargetElement {
-    on_focus_changed: Option<Rc<dyn Fn(FocusState)>>,
+    on_focus_changed: Option<FocusChangedCallback>,
 }
 
 impl FocusTargetElement {
@@ -170,7 +215,7 @@ impl ModifierNodeElement for FocusTargetElement {
     }
 
     fn update(&self, node: &mut Self::Node) {
-        node.on_focus_changed = self.on_focus_changed.clone();
+        node.set_callback(self.on_focus_changed.clone());
     }
 
     fn inspector_name(&self) -> &'static str {
@@ -183,6 +228,199 @@ impl ModifierNodeElement for FocusTargetElement {
 
     fn always_update(&self) -> bool {
         true
+    }
+}
+
+/// Why [`FocusRequester::request_focus`] could not move focus.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FocusRequestError {
+    /// The requester has never been attached to a node via
+    /// [`Modifier::focus_requester`](super::Modifier::focus_requester), or the
+    /// node it was attached to has since left composition.
+    NotAttached,
+    /// The requester's node is attached, but nothing on it — no
+    /// [`Modifier::focus_target`](super::Modifier::focus_target), no
+    /// [`Modifier::on_focus_changed`](super::Modifier::on_focus_changed), no
+    /// text field — is registered to receive focus.
+    NoFocusTarget,
+}
+
+impl std::fmt::Display for FocusRequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FocusRequestError::NotAttached => {
+                write!(f, "FocusRequester is not attached to a node in composition")
+            }
+            FocusRequestError::NoFocusTarget => write!(
+                f,
+                "FocusRequester's node has no focus target to move focus onto"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FocusRequestError {}
+
+#[derive(Clone, Copy)]
+struct FocusRequesterBinding {
+    app_context: AppContextId,
+    node_id: NodeId,
+}
+
+/// A handle an app holds to move focus onto a node imperatively.
+///
+/// `remember` one, hang it on a node with
+/// [`Modifier::focus_requester`](super::Modifier::focus_requester) next to a
+/// [`Modifier::focus_target`](super::Modifier::focus_target) (or
+/// [`Modifier::on_focus_changed`](super::Modifier::on_focus_changed)), and
+/// call [`request_focus`](Self::request_focus) — from a click handler, an
+/// effect that runs once a screen appears, wherever the app decides focus
+/// should move.
+///
+/// ```ignore
+/// let requester = remember(FocusRequester::new).with(Clone::clone);
+/// // ... in the composition:
+/// Modifier::empty().focus_requester(&requester).focus_target()
+/// // ... later, imperatively:
+/// requester.request_focus().ok();
+/// ```
+#[derive(Clone, Default)]
+pub struct FocusRequester {
+    binding: Rc<Cell<Option<FocusRequesterBinding>>>,
+}
+
+impl FocusRequester {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Moves focus onto the node this requester is attached to.
+    ///
+    /// See [`FocusRequestError`] for the two predictable ways this can fail
+    /// instead of moving focus.
+    pub fn request_focus(&self) -> Result<(), FocusRequestError> {
+        let Some(binding) = self.binding.get() else {
+            return Err(FocusRequestError::NotAttached);
+        };
+        match focus_dispatch::request_focus_for(binding.app_context, binding.node_id) {
+            Some(true) => Ok(()),
+            Some(false) => Err(FocusRequestError::NoFocusTarget),
+            None => Err(FocusRequestError::NotAttached),
+        }
+    }
+
+    /// The node this requester is attached to, if attached.
+    pub fn node_id(&self) -> Option<NodeId> {
+        self.binding.get().map(|binding| binding.node_id)
+    }
+
+    fn bind(&self, binding: Option<FocusRequesterBinding>) {
+        self.binding.set(binding);
+    }
+
+    fn binding_here(node_id: Option<NodeId>) -> Option<FocusRequesterBinding> {
+        Some(FocusRequesterBinding {
+            app_context: crate::render_state::current_app_context_id_opt()?,
+            node_id: node_id?,
+        })
+    }
+}
+
+impl std::fmt::Debug for FocusRequester {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FocusRequester")
+            .field("node_id", &self.node_id())
+            .finish()
+    }
+}
+
+pub struct FocusRequesterNode {
+    state: NodeState,
+    requester: FocusRequester,
+}
+
+impl FocusRequesterNode {
+    pub(crate) fn new(requester: FocusRequester) -> Self {
+        Self {
+            state: NodeState::new(),
+            requester,
+        }
+    }
+}
+
+impl DelegatableNode for FocusRequesterNode {
+    fn node_state(&self) -> &NodeState {
+        &self.state
+    }
+}
+
+impl ModifierNode for FocusRequesterNode {
+    fn on_attach(&mut self, context: &mut dyn ModifierNodeContext) {
+        self.state.set_attached(true);
+        self.requester
+            .bind(FocusRequester::binding_here(context.node_id()));
+    }
+
+    fn on_detach(&mut self) {
+        self.state.set_attached(false);
+        self.requester.bind(None);
+    }
+}
+
+/// Modifier element for [`FocusRequester`].
+#[derive(Clone)]
+pub struct FocusRequesterElement {
+    requester: FocusRequester,
+}
+
+impl FocusRequesterElement {
+    pub(crate) fn new(requester: FocusRequester) -> Self {
+        Self { requester }
+    }
+}
+
+impl std::fmt::Debug for FocusRequesterElement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("FocusRequesterElement")
+    }
+}
+
+impl PartialEq for FocusRequesterElement {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.requester.binding, &other.requester.binding)
+    }
+}
+
+impl Eq for FocusRequesterElement {}
+
+impl Hash for FocusRequesterElement {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Rc::as_ptr(&self.requester.binding).hash(state);
+    }
+}
+
+impl ModifierNodeElement for FocusRequesterElement {
+    type Node = FocusRequesterNode;
+
+    fn create(&self) -> Self::Node {
+        FocusRequesterNode::new(self.requester.clone())
+    }
+
+    fn update(&self, node: &mut Self::Node) {
+        if !Rc::ptr_eq(&node.requester.binding, &self.requester.binding) {
+            let bound = node.requester.binding.get();
+            node.requester.bind(None);
+            node.requester = self.requester.clone();
+            node.requester.bind(bound);
+        }
+    }
+
+    fn inspector_name(&self) -> &'static str {
+        "focusRequester"
+    }
+
+    fn capabilities(&self) -> NodeCapabilities {
+        NodeCapabilities::NONE
     }
 }
 
@@ -268,5 +506,184 @@ mod tests {
 
         assert!(FocusState::Captured.is_captured());
         assert!(!FocusState::Active.is_captured());
+    }
+
+    fn attach_at(
+        node_id: NodeId,
+        elements: Vec<cranpose_foundation::DynModifierElement>,
+    ) -> ModifierNodeChain {
+        let mut context = BasicModifierNodeContext::new();
+        context.set_node_id(Some(node_id));
+        let mut chain = ModifierNodeChain::new();
+        chain.update(elements, &mut context);
+        chain
+    }
+
+    #[test]
+    fn request_focus_on_a_never_attached_requester_fails_predictably() {
+        let requester = FocusRequester::new();
+        assert_eq!(
+            requester.request_focus(),
+            Err(FocusRequestError::NotAttached)
+        );
+    }
+
+    #[test]
+    fn request_focus_on_a_requester_with_no_focus_target_fails_predictably() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        let requester = FocusRequester::new();
+
+        let _chain = attach_at(
+            1,
+            vec![cranpose_foundation::modifier_element(
+                FocusRequesterElement::new(requester.clone()),
+            )],
+        );
+
+        assert_eq!(requester.node_id(), Some(1));
+        assert_eq!(
+            requester.request_focus(),
+            Err(FocusRequestError::NoFocusTarget)
+        );
+    }
+
+    #[test]
+    fn a_focus_requester_moves_focus_onto_its_paired_focus_target() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        let requester = FocusRequester::new();
+
+        let chain = attach_at(
+            2,
+            vec![
+                cranpose_foundation::modifier_element(FocusRequesterElement::new(
+                    requester.clone(),
+                )),
+                cranpose_foundation::modifier_element(FocusTargetElement::new()),
+            ],
+        );
+
+        assert_eq!(requester.request_focus(), Ok(()));
+
+        let target = chain.node::<FocusTargetNode>(1).expect("focus target node");
+        assert_eq!(target.focus_state(), FocusState::Active);
+        assert_eq!(focus_dispatch::active_focus_target(), Some(2));
+    }
+
+    #[test]
+    fn request_focus_after_the_node_leaves_composition_fails_predictably() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        let requester = FocusRequester::new();
+
+        let mut context = BasicModifierNodeContext::new();
+        context.set_node_id(Some(3));
+        let mut chain = ModifierNodeChain::new();
+        chain.update(
+            vec![
+                cranpose_foundation::modifier_element(FocusRequesterElement::new(
+                    requester.clone(),
+                )),
+                cranpose_foundation::modifier_element(FocusTargetElement::new()),
+            ],
+            &mut context,
+        );
+        assert!(requester.request_focus().is_ok());
+
+        chain.update(Vec::new(), &mut context);
+
+        assert_eq!(
+            requester.request_focus(),
+            Err(FocusRequestError::NotAttached)
+        );
+    }
+
+    #[test]
+    fn focus_survives_the_requested_node_being_recomposed() {
+        let _app_context = crate::render_state::app_context_test_scope();
+        let requester = FocusRequester::new();
+
+        let mut context = BasicModifierNodeContext::new();
+        context.set_node_id(Some(4));
+        let mut chain = ModifierNodeChain::new();
+        let make_elements = || {
+            vec![
+                cranpose_foundation::modifier_element(FocusRequesterElement::new(
+                    requester.clone(),
+                )),
+                cranpose_foundation::modifier_element(FocusTargetElement::new()),
+            ]
+        };
+        chain.update(make_elements(), &mut context);
+        assert_eq!(requester.request_focus(), Ok(()));
+
+        let node_ptr_before = {
+            let node = chain.node::<FocusTargetNode>(1).unwrap();
+            &*node as *const FocusTargetNode
+        };
+
+        chain.update(make_elements(), &mut context);
+
+        let target = chain.node::<FocusTargetNode>(1).unwrap();
+        let node_ptr_after = &*target as *const FocusTargetNode;
+        assert_eq!(
+            node_ptr_before, node_ptr_after,
+            "recomposition with a structurally equal modifier must reuse the node"
+        );
+        assert_eq!(
+            target.focus_state(),
+            FocusState::Active,
+            "recomposing the focused node must not reset its focus state"
+        );
+        assert_eq!(focus_dispatch::active_focus_target(), Some(4));
+    }
+
+    #[test]
+    fn requesting_focus_from_inside_on_focus_changed_does_not_double_borrow_or_recurse() {
+        let _app_context = crate::render_state::app_context_test_scope();
+
+        let requester_a = FocusRequester::new();
+        let requester_b = FocusRequester::new();
+        let requester_b_for_callback = requester_b.clone();
+        let bounced = Rc::new(Cell::new(false));
+        let bounced_for_callback = bounced.clone();
+
+        let chain_a = attach_at(
+            10,
+            vec![
+                cranpose_foundation::modifier_element(FocusRequesterElement::new(
+                    requester_a.clone(),
+                )),
+                cranpose_foundation::modifier_element(FocusTargetElement::with_callback(
+                    move |state| {
+                        if state == FocusState::Active && !bounced_for_callback.get() {
+                            bounced_for_callback.set(true);
+                            requester_b_for_callback.request_focus().expect(
+                                "a reentrant request_focus must succeed, not double-borrow",
+                            );
+                        }
+                    },
+                )),
+            ],
+        );
+        let chain_b = attach_at(
+            20,
+            vec![
+                cranpose_foundation::modifier_element(FocusRequesterElement::new(
+                    requester_b.clone(),
+                )),
+                cranpose_foundation::modifier_element(FocusTargetElement::new()),
+            ],
+        );
+
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| requester_a.request_focus()));
+        assert!(result.is_ok(), "a reentrant focus request must not panic");
+        assert_eq!(result.unwrap(), Ok(()));
+        assert!(bounced.get(), "the reentrant callback never ran");
+
+        let target_a = chain_a.node::<FocusTargetNode>(1).unwrap();
+        let target_b = chain_b.node::<FocusTargetNode>(1).unwrap();
+        assert_eq!(target_a.focus_state(), FocusState::Inactive);
+        assert_eq!(target_b.focus_state(), FocusState::Active);
+        assert_eq!(focus_dispatch::active_focus_target(), Some(20));
     }
 }

--- a/crates/cranpose-ui/src/modifier/mod.rs
+++ b/crates/cranpose-ui/src/modifier/mod.rs
@@ -52,9 +52,9 @@ pub use cranpose_ui_graphics::{
     Shadow, ShadowScope, Size, TransformOrigin,
 };
 use cranpose_ui_layout::{Alignment, HorizontalAlignment, IntrinsicSize, VerticalAlignment};
-#[allow(unused_imports)]
-pub use focus::FocusDirection;
 use focus::FocusTargetElement;
+#[allow(unused_imports)]
+pub use focus::{FocusDirection, FocusRequestError, FocusRequester, FocusRequesterElement};
 pub use graphics_layer::GlassMaterial;
 pub(crate) use local::{
     ModifierLocalAncestorResolver, ModifierLocalSource, ModifierLocalToken, ResolvedModifierLocal,
@@ -497,6 +497,30 @@ impl Modifier {
         let element = FocusTargetElement::with_callback(callback);
         let modifier = Modifier::from_parts(vec![modifier_element(element)]);
         self.then(modifier)
+    }
+
+    /// Binds a [`FocusRequester`] to this node, so an app can move focus onto
+    /// it imperatively with [`FocusRequester::request_focus`].
+    ///
+    /// Pair it with [`focus_target`](Self::focus_target) (or
+    /// [`on_focus_changed`](Self::on_focus_changed)) on the same node —
+    /// `request_focus` moves whichever focus targets are attached there.
+    pub fn focus_requester(self, requester: &FocusRequester) -> Self {
+        let element = FocusRequesterElement::new(requester.clone());
+        let modifier = Modifier::from_parts(vec![modifier_element(element)]);
+        self.then(modifier)
+    }
+
+    /// The Compose `Modifier.focusable()` convenience.
+    ///
+    /// Compose's version also wires an optional `MutableInteractionSource` so
+    /// a `focusable` can drive its own visual indication. Cranpose's
+    /// [`MutableInteractionSource`](crate::MutableInteractionSource) only
+    /// emits press interactions — there is no focus interaction or indication
+    /// concept to plug in yet — so `focusable` here is honestly just
+    /// [`focus_target`](Self::focus_target), nothing more.
+    pub fn focusable(self) -> Self {
+        self.focus_target()
     }
 
     /// Binds a [`SemanticsRequester`] to this node, so an app can mark the

--- a/crates/cranpose-ui/src/render_state.rs
+++ b/crates/cranpose-ui/src/render_state.rs
@@ -496,6 +496,13 @@ pub(crate) fn with_focus_dispatch<R>(
     f(&context.focus_dispatch)
 }
 
+pub(crate) fn with_focus_dispatch_by_app_context<R>(
+    id: AppContextId,
+    f: impl FnOnce(&crate::focus_dispatch::FocusInvalidationState) -> R,
+) -> Option<R> {
+    with_app_context_by_id(id, |context| f(&context.focus_dispatch))
+}
+
 pub(crate) fn with_semantics_dispatch<R>(
     f: impl FnOnce(&crate::semantics_dispatch::SemanticsInvalidationState) -> R,
 ) -> R {

--- a/crates/cranpose-ui/src/text_field_modifier_node.rs
+++ b/crates/cranpose-ui/src/text_field_modifier_node.rs
@@ -6,7 +6,7 @@ use std::{
 
 use cranpose_core::{MutableState, mutableStateOf};
 use cranpose_foundation::{
-    Constraints, DelegatableNode, DrawModifierNode, DrawScope, InvalidationKind,
+    Constraints, DelegatableNode, DrawModifierNode, DrawScope, FocusState, InvalidationKind,
     LayoutModifierNode, Measurable, ModifierNode, ModifierNodeContext, ModifierNodeElement,
     NodeCapabilities, NodeState, PointerEvent, PointerEventKind, PointerInputNode,
     SemanticsConfiguration, SemanticsNode, Size,
@@ -251,6 +251,47 @@ pub(crate) fn range_visual_line_rects(
     rects
 }
 
+fn build_focus_handler(
+    state: TextFieldState,
+    refs: &TextFieldRefs,
+    line_limits: TextFieldLineLimits,
+    style: &TextStyle,
+) -> Rc<dyn crate::text_field_focus::FocusedTextFieldHandler> {
+    crate::text_field_handler::TextFieldHandler::new(
+        state,
+        refs.node_id.get(),
+        line_limits,
+        crate::text_field_handler::CaretGeometryRefs {
+            node_origin: refs.node_origin.clone(),
+            content_offset: refs.content_offset.clone(),
+            content_y_offset: refs.content_y_offset.clone(),
+            scroll_offset: refs.scroll_offset.clone(),
+            style: style.clone(),
+        },
+    )
+}
+
+struct TextFieldFocusBridge {
+    state: TextFieldState,
+    refs: TextFieldRefs,
+    style: TextStyle,
+    line_limits: TextFieldLineLimits,
+}
+
+impl crate::focus_dispatch::FocusTargetHandle for TextFieldFocusBridge {
+    fn set_focus_state(&self, state: FocusState) {
+        if state.is_focused() {
+            crate::text_field_focus::request_focus(
+                self.refs.is_focused.clone(),
+                build_focus_handler(self.state, &self.refs, self.line_limits, &self.style),
+                self.refs.modal_depth.get(),
+            );
+        } else if crate::text_field_focus::focused_field_node() == self.refs.node_id.get() {
+            crate::text_field_focus::clear_focus();
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct TextFieldRefs {
     pub is_focused: Rc<RefCell<bool>>,
@@ -268,6 +309,7 @@ pub(crate) struct TextFieldRefs {
     pub wrap_width: Rc<Cell<Option<f32>>>,
     pub press_track: MutableState<Option<PointerPressTrack>>,
     pub gesture_claimed: Rc<Cell<bool>>,
+    pub modal_depth: Rc<Cell<usize>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -294,6 +336,7 @@ impl TextFieldRefs {
             wrap_width: Rc::new(Cell::new(None::<f32>)),
             press_track: mutableStateOf(None::<PointerPressTrack>),
             gesture_claimed: Rc::new(Cell::new(false)),
+            modal_depth: Rc::new(Cell::new(0)),
         }
     }
 }
@@ -317,6 +360,7 @@ pub struct TextFieldModifierNode {
     cached_pan_resolver: TextPanResolver,
     handle_controller: Option<TextFieldHandleController>,
     modal_depth: usize,
+    focus_bridge: Option<Rc<dyn crate::focus_dispatch::FocusTargetHandle>>,
 }
 
 impl std::fmt::Debug for TextFieldModifierNode {
@@ -328,8 +372,6 @@ impl std::fmt::Debug for TextFieldModifierNode {
             .finish()
     }
 }
-
-use crate::text_field_handler::TextFieldHandler;
 
 impl TextFieldModifierNode {
     /// Creates a new text field modifier node.
@@ -364,6 +406,7 @@ impl TextFieldModifierNode {
             cached_pan_resolver,
             handle_controller: None,
             modal_depth: 0,
+            focus_bridge: None,
         }
     }
 
@@ -485,21 +528,9 @@ impl TextFieldModifierNode {
                     }));
                     refs.gesture_claimed.set(false);
 
-                    let handler = TextFieldHandler::new(
-                        state,
-                        refs.node_id.get(),
-                        line_limits,
-                        crate::text_field_handler::CaretGeometryRefs {
-                            node_origin: refs.node_origin.clone(),
-                            content_offset: refs.content_offset.clone(),
-                            content_y_offset: refs.content_y_offset.clone(),
-                            scroll_offset: refs.scroll_offset.clone(),
-                            style: style.clone(),
-                        },
-                    );
                     crate::text_field_focus::request_focus(
                         refs.is_focused.clone(),
-                        handler,
+                        build_focus_handler(state, &refs, line_limits, &style),
                         modal_depth,
                     );
 
@@ -794,6 +825,24 @@ impl ModifierNode for TextFieldModifierNode {
         context.invalidate(InvalidationKind::Layout);
         context.invalidate(InvalidationKind::Draw);
         context.invalidate(InvalidationKind::Semantics);
+
+        if let Some(node_id) = context.node_id() {
+            let bridge: Rc<dyn crate::focus_dispatch::FocusTargetHandle> =
+                Rc::new(TextFieldFocusBridge {
+                    state: self.state,
+                    refs: self.refs.clone(),
+                    style: self.style.clone(),
+                    line_limits: self.line_limits,
+                });
+            self.focus_bridge = Some(Rc::clone(&bridge));
+            crate::focus_dispatch::register_focus_target(node_id, bridge);
+        }
+    }
+
+    fn on_detach(&mut self) {
+        if let (Some(node_id), Some(bridge)) = (self.refs.node_id.get(), self.focus_bridge.take()) {
+            crate::focus_dispatch::unregister_focus_target(node_id, &bridge);
+        }
     }
 
     fn as_draw_node(&self) -> Option<&dyn DrawModifierNode> {
@@ -1257,6 +1306,7 @@ impl ModifierNodeElement for TextFieldElement {
             .with_cursor_color(self.cursor_color)
             .with_line_limits(self.line_limits);
         node.modal_depth = self.modal_depth;
+        node.refs.modal_depth.set(self.modal_depth);
         if let Some(controller) = self.handle_controller.clone() {
             node = node.with_handle_controller(controller);
         }
@@ -1271,6 +1321,7 @@ impl ModifierNodeElement for TextFieldElement {
         node.line_limits = self.line_limits;
         node.handle_controller = self.handle_controller.clone();
         node.modal_depth = self.modal_depth;
+        node.refs.modal_depth.set(self.modal_depth);
         node.rebuild_cached_closures();
 
         if node.update_cached_state() {}
@@ -1887,6 +1938,113 @@ mod tests {
             assert_eq!(node.text(), "Test");
 
             assert_eq!(node.selection().start, 4);
+        });
+    }
+
+    #[test]
+    fn a_focus_requester_makes_the_text_field_receive_keyboard_input() {
+        use cranpose_foundation::{BasicModifierNodeContext, ModifierNodeChain};
+
+        use crate::{
+            key_event::{KeyCode, KeyEvent, KeyEventType, Modifiers},
+            modifier::{FocusRequester, FocusRequesterElement},
+        };
+
+        let _app_context = crate::render_state::app_context_test_scope();
+        with_test_runtime(|| {
+            let state = TextFieldState::new("");
+            let requester = FocusRequester::new();
+
+            let mut context = BasicModifierNodeContext::new();
+            context.set_node_id(Some(1));
+            let mut chain = ModifierNodeChain::new();
+            chain.update(
+                vec![
+                    cranpose_foundation::modifier_element(FocusRequesterElement::new(
+                        requester.clone(),
+                    )),
+                    cranpose_foundation::modifier_element(TextFieldElement::new(
+                        state,
+                        TextStyle::default(),
+                    )),
+                ],
+                &mut context,
+            );
+
+            assert!(!crate::text_field_focus::has_focused_field());
+
+            requester
+                .request_focus()
+                .expect("the text field must accept a programmatic focus request");
+
+            assert!(crate::text_field_focus::has_focused_field());
+
+            let key_down = KeyEvent::new(KeyCode::H, "h", Modifiers::NONE, KeyEventType::KeyDown);
+            assert!(
+                crate::text_field_focus::dispatch_key_event(&key_down),
+                "the field must consume a key event once focused programmatically"
+            );
+            assert_eq!(state.text(), "h");
+        });
+    }
+
+    #[test]
+    fn two_text_fields_hand_off_keyboard_focus_via_their_requesters() {
+        use cranpose_foundation::{BasicModifierNodeContext, ModifierNodeChain};
+
+        use crate::modifier::{FocusRequester, FocusRequesterElement};
+
+        let _app_context = crate::render_state::app_context_test_scope();
+        with_test_runtime(|| {
+            let state_a = TextFieldState::new("a-text");
+            let state_b = TextFieldState::new("b-text");
+            let requester_a = FocusRequester::new();
+            let requester_b = FocusRequester::new();
+
+            let mut context = BasicModifierNodeContext::new();
+            context.set_node_id(Some(1));
+            let mut chain_a = ModifierNodeChain::new();
+            chain_a.update(
+                vec![
+                    cranpose_foundation::modifier_element(FocusRequesterElement::new(
+                        requester_a.clone(),
+                    )),
+                    cranpose_foundation::modifier_element(TextFieldElement::new(
+                        state_a,
+                        TextStyle::default(),
+                    )),
+                ],
+                &mut context,
+            );
+
+            context.set_node_id(Some(2));
+            let mut chain_b = ModifierNodeChain::new();
+            chain_b.update(
+                vec![
+                    cranpose_foundation::modifier_element(FocusRequesterElement::new(
+                        requester_b.clone(),
+                    )),
+                    cranpose_foundation::modifier_element(TextFieldElement::new(
+                        state_b,
+                        TextStyle::default(),
+                    )),
+                ],
+                &mut context,
+            );
+
+            requester_a.request_focus().expect("field a accepts focus");
+            assert_eq!(
+                crate::text_field_focus::focused_field_node(),
+                Some(1),
+                "field a should own text-field keyboard focus"
+            );
+
+            requester_b.request_focus().expect("field b accepts focus");
+            assert_eq!(
+                crate::text_field_focus::focused_field_node(),
+                Some(2),
+                "field b must take over text-field keyboard focus from field a"
+            );
         });
     }
 }


### PR DESCRIPTION
## Summary

Closes the two remaining gaps in `docs/compose_api_parity.md`'s focus row:

- **`FocusRequester` / `Modifier.focusRequester()`** — the missing imperative half of the focus system. Nothing could move focus programmatically before this; only reactive `on_focus_changed` existed.
- **`Modifier.focusable()`** — the Compose convenience wrapper.

### The existing focus owner (before this change)

Two disconnected systems, neither of which anything actually drove:
- `FocusTargetNode` (`modifier/focus.rs`) held its own `FocusState` + optional callback, but nothing in production ever called `set_focus_state`/`on_focus_changed` outside unit tests.
- `focus_dispatch::active_focus_target` existed as a documented "owner" surface (read by rotary-input routing), but `set_active_focus_target` was never called in production either — the doc comment there says outright "Cranpose does not yet wire focus automatically."
- The only *real* owner was `text_field_focus::TextFieldFocusState`, a single-owner registry driving O(1) keyboard dispatch for text fields specifically, structurally separate from the generic `FocusState` system.

### Design

`focus_dispatch` becomes the real focus owner: a `NodeId -> Vec<Rc<dyn FocusTargetHandle>>` registry, populated by `FocusTargetNode::on_attach`/`on_detach` and by a new `TextFieldFocusBridge` that lets a text field be moved by a requester too (bridging into `text_field_focus` so real keyboard input follows). `FocusRequester::request_focus()` enqueues the target `NodeId` into a request queue guarded by a `dispatching_focus` flag — the same shape already used by this file's dirty-node processing (`is_processing` + `catch_unwind`/`resume_unwind`).

The safety property the task called out explicitly: **the manager's `RefCell` is never held while a target's `on_focus_changed` callback runs.** Every borrow is scoped to a single statement that completes before invoking a callback. A `request_focus()` call from inside a callback just enqueues and returns immediately (the outer call's loop drains it next iteration) — reentrancy becomes iteration, never recursion. Caught one real footgun myself while writing this: an early draft used `for handle in self.manager.borrow().foo() { ... }`, which keeps the temporary `Ref` alive for the whole loop body (same extended-temporary rule as `match`) — fixed by binding to a `let` first.

Tests: `focus_dispatch.rs` and `modifier/focus.rs` both cover focus moving to the requested node, a detached requester failing predictably, reentrant `request_focus` from inside `on_focus_changed` (no double-borrow, no recursion), a panicking callback still releasing the dispatch lock, and focus surviving the target node being recomposed. `text_field_modifier_node.rs` adds an integration test proving a `FocusRequester` makes a text field actually receive and apply keyboard input, plus a two-field handoff test.

`FocusRequestError` has two variants, both ordinary `Result::Err` (never a panic, never a lying `Ok`): `NotAttached` (never attached, or the node left composition) and `NoFocusTarget` (attached, but nothing registered there to focus).

`focusable()` is the honest subset: Cranpose's `MutableInteractionSource` only emits press interactions, there is no indication/focus-interaction concept to compose with, so `focusable()` is exactly `focus_target()`.

### Robot coverage

Added `apps/desktop-demo/robot-runners/robot_focus_requester.rs` (registered in `apps/desktop-demo/Cargo.toml`), which clicks a "Focus Field 2" button that never touches the text field itself, then types — proving on a live window that the field receives real keyboard focus, not just that state flipped.

## Verification (all run locally, foreground)

- `just fmt` — clean, no diff
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `just clippy-robot` (lints the robot runners `just clippy` skips) — pass
- `just clippy-wasm` — pass
- `cargo test --profile ci --workspace --no-fail-fast` — 162/162 test-result blocks green, 0 failures
- `cargo run -p desktop-app --example robot_focus_requester --features robot-app` — PASS

Rebased onto `main` at `d50fcfa2` (past #608's `TextStyle` → `DrawTextStyle` rename; no fallout in the touched files since `text_field_modifier_node.rs` uses `crate::text::TextStyle`, a different type).

## Doc row changes (for the coordinator to apply to `docs/compose_api_parity.md`)

- `Modifier.focusRequester()` / `FocusRequester` — Absent → **Implemented**.
- `Modifier.focusable()` — Absent → **Implemented** (honest subset: no indication/interaction-source wiring, since Cranpose has neither).

🤖 Generated with [Claude Code](https://claude.com/claude-code)