### PR TITLE
Effect macros become #[track_caller] functions; add key(keys) scoping

### DIFF
--- a/apps/desktop-demo/robot-runners/robot_lazy_lifecycle.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_lifecycle.rs
@@ -100,7 +100,7 @@ fn lifecycle_item(index: usize, stats: MutableState<LifecycleStats>) {
     })
     .with(|s| *s);
 
-    DisposableEffect!(index, move |_key| {
+    DisposableEffect(index, move |_key| {
         stats.update(|s| s.total_effects += 1);
         println!("  [EFFECT] Item {} effect started", index);
 

--- a/apps/desktop-demo/robot-runners/robot_lazy_varheight_lifecycle.rs
+++ b/apps/desktop-demo/robot-runners/robot_lazy_varheight_lifecycle.rs
@@ -104,7 +104,7 @@ fn variable_height_item(index: usize, stats: MutableState<LifecycleStats>) {
         println!("  [COMPOSE] Item {} composition", index);
     });
 
-    DisposableEffect!(index, move |_key| {
+    DisposableEffect(index, move |_key| {
         stats.update(|s| s.total_effects += 1);
         println!("  [EFFECT] Item {} effect started", index);
 

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -1681,7 +1681,7 @@ pub(crate) fn AsyncRuntimeEngine(
     let running = is_running.get();
     let reset_key = reset_signal.get();
 
-    cranpose_core::LaunchedEffect!((reset_key,), move |_scope| {
+    cranpose_core::LaunchedEffect((reset_key,), move |_scope| {
         if last_reset.get() != reset_key {
             last_reset.set(reset_key);
             animation.set(AnimationState::default());
@@ -1746,7 +1746,7 @@ fn counter_app() {
     };
     let wave_state = animateFloatAsState(target_wave, AnimationType::default(), "wave");
     let fetch_key = fetch_request.get();
-    LaunchedEffect!(fetch_key, move |_scope| {
+    LaunchedEffect(fetch_key, move |_scope| {
         if fetch_key == 0 {
             return;
         }
@@ -2179,7 +2179,7 @@ fn counter_app() {
 #[composable]
 fn composition_local_observer() {
     let state = cranpose_core::rememberMutableStateOf(|| 0);
-    DisposableEffect!((), move |_| {
+    DisposableEffect((), move |_| {
         state.set(state.get() + 1);
         DisposableEffectResult::default()
     });

--- a/apps/desktop-demo/src/app/hacker_news.rs
+++ b/apps/desktop-demo/src/app/hacker_news.rs
@@ -696,7 +696,7 @@ fn launch_initial_load(
     state: cranpose_core::MutableState<NewsState>,
     client: HttpClientRef,
 ) {
-    cranpose_core::LaunchedEffect!(trigger, move |scope| {
+    cranpose_core::LaunchedEffect(trigger, move |scope| {
         state.set(NewsState::Loading);
         let client = client.clone();
 
@@ -720,7 +720,7 @@ fn launch_load_more(
     state: cranpose_core::MutableState<NewsState>,
     client: HttpClientRef,
 ) {
-    cranpose_core::LaunchedEffect!(trigger, move |scope| {
+    cranpose_core::LaunchedEffect(trigger, move |scope| {
         if trigger == 0 {
             return;
         }
@@ -784,7 +784,7 @@ fn launch_comment_thread(
 ) {
     let selected_story_id = selected_story.as_ref().map(|story| story.id);
 
-    cranpose_core::LaunchedEffect!((selected_story_id, refresh_trigger), move |scope| {
+    cranpose_core::LaunchedEffect((selected_story_id, refresh_trigger), move |scope| {
         let Some(story) = selected_story.clone() else {
             state.set(ThreadState::Idle);
             return;
@@ -818,7 +818,7 @@ fn launch_load_more_comments(
     state: cranpose_core::MutableState<ThreadState>,
     client: HttpClientRef,
 ) {
-    cranpose_core::LaunchedEffect!(trigger, move |scope| {
+    cranpose_core::LaunchedEffect(trigger, move |scope| {
         if trigger == 0 {
             return;
         }
@@ -907,7 +907,7 @@ fn AutoLoadMore(
         _ => (false, 0),
     };
 
-    cranpose_core::LaunchedEffect!((should_trigger, next_index), move |_scope| {
+    cranpose_core::LaunchedEffect((should_trigger, next_index), move |_scope| {
         if should_trigger {
             auto_load_guard.set(next_index);
             load_more_trigger.update(|value| *value = value.wrapping_add(1));
@@ -936,7 +936,7 @@ fn AutoLoadMoreComments(
         && visible_end >= preload_index
         && auto_load_guard.get() != loaded_count;
 
-    cranpose_core::LaunchedEffect!((should_trigger, loaded_count), move |_scope| {
+    cranpose_core::LaunchedEffect((should_trigger, loaded_count), move |_scope| {
         if should_trigger {
             auto_load_guard.set(loaded_count);
             load_more_trigger.update(|value| *value = value.wrapping_add(1));
@@ -1943,14 +1943,14 @@ pub fn HackerNewsTab() {
         http_client.clone(),
     );
     AutoLoadMore(list_state, news_state, auto_load_guard, load_more_trigger);
-    cranpose_core::LaunchedEffect!(
+    cranpose_core::LaunchedEffect(
         (
             selected_story.as_ref().map(|story| story.id),
-            thread_refresh_trigger.get()
+            thread_refresh_trigger.get(),
         ),
         move |_scope| {
             comment_auto_load_guard.set(0);
-        }
+        },
     );
 
     Column(

--- a/apps/desktop-demo/src/app/lazy_list.rs
+++ b/apps/desktop-demo/src/app/lazy_list.rs
@@ -138,7 +138,7 @@ where
 #[allow(non_snake_case)]
 #[composable]
 fn LifecycleListItem(index: usize, stats: MutableState<LifecycleStats>) {
-    DisposableEffect!(index, move |_key| {
+    DisposableEffect(index, move |_key| {
         stats.update(|current| {
             current.total_composes += 1;
             current.total_effects += 1;

--- a/apps/desktop-demo/src/app/markdown.rs
+++ b/apps/desktop-demo/src/app/markdown.rs
@@ -403,7 +403,7 @@ pub fn markdown_viewer_tab() {
     let request_counter = cranpose_core::rememberMutableStateOf(|| 0u64);
     let http_client = local_http_client().current();
 
-    cranpose_core::LaunchedEffect!(request_counter.get(), move |scope| {
+    cranpose_core::LaunchedEffect(request_counter.get(), move |scope| {
         let tick = request_counter.get();
         if tick == 0 {
             return;

--- a/apps/desktop-demo/src/app/source_view.rs
+++ b/apps/desktop-demo/src/app/source_view.rs
@@ -96,7 +96,7 @@ pub(crate) fn SourcePanel(tab: DemoTab) {
     let http_client = local_http_client().current();
     let list_state = rememberLazyListState();
 
-    cranpose_core::LaunchedEffect!(tab, move |scope| {
+    cranpose_core::LaunchedEffect(tab, move |scope| {
         state.set(SourceState::Loading);
         let client = http_client.clone();
         let url = source_url(tab);

--- a/apps/desktop-demo/src/app/wear.rs
+++ b/apps/desktop-demo/src/app/wear.rs
@@ -152,7 +152,7 @@ pub fn wear_tab() {
     let list = rememberWearScalingListState(CentreAnchor::default());
 
     let tick_state = state.clone();
-    LaunchedEffectAsync!((), move |scope| {
+    LaunchedEffectAsync((), move |scope| {
         Box::pin(async move {
             let clock = scope.runtime().frame_clock();
             loop {

--- a/apps/desktop-demo/src/app/web_fetch.rs
+++ b/apps/desktop-demo/src/app/web_fetch.rs
@@ -44,7 +44,7 @@ pub(crate) fn web_fetch_example() {
     let uri_handler = local_uri_handler().current();
     let http_client = local_http_client().current();
 
-    cranpose_core::LaunchedEffect!(request_counter.get(), move |scope| {
+    cranpose_core::LaunchedEffect(request_counter.get(), move |scope| {
         let request_key = request_counter.get();
         if request_key == 0 {
             return;

--- a/apps/desktop-demo/src/app/xkcd.rs
+++ b/apps/desktop-demo/src/app/xkcd.rs
@@ -119,7 +119,7 @@ pub(crate) fn xkcd_tab() {
     let http_client = local_http_client().current();
     let uri_handler = local_uri_handler().current();
 
-    cranpose_core::LaunchedEffect!(request_id.get(), move |scope| {
+    cranpose_core::LaunchedEffect(request_id.get(), move |scope| {
         let _request_id = request_id.get();
         state.set(XkcdState::Loading);
         let client = http_client.clone();

--- a/apps/desktop-demo/tests/counter_tab_roundtrip_regression.rs
+++ b/apps/desktop-demo/tests/counter_tab_roundtrip_regression.rs
@@ -132,7 +132,7 @@ fn max_layer_translation_y(layer: &LayerNode) -> f32 {
 #[composable]
 fn returned_press_lift(press_tick: MutableState<u64>) -> f32 {
     let press_target = cranpose_core::rememberMutableStateOf(|| 0.0_f32);
-    cranpose_core::LaunchedEffect!(press_tick.value(), {
+    cranpose_core::LaunchedEffect(press_tick.value(), {
         let target_state = press_target;
         let tick_state = press_tick;
         move |_scope| {

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -310,7 +310,7 @@ fn AppShellLifecycleCountDisplay(count: MutableState<usize>) {
 #[composable]
 #[allow(non_snake_case)]
 fn AppShellLifecycleListItem(index: usize, count: MutableState<usize>) {
-    cranpose_core::DisposableEffect!(index, move |_| {
+    cranpose_core::DisposableEffect(index, move |_| {
         count.update(|current| *current += 1);
         cranpose_core::DisposableEffectResult::new(|| {})
     });

--- a/crates/cranpose-core/src/launched_effect.rs
+++ b/crates/cranpose-core/src/launched_effect.rs
@@ -414,15 +414,19 @@ where
     });
 }
 
-#[macro_export]
-macro_rules! LaunchedEffect {
-    ($keys:expr, $effect:expr) => {
-        $crate::__launched_effect_impl(
-            $crate::location_key(file!(), line!(), column!()),
-            $keys,
-            $effect,
-        )
-    };
+/// Runs `effect` when this call site first enters composition, and again
+/// whenever `keys` no longer equals the value it ran with last time.
+///
+/// `keys` may be a tuple to depend on more than one value, matching Jetpack
+/// Compose's `LaunchedEffect(vararg keys)`.
+#[allow(non_snake_case)]
+#[track_caller]
+pub fn LaunchedEffect<K, F>(keys: K, effect: F)
+where
+    K: PartialEq + 'static,
+    F: FnOnce(LaunchedEffectScope) + 'static,
+{
+    __launched_effect_impl(crate::caller_location_key(), keys, effect);
 }
 
 /// `site` is where the effect was written. It travels onto the task the effect
@@ -456,14 +460,16 @@ where
     });
 }
 
-#[macro_export]
-macro_rules! LaunchedEffectAsync {
-    ($keys:expr, $future:expr) => {
-        $crate::__launched_effect_async_impl(
-            $crate::location_key(file!(), line!(), column!()),
-            $crate::TaskSite::new(file!(), line!()),
-            $keys,
-            $future,
-        )
-    };
+/// Like [`LaunchedEffect`], but `mk_future` builds the future to drive rather
+/// than receiving a scope to call back into synchronously.
+#[allow(non_snake_case)]
+#[track_caller]
+pub fn LaunchedEffectAsync<K, F>(keys: K, mk_future: F)
+where
+    K: PartialEq + 'static,
+    F: FnOnce(LaunchedEffectScope) -> Pin<Box<dyn Future<Output = ()>>> + 'static,
+{
+    let caller = std::panic::Location::caller();
+    let group_key = crate::location_key(caller.file(), caller.line(), caller.column());
+    __launched_effect_async_impl(group_key, TaskSite::from(caller), keys, mk_future);
 }

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -65,8 +65,8 @@ pub use hooks::{
 #[doc(hidden)]
 pub use hooks::{withFrameMillis, withFrameNanos};
 pub use launched_effect::{
-    __launched_effect_async_impl, __launched_effect_impl, CancelToken, LaunchedEffectScope,
-    TaskSite,
+    __launched_effect_async_impl, __launched_effect_impl, CancelToken, LaunchedEffect,
+    LaunchedEffectAsync, LaunchedEffectScope, TaskSite,
 };
 pub use owned::Owned;
 pub use platform::{Clock, RuntimeScheduler, SchedulerRef, scheduler_ref};
@@ -1048,10 +1048,33 @@ pub fn current_recompose_scope_invalidated_only_by(
     .flatten()
 }
 
+fn key_scoped<K: Hash, R>(
+    key: &K,
+    caller: &'static std::panic::Location<'static>,
+    content: impl FnOnce() -> R,
+) -> R {
+    let seed = explicit_group_key_seed(key, caller);
+    with_current_composer(|composer| composer.with_group_seed(seed, |_| content()))
+}
+
 #[track_caller]
 pub fn with_key<K: Hash>(key: &K, content: impl FnOnce()) {
-    let seed = explicit_group_key_seed(key, std::panic::Location::caller());
-    with_current_composer(|composer| composer.with_group_seed(seed, |_| content()));
+    key_scoped(key, std::panic::Location::caller(), content);
+}
+
+/// Scopes composition identity to `keys` for the duration of `content`.
+///
+/// Mirrors Jetpack Compose's `key(vararg keys) { content }`. A call keeps its
+/// identity by call-site position alone by default, so a slot survives a
+/// recomposition even when what a caller passes in changes; wrapping the
+/// call in `key(keys, || ...)` folds `keys` into that identity instead, so
+/// changing `keys` discards the previous state and starts fresh, and two
+/// `key` calls at the same call site with different `keys` never share
+/// state. Pass a tuple to key on more than one value, e.g.
+/// `key((a, b), || ...)`.
+#[track_caller]
+pub fn key<K: Hash, R>(keys: K, content: impl FnOnce() -> R) -> R {
+    key_scoped(&keys, std::panic::Location::caller(), content)
 }
 
 #[derive(Default)]
@@ -1147,15 +1170,21 @@ where
     });
 }
 
-#[macro_export]
-macro_rules! DisposableEffect {
-    ($keys:expr, $effect:expr) => {
-        $crate::__disposable_effect_impl(
-            $crate::location_key(file!(), line!(), column!()),
-            $keys,
-            $effect,
-        )
-    };
+/// Runs `effect` when this call site first enters composition, and again
+/// whenever `keys` no longer equals the value it ran with last time; the
+/// previous run's [`DisposableEffectScope::on_dispose`] cleanup, if any,
+/// runs first, and also when the call site leaves composition entirely.
+///
+/// `keys` may be a tuple to depend on more than one value, matching Jetpack
+/// Compose's `DisposableEffect(vararg keys)`.
+#[allow(non_snake_case)]
+#[track_caller]
+pub fn DisposableEffect<K, F>(keys: K, effect: F)
+where
+    K: PartialEq + 'static,
+    F: FnOnce(DisposableEffectScope) -> DisposableEffectResult + 'static,
+{
+    __disposable_effect_impl(crate::caller_location_key(), keys, effect);
 }
 
 #[macro_export]

--- a/crates/cranpose-core/src/tests/branch_group_tests.rs
+++ b/crates/cranpose-core/src/tests/branch_group_tests.rs
@@ -179,7 +179,7 @@ fn each_arm_of_an_else_if_chain_owns_its_slots() {
 
 #[composable]
 fn effect_child(label: &'static str) {
-    DisposableEffect!(0, move |scope| {
+    DisposableEffect(0, move |scope| {
         BRANCH_LOG.with(|log| log.borrow_mut().push(format!("{label}:start")));
         scope.on_dispose(move || {
             BRANCH_LOG.with(|log| log.borrow_mut().push(format!("{label}:dispose")));

--- a/crates/cranpose-core/src/tests/composition_and_recompose_scope_tests.rs
+++ b/crates/cranpose-core/src/tests/composition_and_recompose_scope_tests.rs
@@ -2887,7 +2887,7 @@ fn retained_branch_hides_without_running_disposable_effect_cleanup() {
                             RecomposeOptions::default(),
                             move |_composer| {
                                 let cleanup_calls = Rc::clone(&cleanup_calls);
-                                DisposableEffect!((), move |_| {
+                                DisposableEffect((), move |_| {
                                     let cleanup_calls = Rc::clone(&cleanup_calls);
                                     DisposableEffectResult::new(move || {
                                         cleanup_calls.set(cleanup_calls.get() + 1);
@@ -2939,7 +2939,7 @@ fn conditional_branch_without_retention_runs_disposable_effect_cleanup() {
                     with_current_composer(|composer| {
                         composer.with_group(branch_key, |_composer| {
                             let cleanup_calls = Rc::clone(&cleanup_calls);
-                            DisposableEffect!((), move |_| {
+                            DisposableEffect((), move |_| {
                                 let cleanup_calls = Rc::clone(&cleanup_calls);
                                 DisposableEffectResult::new(move || {
                                     cleanup_calls.set(cleanup_calls.get() + 1);
@@ -4630,5 +4630,113 @@ fn sibling_provider_scopes_from_one_construction_site_stay_distinct() {
         20,
         "two sibling provider scopes fed from one construction site must not \
          share entries; the survivor keeps its reader's subscription"
+    );
+}
+
+#[test]
+fn key_preserves_state_when_unchanged_and_discards_when_key_changes() {
+    thread_local! {
+        static SLOT: RefCell<Option<Owned<i32>>> = const { RefCell::new(None) };
+    }
+
+    let mut composition = test_composition();
+    let runtime = composition.runtime_handle();
+    let variant = MutableState::with_runtime(1u32, runtime.clone());
+    let root_key = location_key(file!(), line!(), column!());
+
+    #[composable]
+    fn root(variant: MutableState<u32>) {
+        cranpose_core::key(variant.value(), || {
+            let slot = with_current_composer(|composer| composer.remember(|| 0_i32));
+            SLOT.with(|cell| cell.replace(Some(slot)));
+        });
+    }
+
+    let pass = |composition: &mut Composition<MemoryApplier>| {
+        composition.render(root_key, || root(variant))
+    };
+
+    pass(&mut composition).expect("initial composition");
+    let slot = SLOT
+        .with(|cell| cell.borrow().clone())
+        .expect("slot captured");
+    slot.replace(42);
+
+    pass(&mut composition).expect("recompose with unchanged key");
+    let unchanged = SLOT
+        .with(|cell| cell.borrow().clone())
+        .expect("slot recaptured");
+    assert_eq!(
+        unchanged.with(|value| *value),
+        42,
+        "state inside key(..) must survive recomposition when the key is unchanged"
+    );
+
+    variant.set_value(2);
+    pass(&mut composition).expect("recompose with changed key");
+    let changed = SLOT
+        .with(|cell| cell.borrow().clone())
+        .expect("slot recaptured after key change");
+    assert_eq!(
+        changed.with(|value| *value),
+        0,
+        "state inside key(..) must be discarded when the key changes"
+    );
+}
+
+#[test]
+fn sibling_key_blocks_with_different_keys_do_not_share_state() {
+    thread_local! {
+        static SLOTS: RefCell<Vec<Owned<i32>>> = const { RefCell::new(Vec::new()) };
+    }
+
+    let mut composition = test_composition();
+    let runtime = composition.runtime_handle();
+    let tick = MutableState::with_runtime(0u32, runtime.clone());
+    let root_key = location_key(file!(), line!(), column!());
+
+    #[composable]
+    fn root(tick: MutableState<u32>) {
+        let _ = tick.value();
+        cranpose_core::key("first", || {
+            let slot = with_current_composer(|composer| composer.remember(|| 1_i32));
+            SLOTS.with(|cell| cell.borrow_mut().push(slot));
+        });
+        cranpose_core::key("second", || {
+            let slot = with_current_composer(|composer| composer.remember(|| 2_i32));
+            SLOTS.with(|cell| cell.borrow_mut().push(slot));
+        });
+    }
+
+    let pass =
+        |composition: &mut Composition<MemoryApplier>| composition.render(root_key, || root(tick));
+
+    pass(&mut composition).expect("initial composition");
+
+    let (first, second) = SLOTS.with(|cell| {
+        let slots = cell.borrow();
+        (slots[0].clone(), slots[1].clone())
+    });
+    SLOTS.with(|cell| cell.borrow_mut().clear());
+
+    first.replace(100);
+    second.replace(200);
+    tick.set_value(1);
+
+    pass(&mut composition).expect("recompose after mutating both siblings");
+    let (first_after, second_after) = SLOTS.with(|cell| {
+        let slots = cell.borrow();
+        (slots[0].clone(), slots[1].clone())
+    });
+
+    assert_eq!(
+        first_after.with(|value| *value),
+        100,
+        "the first sibling key(..) block must keep its own state"
+    );
+    assert_eq!(
+        second_after.with(|value| *value),
+        200,
+        "the second sibling key(..) block must keep its own state, not the first's"
     );
 }

--- a/crates/cranpose-core/src/tests/mod.rs
+++ b/crates/cranpose-core/src/tests/mod.rs
@@ -695,7 +695,7 @@ fn side_effect_component() -> NodeId {
 fn disposable_effect_host() -> NodeId {
     let state = cranpose_core::rememberMutableStateOf(|| 0);
     DISPOSABLE_STATE.with(|slot| *slot.borrow_mut() = Some(state));
-    DisposableEffect!(state.value(), |scope| {
+    DisposableEffect(state.value(), |scope| {
         DISPOSABLE_EFFECT_LOG.with(|log| log.borrow_mut().push("start"));
         scope.on_dispose(|| {
             DISPOSABLE_EFFECT_LOG.with(|log| log.borrow_mut().push("dispose"));

--- a/crates/cranpose-core/src/tests/state_and_effect_tests.rs
+++ b/crates/cranpose-core/src/tests/state_and_effect_tests.rs
@@ -601,7 +601,7 @@ fn disposable_effect_cleanup_can_update_use_state_during_group_removal() {
                 if show.get() {
                     let local = rememberMutableStateOf(|| 0usize);
                     let cleanup_calls = Rc::clone(&cleanup_calls);
-                    DisposableEffect!((), move |_| {
+                    DisposableEffect((), move |_| {
                         let cleanup_calls = Rc::clone(&cleanup_calls);
                         DisposableEffectResult::new(move || {
                             local.set(local.get() + 1);
@@ -639,7 +639,7 @@ fn launched_effect_runs_and_cancels() {
                 let key = state.value();
                 let runs = Arc::clone(&runs);
                 let captured_scopes = Rc::clone(&scopes_for_render);
-                LaunchedEffect!(key, move |scope| {
+                LaunchedEffect(key, move |scope| {
                     runs.fetch_add(1, Ordering::SeqCst);
                     captured_scopes.borrow_mut().push(scope);
                 });
@@ -687,7 +687,7 @@ fn launched_effect_runs_side_effect_body() {
                 let key = state.value();
                 let tx = tx.clone();
                 let captured_scopes = Rc::clone(&captured_scopes);
-                LaunchedEffect!(key, move |scope| {
+                LaunchedEffect(key, move |scope| {
                     let _ = tx.send("start");
                     captured_scopes.borrow_mut().push(scope);
                 });
@@ -722,7 +722,7 @@ fn launched_effect_background_updates_ui() {
         composition
             .render(0, move || {
                 let receiver = Rc::clone(&receiver);
-                LaunchedEffect!((), move |scope| {
+                LaunchedEffect((), move |scope| {
                     if let Some(rx) = receiver.borrow_mut().take() {
                         scope.launch_background(
                             move |_| async move { rx.recv().expect("value available") },
@@ -760,7 +760,7 @@ fn launched_effect_background_async_updates_ui() {
         composition
             .render(0, move || {
                 let receiver = Rc::clone(&receiver);
-                LaunchedEffect!((), move |scope| {
+                LaunchedEffect((), move |scope| {
                     if let Some(rx) = receiver.borrow_mut().take() {
                         scope.launch_background(
                             move |_| async move { rx.recv().expect("value available") },
@@ -800,7 +800,7 @@ fn launched_effect_background_ignores_late_result_after_cancel() {
             .render(0, move || {
                 let key = key_state.value();
                 let receiver = Rc::clone(&receiver);
-                LaunchedEffect!(key, move |scope| {
+                LaunchedEffect(key, move |scope| {
                     if key == 0
                         && let Some(rx) = receiver.borrow_mut().take()
                     {
@@ -822,7 +822,7 @@ fn launched_effect_background_ignores_late_result_after_cancel() {
             .render(0, move || {
                 let key = key_state.value();
                 let receiver = Rc::clone(&receiver);
-                LaunchedEffect!(key, move |scope| {
+                LaunchedEffect(key, move |scope| {
                     if key == 0
                         && let Some(rx) = receiver.borrow_mut().take()
                     {
@@ -863,12 +863,12 @@ fn launched_effect_relaunches_on_branch_change() {
                 let runs = Arc::clone(&runs);
                 let recorded_scopes = Rc::clone(&recorded_scopes);
                 if show_first {
-                    LaunchedEffect!("", move |scope| {
+                    LaunchedEffect("", move |scope| {
                         runs.fetch_add(1, Ordering::SeqCst);
                         recorded_scopes.borrow_mut().push((true, scope));
                     });
                 } else {
-                    LaunchedEffect!("", move |scope| {
+                    LaunchedEffect("", move |scope| {
                         runs.fetch_add(1, Ordering::SeqCst);
                         recorded_scopes.borrow_mut().push((false, scope));
                     });
@@ -935,7 +935,7 @@ fn anchor_survives_conditional_removal() {
 
                 let runs_for_effect = Arc::clone(&runs);
                 let scope_slot = Rc::clone(&captured_scope);
-                LaunchedEffect!((), move |scope| {
+                LaunchedEffect((), move |scope| {
                     runs_for_effect.fetch_add(1, Ordering::SeqCst);
                     scope_slot.borrow_mut().replace(scope);
                 });
@@ -1026,7 +1026,7 @@ fn launched_effect_async_survives_conditional_cycle() {
 
             let log = log.clone();
             let spawns = Arc::clone(&spawns);
-            cranpose_core::LaunchedEffectAsync!((), move |scope| {
+            cranpose_core::LaunchedEffectAsync((), move |scope| {
                 spawns.fetch_add(1, Ordering::SeqCst);
                 let log = log.clone();
                 Box::pin(async move {
@@ -1157,7 +1157,7 @@ fn launched_effect_async_keeps_frames_after_backward_forward_flip() {
 
     let mut render = {
         move || {
-            cranpose_core::LaunchedEffectAsync!((), move |scope| {
+            cranpose_core::LaunchedEffectAsync((), move |scope| {
                 Box::pin(async move {
                     let clock = scope.runtime().frame_clock();
                     let mut last_time: Option<u64> = None;
@@ -1506,7 +1506,7 @@ fn launched_effect_async_restarts_on_key_change() {
         move || {
             let key = key_state.value();
             let log = log.clone();
-            cranpose_core::LaunchedEffectAsync!(key, move |scope| {
+            cranpose_core::LaunchedEffectAsync(key, move |scope| {
                 let log = log.clone();
                 Box::pin(async move {
                     let clock = scope.runtime().frame_clock();
@@ -1653,7 +1653,7 @@ fn a_task_awaiting_a_frame_still_asks_for_frames() {
 #[composable]
 fn frame_callback_node(events: Rc<RefCell<Vec<&'static str>>>) -> NodeId {
     let runtime = cranpose_core::with_current_composer(|composer| composer.runtime_handle());
-    DisposableEffect!((), move |scope| {
+    DisposableEffect((), move |scope| {
         let clock = runtime.frame_clock();
         let events = events.clone();
         let registration = clock.with_frame_nanos(move |_| {
@@ -1735,7 +1735,7 @@ fn disposable_effect_reruns_on_hash_colliding_but_unequal_keys() {
                 let starts = Rc::clone(&starts);
                 let cleanups = Rc::clone(&cleanups);
                 let key = HashCollidingKey { tag: tag.get() };
-                DisposableEffect!(key, move |_| {
+                DisposableEffect(key, move |_| {
                     starts.set(starts.get() + 1);
                     let cleanups = Rc::clone(&cleanups);
                     DisposableEffectResult::new(move || {
@@ -1785,7 +1785,7 @@ fn launched_effect_reruns_on_hash_colliding_but_unequal_keys() {
                 let runs = Arc::clone(&runs);
                 let scopes = Rc::clone(&scopes);
                 let key = HashCollidingKey { tag: tag.get() };
-                LaunchedEffect!(key, move |scope| {
+                LaunchedEffect(key, move |scope| {
                     runs.fetch_add(1, Ordering::SeqCst);
                     scopes.borrow_mut().push(scope);
                 });
@@ -1830,7 +1830,7 @@ fn removal_races_keyed_effect_rerun(flip_key_first: bool) {
     #[composable]
     fn holder(key: MutableState<u32>) {
         let k = key.value();
-        DisposableEffect!(k, move |_| {
+        DisposableEffect(k, move |_| {
             STARTS.with(|c| c.set(c.get() + 1));
             LIVE.with(|c| c.set(c.get() + 1));
             DisposableEffectResult::new(move || LIVE.with(|c| c.set(c.get() - 1)))

--- a/crates/cranpose-ui/src/tests/animated_visibility_tests.rs
+++ b/crates/cranpose-ui/src/tests/animated_visibility_tests.rs
@@ -58,7 +58,7 @@ fn VisibilityHost(visible: MutableState<bool>, alive: Rc<Cell<bool>>) {
         (fade_out() + slide_out_vertically(0.5)).with_animation(transition_spec()),
         move || {
             let alive = Rc::clone(&alive_for_content);
-            cranpose_core::DisposableEffect!((), move |_scope| {
+            cranpose_core::DisposableEffect((), move |_scope| {
                 alive.set(true);
                 let alive = Rc::clone(&alive);
                 DisposableEffectResult::new(move || {

--- a/crates/cranpose-ui/src/tests/crossfade_tests.rs
+++ b/crates/cranpose-ui/src/tests/crossfade_tests.rs
@@ -47,7 +47,7 @@ fn CrossfadeHost(target: MutableState<u32>, alive: Rc<RefCell<Vec<u32>>>) {
         tween(CROSSFADE_MILLIS, Easing::LinearEasing),
         move |value: u32| {
             let alive = Rc::clone(&alive_for_content);
-            cranpose_core::DisposableEffect!(value, move |_scope| {
+            cranpose_core::DisposableEffect(value, move |_scope| {
                 alive.borrow_mut().push(value);
                 let alive = Rc::clone(&alive);
                 DisposableEffectResult::new(move || {

--- a/crates/cranpose-ui/src/tests/lazy_recycle_effect_tests.rs
+++ b/crates/cranpose-ui/src/tests/lazy_recycle_effect_tests.rs
@@ -37,7 +37,7 @@ fn measure(composition: &mut TestComposition, root: NodeId) {
 fn ParkedRow(index: usize, nested: bool) {
     let body = move || {
         if index == 0 {
-            cranpose_core::LaunchedEffectAsync!(0u32, move |_scope| {
+            cranpose_core::LaunchedEffectAsync(0u32, move |_scope| {
                 Box::pin(async move {
                     std::future::pending::<()>().await;
                 })
@@ -143,7 +143,7 @@ fn BusyRow(index: usize, state: cranpose_core::MutableState<bool>, dropped: Rc<C
             move || DropMark(dropped)
         });
         MarkGroup(dropped);
-        cranpose_core::LaunchedEffectAsync!(0u32, move |_scope| {
+        cranpose_core::LaunchedEffectAsync(0u32, move |_scope| {
             Box::pin(async move {
                 std::future::pending::<()>().await;
             })
@@ -266,7 +266,7 @@ fn a_lazy_badge_that_leaves_the_screen_stops_its_loops() {
 #[allow(non_snake_case)]
 fn CapturedBusyRow(index: usize, busy: bool) {
     if busy {
-        cranpose_core::LaunchedEffectAsync!(0u32, move |_scope| {
+        cranpose_core::LaunchedEffectAsync(0u32, move |_scope| {
             Box::pin(async move {
                 std::future::pending::<()>().await;
             })

--- a/crates/cranpose-ui/src/widgets/dialog.rs
+++ b/crates/cranpose-ui/src/widgets/dialog.rs
@@ -177,7 +177,7 @@ pub fn DialogWithScrim<C>(
             }
         }))
     };
-    cranpose_core::DisposableEffect!((), move |scope| {
+    cranpose_core::DisposableEffect((), move |scope| {
         let registration = crate::modal::register_modal(Rc::new(move || (back.value())()));
         scope.on_dispose(move || drop(registration))
     });

--- a/crates/cranpose-ui/src/widgets/lazy_list.rs
+++ b/crates/cranpose-ui/src/widgets/lazy_list.rs
@@ -638,7 +638,7 @@ fn bind_layout_invalidation_callback(
         overscroll.remove_invalidate_callback(previous_id);
     }
 
-    cranpose_core::DisposableEffect!(
+    cranpose_core::DisposableEffect(
         (list_state_id, node_id, callback_id, overscroll_callback_id),
         move |scope| {
             scope.on_dispose(move || {
@@ -647,7 +647,7 @@ fn bind_layout_invalidation_callback(
                 }
                 overscroll.remove_invalidate_callback(overscroll_callback_id);
             })
-        }
+        },
     );
 }
 

--- a/crates/cranpose-ui/src/widgets/popup.rs
+++ b/crates/cranpose-ui/src/widgets/popup.rs
@@ -406,7 +406,7 @@ fn popup_impl(
     });
 
     let dispose_registry = registry;
-    cranpose_core::DisposableEffect!((), move |scope| {
+    cranpose_core::DisposableEffect((), move |scope| {
         let dispose_registry = dispose_registry.clone();
         scope.on_dispose(move || dispose_registry.remove(id))
     });

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -154,10 +154,12 @@ renderer_wgpu_platform_modules!(present_mode, surface_format, wgpu_surface);
 pub use cranpose_audio::{AudioEngine, install as install_audio};
 /// Core runtime helpers commonly used by applications.
 pub use cranpose_core::{
-    CoroutineScope, MutableState, SnapshotStateList, SnapshotStateMap, State, delay, interval,
-    launchBlocking, mutableStateList, mutableStateListOf, mutableStateMap, mutableStateMapOf,
-    mutableStateOf, produceState, remember, rememberCoroutineScope, rememberMutableStateOf,
-    rememberMutableStateOfNeverEqual, rememberUpdatedState,
+    CoroutineScope, DisposableEffect, DisposableEffectResult, DisposableEffectScope,
+    LaunchedEffect, LaunchedEffectAsync, LaunchedEffectScope, MutableState, SnapshotStateList,
+    SnapshotStateMap, State, delay, interval, key, launchBlocking, mutableStateList,
+    mutableStateListOf, mutableStateMap, mutableStateMapOf, mutableStateOf, produceState, remember,
+    rememberCoroutineScope, rememberMutableStateOf, rememberMutableStateOfNeverEqual,
+    rememberUpdatedState,
 };
 /// Liquid UI — the first-party glass component library
 /// (`use cranpose::liquid::prelude::*;`).
@@ -363,10 +365,12 @@ pub mod _docs;
 /// Convenience imports for Cranpose applications.
 pub mod prelude {
     pub use cranpose_core::{
-        CoroutineScope, MutableState, SnapshotStateList, SnapshotStateMap, State, delay, interval,
-        launchBlocking, mutableStateList, mutableStateListOf, mutableStateMap, mutableStateMapOf,
-        mutableStateOf, produceState, remember, rememberCoroutineScope, rememberMutableStateOf,
-        rememberMutableStateOfNeverEqual, rememberUpdatedState,
+        CoroutineScope, DisposableEffect, DisposableEffectResult, DisposableEffectScope,
+        LaunchedEffect, LaunchedEffectAsync, LaunchedEffectScope, MutableState, SnapshotStateList,
+        SnapshotStateMap, State, delay, interval, key, launchBlocking, mutableStateList,
+        mutableStateListOf, mutableStateMap, mutableStateMapOf, mutableStateOf, produceState,
+        remember, rememberCoroutineScope, rememberMutableStateOf, rememberMutableStateOfNeverEqual,
+        rememberUpdatedState,
     };
     pub use cranpose_services::*;
     pub use cranpose_ui::*;

--- a/crates/cranpose/src/native_window.rs
+++ b/crates/cranpose/src/native_window.rs
@@ -819,7 +819,7 @@ fn NativeWindowWithEvents(
 
         {
             let owner = Rc::clone(&owner);
-            cranpose_core::DisposableEffect!(key, move |scope| {
+            cranpose_core::DisposableEffect(key, move |scope| {
                 scope.on_dispose(move || unregister_native_window(key, owner))
             });
         }

--- a/crates/cranpose/tests/prelude_surface.rs
+++ b/crates/cranpose/tests/prelude_surface.rs
@@ -63,6 +63,26 @@ fn app_owned_map_data_composes_from_the_prelude_alone() {
 }
 
 #[test]
+fn effects_and_key_scope_compose_from_the_prelude_alone() {
+    let ran = std::rc::Rc::new(std::cell::Cell::new(0u32));
+    let effect_ran = std::rc::Rc::clone(&ran);
+    run_test_composition(move || {
+        let effect_ran = std::rc::Rc::clone(&effect_ran);
+        key("scoped", || {
+            LaunchedEffect((), move |_scope| {
+                effect_ran.set(effect_ran.get() + 1);
+            });
+        });
+        DisposableEffect((), |scope| scope.on_dispose(|| {}));
+    });
+    assert_eq!(
+        ran.get(),
+        1,
+        "LaunchedEffect nested in key(..) must run once, using only cranpose::prelude::*"
+    );
+}
+
+#[test]
 fn blocking_work_starts_from_the_prelude_alone() {
     let result = std::rc::Rc::new(std::cell::Cell::new(0u32));
     let sink = std::rc::Rc::clone(&result);

--- a/plugins/cranpose/skills/cranpose/SKILL.md
+++ b/plugins/cranpose/skills/cranpose/SKILL.md
@@ -79,11 +79,11 @@ them.
 
 ## Effects
 
-`LaunchedEffect!` is a **macro**, not a function, and takes a key expression
-first. The effect restarts when the key changes:
+`LaunchedEffect` takes a key expression first, like `remember`. The effect
+restarts when the key changes:
 
 ```rust
-cranpose_core::LaunchedEffect!(request_id.get(), move |scope| {
+LaunchedEffect(request_id.get(), move |scope| {
     state.set(Loading);
     scope.launch_background(/* ... */);
 });
@@ -91,6 +91,11 @@ cranpose_core::LaunchedEffect!(request_id.get(), move |scope| {
 
 Use `DisposableEffect` when something must be undone on teardown, and
 `SideEffect` to publish composition results to non-Cranpose code.
+
+`key(keys, || { ... })` scopes composition identity to `keys` instead of just
+call-site position: changing `keys` discards the block's remembered state and
+starts over, and it separates two blocks at the same call site (a loop body,
+a branch) that would otherwise share one.
 
 ## Lists
 
@@ -186,7 +191,7 @@ cranpose = { version = "0.1", features = ["desktop", "renderer-wgpu"] }
   that should react to it.
 - **A `for` loop over a long collection composes all of it.** Use `LazyColumn`.
 - **Do not `.clone()` state handles.** They are `Copy`.
-- **`LaunchedEffect!` needs a key.** Passing a key that changes every
+- **`LaunchedEffect` needs a key.** Passing a key that changes every
   composition restarts the effect every frame.
 - **Cranpose is pre-alpha.** Versions are not compatible with each other and
   APIs change without deprecation cycles. Pin an exact version.


### PR DESCRIPTION
## Summary

Two related call-site-identity items from `docs/compose_api_parity.md`'s "Findings" section (not edited here — see report for the exact row/finding changes for whoever updates that doc).

**Macro verdict: not load-bearing, and measurably worse than the function form.** `LaunchedEffect!`/`DisposableEffect!`/`LaunchedEffectAsync!` were `macro_rules!` capturing `file!()/line!()/column!()` at their own lexical expansion site. `remember` already gets correct per-call-site identity from a plain `#[track_caller]` fn. None of the plausible reasons for the macro (future-boxing, variadic keys, lazy effect-body evaluation, how `keys` is captured) survive: all four are unaffected by macro-vs-function and are identical before/after. Stronger: the same internal impls (`__launched_effect_impl`, `__launched_effect_async_impl`, `__disposable_effect_impl`) were *already* called directly with a `#[track_caller]`-computed key by non-macro code predating this change (`CollectEvents`/`rememberEventStream` in `cranpose-core/src/concurrency.rs`; `KeepScreenOn`/`BundledAssetInstallEffect`/`DurableSaveEffect` in `cranpose`/`cranpose-services`). And the macro was actively worse: its lexical `file!()` stamps every call through a non-`#[composable]` second-order wrapper with one fixed key — a defect commit `a1f64e59`'s "round-36 caller-identity sweep" already hit once in `cranpose-animation` and patched around with a manual `caller_location_key() ^ location_key(file!(), line!(), column!())` XOR instead of at the root. `TaskSite`'s `From<&'static Location<'static>>` impl (doc-commented "The site a `#[track_caller]` function was called from") was dead code before this change — never called — consistent with the track_caller route having been anticipated and never finished.

Converted `LaunchedEffect`, `DisposableEffect`, `LaunchedEffectAsync` to `#[track_caller]` functions with identical generic bounds, dropped the `!` at all ~40 call sites, and re-exported them (plus `DisposableEffectScope`/`DisposableEffectResult`/`LaunchedEffectScope`) through the `cranpose` facade and prelude — closing a gap `plugins/cranpose/skills/cranpose/SKILL.md` had documented as a workaround ("reach into `cranpose_core::` directly").

**`key(keys) { }`**: confirmed absent as a public construct. The identical scoping primitive already existed as `cranpose_core::with_key` (used 100+ places internally: lazy list items, tab switching, crossfade, etc.) but was unit-returning, reference-only, undocumented, and never reachable through the facade/prelude — so application authors genuinely had no path to it. Added `pub fn key<K: Hash, R>(keys: K, content: impl FnOnce() -> R) -> R`, matching Compose's `key(vararg keys) { content }: T` (tuple for multiple keys, Cranpose's existing multi-key convention). `with_key` and `key` now share one `key_scoped` helper instead of duplicating the group-seed setup.

Test written first (compiled to `cannot find function key` before the function existed; verified discriminating by temporarily sabotaging `key()` to a no-op and confirming the test fails):
- `key_preserves_state_when_unchanged_and_discards_when_key_changes`: state inside `key(a) {}` survives when `a` is unchanged, resets when `a` changes.
- `sibling_key_blocks_with_different_keys_do_not_share_state`: two sibling `key(..)` blocks with different keys keep independent state.
- `effects_and_key_scope_compose_from_the_prelude_alone`: `key`/`LaunchedEffect`/`DisposableEffect` all resolve via `cranpose::prelude::*` alone.

## Verification (all run locally, authoritative non-piped exit codes)

- `just fmt` — clean
- `just clippy` (`cargo clippy --workspace --all-targets -- -D warnings`) — exit 0
- `just clippy-wasm` — exit 0
- `cargo clippy -p cranpose --no-default-features --features desktop,renderer-wgpu,camera-desktop,robot,audio-desktop,media,storekit,playbilling --all-targets -- -D warnings` (clippy-optional-backends, extra check on the facade) — exit 0
- `cargo test --profile ci --workspace --no-fail-fast` — exit 0, 162 test binaries, 5080 tests passed, 0 failed
- Targeted build of the two edited robot-runner examples (`robot_lazy_lifecycle`, `robot_lazy_varheight_lifecycle`) — clean
- Rebased onto latest `main` (`7d0ea478`) after the animation/Density work landed; re-ran fmt/clippy/clippy-wasm/full test suite on the rebased tree — all clean

**MERGE FREEZE is on — do not merge.** Holding for the coordinator to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>