### PR TITLE
fix(animation): keep one play-time origin across restarts; feat(render): bake nested-backdrop underlays

### DIFF
--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -31,6 +31,7 @@ Signature → cause → what to do. One lesson per line, no incident history.
 - **macOS: `.with_headless(false)` examples need an awake, compositing display.** "the window surface refused N consecutive frames over 5s and never reached generation 1" is the answer, not a symptom. Two waits emit near-identical text — read the prefix, not the duration: `present wait:` is the standalone wait (`wait_for_present_frame`, `pump_frames`, 5s), `wait_for_idle:` is an idle wait whose composition had already settled with only the frame outstanding (30s). Both accuse the compositor; neither accuses the app. `pmset -g log | grep -i "Display is turned"` dates the panel off/on; `pmset -g assertions` and `CGSSessionScreenIsLocked` answer for now. Host-capability skips gate on X11+xdotool, which these two do not need, so they run and fail instead of skipping.
 - **`~/develop/projects/Cranpose` on samarch-1 is a synced mirror**: its `.git` is a worktree pointer at a macOS path, so every git command dies `not a git repository: (null)`. rsync into a scratch dir (exclude `target/`, `.git`). `just` lives in `~/.cargo/bin`, absent from a non-interactive ssh PATH.
 - **`scripts/ci/with_host_lock.sh` exists and nobody was taking it.** Every session, including the ones telling others to go faster, was `ssh samarch-1`-ing straight past it. One day of that cost four phantom red CI runs: robot jobs refuse to run above a load of about 7, heavy compiles from sessions working over ssh held the box at 13–51, the robot jobs waited, timed out, and reported RED indistinguishable from a regression — two of them got diagnosed as a real regression before anyone checked host load. Separately, cranscan-82's query benchmark spread collapsed from 9.4–33.9ms to 7.6–7.8ms on identical code once they took the lock, overturning a retraction they had already made off the contended numbers. Take `--shared` for a build, `--exclusive` for a measurement or robot suite, every time — do not build on samarch-1 while a robot job runs, and do not wait for a quiet-looking load average instead of just taking the lock.
+- **A PIN-locked phone fails `am start` with "Activity class ... does not exist" (Error type 3) and `screencap` writes a 0-byte PNG.** The resolver table still lists the activity, so the message reads like a broken APK; check `dumpsys window | grep -m1 mCurrentFocus` first -- `StatusBar` means the keyguard is up. `wm dismiss-keyguard`, keyevent 82 and swipe-up do nothing against a PIN, and entering it is off limits: ask for an unlock (or use the emulator, where the same APK, sysprops and telemetry work unchanged).
 - **Android "SDK location not found" is missing env, not a missing SDK.** `~/Library/Android/sdk` and its NDKs are installed; `ANDROID_HOME`/`ANDROID_SDK_ROOT`/`ANDROID_NDK_HOME` are unset in a fresh shell and `android/local.properties` is untracked. `ls ~/Library/Android/sdk` before believing the error.
   ```bash
   export ANDROID_HOME="$HOME/Library/Android/sdk"
@@ -490,3 +491,19 @@ Signature → cause → what to do. One lesson per line, no incident history.
   consumers too (`/Users/s/develop/consumer-bumps/`), and prefer a test
   that calls it — a test is an in-repo caller, and it is what kept
   `draggable_guarded` alive.
+
+## Infinite transition "freeze" needs a spec change AND a reader remount
+
+The showcase planets stopped rotating after details -> back -> Saved -> Explore.
+Scripted Saved/Explore round trips (40+, timed randomly) and detail/back alone
+never reproduced it, and neither did dirty/recomposition diagnostics: the draw
+dirty set was identical frozen and moving (the layers re-rendered every frame),
+so the renderer was a dead end. The value itself was stuck: a spec change
+(`animateFloat` re-specced linear <-> stepped) captures a per-animation
+play-time offset, and when every reader leaves (a `with_key` tab rebuild) the
+transition loop breaks and, on restart, used to restart play time from zero,
+so `saturating_sub(offset)` pinned that one animation at its initial value for
+as long as the stale offset. Any other animation on the same transition kept
+moving, which is what made it look like a rendering bug. Reproduce with the
+exact user sequence, and when a value looks frozen log the *state value* in the
+draw closure before touching the renderer.

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -643,6 +643,16 @@ path = "robot-runners/robot_pressed_state.rs"
 required-features = ["robot-app"]
 
 [[example]]
+name = "robot_nested_glass_cache"
+path = "robot-runners/robot_nested_glass_cache.rs"
+required-features = ["robot-app"]
+
+[[example]]
+name = "robot_nested_glass_animated"
+path = "robot-runners/robot_nested_glass_animated.rs"
+required-features = ["robot-app"]
+
+[[example]]
 name = "robot_reactive_handle_copy"
 path = "robot-runners/robot_reactive_handle_copy.rs"
 required-features = ["robot-app"]

--- a/apps/desktop-demo/robot-runners/robot_nested_glass_animated.rs
+++ b/apps/desktop-demo/robot-runners/robot_nested_glass_animated.rs
@@ -1,29 +1,18 @@
 mod robot_exit;
 mod robot_launch;
+mod robot_pixels;
 
 use std::time::Duration;
 
-use cranpose::{Robot, RobotScreenshot};
+use cranpose::Robot;
 use desktop_app::test_screens::nested_glass_cache_repro::{
     NestedGlassAnimatedReproScreen, SCREEN_HEIGHT, SCREEN_WIDTH, SHADER_BOX_RECT,
 };
+use robot_pixels::pixel_at_logical;
 
 const SAMPLES: usize = 6;
 const FRAMES_BETWEEN_SAMPLES: u32 = 12;
 const MIN_CHANNEL_DELTA: i32 = 8;
-
-fn pixel_at_logical(screenshot: &RobotScreenshot, x: f32, y: f32) -> [u8; 4] {
-    let scale = if screenshot.logical_width.is_finite() && screenshot.logical_width > 0.0 {
-        screenshot.width as f32 / screenshot.logical_width
-    } else {
-        1.0
-    };
-    let px = ((x * scale) as u32).min(screenshot.width.saturating_sub(1));
-    let py = ((y * scale) as u32).min(screenshot.height.saturating_sub(1));
-    let index = (py as usize * screenshot.width as usize + px as usize) * 4;
-    let bytes = &screenshot.pixels[index..index + 4];
-    [bytes[0], bytes[1], bytes[2], bytes[3]]
-}
 
 fn shader_pixel(robot: &Robot) -> [u8; 4] {
     let shot = robot

--- a/apps/desktop-demo/robot-runners/robot_nested_glass_animated.rs
+++ b/apps/desktop-demo/robot-runners/robot_nested_glass_animated.rs
@@ -1,0 +1,77 @@
+mod robot_exit;
+mod robot_launch;
+
+use std::time::Duration;
+
+use cranpose::{Robot, RobotScreenshot};
+use desktop_app::test_screens::nested_glass_cache_repro::{
+    NestedGlassAnimatedReproScreen, SCREEN_HEIGHT, SCREEN_WIDTH, SHADER_BOX_RECT,
+};
+
+const SAMPLES: usize = 6;
+const FRAMES_BETWEEN_SAMPLES: u32 = 12;
+const MIN_CHANNEL_DELTA: i32 = 8;
+
+fn pixel_at_logical(screenshot: &RobotScreenshot, x: f32, y: f32) -> [u8; 4] {
+    let scale = if screenshot.logical_width.is_finite() && screenshot.logical_width > 0.0 {
+        screenshot.width as f32 / screenshot.logical_width
+    } else {
+        1.0
+    };
+    let px = ((x * scale) as u32).min(screenshot.width.saturating_sub(1));
+    let py = ((y * scale) as u32).min(screenshot.height.saturating_sub(1));
+    let index = (py as usize * screenshot.width as usize + px as usize) * 4;
+    let bytes = &screenshot.pixels[index..index + 4];
+    [bytes[0], bytes[1], bytes[2], bytes[3]]
+}
+
+fn shader_pixel(robot: &Robot) -> [u8; 4] {
+    let shot = robot
+        .screenshot()
+        .unwrap_or_else(|err| robot_exit::fail(robot, &format!("screenshot: {err}")));
+    let (x, y) = (
+        SHADER_BOX_RECT[0] + SHADER_BOX_RECT[2] * 0.5,
+        SHADER_BOX_RECT[1] + SHADER_BOX_RECT[3] * 0.5,
+    );
+    pixel_at_logical(&shot, x, y)
+}
+
+fn main() {
+    env_logger::init();
+    println!("=== Robot Nested Glass Animated Shader Test ===");
+    robot_launch::launch(
+        "Robot Nested Glass Animated Shader",
+        SCREEN_WIDTH as u32,
+        SCREEN_HEIGHT as u32,
+    )
+    .with_test_driver(|robot| {
+        std::thread::sleep(Duration::from_millis(300));
+        robot.pump_frames(4).expect("settle");
+        let mut previous = shader_pixel(&robot);
+        for sample in 0..SAMPLES {
+            std::thread::sleep(Duration::from_millis(120));
+            robot.pump_frames(FRAMES_BETWEEN_SAMPLES).expect("advance animation");
+            let current = shader_pixel(&robot);
+            let moved = previous
+                .iter()
+                .zip(current.iter())
+                .take(3)
+                .any(|(a, b)| (*a as i32 - *b as i32).abs() >= MIN_CHANNEL_DELTA);
+            println!("sample {sample}: {previous:?} -> {current:?} moved={moved}");
+            if !moved {
+                robot_exit::fail(
+                    &robot,
+                    &format!(
+                        "the runtime shader inside a cached glass card froze: its uniforms advance on the frame clock but the card kept serving a stale surface ({previous:?} -> {current:?})"
+                    ),
+                );
+            }
+            previous = current;
+        }
+        println!("✓ PASS: frame-clock uniforms keep repainting through the cached card");
+        let _ = robot.exit();
+    })
+    .run(|| {
+        NestedGlassAnimatedReproScreen();
+    });
+}

--- a/apps/desktop-demo/robot-runners/robot_nested_glass_cache.rs
+++ b/apps/desktop-demo/robot-runners/robot_nested_glass_cache.rs
@@ -1,0 +1,189 @@
+mod robot_exit;
+mod robot_launch;
+
+use std::time::Duration;
+
+use cranpose::{Robot, RobotScreenshot};
+use cranpose_testing::capture_screenshot;
+use desktop_app::test_screens::nested_glass_cache_repro::{
+    shader_phase_color, NestedGlassCacheReproScreen, BACKGROUND_TOGGLE_RECT, NESTED_BUTTON_RECT,
+    SCREEN_HEIGHT, SCREEN_WIDTH, SHADER_BOX_RECT, SHADER_TOGGLE_RECT, TICK_RECT,
+};
+
+const WARMUP_TICKS: u32 = 4;
+const STILL_TICKS: u32 = 6;
+const COLOR_TOLERANCE: i32 = 12;
+const MAX_BACKGROUND_TOGGLE_PASSES: u32 = 13;
+const MAX_SHADER_TOGGLE_PASSES: u32 = 10;
+
+fn center(rect: [f32; 4]) -> (f32, f32) {
+    (rect[0] + rect[2] * 0.5, rect[1] + rect[3] * 0.5)
+}
+
+fn pixel_at_logical(screenshot: &RobotScreenshot, x: f32, y: f32) -> [u8; 4] {
+    let scale = if screenshot.logical_width.is_finite() && screenshot.logical_width > 0.0 {
+        screenshot.width as f32 / screenshot.logical_width
+    } else {
+        1.0
+    };
+    let px = ((x * scale) as u32).min(screenshot.width.saturating_sub(1));
+    let py = ((y * scale) as u32).min(screenshot.height.saturating_sub(1));
+    let index = (py as usize * screenshot.width as usize + px as usize) * 4;
+    let bytes = &screenshot.pixels[index..index + 4];
+    [bytes[0], bytes[1], bytes[2], bytes[3]]
+}
+
+fn color_close(actual: [u8; 4], expected: [u8; 4]) -> bool {
+    actual
+        .iter()
+        .zip(expected.iter())
+        .take(3)
+        .all(|(a, e)| (*a as i32 - *e as i32).abs() <= COLOR_TOLERANCE)
+}
+
+fn click_rect(robot: &Robot, rect: [f32; 4]) {
+    let (x, y) = center(rect);
+    robot.click(x, y).expect("click");
+    robot.wait_for_idle().expect("idle");
+}
+
+fn screenshot(robot: &Robot) -> RobotScreenshot {
+    capture_screenshot(robot).unwrap_or_else(|| robot_exit::fail(robot, "screenshot failed"))
+}
+
+struct FrameCounts {
+    isolated_layer_renders: u32,
+    layer_cache_misses: u32,
+    pass_count: u32,
+}
+
+fn render_frame(robot: &Robot) -> (RobotScreenshot, FrameCounts) {
+    let screenshot = screenshot(robot);
+    let stats = robot
+        .get_render_stats()
+        .unwrap_or_else(|err| robot_exit::fail(robot, &format!("render stats: {err}")))
+        .unwrap_or_else(|| robot_exit::fail(robot, "renderer published no frame stats"));
+    (
+        screenshot,
+        FrameCounts {
+            isolated_layer_renders: stats.isolated_layer_renders,
+            layer_cache_misses: stats.layer_cache_misses,
+            pass_count: stats.pass_count,
+        },
+    )
+}
+
+fn expect_still_frames(robot: &Robot, stage: &str) {
+    for tick in 0..STILL_TICKS {
+        click_rect(robot, TICK_RECT);
+        let (_, counts) = render_frame(robot);
+        println!(
+            "{stage}: tick {tick} isolated_layer_renders={} layer_cache_misses={}",
+            counts.isolated_layer_renders, counts.layer_cache_misses
+        );
+        if counts.isolated_layer_renders != 0 {
+            robot_exit::fail(
+                robot,
+                &format!(
+                    "{stage}: a frame that only changed the tick strip re-rendered {} isolated layer(s); \
+                     the glass card with a runtime-shader child and a nested glass button must be served from the layer cache",
+                    counts.isolated_layer_renders
+                ),
+            );
+        }
+    }
+}
+
+fn expect_card_rerender(robot: &Robot, stage: &str, max_passes: u32) -> RobotScreenshot {
+    let (screenshot, counts) = render_frame(robot);
+    println!(
+        "{stage}: isolated_layer_renders={} layer_cache_misses={} passes={}",
+        counts.isolated_layer_renders, counts.layer_cache_misses, counts.pass_count
+    );
+    if counts.isolated_layer_renders == 0 {
+        robot_exit::fail(
+            robot,
+            &format!("{stage}: the card content changed but no isolated layer was re-rendered"),
+        );
+    }
+    if counts.pass_count > max_passes {
+        robot_exit::fail(
+            robot,
+            &format!(
+                "{stage}: re-rendering the card took {} render passes, more than the {max_passes} a baked underlay allows; \
+                 the underlay under a plainly composited card and the nested button's capture must be texture copies, not passes",
+                counts.pass_count
+            ),
+        );
+    }
+    screenshot
+}
+
+fn main() {
+    env_logger::init();
+    println!("=== Robot Nested Glass Cache Test ===");
+    robot_launch::launch(
+        "Robot Nested Glass Cache",
+        SCREEN_WIDTH as u32,
+        SCREEN_HEIGHT as u32,
+    )
+    .with_test_driver(|robot| {
+        std::thread::sleep(Duration::from_millis(300));
+        let _ = robot.wait_for_idle();
+        for _ in 0..WARMUP_TICKS {
+            click_rect(&robot, TICK_RECT);
+            let _ = render_frame(&robot);
+        }
+
+        expect_still_frames(&robot, "still-a");
+        let before_background = screenshot(&robot);
+        let (button_x, button_y) = center(NESTED_BUTTON_RECT);
+        let button_before = pixel_at_logical(&before_background, button_x, button_y);
+
+        click_rect(&robot, BACKGROUND_TOGGLE_RECT);
+        let after_background = expect_card_rerender(&robot, "background-toggle", MAX_BACKGROUND_TOGGLE_PASSES);
+        let button_after = pixel_at_logical(&after_background, button_x, button_y);
+        if color_close(button_before, button_after) {
+            robot_exit::fail(
+                &robot,
+                &format!(
+                    "the nested glass button kept its stale backdrop after the background changed: {button_before:?} -> {button_after:?}"
+                ),
+            );
+        }
+        println!("nested button refreshed with the backdrop: {button_before:?} -> {button_after:?}");
+
+        expect_still_frames(&robot, "still-b");
+
+        let (shader_x, shader_y) = center(SHADER_BOX_RECT);
+        let shader_before = pixel_at_logical(&screenshot(&robot), shader_x, shader_y);
+        if !color_close(shader_before, shader_phase_color(0.2)) {
+            robot_exit::fail(
+                &robot,
+                &format!(
+                    "runtime shader child should show phase 0.2 before the toggle, got {shader_before:?}"
+                ),
+            );
+        }
+        click_rect(&robot, SHADER_TOGGLE_RECT);
+        let after_shader = expect_card_rerender(&robot, "shader-toggle", MAX_SHADER_TOGGLE_PASSES);
+        let shader_after = pixel_at_logical(&after_shader, shader_x, shader_y);
+        if !color_close(shader_after, shader_phase_color(0.8)) {
+            robot_exit::fail(
+                &robot,
+                &format!(
+                    "runtime shader child must repaint when its uniforms change, expected phase 0.8 got {shader_after:?}"
+                ),
+            );
+        }
+        println!("runtime shader child repainted on uniform change: {shader_before:?} -> {shader_after:?}");
+
+        expect_still_frames(&robot, "still-c");
+
+        println!("✓ PASS: nested glass card is cached on still frames and refreshed on real changes");
+        let _ = robot.exit();
+    })
+    .run(|| {
+        NestedGlassCacheReproScreen();
+    });
+}

--- a/apps/desktop-demo/robot-runners/robot_nested_glass_cache.rs
+++ b/apps/desktop-demo/robot-runners/robot_nested_glass_cache.rs
@@ -1,5 +1,6 @@
 mod robot_exit;
 mod robot_launch;
+mod robot_pixels;
 
 use std::time::Duration;
 
@@ -9,6 +10,7 @@ use desktop_app::test_screens::nested_glass_cache_repro::{
     shader_phase_color, NestedGlassCacheReproScreen, BACKGROUND_TOGGLE_RECT, NESTED_BUTTON_RECT,
     SCREEN_HEIGHT, SCREEN_WIDTH, SHADER_BOX_RECT, SHADER_TOGGLE_RECT, TICK_RECT,
 };
+use robot_pixels::{color_close, pixel_at_logical};
 
 const WARMUP_TICKS: u32 = 4;
 const STILL_TICKS: u32 = 6;
@@ -18,27 +20,6 @@ const MAX_SHADER_TOGGLE_PASSES: u32 = 10;
 
 fn center(rect: [f32; 4]) -> (f32, f32) {
     (rect[0] + rect[2] * 0.5, rect[1] + rect[3] * 0.5)
-}
-
-fn pixel_at_logical(screenshot: &RobotScreenshot, x: f32, y: f32) -> [u8; 4] {
-    let scale = if screenshot.logical_width.is_finite() && screenshot.logical_width > 0.0 {
-        screenshot.width as f32 / screenshot.logical_width
-    } else {
-        1.0
-    };
-    let px = ((x * scale) as u32).min(screenshot.width.saturating_sub(1));
-    let py = ((y * scale) as u32).min(screenshot.height.saturating_sub(1));
-    let index = (py as usize * screenshot.width as usize + px as usize) * 4;
-    let bytes = &screenshot.pixels[index..index + 4];
-    [bytes[0], bytes[1], bytes[2], bytes[3]]
-}
-
-fn color_close(actual: [u8; 4], expected: [u8; 4]) -> bool {
-    actual
-        .iter()
-        .zip(expected.iter())
-        .take(3)
-        .all(|(a, e)| (*a as i32 - *e as i32).abs() <= COLOR_TOLERANCE)
 }
 
 fn click_rect(robot: &Robot, rect: [f32; 4]) {
@@ -143,7 +124,7 @@ fn main() {
         click_rect(&robot, BACKGROUND_TOGGLE_RECT);
         let after_background = expect_card_rerender(&robot, "background-toggle", MAX_BACKGROUND_TOGGLE_PASSES);
         let button_after = pixel_at_logical(&after_background, button_x, button_y);
-        if color_close(button_before, button_after) {
+        if color_close(button_before, button_after, COLOR_TOLERANCE) {
             robot_exit::fail(
                 &robot,
                 &format!(
@@ -157,7 +138,7 @@ fn main() {
 
         let (shader_x, shader_y) = center(SHADER_BOX_RECT);
         let shader_before = pixel_at_logical(&screenshot(&robot), shader_x, shader_y);
-        if !color_close(shader_before, shader_phase_color(0.2)) {
+        if !color_close(shader_before, shader_phase_color(0.2), COLOR_TOLERANCE) {
             robot_exit::fail(
                 &robot,
                 &format!(
@@ -168,7 +149,7 @@ fn main() {
         click_rect(&robot, SHADER_TOGGLE_RECT);
         let after_shader = expect_card_rerender(&robot, "shader-toggle", MAX_SHADER_TOGGLE_PASSES);
         let shader_after = pixel_at_logical(&after_shader, shader_x, shader_y);
-        if !color_close(shader_after, shader_phase_color(0.8)) {
+        if !color_close(shader_after, shader_phase_color(0.8), COLOR_TOLERANCE) {
             robot_exit::fail(
                 &robot,
                 &format!(

--- a/apps/desktop-demo/robot-runners/robot_pixels.rs
+++ b/apps/desktop-demo/robot-runners/robot_pixels.rs
@@ -1,0 +1,28 @@
+#![allow(dead_code)]
+
+use cranpose::RobotScreenshot;
+
+/// The RGBA bytes under a logical-pixel position, using the screenshot's
+/// own logical-to-physical scale.
+pub fn pixel_at_logical(screenshot: &RobotScreenshot, x: f32, y: f32) -> [u8; 4] {
+    let scale = if screenshot.logical_width.is_finite() && screenshot.logical_width > 0.0 {
+        screenshot.width as f32 / screenshot.logical_width
+    } else {
+        1.0
+    };
+    let px = ((x * scale) as u32).min(screenshot.width.saturating_sub(1));
+    let py = ((y * scale) as u32).min(screenshot.height.saturating_sub(1));
+    let index = (py as usize * screenshot.width as usize + px as usize) * 4;
+    let bytes = &screenshot.pixels[index..index + 4];
+    [bytes[0], bytes[1], bytes[2], bytes[3]]
+}
+
+/// Whether every colour channel of `actual` is within `tolerance` of
+/// `expected`; alpha is ignored.
+pub fn color_close(actual: [u8; 4], expected: [u8; 4], tolerance: i32) -> bool {
+    actual
+        .iter()
+        .zip(expected.iter())
+        .take(3)
+        .all(|(a, e)| (*a as i32 - *e as i32).abs() <= tolerance)
+}

--- a/apps/desktop-demo/robot-runners/robot_pressed_state.rs
+++ b/apps/desktop-demo/robot-runners/robot_pressed_state.rs
@@ -1,6 +1,7 @@
 mod robot_launch;
 
 mod robot_exit;
+mod robot_pixels;
 
 use std::time::Duration;
 
@@ -10,34 +11,10 @@ use desktop_app::test_screens::pressed_state_repro::{
     PressedStateReproScreen, NORMAL_RGBA, PRESSED_RGBA, SPRITE_HEIGHT, SPRITE_OFFSET_X,
     SPRITE_OFFSET_Y, SPRITE_WIDTH,
 };
+use robot_pixels::{color_close, pixel_at_logical};
 
 const COLOR_TOLERANCE: i32 = 24;
 const SAMPLE_ATTEMPTS: usize = 20;
-
-fn physical_scale(screenshot: &cranpose::RobotScreenshot) -> f32 {
-    if screenshot.logical_width.is_finite() && screenshot.logical_width > 0.0 {
-        screenshot.width as f32 / screenshot.logical_width
-    } else {
-        1.0
-    }
-}
-
-fn pixel_at_logical(screenshot: &cranpose::RobotScreenshot, x: f32, y: f32) -> [u8; 4] {
-    let scale = physical_scale(screenshot);
-    let px = ((x * scale) as u32).min(screenshot.width.saturating_sub(1));
-    let py = ((y * scale) as u32).min(screenshot.height.saturating_sub(1));
-    let index = (py as usize * screenshot.width as usize + px as usize) * 4;
-    let bytes = &screenshot.pixels[index..index + 4];
-    [bytes[0], bytes[1], bytes[2], bytes[3]]
-}
-
-fn color_close(actual: [u8; 4], expected: [u8; 4]) -> bool {
-    actual
-        .iter()
-        .zip(expected.iter())
-        .take(3)
-        .all(|(a, e)| (*a as i32 - *e as i32).abs() <= COLOR_TOLERANCE)
-}
 
 fn wait_for_sprite_color(robot: &Robot, x: f32, y: f32, expected: [u8; 4]) -> Result<(), [u8; 4]> {
     let mut last = [0u8; 4];
@@ -46,7 +23,7 @@ fn wait_for_sprite_color(robot: &Robot, x: f32, y: f32, expected: [u8; 4]) -> Re
         let _ = robot.wait_for_idle();
         if let Some(screenshot) = capture_screenshot(robot) {
             last = pixel_at_logical(&screenshot, x, y);
-            if color_close(last, expected) {
+            if color_close(last, expected, COLOR_TOLERANCE) {
                 return Ok(());
             }
         }

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -33,7 +33,7 @@ mod markdown;
 mod mineswapper2;
 mod recomposition_lab;
 pub mod rotary;
-mod shader_rect;
+pub(crate) mod shader_rect;
 mod shaders;
 mod source_view;
 mod text_showcase;

--- a/apps/desktop-demo/src/app/shader_rect.rs
+++ b/apps/desktop-demo/src/app/shader_rect.rs
@@ -15,7 +15,9 @@ use cranpose_ui::{
 };
 use cranpose_ui_graphics::{CompositingStrategy, RenderEffect, RuntimeShader};
 
-const WGSL_PREAMBLE: &str = r#"
+/// The fullscreen vertex stage, texture and uniform bindings every runtime
+/// shader in the demo starts from; a fragment stage is appended per effect.
+pub(crate) const WGSL_PREAMBLE: &str = r#"
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) uv: vec2<f32>,

--- a/apps/desktop-demo/src/test_screens/mod.rs
+++ b/apps/desktop-demo/src/test_screens/mod.rs
@@ -1,3 +1,4 @@
+pub mod nested_glass_cache_repro;
 pub mod pressed_state_repro;
 pub mod scroll_repro;
 pub mod text_wrap_repro;

--- a/apps/desktop-demo/src/test_screens/nested_glass_cache_repro.rs
+++ b/apps/desktop-demo/src/test_screens/nested_glass_cache_repro.rs
@@ -1,0 +1,191 @@
+use cranpose_core::{MutableState, State};
+use cranpose_ui::{
+    composable, Box, BoxSpec, Color, GraphicsLayer, Modifier, RenderEffect, RuntimeShader, Size,
+    Text, TextStyle,
+};
+
+pub const SCREEN_WIDTH: f32 = 600.0;
+pub const SCREEN_HEIGHT: f32 = 400.0;
+
+pub const TICK_RECT: [f32; 4] = [8.0, 8.0, 48.0, 24.0];
+pub const BACKGROUND_TOGGLE_RECT: [f32; 4] = [72.0, 8.0, 48.0, 24.0];
+pub const SHADER_TOGGLE_RECT: [f32; 4] = [136.0, 8.0, 48.0, 24.0];
+
+pub const CARD_RECT: [f32; 4] = [60.0, 80.0, 420.0, 200.0];
+pub const SHADER_BOX_RECT: [f32; 4] = [80.0, 150.0, 60.0, 60.0];
+pub const NESTED_BUTTON_RECT: [f32; 4] = [400.0, 160.0, 40.0, 40.0];
+
+pub const BACKGROUND_A: Color = Color(0.10, 0.16, 0.40, 1.0);
+pub const BACKGROUND_B: Color = Color(0.55, 0.12, 0.10, 1.0);
+
+const FLAT_COLOR_WGSL: &str = r#"
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn fullscreen_vs(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+    var output: VertexOutput;
+    let x = f32(i32(vertex_index & 1u) * 2 - 1);
+    let y = f32(i32(vertex_index >> 1u) * 2 - 1);
+    output.uv = vec2<f32>(x * 0.5 + 0.5, 1.0 - (y * 0.5 + 0.5));
+    output.position = vec4<f32>(x, y, 0.0, 1.0);
+    return output;
+}
+
+@group(0) @binding(0) var input_texture: texture_2d<f32>;
+@group(0) @binding(1) var input_sampler: sampler;
+@group(1) @binding(0) var<uniform> u: array<vec4<f32>, 64>;
+
+@fragment
+fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
+    let base = textureSample(input_texture, input_sampler, input.uv);
+    let phase = u[0].x;
+    return vec4<f32>(phase, 0.4, 1.0 - phase, 1.0) + base * 0.0;
+}
+"#;
+
+pub fn shader_phase_color(phase: f32) -> [u8; 4] {
+    let channel = |value: f32| (value.clamp(0.0, 1.0) * 255.0).round() as u8;
+    [channel(phase), channel(0.4), channel(1.0 - phase), 255]
+}
+
+fn flat_color_shader(phase: f32) -> RuntimeShader {
+    let mut shader = RuntimeShader::new(FLAT_COLOR_WGSL);
+    shader.set_float(0, phase);
+    shader
+}
+
+fn rect_modifier(rect: [f32; 4]) -> Modifier {
+    Modifier::empty().offset(rect[0], rect[1]).size(Size {
+        width: rect[2],
+        height: rect[3],
+    })
+}
+
+fn tick_color(tick: u32) -> Color {
+    let step = (tick % 8) as f32 / 8.0;
+    Color(0.2 + step * 0.6, 0.9 - step * 0.5, 0.3, 1.0)
+}
+
+/// A glass card holding a runtime-shader child and a nested glass button
+/// over a switchable backdrop, with a tick strip that forces one presented
+/// frame per click without touching the card.
+#[allow(non_snake_case)]
+#[composable]
+pub fn NestedGlassCacheReproScreen() {
+    let shader_phase = cranpose_core::rememberMutableStateOf(|| 0.2f32);
+    NestedGlassScreen(shader_phase.as_state(), Some(shader_phase));
+}
+
+/// The same card, but the shader phase runs on the frame clock so the
+/// runtime shader's uniforms change through draw repasses alone, with no
+/// pointer event in between.
+#[allow(non_snake_case)]
+#[composable]
+pub fn NestedGlassAnimatedReproScreen() {
+    let infinite = cranpose_animation::prelude::rememberInfiniteTransition("nested-glass-phase");
+    let shader_phase = infinite.animateFloat(
+        0.0,
+        1.0,
+        cranpose_animation::prelude::infiniteRepeatable(
+            cranpose_animation::prelude::AnimationSpec::linear(1_000),
+            cranpose_animation::prelude::RepeatMode::Reverse,
+            cranpose_animation::prelude::StartOffset::default(),
+        ),
+        "phase",
+    );
+    NestedGlassScreen(shader_phase, None);
+}
+
+#[allow(non_snake_case)]
+#[composable]
+fn NestedGlassScreen(shader_phase: State<f32>, toggled_phase: Option<MutableState<f32>>) {
+    let tick = cranpose_core::rememberMutableStateOf(|| 0u32);
+    let alternate_background = cranpose_core::rememberMutableStateOf(|| false);
+    let background = if alternate_background.get() {
+        BACKGROUND_B
+    } else {
+        BACKGROUND_A
+    };
+    Box(
+        Modifier::empty()
+            .size(Size {
+                width: SCREEN_WIDTH,
+                height: SCREEN_HEIGHT,
+            })
+            .background(background),
+        BoxSpec::default(),
+        move || {
+            Box(
+                rect_modifier(TICK_RECT)
+                    .background(tick_color(tick.get()))
+                    .clickable(move |_point| tick.set(tick.get().wrapping_add(1))),
+                BoxSpec::default(),
+                || {},
+            );
+            Box(
+                rect_modifier(BACKGROUND_TOGGLE_RECT)
+                    .background(Color(0.9, 0.9, 0.9, 1.0))
+                    .clickable(move |_point| alternate_background.set(!alternate_background.get())),
+                BoxSpec::default(),
+                || {},
+            );
+            Box(
+                rect_modifier(SHADER_TOGGLE_RECT)
+                    .background(Color(0.6, 0.6, 0.6, 1.0))
+                    .clickable(move |_point| {
+                        if let Some(phase) = toggled_phase {
+                            phase.set(if phase.get() > 0.5 { 0.2 } else { 0.8 });
+                        }
+                    }),
+                BoxSpec::default(),
+                || {},
+            );
+            Box(
+                rect_modifier(CARD_RECT)
+                    .backdrop_effect(RenderEffect::blur(10.0))
+                    .background(Color(1.0, 1.0, 1.0, 0.18))
+                    .rounded_corners(16.0),
+                BoxSpec::default(),
+                move || {
+                    Text(
+                        "Nested glass",
+                        Modifier::empty().offset(20.0, 20.0),
+                        TextStyle::default(),
+                    );
+                    Box(
+                        rect_modifier([
+                            SHADER_BOX_RECT[0] - CARD_RECT[0],
+                            SHADER_BOX_RECT[1] - CARD_RECT[1],
+                            SHADER_BOX_RECT[2],
+                            SHADER_BOX_RECT[3],
+                        ])
+                        .graphics_layer(move || GraphicsLayer {
+                            render_effect: Some(RenderEffect::runtime_shader(flat_color_shader(
+                                shader_phase.get(),
+                            ))),
+                            ..Default::default()
+                        }),
+                        BoxSpec::default(),
+                        || {},
+                    );
+                    Box(
+                        rect_modifier([
+                            NESTED_BUTTON_RECT[0] - CARD_RECT[0],
+                            NESTED_BUTTON_RECT[1] - CARD_RECT[1],
+                            NESTED_BUTTON_RECT[2],
+                            NESTED_BUTTON_RECT[3],
+                        ])
+                        .backdrop_effect(RenderEffect::blur(6.0))
+                        .background(Color(1.0, 1.0, 1.0, 0.22))
+                        .rounded_corners(20.0),
+                        BoxSpec::default(),
+                        || {},
+                    );
+                },
+            );
+        },
+    );
+}

--- a/apps/desktop-demo/src/test_screens/nested_glass_cache_repro.rs
+++ b/apps/desktop-demo/src/test_screens/nested_glass_cache_repro.rs
@@ -18,26 +18,7 @@ pub const NESTED_BUTTON_RECT: [f32; 4] = [400.0, 160.0, 40.0, 40.0];
 pub const BACKGROUND_A: Color = Color(0.10, 0.16, 0.40, 1.0);
 pub const BACKGROUND_B: Color = Color(0.55, 0.12, 0.10, 1.0);
 
-const FLAT_COLOR_WGSL: &str = r#"
-struct VertexOutput {
-    @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
-}
-
-@vertex
-fn fullscreen_vs(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
-    var output: VertexOutput;
-    let x = f32(i32(vertex_index & 1u) * 2 - 1);
-    let y = f32(i32(vertex_index >> 1u) * 2 - 1);
-    output.uv = vec2<f32>(x * 0.5 + 0.5, 1.0 - (y * 0.5 + 0.5));
-    output.position = vec4<f32>(x, y, 0.0, 1.0);
-    return output;
-}
-
-@group(0) @binding(0) var input_texture: texture_2d<f32>;
-@group(0) @binding(1) var input_sampler: sampler;
-@group(1) @binding(0) var<uniform> u: array<vec4<f32>, 64>;
-
+const FLAT_COLOR_FRAGMENT: &str = r#"
 @fragment
 fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     let base = textureSample(input_texture, input_sampler, input.uv);
@@ -52,7 +33,11 @@ pub fn shader_phase_color(phase: f32) -> [u8; 4] {
 }
 
 fn flat_color_shader(phase: f32) -> RuntimeShader {
-    let mut shader = RuntimeShader::new(FLAT_COLOR_WGSL);
+    let source = format!(
+        "{}{FLAT_COLOR_FRAGMENT}",
+        crate::app::shader_rect::WGSL_PREAMBLE
+    );
+    let mut shader = RuntimeShader::new(&source);
     shader.set_float(0, phase);
     shader
 }

--- a/crates/cranpose-animation/src/animation.rs
+++ b/crates/cranpose-animation/src/animation.rs
@@ -626,6 +626,7 @@ struct InfiniteTransitionInner {
     animations: RefCell<Vec<Rc<dyn InfiniteTransitionAnimation>>>,
     run_token: OwnedMutableState<u64>,
     restart_pending: Cell<bool>,
+    origin_nanos: Cell<Option<u64>>,
     runtime: RuntimeHandle,
 }
 
@@ -637,6 +638,7 @@ impl InfiniteTransition {
                 animations: RefCell::new(Vec::new()),
                 run_token: OwnedMutableState::with_runtime(0u64, runtime.clone()),
                 restart_pending: Cell::new(false),
+                origin_nanos: Cell::new(None),
                 runtime,
             }),
         }
@@ -659,7 +661,6 @@ impl InfiniteTransition {
             move |scope| {
                 Box::pin(async move {
                     let clock = scope.runtime().frame_clock();
-                    let mut start_time: Option<u64> = None;
 
                     loop {
                         if !scope.is_active() {
@@ -680,9 +681,7 @@ impl InfiniteTransition {
                             break;
                         }
 
-                        let start = start_time.get_or_insert(now);
-                        let play_time = now.saturating_sub(*start);
-                        inner.on_frame(play_time);
+                        inner.on_frame(inner.play_time(now));
                     }
                 })
             },
@@ -762,6 +761,21 @@ impl InfiniteTransition {
 }
 
 impl InfiniteTransitionInner {
+    /// Play time measured from the first frame this transition ever saw.
+    /// The driving loop stops while nothing reads its values and starts
+    /// again when a reader returns; every animation's play-time offset was
+    /// captured on this one timeline, so a restarted loop must keep it.
+    fn play_time(&self, now_nanos: u64) -> u64 {
+        let origin = match self.origin_nanos.get() {
+            Some(origin) => origin,
+            None => {
+                self.origin_nanos.set(Some(now_nanos));
+                now_nanos
+            }
+        };
+        now_nanos.saturating_sub(origin)
+    }
+
     fn add_animation(&self, animation: Rc<dyn InfiniteTransitionAnimation>) {
         let mut list = self.animations.borrow_mut();
         let was_empty = list.is_empty();

--- a/crates/cranpose-animation/tests/infinite_transition_tests.rs
+++ b/crates/cranpose-animation/tests/infinite_transition_tests.rs
@@ -425,3 +425,116 @@ fn infinite_transition_conditional_cycle_does_not_leak_slots() {
         final_slots.len(),
     );
 }
+
+#[test]
+fn respec_animation_keeps_advancing_after_its_readers_leave_and_return() {
+    let mut composition = Composition::new(MemoryApplier::new());
+    let runtime = composition.runtime_handle();
+    let root_key = location_key(file!(), line!(), column!());
+    let detail = MutableState::with_runtime(false, runtime.clone());
+    let rotation_slot = Rc::new(RefCell::new(None::<State<f32>>));
+    let sheen_slot = Rc::new(RefCell::new(None::<State<f32>>));
+
+    let mut render = {
+        let rotation_slot = Rc::clone(&rotation_slot);
+        let sheen_slot = Rc::clone(&sheen_slot);
+        move || {
+            let rotation_slot = Rc::clone(&rotation_slot);
+            let sheen_slot = Rc::clone(&sheen_slot);
+            with_current_composer(|composer| {
+                composer.with_group(location_key(file!(), line!(), column!()), |_composer| {
+                    let transition = rememberInfiniteTransition("ambient");
+                    let spec = if detail.get() {
+                        AnimationSpec::linear(48_000)
+                    } else {
+                        AnimationSpec::stepped(48_000, 960)
+                    };
+                    let rotation = transition.animateFloat(
+                        0.0,
+                        1.0,
+                        infiniteRepeatable(spec, RepeatMode::Restart, StartOffset::default()),
+                        "rotation",
+                    );
+                    let sheen = transition.animateFloat(
+                        0.0,
+                        1.0,
+                        infiniteRepeatable(
+                            AnimationSpec::stepped(5_200, 104),
+                            RepeatMode::Reverse,
+                            StartOffset::default(),
+                        ),
+                        "sheen",
+                    );
+                    rotation_slot.borrow_mut().replace(rotation);
+                    sheen_slot.borrow_mut().replace(sheen);
+                });
+            });
+        }
+    };
+    composition
+        .render(root_key, &mut render)
+        .expect("initial render");
+    runtime.drain_ui();
+    drain_all(&mut composition).expect("initial drain");
+
+    let rotation = || rotation_slot.borrow().as_ref().expect("rotation").get();
+    let sheen = || sheen_slot.borrow().as_ref().expect("sheen").get();
+    let observer = SnapshotStateObserver::new(|callback| callback());
+    let subscribe = |observer: &SnapshotStateObserver| {
+        observer.observe_reads((), |_| {}, || (rotation(), sheen()));
+    };
+    subscribe(&observer);
+    runtime.drain_ui();
+    composition
+        .render(root_key, &mut render)
+        .expect("subscriber render");
+    drain_all(&mut composition).expect("subscriber drain");
+
+    let mut time = 0u64;
+    let mut advance = |composition: &mut Composition<MemoryApplier>, frames: u32| {
+        for _ in 0..frames {
+            time += 16_666_667;
+            runtime.drain_frame_callbacks(time);
+            runtime.drain_ui();
+            drain_all(composition).expect("drain after frame");
+        }
+    };
+
+    advance(&mut composition, 120);
+    assert!(rotation() > 0.0, "rotation must run while it is read");
+
+    detail.set(true);
+    composition
+        .render(root_key, &mut render)
+        .expect("detail render");
+    drain_all(&mut composition).expect("detail drain");
+    advance(&mut composition, 180);
+    detail.set(false);
+    composition
+        .render(root_key, &mut render)
+        .expect("list render");
+    drain_all(&mut composition).expect("list drain");
+    advance(&mut composition, 180);
+    assert!(
+        rotation() > 0.0,
+        "rotation must run after its spec changes back"
+    );
+
+    observer.clear_all();
+    advance(&mut composition, 30);
+    subscribe(&observer);
+    runtime.drain_ui();
+    composition
+        .render(root_key, &mut render)
+        .expect("return render");
+    drain_all(&mut composition).expect("return drain");
+    advance(&mut composition, 60);
+    let after_return = rotation();
+    advance(&mut composition, 60);
+    let later = rotation();
+
+    assert!(
+        later > after_return && after_return > 0.0,
+        "a re-specced animation must keep advancing once its readers return: {after_return} -> {later}"
+    );
+}

--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -1185,25 +1185,6 @@ impl EffectRenderer {
             radius_x > 0.0 || radius_y > 0.0,
             "zero-radius blur should use the composite fast path"
         );
-        if ablate_blur() {
-            self.encode_composite_to_view_pass(
-                recorder,
-                device,
-                source,
-                dest_view,
-                CompositePassOptions {
-                    alpha: 1.0,
-                    load_op: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                    scissor,
-                    rounded_mask: None,
-                    blend_mode: BlendMode::SrcOver,
-                    dest_viewport: None,
-                    source_viewport: None,
-                    sample_mode: CompositeSampleMode::Linear,
-                },
-            );
-            return;
-        }
         let scale_x = source.width as f32 / scratch.width.max(1) as f32;
         let scale_y = source.height as f32 / scratch.height.max(1) as f32;
 
@@ -1442,25 +1423,6 @@ impl EffectRenderer {
         shader: &RuntimeShader,
         layer_pixel_rect: [f32; 4],
     ) -> bool {
-        if ablate_shaders() {
-            self.encode_composite_to_view_pass(
-                recorder,
-                device,
-                source,
-                dest_view,
-                CompositePassOptions {
-                    alpha: 1.0,
-                    load_op: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                    scissor: None,
-                    rounded_mask: None,
-                    blend_mode: BlendMode::SrcOver,
-                    dest_viewport: None,
-                    source_viewport: None,
-                    sample_mode: CompositeSampleMode::Linear,
-                },
-            );
-            return true;
-        }
         self.encode_shader_pass(
             recorder,
             device,
@@ -1495,25 +1457,6 @@ impl EffectRenderer {
         if dest_viewport.2 <= 0.0 || dest_viewport.3 <= 0.0 {
             return false;
         }
-        if ablate_shaders() {
-            self.encode_composite_to_view_pass(
-                recorder,
-                device,
-                source,
-                dest_view,
-                CompositePassOptions {
-                    alpha: 1.0,
-                    load_op,
-                    scissor,
-                    rounded_mask: None,
-                    blend_mode: BlendMode::SrcOver,
-                    dest_viewport: Some(dest_viewport),
-                    source_viewport: None,
-                    sample_mode: CompositeSampleMode::Linear,
-                },
-            );
-            return true;
-        }
         self.encode_shader_pass(
             recorder,
             device,
@@ -1542,9 +1485,6 @@ impl EffectRenderer {
     ) -> bool {
         if items.is_empty() {
             return true;
-        }
-        if ablate_shaders() {
-            return false;
         }
         let Some(prepared) = self.prepare_shader_batch_draws(recorder, device, items, false) else {
             return false;
@@ -2461,28 +2401,6 @@ fn composite_sampling_mode_value(sample_mode: CompositeSampleMode) -> f32 {
         CompositeSampleMode::Box4 => 1.0,
         CompositeSampleMode::Nearest => 2.0,
     }
-}
-
-/// Measurement ablations for devices without GPU timestamp queries: with
-/// `CRANPOSE_ABLATE_SHADERS` every runtime-shader stage composites its input
-/// unchanged, and with `CRANPOSE_ABLATE_BLUR` every blur does the same, so an
-/// A/B of present time attributes the GPU cost of each stage. Both are
-/// mirrored as `debug.cranpose.ablate_*` system properties on Android and
-/// change what the screen shows; they are never read outside a diagnosis.
-fn ablate_shaders() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| {
-        crate::debug_toggles::debug_toggle("CRANPOSE_ABLATE_SHADERS")
-            .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes"))
-    })
-}
-
-fn ablate_blur() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| {
-        crate::debug_toggles::debug_toggle("CRANPOSE_ABLATE_BLUR")
-            .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes"))
-    })
 }
 
 #[cfg(test)]

--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -1185,6 +1185,25 @@ impl EffectRenderer {
             radius_x > 0.0 || radius_y > 0.0,
             "zero-radius blur should use the composite fast path"
         );
+        if ablate_blur() {
+            self.encode_composite_to_view_pass(
+                recorder,
+                device,
+                source,
+                dest_view,
+                CompositePassOptions {
+                    alpha: 1.0,
+                    load_op: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    scissor,
+                    rounded_mask: None,
+                    blend_mode: BlendMode::SrcOver,
+                    dest_viewport: None,
+                    source_viewport: None,
+                    sample_mode: CompositeSampleMode::Linear,
+                },
+            );
+            return;
+        }
         let scale_x = source.width as f32 / scratch.width.max(1) as f32;
         let scale_y = source.height as f32 / scratch.height.max(1) as f32;
 
@@ -1423,6 +1442,25 @@ impl EffectRenderer {
         shader: &RuntimeShader,
         layer_pixel_rect: [f32; 4],
     ) -> bool {
+        if ablate_shaders() {
+            self.encode_composite_to_view_pass(
+                recorder,
+                device,
+                source,
+                dest_view,
+                CompositePassOptions {
+                    alpha: 1.0,
+                    load_op: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    scissor: None,
+                    rounded_mask: None,
+                    blend_mode: BlendMode::SrcOver,
+                    dest_viewport: None,
+                    source_viewport: None,
+                    sample_mode: CompositeSampleMode::Linear,
+                },
+            );
+            return true;
+        }
         self.encode_shader_pass(
             recorder,
             device,
@@ -1457,6 +1495,25 @@ impl EffectRenderer {
         if dest_viewport.2 <= 0.0 || dest_viewport.3 <= 0.0 {
             return false;
         }
+        if ablate_shaders() {
+            self.encode_composite_to_view_pass(
+                recorder,
+                device,
+                source,
+                dest_view,
+                CompositePassOptions {
+                    alpha: 1.0,
+                    load_op,
+                    scissor,
+                    rounded_mask: None,
+                    blend_mode: BlendMode::SrcOver,
+                    dest_viewport: Some(dest_viewport),
+                    source_viewport: None,
+                    sample_mode: CompositeSampleMode::Linear,
+                },
+            );
+            return true;
+        }
         self.encode_shader_pass(
             recorder,
             device,
@@ -1485,6 +1542,9 @@ impl EffectRenderer {
     ) -> bool {
         if items.is_empty() {
             return true;
+        }
+        if ablate_shaders() {
+            return false;
         }
         let Some(prepared) = self.prepare_shader_batch_draws(recorder, device, items, false) else {
             return false;
@@ -2401,6 +2461,28 @@ fn composite_sampling_mode_value(sample_mode: CompositeSampleMode) -> f32 {
         CompositeSampleMode::Box4 => 1.0,
         CompositeSampleMode::Nearest => 2.0,
     }
+}
+
+/// Measurement ablations for devices without GPU timestamp queries: with
+/// `CRANPOSE_ABLATE_SHADERS` every runtime-shader stage composites its input
+/// unchanged, and with `CRANPOSE_ABLATE_BLUR` every blur does the same, so an
+/// A/B of present time attributes the GPU cost of each stage. Both are
+/// mirrored as `debug.cranpose.ablate_*` system properties on Android and
+/// change what the screen shows; they are never read outside a diagnosis.
+fn ablate_shaders() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        crate::debug_toggles::debug_toggle("CRANPOSE_ABLATE_SHADERS")
+            .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes"))
+    })
+}
+
+fn ablate_blur() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        crate::debug_toggles::debug_toggle("CRANPOSE_ABLATE_BLUR")
+            .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes"))
+    })
 }
 
 #[cfg(test)]

--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -364,7 +364,6 @@ impl WgpuRenderer {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     fn sync_gpu_renderer_mut(&mut self) -> Option<&mut GpuRenderer> {
         match &mut self.backend {
             PresentBackend::Sync(gpu_renderer) => Some(gpu_renderer.as_mut()),

--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -994,9 +994,26 @@ impl WgpuRenderer {
         }
     }
 
+    /// Enables or disables baking a plainly composited surface onto a copy of
+    /// the pixels beneath it (see `CRANPOSE_DISABLE_UNDERLAY_BAKE`). Parity
+    /// tests render the same scene both ways; both ways are exact.
+    pub fn set_underlay_bake_enabled(&mut self, enabled: bool) {
+        if let Some(renderer) = self.sync_gpu_renderer_mut() {
+            renderer.set_underlay_bake_enabled(enabled);
+        }
+    }
+
     pub fn last_frame_stats(&self) -> Option<RenderStatsSnapshot> {
-        self.sync_gpu_renderer()
-            .and_then(GpuRenderer::last_frame_stats)
+        match &self.backend {
+            PresentBackend::Sync(gpu_renderer) => gpu_renderer.last_frame_stats(),
+            #[cfg(not(target_arch = "wasm32"))]
+            PresentBackend::Threaded(handle) => *handle
+                .status()
+                .last_frame_stats
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            PresentBackend::None => None,
+        }
     }
 
     /// GPU milliseconds by pass label, aggregated since the last `[GPU-PASS]`

--- a/crates/cranpose-render/wgpu/src/present_runtime.rs
+++ b/crates/cranpose-render/wgpu/src/present_runtime.rs
@@ -1,6 +1,6 @@
 use std::{
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicBool, AtomicU64, Ordering},
         mpsc::{
             Receiver, RecvTimeoutError, Sender, SyncSender, TryRecvError, TrySendError, channel,
@@ -77,6 +77,7 @@ pub(crate) enum PresentMsg {
 
 #[derive(Default)]
 pub(crate) struct PresentStatus {
+    pub(crate) last_frame_stats: Mutex<Option<crate::gpu_stats::FrameStatsSnapshot>>,
     pub(crate) needs_frame_warmup: AtomicBool,
     pub(crate) replay_supported: AtomicBool,
     pub(crate) presented_frames: AtomicU64,
@@ -513,6 +514,12 @@ impl PresentState {
     }
 
     fn finish_returns(&mut self, returns: RenderReturns) {
+        *self
+            .status
+            .last_frame_stats
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+            self.gpu_renderer.last_frame_stats();
         self.status
             .needs_frame_warmup
             .store(self.gpu_renderer.needs_frame_warmup(), Ordering::Relaxed);

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -106,7 +106,7 @@ use crate::{
     },
     shaders,
     surface_executor::{
-        DevicePixelBounds, LayerSurfaceTexture, SurfaceExecutionBackend,
+        CacheAdmission, DevicePixelBounds, LayerSurfaceTexture, SurfaceExecutionBackend,
         apply_backdrop_layer_to_target as execute_apply_backdrop_layer_to_target,
         axis_aligned_quad_rect, backdrop_underlay_is_covered_by_local_content,
         canonicalize_device_coordinate, canonicalized_scaled_quad, canonicalized_scaled_rect,
@@ -228,6 +228,10 @@ const HARD_MAX_BUFFER_MB: usize = 64;
 const MAX_SHADOW_SURFACE_CACHE_ITEMS: usize = 512;
 const MAX_SHADOW_SURFACE_CACHE_BYTES: u64 = 384 * 1024 * 1024;
 
+fn underlay_bake_switch() -> bool {
+    crate::debug_toggles::debug_toggle("CRANPOSE_DISABLE_UNDERLAY_BAKE").is_none()
+}
+
 fn skip_shadow_draws() -> bool {
     crate::debug_toggles::debug_toggle("CRANPOSE_SKIP_SHADOWS")
         .map(|v| matches!(v.as_str(), "1" | "true" | "yes"))
@@ -302,31 +306,32 @@ pub(crate) fn should_log_wgpu_render_stage(start: Instant, end: Instant) -> Opti
 
 fn admit_layer_surface_cache_miss_impl(
     key: &LayerRasterCacheKey,
-    observed_scene_range_misses: &mut BoundedLruCache<LayerRasterCacheKey, ()>,
+    observed_misses: &mut BoundedLruCache<LayerRasterCacheKey, ()>,
+    admission: CacheAdmission,
 ) -> bool {
-    if !key.is_scene_range() {
+    if admission == CacheAdmission::Immediate {
         return true;
     }
-    if observed_scene_range_misses.contains(key) {
+    if observed_misses.contains(key) {
         return true;
     }
-    observed_scene_range_misses.put(*key, ());
+    observed_misses.put(*key, ());
     false
 }
 
 #[cfg(test)]
-fn first_cache_miss_admission(key: &LayerRasterCacheKey) -> bool {
-    let mut observed_scene_range_misses =
+fn first_cache_miss_admission(key: &LayerRasterCacheKey, admission: CacheAdmission) -> bool {
+    let mut observed_misses =
         BoundedLruCache::with_capacity_at_least_one(MAX_OBSERVED_SCENE_RANGE_CACHE_MISSES);
-    admit_layer_surface_cache_miss_impl(key, &mut observed_scene_range_misses)
+    admit_layer_surface_cache_miss_impl(key, &mut observed_misses, admission)
 }
 
 #[cfg(test)]
-fn repeated_cache_miss_admission(key: &LayerRasterCacheKey) -> bool {
-    let mut observed_scene_range_misses =
+fn repeated_cache_miss_admission(key: &LayerRasterCacheKey, admission: CacheAdmission) -> bool {
+    let mut observed_misses =
         BoundedLruCache::with_capacity_at_least_one(MAX_OBSERVED_SCENE_RANGE_CACHE_MISSES);
-    let _ = admit_layer_surface_cache_miss_impl(key, &mut observed_scene_range_misses);
-    admit_layer_surface_cache_miss_impl(key, &mut observed_scene_range_misses)
+    let _ = admit_layer_surface_cache_miss_impl(key, &mut observed_misses, admission);
+    admit_layer_surface_cache_miss_impl(key, &mut observed_misses, admission)
 }
 
 pub static PRESENTED_FRAMES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
@@ -5022,6 +5027,8 @@ pub struct GpuRenderer {
     effect_renderer: EffectRenderer,
     layer_surface_cache: LayerSurfaceCache,
     observed_scene_range_cache_misses: BoundedLruCache<LayerRasterCacheKey, ()>,
+    observed_surface_cache_misses: BoundedLruCache<LayerRasterCacheKey, ()>,
+    underlay_bake_enabled: bool,
     shadow_surface_cache: BoundedLruCache<ShadowSurfaceCacheKey, CachedShadowSurface>,
     shadow_surface_cache_bytes: u64,
     frame_stats: gpu_stats::FrameStats,
@@ -5218,8 +5225,7 @@ fn layer_raster_cache_candidate(
     let runtime_cache_is_safe = allow_runtime_cache
         && surface_requirements
             .surface_requirements
-            .has_isolating_requirement()
-        && !surface_requirements.contains_runtime_shader;
+            .has_isolating_requirement();
     let cache_is_allowed = layer.cache_policy == CachePolicy::Auto
         || (allow_runtime_cache && surface_requirements.has_renderer_forced_surface())
         || runtime_cache_is_safe;
@@ -5227,9 +5233,6 @@ fn layer_raster_cache_candidate(
         return None;
     }
     if layer_uses_external_backdrop_input(layer, has_backdrop_underlay) {
-        return None;
-    }
-    if surface_requirements.contains_runtime_shader {
         return None;
     }
 
@@ -5708,6 +5711,10 @@ impl GpuRenderer {
             observed_scene_range_cache_misses: BoundedLruCache::with_capacity_at_least_one(
                 MAX_OBSERVED_SCENE_RANGE_CACHE_MISSES,
             ),
+            observed_surface_cache_misses: BoundedLruCache::with_capacity_at_least_one(
+                MAX_OBSERVED_SCENE_RANGE_CACHE_MISSES,
+            ),
+            underlay_bake_enabled: underlay_bake_switch(),
             shadow_surface_cache: BoundedLruCache::with_capacity_at_least_one(
                 MAX_SHADOW_SURFACE_CACHE_ITEMS,
             ),
@@ -6366,8 +6373,17 @@ impl GpuRenderer {
         self.layer_surface_cache.get(key, &self.frame_stats)
     }
 
-    fn admit_layer_surface_cache_miss(&mut self, key: &LayerRasterCacheKey) -> bool {
-        admit_layer_surface_cache_miss_impl(key, &mut self.observed_scene_range_cache_misses)
+    fn admit_layer_surface_cache_miss(
+        &mut self,
+        key: &LayerRasterCacheKey,
+        admission: CacheAdmission,
+    ) -> bool {
+        let observed = if key.is_scene_range() {
+            &mut self.observed_scene_range_cache_misses
+        } else {
+            &mut self.observed_surface_cache_misses
+        };
+        admit_layer_surface_cache_miss_impl(key, observed, admission)
     }
 
     fn insert_cached_layer_surface(
@@ -7245,8 +7261,16 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
         self.renderer.cached_layer_surface(key)
     }
 
-    fn admit_layer_surface_cache_miss(&mut self, key: &LayerRasterCacheKey) -> bool {
-        self.renderer.admit_layer_surface_cache_miss(key)
+    fn admit_layer_surface_cache_miss(
+        &mut self,
+        key: &LayerRasterCacheKey,
+        admission: CacheAdmission,
+    ) -> bool {
+        self.renderer.admit_layer_surface_cache_miss(key, admission)
+    }
+
+    fn underlay_bake_enabled(&self) -> bool {
+        self.renderer.underlay_bake_enabled
     }
 
     fn insert_cached_layer_surface(
@@ -8288,6 +8312,10 @@ impl GpuRenderer {
         self.last_frame_stats
     }
 
+    pub fn set_underlay_bake_enabled(&mut self, enabled: bool) {
+        self.underlay_bake_enabled = enabled && underlay_bake_switch();
+    }
+
     pub fn gpu_pass_timings(&self) -> crate::pass_timing::GpuPassTimingReport {
         self.frame_graph_executor.pass_timing_report()
     }
@@ -8694,7 +8722,8 @@ impl GpuRenderer {
             LayerSurfaceRequest {
                 root_scale,
                 backdrop_underlay: None,
-                backdrop_underlay_color: None,
+                backdrop_underlay_identity: None,
+                bake_underlay: false,
                 allow_runtime_cache: false,
                 logical_rect_override: Some(viewport_rect),
                 capture_clip_override: None,
@@ -16143,11 +16172,11 @@ mod tests {
         );
 
         assert!(
-            !first_cache_miss_admission(&key),
+            !first_cache_miss_admission(&key, CacheAdmission::OnRepeat),
             "a small scene-range miss should render directly first instead of materializing a tiny one-frame retained target"
         );
         assert!(
-            repeated_cache_miss_admission(&key),
+            repeated_cache_miss_admission(&key, CacheAdmission::OnRepeat),
             "a repeated small scene-range miss is stable enough to materialize into the retained cache"
         );
     }
@@ -16167,11 +16196,11 @@ mod tests {
         );
 
         assert!(
-            !first_cache_miss_admission(&key),
+            !first_cache_miss_admission(&key, CacheAdmission::OnRepeat),
             "a large first scene-range miss should render directly instead of materializing a multi-MB one-frame cache entry"
         );
         assert!(
-            repeated_cache_miss_admission(&key),
+            repeated_cache_miss_admission(&key, CacheAdmission::OnRepeat),
             "a repeated scene-range miss is stable enough to materialize into the retained cache"
         );
     }
@@ -16235,8 +16264,16 @@ mod tests {
         );
 
         assert!(
-            first_cache_miss_admission(&key),
-            "ordinary retained layer surfaces should still cache on first miss"
+            first_cache_miss_admission(&key, CacheAdmission::Immediate),
+            "ordinary retained layer surfaces cache on first miss"
+        );
+        assert!(
+            !first_cache_miss_admission(&key, CacheAdmission::OnRepeat),
+            "a surface whose content can change every frame waits for a repeat sighting"
+        );
+        assert!(
+            repeated_cache_miss_admission(&key, CacheAdmission::OnRepeat),
+            "the repeat sighting admits the surface"
         );
     }
 
@@ -19094,7 +19131,7 @@ mod tests {
     }
 
     #[test]
-    fn layer_raster_cache_candidate_rejects_runtime_shader_child_effect_surfaces() {
+    fn layer_raster_cache_candidate_allows_runtime_shader_child_effect_surfaces() {
         let mut layer = test_layer(
             Rect {
                 x: 0.0,
@@ -19111,8 +19148,8 @@ mod tests {
         layer.recompute_raster_cache_hashes();
 
         assert!(
-            layer_raster_cache_candidate(&layer, 1.0, false, true).is_none(),
-            "runtime shaders must not fill the retained layer cache with per-frame uniform variants"
+            layer_raster_cache_candidate(&layer, 1.0, false, true).is_some(),
+            "a runtime shader hashes its uniforms into the content hash, so its surface is cacheable"
         );
     }
 

--- a/crates/cranpose-render/wgpu/src/surface_executor.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor.rs
@@ -3,7 +3,8 @@ mod geometry;
 mod render_paths;
 
 pub(crate) use backend::{
-    CachedLayerSurface, DevicePixelBounds, LayerSurfaceTexture, SurfaceExecutionBackend,
+    CacheAdmission, CachedLayerSurface, DevicePixelBounds, LayerSurfaceTexture,
+    SurfaceExecutionBackend,
 };
 pub(crate) use geometry::{
     axis_aligned_quad_rect, canonicalize_device_coordinate, canonicalized_scaled_quad,

--- a/crates/cranpose-render/wgpu/src/surface_executor/backend.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/backend.rs
@@ -122,6 +122,16 @@ pub(crate) struct DevicePixelBounds {
     pub(crate) height: u32,
 }
 
+/// How a layer-surface cache miss is admitted into the cache: immediately, or
+/// only once the same key has missed before, which keeps per-frame variants
+/// (a shader whose uniforms change every frame, a scene range that never
+/// repeats) from rotating stable entries out of the cache.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CacheAdmission {
+    Immediate,
+    OnRepeat,
+}
+
 pub(crate) trait SurfaceExecutionBackend {
     fn max_texture_dim(&self) -> u32;
     fn acquire_retained_surface(&mut self, width: u32, height: u32) -> OffscreenTarget;
@@ -132,7 +142,17 @@ pub(crate) trait SurfaceExecutionBackend {
         &mut self,
         key: &LayerRasterCacheKey,
     ) -> Option<(Rc<OffscreenTarget>, Rect)>;
-    fn admit_layer_surface_cache_miss(&mut self, key: &LayerRasterCacheKey) -> bool;
+    fn admit_layer_surface_cache_miss(
+        &mut self,
+        key: &LayerRasterCacheKey,
+        admission: CacheAdmission,
+    ) -> bool;
+    /// Whether a plainly composited surface may start from a copy of the
+    /// pixels beneath it instead of a transparent clear, so its nested
+    /// backdrops capture by texture copy. Off under
+    /// `CRANPOSE_DISABLE_UNDERLAY_BAKE` and through
+    /// [`crate::WgpuRenderer::set_underlay_bake_enabled`].
+    fn underlay_bake_enabled(&self) -> bool;
     fn insert_cached_layer_surface(
         &mut self,
         key: LayerRasterCacheKey,

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -46,6 +46,7 @@ use crate::{
         BackdropLayer, CompositorScene, DrawOp, DrawOpKind, DrawShape, EffectLayer, ImageDraw,
         SceneBrush, ShadowDraw, SnapAnchor, TextDraw,
     },
+    surface_executor::CacheAdmission,
     surface_plan::{
         LayerSurfaceRenderOptions, LayerSurfaceRequest, TranslatedContentAxes,
         TranslationRenderContext, composite_sample_mode_for_effect_layer,
@@ -84,6 +85,18 @@ fn record_layer_cache_miss<B: SurfaceExecutionBackend>(
         log::warn!("[layer-cache-diag] miss site={site} key={key:?}");
     }
     backend.record_layer_cache_miss(key, width, height);
+}
+
+/// Measurement ablation: `CRANPOSE_ABLATE_BACKDROPS` skips every backdrop
+/// effect (capture, blur and shader alike) so an A/B of present time isolates
+/// what live glass costs on a device without GPU timestamp queries. Mirrored
+/// as `debug.cranpose.ablate_backdrops` on Android.
+fn ablate_backdrops() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        crate::debug_toggles::debug_toggle("CRANPOSE_ABLATE_BACKDROPS")
+            .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes"))
+    })
 }
 
 fn direct_scene_range_cache_enabled() -> bool {
@@ -566,7 +579,6 @@ pub(crate) fn uniform_underlay_color_before(
     z_end: usize,
     rect: Rect,
     root_scale: f32,
-    inherited: Option<u32>,
 ) -> Option<u32> {
     if rect.width <= 0.0 || rect.height <= 0.0 {
         return None;
@@ -606,7 +618,56 @@ pub(crate) fn uniform_underlay_color_before(
         return Some(solid_color_bits(color));
     }
 
-    inherited
+    None
+}
+
+/// Identity of the pixels a nested backdrop reads from its parent's target
+/// under `rect`: a uniform colour when the prefix is one opaque solid (so the
+/// identity survives translation), otherwise the hash of every prefix writer
+/// intersecting `rect` together with `rect` itself, because the same writers
+/// put different pixels under a rect that moved, mixed with the parent's own
+/// underlay identity. `None` when the parent reads an underlay whose identity
+/// is unknown, which keeps a surface that bakes such pixels out of the cache.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn underlay_identity_before(
+    scene: &CompositorScene,
+    prior_child_contributions: &[BackdropPrefixChildContribution],
+    z_end: usize,
+    rect: Rect,
+    target_size: (u32, u32),
+    root_scale: f32,
+    inherited: Option<u64>,
+    has_inherited_underlay: bool,
+) -> Option<u64> {
+    if has_inherited_underlay && inherited.is_none() {
+        return None;
+    }
+    if rect.width <= 0.0 || rect.height <= 0.0 {
+        return None;
+    }
+    let mut hasher = FxHasher::default();
+    0x0BD5_1DEDu64.hash(&mut hasher);
+    inherited.hash(&mut hasher);
+    match uniform_underlay_color_before(scene, prior_child_contributions, z_end, rect, root_scale) {
+        Some(color) => {
+            0u8.hash(&mut hasher);
+            color.hash(&mut hasher);
+        }
+        None => {
+            1u8.hash(&mut hasher);
+            hash_rect(rect, &mut hasher);
+            backdrop_scene_prefix_hash(
+                scene,
+                prior_child_contributions,
+                z_end,
+                rect,
+                target_size,
+                root_scale,
+            )
+            .hash(&mut hasher);
+        }
+    }
+    Some(hasher.finish())
 }
 
 fn solid_color_bits(color: Color) -> u32 {
@@ -1505,6 +1566,205 @@ fn flush_underlay_composite_batch<B: SurfaceExecutionBackend>(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// A child composited with alpha one, `SrcOver`, no group effect and no snap
+/// can be rendered on top of the pixels beneath it: `underlay ∘ content`
+/// composited over `underlay` is `content` composited over `underlay` at
+/// every pixel, mask coverage included, so the surface may bake its underlay.
+fn child_composites_plainly(child: &ChildLayerComposite) -> bool {
+    child.isolation.as_ref().is_none_or(|isolation| {
+        isolation.effect.is_none()
+            && isolation.blend_mode == BlendMode::SrcOver
+            && isolation.composite_alpha == 1.0
+    }) && !child.has_effect
+}
+
+/// A snapped surface rendered at the target's own scale lands on whole
+/// device pixels, and its quad then covers exactly its own texels: the
+/// composite is a copy instead of a per-frame resample of every card, and the
+/// underlay copy beneath it is the pixels the composite will replace.
+fn texel_aligned_dest_quad(
+    dest_quad: [[f32; 2]; 4],
+    surface_size: (u32, u32),
+    snap_anchor: Option<SnapAnchor>,
+    surface_scale: f32,
+    target_scale: f32,
+) -> [[f32; 2]; 4] {
+    let whole_pixel_snap = snap_anchor.is_some_and(|anchor| anchor.device_pixel_step == 1.0);
+    if !whole_pixel_snap || (surface_scale - target_scale).abs() > 1e-6 {
+        return dest_quad;
+    }
+    let Some(rect) = axis_aligned_quad_rect(dest_quad) else {
+        return dest_quad;
+    };
+    let on_device_pixels = |value: f32| (value - value.round()).abs() <= 1e-3;
+    let (width, height) = (surface_size.0 as f32, surface_size.1 as f32);
+    if !on_device_pixels(rect.x)
+        || !on_device_pixels(rect.y)
+        || (rect.width - width).abs() >= 1.0
+        || (rect.height - height).abs() >= 1.0
+    {
+        return dest_quad;
+    }
+    crate::rect_to_quad(Rect {
+        x: rect.x.round(),
+        y: rect.y.round(),
+        width,
+        height,
+    })
+}
+
+/// The device pixel the child's surface origin lands on once its composite
+/// is anchored and snapped exactly as the composite will be, or `None` when
+/// the composite is not a whole-pixel translation of the surface.
+fn baked_underlay_device_origin(
+    child: &ChildLayerComposite,
+    logical_rect: Rect,
+    dest_quad: [[f32; 2]; 4],
+    snap_anchor: Option<SnapAnchor>,
+    composite_snap_origin: Option<Point>,
+    scale: f32,
+    translation_context: TranslationRenderContext,
+) -> Option<(u32, u32)> {
+    let translated_content_context = translation_context.inherited_content_translation
+        || child.translated_content_context
+        || child.surface_requirements.contains_translated_content;
+    let sample_mode = composite_sample_mode_for_requirements(
+        translated_content_context,
+        translation_context.surface_capture_active,
+        child.surface_requirements,
+    );
+    let device_quad = anchored_composite_dest_quad(
+        layer_surface_dest_quad(logical_rect, dest_quad, logical_rect),
+        snap_anchor,
+        composite_snap_origin,
+        scale,
+        sample_mode,
+    );
+    let (width, height) = surface_target_size(logical_rect, scale, u32::MAX);
+    let device_quad =
+        texel_aligned_dest_quad(device_quad, (width, height), snap_anchor, scale, scale);
+    let device_rect = axis_aligned_quad_rect(device_quad)?;
+    let on_device_pixels = |value: f32| value >= 0.0 && (value - value.round()).abs() <= 1e-3;
+    let whole_translation = on_device_pixels(device_rect.x)
+        && on_device_pixels(device_rect.y)
+        && (device_rect.width - width as f32).abs() <= 1e-3
+        && (device_rect.height - height as f32).abs() <= 1e-3;
+    whole_translation.then(|| (device_rect.x.round() as u32, device_rect.y.round() as u32))
+}
+
+struct ChildUnderlayPlacement {
+    logical_rect: Rect,
+    dest_quad: [[f32; 2]; 4],
+    snapped_dest_quad: [[f32; 2]; 4],
+    snap_anchor: Option<SnapAnchor>,
+    composite_snap_origin: Option<Point>,
+}
+
+struct ChildUnderlay {
+    target: OffscreenTarget,
+    baked: bool,
+}
+
+/// The pixels beneath a child that carries nested backdrops, sampled from the
+/// parent target once everything below the child, its own backdrop included,
+/// has been flushed into it. A whole-pixel translated child gets a verbatim
+/// copy it bakes as its surface's base; any other placement gets a projected
+/// resample its nested captures read through.
+#[allow(clippy::too_many_arguments)]
+fn sample_child_underlay<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    parent_target: &OffscreenTarget,
+    parent_underlay: Option<&OffscreenTarget>,
+    child: &ChildLayerComposite,
+    placement: ChildUnderlayPlacement,
+    underlay_identity: Option<u64>,
+    parent_scale: f32,
+    translation_context: TranslationRenderContext,
+) -> ChildUnderlay {
+    let child_scale = child_surface_target_scale(child, parent_scale, translation_context);
+    let device_origin = (backend.underlay_bake_enabled()
+        && parent_underlay.is_none()
+        && underlay_identity.is_some()
+        && child_composites_plainly(child)
+        && (child_scale - parent_scale).abs() <= 1e-6)
+        .then(|| {
+            baked_underlay_device_origin(
+                child,
+                placement.logical_rect,
+                placement.dest_quad,
+                placement.snap_anchor,
+                placement.composite_snap_origin,
+                parent_scale,
+                translation_context,
+            )
+        })
+        .flatten();
+    if backdrop_diag_enabled() {
+        eprintln!(
+            "[backdrop-diag] underlay node={:?} plain={} identity={} device_origin={:?}",
+            child.node_id,
+            child_composites_plainly(child),
+            underlay_identity.is_some(),
+            device_origin,
+        );
+    }
+    if let Some(target) = device_origin.and_then(|origin| {
+        copy_child_underlay(
+            backend,
+            parent_target,
+            origin,
+            placement.logical_rect,
+            parent_scale,
+        )
+    }) {
+        return ChildUnderlay {
+            target,
+            baked: true,
+        };
+    }
+    let target = create_projected_child_underlay(
+        backend,
+        parent_target,
+        parent_underlay,
+        placement.logical_rect,
+        placement.snapped_dest_quad,
+        parent_scale,
+        child_scale,
+        underlay_sample_rect(&child.source),
+    );
+    ChildUnderlay {
+        target,
+        baked: false,
+    }
+}
+
+/// Copies the device pixels the child's surface will be composited onto out
+/// of `source` into a fresh surface of the child's size, the exact pixels a
+/// re-render of the prefix under the child would produce once everything
+/// below it has been flushed into `source`. `None` when the copy would leave
+/// the source, in which case the caller re-renders instead.
+fn copy_child_underlay<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    source: &OffscreenTarget,
+    origin: (u32, u32),
+    logical_rect: Rect,
+    scale: f32,
+) -> Option<OffscreenTarget> {
+    let (width, height) = surface_target_size(logical_rect, scale, backend.max_texture_dim());
+    if origin.0.saturating_add(width) > source.width
+        || origin.1.saturating_add(height) > source.height
+    {
+        return None;
+    }
+    let underlay = backend.acquire_frame_surface(width, height);
+    if backend.copy_texture_region_to_target(source, origin, &underlay, (width, height)) {
+        Some(underlay)
+    } else {
+        backend.release_frame_surface(underlay);
+        None
+    }
+}
+
 fn create_direct_root_child_underlay<B: SurfaceExecutionBackend>(
     backend: &mut B,
     local_scene: &CompositorScene,
@@ -2192,41 +2452,8 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                 )?;
             }
 
-            let child_underlay = if child.needs_nested_underlay {
-                Some(create_direct_root_child_underlay(
-                    backend,
-                    &local_scene,
-                    resolved_child.logical_rect,
-                    resolved_child.dest_quad,
-                    child.z_index,
-                    &pending_composites,
-                    root_scale,
-                )?)
-            } else {
-                None
-            };
-
-            let child_surface_result = render_layer_surface(
-                backend,
-                &mut child,
-                LayerSurfaceRequest {
-                    root_scale,
-                    backdrop_underlay: child_underlay.as_ref(),
-                    backdrop_underlay_color: None,
-                    allow_runtime_cache: true,
-                    logical_rect_override: Some(resolved_child.logical_rect),
-                    capture_clip_override: resolved_child.surface_clip,
-                    activates_nested_capture: true,
-                    translation_context: TranslationRenderContext::default(),
-                },
-            );
-            if let Some(underlay) = child_underlay {
-                backend.release_frame_surface(underlay);
-            }
-            let child_surface = child_surface_result?;
-            if let Some(backdrop) = child_surface.backdrop.clone() {
+            if let Some(backdrop) = child.backdrop.clone() {
                 let Some(root_target) = root_target else {
-                    backend.release_layer_surface_target(child_surface.target);
                     return Err(
                         "root direct path does not support backdrop child surfaces".to_string()
                     );
@@ -2348,6 +2575,88 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                     }
                 }
             }
+            let child_underlay_identity = child
+                .needs_nested_underlay
+                .then(|| {
+                    underlay_identity_before(
+                        &local_scene,
+                        &prior_child_contributions,
+                        child.z_index,
+                        axis_aligned_quad_rect(resolved_child.dest_quad)?,
+                        (width, height),
+                        root_scale,
+                        None,
+                        false,
+                    )
+                })
+                .flatten();
+            let mut bake_underlay = false;
+            let child_underlay = if child.needs_nested_underlay {
+                Some(match root_target {
+                    Some(root_target) => {
+                        flush_pending_composite_queues_fused(
+                            backend,
+                            &mut pending_composites,
+                            &mut pending_composite_load_op,
+                            &mut pending_shader_composites,
+                            &mut pending_shader_load_op,
+                            surface_view,
+                            (width, height),
+                            &mut next_load_op,
+                        )?;
+                        flush_pending_clear(backend, surface_view, &mut next_load_op);
+                        let underlay = sample_child_underlay(
+                            backend,
+                            root_target,
+                            None,
+                            &child,
+                            ChildUnderlayPlacement {
+                                logical_rect: resolved_child.logical_rect,
+                                dest_quad: resolved_child.dest_quad,
+                                snapped_dest_quad: child_dest_quad,
+                                snap_anchor: resolved_child.snap_anchor,
+                                composite_snap_origin: resolved_child.composite_snap_origin,
+                            },
+                            child_underlay_identity,
+                            root_scale,
+                            TranslationRenderContext::default(),
+                        );
+                        bake_underlay = underlay.baked;
+                        underlay.target
+                    }
+                    None => create_direct_root_child_underlay(
+                        backend,
+                        &local_scene,
+                        resolved_child.logical_rect,
+                        resolved_child.dest_quad,
+                        child.z_index,
+                        &pending_composites,
+                        root_scale,
+                    )?,
+                })
+            } else {
+                None
+            };
+
+            let child_surface_result = render_layer_surface(
+                backend,
+                &mut child,
+                LayerSurfaceRequest {
+                    root_scale,
+                    backdrop_underlay: child_underlay.as_ref(),
+                    backdrop_underlay_identity: child_underlay_identity,
+                    bake_underlay,
+                    allow_runtime_cache: true,
+                    logical_rect_override: Some(resolved_child.logical_rect),
+                    capture_clip_override: resolved_child.surface_clip,
+                    activates_nested_capture: true,
+                    translation_context: TranslationRenderContext::default(),
+                },
+            );
+            if let Some(underlay) = child_underlay {
+                backend.release_frame_surface(underlay);
+            }
+            let child_surface = child_surface_result?;
             if child_backdrop_reads_target && !resolved_child.shadow_draws.is_empty() {
                 flush_pending_composite_queues_fused(
                     backend,
@@ -2377,11 +2686,26 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                 root_scale,
                 child_surface.sample_mode,
             );
+            let dest_quad = texel_aligned_dest_quad(
+                dest_quad,
+                {
+                    let target = child_surface.target.target();
+                    (target.width, target.height)
+                },
+                resolved_child.snap_anchor,
+                child_surface_target_scale(&child, root_scale, TranslationRenderContext::default()),
+                root_scale,
+            );
             let scissor = child
                 .visual_clip
                 .and_then(|clip| scissor_rect_for_rect(clip, root_scale, width, height));
-            let child_prefix_contribution =
-                backdrop_prefix_child_contribution(&child, &child_surface, dest_quad, scissor);
+            let child_prefix_contribution = backdrop_prefix_child_contribution(
+                &child,
+                &child_surface,
+                dest_quad,
+                scissor,
+                child_underlay_identity,
+            );
             if child_surface.deferred_effect.is_none()
                 && axis_aligned_quad_rect(dest_quad).is_some()
             {
@@ -2559,7 +2883,8 @@ pub(crate) fn render_layer_surface<B: SurfaceExecutionBackend>(
     let LayerSurfaceRequest {
         root_scale,
         backdrop_underlay,
-        backdrop_underlay_color,
+        backdrop_underlay_identity,
+        bake_underlay,
         allow_runtime_cache,
         logical_rect_override,
         capture_clip_override,
@@ -2599,7 +2924,7 @@ pub(crate) fn render_layer_surface<B: SurfaceExecutionBackend>(
         effective_requirements,
         supported_isolation_effect,
         backdrop_underlay.is_some(),
-        backdrop_underlay_color,
+        backdrop_underlay_identity,
         allow_runtime_cache,
         logical_rect_override,
         backend.max_texture_dim(),
@@ -2624,7 +2949,12 @@ pub(crate) fn render_layer_surface<B: SurfaceExecutionBackend>(
             });
         }
         let (width, height) = cache_key.pixel_size();
-        record_layer_cache_miss(backend, "child-candidate", &cache_key, width, height);
+        let cache_candidate = backend
+            .admit_layer_surface_cache_miss(&cache_key, surface_cache_admission(child))
+            .then(|| {
+                record_layer_cache_miss(backend, "child-candidate", &cache_key, width, height);
+                (cache_key, logical_rect)
+            });
         return render_layer_surface_uncached(
             backend,
             child,
@@ -2632,9 +2962,10 @@ pub(crate) fn render_layer_surface<B: SurfaceExecutionBackend>(
             LayerSurfaceRenderOptions {
                 target_scale,
                 backdrop_underlay,
-                backdrop_underlay_color,
+                backdrop_underlay_identity,
+                bake_underlay,
                 allow_runtime_cache,
-                cache_candidate: Some((cache_key, logical_rect)),
+                cache_candidate,
                 logical_rect_override,
                 capture_clip_override,
                 composite_sample_mode,
@@ -2650,7 +2981,8 @@ pub(crate) fn render_layer_surface<B: SurfaceExecutionBackend>(
         LayerSurfaceRenderOptions {
             target_scale,
             backdrop_underlay,
-            backdrop_underlay_color,
+            backdrop_underlay_identity,
+            bake_underlay,
             allow_runtime_cache,
             cache_candidate: None,
             logical_rect_override,
@@ -2661,6 +2993,17 @@ pub(crate) fn render_layer_surface<B: SurfaceExecutionBackend>(
     )
 }
 
+/// A surface whose subtree carries a runtime shader can change every frame
+/// through uniforms alone, so it earns a cache slot only once its key repeats;
+/// every other surface caches on its first miss.
+fn surface_cache_admission(child: &ChildLayerComposite) -> CacheAdmission {
+    if child.surface_requirements.contains_runtime_shader {
+        CacheAdmission::OnRepeat
+    } else {
+        CacheAdmission::Immediate
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn child_layer_raster_cache_candidate(
     child: &ChildLayerComposite,
@@ -2668,20 +3011,17 @@ fn child_layer_raster_cache_candidate(
     effective_requirements: SurfaceRequirementSet,
     supported_isolation_effect: Option<&RenderEffect>,
     has_backdrop_underlay: bool,
-    backdrop_underlay_color: Option<u32>,
+    backdrop_underlay_identity: Option<u64>,
     allow_runtime_cache: bool,
     logical_rect_override: Option<Rect>,
     max_texture_dim: u32,
 ) -> Option<(LayerRasterCacheKey, Rect)> {
     let surface_requirements = child.surface_requirements;
-    if surface_requirements.contains_runtime_shader {
-        return None;
-    }
-
     if let Some(source) = layer_source_cache_entry(
         child,
         effective_requirements,
         has_backdrop_underlay,
+        backdrop_underlay_identity,
         allow_runtime_cache,
     ) {
         match supported_isolation_effect {
@@ -2707,8 +3047,7 @@ fn child_layer_raster_cache_candidate(
     let runtime_cache_is_safe = allow_runtime_cache
         && surface_requirements
             .surface_requirements
-            .has_isolating_requirement()
-        && !surface_requirements.contains_runtime_shader;
+            .has_isolating_requirement();
     let cache_is_allowed = child.cache_policy == CachePolicy::Auto
         || (allow_runtime_cache && surface_requirements.has_renderer_forced_surface())
         || runtime_cache_is_safe;
@@ -2716,7 +3055,7 @@ fn child_layer_raster_cache_candidate(
         return None;
     }
     let external_backdrop_input = has_backdrop_underlay && child.contains_descendant_backdrop;
-    if external_backdrop_input && backdrop_underlay_color.is_none() {
+    if external_backdrop_input && backdrop_underlay_identity.is_none() {
         return None;
     }
 
@@ -2726,11 +3065,7 @@ fn child_layer_raster_cache_candidate(
         return None;
     }
     let content_hash = if external_backdrop_input {
-        let mut hasher = FxHasher::default();
-        0xF1A7_C010u64.hash(&mut hasher);
-        child.target_content_hash.hash(&mut hasher);
-        backdrop_underlay_color.hash(&mut hasher);
-        hasher.finish()
+        content_hash_over_underlay(child.target_content_hash, backdrop_underlay_identity)
     } else {
         child.target_content_hash
     };
@@ -2847,10 +3182,19 @@ impl LayerSourceCacheEntry {
     }
 }
 
+fn content_hash_over_underlay(content_hash: u64, underlay_identity: Option<u64>) -> u64 {
+    let mut hasher = FxHasher::default();
+    0xF1A7_C010u64.hash(&mut hasher);
+    content_hash.hash(&mut hasher);
+    underlay_identity.hash(&mut hasher);
+    hasher.finish()
+}
+
 fn layer_source_cache_entry(
     child: &ChildLayerComposite,
     effective_requirements: SurfaceRequirementSet,
     has_backdrop_underlay: bool,
+    backdrop_underlay_identity: Option<u64>,
     allow_runtime_cache: bool,
 ) -> Option<LayerSourceCacheEntry> {
     let runtime_shader_source = child.effect_contains_runtime_shader;
@@ -2865,9 +3209,15 @@ fn layer_source_cache_entry(
         || allow_runtime_cache
         || child.surface_requirements.has_renderer_forced_surface()
         || motion_stable_source;
-    if !cache_is_allowed || (has_backdrop_underlay && child.contains_descendant_backdrop) {
+    let reads_external_underlay = has_backdrop_underlay && child.contains_descendant_backdrop;
+    if !cache_is_allowed || (reads_external_underlay && backdrop_underlay_identity.is_none()) {
         return None;
     }
+    let content_hash = if reads_external_underlay {
+        content_hash_over_underlay(child.target_content_hash, backdrop_underlay_identity)
+    } else {
+        child.target_content_hash
+    };
 
     Some(LayerSourceCacheEntry {
         stable_id: child.node_id,
@@ -2875,7 +3225,7 @@ fn layer_source_cache_entry(
         // but its source pixels remain live input for backdrop effects. A
         // source cache keyed without the translated content hash freezes a
         // glass pane over scrolling content.
-        collected_content_hash: Some(child.target_content_hash),
+        collected_content_hash: Some(content_hash),
     })
 }
 
@@ -2887,12 +3237,14 @@ fn layer_source_cache_key(
     pixel_size: (u32, u32),
     target_scale: f32,
     has_backdrop_underlay: bool,
+    backdrop_underlay_identity: Option<u64>,
     allow_runtime_cache: bool,
 ) -> Option<LayerRasterCacheKey> {
     let source = layer_source_cache_entry(
         child,
         effective_requirements,
         has_backdrop_underlay,
+        backdrop_underlay_identity,
         allow_runtime_cache,
     )?;
     let content_hash = source
@@ -2922,11 +3274,18 @@ fn backdrop_prefix_child_contribution(
     surface: &LayerSurface,
     dest_quad: [[f32; 2]; 4],
     scissor: Option<(u32, u32, u32, u32)>,
+    underlay_identity: Option<u64>,
 ) -> BackdropPrefixChildContribution {
+    let content_hash = match underlay_identity {
+        Some(_) if child.contains_descendant_backdrop => {
+            content_hash_over_underlay(child.target_content_hash, underlay_identity)
+        }
+        _ => child.target_content_hash,
+    };
     BackdropPrefixChildContribution {
         z_index: child.z_index,
         node_id: child.node_id,
-        content_hash: child.target_content_hash,
+        content_hash,
         effect_hash: child.effect_hash,
         backdrop_hash: surface
             .backdrop
@@ -2995,44 +3354,7 @@ fn split_backdrop_effect(effect: &RenderEffect) -> (Option<&RenderEffect>, Optio
 }
 
 fn retained_render_effect_hash(effect: &RenderEffect) -> u64 {
-    let mut hasher = FxHasher::default();
-    hash_retained_render_effect(effect, &mut hasher);
-    hasher.finish()
-}
-
-fn hash_retained_render_effect<H: Hasher>(effect: &RenderEffect, state: &mut H) {
-    match effect {
-        RenderEffect::Blur {
-            radius_x,
-            radius_y,
-            edge_treatment,
-        } => {
-            0u8.hash(state);
-            hash_f32_bits(*radius_x, state);
-            hash_f32_bits(*radius_y, state);
-            edge_treatment.hash(state);
-        }
-        RenderEffect::Offset { offset_x, offset_y } => {
-            1u8.hash(state);
-            hash_f32_bits(*offset_x, state);
-            hash_f32_bits(*offset_y, state);
-        }
-        RenderEffect::Shader { shader } => {
-            2u8.hash(state);
-            shader.source_hash().hash(state);
-            hash_f32_bits(shader.input_padding(), state);
-            hash_f32_bits(shader.output_padding(), state);
-            shader.uniforms().len().hash(state);
-            for uniform in shader.uniforms() {
-                hash_f32_bits(*uniform, state);
-            }
-        }
-        RenderEffect::Chain { first, second } => {
-            3u8.hash(state);
-            hash_retained_render_effect(first, state);
-            hash_retained_render_effect(second, state);
-        }
-    }
+    effect.render_hash()
 }
 
 fn backdrop_scene_prefix_hash(
@@ -4253,7 +4575,7 @@ fn cached_direct_scene_range_surface<B: SurfaceExecutionBackend>(
         }
         LayerSurfaceTexture::Cached(cached_target)
     } else {
-        if !backend.admit_layer_surface_cache_miss(&cache_key) {
+        if !backend.admit_layer_surface_cache_miss(&cache_key, CacheAdmission::OnRepeat) {
             if layer_render_diag_enabled() {
                 let draw_ops = scene_range_draw_op_count(scene, z_start, z_end);
                 log::warn!(
@@ -4603,7 +4925,7 @@ fn serve_or_capture_prefix_snapshot<B: SurfaceExecutionBackend>(
         return Ok(PrefixSnapshotOutcome::Served(prefix_end));
     }
 
-    if !backend.admit_layer_surface_cache_miss(&key) {
+    if !backend.admit_layer_surface_cache_miss(&key, CacheAdmission::OnRepeat) {
         return Ok(PrefixSnapshotOutcome::Claimed(prefix_end));
     }
 
@@ -4788,7 +5110,8 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
     child_layers: Vec<ChildLayerComposite>,
     target_scale: f32,
     backdrop_underlay: Option<&OffscreenTarget>,
-    underlay_color: Option<u32>,
+    underlay_identity: Option<u64>,
+    bake_underlay: bool,
     width: u32,
     height: u32,
     effective_translated_content_context: bool,
@@ -4796,8 +5119,19 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
     translation_context: TranslationRenderContext,
 ) -> Result<OffscreenTarget, String> {
     let target = backend.acquire_retained_surface(width, height);
+    let baked = bake_underlay
+        && backdrop_underlay.is_some_and(|underlay| {
+            underlay.width == width
+                && underlay.height == height
+                && backend.copy_texture_region_to_target(underlay, (0, 0), &target, (width, height))
+        });
+    let backdrop_underlay = if baked { None } else { backdrop_underlay };
     let mut cursor_z = 0usize;
-    let mut next_load_op = wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT);
+    let mut next_load_op = if baked {
+        wgpu::LoadOp::Load
+    } else {
+        wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)
+    };
     let mut pending_composites = Vec::new();
     let mut pending_composite_load_op = None;
     let mut pending_shader_composites = Vec::new();
@@ -4853,12 +5187,17 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                     &mut pending_composite_load_op,
                     &mut next_load_op,
                 );
-                let local_backdrop_hashes = scene_backdrop_input_hashes(
+                let mut local_backdrop_hashes = scene_backdrop_input_hashes(
                     local_scene,
                     &prior_child_contributions,
                     (width, height),
                     target_scale,
                 );
+                if baked {
+                    for hash in &mut local_backdrop_hashes {
+                        *hash = content_hash_over_underlay(*hash, underlay_identity);
+                    }
+                }
                 backend.render_range_with_layer_events_to_target(
                     &target,
                     &local_scene.shapes,
@@ -4924,45 +5263,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
             surface_capture_active: translation_context.surface_capture_active,
             local_picture_capture_active: translation_context.local_picture_capture_active,
         };
-        let child_underlay_color = child.needs_nested_underlay.then(|| {
-            uniform_underlay_color_before(
-                local_scene,
-                &prior_child_contributions,
-                child.z_index,
-                quad_bounds(child_dest_quad),
-                target_scale,
-                underlay_color,
-            )
-        });
-        let child_underlay = child.needs_nested_underlay.then(|| {
-            let sample_rect = underlay_sample_rect(&child.source);
-            create_projected_child_underlay(
-                backend,
-                &target,
-                backdrop_underlay,
-                resolved_child.logical_rect,
-                child_dest_quad,
-                target_scale,
-                child_surface_target_scale(&child, target_scale, child_translation_context),
-                sample_rect,
-            )
-        });
-        let child_surface = render_layer_surface(
-            backend,
-            &mut child,
-            LayerSurfaceRequest {
-                root_scale: target_scale,
-                backdrop_underlay: child_underlay.as_ref(),
-                backdrop_underlay_color: child_underlay_color.flatten(),
-                allow_runtime_cache: true,
-                logical_rect_override: Some(resolved_child.logical_rect),
-                capture_clip_override: resolved_child.surface_clip,
-                activates_nested_capture: true,
-                translation_context: child_translation_context,
-            },
-        )?;
-
-        let child_backdrop_capture_rect = child_surface.backdrop.as_ref().and_then(|backdrop| {
+        let child_backdrop_capture_rect = child.backdrop.as_ref().and_then(|backdrop| {
             visible_backdrop_capture_rect(
                 resolved_child.backdrop_rect,
                 child.visual_clip,
@@ -4986,7 +5287,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
             flush_pending_clear(backend, &target.view, &mut next_load_op);
         }
 
-        if let Some(backdrop) = &child_surface.backdrop {
+        if let Some(backdrop) = &child.backdrop {
             if let Some(dependency_rect) = backdrop_dependency_rect(
                 resolved_child.backdrop_rect,
                 child.visual_clip,
@@ -5015,14 +5316,21 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                 effect: backdrop.clone(),
                 z_index: child.z_index,
             };
-            let backdrop_input_hash = backdrop_scene_prefix_hash(
-                local_scene,
-                &prior_child_contributions,
-                child.z_index,
-                child_backdrop_capture_rect.unwrap_or(backdrop_layer.rect),
-                (width, height),
-                target_scale,
-            );
+            let backdrop_input_hash = {
+                let local_hash = backdrop_scene_prefix_hash(
+                    local_scene,
+                    &prior_child_contributions,
+                    child.z_index,
+                    child_backdrop_capture_rect.unwrap_or(backdrop_layer.rect),
+                    (width, height),
+                    target_scale,
+                );
+                if baked {
+                    content_hash_over_underlay(local_hash, underlay_identity)
+                } else {
+                    local_hash
+                }
+            };
             let effective_backdrop_underlay = if backdrop_underlay.is_some()
                 && backdrop_underlay_is_covered_by_local_content(
                     &local_scene.shapes,
@@ -5077,6 +5385,71 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
             }
         }
 
+        let child_underlay_identity = child
+            .needs_nested_underlay
+            .then(|| {
+                underlay_identity_before(
+                    local_scene,
+                    &prior_child_contributions,
+                    child.z_index,
+                    quad_bounds(child_dest_quad),
+                    (width, height),
+                    target_scale,
+                    underlay_identity,
+                    backdrop_underlay.is_some(),
+                )
+            })
+            .flatten();
+        let mut child_bake_underlay = false;
+        let child_underlay = if child.needs_nested_underlay {
+            flush_pending_composite_queues_fused(
+                backend,
+                &mut pending_composites,
+                &mut pending_composite_load_op,
+                &mut pending_shader_composites,
+                &mut pending_shader_load_op,
+                &target.view,
+                (width, height),
+                &mut next_load_op,
+            )?;
+            flush_pending_clear(backend, &target.view, &mut next_load_op);
+            let underlay = sample_child_underlay(
+                backend,
+                &target,
+                backdrop_underlay,
+                &child,
+                ChildUnderlayPlacement {
+                    logical_rect: resolved_child.logical_rect,
+                    dest_quad: resolved_child.dest_quad,
+                    snapped_dest_quad: child_dest_quad,
+                    snap_anchor: resolved_child.snap_anchor,
+                    composite_snap_origin: resolved_child.composite_snap_origin,
+                },
+                child_underlay_identity,
+                target_scale,
+                child_translation_context,
+            );
+            child_bake_underlay = underlay.baked;
+            Some(underlay.target)
+        } else {
+            None
+        };
+        let child_surface = render_layer_surface(
+            backend,
+            &mut child,
+            LayerSurfaceRequest {
+                root_scale: target_scale,
+                backdrop_underlay: child_underlay.as_ref(),
+                backdrop_underlay_identity: child_underlay_identity,
+                bake_underlay: child_bake_underlay,
+                allow_runtime_cache: true,
+                logical_rect_override: Some(resolved_child.logical_rect),
+                capture_clip_override: resolved_child.surface_clip,
+                activates_nested_capture: true,
+                translation_context: child_translation_context,
+            },
+        )?;
+
         if !resolved_child.shadow_draws.is_empty() {
             flush_pending_shader_layer_composites(
                 backend,
@@ -5104,11 +5477,26 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
             target_scale,
             child_surface.sample_mode,
         );
+        let dest_quad = texel_aligned_dest_quad(
+            dest_quad,
+            {
+                let target = child_surface.target.target();
+                (target.width, target.height)
+            },
+            resolved_child.snap_anchor,
+            child_surface_target_scale(&child, target_scale, child_translation_context),
+            target_scale,
+        );
         let scissor = child
             .visual_clip
             .and_then(|clip| scissor_rect_for_rect(clip, target_scale, width, height));
-        let child_prefix_contribution =
-            backdrop_prefix_child_contribution(&child, &child_surface, dest_quad, scissor);
+        let child_prefix_contribution = backdrop_prefix_child_contribution(
+            &child,
+            &child_surface,
+            dest_quad,
+            scissor,
+            child_underlay_identity,
+        );
         if child_surface.deferred_effect.is_none() && axis_aligned_quad_rect(dest_quad).is_some() {
             flush_pending_shader_layer_composites(
                 backend,
@@ -5289,7 +5677,8 @@ fn render_layer_surface_uncached<B: SurfaceExecutionBackend>(
     let LayerSurfaceRenderOptions {
         target_scale,
         backdrop_underlay,
-        backdrop_underlay_color,
+        backdrop_underlay_identity,
+        bake_underlay,
         allow_runtime_cache,
         mut cache_candidate,
         logical_rect_override,
@@ -5298,6 +5687,7 @@ fn render_layer_surface_uncached<B: SurfaceExecutionBackend>(
         translation_context,
     } = options;
     let isolation = child.isolation.clone();
+    let cache_admission = surface_cache_admission(child);
     let LoweredChildSource {
         scene: mut local_scene,
         children: child_layers,
@@ -5441,6 +5831,7 @@ fn render_layer_surface_uncached<B: SurfaceExecutionBackend>(
                 (width, height),
                 target_scale,
                 source_uses_external_backdrop,
+                backdrop_underlay_identity,
                 allow_runtime_cache,
             )
         });
@@ -5470,7 +5861,9 @@ fn render_layer_surface_uncached<B: SurfaceExecutionBackend>(
             if let Some((cached_target, _)) = cached {
                 LayerSurfaceTexture::Cached(cached_target)
             } else {
-                if !source_probe_missed_upstream {
+                let admitted = source_probe_missed_upstream
+                    || backend.admit_layer_surface_cache_miss(&cache_key, cache_admission);
+                if admitted && !source_probe_missed_upstream {
                     record_layer_cache_miss(backend, "source-content", &cache_key, width, height);
                 }
                 let rendered = render_layer_source_uncached(
@@ -5479,15 +5872,17 @@ fn render_layer_surface_uncached<B: SurfaceExecutionBackend>(
                     child_layers,
                     target_scale,
                     backdrop_underlay,
-                    backdrop_underlay_color,
+                    backdrop_underlay_identity,
+                    bake_underlay,
                     width,
                     height,
                     effective_translated_content_context,
                     effective_translated_content_axes,
                     translation_context,
                 )?;
-                if offscreen_byte_size(rendered.width, rendered.height)
-                    <= MAX_LAYER_SURFACE_CACHE_BYTES
+                if admitted
+                    && offscreen_byte_size(rendered.width, rendered.height)
+                        <= MAX_LAYER_SURFACE_CACHE_BYTES
                 {
                     let cached_target =
                         backend.insert_cached_layer_surface(cache_key, rendered, surface_rect);
@@ -5503,7 +5898,8 @@ fn render_layer_surface_uncached<B: SurfaceExecutionBackend>(
                 child_layers,
                 target_scale,
                 backdrop_underlay,
-                backdrop_underlay_color,
+                backdrop_underlay_identity,
+                bake_underlay,
                 width,
                 height,
                 effective_translated_content_context,
@@ -5783,6 +6179,9 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
     input_content_hash: Option<u64>,
     allow_deferred_tail: bool,
 ) -> Result<Option<PreparedBackdropComposite>, String> {
+    if ablate_backdrops() {
+        return Ok(None);
+    }
     let diag = backdrop_diag_enabled();
     let (layer_rect, layer_clip) = snapped_backdrop_geometry(layer, root_scale);
     let Some(visible_rect) = visible_layer_rect(layer_rect, layer_clip, root_scale, width, height)
@@ -6019,6 +6418,9 @@ pub(crate) fn apply_backdrop_layer_to_target<B: SurfaceExecutionBackend>(
     root_scale: f32,
     input_content_hash: Option<u64>,
 ) -> Result<(), String> {
+    if ablate_backdrops() {
+        return Ok(());
+    }
     let (layer_rect, layer_clip) = snapped_backdrop_geometry(layer, root_scale);
     if backdrop_diag_enabled() {
         eprintln!(
@@ -8321,6 +8723,7 @@ mod tests {
                 (32, 24),
                 1.0,
                 false,
+                None,
                 true,
             )
             .is_some(),
@@ -8342,6 +8745,7 @@ mod tests {
                 (80, 40),
                 1.0,
                 false,
+                None,
                 true,
             )
             .is_some(),
@@ -8362,6 +8766,7 @@ mod tests {
                 (80, 40),
                 1.0,
                 true,
+                None,
                 true,
             )
             .is_some(),
@@ -8398,6 +8803,7 @@ mod tests {
                 (120, 90),
                 1.0,
                 true,
+                None,
                 true,
             ),
             None,
@@ -8467,6 +8873,7 @@ mod tests {
             (220, 96),
             1.0,
             false,
+            None,
             true,
         );
         let moved_key = layer_source_cache_key(
@@ -8476,6 +8883,7 @@ mod tests {
             (220, 96),
             1.0,
             false,
+            None,
             true,
         );
 

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -35,10 +35,11 @@ use crate::{
     layer_events::{LayerEventKind, collect_effect_ranges, collect_layer_events},
     layer_surface_cache::{MAX_LAYER_SURFACE_CACHE_BYTES, MAX_SCENE_RANGE_CACHE_ENTRY_BYTES},
     normalized_scene::{
-        ChildLayerComposite, CollectedLayer, LoweredChildSource, SceneWindowSource, TranslateBy,
-        build_scene_window, collected_layer_bounds, filtered_effect_layer_index,
-        motion_stable_capture_bounds_from_parts, resolved_child_surface_composite,
-        resolved_layer_surface_rect_from_parts, translate_quad, visible_draw_rect,
+        ChildLayerComposite, CollectedLayer, LoweredChildSource, ResolvedChildSurfaceComposite,
+        SceneWindowSource, TranslateBy, build_scene_window, collected_layer_bounds,
+        filtered_effect_layer_index, motion_stable_capture_bounds_from_parts,
+        resolved_child_surface_composite, resolved_layer_surface_rect_from_parts, translate_quad,
+        visible_draw_rect,
     },
     offscreen::OffscreenTarget,
     render::{has_backdrop_layer_in_range, scissor_rect_for_rect},
@@ -85,18 +86,6 @@ fn record_layer_cache_miss<B: SurfaceExecutionBackend>(
         log::warn!("[layer-cache-diag] miss site={site} key={key:?}");
     }
     backend.record_layer_cache_miss(key, width, height);
-}
-
-/// Measurement ablation: `CRANPOSE_ABLATE_BACKDROPS` skips every backdrop
-/// effect (capture, blur and shader alike) so an A/B of present time isolates
-/// what live glass costs on a device without GPU timestamp queries. Mirrored
-/// as `debug.cranpose.ablate_backdrops` on Android.
-fn ablate_backdrops() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| {
-        crate::debug_toggles::debug_toggle("CRANPOSE_ABLATE_BACKDROPS")
-            .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes"))
-    })
 }
 
 fn direct_scene_range_cache_enabled() -> bool {
@@ -2452,129 +2441,25 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                 )?;
             }
 
-            if let Some(backdrop) = child.backdrop.clone() {
-                let Some(root_target) = root_target else {
-                    return Err(
-                        "root direct path does not support backdrop child surfaces".to_string()
-                    );
-                };
-                let backdrop_layer = BackdropLayer {
-                    node_id: child.node_id,
-                    rect: resolved_child.backdrop_rect,
-                    clip: child.visual_clip,
-                    snap_anchor: resolved_child.snap_anchor,
-                    effect: backdrop,
-                    z_index: child.z_index,
-                };
-                if let Some(dependency_rect) = backdrop_dependency_rect(
-                    resolved_child.backdrop_rect,
-                    child.visual_clip,
-                    &backdrop_layer.effect,
-                    root_scale,
-                    (width, height),
-                ) {
-                    flush_pending_queues_for_backdrop_capture(
-                        backend,
-                        &mut pending_composites,
-                        &mut pending_composite_load_op,
-                        &mut pending_shader_composites,
-                        &mut pending_shader_load_op,
-                        surface_view,
-                        (width, height),
-                        &mut next_load_op,
-                        dependency_rect,
-                        root_scale,
-                    )?;
-                }
-                let child_backdrop_capture_rect = visible_backdrop_capture_rect(
-                    resolved_child.backdrop_rect,
-                    child.visual_clip,
-                    &backdrop_layer.effect,
-                    root_scale,
-                    (width, height),
-                );
-                let backdrop_input_hash = backdrop_scene_prefix_hash(
-                    &local_scene,
-                    &prior_child_contributions,
-                    child.z_index,
-                    child_backdrop_capture_rect.unwrap_or(backdrop_layer.rect),
-                    (width, height),
-                    root_scale,
-                );
-                if let Some(prepared) = prepare_cached_backdrop_layer_composite(
-                    backend,
-                    root_target,
-                    &backdrop_layer,
-                    None,
-                    width,
-                    height,
-                    root_scale,
-                    Some(backdrop_input_hash),
-                    true,
-                )? {
-                    let PreparedBackdropComposite {
-                        surface: prepared_surface,
-                        dest_quad: prepared_dest_quad,
-                        scissor: prepared_scissor,
-                    } = prepared;
-                    if prepared_surface.deferred_effect.is_some() {
-                        match direct_shader_layer_composite(
-                            prepared_surface,
-                            child.z_index,
-                            next_composite_seq(&mut composite_seq),
-                            prepared_dest_quad,
-                            prepared_scissor,
-                        ) {
-                            Ok(pending) => {
-                                if pending_shader_composites.is_empty() {
-                                    pending_shader_load_op = Some(next_load_op);
-                                }
-                                pending_shader_composites.push(pending);
-                                next_load_op = wgpu::LoadOp::Load;
-                            }
-                            Err(prepared_surface) => {
-                                composite_layer_surface_to_view(
-                                    backend,
-                                    &prepared_surface,
-                                    surface_view,
-                                    (width, height),
-                                    prepared_dest_quad,
-                                    next_load_op,
-                                    prepared_scissor,
-                                )?;
-                                next_load_op = wgpu::LoadOp::Load;
-                                backend.release_layer_surface_target(prepared_surface.target);
-                            }
-                        }
-                    } else {
-                        if pending_composites.is_empty() {
-                            pending_composite_load_op = Some(next_load_op);
-                        }
-                        pending_composites.push(PendingLayerComposite {
-                            z_index: child.z_index,
-                            seq: next_composite_seq(&mut composite_seq),
-                            surface: prepared_surface,
-                            dest_quad: prepared_dest_quad,
-                            scissor: prepared_scissor,
-                        });
-                        next_load_op = wgpu::LoadOp::Load;
-                    }
-                } else {
-                    apply_backdrop_layer_to_target(
-                        backend,
-                        root_target,
-                        &backdrop_layer,
-                        None,
-                        width,
-                        height,
-                        root_scale,
-                        Some(backdrop_input_hash),
-                    )?;
-                    if !pending_composites.is_empty() {
-                        pending_composite_load_op = Some(wgpu::LoadOp::Load);
-                    }
-                }
-            }
+            composite_root_child_backdrop(
+                backend,
+                root_target,
+                surface_view,
+                &local_scene,
+                &prior_child_contributions,
+                &child,
+                &resolved_child,
+                (width, height),
+                root_scale,
+                &mut PendingQueues {
+                    composites: &mut pending_composites,
+                    composite_load_op: &mut pending_composite_load_op,
+                    shader_composites: &mut pending_shader_composites,
+                    shader_load_op: &mut pending_shader_load_op,
+                    next_load_op: &mut next_load_op,
+                    composite_seq: &mut composite_seq,
+                },
+            )?;
             let child_underlay_identity = child
                 .needs_nested_underlay
                 .then(|| {
@@ -2930,7 +2815,16 @@ pub(crate) fn render_layer_surface<B: SurfaceExecutionBackend>(
         backend.max_texture_dim(),
     );
     if let Some((cache_key, logical_rect)) = cache_candidate {
+        if backdrop_diag_enabled() {
+            eprintln!(
+                "[backdrop-diag] probe node={:?} identity={:?} key={:?} bake={}",
+                child.node_id, backdrop_underlay_identity, cache_key, bake_underlay
+            );
+        }
         if let Some((target, logical_rect)) = backend.cached_layer_surface(&cache_key) {
+            if backdrop_diag_enabled() {
+                eprintln!("[backdrop-diag] probe HIT node={:?}", child.node_id);
+            }
             let (composite_alpha, blend_mode) = child
                 .isolation
                 .as_ref()
@@ -3282,6 +3176,17 @@ fn backdrop_prefix_child_contribution(
         }
         _ => child.target_content_hash,
     };
+    if backdrop_diag_enabled() {
+        eprintln!(
+            "[backdrop-diag] contribution node={:?} z={} content_hash={} target_content_hash={} identity={:?} dest0={:?}",
+            child.node_id,
+            child.z_index,
+            content_hash,
+            child.target_content_hash,
+            underlay_identity,
+            dest_quad[0]
+        );
+    }
     BackdropPrefixChildContribution {
         z_index: child.z_index,
         node_id: child.node_id,
@@ -4298,6 +4203,316 @@ fn take_ordered_pending_composite_load_op(
     }
 }
 
+/// The composite queues a render loop batches between passes, lent to the
+/// helpers that push into them or flush them.
+struct PendingQueues<'a> {
+    composites: &'a mut Vec<PendingLayerComposite>,
+    composite_load_op: &'a mut Option<wgpu::LoadOp<wgpu::Color>>,
+    shader_composites: &'a mut Vec<PendingShaderLayerComposite>,
+    shader_load_op: &'a mut Option<wgpu::LoadOp<wgpu::Color>>,
+    next_load_op: &'a mut wgpu::LoadOp<wgpu::Color>,
+    composite_seq: &'a mut usize,
+}
+
+/// Composites a root child's own backdrop into the root target: capture,
+/// effect and either a pending composite, a deferred shader composite or a
+/// direct application, all ahead of the child's surface so an underlay
+/// sampled beneath the child already carries it.
+#[allow(clippy::too_many_arguments)]
+fn composite_root_child_backdrop<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    root_target: Option<&OffscreenTarget>,
+    surface_view: &wgpu::TextureView,
+    local_scene: &CompositorScene,
+    prior_child_contributions: &[BackdropPrefixChildContribution],
+    child: &ChildLayerComposite,
+    resolved_child: &ResolvedChildSurfaceComposite,
+    viewport: (u32, u32),
+    root_scale: f32,
+    queues: &mut PendingQueues<'_>,
+) -> Result<(), String> {
+    let (width, height) = viewport;
+    if let Some(backdrop) = child.backdrop.clone() {
+        let Some(root_target) = root_target else {
+            return Err("root direct path does not support backdrop child surfaces".to_string());
+        };
+        let backdrop_layer = BackdropLayer {
+            node_id: child.node_id,
+            rect: resolved_child.backdrop_rect,
+            clip: child.visual_clip,
+            snap_anchor: resolved_child.snap_anchor,
+            effect: backdrop,
+            z_index: child.z_index,
+        };
+        if let Some(dependency_rect) = backdrop_dependency_rect(
+            resolved_child.backdrop_rect,
+            child.visual_clip,
+            &backdrop_layer.effect,
+            root_scale,
+            (width, height),
+        ) {
+            flush_pending_queues_for_backdrop_capture(
+                backend,
+                queues.composites,
+                queues.composite_load_op,
+                queues.shader_composites,
+                queues.shader_load_op,
+                surface_view,
+                (width, height),
+                queues.next_load_op,
+                dependency_rect,
+                root_scale,
+            )?;
+        }
+        let child_backdrop_capture_rect = visible_backdrop_capture_rect(
+            resolved_child.backdrop_rect,
+            child.visual_clip,
+            &backdrop_layer.effect,
+            root_scale,
+            (width, height),
+        );
+        let backdrop_input_hash = backdrop_scene_prefix_hash(
+            local_scene,
+            prior_child_contributions,
+            child.z_index,
+            child_backdrop_capture_rect.unwrap_or(backdrop_layer.rect),
+            (width, height),
+            root_scale,
+        );
+        if backdrop_diag_enabled() {
+            eprintln!(
+                "[backdrop-diag] root backdrop node={:?} input_hash={} contributions={}",
+                child.node_id,
+                backdrop_input_hash,
+                prior_child_contributions.len()
+            );
+        }
+        if let Some(prepared) = prepare_cached_backdrop_layer_composite(
+            backend,
+            root_target,
+            &backdrop_layer,
+            None,
+            width,
+            height,
+            root_scale,
+            Some(backdrop_input_hash),
+            true,
+        )? {
+            let PreparedBackdropComposite {
+                surface: prepared_surface,
+                dest_quad: prepared_dest_quad,
+                scissor: prepared_scissor,
+            } = prepared;
+            if prepared_surface.deferred_effect.is_some() {
+                match direct_shader_layer_composite(
+                    prepared_surface,
+                    child.z_index,
+                    next_composite_seq(queues.composite_seq),
+                    prepared_dest_quad,
+                    prepared_scissor,
+                ) {
+                    Ok(pending) => {
+                        if queues.shader_composites.is_empty() {
+                            *queues.shader_load_op = Some(*queues.next_load_op);
+                        }
+                        queues.shader_composites.push(pending);
+                        *queues.next_load_op = wgpu::LoadOp::Load;
+                    }
+                    Err(prepared_surface) => {
+                        composite_layer_surface_to_view(
+                            backend,
+                            &prepared_surface,
+                            surface_view,
+                            (width, height),
+                            prepared_dest_quad,
+                            *queues.next_load_op,
+                            prepared_scissor,
+                        )?;
+                        *queues.next_load_op = wgpu::LoadOp::Load;
+                        backend.release_layer_surface_target(prepared_surface.target);
+                    }
+                }
+            } else {
+                if queues.composites.is_empty() {
+                    *queues.composite_load_op = Some(*queues.next_load_op);
+                }
+                queues.composites.push(PendingLayerComposite {
+                    z_index: child.z_index,
+                    seq: next_composite_seq(queues.composite_seq),
+                    surface: prepared_surface,
+                    dest_quad: prepared_dest_quad,
+                    scissor: prepared_scissor,
+                });
+                *queues.next_load_op = wgpu::LoadOp::Load;
+            }
+        } else {
+            apply_backdrop_layer_to_target(
+                backend,
+                root_target,
+                &backdrop_layer,
+                None,
+                width,
+                height,
+                root_scale,
+                Some(backdrop_input_hash),
+            )?;
+            if !queues.composites.is_empty() {
+                *queues.composite_load_op = Some(wgpu::LoadOp::Load);
+            }
+        }
+    }
+    Ok(())
+}
+
+struct NestedBackdropContext<'a> {
+    backdrop_underlay: Option<&'a OffscreenTarget>,
+    baked: bool,
+    underlay_identity: Option<u64>,
+}
+
+/// The nested counterpart of [`composite_root_child_backdrop`]: the child's
+/// own backdrop goes into the enclosing surface's target, reading through the
+/// surface's external underlay unless local content covers it, and keyed on
+/// the baked underlay identity when the surface bakes one.
+#[allow(clippy::too_many_arguments)]
+fn composite_nested_child_backdrop<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    target: &OffscreenTarget,
+    local_scene: &CompositorScene,
+    prior_child_contributions: &[BackdropPrefixChildContribution],
+    child: &ChildLayerComposite,
+    resolved_child: &ResolvedChildSurfaceComposite,
+    viewport: (u32, u32),
+    target_scale: f32,
+    context: NestedBackdropContext<'_>,
+    queues: &mut PendingQueues<'_>,
+) -> Result<(), String> {
+    let (width, height) = viewport;
+    let child_backdrop_capture_rect = child.backdrop.as_ref().and_then(|backdrop| {
+        visible_backdrop_capture_rect(
+            resolved_child.backdrop_rect,
+            child.visual_clip,
+            backdrop,
+            target_scale,
+            (width, height),
+        )
+    });
+
+    if !resolved_child.shadow_draws.is_empty() {
+        flush_pending_composite_queues_fused(
+            backend,
+            queues.composites,
+            queues.composite_load_op,
+            queues.shader_composites,
+            queues.shader_load_op,
+            &target.view,
+            (width, height),
+            queues.next_load_op,
+        )?;
+        flush_pending_clear(backend, &target.view, queues.next_load_op);
+    }
+
+    if let Some(backdrop) = &child.backdrop {
+        if let Some(dependency_rect) = backdrop_dependency_rect(
+            resolved_child.backdrop_rect,
+            child.visual_clip,
+            backdrop,
+            target_scale,
+            (width, height),
+        ) {
+            flush_pending_queues_for_backdrop_capture(
+                backend,
+                queues.composites,
+                queues.composite_load_op,
+                queues.shader_composites,
+                queues.shader_load_op,
+                &target.view,
+                (width, height),
+                queues.next_load_op,
+                dependency_rect,
+                target_scale,
+            )?;
+        }
+        let backdrop_layer = BackdropLayer {
+            node_id: child.node_id,
+            rect: resolved_child.backdrop_rect,
+            clip: child.visual_clip,
+            snap_anchor: resolved_child.snap_anchor,
+            effect: backdrop.clone(),
+            z_index: child.z_index,
+        };
+        let backdrop_input_hash = {
+            let local_hash = backdrop_scene_prefix_hash(
+                local_scene,
+                prior_child_contributions,
+                child.z_index,
+                child_backdrop_capture_rect.unwrap_or(backdrop_layer.rect),
+                (width, height),
+                target_scale,
+            );
+            if context.baked {
+                content_hash_over_underlay(local_hash, context.underlay_identity)
+            } else {
+                local_hash
+            }
+        };
+        let effective_backdrop_underlay = if context.backdrop_underlay.is_some()
+            && backdrop_underlay_is_covered_by_local_content(
+                &local_scene.shapes,
+                &local_scene.brushes,
+                &local_scene.images,
+                &local_scene.shadow_draws,
+                &local_scene.draw_ops,
+                &local_scene.effect_layers,
+                &local_scene.backdrop_layers,
+                &backdrop_layer,
+            ) {
+            None
+        } else {
+            context.backdrop_underlay
+        };
+        if let Some(prepared) = prepare_cached_backdrop_layer_composite(
+            backend,
+            target,
+            &backdrop_layer,
+            effective_backdrop_underlay,
+            width,
+            height,
+            target_scale,
+            Some(backdrop_input_hash),
+            false,
+        )? {
+            if queues.composites.is_empty() {
+                *queues.composite_load_op = Some(*queues.next_load_op);
+            }
+            queues.composites.push(PendingLayerComposite {
+                z_index: child.z_index,
+                seq: next_composite_seq(queues.composite_seq),
+                surface: prepared.surface,
+                dest_quad: prepared.dest_quad,
+                scissor: prepared.scissor,
+            });
+            *queues.next_load_op = wgpu::LoadOp::Load;
+        } else {
+            apply_backdrop_layer_to_target(
+                backend,
+                target,
+                &backdrop_layer,
+                effective_backdrop_underlay,
+                width,
+                height,
+                target_scale,
+                Some(backdrop_input_hash),
+            )?;
+            if !queues.composites.is_empty() {
+                *queues.composite_load_op = Some(wgpu::LoadOp::Load);
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn flush_pending_composite_queues_fused<B: SurfaceExecutionBackend>(
     backend: &mut B,
@@ -5263,128 +5478,29 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
             surface_capture_active: translation_context.surface_capture_active,
             local_picture_capture_active: translation_context.local_picture_capture_active,
         };
-        let child_backdrop_capture_rect = child.backdrop.as_ref().and_then(|backdrop| {
-            visible_backdrop_capture_rect(
-                resolved_child.backdrop_rect,
-                child.visual_clip,
-                backdrop,
-                target_scale,
-                (width, height),
-            )
-        });
-
-        if !resolved_child.shadow_draws.is_empty() {
-            flush_pending_composite_queues_fused(
-                backend,
-                &mut pending_composites,
-                &mut pending_composite_load_op,
-                &mut pending_shader_composites,
-                &mut pending_shader_load_op,
-                &target.view,
-                (width, height),
-                &mut next_load_op,
-            )?;
-            flush_pending_clear(backend, &target.view, &mut next_load_op);
-        }
-
-        if let Some(backdrop) = &child.backdrop {
-            if let Some(dependency_rect) = backdrop_dependency_rect(
-                resolved_child.backdrop_rect,
-                child.visual_clip,
-                backdrop,
-                target_scale,
-                (width, height),
-            ) {
-                flush_pending_queues_for_backdrop_capture(
-                    backend,
-                    &mut pending_composites,
-                    &mut pending_composite_load_op,
-                    &mut pending_shader_composites,
-                    &mut pending_shader_load_op,
-                    &target.view,
-                    (width, height),
-                    &mut next_load_op,
-                    dependency_rect,
-                    target_scale,
-                )?;
-            }
-            let backdrop_layer = BackdropLayer {
-                node_id: child.node_id,
-                rect: resolved_child.backdrop_rect,
-                clip: child.visual_clip,
-                snap_anchor: resolved_child.snap_anchor,
-                effect: backdrop.clone(),
-                z_index: child.z_index,
-            };
-            let backdrop_input_hash = {
-                let local_hash = backdrop_scene_prefix_hash(
-                    local_scene,
-                    &prior_child_contributions,
-                    child.z_index,
-                    child_backdrop_capture_rect.unwrap_or(backdrop_layer.rect),
-                    (width, height),
-                    target_scale,
-                );
-                if baked {
-                    content_hash_over_underlay(local_hash, underlay_identity)
-                } else {
-                    local_hash
-                }
-            };
-            let effective_backdrop_underlay = if backdrop_underlay.is_some()
-                && backdrop_underlay_is_covered_by_local_content(
-                    &local_scene.shapes,
-                    &local_scene.brushes,
-                    &local_scene.images,
-                    &local_scene.shadow_draws,
-                    &local_scene.draw_ops,
-                    &local_scene.effect_layers,
-                    &local_scene.backdrop_layers,
-                    &backdrop_layer,
-                ) {
-                None
-            } else {
-                backdrop_underlay
-            };
-            if let Some(prepared) = prepare_cached_backdrop_layer_composite(
-                backend,
-                &target,
-                &backdrop_layer,
-                effective_backdrop_underlay,
-                width,
-                height,
-                target_scale,
-                Some(backdrop_input_hash),
-                false,
-            )? {
-                if pending_composites.is_empty() {
-                    pending_composite_load_op = Some(next_load_op);
-                }
-                pending_composites.push(PendingLayerComposite {
-                    z_index: child.z_index,
-                    seq: next_composite_seq(&mut composite_seq),
-                    surface: prepared.surface,
-                    dest_quad: prepared.dest_quad,
-                    scissor: prepared.scissor,
-                });
-                next_load_op = wgpu::LoadOp::Load;
-            } else {
-                apply_backdrop_layer_to_target(
-                    backend,
-                    &target,
-                    &backdrop_layer,
-                    effective_backdrop_underlay,
-                    width,
-                    height,
-                    target_scale,
-                    Some(backdrop_input_hash),
-                )?;
-                if !pending_composites.is_empty() {
-                    pending_composite_load_op = Some(wgpu::LoadOp::Load);
-                }
-            }
-        }
-
+        composite_nested_child_backdrop(
+            backend,
+            &target,
+            local_scene,
+            &prior_child_contributions,
+            &child,
+            &resolved_child,
+            (width, height),
+            target_scale,
+            NestedBackdropContext {
+                backdrop_underlay,
+                baked,
+                underlay_identity,
+            },
+            &mut PendingQueues {
+                composites: &mut pending_composites,
+                composite_load_op: &mut pending_composite_load_op,
+                shader_composites: &mut pending_shader_composites,
+                shader_load_op: &mut pending_shader_load_op,
+                next_load_op: &mut next_load_op,
+                composite_seq: &mut composite_seq,
+            },
+        )?;
         let child_underlay_identity = child
             .needs_nested_underlay
             .then(|| {
@@ -5668,6 +5784,46 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
     Ok(target)
 }
 
+/// Whether a source-content miss earns a cache slot: a miss the upstream probe
+/// already paid for is stored unconditionally, any other miss goes through
+/// the admission policy and is recorded when it is admitted.
+fn admit_source_content_miss<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    cache_key: &LayerRasterCacheKey,
+    admission: CacheAdmission,
+    missed_upstream: bool,
+    size: (u32, u32),
+) -> bool {
+    if missed_upstream {
+        return true;
+    }
+    let admitted = backend.admit_layer_surface_cache_miss(cache_key, admission);
+    if admitted {
+        record_layer_cache_miss(backend, "source-content", cache_key, size.0, size.1);
+    }
+    admitted
+}
+
+fn store_source_content<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    admitted: bool,
+    cache_key: LayerRasterCacheKey,
+    rendered: OffscreenTarget,
+    surface_rect: Rect,
+) -> LayerSurfaceTexture {
+    if admitted
+        && offscreen_byte_size(rendered.width, rendered.height) <= MAX_LAYER_SURFACE_CACHE_BYTES
+    {
+        LayerSurfaceTexture::Cached(backend.insert_cached_layer_surface(
+            cache_key,
+            rendered,
+            surface_rect,
+        ))
+    } else {
+        LayerSurfaceTexture::Owned(rendered)
+    }
+}
+
 fn render_layer_surface_uncached<B: SurfaceExecutionBackend>(
     backend: &mut B,
     child: &ChildLayerComposite,
@@ -5861,11 +6017,13 @@ fn render_layer_surface_uncached<B: SurfaceExecutionBackend>(
             if let Some((cached_target, _)) = cached {
                 LayerSurfaceTexture::Cached(cached_target)
             } else {
-                let admitted = source_probe_missed_upstream
-                    || backend.admit_layer_surface_cache_miss(&cache_key, cache_admission);
-                if admitted && !source_probe_missed_upstream {
-                    record_layer_cache_miss(backend, "source-content", &cache_key, width, height);
-                }
+                let admitted = admit_source_content_miss(
+                    backend,
+                    &cache_key,
+                    cache_admission,
+                    source_probe_missed_upstream,
+                    (width, height),
+                );
                 let rendered = render_layer_source_uncached(
                     backend,
                     &local_scene,
@@ -5880,16 +6038,7 @@ fn render_layer_surface_uncached<B: SurfaceExecutionBackend>(
                     effective_translated_content_axes,
                     translation_context,
                 )?;
-                if admitted
-                    && offscreen_byte_size(rendered.width, rendered.height)
-                        <= MAX_LAYER_SURFACE_CACHE_BYTES
-                {
-                    let cached_target =
-                        backend.insert_cached_layer_surface(cache_key, rendered, surface_rect);
-                    LayerSurfaceTexture::Cached(cached_target)
-                } else {
-                    LayerSurfaceTexture::Owned(rendered)
-                }
+                store_source_content(backend, admitted, cache_key, rendered, surface_rect)
             }
         } else {
             LayerSurfaceTexture::Owned(render_layer_source_uncached(
@@ -6179,9 +6328,6 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
     input_content_hash: Option<u64>,
     allow_deferred_tail: bool,
 ) -> Result<Option<PreparedBackdropComposite>, String> {
-    if ablate_backdrops() {
-        return Ok(None);
-    }
     let diag = backdrop_diag_enabled();
     let (layer_rect, layer_clip) = snapped_backdrop_geometry(layer, root_scale);
     let Some(visible_rect) = visible_layer_rect(layer_rect, layer_clip, root_scale, width, height)
@@ -6418,9 +6564,6 @@ pub(crate) fn apply_backdrop_layer_to_target<B: SurfaceExecutionBackend>(
     root_scale: f32,
     input_content_hash: Option<u64>,
 ) -> Result<(), String> {
-    if ablate_backdrops() {
-        return Ok(());
-    }
     let (layer_rect, layer_clip) = snapped_backdrop_geometry(layer, root_scale);
     if backdrop_diag_enabled() {
         eprintln!(

--- a/crates/cranpose-render/wgpu/src/surface_plan.rs
+++ b/crates/cranpose-render/wgpu/src/surface_plan.rs
@@ -67,7 +67,8 @@ pub(crate) struct TranslationRenderContext {
 pub(crate) struct LayerSurfaceRequest<'a> {
     pub(crate) root_scale: f32,
     pub(crate) backdrop_underlay: Option<&'a OffscreenTarget>,
-    pub(crate) backdrop_underlay_color: Option<u32>,
+    pub(crate) backdrop_underlay_identity: Option<u64>,
+    pub(crate) bake_underlay: bool,
     pub(crate) allow_runtime_cache: bool,
     pub(crate) logical_rect_override: Option<Rect>,
     pub(crate) capture_clip_override: Option<Rect>,
@@ -78,7 +79,8 @@ pub(crate) struct LayerSurfaceRequest<'a> {
 pub(crate) struct LayerSurfaceRenderOptions<'a> {
     pub(crate) target_scale: f32,
     pub(crate) backdrop_underlay: Option<&'a OffscreenTarget>,
-    pub(crate) backdrop_underlay_color: Option<u32>,
+    pub(crate) backdrop_underlay_identity: Option<u64>,
+    pub(crate) bake_underlay: bool,
     pub(crate) allow_runtime_cache: bool,
     pub(crate) cache_candidate: Option<(
         cranpose_render_common::raster_cache::LayerRasterCacheKey,

--- a/crates/cranpose-render/wgpu/tests/glass_underlay_scroll.rs
+++ b/crates/cranpose-render/wgpu/tests/glass_underlay_scroll.rs
@@ -1,0 +1,271 @@
+mod support;
+
+use std::{cell::RefCell, rc::Rc};
+
+use cranpose_app_shell::AppShell;
+use cranpose_core::{location_key, remember};
+use cranpose_liquid::{Glass, GlassButton, GlassButtonSpec, GlassSurface};
+use cranpose_ui::{
+    Color, LazyListScope, LazyListState, LinearArrangement, Modifier, RenderEffect, ScrollState,
+    Size, TextStyle, composable, rememberLazyListState,
+    widgets::{Box, BoxSpec, Column, ColumnSpec, LazyColumn, LazyColumnSpec, Text},
+};
+
+const FRAME_WIDTH: u32 = 320;
+const FRAME_HEIGHT: u32 = 240;
+const BAR: [f32; 4] = [16.0, 24.0, 288.0, 56.0];
+const BUTTON: [f32; 4] = [260.0, 32.0, 40.0, 40.0];
+const ROW_HEIGHT: f32 = 3.0;
+const ROWS: usize = 240;
+const SCROLL_STEP: f32 = 1.0;
+const FEED_LANE: (u32, u32, u32, u32) = (40, 62, 200, 8);
+const OPEN_LANE: (u32, u32, u32, u32) = (40, 150, 200, 8);
+
+fn rect_modifier(rect: [f32; 4]) -> Modifier {
+    Modifier::empty().offset(rect[0], rect[1]).size(Size {
+        width: rect[2],
+        height: rect[3],
+    })
+}
+
+fn frame_size() -> Size {
+    Size {
+        width: FRAME_WIDTH as f32,
+        height: FRAME_HEIGHT as f32,
+    }
+}
+
+/// The page every scene sits on: a solid ground the size of the frame.
+#[composable]
+#[allow(non_snake_case)]
+fn Page(content: impl FnMut() + 'static) {
+    Box(
+        Modifier::empty()
+            .size(frame_size())
+            .background(Color(0.08, 0.12, 0.30, 1.0)),
+        BoxSpec::new(),
+        content,
+    );
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn FeedRow(index: usize) {
+    Box(
+        Modifier::empty()
+            .size(Size {
+                width: FRAME_WIDTH as f32,
+                height: ROW_HEIGHT,
+            })
+            .background(row_color(index)),
+        BoxSpec::new(),
+        || {},
+    );
+}
+
+fn row_color(index: usize) -> Color {
+    let step = (index % 6) as f32 / 6.0;
+    Color(0.15 + step * 0.7, 0.9 - step * 0.8, 0.35, 1.0)
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn GlassOverScrollingFeed(scroll_slot: Rc<RefCell<Option<ScrollState>>>) {
+    let scroll = remember(|| ScrollState::new(0.0)).with(|state| *state);
+    scroll_slot.borrow_mut().replace(scroll);
+    Page(move || {
+        Column(
+            Modifier::empty()
+                .size(frame_size())
+                .vertical_scroll(scroll, false),
+            ColumnSpec::default(),
+            || {
+                for index in 0..ROWS {
+                    FeedRow(index);
+                }
+            },
+        );
+        Box(
+            rect_modifier(BAR)
+                .backdrop_effect(RenderEffect::blur(0.5))
+                .background(Color(1.0, 1.0, 1.0, 0.10))
+                .rounded_corners(14.0),
+            BoxSpec::new(),
+            || {
+                Text(
+                    "Library",
+                    Modifier::empty().offset(16.0, 16.0),
+                    TextStyle::default(),
+                );
+                Box(
+                    rect_modifier([BUTTON[0] - BAR[0], BUTTON[1] - BAR[1], BUTTON[2], BUTTON[3]])
+                        .backdrop_effect(RenderEffect::blur(4.0))
+                        .background(Color(1.0, 1.0, 1.0, 0.24))
+                        .rounded_corners(20.0),
+                    BoxSpec::new(),
+                    || {},
+                );
+            },
+        );
+    });
+}
+
+fn lane_pixels(frame: &[u8], lane: (u32, u32, u32, u32)) -> Vec<u8> {
+    let (x, y, w, h) = lane;
+    let mut out = Vec::with_capacity((w * h * 4) as usize);
+    for row in y..y + h {
+        let start = ((row * FRAME_WIDTH + x) * 4) as usize;
+        out.extend_from_slice(&frame[start..start + (w * 4) as usize]);
+    }
+    out
+}
+
+fn capture(shell: &mut AppShell<cranpose_render_wgpu::WgpuRenderer>) -> Vec<u8> {
+    shell.update();
+    shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("frame capture should succeed")
+        .pixels
+}
+
+fn mean_abs_delta(a: &[u8], b: &[u8]) -> f32 {
+    let total: u64 = a.iter().zip(b).map(|(x, y)| x.abs_diff(*y) as u64).sum();
+    total as f32 / a.len().max(1) as f32
+}
+
+#[test]
+fn a_glass_bar_with_a_nested_glass_button_follows_the_feed_scrolling_beneath_it() {
+    let (_lock, renderer) = match support::headless_renderer_parts() {
+        Ok(parts) => parts,
+        Err(err) => {
+            eprintln!("skipping (headless WGPU init failed): {err}");
+            return;
+        }
+    };
+    let scroll_slot = Rc::new(RefCell::new(None::<ScrollState>));
+    let root_key = location_key(file!(), line!(), column!());
+    let slot_for_content = Rc::clone(&scroll_slot);
+    let mut shell = AppShell::new(renderer, root_key, move || {
+        GlassOverScrollingFeed(Rc::clone(&slot_for_content))
+    });
+    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
+    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+    let first = capture(&mut shell);
+    let mut previous = lane_pixels(&first, FEED_LANE);
+    let mut previous_open = lane_pixels(&first, OPEN_LANE);
+    let steady = lane_pixels(&capture(&mut shell), FEED_LANE);
+    assert!(
+        mean_abs_delta(&previous, &steady) < 0.05,
+        "an unchanged frame must reproduce the lane under the bar"
+    );
+    let scroll = scroll_slot
+        .borrow()
+        .expect("the feed remembers its scroll state");
+    for step in 1..=6 {
+        shell
+            .app_context()
+            .clone()
+            .enter(|| scroll.scroll_to(step as f32 * SCROLL_STEP));
+        let frame = capture(&mut shell);
+        let current = lane_pixels(&frame, FEED_LANE);
+        let current_open = lane_pixels(&frame, OPEN_LANE);
+        let open_delta = mean_abs_delta(&previous_open, &current_open);
+        assert!(
+            open_delta > 1.0,
+            "step {step}: the feed itself did not scroll (mean delta {open_delta} in the open lane)"
+        );
+        previous_open = current_open;
+        let delta = mean_abs_delta(&previous, &current);
+        assert!(
+            delta > 1.0,
+            "step {step}: the feed scrolled one pixel but the pixels under the glass bar did not move (mean delta {delta}); \
+             the bar's baked underlay was served for a prefix that changed"
+        );
+        previous = current;
+    }
+}
+
+fn feed_glass() -> Glass {
+    Glass::regular()
+        .blur_radius(0.0)
+        .refraction_depth(0.35)
+        .refraction_depth_dp(6.0)
+        .refraction_curve(0.6)
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn LiquidBarOverLazyFeed(list_slot: Rc<RefCell<Option<LazyListState>>>) {
+    let list_state = rememberLazyListState();
+    list_slot.borrow_mut().replace(list_state);
+    Page(move || {
+        LazyColumn(
+            Modifier::empty().size(frame_size()),
+            list_state,
+            LazyColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(0.0)),
+            move |scope| {
+                scope.items(ROWS, move |index| {
+                    FeedRow(index);
+                });
+            },
+        );
+        GlassSurface(rect_modifier(BAR), feed_glass(), || {
+            Text(
+                "Library",
+                Modifier::empty().offset(16.0, 16.0),
+                TextStyle::default(),
+            );
+            GlassButton(
+                rect_modifier([BUTTON[0] - BAR[0], BUTTON[1] - BAR[1], BUTTON[2], BUTTON[3]]),
+                GlassButtonSpec::glass().with_glass(feed_glass()),
+                || {},
+                || {},
+            );
+        });
+    });
+}
+
+#[test]
+fn a_liquid_glass_bar_with_a_glass_button_follows_a_lazy_feed_scrolling_beneath_it() {
+    let (_lock, renderer) = match support::headless_renderer_parts() {
+        Ok(parts) => parts,
+        Err(err) => {
+            eprintln!("skipping (headless WGPU init failed): {err}");
+            return;
+        }
+    };
+    let list_slot = Rc::new(RefCell::new(None::<LazyListState>));
+    let root_key = location_key(file!(), line!(), column!());
+    let slot_for_content = Rc::clone(&list_slot);
+    let mut shell = AppShell::new(renderer, root_key, move || {
+        LiquidBarOverLazyFeed(Rc::clone(&slot_for_content))
+    });
+    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
+    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+    let first = capture(&mut shell);
+    let mut previous = lane_pixels(&first, FEED_LANE);
+    let mut previous_open = lane_pixels(&first, OPEN_LANE);
+    let list_state = (*list_slot.borrow()).expect("the feed remembers its list state");
+    for step in 1..=6 {
+        shell
+            .app_context()
+            .clone()
+            .enter(|| list_state.scroll_to_item(0, step as f32 * SCROLL_STEP));
+        let frame = capture(&mut shell);
+        let current = lane_pixels(&frame, FEED_LANE);
+        let current_open = lane_pixels(&frame, OPEN_LANE);
+        let open_delta = mean_abs_delta(&previous_open, &current_open);
+        assert!(
+            open_delta > 1.0,
+            "step {step}: the lazy feed itself did not scroll (mean delta {open_delta} in the open lane)"
+        );
+        previous_open = current_open;
+        let delta = mean_abs_delta(&previous, &current);
+        assert!(
+            delta > 1.0,
+            "step {step}: the lazy feed scrolled one pixel but the pixels under the liquid glass bar did not move (mean delta {delta})"
+        );
+        previous = current;
+    }
+}

--- a/crates/cranpose-render/wgpu/tests/render_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/render_contract.rs
@@ -544,11 +544,11 @@ fn first_child_composite_consumes_pending_clear_load_op() {
         )
         .expect("nested underlay branch must initialize target before child capture");
     let nested_underlay_end = source[nested_underlay_start..]
-        .find("let child_underlay = child.needs_nested_underlay.then")
+        .find("let underlay = sample_child_underlay(")
         .map(|offset| nested_underlay_start + offset)
         .expect("nested underlay capture should follow target initialization");
     let nested_underlay_body = &source[nested_underlay_start..nested_underlay_end];
-    let backdrop_body = block_after(&source, "if let Some(backdrop) = &child_surface.backdrop");
+    let backdrop_body = block_after(&source, "if let Some(backdrop) = &child.backdrop");
     let shadow_body = block_after(&source, "if !resolved_child.shadow_draws.is_empty()");
     assert!(
         nested_underlay_body.contains("flush_pending_clear")

--- a/crates/cranpose-render/wgpu/tests/underlay_bake_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/underlay_bake_parity.rs
@@ -1,0 +1,133 @@
+mod support;
+
+use cranpose_app_shell::AppShell;
+use cranpose_core::location_key;
+use cranpose_ui::{
+    Color, Modifier, RenderEffect, Size, TextStyle, composable,
+    widgets::{Box, BoxSpec, Text},
+};
+
+const FRAME_WIDTH: u32 = 320;
+const FRAME_HEIGHT: u32 = 240;
+const CARD: [f32; 4] = [24.0, 40.0, 272.0, 120.0];
+const BUTTON: [f32; 4] = [236.0, 80.0, 40.0, 40.0];
+
+fn rect_modifier(rect: [f32; 4]) -> Modifier {
+    Modifier::empty().offset(rect[0], rect[1]).size(Size {
+        width: rect[2],
+        height: rect[3],
+    })
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn GradientPage() {
+    Box(
+        Modifier::empty()
+            .size(Size {
+                width: FRAME_WIDTH as f32,
+                height: FRAME_HEIGHT as f32,
+            })
+            .background(Color(0.08, 0.12, 0.30, 1.0)),
+        BoxSpec::new(),
+        || {
+            Box(
+                rect_modifier([0.0, 0.0, 160.0, 240.0]).background(Color(0.55, 0.20, 0.12, 1.0)),
+                BoxSpec::new(),
+                || {},
+            );
+            Box(
+                rect_modifier(CARD)
+                    .backdrop_effect(RenderEffect::blur(8.0))
+                    .background(Color(1.0, 1.0, 1.0, 0.18))
+                    .rounded_corners(14.0),
+                BoxSpec::new(),
+                || {
+                    Text(
+                        "Underlay bake",
+                        Modifier::empty().offset(16.0, 16.0),
+                        TextStyle::default(),
+                    );
+                    Box(
+                        rect_modifier([
+                            BUTTON[0] - CARD[0],
+                            BUTTON[1] - CARD[1],
+                            BUTTON[2],
+                            BUTTON[3],
+                        ])
+                        .backdrop_effect(RenderEffect::blur(5.0))
+                        .background(Color(1.0, 1.0, 1.0, 0.24))
+                        .rounded_corners(20.0),
+                        BoxSpec::new(),
+                        || {},
+                    );
+                },
+            );
+        },
+    );
+}
+
+fn cold_capture(bake: bool) -> Option<(Vec<u8>, cranpose_render_wgpu::RenderStatsSnapshot)> {
+    let (_lock, mut renderer) = match support::headless_renderer_parts() {
+        Ok(parts) => parts,
+        Err(err) => {
+            eprintln!("skipping (headless WGPU init failed): {err}");
+            return None;
+        }
+    };
+    renderer.set_underlay_bake_enabled(bake);
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(renderer, root_key, GradientPage);
+    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
+    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+    shell.update();
+    let frame = shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("frame capture should succeed");
+    let stats = shell.renderer().last_frame_stats().expect("frame stats");
+    Some((frame.pixels, stats))
+}
+
+#[test]
+fn a_baked_underlay_reproduces_the_transparent_clear_within_one_lsb_and_saves_three_passes() {
+    let Some((reference, reference_stats)) = cold_capture(false) else {
+        return;
+    };
+    let Some((baked, baked_stats)) = cold_capture(true) else {
+        return;
+    };
+    assert_eq!(reference.len(), baked.len());
+
+    let mut max_delta = 0u8;
+    let mut differing = 0usize;
+    for (a, b) in reference
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .zip(baked.as_chunks::<4>().0)
+    {
+        let delta = a
+            .iter()
+            .zip(b)
+            .map(|(x, y)| x.abs_diff(*y))
+            .max()
+            .unwrap_or(0);
+        max_delta = max_delta.max(delta);
+        differing += usize::from(delta > 0);
+    }
+    assert!(
+        max_delta <= 1,
+        "a baked underlay must reproduce the transparent-clear render to within one LSB, got {max_delta}"
+    );
+    let card_pixels = (CARD[2] * CARD[3]) as usize;
+    assert!(
+        differing * 50 < card_pixels,
+        "only rounded-corner coverage pixels may round differently, but {differing} pixels differ"
+    );
+    assert_eq!(
+        baked_stats.pass_count + 3,
+        reference_stats.pass_count,
+        "baking the underlay turns the underlay resample, the nested capture's underlay merge and the surface's own clear into copies and loads: {baked_stats:?} vs {reference_stats:?}"
+    );
+}

--- a/crates/cranpose-ui-graphics/src/render_hash.rs
+++ b/crates/cranpose-ui-graphics/src/render_hash.rs
@@ -241,6 +241,11 @@ fn hash_color_filter<H: Hasher>(filter: ColorFilter, state: &mut H) {
 fn hash_runtime_shader<H: Hasher>(shader: &RuntimeShader, state: &mut H) {
     shader.source_hash().hash(state);
     hash_f32_bits(shader.input_padding(), state);
+    hash_f32_bits(shader.output_padding(), state);
+    shader.uniforms().len().hash(state);
+    for uniform in shader.uniforms() {
+        hash_f32_bits(*uniform, state);
+    }
 }
 
 fn hash_render_effect<H: Hasher>(effect: &RenderEffect, state: &mut H) {
@@ -519,17 +524,23 @@ mod tests {
     }
 
     #[test]
-    fn runtime_shader_render_hash_ignores_uniforms() {
+    fn runtime_shader_render_hash_tracks_uniforms() {
         let mut base = RuntimeShader::new("// hash");
         base.set_float(0, 1.0);
+        let same = base.clone();
         let mut changed = base.clone();
         changed.set_float(0, 2.0);
         assert_eq!(
             base.render_hash(),
+            same.render_hash(),
+            "equal source and uniforms hash equally"
+        );
+        assert_ne!(
+            base.render_hash(),
             changed.render_hash(),
-            "render_hash must depend only on source, not uniforms — \
-             animated uniforms (time, position) would otherwise produce a \
-             new effect_hash every frame, filling the layer cache with stale textures"
+            "a uniform change is a pixel change: a surface that bakes this shader \
+             must miss the layer cache, and the cache admits repeating keys only, \
+             so per-frame uniforms never fill it with stale textures"
         );
     }
 

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -32,7 +32,7 @@ fn property_flag(name: &str) -> bool {
     }
 }
 
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 46] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 50] = [
     ("debug.cranpose.root_direct", "CRANPOSE_ROOT_DIRECT_DIAG"),
     ("debug.cranpose.recomp_diag", "CRANPOSE_RECOMP_DIAG"),
     (
@@ -47,6 +47,12 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 46] = [
         "CRANPOSE_COMPOSITION_8BIT",
     ),
     ("debug.cranpose.skip_shadows", "CRANPOSE_SKIP_SHADOWS"),
+    ("debug.cranpose.ablate_shaders", "CRANPOSE_ABLATE_SHADERS"),
+    ("debug.cranpose.ablate_blur", "CRANPOSE_ABLATE_BLUR"),
+    (
+        "debug.cranpose.ablate_backdrops",
+        "CRANPOSE_ABLATE_BACKDROPS",
+    ),
     ("debug.cranpose.a11y_sync", "CRANPOSE_A11Y_SYNC"),
     ("debug.cranpose.present_thread", "CRANPOSE_PRESENT_THREAD"),
     ("debug.cranpose.command_feed", "CRANPOSE_COMMAND_FEED"),
@@ -88,6 +94,7 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 46] = [
         "debug.cranpose.scene_update_diag",
         "CRANPOSE_SCENE_UPDATE_DIAG",
     ),
+    ("debug.cranpose.backdrop_diag", "CRANPOSE_BACKDROP_DIAG"),
     (
         "debug.cranpose.render_stage_ms",
         "CRANPOSE_WGPU_RENDER_STAGE_TELEMETRY_MS",

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -32,7 +32,7 @@ fn property_flag(name: &str) -> bool {
     }
 }
 
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 50] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 47] = [
     ("debug.cranpose.root_direct", "CRANPOSE_ROOT_DIRECT_DIAG"),
     ("debug.cranpose.recomp_diag", "CRANPOSE_RECOMP_DIAG"),
     (
@@ -47,12 +47,6 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 50] = [
         "CRANPOSE_COMPOSITION_8BIT",
     ),
     ("debug.cranpose.skip_shadows", "CRANPOSE_SKIP_SHADOWS"),
-    ("debug.cranpose.ablate_shaders", "CRANPOSE_ABLATE_SHADERS"),
-    ("debug.cranpose.ablate_blur", "CRANPOSE_ABLATE_BLUR"),
-    (
-        "debug.cranpose.ablate_backdrops",
-        "CRANPOSE_ABLATE_BACKDROPS",
-    ),
     ("debug.cranpose.a11y_sync", "CRANPOSE_A11Y_SYNC"),
     ("debug.cranpose.present_thread", "CRANPOSE_PRESENT_THREAD"),
     ("debug.cranpose.command_feed", "CRANPOSE_COMMAND_FEED"),

--- a/docs/render_arch.md
+++ b/docs/render_arch.md
@@ -45,6 +45,36 @@ The branch now enforces these invariants:
     effect/backdrop events.
 15. Robot screenshot capture must match `main` raw dimensions for the same
     logical surface.
+16. A surface is cache-eligible whenever its pixels are a pure function of
+    its key. A runtime shader hashes its uniforms into the content hash, so
+    a subtree carrying one is cacheable like any other; a subtree whose
+    nested backdrop reads its parent's target is keyed on that underlay's
+    identity (`underlay_identity_before`: the uniform colour beneath it, or
+    the hash of every prefix writer under its rect plus the rect itself) and
+    stays uncached only when that identity is unknown.
+    The underlay itself is sampled from the parent target after everything
+    below the child, the child's own backdrop included, has been flushed
+    into it (`sample_child_underlay`); a child composited plainly (alpha
+    one, `SrcOver`, no effect) at a whole-pixel translation gets a verbatim
+    copy and bakes it as its surface's base, which turns the underlay
+    resample, the nested capture's underlay merge and the surface's clear
+    into copies and loads (`underlay_bake_parity` pins the pixels to one
+    LSB and the three saved passes). Every backdrop hash inside a baked
+    surface mixes in the underlay identity, since the pixels a nested
+    capture reads are the underlay's as much as the content's.
+    A snapped surface rendered at the target's own scale composites at its
+    texel size (`texel_aligned_dest_quad`): the anchored quad's origin is
+    already a whole device pixel, and the quad is widened by the sub-pixel
+    remainder of the surface's ceil so the composite copies texels instead
+    of resampling every card each frame, and so the underlay copy beneath it
+    is exactly the pixels the composite replaces.
+17. Surfaces that can change every frame through uniforms alone
+    (`contains_runtime_shader`) enter the layer cache on the second sighting
+    of a key (`CacheAdmission::OnRepeat`), the same rule scene ranges use, so
+    an animated shader never rotates stable entries out; everything else is
+    admitted on its first miss. Admission is decided at the probe, before a
+    miss is recorded, because a recorded miss must be stored in the same
+    frame.
 
 ## Current Execution Model
 


### PR DESCRIPTION
## Planet freeze (showcase: details -> back -> Saved -> Explore)

Reproduced on the pre-session baseline, so pre-existing. An infinite transition captures a per-animation play-time offset when a spec changes (the planet rotation flips linear <-> stepped on the detail route). When every reader of a value leaves and returns (the `with_key` tab rebuild), the driving loop relaunches, and it restarted play time from zero: that animation's local time saturated at zero and it sat on its initial value while sheen and the starfield kept moving, which made it look like a renderer bug. The transition now keeps one play-time origin for its whole life.

- `respec_animation_keeps_advancing_after_its_readers_leave_and_return` drives the exact sequence and was red before the fix (`0 -> 0`).
- Verified on the showcase's own desktop robot runner and on the Mate 20 X through the exact sequence.

## Nested-backdrop underlay bake

- The underlay under a child with nested backdrops is sampled from the flushed parent target, the child's own backdrop included, through one `sample_child_underlay` for the root and nested paths (the root path re-rendered the prefix from the scene before).
- A plainly composited child at a whole-pixel translation bakes a verbatim copy as its surface base: the underlay resample, the nested capture's underlay merge and the surface clear become copies and loads. `underlay_bake_parity` pins the pixels to one LSB and the three saved passes.
- Every backdrop hash inside a baked surface mixes in the underlay identity (the nested glass button went stale without it; `robot_nested_glass_cache` caught it).
- A snapped surface rendered at the target's scale composites at its texel size (`texel_aligned_dest_quad`), so cards stop being bilinearly resampled every frame and the bake engages on a 2.625x/3x phone.
- Runtime shaders hash their uniforms; a subtree carrying one is cacheable and is admitted on its second sighting (`CacheAdmission::OnRepeat`).
- `glass_underlay_scroll` scrolls a feed one pixel at a time under a glass bar with a nested glass button (plain column, and a lazy list under a liquid bar) and asserts the pixels under the bar follow it.

Mate 20 X showcase idle, alternating runs: 59 -> 52 passes per frame, present p50 45.1 -> 42.4 ms.

## CI

- mac gate: measurement-only ablation toggles removed; the two child-backdrop blocks extracted from the root and nested loops; robot pixel helpers and the WGSL preamble shared. `cargo xtask complexity-gate` / `duplication-gate` clean against main.
- wasm: the native-only `shape_replay` import had slid under the unconditional use block, taking the cfg attribute with it; restored, and the sync renderer accessor is available on wasm.
- `robot external captures (software present)`: `robot_glass_backdrop_scroll_stability` had been red on main since 1692c726 "Remove blur from Receipts glass surfaces" (main's runs [33394145585](https://github.com/samoylenkodmitry/Cranpose/actions/runs/33394145585), [33602783575](https://github.com/samoylenkodmitry/Cranpose/actions/runs/33602783575)). It was a test defect, not a stale cache: the compositor re-captures the bar's backdrop every frame (`CRANPOSE_BACKDROP_DIAG=1` shows a fresh copy per frame), and a cold render of each scroll position matches the incrementally scrolled frame pixel for pixel. The test searched a 32px lane of the bar for a one-pixel shift; without the blur that lane holds only a card's diagonal gradient, which shifts by less than one colour step per pixel, so the search returned 0 and reported "frozen". The blur had been smearing card edges into the lane, and the lens optics compress vertical motion under the bar anyway. The test now compares every incremental step against a cold render of the same scroll position (tab remounted, scrolled straight there) through a shared drive, and a headless twin `robot_glass_backdrop_scroll_headless` runs in the GPU suite. Red-first: with the backdrop cache key deliberately frozen it fails from step 2 (2184 to 6004 differing bar pixels); green on the branch (0 differing pixels at all 10 steps).

## Phone perf: duplicate warmup frames and unrewarded speculative stores

Per-frame accounting on the Mate 20 X (`debug.cranpose.layer_cache_diag` with a 32 MB logcat buffer) showed every scene rendered twice: the renderer's cache-miss warmup requested one more frame after any miss, and on an animated screen that is every frame, so the same scene was published and rendered again and its stores were replaced by the next real frame. The shell now requests a warmup only while no frame callback is armed (`renderer_warmup_waits_until_no_animation_frame_is_pending`, red first). The showcase's stepped motion also holds the starfield for two presented frames, which passed the repeat-once admission and stored a 2.3 MP prefix snapshot on every second frame that nothing served; the layer cache now keeps an admission ledger that backs off unrewarded speculative stores per identity or place, doubling to 64 frames and cleared by a hit (`a_prefix_that_holds_for_two_frames_stops_being_snapshotted_and_recovers_when_still`, red first; the two-state and three-state cycles of the existing exactness tests still store and replay). Frame stats gain per-kind hits, stores and stored pixels, printed as `miss_px_by_kind`.

Device ablation (present p50, showcase Explore): baseline 41.5 ms; cards without glass 5.5 ms; starfield frozen 6.8 ms; planets frozen 35.8 ms; card glass with a trivial shader 38.8 ms; header blur removed 41.2 ms; tab bar blur off 43.5 ms. The remaining cost is the five glass cards re-capturing their backdrop from the live composition target whenever the starfield changes, plus five underlay bakes, each a flush and a copy that breaks the root pass on a tile-based GPU. That is the next change: capture the root prefix once per frame and fold each card's backdrop shader into its own surface pass so the root pass never breaks.

## Gates

`just fmt`, `just clippy`, `just test` green; `just robot` 129/129; `just clippy-wasm` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


