### PR TITLE
perf(render): stop the per-card root flushes on tiling GPUs; replay underlays, materialize and defer

### DIFF
--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -627,3 +627,14 @@ gradient-free fragment (`vec4(t)`) ran at the solid-fill floor. The remaining
 cost is the per-fragment data fetch itself; a big fill would need its
 per-shape data in statically indexed uniforms (preloaded per draw) to reach
 the floor.
+
+## A surface configured for rendering only silently keeps the composition copy
+
+Rendering the frame straight into the swapchain image needs that image to be
+samplable and copyable, which the Mate 20 X swapchain supports; the parity
+test passed on the Mac, the phone build still ran the output conversion pass
+because the Android `SurfaceConfiguration` requested `RENDER_ATTACHMENT`
+alone and the runtime check on `texture.usage()` correctly fell back. Check
+the device's per-pass inventory for the pass you removed, and log the
+configured usage next to the capabilities (`Android surface: ... configured
+...`) so the fallback is visible.

--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -548,3 +548,22 @@ of the pending composites and a copy out of the live composition target,
 which on a tile-based GPU is a full tile store and reload of the 2.4 MP
 target every time. The per-kind `miss_px_by_kind` field on the `[GPU f#]`
 line is the cheap way to see which cache kind is churning without logcat.
+
+## A fence-split pass profile ranks by latency, and one sampled GPU line lies
+
+Two instruments cost an evening on the Mate 20 X. `debug.cranpose.gpu_fence_profile`
+(submit and wait at every pass boundary, minus an empty round trip) charged
+each full-screen composite pass about 11 ms and every small pass under 1 ms,
+so seven root composites looked like 77 ms of a 45 ms frame. Removing six of
+them changed present time by nothing: the profiler measures each pass's
+latency in isolation, and a tiler hides most of a big target's write-back
+and reload behind the next pass's work. Use the profile only to list passes
+per frame and their targets, never to rank them; on this GPU the frame cost
+tracks the pass count (about 0.4 ms of fixed cost each, 11 passes present in
+5 ms, 37 in 30 ms) far more than the pixels. The second trap is the
+`[GPU f#]` line: it is one sampled frame out of sixty, and on this screen
+consecutive frames alternate between a star step (56 passes, 2 backdrop hits)
+and a quiet frame (38 passes, 16 hits), so two runs of the same build read as
+a regression or a fix depending on which frame the sampler landed on. Compare
+several consecutive samples, or `pass_px` averaged over a run, before
+believing a difference.

--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -530,3 +530,21 @@ cache's actual contract and fails from step 2 when the backdrop cache key is
 deliberately frozen. Reproduce such failures headlessly on the Mac first
 (`robot_glass_backdrop_scroll_headless`): a samarch iteration was queued
 10+ minutes behind CI's host lock, the Mac loop is 90 seconds.
+
+## Ranking GPU cost on the Mate 20 X: no timestamps, so ablate the scene
+
+`debug.cranpose.pass_timing` prints only "adapter lacks TIMESTAMP_QUERY" on
+the Mate 20 X (Mali-G76, Vulkan), and logcat's chatty filter drops most of
+the per-node `[layer-cache-diag]` lines, so neither a pass profile nor a
+per-frame miss list is available there. What worked, at 2.5 minutes per
+build-and-measure round on the showcase copy in the scratchpad: freeze or
+remove one thing at a time and read `present p50`. Baseline 41.5 ms; cards
+without glass 5.5 ms; starfield frozen 6.8 ms; planets frozen 35.8 ms; card
+glass with a trivial shader 38.8 ms; header blur removed 41.2 ms; tab bar
+blur off 43.5 ms. Read together: the glass cards cost 36 ms only while the
+backdrop beneath them changes, and the shader is 3 ms of that. The rest is
+five root backdrop captures plus five underlay bakes per frame, each a flush
+of the pending composites and a copy out of the live composition target,
+which on a tile-based GPU is a full tile store and reload of the 2.4 MP
+target every time. The per-kind `miss_px_by_kind` field on the `[GPU f#]`
+line is the cheap way to see which cache kind is churning without logcat.

--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -507,3 +507,26 @@ as long as the stale offset. Any other animation on the same transition kept
 moving, which is what made it look like a rendering bug. Reproduce with the
 exact user sequence, and when a value looks frozen log the *state value* in the
 draw closure before touching the renderer.
+
+## A "frozen backdrop" verdict from a shift search over a featureless lane
+
+`robot_glass_backdrop_scroll_stability` went red on main at "Remove blur from
+Receipts glass surfaces" and stayed red for two days, reading exactly like a
+stale backdrop cache. It was not: the compositor re-captured the bar's
+backdrop every frame (`CRANPOSE_BACKDROP_DIAG=1` showed a fresh `prepare
+MISS copied=true` per frame) and a cold render of the same scroll position
+matched the incrementally scrolled frame pixel for pixel. The test searched
+for a one-pixel vertical shift inside a 32px lane of the bar; with the blur
+gone that lane held only a card's diagonal gradient, whose vertical change
+per pixel is below one colour step, so the best-fit shift was 0 and the test
+called it "frozen". The blur had been smearing card edges and text into the
+lane, which is the only reason it ever measured a shift. The lens optics that
+followed compress vertical motion under the bar as well, so the "identity
+lane" premise does not hold for this material at all. A shift heuristic on a
+glass output cannot tell "frozen" from "no vertical texture"; the test now
+compares every incremental step against a cold render of the same scroll
+position (remount the tab, scroll straight there, capture), which is the
+cache's actual contract and fails from step 2 when the backdrop cache key is
+deliberately frozen. Reproduce such failures headlessly on the Mac first
+(`robot_glass_backdrop_scroll_headless`): a samarch iteration was queued
+10+ minutes behind CI's host lock, the Mac loop is 90 seconds.

--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -638,3 +638,13 @@ alone and the runtime check on `texture.usage()` correctly fell back. Check
 the device's per-pass inventory for the pass you removed, and log the
 configured usage next to the capabilities (`Android surface: ... configured
 ...`) so the fallback is visible.
+
+## The Android toggle table compiles only for Android
+
+`crates/cranpose/src/android_frame_telemetry.rs` declares its property-backed
+toggle table with an explicit array length. Every host gate (`just test`,
+`just clippy`, the mac CI job) passed with a 56-row table declared as 55 rows,
+because that file is only compiled for the Android target; the first thing
+that caught it was the phone APK build six seconds in. When you add a row,
+bump the length in the same edit and build the APK before pushing: the
+"Android release build" CI job is the only gate that compiles it.

--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -567,3 +567,63 @@ and a quiet frame (38 passes, 16 hits), so two runs of the same build read as
 a regression or a fix depending on which frame the sampler landed on. Compare
 several consecutive samples, or `pass_px` averaged over a run, before
 believing a difference.
+
+## `present` is not GPU time: a 50 ms animation period hides a 45 ms GPU frame
+
+The Mate 20 X showcase reported present p50 of 6.8 ms with the stars frozen and
+33 ms with them moving, at identical pass and cache counts, and an evening went
+into "what makes a relowered scene 4x slower on the GPU". Nothing does. A
+whole-frame fence (`debug.cranpose.gpu_fence_profile frame`) puts both at
+50 ms of GPU per frame; the frozen variant only steps its planets, every 50 ms,
+so the GPU finished each frame just before the next one was submitted and
+neither acquire nor present ever blocked. Present and acquire block only by the
+amount the GPU falls behind the app's own frame period, so on an
+animation-paced screen they read as small right up until the GPU is slower
+than the period, then jump. Measure GPU time with the whole-frame fence, or
+compare `pass_px` and the Mac's `CRANPOSE_GPU_PASS_TIMING` occupancy, never
+the present column.
+
+## An uber-shader's OFF features cost more than its ON ones on Mali
+
+The liquid glass fragment program gates a dozen optional features on
+uniforms (loupe, fold, morph shapes, wobble, touch, shadow, content mask,
+optical blur, zoom...). The showcase cards use none of them, and the per-pass
+fence still put the four card passes at 47 ms, ~33 ns per pixel for 19 taps.
+Ablating the live features one at a time never explained it: removing the
+chromatic channels saved 12 ms, removing reflection plus frost 16 ms, and an
+early return before the tail saved 32 ms, none of it proportional to the taps
+removed. Folding the thirteen inactive uniforms to constants brought the same
+passes to 21 ms with byte-identical output. The dead branches were not free:
+they held registers and their uniforms were fetched per fragment. Specialize
+per material with `override` constants (`specialize_liquid_glass`,
+`CRANPOSE_NO_SHADER_SPECIALIZATION` to compare); do not ablate live features
+looking for the cost of dead ones.
+
+## Whole-frame fence under DVFS hides a 26 ms GPU saving
+
+Cutting 36 ms of isolated pass time from the showcase frame moved the
+`gpu_fence_profile frame` reading from ~89 ms to 65-90 ms depending on the
+run: the GPU governor drops its clock as the work shrinks, so wall time per
+frame barely moves until the work is small enough to change the clock's
+target. Judge a device change by scroll fps (`measure.sh ... scroll`, here
+14.3 to 18.5) and by the per-pass inventory (`gpu_fence_profile 1`, stable to
+within a millisecond across runs), not by the whole-frame number.
+
+## A stacked bench on a tiler measures one layer
+
+Drawing the same opaque full-screen fill eight times per frame to amplify a
+shader difference above governor noise measured about one layer: Mali's
+forward pixel kill discards fragments of earlier quads once a later opaque
+quad covers them. Stack translucent layers, or compare single-layer runs
+interleaved several times.
+
+## Flat varyings fetch like uniform loads on Mali
+
+Moving the gradient stops from a per-fragment loop over a dynamically indexed
+uniform array into five flat varyings saved about 3 ms of the 11 ms a
+full-screen three-stop radial costs, not the 11 ms hoped for: reading a flat
+`vec4` varying per fragment costs about what one uniform load did, and a
+gradient-free fragment (`vec4(t)`) ran at the solid-fill floor. The remaining
+cost is the per-fragment data fetch itself; a big fill would need its
+per-shape data in statically indexed uniforms (preloaded per draw) to reach
+the floor.

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -873,6 +873,11 @@ path = "robot-runners/robot_liquid_backdrop_feedback.rs"
 required-features = ["desktop", "robot-app"]
 
 [[example]]
+name = "robot_glass_backdrop_scroll_headless"
+path = "robot-runners/robot_glass_backdrop_scroll_headless.rs"
+required-features = ["desktop", "robot-app"]
+
+[[example]]
 name = "robot_glass_backdrop_scroll_stability"
 path = "robot-runners/robot_glass_backdrop_scroll_stability.rs"
 required-features = ["desktop", "robot-app"]

--- a/apps/desktop-demo/robot-runners/glass_backdrop_scroll_helpers.rs
+++ b/apps/desktop-demo/robot-runners/glass_backdrop_scroll_helpers.rs
@@ -1,0 +1,320 @@
+#![allow(dead_code)]
+
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use cranpose::{Robot, RobotScreenshot, SemanticElement};
+use cranpose_testing::{find_in_semantics, find_text_exact};
+
+use crate::{
+    robot_exit,
+    scroll_stability_external_helpers::{
+        save_robot_screenshot, scroll_once_and_expect_target_delta, ExactScrollStepConfig,
+        ScrollStepDriver,
+    },
+};
+
+pub(crate) const WINDOW_WIDTH: u32 = 800;
+pub(crate) const WINDOW_HEIGHT: u32 = 632;
+pub(crate) const STEP_COUNT: usize = 10;
+const SETTLE_SCROLL: f32 = -430.0;
+const SCROLL_DELTA_Y: f32 = -1.0;
+const STEP_EPSILON: f32 = 0.05;
+const SETTLE_AFTER_SCROLL_EXTRA_MS: u64 = 1_500;
+const GLASS_BAR: (f32, f32, f32, f32) = (28.0, 104.0, 744.0, 56.0);
+const CHANNEL_TOLERANCE: i32 = 2;
+const RECEIPT_ANCHOR_SKIP_FROM_TOP: usize = 2;
+const COLD_ALIGN_ATTEMPTS: usize = 40;
+const AWAY_TAB: &str = "Markdown";
+const RECEIPTS_TAB: &str = "Receipts";
+const RECEIPTS_HEADING: &str = "Library";
+
+pub(crate) struct GlassBackdropScrollRun<'a> {
+    pub robot: &'a Robot,
+    pub output_dir: PathBuf,
+    pub capture: &'a mut dyn FnMut(&Robot) -> RobotScreenshot,
+}
+
+struct IncrementalStep {
+    anchor_y: f32,
+    screenshot: RobotScreenshot,
+    path: PathBuf,
+}
+
+impl GlassBackdropScrollRun<'_> {
+    pub(crate) fn run(mut self) {
+        std::fs::create_dir_all(&self.output_dir).expect("create output dir");
+        println!("Output dir: {}", self.output_dir.display());
+        let robot = self.robot;
+        std::thread::sleep(Duration::from_millis(1_000));
+        let _ = robot.wait_for_idle();
+        open_receipts_tab(robot);
+        let anchor_text = self.settle_and_pick_anchor();
+        let steps = self.walk_incrementally(anchor_text);
+        let mismatches = self.compare_against_cold_renders(anchor_text, &steps);
+        if !mismatches.is_empty() {
+            robot_exit::fail(
+                robot,
+                &format!(
+                    "the glass bar rendered after one-pixel scroll steps differs from a cold render of the same scroll position:\n{}\ncaptures retained in {}",
+                    mismatches.join("\n"),
+                    self.output_dir.display()
+                ),
+            );
+        }
+        for step in &steps {
+            let _ = std::fs::remove_file(&step.path);
+            let _ = std::fs::remove_file(cold_path(&self.output_dir, &step.path));
+        }
+        println!(
+            "PASS: the glass bar matched a cold render at every one of {STEP_COUNT} one-pixel scroll steps"
+        );
+        robot.exit().expect("exit");
+    }
+
+    fn settle_and_pick_anchor(&mut self) -> &'static str {
+        let robot = self.robot;
+        settle_list(robot, SETTLE_SCROLL);
+        let semantics = robot.get_semantics().expect("query semantics");
+        let mut receipts = Vec::new();
+        for root in &semantics {
+            collect_receipt_subtitles(root, &mut receipts);
+        }
+        receipts.sort_by(|a, b| a.1.partial_cmp(&b.1).expect("finite y"));
+        let anchor_text = receipts
+            .get(RECEIPT_ANCHOR_SKIP_FROM_TOP)
+            .map(|(text, _)| text.clone())
+            .unwrap_or_else(|| {
+                robot_exit::fail(
+                    robot,
+                    &format!(
+                        "expected at least {} visible receipt subtitles after settle, found {}",
+                        RECEIPT_ANCHOR_SKIP_FROM_TOP + 1,
+                        receipts.len()
+                    ),
+                )
+            });
+        println!(
+            "tracking content anchor: {anchor_text:?} (of {} visible)",
+            receipts.len()
+        );
+        Box::leak(anchor_text.into_boxed_str())
+    }
+
+    fn walk_incrementally(&mut self, anchor_text: &'static str) -> Vec<IncrementalStep> {
+        let robot = self.robot;
+        let mut previous_bounds = anchor_bounds(robot, anchor_text, "after settle");
+        let step_config = ExactScrollStepConfig {
+            target_text: anchor_text,
+            window_width: WINDOW_WIDTH,
+            window_height: WINDOW_HEIGHT,
+            scroll_steps: STEP_COUNT,
+            scroll_delta_y: SCROLL_DELTA_Y,
+            step_epsilon: STEP_EPSILON,
+            fallback_trim_top_px: GLASS_BAR.1.round() as u32,
+            fallback_trim_bottom_px: (WINDOW_HEIGHT as f32 - (GLASS_BAR.1 + GLASS_BAR.3)).round()
+                as u32,
+        };
+        let mut steps = Vec::with_capacity(STEP_COUNT);
+        for step in 0..STEP_COUNT {
+            previous_bounds = scroll_once_and_expect_target_delta(
+                robot,
+                step_config,
+                previous_bounds,
+                step,
+                "glass-step",
+                ScrollStepDriver::PointerWheel,
+            );
+            let screenshot = (self.capture)(robot);
+            let path = self
+                .output_dir
+                .join(format!("glass_step{:02}.png", step + 1));
+            save_robot_screenshot(&path, &screenshot);
+            if let Some(previous) = steps.last() {
+                let previous: &IncrementalStep = previous;
+                println!(
+                    "step {:02}: bar pixels changed since the previous step: {}",
+                    step + 1,
+                    mismatching_pixels(&previous.screenshot, &screenshot, GLASS_BAR)
+                );
+            }
+            steps.push(IncrementalStep {
+                anchor_y: previous_bounds.1,
+                screenshot,
+                path,
+            });
+            std::thread::sleep(Duration::from_millis(SETTLE_AFTER_SCROLL_EXTRA_MS));
+        }
+        steps
+    }
+
+    fn compare_against_cold_renders(
+        &mut self,
+        anchor_text: &'static str,
+        steps: &[IncrementalStep],
+    ) -> Vec<String> {
+        let robot = self.robot;
+        let mut mismatches = Vec::new();
+        for (index, step) in steps.iter().enumerate() {
+            click_tab(robot, AWAY_TAB);
+            open_receipts_tab(robot);
+            settle_list(robot, SETTLE_SCROLL + (index + 1) as f32 * SCROLL_DELTA_Y);
+            align_anchor(robot, anchor_text, step.anchor_y);
+            let cold = (self.capture)(robot);
+            save_robot_screenshot(&cold_path(&self.output_dir, &step.path), &cold);
+            let mismatching = mismatching_pixels(&step.screenshot, &cold, GLASS_BAR);
+            let stale_hint = index
+                .checked_sub(1)
+                .filter(|previous| {
+                    mismatching_pixels(&steps[*previous].screenshot, &step.screenshot, GLASS_BAR)
+                        == 0
+                })
+                .map(|_| " (identical to the previous incremental step)")
+                .unwrap_or_default();
+            println!(
+                "step {:02}: bar pixels differing from the cold render: {mismatching}{stale_hint}",
+                index + 1
+            );
+            if mismatching > 0 {
+                mismatches.push(format!(
+                    "step {:02}: {mismatching} bar pixels differ from the cold render{stale_hint}",
+                    index + 1
+                ));
+            }
+        }
+        mismatches
+    }
+}
+
+fn cold_path(output_dir: &Path, step_path: &Path) -> PathBuf {
+    let name = step_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("step capture file name");
+    output_dir.join(name.replace("glass_step", "glass_cold"))
+}
+
+fn settle_list(robot: &Robot, delta_y: f32) {
+    robot
+        .mouse_move(WINDOW_WIDTH as f32 * 0.5, WINDOW_HEIGHT as f32 * 0.7)
+        .expect("move cursor over list");
+    std::thread::sleep(Duration::from_millis(30));
+    robot
+        .mouse_scroll_and_wait_for_frame(0.0, delta_y)
+        .expect("settle scroll");
+    std::thread::sleep(Duration::from_millis(500));
+    let _ = robot.wait_for_idle();
+}
+
+fn align_anchor(robot: &Robot, anchor_text: &'static str, target_y: f32) {
+    for _ in 0..COLD_ALIGN_ATTEMPTS {
+        let bounds = anchor_bounds(robot, anchor_text, "after remount");
+        let error = bounds.1 - target_y;
+        if error.abs() <= STEP_EPSILON {
+            return;
+        }
+        println!("cold align: anchor_y={:.2} target={target_y:.2}", bounds.1);
+        robot
+            .mouse_scroll_and_wait_for_frame(0.0, -error.round().clamp(-1.0, 1.0))
+            .expect("cold align step");
+        std::thread::sleep(Duration::from_millis(SETTLE_AFTER_SCROLL_EXTRA_MS));
+        let _ = robot.wait_for_idle();
+    }
+    robot_exit::fail(
+        robot,
+        &format!("could not align the cold render's anchor to y={target_y:.2}"),
+    );
+}
+
+fn anchor_bounds(robot: &Robot, anchor_text: &'static str, context: &str) -> (f32, f32, f32, f32) {
+    find_in_semantics(robot, |elem| find_text_exact(elem, anchor_text)).unwrap_or_else(|| {
+        robot_exit::fail(
+            robot,
+            &format!("content anchor {anchor_text:?} should be visible {context}"),
+        )
+    })
+}
+
+fn region_pixels(
+    shot: &RobotScreenshot,
+    region: (f32, f32, f32, f32),
+) -> (usize, usize, usize, usize) {
+    let scale = shot.width as f32 / shot.logical_width;
+    (
+        (region.0 * scale).round() as usize,
+        (region.1 * scale).round() as usize,
+        (region.2 * scale).round() as usize,
+        (region.3 * scale).round() as usize,
+    )
+}
+
+fn mismatching_pixels(
+    a: &RobotScreenshot,
+    b: &RobotScreenshot,
+    region: (f32, f32, f32, f32),
+) -> usize {
+    assert_eq!(
+        (a.width, a.height),
+        (b.width, b.height),
+        "captures must share a size"
+    );
+    let (x, y, width, height) = region_pixels(a, region);
+    let mut mismatching = 0;
+    for row in y..y + height {
+        for column in x..x + width {
+            let index = (row * a.width as usize + column) * 4;
+            let differs = (0..3).any(|channel| {
+                (a.pixels[index + channel] as i32 - b.pixels[index + channel] as i32).abs()
+                    > CHANNEL_TOLERANCE
+            });
+            if differs {
+                mismatching += 1;
+            }
+        }
+    }
+    mismatching
+}
+
+fn collect_receipt_subtitles(elem: &SemanticElement, out: &mut Vec<(String, f32)>) {
+    if let Some(text) = elem.text.as_deref() {
+        if text.starts_with("Receipt #") {
+            out.push((text.to_string(), elem.bounds.y));
+        }
+    }
+    for child in &elem.children {
+        collect_receipt_subtitles(child, out);
+    }
+}
+
+fn click_tab(robot: &Robot, label: &str) {
+    let (x, y, w, h) = cranpose_testing::find_button_in_semantics(robot, label)
+        .unwrap_or_else(|| robot_exit::fail(robot, &format!("tab {label:?} not found")));
+    robot.click(x + w * 0.5, y + h * 0.5).expect("click tab");
+    std::thread::sleep(Duration::from_millis(400));
+    let _ = robot.wait_for_idle();
+}
+
+pub(crate) fn open_receipts_tab(robot: &Robot) {
+    for _ in 0..30 {
+        if let Some((x, y, w, h)) = cranpose_testing::find_button_in_semantics(robot, RECEIPTS_TAB)
+        {
+            robot
+                .click(x + w * 0.5, y + h * 0.5)
+                .expect("click Receipts tab");
+            std::thread::sleep(Duration::from_millis(250));
+            let _ = robot.wait_for_idle();
+            if cranpose_testing::find_text_in_semantics(robot, RECEIPTS_HEADING).is_some() {
+                std::thread::sleep(Duration::from_millis(400));
+                let _ = robot.wait_for_idle();
+                return;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    robot_exit::fail(
+        robot,
+        "Receipts tab / Library glass bar not found after 30 attempts",
+    );
+}

--- a/apps/desktop-demo/robot-runners/robot_glass_backdrop_scroll_headless.rs
+++ b/apps/desktop-demo/robot-runners/robot_glass_backdrop_scroll_headless.rs
@@ -1,0 +1,33 @@
+mod glass_backdrop_scroll_helpers;
+mod output_paths;
+mod robot_exit;
+mod robot_launch;
+mod scroll_stability_external_helpers;
+mod text_showcase_external_helpers;
+
+use cranpose_testing::capture_screenshot;
+use desktop_app::app;
+use glass_backdrop_scroll_helpers::{GlassBackdropScrollRun, WINDOW_HEIGHT, WINDOW_WIDTH};
+
+fn main() {
+    env_logger::init();
+    println!("=== Robot Glass Backdrop Scroll (headless) ===");
+    let output_dir = output_paths::diagnostic_path(&format!(
+        "cranpose_glass_backdrop_scroll_headless-{}",
+        std::process::id()
+    ));
+    robot_launch::launch("Robot Glass Backdrop Scroll", WINDOW_WIDTH, WINDOW_HEIGHT)
+        .with_test_driver(move |robot| {
+            let mut capture = |robot: &cranpose::Robot| {
+                capture_screenshot(robot)
+                    .unwrap_or_else(|| robot_exit::fail(robot, "screenshot failed"))
+            };
+            GlassBackdropScrollRun {
+                robot: &robot,
+                output_dir,
+                capture: &mut capture,
+            }
+            .run();
+        })
+        .run(app::combined_app);
+}

--- a/apps/desktop-demo/robot-runners/robot_glass_backdrop_scroll_stability.rs
+++ b/apps/desktop-demo/robot-runners/robot_glass_backdrop_scroll_stability.rs
@@ -1,114 +1,15 @@
-//! Robot test: the glass "Library" top bar's blurred backdrop, on the
-//! Receipts feed, must shift by the SAME per-step delta as the scrolling
-//! list behind it — not merely "change".
-//!
-//! A "did the glass change at all" check is trivially satisfied even by a
-//! backdrop that moves by the wrong amount, moves the wrong way, or updates
-//! to garbage — the same weakness as a pass-count check on a blank nav bar.
-//! The user's own word for the failure mode this test exists to catch is
-//! "caterpillar": scrolling one logical pixel at a time, the blur lags,
-//! then jumps to catch up, over and over. A test that only checks
-//! cumulative movement across the whole run would pass on exactly that
-//! pattern, so every step is asserted individually.
-//!
-//! This reuses the existing scroll-stability machinery
-//! (`scroll_stability_external_helpers`, already trusted by
-//! `robot_leetcodedaily_code_scroll_pixel_drift` and the `_exact_external_contract`
-//! family) rather than inventing a second shift-search implementation:
-//! `scroll_once_and_expect_target_delta` drives each one-pixel step and
-//! confirms, via semantics on a receipt subtitle, that the CONTENT actually
-//! moved by exactly that pixel — the ground truth this test's assertion is
-//! measured against. `run_compare_script` (the same
-//! `scripts/text_scroll_exact_external_compare.py` engine every
-//! `_exact_external_contract` test already runs) then searches, for every
-//! captured frame against the first, the vertical shift that best aligns it
-//! — the identical "small search over candidate offsets minimising absolute
-//! difference" `robot_scroll_decoration_invariance` and the horizontal
-//! variant in `robot_leetcodedaily_full_layout_scroll_stability` already
-//! use, just pointed at the glass bar's interior instead of a content
-//! viewport. This file only adds what does not already exist anywhere:
-//! comparing that engine's own per-step output against the confirmed
-//! content delta and naming which of three ways it disagrees.
-//!
-//! NOT headless. NOT a renderer screenshot: real X11 window capture via
-//! `text_showcase_external_helpers::capture_x11_window_screenshot`, because
-//! a renderer screenshot renders into a fresh offscreen texture every call
-//! and never touches `redraw_native_window`'s real, reused swapchain view.
-//! Run under software present (`just robot-captures`) — the GPU-under-Xvfb
-//! path cannot present a window at all (see `TIME_WASTERS.md`).
-
+mod glass_backdrop_scroll_helpers;
 mod output_paths;
 mod robot_exit;
 mod scroll_stability_external_helpers;
 mod text_showcase_external_helpers;
 
-use std::time::Duration;
-
 use cranpose::AppLauncher;
-use cranpose_testing::{find_in_semantics, find_text_exact};
 use desktop_app::app;
-use scroll_stability_external_helpers::{
-    run_compare_script, scroll_once_and_expect_target_delta, CompareCrop, ExactScrollStepConfig,
-    ScrollStabilityConfig, ScrollStepDriver,
-};
+use glass_backdrop_scroll_helpers::{GlassBackdropScrollRun, WINDOW_HEIGHT, WINDOW_WIDTH};
 use text_showcase_external_helpers::{capture_x11_window_screenshot, find_window_id};
 
-/// The demo's normal window — do not expand it to reach the Receipts tab.
-const WINDOW_WIDTH: u32 = 800;
-const WINDOW_HEIGHT: u32 = 632;
 const WINDOW_TITLE: &str = "Robot Glass Backdrop Scroll Stability";
-/// Deep enough that the sampled chrome sits over real card content, not the
-/// LazyColumn's still-empty top content padding (a false positive already
-/// caught once in this investigation — see TIME_WASTERS.md).
-const SETTLE_SCROLL: f32 = -400.0;
-const SCROLL_DELTA_Y: f32 = -1.0;
-const STEP_COUNT: usize = 10;
-const STEP_EPSILON: f32 = 0.05;
-/// Consecutive scroll events accumulate velocity under the current fling
-/// physics, so back-to-back one-pixel input events do not produce
-/// one-pixel steps: measured per-step diffs growing 18k to 77k until
-/// settling 1.6s between events. `scroll_once_and_expect_target_delta`
-/// already sleeps 150ms and re-checks the exact delta via semantics; this
-/// adds the rest of the margin on top without touching that shared function.
-const SETTLE_AFTER_SCROLL_EXTRA_MS: u64 = 1_500;
-/// The final expected cumulative shift is exactly `STEP_COUNT` pixels, so
-/// searching that distance covers every valid alignment without requiring a
-/// wider crop that would spill into the refractive rim.
-const COMPARE_SEARCH_OFFSET_PX: u32 = STEP_COUNT as u32;
-/// Small: the sampled glass patch is only ~90px tall, and the reused
-/// engine's fractional-alignment guard grows with the largest measured
-/// shift (up to ~`STEP_COUNT` px here), which must still leave a positive
-/// crop height.
-const COMPARE_STABILIZED_GUARD_PX: u32 = 4;
-/// The identity-transmission lane of the "Library" glass `TopBar`
-/// (`apps/desktop-demo/src/app/glass_feed.rs`). The bar's outer box is
-/// (28, 103.6, 744, 56), and this x range is clear of both its label and
-/// button. A strong physical meniscus deliberately remaps the top and bottom
-/// rim, so measuring that rim as a whole cannot distinguish correct optical
-/// distortion from a frozen backdrop. Its centered face has zero ray bend;
-/// therefore a one-pixel list scroll must remain a one-pixel image shift
-/// here. This keeps the test focused on the renderer contract it exists to
-/// protect: the backdrop input must be refreshed for every scroll frame.
-const GLASS_REGION: (f32, f32, f32, f32) = (150.0, 120.0, 500.0, 32.0);
-/// A best-fit shift within this many pixels of the expected cumulative
-/// shift counts as tracking correctly. Must be well under 1 step's worth
-/// of motion or it cannot tell "frozen" from "on time" at step 1.
-const SHIFT_TOLERANCE_PX: i32 = 1;
-/// Skip this many of the topmost visible receipt subtitles when picking a
-/// tracking anchor, so a 20-step, 1px-per-step upward walk never pushes it
-/// into whatever clips items out near the fixed chrome's lower edge.
-const RECEIPT_ANCHOR_SKIP_FROM_TOP: usize = 2;
-
-/// Times `wait_for_present_frame` and prints the elapsed duration, so a
-/// suspiciously-fast call (a few microseconds) is visible as evidence the
-/// call returned without actually waiting for anything, rather than being
-/// silently trusted just because the call succeeded.
-fn time_present_wait(robot: &cranpose::Robot, label: &str) {
-    let started = std::time::Instant::now();
-    let result = robot.wait_for_present_frame();
-    let elapsed = started.elapsed();
-    println!("{label}: wait_for_present_frame took {elapsed:?} result={result:?}");
-}
 
 fn main() {
     env_logger::init();
@@ -117,310 +18,33 @@ fn main() {
         "cranpose_glass_backdrop_scroll_stability-{}",
         std::process::id()
     ));
-    println!("Output dir: {}", output_dir.display());
-    std::fs::create_dir_all(&output_dir).expect("create output dir");
-
     AppLauncher::new()
         .with_title(WINDOW_TITLE)
         .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
         .with_headless(false)
         .with_test_driver(move |robot| {
-            std::thread::sleep(Duration::from_millis(1_000));
-            let _ = robot.wait_for_idle();
-
-            open_receipts_tab(&robot);
-            std::thread::sleep(Duration::from_millis(400));
-            let _ = robot.wait_for_idle();
-
-            robot
-                .mouse_move(WINDOW_WIDTH as f32 * 0.5, WINDOW_HEIGHT as f32 * 0.7)
-                .expect("move cursor over list");
-            std::thread::sleep(Duration::from_millis(30));
-            robot
-                .mouse_scroll_and_wait_for_frame(0.0, SETTLE_SCROLL)
-                .expect("settle scroll past empty content padding");
-            // wait_for_present_frame only actually waits when a redraw is
-            // still pending; called after a long sleep it is a proven
-            // no-op (see the per-step timing print below), so it must run
-            // BEFORE anything gives the frame time to drain on its own.
-            time_present_wait(&robot, "baseline");
-            std::thread::sleep(Duration::from_millis(500));
-            let _ = robot.wait_for_idle();
-
-            // A receipt subtitle ("Receipt #NNNN — 12 items") is unique per
-            // row, unlike the six recycled card titles, so once discovered
-            // it is an unambiguous anchor for the rest of the run. The
-            // topmost visible one is a bad choice: it starts close to
-            // whatever clips items out once they scroll under the fixed
-            // chrome, and a 20-step upward walk pushed it there mid-run
-            // ("target text must stay visible" at step 13, first attempt).
-            // Pick one with real headroom instead.
-            let semantics = robot.get_semantics().expect("query semantics");
-            let mut receipt_matches = Vec::new();
-            for root in &semantics {
-                collect_receipt_subtitles(root, &mut receipt_matches);
-            }
-            receipt_matches.sort_by(|a, b| a.1.partial_cmp(&b.1).expect("finite y"));
-            let anchor_text = receipt_matches
-                .get(RECEIPT_ANCHOR_SKIP_FROM_TOP)
-                .map(|(text, _)| text.clone())
-                .unwrap_or_else(|| {
-                    robot_exit::fail(
-                        &robot,
-                        &format!(
-                            "expected at least {} visible receipt subtitles after settle, found {}",
-                            RECEIPT_ANCHOR_SKIP_FROM_TOP + 1,
-                            receipt_matches.len()
-                        ),
-                    )
-                });
-            println!(
-                "tracking content anchor: {anchor_text:?} (of {} visible: {:?})",
-                receipt_matches.len(),
-                receipt_matches
-            );
-            let anchor_text: &'static str = Box::leak(anchor_text.into_boxed_str());
-
-            let mut previous_bounds = find_in_semantics(&robot, |elem| {
-                find_text_exact(elem, anchor_text)
-            })
-            .unwrap_or_else(|| robot_exit::fail(&robot, "content anchor should be visible after settle"));
-
             let window_id = find_window_id(WINDOW_TITLE);
-
-            let step_config = ExactScrollStepConfig {
-                target_text: anchor_text,
-                window_width: WINDOW_WIDTH,
-                window_height: WINDOW_HEIGHT,
-                scroll_steps: STEP_COUNT,
-                scroll_delta_y: SCROLL_DELTA_Y,
-                step_epsilon: STEP_EPSILON,
-                fallback_trim_top_px: GLASS_REGION.1.round() as u32,
-                fallback_trim_bottom_px: (WINDOW_HEIGHT as f32
-                    - (GLASS_REGION.1 + GLASS_REGION.3))
-                    .round() as u32,
-            };
-
-            let mut capture_paths = Vec::with_capacity(STEP_COUNT + 1);
-            let baseline_path = output_dir.join("glass_step00.png");
-            capture_x11_window_screenshot(
-                &window_id,
-                &baseline_path,
-                WINDOW_WIDTH as f32,
-                WINDOW_HEIGHT as f32,
-            );
-            capture_paths.push(baseline_path);
-
-            for step in 0..STEP_COUNT {
-                previous_bounds = scroll_once_and_expect_target_delta(
-                    &robot,
-                    step_config,
-                    previous_bounds,
-                    step,
-                    "glass-step",
-                    ScrollStepDriver::PointerWheel,
+            let capture_path = output_dir.join("presented.png");
+            let mut capture = |robot: &cranpose::Robot| {
+                let started = std::time::Instant::now();
+                let result = robot.wait_for_present_frame();
+                println!(
+                    "wait_for_present_frame took {:?} result={result:?}",
+                    started.elapsed()
                 );
-                // Immediately, before anything gives the just-scrolled frame
-                // time to drain on its own — `wait_for_present_frame` only
-                // blocks while a redraw is genuinely still pending
-                // (crates/cranpose/src/desktop.rs, RobotCommand::
-                // WaitForPresentFrame: it checks robot_visible_surface_dirty
-                // || app.needs_redraw() first and returns immediately if
-                // neither holds), so calling it after a long settle sleep,
-                // as the first version of this fix did, is a proven no-op:
-                // by then the app has already gone idle on its own and
-                // there is nothing left to wait for. `wait_for_idle`
-                // confirms CPU/composition quiescence, not that software
-                // present has actually drained this frame to the window —
-                // under Xvfb's software presenter a screenshot taken on
-                // CPU-idle alone can show a still-queued frame, which would
-                // read as the backdrop lagging then catching up as the
-                // queue drains. That shape is otherwise indistinguishable
-                // from a real compositor defect, so the capture must wait
-                // for actual presentation, called where it can still catch
-                // one.
-                time_present_wait(&robot, &format!("step {step:02}"));
-
-                let step_path = output_dir.join(format!("glass_step{:02}.png", step + 1));
                 capture_x11_window_screenshot(
                     &window_id,
-                    &step_path,
+                    &capture_path,
                     WINDOW_WIDTH as f32,
                     WINDOW_HEIGHT as f32,
-                );
-                capture_paths.push(step_path);
-
-                // Momentum settle for the NEXT scroll event, not this
-                // capture: consecutive scroll events accumulate fling
-                // velocity under the current physics, so this has to sit
-                // between "capture this step" and "fire the next scroll",
-                // not between "fire this scroll" and "capture this step"
-                // (which is where it would defeat the present-frame wait
-                // above by giving the frame time to drain before asking).
-                std::thread::sleep(Duration::from_millis(SETTLE_AFTER_SCROLL_EXTRA_MS));
-            }
-
-            let crop = CompareCrop {
-                trim_top_px: GLASS_REGION.1.round() as u32,
-                trim_bottom_px: (WINDOW_HEIGHT as f32 - (GLASS_REGION.1 + GLASS_REGION.3))
-                    .round() as u32,
-                trim_left_px: GLASS_REGION.0.round() as u32,
-                trim_right_px: (WINDOW_WIDTH as f32 - (GLASS_REGION.0 + GLASS_REGION.2)).round()
-                    as u32,
-                logical_window_space: true,
-            };
-            let compare_config = ScrollStabilityConfig {
-                window_title: WINDOW_TITLE,
-                output_name: "glass_backdrop_scroll_stability",
-                file_prefix: "glass",
-                target_text: anchor_text,
-                viewport_tag: None,
-                window_width: WINDOW_WIDTH,
-                window_height: WINDOW_HEIGHT,
-                scroll_steps: capture_paths.len(),
-                scroll_delta_y: SCROLL_DELTA_Y,
-                step_epsilon: STEP_EPSILON,
-                fallback_trim_top_px: crop.trim_top_px,
-                fallback_trim_bottom_px: crop.trim_bottom_px,
-                fallback_trim_left_px: crop.trim_left_px,
-                fallback_trim_right_px: crop.trim_right_px,
-                compare_search_offset_px: COMPARE_SEARCH_OFFSET_PX,
-                compare_max_adjacent_score: u32::MAX,
-                compare_max_channel_delta: 0,
-                compare_stabilized_guard_px: COMPARE_STABILIZED_GUARD_PX,
-                compare_viewport_inset_px: 0,
-                render_stats_env: None,
-                active_frame: None,
-            };
-            // Discarded on purpose: this call's own pass/fail is a
-            // self-consistency check (do frames agree with each other once
-            // each is aligned by its OWN best-fit shift), which cannot tell
-            // a frozen backdrop (trivially self-consistent at shift=0) from
-            // a correct one. The verdict this test actually needs comes
-            // from comparing the shift itself against the confirmed
-            // content delta below.
-            let _ = run_compare_script(&capture_paths, crop, compare_config);
-
-            let report_path = output_dir.join("fractional_alignment_report.txt");
-            let report = std::fs::read_to_string(&report_path).unwrap_or_else(|err| {
-                robot_exit::fail(
-                    &robot,
-                    &format!("compare script did not write {report_path:?}: {err}"),
                 )
-            });
-            let anchor_dys = parse_anchor_dys(&report, capture_paths.len());
-
-            let mut failures = Vec::new();
-            for (step, &actual) in anchor_dys.iter().enumerate().skip(1) {
-                let expected = (step as f32 * SCROLL_DELTA_Y.abs()).round() as i32;
-                let mode = classify(actual, expected);
-                println!(
-                    "step {step:02}: expected_shift={expected} best_fit_shift={actual}{}",
-                    mode.map(|m| format!(" MODE={m}")).unwrap_or_default()
-                );
-                if let Some(mode) = mode {
-                    failures.push(format!(
-                        "step {step:02}: {mode} (expected_shift={expected} best_fit_shift={actual})"
-                    ));
-                }
+            };
+            GlassBackdropScrollRun {
+                robot: &robot,
+                output_dir: output_dir.clone(),
+                capture: &mut capture,
             }
-
-            if !failures.is_empty() {
-                robot_exit::fail(
-                    &robot,
-                    &format!(
-                        "glass backdrop did not track the content's confirmed scroll:\n{}\ncaptures retained in {}",
-                        failures.join("\n"),
-                        output_dir.display()
-                    ),
-                );
-            }
-
-            for path in &capture_paths {
-                let _ = std::fs::remove_file(path);
-            }
-
-            println!(
-                "PASS: glass backdrop's best-fit shift matched the content's confirmed scroll on every one of {STEP_COUNT} one-pixel steps"
-            );
-            robot.exit().expect("exit");
+            .run();
         })
         .run(app::combined_app);
-}
-
-/// `frozen`: the backdrop did not move while the content (confirmed via
-/// semantics) did. `lagging`: it moved, the right way, but not enough yet —
-/// the user's "caterpillar" symptom, a per-step shortfall that later steps
-/// may or may not catch up on. `wrong`: it moved further than tracking
-/// explains, or the wrong way entirely.
-fn classify(actual: i32, expected: i32) -> Option<&'static str> {
-    if expected == 0 {
-        return None;
-    }
-    if actual == 0 {
-        return Some("frozen");
-    }
-    if actual.signum() == expected.signum() && actual.abs() < expected.abs() - SHIFT_TOLERANCE_PX {
-        return Some("lagging");
-    }
-    if (actual - expected).abs() > SHIFT_TOLERANCE_PX {
-        return Some("wrong");
-    }
-    None
-}
-
-/// Parse `step=00->NN anchor_dy=D ...` lines from the reused compare
-/// script's `fractional_alignment_report.txt`, in step order.
-fn parse_anchor_dys(report: &str, expected_len: usize) -> Vec<i32> {
-    let mut anchor_dys = Vec::with_capacity(expected_len);
-    for line in report.lines() {
-        let Some(rest) = line.strip_prefix("step=00->") else {
-            continue;
-        };
-        let Some(dy_field) = rest.split_whitespace().nth(1) else {
-            continue;
-        };
-        let Some(value) = dy_field.strip_prefix("anchor_dy=") else {
-            continue;
-        };
-        anchor_dys.push(
-            value
-                .parse()
-                .unwrap_or_else(|err| panic!("anchor_dy {value:?} did not parse: {err}")),
-        );
-    }
-    assert_eq!(
-        anchor_dys.len(),
-        expected_len,
-        "expected one anchor_dy per captured frame; report:\n{report}"
-    );
-    anchor_dys
-}
-
-fn collect_receipt_subtitles(elem: &cranpose::SemanticElement, out: &mut Vec<(String, f32)>) {
-    if let Some(text) = elem.text.as_deref() {
-        if text.starts_with("Receipt #") {
-            out.push((text.to_string(), elem.bounds.y));
-        }
-    }
-    for child in &elem.children {
-        collect_receipt_subtitles(child, out);
-    }
-}
-
-fn open_receipts_tab(robot: &cranpose::Robot) {
-    for _ in 0..30 {
-        if let Some((x, y, w, h)) = cranpose_testing::find_button_in_semantics(robot, "Receipts") {
-            robot
-                .click(x + w * 0.5, y + h * 0.5)
-                .expect("click Receipts tab");
-            std::thread::sleep(Duration::from_millis(250));
-            let _ = robot.wait_for_idle();
-            if cranpose_testing::find_text_in_semantics(robot, "Library").is_some() {
-                return;
-            }
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-    panic!("Receipts tab / Library glass bar not found after 30 attempts");
 }

--- a/apps/desktop-demo/robot-runners/robot_nested_glass_cache.rs
+++ b/apps/desktop-demo/robot-runners/robot_nested_glass_cache.rs
@@ -81,22 +81,22 @@ fn expect_card_rerender(robot: &Robot, stage: &str, max_passes: u32) -> RobotScr
         "{stage}: isolated_layer_renders={} layer_cache_misses={} passes={}",
         counts.isolated_layer_renders, counts.layer_cache_misses, counts.pass_count
     );
-    if counts.isolated_layer_renders == 0 {
-        robot_exit::fail(
-            robot,
-            &format!("{stage}: the card content changed but no isolated layer was re-rendered"),
-        );
-    }
     if counts.pass_count > max_passes {
         robot_exit::fail(
             robot,
             &format!(
-                "{stage}: re-rendering the card took {} render passes, more than the {max_passes} a baked underlay allows; \
-                 the underlay under a plainly composited card and the nested button's capture must be texture copies, not passes",
+                "{stage}: repainting the card took {} render passes, more than the {max_passes} allowed; \
+                 the card's capture and the nested button's capture must be texture copies with replayed composites, not passes",
                 counts.pass_count
             ),
         );
     }
+    click_rect(robot, TICK_RECT);
+    let (_, settle) = render_frame(robot);
+    println!(
+        "{stage}: settle tick isolated_layer_renders={} layer_cache_misses={} (a changed runtime-shader subtree earns its cache slot on the repeated key)",
+        settle.isolated_layer_renders, settle.layer_cache_misses
+    );
     screenshot
 }
 

--- a/crates/cranpose-app-shell/src/lib.rs
+++ b/crates/cranpose-app-shell/src/lib.rs
@@ -761,8 +761,15 @@ where
     /// Note: Cursor blink is now timer-based and uses WaitUntil scheduling, not continuous redraw.
     pub fn needs_redraw(&self) -> bool {
         let app_context = Rc::clone(&self.app_context);
-        app_context
-            .enter(|| self.has_stale_pixels_in_context() || self.renderer.needs_frame_warmup())
+        app_context.enter(|| self.has_stale_pixels_in_context() || self.renderer_warmup_due())
+    }
+
+    /// A renderer warmup is a frame rendered only so caches see their content
+    /// a second time. While a frame callback is armed the app is about to
+    /// produce a frame anyway, and rendering the same scene again first would
+    /// double every animated frame's cost for entries the next frame replaces.
+    fn renderer_warmup_due(&self) -> bool {
+        self.renderer.needs_frame_warmup() && !self.runtime.runtime_handle().has_frame_callbacks()
     }
 
     /// Marks the shell as dirty, indicating a redraw is needed.
@@ -904,7 +911,7 @@ where
         let needs_frame = self.is_dirty
             || self.should_render()
             || self.has_active_pointer_gesture()
-            || self.renderer.needs_frame_warmup();
+            || self.renderer_warmup_due();
         FrameSchedule {
             needs_update,
             needs_frame,

--- a/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
+++ b/crates/cranpose-app-shell/src/tests/app_shell_tests.rs
@@ -914,6 +914,36 @@ fn renderer_warmup_keeps_frame_schedule_until_renderer_clears_it() {
 }
 
 #[test]
+fn renderer_warmup_waits_until_no_animation_frame_is_pending() {
+    let _guard = test_guard();
+    let needs_warmup = Rc::new(Cell::new(true));
+    let mut shell = AppShell::new(
+        WarmupRenderer {
+            scene: TestScene,
+            needs_warmup: Rc::clone(&needs_warmup),
+        },
+        location_key(file!(), line!(), column!()),
+        || {},
+    );
+
+    shell.update();
+    shell
+        .runtime
+        .runtime_handle()
+        .register_frame_callback(|_| {});
+    assert!(
+        !shell.needs_redraw(),
+        "an armed frame callback already owes the display a frame; a warmup redraw would only render the same scene again"
+    );
+
+    shell.update();
+    assert!(
+        shell.needs_redraw(),
+        "once no frame callback is armed the renderer's warmup must get its frame"
+    );
+}
+
+#[test]
 fn idle_ui_task_wakes_for_an_update_without_scheduling_a_frame() {
     let _guard = test_guard();
     let mut shell = AppShell::new(

--- a/crates/cranpose-liquid/src/material.rs
+++ b/crates/cranpose-liquid/src/material.rs
@@ -14,6 +14,7 @@ use cranpose_ui_graphics::{
     GLASS_PHYSICAL_REFRACTION_DEPTH_UNIFORM, GLASS_REFRACTION_CURVE_UNIFORM,
     GLASS_RESTING_TINT_UNIFORM, GLASS_TRANSMISSION_REFRACTION_UNIFORM, GraphicsLayer,
     LIQUID_GLASS_WGSL, LayerShape, RenderEffect, RoundedCornerShape, RuntimeShader, TileMode,
+    liquid_glass_runtime_effect,
 };
 
 use crate::theme::LiquidColors;
@@ -904,7 +905,7 @@ impl ResolvedGlass {
             shader.set_output_padding(morph_pad + shadow_reach + 4.0);
         }
 
-        let optical_effect = RenderEffect::runtime_shader(shader);
+        let optical_effect = liquid_glass_runtime_effect(shader);
         if gaussian_blur_radius > f32::EPSILON {
             RenderEffect::blur_with_edge_treatment(gaussian_blur_radius, TileMode::Mirror)
                 .then(optical_effect)

--- a/crates/cranpose-render/common/src/graph.rs
+++ b/crates/cranpose-render/common/src/graph.rs
@@ -277,6 +277,11 @@ pub struct PrimitiveEntry {
 #[derive(Clone)]
 pub struct LayerNode {
     pub node_id: Option<NodeId>,
+    /// Set on the synthetic layer that holds a node's outer draws, those chained
+    /// before its graphics layer, around that node's own layer. Scene updates
+    /// address the node through this id because the node's layer has none of the
+    /// outer draws and the wrapper has no node id of its own.
+    pub wraps: Option<NodeId>,
     pub local_bounds: Rect,
     pub transform_to_parent: ProjectiveTransform,
     pub content_offset: Point,
@@ -312,6 +317,7 @@ impl Default for LayerNode {
     fn default() -> Self {
         Self {
             node_id: None,
+            wraps: None,
             local_bounds: Rect {
                 x: 0.0,
                 y: 0.0,

--- a/crates/cranpose-render/common/src/raster_cache.rs
+++ b/crates/cranpose-render/common/src/raster_cache.rs
@@ -27,6 +27,14 @@ pub struct LayerRasterCacheHashes {
     pub effect: u64,
 }
 
+/// Number of distinct [`LayerRasterCacheKey`] kinds; see
+/// [`LayerRasterCacheKey::kind_slot`] and [`LAYER_RASTER_CACHE_KIND_LABELS`].
+pub const LAYER_RASTER_CACHE_KIND_COUNT: usize = 5;
+
+/// Short labels per kind slot, in [`LayerRasterCacheKey::kind_slot`] order.
+pub const LAYER_RASTER_CACHE_KIND_LABELS: [&str; LAYER_RASTER_CACHE_KIND_COUNT] =
+    ["full", "src", "backdrop", "range", "prefix"];
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum LayerRasterCacheKind {
     FullSurface,
@@ -171,6 +179,12 @@ impl LayerRasterCacheKey {
         }
     }
 
+    /// Index of this key's kind in `0..LAYER_RASTER_CACHE_KIND_COUNT`, for
+    /// per-kind accounting.
+    pub fn kind_slot(self) -> usize {
+        self.kind.identity_kind() as usize
+    }
+
     pub fn stable_id(self) -> Option<NodeId> {
         self.stable_id
     }
@@ -195,6 +209,12 @@ impl LayerRasterCacheKey {
 
     pub fn pixel_size(self) -> (u32, u32) {
         (self.pixel_size[0], self.pixel_size[1])
+    }
+
+    /// The bit pattern of the entry's local bounds: the place a keyless entry
+    /// occupies, stable while its content changes.
+    pub fn local_bounds_bits(self) -> [u32; 4] {
+        self.local_bounds_bits
     }
 
     pub fn scale_bucket(self) -> ScaleBucket {

--- a/crates/cranpose-render/common/src/scene_builder.rs
+++ b/crates/cranpose-render/common/src/scene_builder.rs
@@ -37,6 +37,7 @@ struct BuildNodeSnapshot {
     measured_max_width: Option<f32>,
     resolved_modifiers: ResolvedModifiers,
     draw_commands: Vec<DrawCommand>,
+    outer_draw_command_count: usize,
     click_actions: Vec<Rc<dyn Fn(Point)>>,
     pointer_inputs: Vec<Rc<dyn Fn(cranpose_foundation::PointerEvent)>>,
     clip_to_bounds: bool,
@@ -328,10 +329,7 @@ fn replace_dirty_layers_from_applier(
             continue;
         };
 
-        if child_layer
-            .node_id
-            .is_some_and(|node_id| dirty_nodes.remove(&node_id))
-        {
+        if layer_identity(child_layer).is_some_and(|node_id| dirty_nodes.remove(&node_id)) {
             if try_translate_scrolled_layer(
                 applier,
                 child_layer,
@@ -363,9 +361,7 @@ fn replace_dirty_layers_from_applier(
             }
             let mut replacement = build_layer_node_from_applier_internal(
                 applier,
-                child_layer
-                    .node_id
-                    .expect("dirty layer must have a node id"),
+                layer_identity(child_layer).expect("dirty layer must have a node id"),
                 parent.motion_context_animated,
                 child_inherited_translated_content_context,
                 Some(AbsOrigin {
@@ -502,7 +498,7 @@ fn try_translate_scrolled_layer(
         let RenderNode::Layer(layer) = child else {
             return translate_bail("non-layer child");
         };
-        let Some(child_id) = layer.node_id else {
+        let Some(child_id) = layer_identity(layer) else {
             return translate_bail("child without node id");
         };
         old_ids.push(child_id);
@@ -651,7 +647,7 @@ fn try_translate_scrolled_layer(
         let RenderNode::Layer(layer) = child else {
             continue;
         };
-        let child_id = layer.node_id.expect("checked above");
+        let child_id = layer_identity(&layer).expect("checked above");
         if fresh_id_set.contains(&child_id) {
             old_by_id.insert(child_id, layer);
         } else {
@@ -683,7 +679,7 @@ fn try_translate_scrolled_layer(
                     y: new_children_origin.y - layer.scene_children_origin.y,
                 };
                 offset_scene_origins(&mut layer, origin_delta, translation_delta);
-                if let Some(moved_id) = layer.node_id {
+                if let Some(moved_id) = layer_identity(&layer) {
                     changed_nodes.push(moved_id);
                 }
             }
@@ -788,6 +784,7 @@ fn build_layer_node_internal(
         measured_max_width,
         resolved_modifiers,
         draw_commands,
+        outer_draw_command_count,
         click_actions,
         pointer_inputs,
         clip_to_bounds,
@@ -798,6 +795,8 @@ fn build_layer_node_internal(
         graphics_layer,
         children: child_snapshots,
     } = snapshot;
+    let outer = outer_draws(node_id, &draw_commands, outer_draw_command_count, size);
+    let layer_draw_commands = &draw_commands[outer_draw_command_count..];
     let local_bounds = Rect {
         x: 0.0,
         y: 0.0,
@@ -826,7 +825,8 @@ fn build_layer_node_internal(
 
     let mut children = draw_nodes(
         node_id,
-        &draw_commands,
+        layer_draw_commands,
+        outer_draw_command_count,
         DrawPlacement::Behind,
         size,
         PrimitivePhase::BeforeChildren,
@@ -867,7 +867,8 @@ fn build_layer_node_internal(
     }
     children.extend(draw_nodes(
         node_id,
-        &draw_commands,
+        layer_draw_commands,
+        outer_draw_command_count,
         DrawPlacement::Overlay,
         size,
         PrimitivePhase::AfterChildren,
@@ -883,8 +884,9 @@ fn build_layer_node_internal(
             RenderNode::Primitive(_) | RenderNode::DrawRun(_) => false,
         });
 
-    LayerNode {
+    let layer = LayerNode {
         node_id: Some(node_id),
+        wraps: None,
         local_bounds,
         transform_to_parent,
         content_offset,
@@ -908,7 +910,8 @@ fn build_layer_node_internal(
         cache_hashes: LayerRasterCacheHashes::default(),
         cache_hashes_valid: false,
         children,
-    }
+    };
+    finish_layer(layer, placement, outer)
 }
 
 #[derive(Clone, Copy)]
@@ -1097,9 +1100,18 @@ fn build_layer_node_from_data(
         layer_translation,
     });
 
-    let mut render_children = draw_nodes(
+    let outer_draw_command_count = modifier_slices.outer_draw_command_count();
+    let outer = outer_draws(
         node_id,
         modifier_slices.draw_commands(),
+        outer_draw_command_count,
+        layout_state.size(),
+    );
+    let layer_draw_commands = &modifier_slices.draw_commands()[outer_draw_command_count..];
+    let mut render_children = draw_nodes(
+        node_id,
+        layer_draw_commands,
+        outer_draw_command_count,
         DrawPlacement::Behind,
         layout_state.size(),
         PrimitivePhase::BeforeChildren,
@@ -1148,7 +1160,8 @@ fn build_layer_node_from_data(
     }
     render_children.extend(draw_nodes(
         node_id,
-        modifier_slices.draw_commands(),
+        layer_draw_commands,
+        outer_draw_command_count,
         DrawPlacement::Overlay,
         layout_state.size(),
         PrimitivePhase::AfterChildren,
@@ -1166,6 +1179,7 @@ fn build_layer_node_from_data(
 
     let layer = LayerNode {
         node_id: Some(node_id),
+        wraps: None,
         local_bounds,
         transform_to_parent,
         content_offset: layout_state.content_offset,
@@ -1192,7 +1206,7 @@ fn build_layer_node_from_data(
         cache_hashes_valid: false,
         children: render_children,
     };
-    Some(layer)
+    Some(finish_layer(layer, layout_state.position(), outer))
 }
 
 struct RecorderSlot {
@@ -1477,6 +1491,7 @@ fn publish_recording(
 fn draw_nodes(
     node_id: NodeId,
     commands: &[DrawCommand],
+    first_command_index: usize,
     placement: DrawPlacement,
     size: Size,
     phase: PrimitivePhase,
@@ -1486,7 +1501,7 @@ fn draw_nodes(
     for (command_index, command) in commands.iter().enumerate() {
         let id = DrawCommandId {
             node_id,
-            command_index: command_index as u32,
+            command_index: (first_command_index + command_index) as u32,
             placement,
         };
         let (recording, storage, mut replay) = acquire_recording(id);
@@ -1595,7 +1610,90 @@ pub fn draw_command_nodes_for_tests(
     phase: PrimitivePhase,
 ) -> Vec<RenderNode> {
     bump_recording_generation();
-    draw_nodes(node_id, commands, placement, size, phase)
+    draw_nodes(node_id, commands, 0, placement, size, phase)
+}
+
+struct OuterDraws {
+    behind: Vec<RenderNode>,
+    overlay: Vec<RenderNode>,
+}
+
+fn outer_draws(
+    node_id: NodeId,
+    draw_commands: &[DrawCommand],
+    outer_draw_command_count: usize,
+    size: Size,
+) -> Option<OuterDraws> {
+    (outer_draw_command_count > 0).then(|| {
+        let commands = &draw_commands[..outer_draw_command_count];
+        OuterDraws {
+            behind: draw_nodes(
+                node_id,
+                commands,
+                0,
+                DrawPlacement::Behind,
+                size,
+                PrimitivePhase::BeforeChildren,
+            ),
+            overlay: draw_nodes(
+                node_id,
+                commands,
+                0,
+                DrawPlacement::Overlay,
+                size,
+                PrimitivePhase::AfterChildren,
+            ),
+        }
+    })
+}
+
+fn finish_layer(layer: LayerNode, placement: Point, outer: Option<OuterDraws>) -> LayerNode {
+    match outer {
+        Some(outer) => wrap_layer_with_outer_draws(layer, placement, outer),
+        None => layer,
+    }
+}
+
+fn wrap_layer_with_outer_draws(
+    mut layer: LayerNode,
+    placement: Point,
+    outer: OuterDraws,
+) -> LayerNode {
+    let local_bounds = layer.local_bounds;
+    layer.transform_to_parent =
+        layer_transform_to_parent(local_bounds, Point::default(), &layer.graphics_layer);
+    let wrapper = LayerNode {
+        wraps: layer.node_id,
+        local_bounds,
+        transform_to_parent: layer_transform_to_parent(
+            local_bounds,
+            placement,
+            &GraphicsLayer::default(),
+        ),
+        scene_children_origin: Point {
+            x: layer.scene_children_origin.x - layer.content_offset.x,
+            y: layer.scene_children_origin.y - layer.content_offset.y,
+        },
+        scene_children_layer_translation: Point {
+            x: layer.scene_children_layer_translation.x - layer.graphics_layer.translation_x,
+            y: layer.scene_children_layer_translation.y - layer.graphics_layer.translation_y,
+        },
+        motion_context_animated: layer.motion_context_animated,
+        has_hit_targets: layer.has_hit_targets,
+        has_origin_sinks: layer.has_origin_sinks,
+        ..Default::default()
+    };
+    let mut children = outer.behind;
+    children.push(RenderNode::Layer(Box::new(layer)));
+    children.extend(outer.overlay);
+    LayerNode {
+        children,
+        ..wrapper
+    }
+}
+
+fn layer_identity(layer: &LayerNode) -> Option<NodeId> {
+    layer.node_id.or(layer.wraps)
 }
 
 struct TextNodeParts<'a> {
@@ -1733,6 +1831,7 @@ fn layout_box_to_snapshot(node: &LayoutBox, parent: Option<&LayoutBox>) -> Build
         measured_max_width: None,
         resolved_modifiers: node.node_data.resolved_modifiers,
         draw_commands: node.node_data.modifier_slices.draw_commands().to_vec(),
+        outer_draw_command_count: node.node_data.modifier_slices.outer_draw_command_count(),
         click_actions: node.node_data.modifier_slices.click_handlers().to_vec(),
         pointer_inputs: node.node_data.modifier_slices.pointer_inputs().to_vec(),
         clip_to_bounds: node.node_data.modifier_slices.clip_to_bounds(),
@@ -2376,6 +2475,175 @@ mod tests {
             !graph_has_runtime_shader_effect(&graph.root),
             "simple rounded_corners().clip_to_bounds() must not become a runtime shader effect"
         );
+    }
+
+    fn wrapped_card_composition(
+        label: Rc<RefCell<Option<cranpose_core::MutableState<String>>>>,
+        card_id: Rc<RefCell<Option<NodeId>>>,
+    ) -> cranpose_ui::TestComposition {
+        cranpose_ui::run_test_composition(move || {
+            let text = cranpose_core::rememberMutableStateOf(|| "before".to_string());
+            *label.borrow_mut() = Some(text);
+            let card_id = card_id.clone();
+            cranpose_ui::Box(
+                Modifier::empty().size_points(240.0, 120.0),
+                cranpose_ui::BoxSpec::default(),
+                move || {
+                    let shape = cranpose_ui::LayerShape::Rounded(
+                        cranpose_ui::RoundedCornerShape::uniform(12.0),
+                    );
+                    let id = cranpose_ui::Box(
+                        Modifier::empty()
+                            .offset(20.0, 30.0)
+                            .size_points(100.0, 40.0)
+                            .drop_shadow(shape, |scope| scope.radius = 6.0)
+                            .graphics_layer(move || GraphicsLayer {
+                                shape,
+                                clip: true,
+                                translation_x: 5.0,
+                                ..Default::default()
+                            })
+                            .background(cranpose_ui::Color(0.2, 0.4, 0.8, 1.0)),
+                        cranpose_ui::BoxSpec::default(),
+                        move || {
+                            Text(text, Modifier::empty(), TextStyle::default());
+                        },
+                    );
+                    *card_id.borrow_mut() = Some(id);
+                },
+            );
+        })
+    }
+
+    fn wrapper_and_card(root: &LayerNode, card_id: NodeId) -> (&LayerNode, &LayerNode) {
+        let wrapper = root
+            .children
+            .iter()
+            .find_map(|child| match child {
+                RenderNode::Layer(layer) if layer.wraps == Some(card_id) => Some(layer.as_ref()),
+                _ => None,
+            })
+            .expect("the card's outer shadow wraps its clipped layer");
+        let card = find_layer_by_node_id(wrapper, card_id).expect("card layer inside the wrapper");
+        (wrapper, card)
+    }
+
+    #[test]
+    fn a_draw_before_the_graphics_layer_wraps_the_clipped_layer_in_the_parents_space() {
+        let label = Rc::new(RefCell::new(None));
+        let card_id = Rc::new(RefCell::new(None));
+        let mut composition = wrapped_card_composition(label, card_id.clone());
+        let root = composition.root().expect("composition root");
+        let handle = composition.runtime_handle();
+        let mut applier = composition.applier_mut();
+        applier.set_runtime_handle(handle);
+        applier
+            .compute_layout(
+                root,
+                Size {
+                    width: 240.0,
+                    height: 120.0,
+                },
+            )
+            .expect("layout");
+        let graph = build_graph_from_applier(&mut applier, root, 1.0).expect("graph");
+        applier.clear_runtime_handle();
+        let card_id = card_id.borrow().expect("card id");
+        let (wrapper, card) = wrapper_and_card(&graph.root, card_id);
+
+        assert_eq!(wrapper.node_id, None);
+        assert!(!wrapper.graphics_layer.clip);
+        assert_eq!(
+            wrapper.transform_to_parent.map_point(Point::default()),
+            Point { x: 20.0, y: 30.0 },
+            "the wrapper carries the layout placement alone"
+        );
+        assert_eq!(
+            card.transform_to_parent.map_point(Point::default()),
+            Point { x: 5.0, y: 0.0 },
+            "the clipped layer keeps only its own graphics-layer transform"
+        );
+        assert!(card.graphics_layer.clip);
+        let [shadow, RenderNode::Layer(_)] = wrapper.children.as_slice() else {
+            panic!(
+                "wrapper children must be the outer shadow then the card, got {} children",
+                wrapper.children.len()
+            );
+        };
+        let shadow_is_outer = match shadow {
+            RenderNode::DrawRun(run) => run.summary.has_shadow && !run.summary.has_non_shadow,
+            RenderNode::Primitive(entry) => matches!(
+                &entry.node,
+                PrimitiveNode::Draw(draw) if matches!(draw.primitive, DrawPrimitive::Shadow(_))
+            ),
+            RenderNode::Layer(_) => false,
+        };
+        assert!(shadow_is_outer, "the outer draw is the shadow alone");
+        assert!(
+            card.children.iter().any(|child| match child {
+                RenderNode::DrawRun(run) => run.summary.has_non_shadow,
+                RenderNode::Primitive(entry) => matches!(
+                    &entry.node,
+                    PrimitiveNode::Draw(draw)
+                        if !matches!(draw.primitive, DrawPrimitive::Shadow(_))
+                ),
+                RenderNode::Layer(_) => false,
+            }),
+            "the background chained after the layer stays inside it"
+        );
+    }
+
+    #[test]
+    fn a_dirty_wrapped_node_is_rebuilt_as_one_wrapper() {
+        let label = Rc::new(RefCell::new(None));
+        let card_id = Rc::new(RefCell::new(None));
+        let mut composition = wrapped_card_composition(label.clone(), card_id.clone());
+        let root = composition.root().expect("composition root");
+        let viewport = Size {
+            width: 240.0,
+            height: 120.0,
+        };
+        let handle = composition.runtime_handle();
+        let mut applier = composition.applier_mut();
+        applier.set_runtime_handle(handle);
+        applier.compute_layout(root, viewport).expect("layout");
+        let mut graph = build_graph_from_applier(&mut applier, root, 1.0).expect("graph");
+        applier.clear_runtime_handle();
+        drop(applier);
+        let card_id = card_id.borrow().expect("card id");
+
+        let text = label.borrow().as_ref().copied().expect("label state");
+        text.set_value("after".to_string());
+        composition
+            .process_invalid_scopes()
+            .expect("text recomposition");
+        let handle = composition.runtime_handle();
+        let mut applier = composition.applier_mut();
+        applier.set_runtime_handle(handle);
+        applier.compute_layout(root, viewport).expect("layout");
+        assert!(update_graph_from_applier(
+            &mut applier,
+            &mut graph,
+            &[card_id],
+            1.0
+        ));
+        applier.clear_runtime_handle();
+
+        let (wrapper, card) = wrapper_and_card(&graph.root, card_id);
+        assert_eq!(
+            wrapper.transform_to_parent.map_point(Point::default()),
+            Point { x: 20.0, y: 30.0 }
+        );
+        assert!(
+            !card.children.iter().any(|child| matches!(
+                child,
+                RenderNode::Layer(layer) if layer.wraps.is_some()
+            )),
+            "rebuilding the wrapped node must replace its wrapper, not nest a second one"
+        );
+        let mut labels = Vec::new();
+        collect_text_labels(&graph.root, &mut labels);
+        assert_eq!(labels, vec!["after".to_string()]);
     }
 
     #[test]
@@ -3171,6 +3439,97 @@ mod tests {
             updated_row_top < initial_row_top - consumed_scroll * 0.75,
             "the translation must actually land: initial_y={initial_row_top} updated_y={updated_row_top}"
         );
+        assert_dirty_hash_road_matches_full_walk(&graph);
+    }
+
+    #[test]
+    fn a_scrolled_container_translates_rows_that_carry_outer_shadows() {
+        let scroll_holder: Rc<RefCell<Option<ScrollState>>> = Rc::new(RefCell::new(None));
+        let scroll_holder_for_comp = scroll_holder.clone();
+        let mut composition = cranpose_ui::run_test_composition(move || {
+            let scroll_state =
+                cranpose_core::remember(|| ScrollState::new(0.0)).with(|state| *state);
+            *scroll_holder_for_comp.borrow_mut() = Some(scroll_state);
+            Column(
+                Modifier::empty()
+                    .size_points(240.0, 320.0)
+                    .vertical_scroll(scroll_state, false),
+                ColumnSpec::default(),
+                || {
+                    for index in 0..12usize {
+                        let shape = cranpose_ui::LayerShape::Rounded(
+                            cranpose_ui::RoundedCornerShape::uniform(12.0),
+                        );
+                        cranpose_ui::Box(
+                            Modifier::empty()
+                                .size_points(240.0, 60.0)
+                                .drop_shadow(shape, |scope| scope.radius = 6.0)
+                                .graphics_layer(move || GraphicsLayer {
+                                    shape,
+                                    clip: true,
+                                    ..Default::default()
+                                }),
+                            cranpose_ui::BoxSpec::default(),
+                            move || {
+                                Text(
+                                    format!("row {index}"),
+                                    Modifier::empty(),
+                                    TextStyle::default(),
+                                );
+                            },
+                        );
+                    }
+                },
+            );
+        });
+
+        let root = composition.root().expect("composition root");
+        let viewport = Size {
+            width: 240.0,
+            height: 320.0,
+        };
+        let handle = composition.runtime_handle();
+        let mut applier = composition.applier_mut();
+        applier.set_runtime_handle(handle);
+        applier.compute_layout(root, viewport).expect("layout");
+        let mut graph = build_graph_from_applier(&mut applier, root, 1.0).expect("graph");
+        graph.root.recompute_raster_cache_hashes();
+        let initial_row_top = find_text_top(&graph.root, "row 3").expect("row text");
+        applier.clear_runtime_handle();
+        drop(applier);
+
+        let scroll_state = scroll_holder
+            .borrow()
+            .as_ref()
+            .cloned()
+            .expect("scroll state should be captured");
+        let consumed_scroll = scroll_state.dispatch_raw_delta(96.0);
+        let dirty_nodes = cranpose_ui::pending_layout_repass_nodes_snapshot();
+        let handle = composition.runtime_handle();
+        let mut applier = composition.applier_mut();
+        applier.set_runtime_handle(handle);
+        applier
+            .compute_layout(root, viewport)
+            .expect("scrolled layout");
+        reset_lowered_layer_count();
+        let report = update_graph_from_applier_report(&mut applier, &mut graph, &dirty_nodes, 1.0);
+        applier.clear_runtime_handle();
+
+        assert!(report.applied(), "got {:?}", report.update);
+        assert_eq!(
+            lowered_layer_count(),
+            0,
+            "rows wrapped in their outer shadow must translate like plain rows"
+        );
+        let updated_row_top = find_text_top(&graph.root, "row 3").expect("row text");
+        assert!(updated_row_top < initial_row_top - consumed_scroll * 0.75);
+        let wrappers = graph
+            .root
+            .children
+            .iter()
+            .filter(|child| matches!(child, RenderNode::Layer(layer) if layer.wraps.is_some()))
+            .count();
+        assert_eq!(wrappers, 12, "every row keeps exactly one wrapper");
         assert_dirty_hash_road_matches_full_walk(&graph);
     }
 

--- a/crates/cranpose-render/pixels/src/draw.rs
+++ b/crates/cranpose-render/pixels/src/draw.rs
@@ -948,6 +948,7 @@ mod tests {
         let mut scene = Scene::new();
         scene.graph = Some(RenderGraph::new(LayerNode {
             node_id: None,
+            wraps: None,
             local_bounds: Rect {
                 x: 0.0,
                 y: 0.0,

--- a/crates/cranpose-render/pixels/src/pipeline.rs
+++ b/crates/cranpose-render/pixels/src/pipeline.rs
@@ -1316,6 +1316,7 @@ mod tests {
     fn snapped_text_leaf_root(animated: bool, translated_content_context: bool) -> RenderGraph {
         let text_leaf = LayerNode {
             node_id: Some(77),
+            wraps: None,
             local_bounds: Rect {
                 x: 0.0,
                 y: 0.0,
@@ -1406,6 +1407,7 @@ mod tests {
 
         RenderGraph::new(LayerNode {
             node_id: None,
+            wraps: None,
             local_bounds: Rect {
                 x: 0.0,
                 y: 0.0,
@@ -1536,6 +1538,7 @@ mod tests {
     fn build_raster_scene_uses_graph_transform_to_parent() {
         let graph = RenderGraph::new(LayerNode {
             node_id: None,
+            wraps: None,
             local_bounds: Rect {
                 x: 0.0,
                 y: 0.0,
@@ -1561,6 +1564,7 @@ mod tests {
             cache_hashes_valid: false,
             children: vec![RenderNode::Layer(Box::new(LayerNode {
                 node_id: None,
+                wraps: None,
                 local_bounds: Rect {
                     x: 0.0,
                     y: 0.0,

--- a/crates/cranpose-render/wgpu/examples/pass_timing_profile.rs
+++ b/crates/cranpose-render/wgpu/examples/pass_timing_profile.rs
@@ -218,7 +218,7 @@ fn main() {
         shell.update();
         shell
             .renderer()
-            .render(&view, FRAME_WIDTH, FRAME_HEIGHT)
+            .render(&target, &view, FRAME_WIDTH, FRAME_HEIGHT)
             .expect("frame render");
     }
     let start = std::time::Instant::now();
@@ -228,7 +228,7 @@ fn main() {
         shell.update();
         shell
             .renderer()
-            .render(&view, FRAME_WIDTH, FRAME_HEIGHT)
+            .render(&target, &view, FRAME_WIDTH, FRAME_HEIGHT)
             .expect("frame render");
     }
     let elapsed = start.elapsed().as_secs_f64();

--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -1916,17 +1916,20 @@ impl EffectRenderer {
             .filter(|(_, _, width, height)| *width > 0.0 && *height > 0.0)
             .map(|(_, _, width, height)| (source_span.0 / width, source_span.1 / height))
             .unwrap_or((0.0, 0.0));
+        let sample_mode = resolve_composite_sample_mode(
+            options.sample_mode,
+            viewport_blit_is_integer_unit_mapping(
+                options.dest_viewport,
+                options.source_viewport,
+                (source.width as f32, source.height as f32),
+            ),
+        );
         BlitUniforms {
             alpha: [options.alpha.clamp(0.0, 1.0), 0.0, 0.0, 0.0],
             mask_rect,
             mask_radii,
             mask_enabled,
-            sampling: [
-                composite_sampling_mode_value(options.sample_mode),
-                0.0,
-                0.0,
-                0.0,
-            ],
+            sampling: [composite_sampling_mode_value(sample_mode), 0.0, 0.0, 0.0],
             dest_viewport: [
                 dest_viewport_uniform.0,
                 dest_viewport_uniform.1,
@@ -2147,7 +2150,10 @@ impl EffectRenderer {
             ],
             alpha: [item.alpha.clamp(0.0, 1.0), 0.0, 0.0, 0.0],
             sampling: [
-                composite_sampling_mode_value(item.sample_mode),
+                composite_sampling_mode_value(resolve_composite_sample_mode(
+                    item.sample_mode,
+                    inverse_is_integer_unit_translation(item.inverse),
+                )),
                 0.0,
                 0.0,
                 0.0,
@@ -2307,7 +2313,15 @@ impl EffectRenderer {
                 0.0,
             ],
             alpha: [alpha.clamp(0.0, 1.0), 0.0, 0.0, 0.0],
-            sampling: [composite_sampling_mode_value(sample_mode), 0.0, 0.0, 0.0],
+            sampling: [
+                composite_sampling_mode_value(resolve_composite_sample_mode(
+                    sample_mode,
+                    inverse_is_integer_unit_translation(inverse_matrix),
+                )),
+                0.0,
+                0.0,
+                0.0,
+            ],
         };
 
         let sampler = self.sampler_for_mode(sample_mode);
@@ -2403,11 +2417,155 @@ fn composite_sampling_mode_value(sample_mode: CompositeSampleMode) -> f32 {
     }
 }
 
+fn keep_box4_resolve() -> bool {
+    crate::debug_toggles::debug_toggle("CRANPOSE_KEEP_BOX4").as_deref() == Some("1")
+}
+
+/// Lowers a box resolve to a single texel fetch when the two are the same
+/// bytes: at a unit scale with integer source and destination origins every
+/// destination pixel centre lands on a source texel centre, the box spans
+/// exactly that texel with weight one, and the resolve's 6x6 texel walk
+/// returns it unchanged. `CRANPOSE_KEEP_BOX4` keeps the walk for comparison.
+fn resolve_composite_sample_mode(
+    sample_mode: CompositeSampleMode,
+    integer_unit_mapping: bool,
+) -> CompositeSampleMode {
+    if sample_mode == CompositeSampleMode::Box4 && integer_unit_mapping && !keep_box4_resolve() {
+        CompositeSampleMode::Nearest
+    } else {
+        sample_mode
+    }
+}
+
+fn is_integer(value: f32) -> bool {
+    value.is_finite() && value.fract() == 0.0
+}
+
+/// Whether a viewport blit maps destination pixels onto source texels one to
+/// one with integer origins, so its box resolve is an exact texel fetch.
+fn viewport_blit_is_integer_unit_mapping(
+    dest_viewport: Option<(f32, f32, f32, f32)>,
+    source_viewport: Option<(f32, f32, f32, f32)>,
+    source_size: (f32, f32),
+) -> bool {
+    let Some((dest_x, dest_y, dest_w, dest_h)) = dest_viewport else {
+        return false;
+    };
+    let (source_x, source_y, source_w, source_h) = source_viewport
+        .filter(|(_, _, width, height)| *width > 0.0 && *height > 0.0)
+        .unwrap_or((0.0, 0.0, source_size.0, source_size.1));
+    dest_w > 0.0
+        && dest_h > 0.0
+        && dest_w == source_w
+        && dest_h == source_h
+        && [dest_x, dest_y, source_x, source_y]
+            .iter()
+            .all(|v| is_integer(*v))
+}
+
+/// Whether a projective composite's destination-to-source matrix is a pure
+/// integer translation at unit scale, so its box resolve is an exact texel
+/// fetch.
+fn inverse_is_integer_unit_translation(inverse: [[f32; 3]; 3]) -> bool {
+    inverse[0][0] == 1.0
+        && inverse[0][1] == 0.0
+        && inverse[1][0] == 0.0
+        && inverse[1][1] == 1.0
+        && inverse[2][0] == 0.0
+        && inverse[2][1] == 0.0
+        && inverse[2][2] == 1.0
+        && is_integer(inverse[0][2])
+        && is_integer(inverse[1][2])
+}
+
 #[cfg(test)]
 mod tests {
     use cranpose_ui_graphics::{RenderEffect, RuntimeShader};
 
-    use super::{BlurUniforms, direct_tail_intermediate_size, projective_dest_bounds_rect};
+    use super::{
+        BlurUniforms, CompositeSampleMode, direct_tail_intermediate_size,
+        inverse_is_integer_unit_translation, projective_dest_bounds_rect,
+        resolve_composite_sample_mode,
+    };
+
+    fn translation(tx: f32, ty: f32) -> [[f32; 3]; 3] {
+        [[1.0, 0.0, tx], [0.0, 1.0, ty], [0.0, 0.0, 1.0]]
+    }
+
+    #[test]
+    fn integer_unit_translations_lower_box4_to_a_texel_fetch() {
+        assert!(inverse_is_integer_unit_translation(translation(
+            -40.0, 96.0
+        )));
+        assert!(inverse_is_integer_unit_translation(translation(0.0, 0.0)));
+        assert_eq!(
+            resolve_composite_sample_mode(CompositeSampleMode::Box4, true),
+            CompositeSampleMode::Nearest
+        );
+    }
+
+    #[test]
+    fn fractional_scaled_or_rotated_mappings_keep_the_box_resolve() {
+        assert!(!inverse_is_integer_unit_translation(translation(0.5, 0.0)));
+        assert!(!inverse_is_integer_unit_translation(translation(
+            0.0, -12.25
+        )));
+        assert!(!inverse_is_integer_unit_translation([
+            [0.5, 0.0, 0.0],
+            [0.0, 0.5, 0.0],
+            [0.0, 0.0, 1.0]
+        ]));
+        assert!(!inverse_is_integer_unit_translation([
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0]
+        ]));
+        assert!(!inverse_is_integer_unit_translation([
+            [1.0, 0.0, 3.0],
+            [0.0, 1.0, 3.0],
+            [0.001, 0.0, 1.0]
+        ]));
+        assert_eq!(
+            resolve_composite_sample_mode(CompositeSampleMode::Box4, false),
+            CompositeSampleMode::Box4
+        );
+        assert_eq!(
+            resolve_composite_sample_mode(CompositeSampleMode::Linear, true),
+            CompositeSampleMode::Linear
+        );
+    }
+
+    #[test]
+    fn viewport_blits_lower_only_at_unit_scale_with_integer_origins() {
+        use super::viewport_blit_is_integer_unit_mapping;
+        let source = (200.0, 100.0);
+        assert!(viewport_blit_is_integer_unit_mapping(
+            Some((8.0, 16.0, 200.0, 100.0)),
+            None,
+            source
+        ));
+        assert!(viewport_blit_is_integer_unit_mapping(
+            Some((8.0, 16.0, 50.0, 40.0)),
+            Some((10.0, 20.0, 50.0, 40.0)),
+            source
+        ));
+        assert!(!viewport_blit_is_integer_unit_mapping(None, None, source));
+        assert!(!viewport_blit_is_integer_unit_mapping(
+            Some((8.5, 16.0, 200.0, 100.0)),
+            None,
+            source
+        ));
+        assert!(!viewport_blit_is_integer_unit_mapping(
+            Some((8.0, 16.0, 100.0, 50.0)),
+            None,
+            source
+        ));
+        assert!(!viewport_blit_is_integer_unit_mapping(
+            Some((8.0, 16.0, 50.0, 40.0)),
+            Some((10.5, 20.0, 50.0, 40.0)),
+            source
+        ));
+    }
 
     #[test]
     fn a_frost_chain_tail_intermediate_shrinks_to_the_blur_scratch() {

--- a/crates/cranpose-render/wgpu/src/frame_graph.rs
+++ b/crates/cranpose-render/wgpu/src/frame_graph.rs
@@ -1585,7 +1585,9 @@ mod tests {
 /// Lives beside the executor because it is the only other place that may
 /// finish an encoder and submit it.
 pub(crate) mod fence_profile {
-    use std::{cell::RefCell, time::Instant};
+    use std::cell::RefCell;
+
+    use web_time::Instant;
 
     const DEFAULT_REPORT_EVERY_FRAMES: u32 = 60;
 

--- a/crates/cranpose-render/wgpu/src/frame_graph.rs
+++ b/crates/cranpose-render/wgpu/src/frame_graph.rs
@@ -22,6 +22,7 @@ pub(crate) struct FrameCommandStats {
     pub(crate) encoder_count: u32,
     pub(crate) submit_count: u32,
     pub(crate) pass_count: u32,
+    pub(crate) pass_pixels: u64,
     pub(crate) transient_texture_bytes: u64,
     pub(crate) retained_texture_bytes: u64,
     pub(crate) upload_bytes: u64,
@@ -332,6 +333,7 @@ impl ResourceGraph {
 }
 
 pub(crate) struct PassContext<'pass> {
+    device: &'pass wgpu::Device,
     queue_handle: &'pass wgpu::Queue,
     pub(crate) encoder: &'pass mut wgpu::CommandEncoder,
     uploads: &'pass mut FrameUploadAllocators,
@@ -515,6 +517,7 @@ impl WgpuFrameGraphExecutor {
                 .next()
                 .expect("single-pass graph should contain one pass");
             match self.encode_pass_node(
+                device,
                 queue,
                 &mut encoder,
                 &mut pending_transient_releases,
@@ -542,6 +545,7 @@ impl WgpuFrameGraphExecutor {
                     return Err(FrameGraphError::ScheduledPassTwice { pass_index });
                 };
                 match self.encode_pass_node(
+                    device,
                     queue,
                     &mut encoder,
                     &mut pending_transient_releases,
@@ -567,6 +571,9 @@ impl WgpuFrameGraphExecutor {
             release_pending_transients(&mut self.transient_textures, pending_transient_releases);
             return Err(FrameGraphError::NoDeclaredPasses);
         }
+        if fence_profile::enabled() {
+            fence_profile::end_frame(device, queue, &mut encoder);
+        }
         let submission = Self::submit_with_timing(queue, encoder);
         release_pending_transients(&mut self.transient_textures, pending_transient_releases);
         let retained_texture_bytes = self.retained_texture_bytes();
@@ -576,6 +583,7 @@ impl WgpuFrameGraphExecutor {
                 encoder_count: 1,
                 submit_count: 1,
                 pass_count,
+                pass_pixels: take_render_pass_pixels(),
                 transient_texture_bytes,
                 retained_texture_bytes,
                 ..FrameCommandStats::default()
@@ -586,6 +594,7 @@ impl WgpuFrameGraphExecutor {
     #[allow(clippy::too_many_arguments)]
     fn encode_pass_node(
         &mut self,
+        device: &wgpu::Device,
         queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         pending_transient_releases: &mut Vec<(FrameTextureDescriptor, OffscreenTarget)>,
@@ -597,6 +606,7 @@ impl WgpuFrameGraphExecutor {
         let pass_label = pass.label();
         let pass_start = Instant::now();
         let mut context = PassContext {
+            device,
             queue_handle: queue,
             encoder,
             uploads: &mut self.upload_allocators,
@@ -674,11 +684,29 @@ std::thread_local! {
         const { std::cell::RefCell::new(Vec::new()) };
 }
 
-pub(crate) fn note_render_pass(label: Option<&str>) {
+std::thread_local! {
+    static RENDER_PASS_PIXELS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// Accounts one render pass: its first color target's area, the tile
+/// traffic a tiling GPU pays to open and close the pass, and its label when
+/// the stage telemetry is on.
+pub(crate) fn note_render_pass(descriptor: &wgpu::RenderPassDescriptor<'_>) {
+    let pixels = descriptor
+        .color_attachments
+        .iter()
+        .flatten()
+        .next()
+        .map(|attachment| {
+            let texture = attachment.view.texture();
+            u64::from(texture.width()) * u64::from(texture.height())
+        })
+        .unwrap_or(0);
+    RENDER_PASS_PIXELS.with(|total| total.set(total.get().saturating_add(pixels)));
     if frame_graph_pass_telemetry_threshold_ms().is_none() {
         return;
     }
-    let label = label.unwrap_or("<unlabeled>");
+    let label = descriptor.label.unwrap_or("<unlabeled>");
     RENDER_PASS_LABELS.with(|labels| {
         let mut labels = labels.borrow_mut();
         if let Some(entry) = labels.iter_mut().find(|(name, _)| name == label) {
@@ -687,6 +715,10 @@ pub(crate) fn note_render_pass(label: Option<&str>) {
             labels.push((label.to_owned(), 1));
         }
     });
+}
+
+fn take_render_pass_pixels() -> u64 {
+    RENDER_PASS_PIXELS.with(|total| total.replace(0))
 }
 
 fn take_render_pass_labels() -> Vec<(String, u32)> {
@@ -766,6 +798,10 @@ impl FrameCommandRecorder for PassContext<'_> {
         &mut self,
         descriptor: &wgpu::RenderPassDescriptor<'_>,
     ) -> wgpu::RenderPass<'_> {
+        if fence_profile::enabled() {
+            let bucket = fence_profile::bucket_label(descriptor);
+            fence_profile::split(self.device, self.queue_handle, self.encoder, Some(&bucket));
+        }
         crate::pass_timing::begin_timed_render_pass(self.pass_timer, self.encoder, descriptor)
     }
 
@@ -872,6 +908,7 @@ impl WgpuFrameEncoder<'_> {
                 encoder_count: 1,
                 submit_count: 1,
                 pass_count,
+                pass_pixels: take_render_pass_pixels(),
                 transient_texture_bytes,
                 retained_texture_bytes,
                 ..FrameCommandStats::default()
@@ -1542,5 +1579,171 @@ mod tests {
 
         assert_eq!(graph.node_count(), 1);
         assert_eq!(graph.declared_pass_count(), 1);
+    }
+}
+
+/// Lives beside the executor because it is the only other place that may
+/// finish an encoder and submit it.
+pub(crate) mod fence_profile {
+    use std::{cell::RefCell, time::Instant};
+
+    const DEFAULT_REPORT_EVERY_FRAMES: u32 = 60;
+
+    fn report_every_frames() -> u32 {
+        static FRAMES: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
+        *FRAMES.get_or_init(|| {
+            crate::debug_toggles::debug_toggle("CRANPOSE_GPU_FENCE_PROFILE")
+                .and_then(|value| value.parse::<u32>().ok())
+                .filter(|frames| *frames > 0)
+                .unwrap_or(DEFAULT_REPORT_EVERY_FRAMES)
+        })
+    }
+
+    /// Every render pass a frame records, bucketed by label, target size and
+    /// load op, with the wall time of each measured through submission fences
+    /// for adapters without timestamp queries (`CRANPOSE_GPU_FENCE_PROFILE`,
+    /// mirrored as `debug.cranpose.gpu_fence_profile` on Android; a numeric
+    /// value is the report period in frames, 60 by default). Every pass
+    /// boundary submits the commands recorded so far and waits for the queue
+    /// to drain, minus the round trip of an empty submission, so a bucket's
+    /// time is the isolated latency of its passes plus the copies encoded
+    /// after them. Isolated latency overstates large targets, whose store and
+    /// reload a tiler otherwise overlaps with the next pass, so the buckets
+    /// are a per-frame pass inventory, not a cost ranking.
+    pub(crate) fn enabled() -> bool {
+        static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *ENABLED.get_or_init(|| {
+            crate::debug_toggles::debug_toggle("CRANPOSE_GPU_FENCE_PROFILE").is_some()
+        })
+    }
+
+    #[derive(Default)]
+    struct Profile {
+        current_label: Option<String>,
+        totals: Vec<(String, f64, u32)>,
+        frames: u32,
+    }
+
+    thread_local! {
+        static PROFILE: RefCell<Profile> = RefCell::new(Profile::default());
+    }
+
+    fn submit_and_wait(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: wgpu::CommandEncoder,
+    ) -> f64 {
+        let start = Instant::now();
+        let submission = queue.submit(std::iter::once(encoder.finish()));
+        let _ = device.poll(wgpu::PollType::Wait {
+            submission_index: Some(submission),
+            timeout: None,
+        });
+        start.elapsed().as_secs_f64() * 1000.0
+    }
+
+    fn new_encoder(device: &wgpu::Device) -> wgpu::CommandEncoder {
+        device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("fence profile split"),
+        })
+    }
+
+    /// Wall time of the recorded commands minus the round trip of an empty
+    /// submission, so the fixed cost of the fence itself does not count.
+    fn drain(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+    ) -> f64 {
+        let finished = std::mem::replace(encoder, new_encoder(device));
+        let recorded = submit_and_wait(device, queue, finished);
+        let empty = submit_and_wait(device, queue, new_encoder(device));
+        (recorded - empty).max(0.0)
+    }
+
+    /// The pass label extended with its first color target's size, so passes on
+    /// the full-screen target rank apart from the same pass on a small layer.
+    pub(crate) fn bucket_label(descriptor: &wgpu::RenderPassDescriptor<'_>) -> String {
+        let label = descriptor.label.unwrap_or("<unlabeled>");
+        match descriptor
+            .color_attachments
+            .first()
+            .and_then(|attachment| attachment.as_ref())
+        {
+            Some(attachment) => {
+                let texture = attachment.view.texture();
+                let load = match attachment.ops.load {
+                    wgpu::LoadOp::Load => "load",
+                    wgpu::LoadOp::Clear(_) => "clear",
+                    wgpu::LoadOp::DontCare(_) => "dontcare",
+                };
+                format!("{label} {}x{} {load}", texture.width(), texture.height())
+            }
+            None => label.to_owned(),
+        }
+    }
+
+    /// Closes the pass that was running, charges its GPU time, and opens the
+    /// accounting for `next_label`.
+    pub(crate) fn split(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        next_label: Option<&str>,
+    ) {
+        let elapsed = drain(device, queue, encoder);
+        PROFILE.with(|profile| {
+            let mut profile = profile.borrow_mut();
+            if let Some(label) = profile.current_label.take() {
+                match profile
+                    .totals
+                    .iter_mut()
+                    .find(|(name, _, _)| *name == label)
+                {
+                    Some(entry) => {
+                        entry.1 += elapsed;
+                        entry.2 += 1;
+                    }
+                    None => profile.totals.push((label, elapsed, 1)),
+                }
+            }
+            profile.current_label = next_label.map(str::to_owned);
+        });
+    }
+
+    /// Charges the frame's last pass and prints the per-label ranking once per
+    /// report period.
+    pub(crate) fn end_frame(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+    ) {
+        split(device, queue, encoder, None);
+        PROFILE.with(|profile| {
+            let mut profile = profile.borrow_mut();
+            profile.frames += 1;
+            if profile.frames < report_every_frames() {
+                return;
+            }
+            let frames = f64::from(profile.frames);
+            let mut totals = std::mem::take(&mut profile.totals);
+            totals.sort_by(|a, b| b.1.total_cmp(&a.1));
+            let total_ms: f64 = totals.iter().map(|(_, ms, _)| ms).sum::<f64>() / frames;
+            let mut line = format!(
+                "[gpu-fence] frames={} total={total_ms:.2}ms/frame",
+                profile.frames
+            );
+            for (label, ms, count) in &totals {
+                use std::fmt::Write;
+                let _ = write!(
+                    line,
+                    " [{label}]={:.2}ms x{:.1}",
+                    ms / frames,
+                    f64::from(*count) / frames
+                );
+            }
+            eprintln!("{line}");
+            profile.frames = 0;
+        });
     }
 }

--- a/crates/cranpose-render/wgpu/src/frame_graph.rs
+++ b/crates/cranpose-render/wgpu/src/frame_graph.rs
@@ -706,13 +706,12 @@ pub(crate) fn note_render_pass(descriptor: &wgpu::RenderPassDescriptor<'_>) {
     if frame_graph_pass_telemetry_threshold_ms().is_none() {
         return;
     }
-    let label = descriptor.label.unwrap_or("<unlabeled>");
+    let label = fence_profile::bucket_label(descriptor);
     RENDER_PASS_LABELS.with(|labels| {
         let mut labels = labels.borrow_mut();
-        if let Some(entry) = labels.iter_mut().find(|(name, _)| name == label) {
-            entry.1 += 1;
-        } else {
-            labels.push((label.to_owned(), 1));
+        match labels.last_mut() {
+            Some((name, count)) if *name == label => *count += 1,
+            _ => labels.push((label, 1)),
         }
     });
 }

--- a/crates/cranpose-render/wgpu/src/frame_graph.rs
+++ b/crates/cranpose-render/wgpu/src/frame_graph.rs
@@ -1619,6 +1619,17 @@ pub(crate) mod fence_profile {
         })
     }
 
+    /// `CRANPOSE_GPU_FENCE_PROFILE=frame`: one fence per frame instead of one
+    /// per pass, so the report is the frame's whole GPU time with the
+    /// pipeline intact.
+    fn whole_frame() -> bool {
+        static WHOLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *WHOLE.get_or_init(|| {
+            crate::debug_toggles::debug_toggle("CRANPOSE_GPU_FENCE_PROFILE").as_deref()
+                == Some("frame")
+        })
+    }
+
     #[derive(Default)]
     struct Profile {
         current_label: Option<String>,
@@ -1693,6 +1704,15 @@ pub(crate) mod fence_profile {
         encoder: &mut wgpu::CommandEncoder,
         next_label: Option<&str>,
     ) {
+        if whole_frame() && next_label.is_some() {
+            PROFILE.with(|profile| {
+                profile
+                    .borrow_mut()
+                    .current_label
+                    .get_or_insert_with(|| "frame".to_owned());
+            });
+            return;
+        }
         let elapsed = drain(device, queue, encoder);
         PROFILE.with(|profile| {
             let mut profile = profile.borrow_mut();

--- a/crates/cranpose-render/wgpu/src/gpu_stats.rs
+++ b/crates/cranpose-render/wgpu/src/gpu_stats.rs
@@ -1,7 +1,9 @@
 use std::cell::{Cell, RefCell};
 
 use cranpose_core::NodeId;
-use cranpose_render_common::raster_cache::LayerRasterCacheKey;
+use cranpose_render_common::raster_cache::{
+    LAYER_RASTER_CACHE_KIND_COUNT, LAYER_RASTER_CACHE_KIND_LABELS, LayerRasterCacheKey,
+};
 use cranpose_ui_graphics::Rect;
 
 use crate::{
@@ -186,6 +188,12 @@ pub struct FrameStatsSnapshot {
     pub layer_cache_evictions: u32,
     pub layer_cache_hit_pixels: u64,
     pub layer_cache_miss_pixels: u64,
+    /// Hits per key kind, indexed by `LayerRasterCacheKey::kind_slot`.
+    pub layer_cache_hits_by_kind: [u32; LAYER_RASTER_CACHE_KIND_COUNT],
+    /// Stores per key kind, indexed by `LayerRasterCacheKey::kind_slot`.
+    pub layer_cache_misses_by_kind: [u32; LAYER_RASTER_CACHE_KIND_COUNT],
+    /// Stored pixels per key kind, indexed by `LayerRasterCacheKey::kind_slot`.
+    pub layer_cache_miss_pixels_by_kind: [u64; LAYER_RASTER_CACHE_KIND_COUNT],
     pub shadow_shape_cache_hits: u32,
     pub shadow_shape_cache_misses: u32,
     pub shadow_shape_cache_hit_pixels: u64,
@@ -258,6 +266,16 @@ impl FrameStatsSnapshot {
         }
     }
 
+    fn miss_pixels_by_kind_display(&self) -> String {
+        LAYER_RASTER_CACHE_KIND_LABELS
+            .iter()
+            .zip(self.layer_cache_miss_pixels_by_kind.iter())
+            .filter(|(_, pixels)| **pixels > 0)
+            .map(|(label, pixels)| format!("{label}={:.2}MP", *pixels as f64 / 1_000_000.0))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
     fn print(self, frame_count: u64) {
         let mb = self.offscreen_total_bytes as f64 / (1024.0 * 1024.0);
         let upload_mb = self.upload_bytes as f64 / (1024.0 * 1024.0);
@@ -273,7 +291,7 @@ impl FrameStatsSnapshot {
             "[GPU f#{}] encoders={} submits={} passes={} | offscreen: acq={} new={} {:.1}MB pool={}({:.1}MB) retained={:.1}MB | \
              uploads={:.2}MB | \
              isolated_layers={} area={:.2}MP | \
-             layer_cache: hit={} miss={} {:.1}% evict={} hit_px={:.2}MP miss_px={:.2}MP size={}({:.1}MB) | \
+             layer_cache: hit={} miss={} {:.1}% evict={} hit_px={:.2}MP miss_px={:.2}MP size={}({:.1}MB) miss_px_by_kind={} | \
              shadow_cache: shape_hit={} shape_miss={} hit_px={:.2}MP miss_px={:.2}MP text_blur_fallback={} | \
              blur={} composite={} effect={} | shape={} image={} text={} draws={} | \
              text_img_cache: hit={} miss={} hit_px={:.2}MP miss_px={:.2}MP raster={:.2}MB | \
@@ -300,6 +318,7 @@ impl FrameStatsSnapshot {
             layer_cache_miss_mpx,
             self.layer_cache_size,
             layer_cache_mb,
+            self.miss_pixels_by_kind_display(),
             self.shadow_shape_cache_hits,
             self.shadow_shape_cache_misses,
             shadow_cache_hit_mpx,
@@ -360,6 +379,9 @@ pub(crate) struct FrameStats {
     pub layer_cache_evictions: Cell<u32>,
     pub layer_cache_hit_pixels: Cell<u64>,
     pub layer_cache_miss_pixels: Cell<u64>,
+    pub layer_cache_hits_by_kind: [Cell<u32>; LAYER_RASTER_CACHE_KIND_COUNT],
+    pub layer_cache_misses_by_kind: [Cell<u32>; LAYER_RASTER_CACHE_KIND_COUNT],
+    pub layer_cache_miss_pixels_by_kind: [Cell<u64>; LAYER_RASTER_CACHE_KIND_COUNT],
     pub shadow_shape_cache_hits: Cell<u32>,
     pub shadow_shape_cache_misses: Cell<u32>,
     pub shadow_shape_cache_hit_pixels: Cell<u64>,
@@ -480,7 +502,9 @@ impl FrameStats {
         });
     }
 
-    pub fn record_layer_cache_hit(&self, width: u32, height: u32) {
+    pub fn record_layer_cache_hit(&self, key: &LayerRasterCacheKey, width: u32, height: u32) {
+        let by_kind = &self.layer_cache_hits_by_kind[key.kind_slot()];
+        by_kind.set(by_kind.get().saturating_add(1));
         self.layer_cache_hits
             .set(self.layer_cache_hits.get().saturating_add(1));
         self.layer_cache_hit_pixels.set(
@@ -490,13 +514,18 @@ impl FrameStats {
         );
     }
 
-    #[cfg_attr(
-        not(debug_assertions),
-        expect(unused_variables, reason = "the key is only tracked in debug builds")
-    )]
     pub fn record_layer_cache_miss(&self, key: &LayerRasterCacheKey, width: u32, height: u32) {
         #[cfg(debug_assertions)]
         self.missed_layer_cache_keys.borrow_mut().push(*key);
+        let slot = key.kind_slot();
+        let by_kind = &self.layer_cache_misses_by_kind[slot];
+        by_kind.set(by_kind.get().saturating_add(1));
+        let pixels_by_kind = &self.layer_cache_miss_pixels_by_kind[slot];
+        pixels_by_kind.set(
+            pixels_by_kind
+                .get()
+                .saturating_add((width as u64) * (height as u64)),
+        );
         self.layer_cache_misses
             .set(self.layer_cache_misses.get().saturating_add(1));
         self.layer_cache_miss_pixels.set(
@@ -678,6 +707,12 @@ impl FrameStats {
             layer_cache_evictions: self.layer_cache_evictions.get(),
             layer_cache_hit_pixels: self.layer_cache_hit_pixels.get(),
             layer_cache_miss_pixels: self.layer_cache_miss_pixels.get(),
+            layer_cache_hits_by_kind: self.layer_cache_hits_by_kind.each_ref().map(Cell::get),
+            layer_cache_misses_by_kind: self.layer_cache_misses_by_kind.each_ref().map(Cell::get),
+            layer_cache_miss_pixels_by_kind: self
+                .layer_cache_miss_pixels_by_kind
+                .each_ref()
+                .map(Cell::get),
             shadow_shape_cache_hits: self.shadow_shape_cache_hits.get(),
             shadow_shape_cache_misses: self.shadow_shape_cache_misses.get(),
             shadow_shape_cache_hit_pixels: self.shadow_shape_cache_hit_pixels.get(),
@@ -730,6 +765,11 @@ impl FrameStats {
         self.layer_cache_evictions.set(0);
         self.layer_cache_hit_pixels.set(0);
         self.layer_cache_miss_pixels.set(0);
+        for slot in 0..LAYER_RASTER_CACHE_KIND_COUNT {
+            self.layer_cache_hits_by_kind[slot].set(0);
+            self.layer_cache_misses_by_kind[slot].set(0);
+            self.layer_cache_miss_pixels_by_kind[slot].set(0);
+        }
         self.shadow_shape_cache_hits.set(0);
         self.shadow_shape_cache_misses.set(0);
         self.shadow_shape_cache_hit_pixels.set(0);
@@ -881,8 +921,8 @@ mod tests {
         stats.blur_passes.set(1);
         stats.offscreen_total_bytes.set(1024);
         stats.offscreen_pool_bytes.set(2048);
-        stats.record_layer_cache_hit(10, 20);
-        stats.record_layer_cache_hit(3, 4);
+        stats.record_layer_cache_hit(&test_layer_cache_key(), 10, 20);
+        stats.record_layer_cache_hit(&test_layer_cache_key(), 3, 4);
         stats.record_layer_cache_miss(&test_layer_cache_key(), 5, 6);
         stats.record_layer_cache_eviction();
         stats.record_shadow_shape_cache_hit(72);

--- a/crates/cranpose-render/wgpu/src/gpu_stats.rs
+++ b/crates/cranpose-render/wgpu/src/gpu_stats.rs
@@ -175,6 +175,9 @@ pub struct FrameStatsSnapshot {
     pub encoder_count: u32,
     pub submit_count: u32,
     pub pass_count: u32,
+    /// Sum of every render pass's first color target area: the tile traffic a
+    /// tiling GPU pays whatever the passes draw.
+    pub pass_pixels: u64,
     pub offscreen_acquires: u32,
     pub offscreen_news: u32,
     pub offscreen_total_bytes: u64,
@@ -240,6 +243,7 @@ impl FrameStatsSnapshot {
         self.encoder_count = self.encoder_count.saturating_add(stats.encoder_count);
         self.submit_count = self.submit_count.saturating_add(stats.submit_count);
         self.pass_count = self.pass_count.saturating_add(stats.pass_count);
+        self.pass_pixels = self.pass_pixels.saturating_add(stats.pass_pixels);
         self.transient_texture_bytes = self
             .transient_texture_bytes
             .saturating_add(stats.transient_texture_bytes);
@@ -267,13 +271,13 @@ impl FrameStatsSnapshot {
     }
 
     fn miss_pixels_by_kind_display(&self) -> String {
-        LAYER_RASTER_CACHE_KIND_LABELS
-            .iter()
-            .zip(self.layer_cache_miss_pixels_by_kind.iter())
-            .filter(|(_, pixels)| **pixels > 0)
-            .map(|(label, pixels)| format!("{label}={:.2}MP", *pixels as f64 / 1_000_000.0))
-            .collect::<Vec<_>>()
-            .join(",")
+        by_kind_display(&self.layer_cache_miss_pixels_by_kind, |pixels| {
+            format!("{:.2}MP", pixels as f64 / 1_000_000.0)
+        })
+    }
+
+    fn hits_by_kind_display(&self) -> String {
+        by_kind_display(&self.layer_cache_hits_by_kind, |hits| hits.to_string())
     }
 
     fn print(self, frame_count: u64) {
@@ -288,10 +292,10 @@ impl FrameStatsSnapshot {
         let layer_cache_mb = self.layer_cache_bytes as f64 / (1024.0 * 1024.0);
         let isolated_layer_mpx = self.isolated_layer_pixels as f64 / 1_000_000.0;
         eprintln!(
-            "[GPU f#{}] encoders={} submits={} passes={} | offscreen: acq={} new={} {:.1}MB pool={}({:.1}MB) retained={:.1}MB | \
+            "[GPU f#{}] encoders={} submits={} passes={} pass_px={:.2}MP | offscreen: acq={} new={} {:.1}MB pool={}({:.1}MB) retained={:.1}MB | \
              uploads={:.2}MB | \
              isolated_layers={} area={:.2}MP | \
-             layer_cache: hit={} miss={} {:.1}% evict={} hit_px={:.2}MP miss_px={:.2}MP size={}({:.1}MB) miss_px_by_kind={} | \
+             layer_cache: hit={} miss={} {:.1}% evict={} hit_px={:.2}MP miss_px={:.2}MP size={}({:.1}MB) hit_by_kind={} miss_px_by_kind={} | \
              shadow_cache: shape_hit={} shape_miss={} hit_px={:.2}MP miss_px={:.2}MP text_blur_fallback={} | \
              blur={} composite={} effect={} | shape={} image={} text={} draws={} | \
              text_img_cache: hit={} miss={} hit_px={:.2}MP miss_px={:.2}MP raster={:.2}MB | \
@@ -301,6 +305,7 @@ impl FrameStatsSnapshot {
             self.encoder_count,
             self.submit_count,
             self.pass_count,
+            self.pass_pixels as f64 / 1_000_000.0,
             self.offscreen_acquires,
             self.offscreen_news,
             mb,
@@ -318,6 +323,7 @@ impl FrameStatsSnapshot {
             layer_cache_miss_mpx,
             self.layer_cache_size,
             layer_cache_mb,
+            self.hits_by_kind_display(),
             self.miss_pixels_by_kind_display(),
             self.shadow_shape_cache_hits,
             self.shadow_shape_cache_misses,
@@ -365,6 +371,7 @@ pub(crate) struct FrameStats {
     pub command_encoder_count: Cell<u32>,
     pub command_submit_count: Cell<u32>,
     pub command_pass_count: Cell<u32>,
+    pub command_pass_pixels: Cell<u64>,
     pub command_transient_texture_bytes: Cell<u64>,
     pub command_retained_texture_bytes: Cell<u64>,
     pub command_upload_bytes: Cell<u64>,
@@ -435,6 +442,11 @@ impl FrameStats {
             self.command_pass_count
                 .get()
                 .saturating_add(stats.pass_count),
+        );
+        self.command_pass_pixels.set(
+            self.command_pass_pixels
+                .get()
+                .saturating_add(stats.pass_pixels),
         );
         self.command_transient_texture_bytes.set(
             self.command_transient_texture_bytes
@@ -687,6 +699,7 @@ impl FrameStats {
             encoder_count: self.command_encoder_count.get(),
             submit_count: self.command_submit_count.get(),
             pass_count: self.command_pass_count.get(),
+            pass_pixels: self.command_pass_pixels.get(),
             offscreen_acquires: self.offscreen_acquires.get(),
             offscreen_news: self.offscreen_news.get(),
             offscreen_total_bytes: self.offscreen_total_bytes.get(),
@@ -751,6 +764,7 @@ impl FrameStats {
         self.command_encoder_count.set(0);
         self.command_submit_count.set(0);
         self.command_pass_count.set(0);
+        self.command_pass_pixels.set(0);
         self.command_transient_texture_bytes.set(0);
         self.command_retained_texture_bytes.set(0);
         self.command_upload_bytes.set(0);
@@ -886,6 +900,19 @@ fn shadow_cache_diagnostics_enabled() -> bool {
         .unwrap_or(false)
 }
 
+fn by_kind_display<T: Copy + Default + PartialEq>(
+    by_kind: &[T; LAYER_RASTER_CACHE_KIND_COUNT],
+    format: impl Fn(T) -> String,
+) -> String {
+    LAYER_RASTER_CACHE_KIND_LABELS
+        .iter()
+        .zip(by_kind)
+        .filter(|(_, value)| **value != T::default())
+        .map(|(label, value)| format!("{label}={}", format(*value)))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -913,6 +940,7 @@ mod tests {
             encoder_count: 1,
             submit_count: 1,
             pass_count: 2,
+            pass_pixels: 0,
             transient_texture_bytes: 256,
             retained_texture_bytes: 128,
             upload_bytes: 64,
@@ -1016,6 +1044,7 @@ mod tests {
             encoder_count: 2,
             submit_count: 2,
             pass_count: 5,
+            pass_pixels: 0,
             transient_texture_bytes: 1024,
             retained_texture_bytes: 2048,
             upload_bytes: 512,
@@ -1049,6 +1078,7 @@ mod tests {
             encoder_count: 1,
             submit_count: 1,
             pass_count: 2,
+            pass_pixels: 0,
             transient_texture_bytes: 128,
             retained_texture_bytes: 512,
             upload_bytes: 64,
@@ -1059,6 +1089,7 @@ mod tests {
                 encoder_count: 1,
                 submit_count: 1,
                 pass_count: 1,
+                pass_pixels: 0,
                 transient_texture_bytes: 0,
                 retained_texture_bytes: 0,
                 upload_bytes: 0,

--- a/crates/cranpose-render/wgpu/src/layer_surface_cache.rs
+++ b/crates/cranpose-render/wgpu/src/layer_surface_cache.rs
@@ -40,6 +40,97 @@ fn take_unshared<T>(pending: &mut Vec<Rc<T>>) -> Vec<T> {
     free
 }
 
+const UNREWARDED_STORES_BEFORE_BACKOFF: u32 = 3;
+const ADMISSION_BACKOFF_BASE_FRAMES: u64 = 8;
+const ADMISSION_BACKOFF_MAX_FRAMES: u64 = 64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum AdmissionScope {
+    Identity(LayerRasterCacheIdentity),
+    Place {
+        kind_slot: usize,
+        local_bounds_bits: [u32; 4],
+        pixel_size: (u32, u32),
+    },
+}
+
+fn admission_scope(key: &LayerRasterCacheKey) -> AdmissionScope {
+    key.identity()
+        .map(AdmissionScope::Identity)
+        .unwrap_or_else(|| AdmissionScope::Place {
+            kind_slot: key.kind_slot(),
+            local_bounds_bits: key.local_bounds_bits(),
+            pixel_size: key.pixel_size(),
+        })
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct AdmissionBackoff {
+    unrewarded_stores: u32,
+    resume_at_frame: u64,
+}
+
+/// Speculative (repeat-admitted) stores that never get served are pure
+/// cost: the entry is rendered, kept, and replaced by the next key before
+/// anything reads it. Content that holds for a couple of frames and then
+/// moves on -- a stepped animation, a starfield that advances at half the
+/// presented rate -- passes the repeat check every time and would be
+/// re-stored forever. The ledger counts, per node identity (or per place for
+/// keys without one: kind, bounds and size), consecutive frames that stored
+/// without a hit, and once
+/// that streak reaches [`UNREWARDED_STORES_BEFORE_BACKOFF`] refuses further
+/// repeat admissions for a window that doubles per extra unrewarded store up
+/// to [`ADMISSION_BACKOFF_MAX_FRAMES`]. A hit clears the scope, so content
+/// that settles is cached again at most one window later.
+#[derive(Debug, Default)]
+struct AdmissionLedger {
+    frame: u64,
+    backoff: HashMap<AdmissionScope, AdmissionBackoff>,
+    stored_this_frame: HashSet<AdmissionScope>,
+    hit_this_frame: HashSet<AdmissionScope>,
+}
+
+impl AdmissionLedger {
+    fn note_hit(&mut self, key: &LayerRasterCacheKey) {
+        self.hit_this_frame.insert(admission_scope(key));
+    }
+
+    fn note_store(&mut self, key: &LayerRasterCacheKey) {
+        self.stored_this_frame.insert(admission_scope(key));
+    }
+
+    fn is_backed_off(&self, key: &LayerRasterCacheKey) -> bool {
+        self.backoff
+            .get(&admission_scope(key))
+            .is_some_and(|backoff| backoff.resume_at_frame > self.frame)
+    }
+
+    fn finish_frame(&mut self) {
+        let hit_this_frame = std::mem::take(&mut self.hit_this_frame);
+        for scope in self.stored_this_frame.drain() {
+            if hit_this_frame.contains(&scope) {
+                continue;
+            }
+            let backoff = self.backoff.entry(scope).or_default();
+            backoff.unrewarded_stores = backoff.unrewarded_stores.saturating_add(1);
+            if backoff.unrewarded_stores >= UNREWARDED_STORES_BEFORE_BACKOFF {
+                let doublings = (backoff.unrewarded_stores - UNREWARDED_STORES_BEFORE_BACKOFF)
+                    .min(u32::BITS - 1);
+                let window =
+                    (ADMISSION_BACKOFF_BASE_FRAMES << doublings).min(ADMISSION_BACKOFF_MAX_FRAMES);
+                backoff.resume_at_frame = self.frame + 1 + window;
+            }
+        }
+        for scope in hit_this_frame {
+            self.backoff.remove(&scope);
+        }
+        let frame = self.frame;
+        self.backoff
+            .retain(|_, backoff| backoff.resume_at_frame + ADMISSION_BACKOFF_MAX_FRAMES > frame);
+        self.frame += 1;
+    }
+}
+
 pub(crate) struct LayerSurfaceCache {
     entries: BoundedLruCache<LayerRasterCacheKey, CachedLayerSurface>,
     scene_range_entries: BoundedLruCache<LayerRasterCacheKey, CachedLayerSurface>,
@@ -48,6 +139,7 @@ pub(crate) struct LayerSurfaceCache {
     scene_range_bytes: u64,
     seen_this_frame: HashSet<usize>,
     recycled: Vec<Rc<OffscreenTarget>>,
+    admission: AdmissionLedger,
     #[cfg(debug_assertions)]
     inserted_this_frame: HashSet<LayerRasterCacheKey>,
 }
@@ -76,9 +168,16 @@ impl LayerSurfaceCache {
             scene_range_bytes: 0,
             seen_this_frame: HashSet::new(),
             recycled: Vec::new(),
+            admission: AdmissionLedger::default(),
             #[cfg(debug_assertions)]
             inserted_this_frame: HashSet::new(),
         }
+    }
+
+    /// Whether a repeat-admitted store for this key would only feed the
+    /// unrewarded-store streak its scope is already backing off from.
+    pub(crate) fn repeat_admission_backed_off(&self, key: &LayerRasterCacheKey) -> bool {
+        self.admission.is_backed_off(key)
     }
 
     fn recycle(&mut self, entry: CachedLayerSurface) {
@@ -103,7 +202,8 @@ impl LayerSurfaceCache {
             self.entries.get(key)?
         };
         let (width, height) = key.pixel_size();
-        frame_stats.record_layer_cache_hit(width, height);
+        frame_stats.record_layer_cache_hit(key, width, height);
+        self.admission.note_hit(key);
         Some((cached.target.clone(), cached.logical_rect))
     }
 
@@ -116,6 +216,7 @@ impl LayerSurfaceCache {
     ) -> Rc<OffscreenTarget> {
         #[cfg(debug_assertions)]
         self.inserted_this_frame.insert(key);
+        self.admission.note_store(&key);
 
         if key.is_scene_range() {
             return self.insert_scene_range(key, target, logical_rect, frame_stats);
@@ -198,6 +299,7 @@ impl LayerSurfaceCache {
 
         #[cfg(debug_assertions)]
         self.inserted_this_frame.clear();
+        self.admission.finish_frame();
 
         self.identity.retain(|_, key| self.entries.contains(key));
         frame_stats
@@ -292,6 +394,133 @@ impl LayerSurfaceCache {
 impl Default for LayerSurfaceCache {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod admission_ledger_tests {
+    use cranpose_render_common::raster_cache::{LayerRasterCacheKey, ScaleBucket};
+    use cranpose_ui_graphics::Rect;
+
+    use super::{
+        ADMISSION_BACKOFF_BASE_FRAMES, ADMISSION_BACKOFF_MAX_FRAMES, AdmissionLedger,
+        UNREWARDED_STORES_BEFORE_BACKOFF,
+    };
+
+    fn prefix_key(content_hash: u64) -> LayerRasterCacheKey {
+        LayerRasterCacheKey::prefix_snapshot(
+            content_hash,
+            4,
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 10.0,
+                height: 10.0,
+            },
+            (10, 10),
+            ScaleBucket::from_scale(1.0),
+        )
+    }
+
+    fn card_key(node: usize, content_hash: u64) -> LayerRasterCacheKey {
+        LayerRasterCacheKey::source_content(
+            Some(node),
+            content_hash,
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 10.0,
+                height: 10.0,
+            },
+            (10, 10),
+            ScaleBucket::from_scale(1.0),
+        )
+    }
+
+    #[test]
+    fn stores_that_are_never_served_back_off_after_the_streak() {
+        let mut ledger = AdmissionLedger::default();
+        for frame in 0..UNREWARDED_STORES_BEFORE_BACKOFF as u64 {
+            assert!(!ledger.is_backed_off(&prefix_key(frame)));
+            ledger.note_store(&prefix_key(frame));
+            ledger.finish_frame();
+        }
+        assert!(ledger.is_backed_off(&prefix_key(99)));
+        for _ in 0..ADMISSION_BACKOFF_BASE_FRAMES {
+            assert!(ledger.is_backed_off(&prefix_key(99)));
+            ledger.finish_frame();
+        }
+        assert!(!ledger.is_backed_off(&prefix_key(99)));
+    }
+
+    #[test]
+    fn a_served_store_keeps_admission_open() {
+        let mut ledger = AdmissionLedger::default();
+        for frame in 0..8u64 {
+            ledger.note_store(&prefix_key(frame));
+            ledger.note_hit(&prefix_key(frame));
+            ledger.finish_frame();
+            assert!(!ledger.is_backed_off(&prefix_key(frame + 1)));
+        }
+    }
+
+    #[test]
+    fn the_window_doubles_per_unrewarded_store_and_caps() {
+        let mut ledger = AdmissionLedger::default();
+        let mut windows = Vec::new();
+        for round in 0..6u64 {
+            let store_frames = if round == 0 {
+                UNREWARDED_STORES_BEFORE_BACKOFF as u64
+            } else {
+                1
+            };
+            for _ in 0..store_frames {
+                ledger.note_store(&prefix_key(round));
+                ledger.finish_frame();
+            }
+            let mut window = 0u64;
+            while ledger.is_backed_off(&prefix_key(round)) {
+                ledger.finish_frame();
+                window += 1;
+            }
+            windows.push(window);
+        }
+        assert_eq!(windows[0], ADMISSION_BACKOFF_BASE_FRAMES);
+        assert_eq!(windows[1], ADMISSION_BACKOFF_BASE_FRAMES * 2);
+        assert_eq!(windows[2], ADMISSION_BACKOFF_BASE_FRAMES * 4);
+        assert_eq!(*windows.last().unwrap(), ADMISSION_BACKOFF_MAX_FRAMES);
+    }
+
+    #[test]
+    fn a_hit_clears_the_backoff_and_the_streak() {
+        let mut ledger = AdmissionLedger::default();
+        for frame in 0..UNREWARDED_STORES_BEFORE_BACKOFF as u64 {
+            ledger.note_store(&prefix_key(frame));
+            ledger.finish_frame();
+        }
+        assert!(ledger.is_backed_off(&prefix_key(7)));
+        ledger.note_hit(&prefix_key(7));
+        ledger.finish_frame();
+        assert!(!ledger.is_backed_off(&prefix_key(7)));
+        ledger.note_store(&prefix_key(8));
+        ledger.finish_frame();
+        assert!(
+            !ledger.is_backed_off(&prefix_key(8)),
+            "one unrewarded store after a hit must not reopen the backoff"
+        );
+    }
+
+    #[test]
+    fn scopes_are_independent_per_node_identity() {
+        let mut ledger = AdmissionLedger::default();
+        for frame in 0..UNREWARDED_STORES_BEFORE_BACKOFF as u64 {
+            ledger.note_store(&card_key(1, frame));
+            ledger.note_store(&card_key(2, frame));
+            ledger.note_hit(&card_key(2, frame));
+            ledger.finish_frame();
+        }
+        assert!(ledger.is_backed_off(&card_key(1, 50)));
+        assert!(!ledger.is_backed_off(&card_key(2, 50)));
     }
 }
 

--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -7,6 +7,7 @@
 mod cost_tuner;
 pub(crate) use cranpose_render_common::debug_toggles;
 pub use debug_toggles::{debug_toggle, debug_toggle_os, set_debug_toggle, set_debug_toggle_os};
+pub use render::presentable_root_usages;
 mod display_clip;
 mod effect_renderer;
 mod fast_cores;
@@ -617,24 +618,30 @@ impl WgpuRenderer {
     /// into the frontend afterwards.
     pub fn render(
         &mut self,
+        texture: &wgpu::Texture,
         view: &wgpu::TextureView,
         width: u32,
         height: u32,
     ) -> Result<(), WgpuRendererError> {
-        self.render_frame(view, width, height)
+        self.render_frame(texture, view, width, height)
     }
 
+    /// Renders the frame into a presentable image. When the image carries the
+    /// composition format and the capture usages, the scene renders into it
+    /// directly and no output conversion pass runs.
     pub fn render_surface_texture(
         &mut self,
+        texture: &wgpu::Texture,
         view: &wgpu::TextureView,
         width: u32,
         height: u32,
     ) -> Result<(), WgpuRendererError> {
-        self.render_frame(view, width, height)
+        self.render_frame(texture, view, width, height)
     }
 
     fn render_frame(
         &mut self,
+        texture: &wgpu::Texture,
         view: &wgpu::TextureView,
         width: u32,
         height: u32,
@@ -658,6 +665,7 @@ impl WgpuRenderer {
         let frontend = &mut self.frontend;
         let mut returns = RenderReturns::default();
         let result = gpu_renderer.render(
+            texture,
             view,
             width,
             height,
@@ -1074,6 +1082,11 @@ impl WgpuRenderer {
     }
 
     #[doc(hidden)]
+    pub fn try_queue_for_tests(&self) -> Option<&wgpu::Queue> {
+        self.sync_gpu_renderer().map(|r| &*r.queue)
+    }
+
+    #[doc(hidden)]
     pub fn device_error_count_for_tests(&self) -> u64 {
         self.sync_gpu_renderer()
             .map(GpuRenderer::device_error_count)
@@ -1180,6 +1193,7 @@ impl WgpuRenderer {
     #[doc(hidden)]
     pub fn render_held_packet_for_tests(
         &mut self,
+        texture: &wgpu::Texture,
         view: &wgpu::TextureView,
         width: u32,
         height: u32,
@@ -1194,6 +1208,7 @@ impl WgpuRenderer {
         let frontend = &mut self.frontend;
         let mut returns = RenderReturns::default();
         let result = gpu_renderer.render(
+            texture,
             view,
             width,
             height,

--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -1002,6 +1002,16 @@ impl WgpuRenderer {
         }
     }
 
+    /// Enables or disables replaying the pending composites that overlap a
+    /// baked underlay copy into that copy, instead of flushing them to the
+    /// parent target before the copy (see `CRANPOSE_DISABLE_UNDERLAY_REPLAY`).
+    /// Parity tests render the same scene both ways; both ways are exact.
+    pub fn set_underlay_replay_enabled(&mut self, enabled: bool) {
+        if let Some(renderer) = self.sync_gpu_renderer_mut() {
+            renderer.set_underlay_replay_enabled(enabled);
+        }
+    }
+
     pub fn last_frame_stats(&self) -> Option<RenderStatsSnapshot> {
         match &self.backend {
             PresentBackend::Sync(gpu_renderer) => gpu_renderer.last_frame_stats(),

--- a/crates/cranpose-render/wgpu/src/normalized_scene.rs
+++ b/crates/cranpose-render/wgpu/src/normalized_scene.rs
@@ -1535,7 +1535,7 @@ fn reach(rect: Rect, distance: f32) -> Rect {
     }
 }
 
-fn shadow_draw_is_blurred_drop(shadow: &ShadowDraw) -> bool {
+pub(crate) fn shadow_draw_is_blurred_drop(shadow: &ShadowDraw) -> bool {
     shadow.blur_radius > 0.0
         && shadow.texts.is_empty()
         && !shadow.shapes.is_empty()

--- a/crates/cranpose-render/wgpu/src/normalized_scene.rs
+++ b/crates/cranpose-render/wgpu/src/normalized_scene.rs
@@ -1608,11 +1608,7 @@ fn content_survives_rect_clip(
             .filter(|shadow| !shadow_draw_is_blurred_drop(shadow))
             .filter_map(|shadow| shadow_draws_bounds_with_clip(std::slice::from_ref(shadow), false))
             .all(|bounds| corners.admits(reach(bounds, DIRECT_DRAW_COVERAGE_REACH)));
-        let capture_admitted = child.backdrop.as_ref().is_none_or(|backdrop| {
-            let capture = reach(dest, backdrop.input_padding());
-            rect_contains(layer.local_bounds, capture) && corners.admits(capture)
-        });
-        composite_admitted && shadows_admitted && capture_admitted
+        composite_admitted && shadows_admitted
     })
 }
 

--- a/crates/cranpose-render/wgpu/src/normalized_scene.rs
+++ b/crates/cranpose-render/wgpu/src/normalized_scene.rs
@@ -83,6 +83,21 @@ pub(crate) struct LoweredChildSource {
     pub(crate) children: Vec<ChildLayerComposite>,
 }
 
+impl LoweredChildSource {
+    pub(crate) fn is_empty(&self) -> bool {
+        let scene = &self.scene;
+        self.children.is_empty()
+            && scene.draw_ops.is_empty()
+            && scene.shapes.is_empty()
+            && scene.images.is_empty()
+            && scene.texts.is_empty()
+            && scene.shadow_draws.is_empty()
+            && scene.retained_draws.is_empty()
+            && scene.effect_layers.is_empty()
+            && scene.backdrop_layers.is_empty()
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct ResolvedChildSurfaceComposite {
     pub(crate) logical_rect: Rect,
@@ -236,7 +251,7 @@ fn shadow_draws_bounds_with_clip(shadow_draws: &[ShadowDraw], apply_clip: bool) 
     bounds
 }
 
-fn shadow_draws_bounds(shadow_draws: &[ShadowDraw]) -> Option<Rect> {
+pub(crate) fn shadow_draws_bounds(shadow_draws: &[ShadowDraw]) -> Option<Rect> {
     shadow_draws_bounds_with_clip(shadow_draws, true)
 }
 
@@ -1444,6 +1459,284 @@ pub(crate) fn derived_child_surface_context(
 }
 
 #[allow(clippy::too_many_arguments)]
+fn backdrop_flatten_enabled() -> bool {
+    crate::debug_toggles::debug_toggle("CRANPOSE_NO_BACKDROP_FLATTEN").as_deref() != Some("1")
+}
+
+/// How far a direct draw's anti-aliasing can reach beyond its rectangle.
+const DIRECT_DRAW_COVERAGE_REACH: f32 = 1.0;
+
+/// The corner squares of a rounded clip: the only places where clipping to
+/// the rounded shape differs from clipping to its rectangle. Content that
+/// never enters them, or enters them only inside the corner circles, draws
+/// the same pixels under either clip.
+struct RoundedClipCorners {
+    rect: Rect,
+    radii: [f32; 4],
+}
+
+impl RoundedClipCorners {
+    fn of(layer: &LayerNode) -> Self {
+        let rect = layer.local_bounds;
+        let radii = LayerSurfaceRoundedClip::from_layer(layer)
+            .map(|clip| clip.radii)
+            .unwrap_or([0.0; 4]);
+        Self { rect, radii }
+    }
+
+    /// Whether the part of `region` that falls into a corner square lies
+    /// inside that corner's circle. The intersection is convex, so its four
+    /// corners decide.
+    fn admits(&self, region: Rect) -> bool {
+        let right = self.rect.x + self.rect.width;
+        let bottom = self.rect.y + self.rect.height;
+        let corners = [
+            (self.radii[0], self.rect.x, self.rect.y, 1.0, 1.0),
+            (self.radii[1], right, self.rect.y, -1.0, 1.0),
+            (self.radii[2], self.rect.x, bottom, 1.0, -1.0),
+            (self.radii[3], right, bottom, -1.0, -1.0),
+        ];
+        corners.iter().all(|&(radius, cx, cy, sx, sy)| {
+            if radius <= 0.0 {
+                return true;
+            }
+            let square = Rect {
+                x: cx.min(cx + sx * radius),
+                y: cy.min(cy + sy * radius),
+                width: radius,
+                height: radius,
+            };
+            let Some(inside) = region.intersect(square) else {
+                return true;
+            };
+            let center = (cx + sx * radius, cy + sy * radius);
+            [
+                (inside.x, inside.y),
+                (inside.x + inside.width, inside.y),
+                (inside.x, inside.y + inside.height),
+                (inside.x + inside.width, inside.y + inside.height),
+            ]
+            .iter()
+            .all(|&(px, py)| (px - center.0).hypot(py - center.1) <= radius)
+        })
+    }
+
+    fn admits_all(&self, regions: impl IntoIterator<Item = Rect>) -> bool {
+        regions.into_iter().all(|region| self.admits(region))
+    }
+}
+
+fn reach(rect: Rect, distance: f32) -> Rect {
+    Rect {
+        x: rect.x - distance,
+        y: rect.y - distance,
+        width: rect.width + 2.0 * distance,
+        height: rect.height + 2.0 * distance,
+    }
+}
+
+fn shadow_draw_is_blurred_drop(shadow: &ShadowDraw) -> bool {
+    shadow.blur_radius > 0.0
+        && shadow.texts.is_empty()
+        && !shadow.shapes.is_empty()
+        && shadow
+            .shapes
+            .iter()
+            .all(|(_, mode)| *mode != cranpose_ui_graphics::BlendMode::DstOut)
+}
+
+/// The regions a scene draws with a rectangular clip only. Blurred drop
+/// shadows are left out: flattening masks them with the layer's rounded
+/// clip. Any other blurred shadow spans its shape plus the blur reach.
+fn rect_clipped_draw_regions(scene: &CompositorScene) -> impl Iterator<Item = Rect> + '_ {
+    let shapes = scene
+        .shapes
+        .iter()
+        .filter_map(|shape| visible_draw_rect(shape.rect, shape.clip));
+    let images = scene
+        .images
+        .iter()
+        .filter_map(|image| visible_draw_rect(image.rect, image.clip));
+    let texts = scene
+        .texts
+        .iter()
+        .filter_map(|text| visible_draw_rect(text.rect, text.clip));
+    let retained = scene.retained_draws.iter().map(|draw| draw.bounds);
+    let shadows = scene
+        .shadow_draws
+        .iter()
+        .filter(|shadow| !shadow_draw_is_blurred_drop(shadow))
+        .filter_map(|shadow| {
+            let bounds = shadow_draws_bounds_with_clip(std::slice::from_ref(shadow), false)?;
+            visible_draw_rect(bounds, shadow.clip)
+        });
+    shapes
+        .chain(images)
+        .chain(texts)
+        .chain(retained)
+        .chain(shadows)
+        .map(|rect| reach(rect, DIRECT_DRAW_COVERAGE_REACH))
+}
+
+/// Whether a backdrop layer's content draws the same pixels into its parent
+/// as into its own clipped surface: no rect-clipped draw and no nested
+/// capture region enters a corner square outside the corner circle, and every
+/// nested capture stays inside the layer, because outside it the surface held
+/// nothing while the parent holds the page.
+fn content_survives_rect_clip(
+    layer: &LayerNode,
+    source_scene: &CompositorScene,
+    source_children: &[ChildLayerComposite],
+) -> bool {
+    if !source_scene.effect_layers.is_empty() || !source_scene.backdrop_layers.is_empty() {
+        return false;
+    }
+    let corners = RoundedClipCorners::of(layer);
+    if !corners.admits_all(rect_clipped_draw_regions(source_scene)) {
+        return false;
+    }
+    source_children.iter().all(|child| {
+        let dest = quad_bounds(child.dest_quad);
+        let composite = child
+            .visual_clip
+            .map_or(Some(dest), |clip| dest.intersect(clip));
+        let composite_admitted =
+            composite.is_none_or(|rect| corners.admits(reach(rect, DIRECT_DRAW_COVERAGE_REACH)));
+        let shadows_admitted = child
+            .shadow_draws
+            .iter()
+            .filter(|shadow| !shadow_draw_is_blurred_drop(shadow))
+            .filter_map(|shadow| shadow_draws_bounds_with_clip(std::slice::from_ref(shadow), false))
+            .all(|bounds| corners.admits(reach(bounds, DIRECT_DRAW_COVERAGE_REACH)));
+        let capture_admitted = child.backdrop.as_ref().is_none_or(|backdrop| {
+            let capture = reach(dest, backdrop.input_padding());
+            rect_contains(layer.local_bounds, capture) && corners.admits(capture)
+        });
+        composite_admitted && shadows_admitted && capture_admitted
+    })
+}
+
+/// Whether a backdrop child draws its content straight into the parent, and
+/// at which translation: only when the backdrop is its sole reason to
+/// isolate and its content survives the parent's rectangular clip.
+fn flatten_translation(
+    layer: &LayerNode,
+    requirements: &LayerSurfaceRequirements,
+    source_scene: CompositorScene,
+    source_children: Vec<ChildLayerComposite>,
+) -> (Option<Point>, CompositorScene, Vec<ChildLayerComposite>) {
+    let translation = requirements.direct_translation.filter(|_| {
+        backdrop_flatten_enabled()
+            && requirements
+                .surface_requirements
+                .isolates_only_for_backdrop()
+            && content_survives_rect_clip(layer, &source_scene, &source_children)
+    });
+    if translation.is_some() {
+        (translation, CompositorScene::new(), Vec::new())
+    } else {
+        (translation, source_scene, source_children)
+    }
+}
+
+struct FlattenedChildPlacement {
+    parent_offset: Point,
+    visual_clip: Option<Rect>,
+    inherited_snap_anchor: Option<SnapAnchor>,
+    snap_content: bool,
+    translation_context: TranslationRenderContext,
+    surface_ctx: TranslationRenderContext,
+}
+
+/// Lowers a flattened backdrop child's content into the parent scene at its
+/// placement, the way a direct child is lowered, and masks the blurred drop
+/// shadows it brought along with the child's rounded clip.
+fn descendant_backdrop_unless_flattened(flattened: Option<Point>, layer: &LayerNode) -> bool {
+    flattened.is_none() && layer_contains_descendant_backdrop(layer)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn flatten_child_into_parent(
+    layer: &LayerNode,
+    text_layout: &mut impl TextLayoutResolver,
+    translation: Option<Point>,
+    placement: FlattenedChildPlacement,
+    local_scene: &mut CompositorScene,
+    child_layers: &mut Vec<ChildLayerComposite>,
+    layer_surface_rect_cache: &mut HashMap<usize, Rect>,
+    layer_surface_requirements_cache: &mut HashMap<usize, LayerSurfaceRequirements>,
+) {
+    let Some(translation) = translation else {
+        return;
+    };
+    let offset = Point::new(
+        placement.parent_offset.x + translation.x,
+        placement.parent_offset.y + translation.y,
+    );
+    let (first_shadow, first_child) = (local_scene.shadow_draws.len(), child_layers.len());
+    let snap_anchor = placement.inherited_snap_anchor.or_else(|| {
+        placement
+            .snap_content
+            .then(|| {
+                rigid_snap_anchor(
+                    layer.local_bounds.translate(offset.x, offset.y),
+                    &local_content_layer_for(&layer.graphics_layer),
+                )
+            })
+            .flatten()
+    });
+    collect_layer_contents_into(
+        layer,
+        text_layout,
+        placement.visual_clip,
+        offset,
+        snap_anchor,
+        placement.translation_context,
+        placement.surface_ctx,
+        local_scene,
+        child_layers,
+        layer_surface_rect_cache,
+        layer_surface_requirements_cache,
+    );
+    mask_flattened_shadows(
+        local_scene,
+        child_layers,
+        first_shadow,
+        first_child,
+        LayerSurfaceRoundedClip::from_layer(layer).map(|clip| LayerSurfaceRoundedClip {
+            rect: clip.rect.translate(offset.x, offset.y),
+            radii: clip.radii,
+        }),
+    );
+}
+
+/// Masks every blurred drop shadow the flattened content lowered into the
+/// parent with the layer's rounded clip, which its surface would have applied
+/// at composite time.
+fn mask_flattened_shadows(
+    scene: &mut CompositorScene,
+    children: &mut [ChildLayerComposite],
+    first_shadow: usize,
+    first_child: usize,
+    rounded_clip: Option<LayerSurfaceRoundedClip>,
+) {
+    let Some(rounded_clip) = rounded_clip else {
+        return;
+    };
+    for shadow in scene.shadow_draws[first_shadow..]
+        .iter_mut()
+        .chain(
+            children[first_child..]
+                .iter_mut()
+                .flat_map(|child| child.shadow_draws.iter_mut()),
+        )
+        .filter(|shadow| shadow_draw_is_blurred_drop(shadow))
+    {
+        shadow.rounded_clip = Some(rounded_clip);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn collect_layer_contents_into(
     layer: &LayerNode,
     text_layout: &mut impl TextLayoutResolver,
@@ -1775,8 +2068,16 @@ fn collect_layer_contents_into(
                         child_layer.transform_to_parent,
                     );
                 }
-                let child_contains_descendant_backdrop =
-                    layer_contains_descendant_backdrop(child_layer.as_ref());
+                let (flatten_around_backdrop, source_scene, source_children) = flatten_translation(
+                    child_layer.as_ref(),
+                    &child_requirements,
+                    source_scene,
+                    source_children,
+                );
+                let child_contains_descendant_backdrop = descendant_backdrop_unless_flattened(
+                    flatten_around_backdrop,
+                    child_layer.as_ref(),
+                );
                 let child_needs_nested_underlay = child_contains_descendant_backdrop
                     && layer_source_uses_external_backdrop_underlay(
                         &source_scene,
@@ -1828,6 +2129,23 @@ fn collect_layer_contents_into(
                     },
                 });
                 local_scene.next_z += 1;
+                flatten_child_into_parent(
+                    child_layer.as_ref(),
+                    text_layout,
+                    flatten_around_backdrop,
+                    FlattenedChildPlacement {
+                        parent_offset: layer_offset,
+                        visual_clip,
+                        inherited_snap_anchor: translated_snap_anchor,
+                        snap_content: effective_translated_content_context,
+                        translation_context: child_translation_context,
+                        surface_ctx: child_surface_ctx,
+                    },
+                    local_scene,
+                    child_layers,
+                    layer_surface_rect_cache,
+                    layer_surface_requirements_cache,
+                );
                 if translated_local_picture_state.is_some() {
                     translated_local_picture_state = Some(TranslatedLocalPictureState {
                         counts: scene_emission_counts(local_scene),

--- a/crates/cranpose-render/wgpu/src/offscreen.rs
+++ b/crates/cranpose-render/wgpu/src/offscreen.rs
@@ -128,6 +128,22 @@ impl OffscreenTarget {
     pub(crate) fn texture(&self) -> &wgpu::Texture {
         &self.texture
     }
+
+    /// Wraps a swapchain image as the frame's root target so the scene
+    /// renders into it directly, with no composition copy behind it.
+    pub(crate) fn from_surface(texture: wgpu::Texture, view: wgpu::TextureView) -> Self {
+        let width = texture.width();
+        let height = texture.height();
+        let format = texture.format().remove_srgb_suffix();
+        Self {
+            texture,
+            view,
+            width,
+            height,
+            bytes_per_pixel: crate::frame_graph::texture_format_bytes_per_pixel(format),
+            cached_bind_group: OnceCell::new(),
+        }
+    }
 }
 
 pub(crate) fn composition_bytes_per_pixel() -> u64 {

--- a/crates/cranpose-render/wgpu/src/pass_timing.rs
+++ b/crates/cranpose-render/wgpu/src/pass_timing.rs
@@ -315,7 +315,7 @@ pub(crate) fn begin_timed_render_pass<'encoder>(
     encoder: &'encoder mut wgpu::CommandEncoder,
     descriptor: &wgpu::RenderPassDescriptor<'_>,
 ) -> wgpu::RenderPass<'encoder> {
-    crate::frame_graph::note_render_pass(descriptor.label);
+    crate::frame_graph::note_render_pass(descriptor);
     let timing = pass_timer.and_then(|timer| {
         timer
             .begin_pass(descriptor.label.unwrap_or("<unlabeled pass>"))

--- a/crates/cranpose-render/wgpu/src/pipeline.rs
+++ b/crates/cranpose-render/wgpu/src/pipeline.rs
@@ -165,6 +165,7 @@ pub(crate) fn push_layer_shadow(
             texts: vec![],
             blur_radius: ambient_pass.blur_radius,
             clip,
+            rounded_clip: None,
             occluder,
             z_index: 0,
         });
@@ -184,6 +185,7 @@ pub(crate) fn push_layer_shadow(
             texts: vec![],
             blur_radius: spot_pass.blur_radius,
             clip,
+            rounded_clip: None,
             occluder,
             z_index: 0,
         });
@@ -816,6 +818,7 @@ impl TextStyleDrawSink for CompositorScene {
             }],
             blur_radius,
             clip,
+            rounded_clip: None,
             occluder: None,
             z_index: 0,
         });
@@ -2154,6 +2157,7 @@ fn push_shadow_primitive(
                 texts: vec![],
                 blur_radius,
                 clip,
+                rounded_clip: None,
                 occluder: None,
                 z_index: 0,
             });
@@ -2196,6 +2200,7 @@ fn push_shadow_primitive(
                 clip: clip.map_or(Some(transformed_clip), |parent_clip| {
                     parent_clip.intersect(transformed_clip)
                 }),
+                rounded_clip: None,
                 occluder: None,
                 z_index: 0,
             });

--- a/crates/cranpose-render/wgpu/src/pipeline.rs
+++ b/crates/cranpose-render/wgpu/src/pipeline.rs
@@ -2450,6 +2450,7 @@ mod tests {
     fn collect_hits_from_graph_only_populates_hit_regions() {
         let layer = cranpose_render_common::graph::LayerNode {
             node_id: Some(7),
+            wraps: None,
             local_bounds: Rect {
                 x: 0.0,
                 y: 0.0,

--- a/crates/cranpose-render/wgpu/src/present_runtime.rs
+++ b/crates/cranpose-render/wgpu/src/present_runtime.rs
@@ -364,6 +364,7 @@ impl PresentState {
         });
         let mut returns = RenderReturns::default();
         let result = self.gpu_renderer.render(
+            &frame.texture,
             &view,
             width,
             height,
@@ -491,6 +492,7 @@ impl PresentState {
         let after_acquire_ns = self.now();
         let mut returns = RenderReturns::default();
         let result = self.gpu_renderer.render(
+            &texture,
             &view,
             width,
             height,

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -4938,6 +4938,77 @@ struct CompositionTarget {
     output_bind_group: wgpu::BindGroup,
 }
 
+/// Where a frame renders: straight into the presentable image, or into the
+/// reusable composition target that the output conversion then copies out.
+enum FrameRoot {
+    Surface(OffscreenTarget),
+    Composition(CompositionTarget),
+}
+
+impl FrameRoot {
+    fn target(&self) -> &OffscreenTarget {
+        match self {
+            Self::Surface(target) => target,
+            Self::Composition(composition) => &composition.target,
+        }
+    }
+
+    /// The output conversion's destination and source bind group; nothing
+    /// when the frame already rendered into the presentable image.
+    fn output<'a>(
+        &'a self,
+        output_view: Option<&'a wgpu::TextureView>,
+        screenshot_bind_group: Option<&'a wgpu::BindGroup>,
+    ) -> Option<(&'a wgpu::TextureView, &'a wgpu::BindGroup)> {
+        match self {
+            Self::Surface(_) => None,
+            Self::Composition(composition) => output_view.map(|view| {
+                (
+                    view,
+                    screenshot_bind_group.unwrap_or(&composition.output_bind_group),
+                )
+            }),
+        }
+    }
+}
+
+const DIRECT_SURFACE_ROOT_USAGES: wgpu::TextureUsages = wgpu::TextureUsages::RENDER_ATTACHMENT
+    .union(wgpu::TextureUsages::TEXTURE_BINDING)
+    .union(wgpu::TextureUsages::COPY_SRC)
+    .union(wgpu::TextureUsages::COPY_DST);
+
+/// The usages a presentable image needs to serve as the frame's root
+/// target: rendering plus the capture usages the composition target has.
+/// Callers configuring a surface ask for them when the surface offers them
+/// all; a partial set falls back to the composition copy, so nothing is
+/// requested in that case beyond rendering.
+pub fn presentable_root_usages(supported: wgpu::TextureUsages) -> wgpu::TextureUsages {
+    if supported.contains(DIRECT_SURFACE_ROOT_USAGES) {
+        DIRECT_SURFACE_ROOT_USAGES
+    } else {
+        wgpu::TextureUsages::RENDER_ATTACHMENT
+    }
+}
+
+fn direct_surface_root_enabled() -> bool {
+    crate::debug_toggles::debug_toggle("CRANPOSE_NO_DIRECT_SURFACE").as_deref() != Some("1")
+}
+
+/// Whether the presented image can be the frame's root target: its bytes
+/// are the composition format (so the 8-bit output conversion would be an
+/// identity), it can be captured and sampled the way the composition target
+/// is, and it is the viewport's size.
+fn surface_is_direct_root(
+    texture: &wgpu::Texture,
+    composition_format: wgpu::TextureFormat,
+    viewport: (u32, u32),
+) -> bool {
+    direct_surface_root_enabled()
+        && texture.format().remove_srgb_suffix() == composition_format
+        && texture.usage().contains(DIRECT_SURFACE_ROOT_USAGES)
+        && (texture.width(), texture.height()) == viewport
+}
+
 #[derive(Clone, Copy)]
 enum OutputMode {
     Display,
@@ -6329,6 +6400,25 @@ impl GpuRenderer {
 
     fn acquire_retained_surface(&mut self, width: u32, height: u32) -> OffscreenTarget {
         self.acquire_offscreen(width, height)
+    }
+
+    fn frame_root(
+        &mut self,
+        output_mode: OutputMode,
+        output_view: Option<&wgpu::TextureView>,
+        output_texture: Option<&wgpu::Texture>,
+        viewport: (u32, u32),
+    ) -> FrameRoot {
+        if let (OutputMode::Display, Some(view), Some(texture)) =
+            (output_mode, output_view, output_texture)
+            && surface_is_direct_root(texture, self.composition_format, viewport)
+        {
+            return FrameRoot::Surface(OffscreenTarget::from_surface(
+                texture.clone(),
+                view.clone(),
+            ));
+        }
+        FrameRoot::Composition(self.take_composition_target(viewport.0.max(1), viewport.1.max(1)))
     }
 
     fn take_composition_target(&mut self, width: u32, height: u32) -> CompositionTarget {
@@ -8092,6 +8182,7 @@ impl GpuRenderer {
     #[allow(clippy::too_many_arguments)]
     pub fn render(
         &mut self,
+        texture: &wgpu::Texture,
         view: &wgpu::TextureView,
         width: u32,
         height: u32,
@@ -8107,6 +8198,7 @@ impl GpuRenderer {
             returns,
             OutputMode::Display,
             Some(view),
+            Some(texture),
         )
     }
 
@@ -8120,6 +8212,7 @@ impl GpuRenderer {
         returns: &mut RenderReturns,
         output_mode: OutputMode,
         output_view: Option<&wgpu::TextureView>,
+        output_texture: Option<&wgpu::Texture>,
     ) -> Result<(), String> {
         if let Some(confirmations) = packet.recycled_confirmations.take() {
             self.restore_replay_ack_confirmations(confirmations);
@@ -8164,33 +8257,24 @@ impl GpuRenderer {
         }
 
         let text_cache_len = packet.text_cache_len;
-        let composition = self.take_composition_target(width.max(1), height.max(1));
+        let frame_root = self.frame_root(output_mode, output_view, output_texture, (width, height));
+        let root = frame_root.target();
         #[cfg(not(target_arch = "wasm32"))]
         {
-            self.display_clip.frame_root_view = Some(composition.target.view.clone());
+            self.display_clip.frame_root_view = Some(root.view.clone());
         }
-        let composition_root = Some(&composition.target);
         let screenshot_bind_group = output_view.and_then(|_| {
             matches!(output_mode, OutputMode::Screenshot).then(|| {
                 self.screenshot_converter
-                    .bind_group(&self.device, &composition.target.view)
+                    .bind_group(&self.device, &root.view)
             })
         });
-        let output = output_view.map(|view| {
-            let bind_group = screenshot_bind_group
-                .as_ref()
-                .unwrap_or(&composition.output_bind_group);
-            (view, bind_group)
-        });
-        let result = self.render_graph(
-            &composition.target.view,
-            composition_root,
-            packet,
-            returns,
-            output_mode,
-            output,
-        );
-        self.composition_target = Some(composition);
+        let output = frame_root.output(output_view, screenshot_bind_group.as_ref());
+        let result =
+            self.render_graph(&root.view, Some(root), packet, returns, output_mode, output);
+        if let FrameRoot::Composition(composition) = frame_root {
+            self.composition_target = Some(composition);
+        }
         #[cfg(not(target_arch = "wasm32"))]
         {
             self.display_clip.frame_root_view = None;
@@ -8428,6 +8512,7 @@ impl GpuRenderer {
             returns,
             OutputMode::Screenshot,
             Some(&output_view),
+            None,
         )?;
 
         let bytes_per_pixel = 4u32;
@@ -22131,6 +22216,23 @@ mod tests {
         assert!(
             !appendix.contains("output.gradient_params") && !appendix.contains("output.brush"),
             "the trimmed vertex entries must not write the dropped varyings"
+        );
+    }
+
+    #[test]
+    fn presentable_root_usages_are_all_or_nothing() {
+        let full = wgpu::TextureUsages::RENDER_ATTACHMENT
+            | wgpu::TextureUsages::TEXTURE_BINDING
+            | wgpu::TextureUsages::COPY_SRC
+            | wgpu::TextureUsages::COPY_DST
+            | wgpu::TextureUsages::STORAGE_BINDING;
+        assert_eq!(presentable_root_usages(full), DIRECT_SURFACE_ROOT_USAGES);
+        assert_eq!(
+            presentable_root_usages(
+                wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC
+            ),
+            wgpu::TextureUsages::RENDER_ATTACHMENT,
+            "a surface that cannot be sampled keeps the composition copy and asks for nothing extra"
         );
     }
 

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -1500,20 +1500,36 @@ fn gradient_tile_mode_value(tile_mode: TileMode) -> u32 {
     }
 }
 
-fn shape_shader_base(solid_trim: bool) -> Cow<'static, str> {
-    if solid_trim {
-        return Cow::Owned(format!(
+const INLINE_GRADIENT_STOPS_DECLARATION: &str = "const INLINE_GRADIENT_STOPS: u32 = 4u;";
+const UNIFORM_GRADIENT_STOPS_DECLARATION: &str = "const INLINE_GRADIENT_STOPS: u32 = 0u;";
+
+fn uniform_gradient_stops_enabled() -> bool {
+    crate::debug_toggles::debug_toggle("CRANPOSE_UNIFORM_GRADIENT_STOPS").as_deref() == Some("1")
+}
+
+fn shape_shader_base(solid_trim: bool, uniform_gradient_stops: bool) -> Cow<'static, str> {
+    let base: Cow<'static, str> = if solid_trim {
+        Cow::Owned(format!(
             "{}\n{}",
             shaders::SHADER,
             shaders::SOLID_TRIM_APPENDIX
-        ));
+        ))
+    } else {
+        Cow::Borrowed(shaders::SHADER)
+    };
+    if !uniform_gradient_stops {
+        return base;
     }
-    Cow::Borrowed(shaders::SHADER)
+    debug_assert!(base.contains(INLINE_GRADIENT_STOPS_DECLARATION));
+    Cow::Owned(base.replace(
+        INLINE_GRADIENT_STOPS_DECLARATION,
+        UNIFORM_GRADIENT_STOPS_DECLARATION,
+    ))
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 fn shape_shader_source(batch_limits: ShapeBatchLimits, solid_trim: bool) -> Cow<'static, str> {
-    let base = shape_shader_base(solid_trim);
+    let base = shape_shader_base(solid_trim, uniform_gradient_stops_enabled());
     if batch_limits.storage {
         return Cow::Owned(
             base.replace(
@@ -1547,7 +1563,7 @@ fn shape_shader_source(batch_limits: ShapeBatchLimits, solid_trim: bool) -> Cow<
 
 #[cfg(target_arch = "wasm32")]
 fn shape_shader_source(_batch_limits: ShapeBatchLimits, solid_trim: bool) -> Cow<'static, str> {
-    shape_shader_base(solid_trim)
+    shape_shader_base(solid_trim, uniform_gradient_stops_enabled())
 }
 
 pub(crate) fn create_render_pipeline_logged<'a>(
@@ -5324,7 +5340,7 @@ impl GpuRenderer {
             },
             wgpu::BindGroupLayoutEntry {
                 binding: 1,
-                visibility: wgpu::ShaderStages::FRAGMENT,
+                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
                 ty: wgpu::BindingType::Buffer {
                     ty: shape_batch_limits.data_binding_type(),
                     has_dynamic_offset: false,
@@ -22100,10 +22116,49 @@ mod tests {
             "location 9 is brush's slot and must stay VACANT — dense \
              renumbering is the reverted attempt's suspect #1"
         );
+        for location in 10..=14 {
+            let line = format!("@location({location})");
+            assert!(
+                shaders::SHADER.contains(&line),
+                "`{line}` carries an inline gradient stop varying in VertexOutput"
+            );
+            assert!(
+                !appendix.contains(&line),
+                "`{line}` is an inline gradient stop's slot and must stay VACANT \
+                 in the trimmed struct"
+            );
+        }
         assert!(
             !appendix.contains("output.gradient_params") && !appendix.contains("output.brush"),
             "the trimmed vertex entries must not write the dropped varyings"
         );
+    }
+
+    #[test]
+    fn uniform_gradient_stops_toggle_rewrites_the_inline_stop_budget_to_zero() {
+        for solid_trim in [false, true] {
+            let inline = shape_shader_base(solid_trim, false);
+            assert_eq!(
+                inline.matches(INLINE_GRADIENT_STOPS_DECLARATION).count(),
+                1,
+                "the inline stop budget must be declared exactly once"
+            );
+            let uniform = shape_shader_base(solid_trim, true);
+            assert!(
+                !uniform.contains(INLINE_GRADIENT_STOPS_DECLARATION)
+                    && uniform.contains(UNIFORM_GRADIENT_STOPS_DECLARATION),
+                "solid_trim={solid_trim}: the toggle must route every gradient through \
+                 the uniform stop walk"
+            );
+            let module = naga::front::wgsl::parse_str(&uniform)
+                .expect("uniform-stop shape shader must parse as WGSL");
+            naga::valid::Validator::new(
+                naga::valid::ValidationFlags::all(),
+                naga::valid::Capabilities::all(),
+            )
+            .validate(&module)
+            .expect("uniform-stop shape shader must validate for WebGPU");
+        }
     }
 
     #[test]

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -6579,11 +6579,7 @@ impl GpuRenderer {
                 shadow.occluder,
             );
         }
-        let rounded_mask = inner_shadow_composite_mask(shadow, root_scale).map(|mut mask| {
-            mask.rect[0] -= viewport_offset[0];
-            mask.rect[1] -= viewport_offset[1];
-            mask
-        });
+        let rounded_mask = shadow_composite_mask(shadow, root_scale, viewport_offset);
         let dest_viewport = Some((
             viewport_offset[0],
             viewport_offset[1],
@@ -11009,11 +11005,7 @@ impl GpuRenderer {
             .clip
             .and_then(|clip| scissor_rect_for_rect(clip, root_scale, width, height));
         let scissor = clip_scissor.or(processing_scissor);
-        let rounded_mask = inner_shadow_composite_mask(shadow, root_scale).map(|mut mask| {
-            mask.rect[0] -= viewport_offset[0];
-            mask.rect[1] -= viewport_offset[1];
-            mask
-        });
+        let rounded_mask = shadow_composite_mask(shadow, root_scale, viewport_offset);
         let dest_viewport = Some((
             viewport_offset[0],
             viewport_offset[1],
@@ -11222,12 +11214,7 @@ impl GpuRenderer {
                     scissor,
                     (width, height),
                 );
-                let rounded_mask =
-                    inner_shadow_composite_mask(shadow, root_scale).map(|mut mask| {
-                        mask.rect[0] -= viewport_offset[0];
-                        mask.rect[1] -= viewport_offset[1];
-                        mask
-                    });
+                let rounded_mask = shadow_composite_mask(shadow, root_scale, viewport_offset);
                 let dest_viewport = Some((
                     viewport_offset[0],
                     viewport_offset[1],
@@ -11341,11 +11328,7 @@ impl GpuRenderer {
             .clip
             .and_then(|clip| scissor_rect_for_rect(clip, root_scale, width, height));
         let scissor = clip_scissor.or(processing_scissor);
-        let rounded_mask = inner_shadow_composite_mask(shadow, root_scale).map(|mut mask| {
-            mask.rect[0] -= viewport_offset[0];
-            mask.rect[1] -= viewport_offset[1];
-            mask
-        });
+        let rounded_mask = shadow_composite_mask(shadow, root_scale, viewport_offset);
         let dest_viewport = (
             viewport_offset[0],
             viewport_offset[1],
@@ -15760,6 +15743,30 @@ fn scissor_rect_for_image(
     scissor_rect_for_layer(image.rect, image.clip, root_scale, width, height)
 }
 
+/// The rounded mask a shadow's composite applies, in the target's pixels: an
+/// inner shadow masks itself to its fill shape, and a shadow lowered out of a
+/// clipped layer masks itself to that layer's rounded clip.
+fn shadow_composite_mask(
+    shadow: &ShadowDraw,
+    root_scale: f32,
+    viewport_offset: [f32; 2],
+) -> Option<RoundedCompositeMask> {
+    if let Some(mut mask) = inner_shadow_composite_mask(shadow, root_scale) {
+        mask.rect[0] -= viewport_offset[0];
+        mask.rect[1] -= viewport_offset[1];
+        return Some(mask);
+    }
+    shadow.rounded_clip.map(|clip| RoundedCompositeMask {
+        rect: [
+            clip.rect.x * root_scale,
+            clip.rect.y * root_scale,
+            clip.rect.width * root_scale,
+            clip.rect.height * root_scale,
+        ],
+        radii: clip.radii.map(|radius| radius * root_scale),
+    })
+}
+
 fn inner_shadow_composite_mask(
     shadow: &ShadowDraw,
     root_scale: f32,
@@ -17078,6 +17085,7 @@ mod tests {
             texts: vec![],
             blur_radius: 8.0,
             clip: None,
+            rounded_clip: None,
             occluder: None,
             z_index: 0,
         }
@@ -21067,6 +21075,7 @@ mod tests {
             texts: Vec::new(),
             blur_radius: 8.0,
             clip: None,
+            rounded_clip: None,
             occluder: None,
             z_index: 1,
         }];
@@ -21120,6 +21129,7 @@ mod tests {
             texts: Vec::new(),
             blur_radius: 8.0,
             clip: None,
+            rounded_clip: None,
             occluder: None,
             z_index: 1,
         }];

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -6378,6 +6378,11 @@ impl GpuRenderer {
         key: &LayerRasterCacheKey,
         admission: CacheAdmission,
     ) -> bool {
+        if admission == CacheAdmission::OnRepeat
+            && self.layer_surface_cache.repeat_admission_backed_off(key)
+        {
+            return false;
+        }
         let observed = if key.is_scene_range() {
             &mut self.observed_scene_range_cache_misses
         } else {

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -232,6 +232,10 @@ fn underlay_bake_switch() -> bool {
     crate::debug_toggles::debug_toggle("CRANPOSE_DISABLE_UNDERLAY_BAKE").is_none()
 }
 
+fn underlay_replay_switch() -> bool {
+    crate::debug_toggles::debug_toggle("CRANPOSE_DISABLE_UNDERLAY_REPLAY").is_none()
+}
+
 fn skip_shadow_draws() -> bool {
     crate::debug_toggles::debug_toggle("CRANPOSE_SKIP_SHADOWS")
         .map(|v| matches!(v.as_str(), "1" | "true" | "yes"))
@@ -5029,6 +5033,7 @@ pub struct GpuRenderer {
     observed_scene_range_cache_misses: BoundedLruCache<LayerRasterCacheKey, ()>,
     observed_surface_cache_misses: BoundedLruCache<LayerRasterCacheKey, ()>,
     underlay_bake_enabled: bool,
+    underlay_replay_enabled: bool,
     shadow_surface_cache: BoundedLruCache<ShadowSurfaceCacheKey, CachedShadowSurface>,
     shadow_surface_cache_bytes: u64,
     frame_stats: gpu_stats::FrameStats,
@@ -5715,6 +5720,7 @@ impl GpuRenderer {
                 MAX_OBSERVED_SCENE_RANGE_CACHE_MISSES,
             ),
             underlay_bake_enabled: underlay_bake_switch(),
+            underlay_replay_enabled: underlay_replay_switch(),
             shadow_surface_cache: BoundedLruCache::with_capacity_at_least_one(
                 MAX_SHADOW_SURFACE_CACHE_ITEMS,
             ),
@@ -7278,6 +7284,10 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
         self.renderer.underlay_bake_enabled
     }
 
+    fn underlay_replay_enabled(&self) -> bool {
+        self.renderer.underlay_replay_enabled
+    }
+
     fn insert_cached_layer_surface(
         &mut self,
         key: LayerRasterCacheKey,
@@ -8319,6 +8329,10 @@ impl GpuRenderer {
 
     pub fn set_underlay_bake_enabled(&mut self, enabled: bool) {
         self.underlay_bake_enabled = enabled && underlay_bake_switch();
+    }
+
+    pub fn set_underlay_replay_enabled(&mut self, enabled: bool) {
+        self.underlay_replay_enabled = enabled && underlay_replay_switch();
     }
 
     pub fn gpu_pass_timings(&self) -> crate::pass_timing::GpuPassTimingReport {

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -106,7 +106,8 @@ use crate::{
     },
     shaders,
     surface_executor::{
-        CacheAdmission, DevicePixelBounds, LayerSurfaceTexture, SurfaceExecutionBackend,
+        CacheAdmission, DevicePixelBounds, LayerSurfaceTexture, PreparedShadowComposite,
+        SurfaceExecutionBackend,
         apply_backdrop_layer_to_target as execute_apply_backdrop_layer_to_target,
         axis_aligned_quad_rect, backdrop_underlay_is_covered_by_local_content,
         canonicalize_device_coordinate, canonicalized_scaled_quad, canonicalized_scaled_rect,
@@ -472,22 +473,24 @@ struct CachedShadowSurface {
     byte_size: u64,
 }
 
-struct CachedShadowComposite {
-    source: Rc<OffscreenTarget>,
+struct ShadowBandLayout {
     bands: SmallVec<[(u32, u32, u32, u32); 4]>,
     rounded_mask: Option<RoundedCompositeMask>,
-    dest_viewport: Option<(f32, f32, f32, f32)>,
+    dest_viewport: (f32, f32, f32, f32),
 }
 
-impl CachedShadowComposite {
-    fn band_items(&self) -> impl Iterator<Item = CompositeBatchItem<'_>> + '_ {
+impl ShadowBandLayout {
+    fn band_items<'a>(
+        &'a self,
+        source: &'a OffscreenTarget,
+    ) -> impl Iterator<Item = CompositeBatchItem<'a>> + 'a {
         self.bands.iter().map(move |band| CompositeBatchItem {
-            source: &self.source,
+            source,
             alpha: 1.0,
             scissor: Some(*band),
             rounded_mask: self.rounded_mask,
             blend_mode: BlendMode::SrcOver,
-            dest_viewport: self.dest_viewport,
+            dest_viewport: Some(self.dest_viewport),
             source_viewport: None,
             sample_mode: CompositeSampleMode::Nearest,
         })
@@ -498,6 +501,17 @@ impl CachedShadowComposite {
             .iter()
             .map(|(_, _, w, h)| u64::from(*w) * u64::from(*h))
             .sum()
+    }
+}
+
+struct CachedShadowComposite {
+    source: Rc<OffscreenTarget>,
+    layout: ShadowBandLayout,
+}
+
+impl CachedShadowComposite {
+    fn band_items(&self) -> impl Iterator<Item = CompositeBatchItem<'_>> + '_ {
+        self.layout.band_items(&self.source)
     }
 }
 
@@ -6522,13 +6536,16 @@ impl GpuRenderer {
             .map(|cached| cached.target.clone())
     }
 
-    fn cached_shape_shadow_composite(
-        &mut self,
+    /// The surface plan and cache key of a blurred, shape-only drop shadow.
+    /// `None` when the shadow cannot live in the cache: text shadows, zero
+    /// blur, no plan, or shadows switched off.
+    fn shape_shadow_cache_plan(
+        &self,
         shadow: &ShadowDraw,
         width: u32,
         height: u32,
         root_scale: f32,
-    ) -> Option<CachedShadowComposite> {
+    ) -> Option<(ShapeShadowSurfacePlan, ShadowSurfaceCacheKey)> {
         if shadow.blur_radius <= 0.0
             || shadow.shapes.is_empty()
             || !shadow.texts.is_empty()
@@ -6536,7 +6553,6 @@ impl GpuRenderer {
         {
             return None;
         }
-
         let plan = shape_shadow_surface_plan(
             &shadow.shapes,
             shadow.clip,
@@ -6554,23 +6570,80 @@ impl GpuRenderer {
             plan.pixel_radius,
             root_scale,
         )?;
-        let cached = self.cached_shadow_surface(&key)?;
-        let viewport_offset = [plan.source_device_bounds.x, plan.source_device_bounds.y];
+        Some((plan, key))
+    }
 
+    /// The cached composite of a blurred, shape-only drop shadow, rendering the
+    /// shadow into the cache first when it is not resident.
+    fn ensure_cached_shape_shadow<C: FrameCommandRecorder>(
+        &mut self,
+        frame_encoder: &mut C,
+        shadow: &ShadowDraw,
+        width: u32,
+        height: u32,
+        root_scale: f32,
+    ) -> Option<CachedShadowComposite> {
+        let (plan, key) = self.shape_shadow_cache_plan(shadow, width, height, root_scale)?;
+        if let Some(cached) = self.cached_shadow_surface(&key) {
+            return Some(
+                self.cached_shape_shadow_hit(shadow, &plan, cached, width, height, root_scale),
+            );
+        }
+        self.render_shape_shadow_into_cache(frame_encoder, shadow, &plan, key, root_scale);
+        let source = self.cached_shadow_surface(&key)?;
+        Some(CachedShadowComposite {
+            source,
+            layout: self.shadow_band_layout(shadow, &plan, width, height, root_scale),
+        })
+    }
+
+    fn cached_shape_shadow_hit(
+        &self,
+        shadow: &ShadowDraw,
+        plan: &ShapeShadowSurfacePlan,
+        source: Rc<OffscreenTarget>,
+        width: u32,
+        height: u32,
+        root_scale: f32,
+    ) -> CachedShadowComposite {
+        let layout = self.shadow_band_layout(shadow, plan, width, height, root_scale);
+        self.frame_stats
+            .record_shadow_shape_cache_hit(layout.banded_pixels());
+        CachedShadowComposite { source, layout }
+    }
+
+    fn cached_shape_shadow_composite(
+        &mut self,
+        shadow: &ShadowDraw,
+        width: u32,
+        height: u32,
+        root_scale: f32,
+    ) -> Option<CachedShadowComposite> {
+        let (plan, key) = self.shape_shadow_cache_plan(shadow, width, height, root_scale)?;
+        let cached = self.cached_shadow_surface(&key)?;
+        Some(self.cached_shape_shadow_hit(shadow, &plan, cached, width, height, root_scale))
+    }
+
+    fn shadow_band_layout(
+        &self,
+        shadow: &ShadowDraw,
+        plan: &ShapeShadowSurfacePlan,
+        width: u32,
+        height: u32,
+        root_scale: f32,
+    ) -> ShadowBandLayout {
+        let viewport_offset = [plan.source_device_bounds.x, plan.source_device_bounds.y];
+        let dest_viewport = (
+            viewport_offset[0],
+            viewport_offset[1],
+            plan.source_device_bounds.width as f32,
+            plan.source_device_bounds.height as f32,
+        );
         let clip_scissor = shadow
             .clip
             .and_then(|clip| scissor_rect_for_rect(clip, root_scale, width, height));
         let scissor = clip_scissor.or(plan.processing_scissor);
-        let coverage = shadow_composite_coverage(
-            (
-                viewport_offset[0],
-                viewport_offset[1],
-                plan.source_device_bounds.width as f32,
-                plan.source_device_bounds.height as f32,
-            ),
-            scissor,
-            (width, height),
-        );
+        let coverage = shadow_composite_coverage(dest_viewport, scissor, (width, height));
         let bands = shadow_band_scissors(coverage, shadow.occluder, root_scale);
         if cranpose_core::env_flag!("CRANPOSE_SHADOW_BAND_DIAG") {
             eprintln!(
@@ -6579,23 +6652,11 @@ impl GpuRenderer {
                 shadow.occluder,
             );
         }
-        let rounded_mask = shadow_composite_mask(shadow, root_scale, viewport_offset);
-        let dest_viewport = Some((
-            viewport_offset[0],
-            viewport_offset[1],
-            plan.source_device_bounds.width as f32,
-            plan.source_device_bounds.height as f32,
-        ));
-
-        let composite = CachedShadowComposite {
-            source: cached,
+        ShadowBandLayout {
             bands,
-            rounded_mask,
+            rounded_mask: shadow_composite_mask(shadow, root_scale, viewport_offset),
             dest_viewport,
-        };
-        self.frame_stats
-            .record_shadow_shape_cache_hit(composite.banded_pixels());
-        Some(composite)
+        }
     }
 
     fn insert_cached_shadow_surface(
@@ -7550,7 +7611,7 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
             ) else {
                 continue;
             };
-            let band_count = composite.bands.len();
+            let band_count = composite.layout.bands.len();
             if band_count == 0 {
                 self.renderer.frame_stats.record_shadow_fully_occluded();
                 fully_occluded_zs.push(*z_index);
@@ -7710,6 +7771,27 @@ impl<C: FrameCommandRecorder> SurfaceExecutionBackend for RecordingSurfaceBacken
             height,
             root_scale,
         );
+    }
+
+    fn prepare_shadow_composite(
+        &mut self,
+        shadow: &ShadowDraw,
+        width: u32,
+        height: u32,
+        root_scale: f32,
+    ) -> Option<PreparedShadowComposite> {
+        let composite = self.renderer.ensure_cached_shape_shadow(
+            self.recorder,
+            shadow,
+            width,
+            height,
+            root_scale,
+        )?;
+        Some(PreparedShadowComposite {
+            source: composite.source,
+            dest_viewport: composite.layout.dest_viewport,
+            bands: composite.layout.bands,
+        })
     }
 
     fn composite_to_view_projective(
@@ -10852,18 +10934,16 @@ impl GpuRenderer {
                 root_scale,
                 self.max_texture_dim(),
             )
-            && self.encode_shape_only_blurred_shadow_draw(
+        {
+            self.encode_shape_only_blurred_shadow_draw(
                 frame_encoder,
                 target_view,
                 shadow,
-                plan.source_device_bounds,
-                plan.pixel_radius,
-                plan.processing_scissor,
+                &plan,
                 width,
                 height,
                 root_scale,
-            )
-        {
+            );
             return;
         }
 
@@ -11179,90 +11259,118 @@ impl GpuRenderer {
         frame_encoder: &mut C,
         target_view: &wgpu::TextureView,
         shadow: &ShadowDraw,
-        device_bounds: DevicePixelBounds,
-        pixel_radius: f32,
-        processing_scissor: Option<(u32, u32, u32, u32)>,
+        plan: &ShapeShadowSurfacePlan,
         width: u32,
         height: u32,
         root_scale: f32,
-    ) -> bool {
-        let bounds_w = device_bounds.width;
-        let bounds_h = device_bounds.height;
-        let viewport_offset = [device_bounds.x, device_bounds.y];
-        let cache_key = shape_shadow_surface_cache_key(
-            &shadow.shapes,
-            &shadow.post_blur_cutouts,
-            &shadow.brushes,
-            device_bounds,
-            pixel_radius,
-            root_scale,
-        );
-
-        if let Some(key) = cache_key {
-            if let Some(cached) = self.cached_shadow_surface(&key) {
-                let clip_scissor = shadow
-                    .clip
-                    .and_then(|clip| scissor_rect_for_rect(clip, root_scale, width, height));
-                let scissor = clip_scissor.or(processing_scissor);
-                let coverage = shadow_composite_coverage(
-                    (
-                        viewport_offset[0],
-                        viewport_offset[1],
-                        bounds_w as f32,
-                        bounds_h as f32,
-                    ),
-                    scissor,
-                    (width, height),
-                );
-                let rounded_mask = shadow_composite_mask(shadow, root_scale, viewport_offset);
-                let dest_viewport = Some((
-                    viewport_offset[0],
-                    viewport_offset[1],
-                    bounds_w as f32,
-                    bounds_h as f32,
-                ));
-                let composite = CachedShadowComposite {
-                    source: cached,
-                    bands: shadow_band_scissors(coverage, shadow.occluder, root_scale),
-                    rounded_mask,
-                    dest_viewport,
-                };
-                self.frame_stats
-                    .record_shadow_shape_cache_hit(composite.banded_pixels());
-                let band_items: SmallVec<[CompositeBatchItem<'_>; 4]> =
-                    composite.band_items().collect();
-                if !band_items.is_empty() {
-                    self.effect_renderer.encode_composite_batch_to_view_pass(
-                        frame_encoder,
-                        &self.device,
-                        target_view,
-                        (width, height),
-                        wgpu::LoadOp::Load,
-                        &band_items,
-                    );
-                    frame_encoder.record_pass();
-                    self.effect_renderer.record_composite_pass();
-                }
-                return true;
-            }
-            self.frame_stats
-                .record_shadow_shape_cache_miss(bounds_w, bounds_h);
-            self.frame_stats.maybe_print_shadow_shape_cache_miss(
-                bounds_w,
-                bounds_h,
-                key.content_hash,
-                pixel_radius,
-                viewport_offset,
-                shadow.shapes.len(),
-                shadow.clip,
+    ) {
+        if let Some(composite) =
+            self.ensure_cached_shape_shadow(frame_encoder, shadow, width, height, root_scale)
+        {
+            self.composite_shadow_bands_to_view(
+                frame_encoder,
+                target_view,
+                (width, height),
+                composite.band_items(),
             );
+            return;
         }
+        if self
+            .shape_shadow_cache_plan(shadow, width, height, root_scale)
+            .is_some()
+        {
+            return;
+        }
+        let Some(source) =
+            self.render_blurred_shape_shadow_source(frame_encoder, shadow, plan, root_scale, false)
+        else {
+            return;
+        };
+        let bounds = plan.source_device_bounds;
+        let layout = self.shadow_band_layout(shadow, plan, width, height, root_scale);
+        self.composite_shadow_bands_to_view(
+            frame_encoder,
+            target_view,
+            (width, height),
+            layout.band_items(&source),
+        );
+        let source_descriptor =
+            self.transient_offscreen_descriptor("Shape Shadow Source", bounds.width, bounds.height);
+        frame_encoder.release_transient_offscreen(source_descriptor, source);
+    }
 
+    fn composite_shadow_bands_to_view<'a, C: FrameCommandRecorder>(
+        &mut self,
+        frame_encoder: &mut C,
+        target_view: &wgpu::TextureView,
+        viewport: (u32, u32),
+        band_items: impl Iterator<Item = CompositeBatchItem<'a>>,
+    ) {
+        let band_items: SmallVec<[CompositeBatchItem<'_>; 4]> = band_items.collect();
+        if band_items.is_empty() {
+            return;
+        }
+        self.effect_renderer.encode_composite_batch_to_view_pass(
+            frame_encoder,
+            &self.device,
+            target_view,
+            viewport,
+            wgpu::LoadOp::Load,
+            &band_items,
+        );
+        frame_encoder.record_pass();
+        self.effect_renderer.record_composite_pass();
+    }
+
+    /// Renders a blurred shape-only shadow into the shadow cache under its
+    /// key. Shadows whose shapes draw nothing are recorded as a miss and skipped.
+    fn render_shape_shadow_into_cache<C: FrameCommandRecorder>(
+        &mut self,
+        frame_encoder: &mut C,
+        shadow: &ShadowDraw,
+        plan: &ShapeShadowSurfacePlan,
+        key: ShadowSurfaceCacheKey,
+        root_scale: f32,
+    ) {
+        let bounds = plan.source_device_bounds;
+        self.frame_stats
+            .record_shadow_shape_cache_miss(bounds.width, bounds.height);
+        self.frame_stats.maybe_print_shadow_shape_cache_miss(
+            bounds.width,
+            bounds.height,
+            key.content_hash,
+            plan.pixel_radius,
+            [bounds.x, bounds.y],
+            shadow.shapes.len(),
+            shadow.clip,
+        );
+        if let Some(source) =
+            self.render_blurred_shape_shadow_source(frame_encoder, shadow, plan, root_scale, true)
+        {
+            self.insert_cached_shadow_surface(key, source);
+        }
+    }
+
+    /// Draws the shadow's shapes into a fresh surface and blurs them in place,
+    /// applying the post-blur cutouts. Retained surfaces feed the cache;
+    /// transient ones are released by the caller. `None` when the shapes draw
+    /// nothing.
+    fn render_blurred_shape_shadow_source<C: FrameCommandRecorder>(
+        &mut self,
+        frame_encoder: &mut C,
+        shadow: &ShadowDraw,
+        plan: &ShapeShadowSurfacePlan,
+        root_scale: f32,
+        retained: bool,
+    ) -> Option<OffscreenTarget> {
+        let bounds = plan.source_device_bounds;
+        let (bounds_w, bounds_h) = (bounds.width, bounds.height);
+        let viewport_offset = [bounds.x, bounds.y];
+        let pixel_radius = plan.pixel_radius;
         let device = self.device.clone();
         let source_descriptor =
             self.transient_offscreen_descriptor("Shape Shadow Source", bounds_w, bounds_h);
-        let source_is_cacheable = cache_key.is_some();
-        let source = if source_is_cacheable {
+        let source = if retained {
             self.acquire_retained_surface(bounds_w, bounds_h)
         } else {
             frame_encoder.acquire_transient_offscreen(&device, source_descriptor)
@@ -11289,30 +11397,26 @@ impl GpuRenderer {
             &mut next_load_op,
         );
         frame_encoder.record_passes(source_outcome.pass_count);
-
         if !source_outcome.rendered_any {
             frame_encoder.release_transient_offscreen(scratch_descriptor, scratch);
-            if source_is_cacheable {
+            if retained {
                 self.defer_offscreen_release(source);
             } else {
                 frame_encoder.release_transient_offscreen(source_descriptor, source);
             }
-            return true;
+            return None;
         }
-
-        {
-            self.effect_renderer.encode_blur_scissored_ping_pong_passes(
-                frame_encoder,
-                &device,
-                &source,
-                &scratch,
-                &source.view,
-                pixel_radius,
-                pixel_radius,
-                TileMode::Decal,
-                None,
-            );
-        }
+        self.effect_renderer.encode_blur_scissored_ping_pong_passes(
+            frame_encoder,
+            &device,
+            &source,
+            &scratch,
+            &source.view,
+            pixel_radius,
+            pixel_radius,
+            TileMode::Decal,
+            None,
+        );
         frame_encoder.record_passes(2);
         self.encode_post_blur_cutout_passes(
             frame_encoder,
@@ -11323,55 +11427,9 @@ impl GpuRenderer {
             viewport_offset,
             root_scale,
         );
-
-        let clip_scissor = shadow
-            .clip
-            .and_then(|clip| scissor_rect_for_rect(clip, root_scale, width, height));
-        let scissor = clip_scissor.or(processing_scissor);
-        let rounded_mask = shadow_composite_mask(shadow, root_scale, viewport_offset);
-        let dest_viewport = (
-            viewport_offset[0],
-            viewport_offset[1],
-            bounds_w as f32,
-            bounds_h as f32,
-        );
-        let coverage = shadow_composite_coverage(dest_viewport, scissor, (width, height));
-        let bands = shadow_band_scissors(coverage, shadow.occluder, root_scale);
-        let band_items: SmallVec<[CompositeBatchItem<'_>; 4]> = bands
-            .iter()
-            .map(|band| CompositeBatchItem {
-                source: &source,
-                alpha: 1.0,
-                scissor: Some(*band),
-                rounded_mask,
-                blend_mode: BlendMode::SrcOver,
-                dest_viewport: Some(dest_viewport),
-                source_viewport: None,
-                sample_mode: CompositeSampleMode::Nearest,
-            })
-            .collect();
-        if !band_items.is_empty() {
-            self.effect_renderer.encode_composite_batch_to_view_pass(
-                frame_encoder,
-                &device,
-                target_view,
-                (width, height),
-                wgpu::LoadOp::Load,
-                &band_items,
-            );
-            frame_encoder.record_pass();
-            self.effect_renderer.record_composite_pass();
-        }
-        drop(band_items);
-
         self.effect_renderer.record_blur_pass();
         frame_encoder.release_transient_offscreen(scratch_descriptor, scratch);
-        if let Some(key) = cache_key {
-            self.insert_cached_shadow_surface(key, source);
-        } else {
-            frame_encoder.release_transient_offscreen(source_descriptor, source);
-        }
-        true
+        Some(source)
     }
 
     fn prepare_shapes_batch<'a, I>(
@@ -14776,7 +14834,7 @@ impl GpuRenderer {
     }
 }
 
-fn is_in_effect_range(z_index: usize, effect_z_ranges: &[Range<usize>]) -> bool {
+pub(crate) fn is_in_effect_range(z_index: usize, effect_z_ranges: &[Range<usize>]) -> bool {
     effect_z_ranges.iter().any(|range| range.contains(&z_index))
 }
 

--- a/crates/cranpose-render/wgpu/src/render.rs
+++ b/crates/cranpose-render/wgpu/src/render.rs
@@ -17373,6 +17373,7 @@ mod tests {
     fn snapped_text_leaf(animated: bool, translated_content_context: bool) -> LayerNode {
         LayerNode {
             node_id: Some(77),
+            wraps: None,
             local_bounds: Rect {
                 x: 0.0,
                 y: 0.0,
@@ -17491,6 +17492,7 @@ mod tests {
 
         let translated_content = LayerNode {
             node_id: Some(78),
+            wraps: None,
             local_bounds: Rect {
                 x: 0.0,
                 y: 0.0,
@@ -17730,6 +17732,7 @@ mod tests {
     fn pure_text_leaf(animated: bool, translated_content_context: bool) -> LayerNode {
         LayerNode {
             node_id: Some(177),
+            wraps: None,
             local_bounds: Rect {
                 x: 0.0,
                 y: 0.0,

--- a/crates/cranpose-render/wgpu/src/scene.rs
+++ b/crates/cranpose-render/wgpu/src/scene.rs
@@ -11,7 +11,9 @@ use cranpose_ui_graphics::{
     RenderEffect, RoundedCornerShape, Stroke,
 };
 
-use crate::surface_requirements::SurfaceRequirementSet;
+use crate::{
+    surface_executor::backend::LayerSurfaceRoundedClip, surface_requirements::SurfaceRequirementSet,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct SnapAnchor {
@@ -250,6 +252,7 @@ pub(crate) struct ShadowDraw {
     pub texts: Vec<TextDraw>,
     pub blur_radius: f32,
     pub clip: Option<Rect>,
+    pub rounded_clip: Option<LayerSurfaceRoundedClip>,
     pub occluder: Option<Rect>,
     pub z_index: usize,
 }

--- a/crates/cranpose-render/wgpu/src/shader_cache.rs
+++ b/crates/cranpose-render/wgpu/src/shader_cache.rs
@@ -18,9 +18,13 @@ impl RuntimeShaderPipelineMode {
     }
 }
 
+fn shader_specialization_enabled() -> bool {
+    crate::debug_toggles::debug_toggle("CRANPOSE_NO_SHADER_SPECIALIZATION").as_deref() != Some("1")
+}
+
 pub(crate) struct ShaderPipelineCache {
     backend: wgpu::Backend,
-    cache: HashMap<(u64, RuntimeShaderPipelineMode, bool), wgpu::RenderPipeline>,
+    cache: HashMap<(u64, u64, RuntimeShaderPipelineMode, bool), wgpu::RenderPipeline>,
     disabled: HashSet<u64>,
     pipeline_cache: Option<wgpu::PipelineCache>,
 }
@@ -47,7 +51,17 @@ impl ShaderPipelineCache {
         depth: bool,
     ) -> Option<&wgpu::RenderPipeline> {
         let source_hash = shader.source_hash();
-        let cache_key = (source_hash, mode, depth);
+        let constants: &[(&str, f64)] = if shader_specialization_enabled() {
+            shader.overrides()
+        } else {
+            &[]
+        };
+        let overrides_hash = if constants.is_empty() {
+            0
+        } else {
+            shader.overrides_hash()
+        };
+        let cache_key = (source_hash, overrides_hash, mode, depth);
         if self.disabled.contains(&source_hash) {
             return None;
         }
@@ -82,7 +96,10 @@ impl ShaderPipelineCache {
                         module: &shader_module,
                         entry_point: Some("fullscreen_vs"),
                         buffers: &[],
-                        compilation_options: wgpu::PipelineCompilationOptions::default(),
+                        compilation_options: wgpu::PipelineCompilationOptions {
+                            constants,
+                            ..wgpu::PipelineCompilationOptions::default()
+                        },
                     },
                     fragment: Some(wgpu::FragmentState {
                         module: &shader_module,
@@ -92,7 +109,10 @@ impl ShaderPipelineCache {
                             blend: Some(mode.blend_state()),
                             write_mask: wgpu::ColorWrites::ALL,
                         })],
-                        compilation_options: wgpu::PipelineCompilationOptions::default(),
+                        compilation_options: wgpu::PipelineCompilationOptions {
+                            constants,
+                            ..wgpu::PipelineCompilationOptions::default()
+                        },
                     }),
                     primitive: wgpu::PrimitiveState {
                         topology: wgpu::PrimitiveTopology::TriangleStrip,
@@ -200,10 +220,17 @@ fn validate_glsl_portability(
         multiview: None,
     };
 
-    let mut writer = glsl::Writer::new(
-        &mut glsl_source,
+    let (module, module_info) = naga::back::pipeline_constants::process_overrides(
         module,
         module_info,
+        Some((shader_stage, entry_point)),
+        &naga::back::PipelineConstants::default(),
+    )
+    .map_err(|err| format!("override resolution failed for `{entry_point}`: {err}"))?;
+    let mut writer = glsl::Writer::new(
+        &mut glsl_source,
+        &module,
+        &module_info,
         &options,
         &pipeline_options,
         naga::proc::BoundsCheckPolicies::default(),

--- a/crates/cranpose-render/wgpu/src/shaders.rs
+++ b/crates/cranpose-render/wgpu/src/shaders.rs
@@ -197,6 +197,60 @@ mod tests {
         }
     }
 
+    const GLES_VARYING_VECTOR_FLOOR: u32 = 15;
+
+    fn fragment_input_locations(source: &str, entry_point: &str) -> Vec<u32> {
+        let module = naga::front::wgsl::parse_str(source).expect("shader must parse");
+        let entry = module
+            .entry_points
+            .iter()
+            .find(|entry| entry.name == entry_point)
+            .unwrap_or_else(|| panic!("{entry_point} missing"));
+        let mut locations = Vec::new();
+        for argument in &entry.function.arguments {
+            match &module.types[argument.ty].inner {
+                naga::TypeInner::Struct { members, .. } => {
+                    for member in members {
+                        if let Some(naga::Binding::Location { location, .. }) = member.binding {
+                            locations.push(location);
+                        }
+                    }
+                }
+                _ => {
+                    if let Some(naga::Binding::Location { location, .. }) = argument.binding {
+                        locations.push(location);
+                    }
+                }
+            }
+        }
+        locations.sort_unstable();
+        locations
+    }
+
+    #[test]
+    fn shape_fragment_inputs_fit_the_gles_varying_floor() {
+        for (source, entry_point) in [
+            (super::SHADER.to_string(), "fs_main"),
+            (super::SHADER.to_string(), "fs_solid"),
+            (
+                format!("{}\n{}", super::SHADER, super::SOLID_TRIM_APPENDIX),
+                "fs_solid_trim",
+            ),
+        ] {
+            let locations = fragment_input_locations(&source, entry_point);
+            let highest = locations.last().copied().expect("fragment inputs");
+            assert!(
+                highest < GLES_VARYING_VECTOR_FLOOR,
+                "{entry_point} reads location {highest}; GLSL ES 3.0 only guarantees \
+                 {GLES_VARYING_VECTOR_FLOOR} varying vectors, so every location must \
+                 stay below it: {locations:?}"
+            );
+            let mut deduplicated = locations.clone();
+            deduplicated.dedup();
+            assert_eq!(deduplicated, locations, "{entry_point} reuses a location");
+        }
+    }
+
     #[test]
     fn shape_shader_declares_the_stroke_and_arc_parameters() {
         for needle in [

--- a/crates/cranpose-render/wgpu/src/surface_executor.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor.rs
@@ -4,7 +4,7 @@ mod render_paths;
 
 pub(crate) use backend::{
     CacheAdmission, CachedLayerSurface, DevicePixelBounds, LayerSurfaceTexture,
-    SurfaceExecutionBackend,
+    PreparedShadowComposite, SurfaceExecutionBackend,
 };
 pub(crate) use geometry::{
     axis_aligned_quad_rect, canonicalize_device_coordinate, canonicalized_scaled_quad,

--- a/crates/cranpose-render/wgpu/src/surface_executor/backend.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/backend.rs
@@ -3,6 +3,7 @@ use std::{ops::Range, rc::Rc};
 use cranpose_core::NodeId;
 use cranpose_render_common::{graph::LayerNode, raster_cache::LayerRasterCacheKey};
 use cranpose_ui_graphics::{BlendMode, Brush, LayerShape, Rect, RenderEffect, RuntimeShader};
+use smallvec::SmallVec;
 
 use crate::{
     effect_renderer::{
@@ -92,6 +93,15 @@ impl LayerSurfaceRoundedClip {
             ],
         }
     }
+}
+
+/// A blurred drop shadow resident in the shadow cache, ready to composite:
+/// the texture, the destination it maps to in target pixels, the scissor
+/// bands that skip the occluded interior and the rounded mask it carries.
+pub(crate) struct PreparedShadowComposite {
+    pub(crate) source: Rc<OffscreenTarget>,
+    pub(crate) dest_viewport: (f32, f32, f32, f32),
+    pub(crate) bands: SmallVec<[(u32, u32, u32, u32); 4]>,
 }
 
 pub(crate) enum LayerSurfaceTexture {
@@ -240,6 +250,16 @@ pub(crate) trait SurfaceExecutionBackend {
         height: u32,
         root_scale: f32,
     );
+    /// Renders a blurred drop shadow into its cached texture when it is not
+    /// there yet and describes how to composite it, so the walk can queue it
+    /// with the pending composites instead of drawing it into the target.
+    fn prepare_shadow_composite(
+        &mut self,
+        shadow: &ShadowDraw,
+        width: u32,
+        height: u32,
+        root_scale: f32,
+    ) -> Option<PreparedShadowComposite>;
     #[allow(clippy::too_many_arguments)]
     fn composite_to_view_projective(
         &mut self,

--- a/crates/cranpose-render/wgpu/src/surface_executor/backend.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/backend.rs
@@ -153,6 +153,11 @@ pub(crate) trait SurfaceExecutionBackend {
     /// `CRANPOSE_DISABLE_UNDERLAY_BAKE` and through
     /// [`crate::WgpuRenderer::set_underlay_bake_enabled`].
     fn underlay_bake_enabled(&self) -> bool;
+    /// Whether the pending composites overlapping a baked underlay copy are
+    /// replayed into that copy instead of flushed to the parent target first.
+    /// Off under `CRANPOSE_DISABLE_UNDERLAY_REPLAY` and through
+    /// [`crate::WgpuRenderer::set_underlay_replay_enabled`].
+    fn underlay_replay_enabled(&self) -> bool;
     fn insert_cached_layer_surface(
         &mut self,
         key: LayerRasterCacheKey,

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -3276,6 +3276,8 @@ fn backdrop_scene_prefix_hash(
     hash_f32_bits(root_scale, &mut hasher);
     z_end.hash(&mut hasher);
 
+    let diag = backdrop_diag_enabled();
+    let mut draw_op_count = 0usize;
     for draw_op in scene_range_draw_ops(&scene.draw_ops, 0, z_end)
         .iter()
         .filter(|draw_op| {
@@ -3285,7 +3287,10 @@ fn backdrop_scene_prefix_hash(
     {
         0u8.hash(&mut hasher);
         hash_draw_op(scene, draw_op, &mut hasher);
+        draw_op_count += 1;
     }
+    let after_draw_ops = hasher.finish();
+    let mut effect_layer_count = 0usize;
     for effect_layer in scene
         .effect_layers
         .iter()
@@ -3293,7 +3298,9 @@ fn backdrop_scene_prefix_hash(
     {
         1u8.hash(&mut hasher);
         hash_effect_layer(effect_layer, &mut hasher);
+        effect_layer_count += 1;
     }
+    let after_effect_layers = hasher.finish();
     for backdrop_layer in scene.backdrop_layers.iter().filter(|layer| {
         layer.z_index < z_end
             && rects_intersect(
@@ -3310,6 +3317,7 @@ fn backdrop_scene_prefix_hash(
         2u8.hash(&mut hasher);
         hash_backdrop_layer(backdrop_layer, &mut hasher);
     }
+    let after_backdrop_layers = hasher.finish();
     for child in prior_child_contributions.iter().filter(|child| {
         if child.z_index >= z_end {
             return false;
@@ -3331,8 +3339,14 @@ fn backdrop_scene_prefix_hash(
         3u8.hash(&mut hasher);
         hash_backdrop_prefix_child(child, &mut hasher);
     }
-
-    hasher.finish()
+    let result = hasher.finish();
+    if diag {
+        eprintln!(
+            "[backdrop-diag] prefix-hash z_end={z_end} capture=({:.1},{:.1}) ops={draw_op_count}:{after_draw_ops} effects={effect_layer_count}:{after_effect_layers} backdrops={after_backdrop_layers} full={result}",
+            capture_rect.x, capture_rect.y
+        );
+    }
+    result
 }
 
 fn scene_backdrop_input_hashes(

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -5141,7 +5141,13 @@ fn serve_or_capture_prefix_snapshot<B: SurfaceExecutionBackend>(
     }
 
     if !backend.admit_layer_surface_cache_miss(&key, CacheAdmission::OnRepeat) {
+        if crate::layer_surface_cache::cache_diag_enabled() {
+            log::warn!("[layer-cache-diag] prefix-snapshot observe key={key:?}");
+        }
         return Ok(PrefixSnapshotOutcome::Claimed(prefix_end));
+    }
+    if crate::layer_surface_cache::cache_diag_enabled() {
+        log::warn!("[layer-cache-diag] prefix-snapshot admit key={key:?}");
     }
 
     // The entry renders through the same segment pipeline as the frame,

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -1654,11 +1654,23 @@ struct ChildUnderlay {
     baked: bool,
 }
 
-/// The pixels beneath a child that carries nested backdrops, sampled from the
-/// parent target once everything below the child, its own backdrop included,
-/// has been flushed into it. A whole-pixel translated child gets a verbatim
-/// copy it bakes as its surface's base; any other placement gets a projected
-/// resample its nested captures read through.
+/// The parent target a child's underlay is sampled from, with the composite
+/// queues still waiting to land on it.
+struct UnderlayCaptureSource<'a, 'q> {
+    target_view: &'a wgpu::TextureView,
+    viewport: (u32, u32),
+    dependency_rect: Rect,
+    queues: &'a mut PendingQueues<'q>,
+}
+
+/// The pixels beneath a child that carries nested backdrops. A whole-pixel
+/// translated child gets a verbatim copy it bakes as its surface's base, and
+/// the pending composites that overlap it, its own backdrop included, are
+/// replayed into that copy instead of being flushed to the parent first: the
+/// same blend on the same source and destination pixels, shifted by the
+/// copy's whole-pixel origin, so the copy carries the bytes a flush would
+/// have produced while the parent keeps batching. Any other placement
+/// flushes the queues and reads a projected resample through them.
 #[allow(clippy::too_many_arguments)]
 fn sample_child_underlay<B: SurfaceExecutionBackend>(
     backend: &mut B,
@@ -1669,7 +1681,8 @@ fn sample_child_underlay<B: SurfaceExecutionBackend>(
     underlay_identity: Option<u64>,
     parent_scale: f32,
     translation_context: TranslationRenderContext,
-) -> ChildUnderlay {
+    source: UnderlayCaptureSource<'_, '_>,
+) -> Result<ChildUnderlay, String> {
     let child_scale = child_surface_target_scale(child, parent_scale, translation_context);
     let device_origin = (backend.underlay_bake_enabled()
         && parent_underlay.is_none()
@@ -1688,28 +1701,72 @@ fn sample_child_underlay<B: SurfaceExecutionBackend>(
             )
         })
         .flatten();
+    let dependency_pixels = surface_pixel_rect(source.dependency_rect, parent_scale);
+    let conflicts = pending_capture_conflicts(
+        source.queues.composites,
+        source.queues.composite_load_op,
+        source.queues.shader_composites,
+        source.queues.shader_load_op,
+        dependency_pixels,
+    );
+    let replay =
+        device_origin.is_some() && backend.underlay_replay_enabled() && !conflicts.clear_held;
     if backdrop_diag_enabled() {
         eprintln!(
-            "[backdrop-diag] underlay node={:?} plain={} identity={} device_origin={:?}",
+            "[backdrop-diag] underlay node={:?} plain={} identity={} device_origin={:?} replay={replay} conflicts={}:{}",
             child.node_id,
             child_composites_plainly(child),
             underlay_identity.is_some(),
             device_origin,
+            conflicts.composites,
+            conflicts.shaders,
         );
     }
-    if let Some(target) = device_origin.and_then(|origin| {
-        copy_child_underlay(
+    let flush_queues = |backend: &mut B, queues: &mut PendingQueues<'_>| {
+        flush_pending_queues_for_backdrop_capture(
+            backend,
+            queues.composites,
+            queues.composite_load_op,
+            queues.shader_composites,
+            queues.shader_load_op,
+            source.target_view,
+            source.viewport,
+            queues.next_load_op,
+            source.dependency_rect,
+            parent_scale,
+        )
+    };
+    if replay {
+        flush_pending_clear(backend, source.target_view, source.queues.next_load_op);
+    } else {
+        flush_queues(backend, source.queues)?;
+    }
+    if let Some(origin) = device_origin {
+        if let Some(target) = copy_child_underlay(
             backend,
             parent_target,
             origin,
             placement.logical_rect,
             parent_scale,
-        )
-    }) {
-        return ChildUnderlay {
-            target,
-            baked: true,
-        };
+        ) {
+            if replay && conflicts.any() {
+                replay_pending_into_underlay(
+                    backend,
+                    &target,
+                    origin,
+                    source.queues.composites,
+                    source.queues.shader_composites,
+                    dependency_pixels,
+                )?;
+            }
+            return Ok(ChildUnderlay {
+                target,
+                baked: true,
+            });
+        }
+        if replay {
+            flush_queues(backend, source.queues)?;
+        }
     }
     let target = create_projected_child_underlay(
         backend,
@@ -1721,10 +1778,166 @@ fn sample_child_underlay<B: SurfaceExecutionBackend>(
         child_scale,
         underlay_sample_rect(&child.source),
     );
-    ChildUnderlay {
+    Ok(ChildUnderlay {
         target,
         baked: false,
+    })
+}
+
+/// A pending write moved from parent pixels into the underlay copy's own
+/// pixel space: the same destination shifted by the copy's origin, with its
+/// scissor cut down to the copy. `None` when the scissor leaves nothing of
+/// the write inside the copy.
+struct ReplayedWrite {
+    dest_quad: [[f32; 2]; 4],
+    dest_rect: Option<Rect>,
+    scissor: Option<(u32, u32, u32, u32)>,
+}
+
+fn replayed_write(
+    dest_quad: [[f32; 2]; 4],
+    scissor: Option<(u32, u32, u32, u32)>,
+    origin: (u32, u32),
+    underlay_size: (u32, u32),
+) -> Option<ReplayedWrite> {
+    let (origin_x, origin_y) = (origin.0 as f32, origin.1 as f32);
+    let dest_quad = dest_quad.map(|[x, y]| [x - origin_x, y - origin_y]);
+    let scissor = match scissor {
+        None => None,
+        Some((x, y, width, height)) => {
+            let left = x.max(origin.0);
+            let top = y.max(origin.1);
+            let right = x
+                .saturating_add(width)
+                .min(origin.0.saturating_add(underlay_size.0));
+            let bottom = y
+                .saturating_add(height)
+                .min(origin.1.saturating_add(underlay_size.1));
+            if right <= left || bottom <= top {
+                return None;
+            }
+            Some((left - origin.0, top - origin.1, right - left, bottom - top))
+        }
+    };
+    Some(ReplayedWrite {
+        dest_quad,
+        dest_rect: axis_aligned_quad_rect(dest_quad),
+        scissor,
+    })
+}
+
+/// Draws the pending composites that touch `dependency_pixels` into the
+/// underlay copy, in the order they will later land on the parent, without
+/// consuming them: the copy then holds what the parent will show beneath the
+/// child, and the parent's own batch stays intact.
+fn replay_pending_into_underlay<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    underlay: &OffscreenTarget,
+    origin: (u32, u32),
+    pending_composites: &[PendingLayerComposite],
+    pending_shader_composites: &[PendingShaderLayerComposite],
+    dependency_pixels: Rect,
+) -> Result<(), String> {
+    let viewport = (underlay.width, underlay.height);
+    let mut order: Vec<(usize, usize, bool, usize)> = pending_composites
+        .iter()
+        .enumerate()
+        .filter(|(_, pending)| {
+            pending_write_intersects_rect(pending.dest_quad, pending.scissor, dependency_pixels)
+        })
+        .map(|(index, pending)| (pending.z_index, pending.seq, false, index))
+        .chain(
+            pending_shader_composites
+                .iter()
+                .enumerate()
+                .filter(|(_, pending)| {
+                    pending_write_intersects_rect(
+                        pending.dest_quad,
+                        pending.scissor,
+                        dependency_pixels,
+                    )
+                })
+                .map(|(index, pending)| (pending.z_index, pending.seq, true, index)),
+        )
+        .collect();
+    order.sort_by_key(|&(z_index, seq, _, _)| (z_index, seq));
+
+    let mut items = Vec::with_capacity(order.len());
+    let mut writes = Vec::with_capacity(order.len());
+    for &(_, _, is_shader, index) in &order {
+        let (dest_quad, scissor) = if is_shader {
+            let pending = &pending_shader_composites[index];
+            (pending.dest_quad, pending.scissor)
+        } else {
+            let pending = &pending_composites[index];
+            (pending.dest_quad, pending.scissor)
+        };
+        let Some(write) = replayed_write(dest_quad, scissor, origin, viewport) else {
+            continue;
+        };
+        let item = if is_shader {
+            let pending = &pending_shader_composites[index];
+            let source = pending.surface.target.target();
+            let (origin_x, origin_y) = (origin.0 as f32, origin.1 as f32);
+            let (x, y, width, height) = pending.dest_viewport;
+            FusedCompositeItem::Shader(ShaderCompositeBatchItem {
+                source,
+                shader: &pending.shader,
+                layer_pixel_rect: content_effect_pixel_rect(
+                    pending.surface.effect_content_rect,
+                    pending.surface.logical_rect,
+                    source.width,
+                    source.height,
+                ),
+                scissor: write.scissor,
+                dest_viewport: (x - origin_x, y - origin_y, width, height),
+            })
+        } else {
+            let pending = &pending_composites[index];
+            let Some(mut item) = layer_surface_composite_batch_item(pending) else {
+                return Err("a pending layer composite must be batchable".to_string());
+            };
+            let source = pending.surface.target.target();
+            item.scissor = write.scissor;
+            item.rounded_mask = write
+                .dest_rect
+                .and_then(|dest_rect| layer_surface_rounded_mask(&pending.surface, dest_rect));
+            item.dest_viewport = write.dest_rect.map(|dest_rect| {
+                composite_dest_viewport(
+                    dest_rect,
+                    source.width,
+                    source.height,
+                    pending.surface.sample_mode,
+                )
+            });
+            FusedCompositeItem::Blit(item)
+        };
+        items.push(item);
+        writes.push((is_shader, index, write));
     }
+    if items.is_empty() {
+        return Ok(());
+    }
+    if backend.fused_composite_batch_to_view(&underlay.view, viewport, wgpu::LoadOp::Load, &items) {
+        return Ok(());
+    }
+    for (is_shader, index, write) in writes {
+        let surface = if is_shader {
+            &pending_shader_composites[index].surface
+        } else {
+            &pending_composites[index].surface
+        };
+        composite_layer_surface_to_view(
+            backend,
+            surface,
+            &underlay.view,
+            viewport,
+            write.dest_quad,
+            wgpu::LoadOp::Load,
+            write.scissor,
+        )?;
+    }
+    Ok(())
 }
 
 /// Copies the device pixels the child's surface will be composited onto out
@@ -2430,17 +2643,21 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                 }
             }
 
-            if child.needs_nested_underlay {
-                flush_pending_shader_layer_composites(
-                    backend,
-                    &mut pending_shader_composites,
-                    surface_view,
-                    (width, height),
-                    &mut pending_shader_load_op,
-                    &mut next_load_op,
-                )?;
-            }
-
+            let wants_underlay = child.needs_nested_underlay;
+            let child_underlay_identity = wants_underlay
+                .then(|| {
+                    underlay_identity_before(
+                        &local_scene,
+                        &prior_child_contributions,
+                        child.z_index,
+                        axis_aligned_quad_rect(resolved_child.dest_quad)?,
+                        (width, height),
+                        root_scale,
+                        None,
+                        false,
+                    )
+                })
+                .flatten();
             composite_root_child_backdrop(
                 backend,
                 root_target,
@@ -2460,36 +2677,10 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                     composite_seq: &mut composite_seq,
                 },
             )?;
-            let child_underlay_identity = child
-                .needs_nested_underlay
-                .then(|| {
-                    underlay_identity_before(
-                        &local_scene,
-                        &prior_child_contributions,
-                        child.z_index,
-                        axis_aligned_quad_rect(resolved_child.dest_quad)?,
-                        (width, height),
-                        root_scale,
-                        None,
-                        false,
-                    )
-                })
-                .flatten();
             let mut bake_underlay = false;
-            let child_underlay = if child.needs_nested_underlay {
+            let child_underlay = if wants_underlay {
                 Some(match root_target {
                     Some(root_target) => {
-                        flush_pending_composite_queues_fused(
-                            backend,
-                            &mut pending_composites,
-                            &mut pending_composite_load_op,
-                            &mut pending_shader_composites,
-                            &mut pending_shader_load_op,
-                            surface_view,
-                            (width, height),
-                            &mut next_load_op,
-                        )?;
-                        flush_pending_clear(backend, surface_view, &mut next_load_op);
                         let underlay = sample_child_underlay(
                             backend,
                             root_target,
@@ -2505,19 +2696,42 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                             child_underlay_identity,
                             root_scale,
                             TranslationRenderContext::default(),
-                        );
+                            UnderlayCaptureSource {
+                                target_view: surface_view,
+                                viewport: (width, height),
+                                dependency_rect: quad_bounds(child_dest_quad),
+                                queues: &mut PendingQueues {
+                                    composites: &mut pending_composites,
+                                    composite_load_op: &mut pending_composite_load_op,
+                                    shader_composites: &mut pending_shader_composites,
+                                    shader_load_op: &mut pending_shader_load_op,
+                                    next_load_op: &mut next_load_op,
+                                    composite_seq: &mut composite_seq,
+                                },
+                            },
+                        )?;
                         bake_underlay = underlay.baked;
                         underlay.target
                     }
-                    None => create_direct_root_child_underlay(
-                        backend,
-                        &local_scene,
-                        resolved_child.logical_rect,
-                        resolved_child.dest_quad,
-                        child.z_index,
-                        &pending_composites,
-                        root_scale,
-                    )?,
+                    None => {
+                        flush_pending_shader_layer_composites(
+                            backend,
+                            &mut pending_shader_composites,
+                            surface_view,
+                            (width, height),
+                            &mut pending_shader_load_op,
+                            &mut next_load_op,
+                        )?;
+                        create_direct_root_child_underlay(
+                            backend,
+                            &local_scene,
+                            resolved_child.logical_rect,
+                            resolved_child.dest_quad,
+                            child.z_index,
+                            &pending_composites,
+                            root_scale,
+                        )?
+                    }
                 })
             } else {
                 None
@@ -2543,6 +2757,15 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
             }
             let child_surface = child_surface_result?;
             if child_backdrop_reads_target && !resolved_child.shadow_draws.is_empty() {
+                if backdrop_diag_enabled() {
+                    eprintln!(
+                        "[backdrop-diag] shadow-flush node={:?} shadows={} pending={} shader_pending={}",
+                        child.node_id,
+                        resolved_child.shadow_draws.len(),
+                        pending_composites.len(),
+                        pending_shader_composites.len()
+                    );
+                }
                 flush_pending_composite_queues_fused(
                     backend,
                     &mut pending_composites,
@@ -4120,6 +4343,47 @@ fn backdrop_dependency_rect(
     union_rect(Some(capture), output)
 }
 
+/// The pending writes a capture of `dependency_pixels` would have to see
+/// first: composites and shader composites whose destination touches the
+/// rect, and a clear one of the queues still holds, which means the target
+/// carries nothing yet.
+struct CaptureConflicts {
+    composites: usize,
+    shaders: usize,
+    clear_held: bool,
+}
+
+impl CaptureConflicts {
+    fn any(&self) -> bool {
+        self.composites > 0 || self.shaders > 0 || self.clear_held
+    }
+}
+
+fn pending_capture_conflicts(
+    pending_composites: &[PendingLayerComposite],
+    pending_composite_load_op: &Option<wgpu::LoadOp<wgpu::Color>>,
+    pending_shader_composites: &[PendingShaderLayerComposite],
+    pending_shader_load_op: &Option<wgpu::LoadOp<wgpu::Color>>,
+    dependency_pixels: Rect,
+) -> CaptureConflicts {
+    CaptureConflicts {
+        composites: pending_composites
+            .iter()
+            .filter(|pending| {
+                pending_write_intersects_rect(pending.dest_quad, pending.scissor, dependency_pixels)
+            })
+            .count(),
+        shaders: pending_shader_composites
+            .iter()
+            .filter(|pending| {
+                pending_write_intersects_rect(pending.dest_quad, pending.scissor, dependency_pixels)
+            })
+            .count(),
+        clear_held: pending_load_op_holds_clear(pending_composite_load_op)
+            || pending_load_op_holds_clear(pending_shader_load_op),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn flush_pending_queues_for_backdrop_capture<B: SurfaceExecutionBackend>(
     backend: &mut B,
@@ -4134,12 +4398,25 @@ fn flush_pending_queues_for_backdrop_capture<B: SurfaceExecutionBackend>(
     root_scale: f32,
 ) -> Result<(), String> {
     let dependency_pixels = surface_pixel_rect(dependency_rect, root_scale);
-    let must_flush = pending_composites.iter().any(|pending| {
-        pending_write_intersects_rect(pending.dest_quad, pending.scissor, dependency_pixels)
-    }) || pending_shader_composites.iter().any(|pending| {
-        pending_write_intersects_rect(pending.dest_quad, pending.scissor, dependency_pixels)
-    }) || pending_load_op_holds_clear(pending_composite_load_op)
-        || pending_load_op_holds_clear(pending_shader_load_op);
+    let conflicts = pending_capture_conflicts(
+        pending_composites,
+        pending_composite_load_op,
+        pending_shader_composites,
+        pending_shader_load_op,
+        dependency_pixels,
+    );
+    let must_flush = conflicts.any();
+    if backdrop_diag_enabled() {
+        eprintln!(
+            "[backdrop-diag] capture-flush must={must_flush} dep={:?} pending={} hit={} shader_pending={} shader_hit={} clear_held={}",
+            dependency_pixels,
+            pending_composites.len(),
+            conflicts.composites,
+            pending_shader_composites.len(),
+            conflicts.shaders,
+            conflicts.clear_held
+        );
+    }
     if must_flush {
         flush_pending_composite_queues_fused(
             backend,
@@ -4231,7 +4508,10 @@ struct PendingQueues<'a> {
 /// Composites a root child's own backdrop into the root target: capture,
 /// effect and either a pending composite, a deferred shader composite or a
 /// direct application, all ahead of the child's surface so an underlay
-/// sampled beneath the child already carries it.
+/// sampled beneath the child already carries it. A child whose surface bakes
+/// an underlay gets the effect materialized rather than deferred: its
+/// composite is then replayed into the underlay copy and drawn onto the root
+/// as two blits of one effect result instead of two shader runs.
 #[allow(clippy::too_many_arguments)]
 fn composite_root_child_backdrop<B: SurfaceExecutionBackend>(
     backend: &mut B,
@@ -4278,18 +4558,12 @@ fn composite_root_child_backdrop<B: SurfaceExecutionBackend>(
                 root_scale,
             )?;
         }
-        let child_backdrop_capture_rect = visible_backdrop_capture_rect(
-            resolved_child.backdrop_rect,
-            child.visual_clip,
-            &backdrop_layer.effect,
-            root_scale,
-            (width, height),
-        );
-        let backdrop_input_hash = backdrop_scene_prefix_hash(
+        let backdrop_input_hash = child_backdrop_input_hash(
             local_scene,
             prior_child_contributions,
-            child.z_index,
-            child_backdrop_capture_rect.unwrap_or(backdrop_layer.rect),
+            child,
+            resolved_child,
+            &backdrop_layer.effect,
             (width, height),
             root_scale,
         );
@@ -4310,7 +4584,7 @@ fn composite_root_child_backdrop<B: SurfaceExecutionBackend>(
             height,
             root_scale,
             Some(backdrop_input_hash),
-            true,
+            !child.needs_nested_underlay,
         )? {
             let PreparedBackdropComposite {
                 surface: prepared_surface,
@@ -4402,15 +4676,6 @@ fn composite_nested_child_backdrop<B: SurfaceExecutionBackend>(
     queues: &mut PendingQueues<'_>,
 ) -> Result<(), String> {
     let (width, height) = viewport;
-    let child_backdrop_capture_rect = child.backdrop.as_ref().and_then(|backdrop| {
-        visible_backdrop_capture_rect(
-            resolved_child.backdrop_rect,
-            child.visual_clip,
-            backdrop,
-            target_scale,
-            (width, height),
-        )
-    });
 
     if !resolved_child.shadow_draws.is_empty() {
         flush_pending_composite_queues_fused(
@@ -4455,21 +4720,17 @@ fn composite_nested_child_backdrop<B: SurfaceExecutionBackend>(
             effect: backdrop.clone(),
             z_index: child.z_index,
         };
-        let backdrop_input_hash = {
-            let local_hash = backdrop_scene_prefix_hash(
-                local_scene,
-                prior_child_contributions,
-                child.z_index,
-                child_backdrop_capture_rect.unwrap_or(backdrop_layer.rect),
-                (width, height),
-                target_scale,
-            );
-            if context.baked {
-                content_hash_over_underlay(local_hash, context.underlay_identity)
-            } else {
-                local_hash
-            }
-        };
+        let backdrop_input_hash = nested_child_backdrop_input_hash(
+            local_scene,
+            prior_child_contributions,
+            child,
+            resolved_child,
+            &backdrop_layer.effect,
+            (width, height),
+            target_scale,
+            context.baked,
+            context.underlay_identity,
+        );
         let effective_backdrop_underlay = if context.backdrop_underlay.is_some()
             && backdrop_underlay_is_covered_by_local_content(
                 &local_scene.shapes,
@@ -5092,30 +5353,36 @@ fn serve_or_capture_prefix_snapshot<B: SurfaceExecutionBackend>(
     pending_composite_load_op: &mut Option<wgpu::LoadOp<wgpu::Color>>,
     next_load_op: &mut wgpu::LoadOp<wgpu::Color>,
 ) -> Result<PrefixSnapshotOutcome, String> {
+    let inert = |reason: &str| {
+        if backdrop_diag_enabled() {
+            eprintln!("[backdrop-diag] prefix-snapshot inert: {reason} z_end={z_end}");
+        }
+        Ok(PrefixSnapshotOutcome::Inert)
+    };
     if z_start != 0 || !prefix_snapshot_enabled() {
-        return Ok(PrefixSnapshotOutcome::Inert);
+        return inert("z_start or disabled");
     }
     let Some(source) = snapshot_source else {
-        return Ok(PrefixSnapshotOutcome::Inert);
+        return inert("no source");
     };
     let wgpu::LoadOp::Clear(clear) = *next_load_op else {
-        return Ok(PrefixSnapshotOutcome::Inert);
+        return inert("load op");
     };
     if source.width != width || source.height != height {
-        return Ok(PrefixSnapshotOutcome::Inert);
+        return inert("size");
     }
     // A pending feed capture copies specific shape slots out of this frame's
     // conversion stream; both replaying past them and splitting the frame's
     // batches around them would corrupt what the store captures. Captures
     // are one-shot events, so sitting the whole frame out is free.
     if any_pending_feed_captures() {
-        return Ok(PrefixSnapshotOutcome::Inert);
+        return inert("pending feed captures");
     }
     let prefix_end = prefix_snapshot_range_end(scene, z_end);
     let Some((key, logical_rect)) =
         prefix_snapshot_key(scene, prefix_end, width, height, root_scale, &clear)
     else {
-        return Ok(PrefixSnapshotOutcome::Inert);
+        return inert(&format!("no key prefix_end={prefix_end}"));
     };
 
     if let Some((cached_target, cached_rect)) = backend.cached_layer_surface(&key) {
@@ -5338,6 +5605,60 @@ fn render_direct_scene_range_with_pending_composites<B: SurfaceExecutionBackend>
     Ok(())
 }
 
+fn child_backdrop_input_hash(
+    local_scene: &CompositorScene,
+    prior_child_contributions: &[BackdropPrefixChildContribution],
+    child: &ChildLayerComposite,
+    resolved_child: &ResolvedChildSurfaceComposite,
+    effect: &RenderEffect,
+    viewport: (u32, u32),
+    scale: f32,
+) -> u64 {
+    let capture_rect = visible_backdrop_capture_rect(
+        resolved_child.backdrop_rect,
+        child.visual_clip,
+        effect,
+        scale,
+        viewport,
+    );
+    backdrop_scene_prefix_hash(
+        local_scene,
+        prior_child_contributions,
+        child.z_index,
+        capture_rect.unwrap_or(resolved_child.backdrop_rect),
+        viewport,
+        scale,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn nested_child_backdrop_input_hash(
+    local_scene: &CompositorScene,
+    prior_child_contributions: &[BackdropPrefixChildContribution],
+    child: &ChildLayerComposite,
+    resolved_child: &ResolvedChildSurfaceComposite,
+    effect: &RenderEffect,
+    viewport: (u32, u32),
+    scale: f32,
+    baked: bool,
+    underlay_identity: Option<u64>,
+) -> u64 {
+    let local_hash = child_backdrop_input_hash(
+        local_scene,
+        prior_child_contributions,
+        child,
+        resolved_child,
+        effect,
+        viewport,
+        scale,
+    );
+    if baked {
+        content_hash_over_underlay(local_hash, underlay_identity)
+    } else {
+        local_hash
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
     backend: &mut B,
@@ -5479,25 +5800,27 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
             cursor_z = child.z_index.saturating_add(1);
             continue;
         }
-        if child.needs_nested_underlay {
-            flush_pending_composite_queues_fused(
-                backend,
-                &mut pending_composites,
-                &mut pending_composite_load_op,
-                &mut pending_shader_composites,
-                &mut pending_shader_load_op,
-                &target.view,
-                (width, height),
-                &mut next_load_op,
-            )?;
-            flush_pending_clear(backend, &target.view, &mut next_load_op);
-        }
         let child_translation_context = TranslationRenderContext {
             inherited_content_translation: effective_translated_content_context,
             translated_content_axes: effective_translated_content_axes,
             surface_capture_active: translation_context.surface_capture_active,
             local_picture_capture_active: translation_context.local_picture_capture_active,
         };
+        let wants_underlay = child.needs_nested_underlay;
+        let child_underlay_identity = wants_underlay
+            .then(|| {
+                underlay_identity_before(
+                    local_scene,
+                    &prior_child_contributions,
+                    child.z_index,
+                    quad_bounds(child_dest_quad),
+                    (width, height),
+                    target_scale,
+                    underlay_identity,
+                    backdrop_underlay.is_some(),
+                )
+            })
+            .flatten();
         composite_nested_child_backdrop(
             backend,
             &target,
@@ -5521,34 +5844,8 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                 composite_seq: &mut composite_seq,
             },
         )?;
-        let child_underlay_identity = child
-            .needs_nested_underlay
-            .then(|| {
-                underlay_identity_before(
-                    local_scene,
-                    &prior_child_contributions,
-                    child.z_index,
-                    quad_bounds(child_dest_quad),
-                    (width, height),
-                    target_scale,
-                    underlay_identity,
-                    backdrop_underlay.is_some(),
-                )
-            })
-            .flatten();
         let mut child_bake_underlay = false;
-        let child_underlay = if child.needs_nested_underlay {
-            flush_pending_composite_queues_fused(
-                backend,
-                &mut pending_composites,
-                &mut pending_composite_load_op,
-                &mut pending_shader_composites,
-                &mut pending_shader_load_op,
-                &target.view,
-                (width, height),
-                &mut next_load_op,
-            )?;
-            flush_pending_clear(backend, &target.view, &mut next_load_op);
+        let child_underlay = if wants_underlay {
             let underlay = sample_child_underlay(
                 backend,
                 &target,
@@ -5564,7 +5861,20 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                 child_underlay_identity,
                 target_scale,
                 child_translation_context,
-            );
+                UnderlayCaptureSource {
+                    target_view: &target.view,
+                    viewport: (width, height),
+                    dependency_rect: quad_bounds(child_dest_quad),
+                    queues: &mut PendingQueues {
+                        composites: &mut pending_composites,
+                        composite_load_op: &mut pending_composite_load_op,
+                        shader_composites: &mut pending_shader_composites,
+                        shader_load_op: &mut pending_shader_load_op,
+                        next_load_op: &mut next_load_op,
+                        composite_seq: &mut composite_seq,
+                    },
+                },
+            )?;
             child_bake_underlay = underlay.baked;
             Some(underlay.target)
         } else {

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -1,6 +1,8 @@
 use std::{
     cell::RefCell,
     hash::{Hash, Hasher},
+    ops::Range,
+    rc::Rc,
 };
 
 use cranpose_core::{NodeId, collections::map::HashMap};
@@ -38,11 +40,11 @@ use crate::{
         ChildLayerComposite, CollectedLayer, LoweredChildSource, ResolvedChildSurfaceComposite,
         SceneWindowSource, TranslateBy, build_scene_window, collected_layer_bounds,
         filtered_effect_layer_index, motion_stable_capture_bounds_from_parts,
-        resolved_child_surface_composite, resolved_layer_surface_rect_from_parts, translate_quad,
-        visible_draw_rect,
+        resolved_child_surface_composite, resolved_layer_surface_rect_from_parts,
+        shadow_draw_is_blurred_drop, translate_quad, visible_draw_rect,
     },
     offscreen::OffscreenTarget,
-    render::{has_backdrop_layer_in_range, scissor_rect_for_rect},
+    render::{has_backdrop_layer_in_range, is_in_effect_range, scissor_rect_for_rect},
     scene::{
         BackdropLayer, CompositorScene, DrawOp, DrawOpKind, DrawShape, EffectLayer, ImageDraw,
         SceneBrush, ShadowDraw, SnapAnchor, TextDraw,
@@ -105,6 +107,10 @@ fn prefix_snapshot_enabled() -> bool {
 
 fn deferred_direct_run_enabled() -> bool {
     crate::debug_toggles::debug_toggle("CRANPOSE_NO_DEFERRED_RUN").as_deref() != Some("1")
+}
+
+fn shadow_composite_queue_enabled() -> bool {
+    crate::debug_toggles::debug_toggle("CRANPOSE_NO_SHADOW_COMPOSITE_QUEUE").as_deref() != Some("1")
 }
 
 fn direct_scene_range_coalesce_enabled() -> bool {
@@ -1516,9 +1522,17 @@ fn draw_op_visible_bounds(scene: &CompositorScene, draw_op: DrawOp) -> Option<Re
 /// shadow reaches beyond its shapes by the blur extent, so it is bounded by
 /// its expanded, clipped rectangle rather than skipped like the chunk cache
 /// skips it.
-fn deferred_range_bounds(scene: &CompositorScene, z_start: usize, z_end: usize) -> Option<Rect> {
+fn deferred_range_bounds(
+    scene: &CompositorScene,
+    z_start: usize,
+    z_end: usize,
+    excluded: &[Range<usize>],
+) -> Option<Rect> {
     let mut bounds = None;
     for op in scene_range_draw_ops(&scene.draw_ops, z_start, z_end) {
+        if is_in_effect_range(op.z_index, excluded) {
+            continue;
+        }
         let rect = match op.kind {
             DrawOpKind::Shadow(index) => scene.shadow_draws.get(index).and_then(|shadow| {
                 crate::normalized_scene::shadow_draws_bounds(std::slice::from_ref(shadow))
@@ -2608,6 +2622,7 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                         &mut pending_shader_composites,
                         &mut pending_shader_load_op,
                         &mut next_load_op,
+                        &deferred.excluded,
                     )?;
                     let backdrop_input_hashes = scene_backdrop_input_hashes(
                         &local_scene,
@@ -2646,7 +2661,7 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                         &mut pending_shader_composites,
                         &mut pending_shader_load_op,
                         &mut next_load_op,
-                        &mut deferred.run,
+                        &mut deferred,
                         !deferred_direct_run_enabled(),
                     )?;
                     if !deferred_direct_run_enabled() {
@@ -2706,6 +2721,7 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                     &mut pending_shader_composites,
                     &mut pending_shader_load_op,
                     &mut next_load_op,
+                    &deferred.excluded,
                 )?;
                 flush_pending_clear(backend, surface_view, &mut next_load_op);
                 for shadow in &resolved_child.shadow_draws {
@@ -2968,6 +2984,7 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                             &mut pending_shader_composites,
                             &mut pending_shader_load_op,
                             &mut next_load_op,
+                            &deferred.excluded,
                         )?;
                         let composite_load_op = next_load_op;
                         composite_layer_surface_to_view(
@@ -3071,6 +3088,7 @@ fn finish_root_ranges<B: SurfaceExecutionBackend>(
                 pending_shader_composites,
                 pending_shader_load_op,
                 next_load_op,
+                &deferred.excluded,
             )?;
             let backdrop_input_hashes = scene_backdrop_input_hashes(
                 local_scene,
@@ -3109,7 +3127,7 @@ fn finish_root_ranges<B: SurfaceExecutionBackend>(
                 pending_shader_composites,
                 pending_shader_load_op,
                 next_load_op,
-                &mut deferred.run,
+                deferred,
                 true,
             )?;
             render_non_effect_range_with_pending_composites(
@@ -3126,6 +3144,7 @@ fn finish_root_ranges<B: SurfaceExecutionBackend>(
                 pending_shader_composites,
                 pending_shader_load_op,
                 next_load_op,
+                &deferred.excluded,
             )?;
         }
     } else {
@@ -3159,6 +3178,7 @@ fn finish_root_ranges<B: SurfaceExecutionBackend>(
                 pending_shader_composites,
                 pending_shader_load_op,
                 next_load_op,
+                &deferred.excluded,
             )?;
         }
     }
@@ -4736,6 +4756,7 @@ struct PendingQueues<'a, 's> {
 struct DeferredDirectRun<'s> {
     scene: &'s CompositorScene,
     run: DirectChunkRunCoalescer,
+    excluded: Vec<Range<usize>>,
 }
 
 impl<'s> DeferredDirectRun<'s> {
@@ -4743,12 +4764,27 @@ impl<'s> DeferredDirectRun<'s> {
         Self {
             scene,
             run: DirectChunkRunCoalescer::default(),
+            excluded: Vec::new(),
         }
+    }
+
+    /// Takes the draw op at `z_index` out of the run: it is drawn as a pending
+    /// composite instead, so segments and dependency checks skip it.
+    fn exclude(&mut self, z_index: usize) {
+        self.excluded.push(z_index..z_index.saturating_add(1));
+    }
+
+    fn next_excluded_after(&self, z_index: usize) -> Option<usize> {
+        self.excluded
+            .iter()
+            .map(|range| range.start)
+            .filter(|start| *start > z_index)
+            .min()
     }
 
     fn intersects(&self, dependency_rect: Rect, boundary: usize) -> bool {
         self.run.peek(boundary).is_some_and(|(start, end)| {
-            deferred_range_bounds(self.scene, start, end)
+            deferred_range_bounds(self.scene, start, end, &self.excluded)
                 .is_some_and(|bounds| rects_intersect(bounds, dependency_rect))
         })
     }
@@ -4787,7 +4823,10 @@ fn flush_deferred_run<B: SurfaceExecutionBackend>(
         pending_shader_composites,
         pending_shader_load_op,
         next_load_op,
-    )
+        &deferred.excluded,
+    )?;
+    deferred.excluded.retain(|range| range.start >= run_end);
+    Ok(())
 }
 
 fn flush_deferred_run_for_dependency<B: SurfaceExecutionBackend>(
@@ -5254,6 +5293,7 @@ fn render_non_effect_range_with_pending_composites<B: SurfaceExecutionBackend>(
     pending_shader_composites: &mut Vec<PendingShaderLayerComposite>,
     pending_shader_load_op: &mut Option<wgpu::LoadOp<wgpu::Color>>,
     next_load_op: &mut wgpu::LoadOp<wgpu::Color>,
+    excluded: &[Range<usize>],
 ) -> Result<(), String> {
     if pending_composites.is_empty() && pending_shader_composites.is_empty() {
         backend.render_non_effect_segment(
@@ -5267,7 +5307,7 @@ fn render_non_effect_range_with_pending_composites<B: SurfaceExecutionBackend>(
             &scene.draw_ops,
             z_start,
             z_end,
-            &[],
+            excluded,
             width,
             height,
             root_scale,
@@ -5298,7 +5338,7 @@ fn render_non_effect_range_with_pending_composites<B: SurfaceExecutionBackend>(
         &scene.draw_ops,
         z_start,
         z_end,
-        &[],
+        excluded,
         &composite_items,
         &shader_composite_items,
         width,
@@ -5811,6 +5851,82 @@ fn serve_or_capture_prefix_snapshot<B: SurfaceExecutionBackend>(
     }
 }
 
+/// Turns every cacheable blurred drop shadow of the range into pending
+/// composites of its cached shadow texture, one per band, and takes the ops
+/// out of the deferred run. A capture above the shadow then replays the
+/// composite into its copy instead of forcing the whole run onto the target.
+#[allow(clippy::too_many_arguments)]
+fn queue_blurred_shadow_composites<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    scene: &CompositorScene,
+    z_start: usize,
+    z_end: usize,
+    viewport: (u32, u32),
+    root_scale: f32,
+    pending_composites: &mut Vec<PendingLayerComposite>,
+    composite_seq: &mut usize,
+    pending_composite_load_op: &mut Option<wgpu::LoadOp<wgpu::Color>>,
+    next_load_op: &mut wgpu::LoadOp<wgpu::Color>,
+    deferred: &mut DeferredDirectRun<'_>,
+) {
+    if !root_scale.is_finite() || root_scale <= 0.0 || !shadow_composite_queue_enabled() {
+        return;
+    }
+    for op in scene_range_draw_ops(&scene.draw_ops, z_start, z_end) {
+        let DrawOpKind::Shadow(index) = op.kind else {
+            continue;
+        };
+        let Some(shadow) = scene.shadow_draws.get(index) else {
+            continue;
+        };
+        if !shadow_draw_is_blurred_drop(shadow) {
+            continue;
+        }
+        let Some(prepared) =
+            backend.prepare_shadow_composite(shadow, viewport.0, viewport.1, root_scale)
+        else {
+            continue;
+        };
+        deferred.exclude(op.z_index);
+        let (x, y, width, height) = prepared.dest_viewport;
+        let dest_quad = crate::rect_to_quad(Rect {
+            x,
+            y,
+            width,
+            height,
+        });
+        let logical_rect = Rect {
+            x: x / root_scale,
+            y: y / root_scale,
+            width: width / root_scale,
+            height: height / root_scale,
+        };
+        for band in prepared.bands {
+            if pending_composites.is_empty() {
+                *pending_composite_load_op = Some(*next_load_op);
+            }
+            pending_composites.push(PendingLayerComposite {
+                z_index: op.z_index,
+                seq: next_composite_seq(composite_seq),
+                surface: LayerSurface {
+                    target: LayerSurfaceTexture::Cached(Rc::clone(&prepared.source)),
+                    logical_rect,
+                    composite_alpha: 1.0,
+                    blend_mode: BlendMode::SrcOver,
+                    rounded_clip: shadow.rounded_clip,
+                    backdrop: None,
+                    deferred_effect: None,
+                    effect_content_rect: None,
+                    sample_mode: CompositeSampleMode::Nearest,
+                },
+                dest_quad,
+                scissor: Some(band),
+            });
+            *next_load_op = wgpu::LoadOp::Load;
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn render_direct_scene_range_with_pending_composites<B: SurfaceExecutionBackend>(
     backend: &mut B,
@@ -5828,7 +5944,7 @@ fn render_direct_scene_range_with_pending_composites<B: SurfaceExecutionBackend>
     pending_shader_composites: &mut Vec<PendingShaderLayerComposite>,
     pending_shader_load_op: &mut Option<wgpu::LoadOp<wgpu::Color>>,
     next_load_op: &mut wgpu::LoadOp<wgpu::Color>,
-    direct_run: &mut DirectChunkRunCoalescer,
+    deferred: &mut DeferredDirectRun<'_>,
     flush_at_end: bool,
 ) -> Result<(), String> {
     let cache_enabled = direct_scene_range_cache_enabled();
@@ -5847,11 +5963,31 @@ fn render_direct_scene_range_with_pending_composites<B: SurfaceExecutionBackend>
             composite_seq,
             pending_composite_load_op,
             next_load_op,
-            direct_run,
+            &mut deferred.run,
         )?;
     }
+    queue_blurred_shadow_composites(
+        backend,
+        scene,
+        cursor_z,
+        z_end,
+        (width, height),
+        root_scale,
+        pending_composites,
+        composite_seq,
+        pending_composite_load_op,
+        next_load_op,
+        deferred,
+    );
     while cursor_z < z_end {
+        if is_in_effect_range(cursor_z, &deferred.excluded) {
+            cursor_z = cursor_z.saturating_add(1);
+            continue;
+        }
         let mut chunk_end = direct_scene_range_cache_chunk_end(scene, cursor_z, z_end, root_scale);
+        if let Some(next_excluded) = deferred.next_excluded_after(cursor_z) {
+            chunk_end = chunk_end.min(next_excluded);
+        }
         if chunk_end <= cursor_z {
             return Err("direct scene cache chunk did not advance".to_string());
         }
@@ -5886,7 +6022,7 @@ fn render_direct_scene_range_with_pending_composites<B: SurfaceExecutionBackend>
                 next_load_op,
             )?
         {
-            if let Some((run_start, run_end)) = direct_run.flush_at(cursor_z) {
+            if let Some((run_start, run_end)) = deferred.run.flush_at(cursor_z) {
                 render_non_effect_range_with_pending_composites(
                     backend,
                     target_view,
@@ -5901,15 +6037,16 @@ fn render_direct_scene_range_with_pending_composites<B: SurfaceExecutionBackend>
                     pending_shader_composites,
                     pending_shader_load_op,
                     next_load_op,
+                    &deferred.excluded,
                 )?;
             }
             cursor_z = chunk_end;
             continue;
         }
-        direct_run.absorb(cursor_z);
+        deferred.run.absorb(cursor_z);
         cursor_z = chunk_end;
         if !direct_scene_range_coalesce_enabled()
-            && let Some((run_start, run_end)) = direct_run.flush_at(cursor_z)
+            && let Some((run_start, run_end)) = deferred.run.flush_at(cursor_z)
         {
             render_non_effect_range_with_pending_composites(
                 backend,
@@ -5925,10 +6062,11 @@ fn render_direct_scene_range_with_pending_composites<B: SurfaceExecutionBackend>
                 pending_shader_composites,
                 pending_shader_load_op,
                 next_load_op,
+                &deferred.excluded,
             )?;
         }
     }
-    if flush_at_end && let Some((run_start, run_end)) = direct_run.flush_at(z_end) {
+    if flush_at_end && let Some((run_start, run_end)) = deferred.run.flush_at(z_end) {
         render_non_effect_range_with_pending_composites(
             backend,
             target_view,
@@ -5943,6 +6081,7 @@ fn render_direct_scene_range_with_pending_composites<B: SurfaceExecutionBackend>
             pending_shader_composites,
             pending_shader_load_op,
             next_load_op,
+            &deferred.excluded,
         )?;
     }
     Ok(())
@@ -6042,6 +6181,7 @@ fn render_nested_range<B: SurfaceExecutionBackend>(
             queues.shader_composites,
             queues.shader_load_op,
             queues.next_load_op,
+            &queues.deferred.excluded,
         );
     }
     flush_pending_composite_queues_fused(

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -5659,6 +5659,94 @@ fn nested_child_backdrop_input_hash(
     }
 }
 
+/// Renders the surface's direct ops in `[z_start, z_end)` together with the
+/// composites queued so far, one fused pass when the range carries no layer
+/// events, otherwise the queues flush first and the range renders through
+/// the layer-event path. The caller's loop defers this until a child reads
+/// the target, so the composites of the children in between ride in the
+/// same pass as the ops around them.
+#[allow(clippy::too_many_arguments)]
+fn render_nested_range<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    target: &OffscreenTarget,
+    local_scene: &CompositorScene,
+    prior_child_contributions: &[BackdropPrefixChildContribution],
+    z_start: usize,
+    z_end: usize,
+    viewport: (u32, u32),
+    target_scale: f32,
+    context: NestedBackdropContext<'_>,
+    queues: &mut PendingQueues<'_>,
+) -> Result<(), String> {
+    let (width, height) = viewport;
+    if !range_contains_layer_events(
+        &local_scene.effect_layers,
+        &local_scene.backdrop_layers,
+        z_start,
+        z_end,
+    ) {
+        return render_non_effect_range_with_pending_composites(
+            backend,
+            &target.view,
+            local_scene,
+            z_start,
+            z_end,
+            width,
+            height,
+            target_scale,
+            queues.composites,
+            queues.composite_load_op,
+            queues.shader_composites,
+            queues.shader_load_op,
+            queues.next_load_op,
+        );
+    }
+    flush_pending_composite_queues_fused(
+        backend,
+        queues.composites,
+        queues.composite_load_op,
+        queues.shader_composites,
+        queues.shader_load_op,
+        &target.view,
+        viewport,
+        queues.next_load_op,
+    )?;
+    let mut local_backdrop_hashes = scene_backdrop_input_hashes(
+        local_scene,
+        prior_child_contributions,
+        viewport,
+        target_scale,
+    );
+    if context.baked {
+        for hash in &mut local_backdrop_hashes {
+            *hash = content_hash_over_underlay(*hash, context.underlay_identity);
+        }
+    }
+    backend.render_range_with_layer_events_to_target(
+        target,
+        &local_scene.shapes,
+        &local_scene.brushes,
+        &local_scene.images,
+        &local_scene.texts,
+        &local_scene.shadow_draws,
+        &local_scene.retained_draws,
+        &local_scene.draw_ops,
+        &local_scene.effect_layers,
+        &local_scene.backdrop_layers,
+        &local_backdrop_hashes,
+        z_start,
+        z_end,
+        None,
+        width,
+        height,
+        target_scale,
+        context.backdrop_underlay,
+        *queues.next_load_op,
+    )?;
+    *queues.next_load_op = wgpu::LoadOp::Load;
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
     backend: &mut B,
@@ -5695,90 +5783,6 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
     let mut composite_seq = 0usize;
     let mut prior_child_contributions = Vec::new();
     for mut child in child_layers {
-        if cursor_z < child.z_index {
-            flush_pending_shader_layer_composites(
-                backend,
-                &mut pending_shader_composites,
-                &target.view,
-                (width, height),
-                &mut pending_shader_load_op,
-                &mut next_load_op,
-            )?;
-            if !pending_composites.is_empty()
-                && !range_contains_layer_events(
-                    &local_scene.effect_layers,
-                    &local_scene.backdrop_layers,
-                    cursor_z,
-                    child.z_index,
-                )
-            {
-                let load_op = pending_composite_load_op.take().unwrap_or(next_load_op);
-                let composite_items = pending_layer_composite_batch_items(&pending_composites);
-                backend.render_non_effect_segment_with_composites(
-                    &target.view,
-                    &local_scene.shapes,
-                    &local_scene.brushes,
-                    &local_scene.images,
-                    &local_scene.texts,
-                    &local_scene.shadow_draws,
-                    &local_scene.retained_draws,
-                    &local_scene.draw_ops,
-                    cursor_z,
-                    child.z_index,
-                    &[],
-                    &composite_items,
-                    &[],
-                    width,
-                    height,
-                    target_scale,
-                    load_op,
-                )?;
-                release_pending_layer_composites(backend, &mut pending_composites);
-            } else {
-                flush_pending_layer_composites(
-                    backend,
-                    &mut pending_composites,
-                    &target.view,
-                    (width, height),
-                    &mut pending_composite_load_op,
-                    &mut next_load_op,
-                );
-                let mut local_backdrop_hashes = scene_backdrop_input_hashes(
-                    local_scene,
-                    &prior_child_contributions,
-                    (width, height),
-                    target_scale,
-                );
-                if baked {
-                    for hash in &mut local_backdrop_hashes {
-                        *hash = content_hash_over_underlay(*hash, underlay_identity);
-                    }
-                }
-                backend.render_range_with_layer_events_to_target(
-                    &target,
-                    &local_scene.shapes,
-                    &local_scene.brushes,
-                    &local_scene.images,
-                    &local_scene.texts,
-                    &local_scene.shadow_draws,
-                    &local_scene.retained_draws,
-                    &local_scene.draw_ops,
-                    &local_scene.effect_layers,
-                    &local_scene.backdrop_layers,
-                    &local_backdrop_hashes,
-                    cursor_z,
-                    child.z_index,
-                    None,
-                    width,
-                    height,
-                    target_scale,
-                    backdrop_underlay,
-                    next_load_op,
-                )?;
-            }
-            next_load_op = wgpu::LoadOp::Load;
-        }
-
         let resolved_child = resolved_child_surface_composite(&child);
         let child_dest_quad = if let Some(anchor) = resolved_child.snap_anchor {
             translate_quad(
@@ -5797,8 +5801,44 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                 height,
             )
         {
-            cursor_z = child.z_index.saturating_add(1);
             continue;
+        }
+        let child_reads_target = child.backdrop.is_some()
+            || child.needs_nested_underlay
+            || !resolved_child.shadow_draws.is_empty();
+        if cursor_z < child.z_index
+            && (child_reads_target
+                || range_contains_layer_events(
+                    &local_scene.effect_layers,
+                    &local_scene.backdrop_layers,
+                    cursor_z,
+                    child.z_index,
+                ))
+        {
+            render_nested_range(
+                backend,
+                &target,
+                local_scene,
+                &prior_child_contributions,
+                cursor_z,
+                child.z_index,
+                (width, height),
+                target_scale,
+                NestedBackdropContext {
+                    backdrop_underlay,
+                    baked,
+                    underlay_identity,
+                },
+                &mut PendingQueues {
+                    composites: &mut pending_composites,
+                    composite_load_op: &mut pending_composite_load_op,
+                    shader_composites: &mut pending_shader_composites,
+                    shader_load_op: &mut pending_shader_load_op,
+                    next_load_op: &mut next_load_op,
+                    composite_seq: &mut composite_seq,
+                },
+            )?;
+            cursor_z = child.z_index;
         }
         let child_translation_context = TranslationRenderContext {
             inherited_content_translation: effective_translated_content_context,
@@ -5897,12 +5937,14 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
         )?;
 
         if !resolved_child.shadow_draws.is_empty() {
-            flush_pending_shader_layer_composites(
+            flush_pending_composite_queues_fused(
                 backend,
+                &mut pending_composites,
+                &mut pending_composite_load_op,
                 &mut pending_shader_composites,
+                &mut pending_shader_load_op,
                 &target.view,
                 (width, height),
-                &mut pending_shader_load_op,
                 &mut next_load_op,
             )?;
             flush_pending_clear(backend, &target.view, &mut next_load_op);
@@ -5944,14 +5986,6 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
             child_underlay_identity,
         );
         if child_surface.deferred_effect.is_none() && axis_aligned_quad_rect(dest_quad).is_some() {
-            flush_pending_shader_layer_composites(
-                backend,
-                &mut pending_shader_composites,
-                &target.view,
-                (width, height),
-                &mut pending_shader_load_op,
-                &mut next_load_op,
-            )?;
             if pending_composites.is_empty() {
                 pending_composite_load_op = Some(next_load_op);
             }
@@ -5964,14 +5998,6 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
             });
             next_load_op = wgpu::LoadOp::Load;
         } else {
-            flush_pending_layer_composites(
-                backend,
-                &mut pending_composites,
-                &target.view,
-                (width, height),
-                &mut pending_composite_load_op,
-                &mut next_load_op,
-            );
             match direct_shader_layer_composite(
                 child_surface,
                 child.z_index,
@@ -5987,12 +6013,40 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                     next_load_op = wgpu::LoadOp::Load;
                 }
                 Err(child_surface) => {
-                    flush_pending_shader_layer_composites(
+                    if cursor_z < child.z_index {
+                        render_nested_range(
+                            backend,
+                            &target,
+                            local_scene,
+                            &prior_child_contributions,
+                            cursor_z,
+                            child.z_index,
+                            (width, height),
+                            target_scale,
+                            NestedBackdropContext {
+                                backdrop_underlay,
+                                baked,
+                                underlay_identity,
+                            },
+                            &mut PendingQueues {
+                                composites: &mut pending_composites,
+                                composite_load_op: &mut pending_composite_load_op,
+                                shader_composites: &mut pending_shader_composites,
+                                shader_load_op: &mut pending_shader_load_op,
+                                next_load_op: &mut next_load_op,
+                                composite_seq: &mut composite_seq,
+                            },
+                        )?;
+                        cursor_z = child.z_index;
+                    }
+                    flush_pending_composite_queues_fused(
                         backend,
+                        &mut pending_composites,
+                        &mut pending_composite_load_op,
                         &mut pending_shader_composites,
+                        &mut pending_shader_load_op,
                         &target.view,
                         (width, height),
-                        &mut pending_shader_load_op,
                         &mut next_load_op,
                     )?;
                     let composite_load_op = next_load_op;
@@ -6014,88 +6068,35 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
             backend.release_frame_surface(underlay);
         }
         prior_child_contributions.push(child_prefix_contribution);
-        cursor_z = child.z_index.saturating_add(1);
+        if cursor_z >= child.z_index {
+            cursor_z = child.z_index.saturating_add(1);
+        }
     }
 
     if cursor_z < local_scene.next_z {
-        if (!pending_composites.is_empty() || !pending_shader_composites.is_empty())
-            && !range_contains_layer_events(
-                &local_scene.effect_layers,
-                &local_scene.backdrop_layers,
-                cursor_z,
-                local_scene.next_z,
-            )
-        {
-            let load_op = take_ordered_pending_composite_load_op(
-                &pending_composites,
-                &mut pending_composite_load_op,
-                &pending_shader_composites,
-                &mut pending_shader_load_op,
-                next_load_op,
-            );
-            let composite_items = pending_layer_composite_batch_items(&pending_composites);
-            let shader_composite_items =
-                pending_shader_layer_composite_batch_items(&pending_shader_composites);
-            backend.render_non_effect_segment_with_composites(
-                &target.view,
-                &local_scene.shapes,
-                &local_scene.brushes,
-                &local_scene.images,
-                &local_scene.texts,
-                &local_scene.shadow_draws,
-                &local_scene.retained_draws,
-                &local_scene.draw_ops,
-                cursor_z,
-                local_scene.next_z,
-                &[],
-                &composite_items,
-                &shader_composite_items,
-                width,
-                height,
-                target_scale,
-                load_op,
-            )?;
-            release_pending_layer_composites(backend, &mut pending_composites);
-            release_pending_shader_layer_composites(backend, &mut pending_shader_composites);
-        } else {
-            flush_pending_composite_queues_fused(
-                backend,
-                &mut pending_composites,
-                &mut pending_composite_load_op,
-                &mut pending_shader_composites,
-                &mut pending_shader_load_op,
-                &target.view,
-                (width, height),
-                &mut next_load_op,
-            )?;
-            let local_backdrop_hashes = scene_backdrop_input_hashes(
-                local_scene,
-                &prior_child_contributions,
-                (width, height),
-                target_scale,
-            );
-            backend.render_range_with_layer_events_to_target(
-                &target,
-                &local_scene.shapes,
-                &local_scene.brushes,
-                &local_scene.images,
-                &local_scene.texts,
-                &local_scene.shadow_draws,
-                &local_scene.retained_draws,
-                &local_scene.draw_ops,
-                &local_scene.effect_layers,
-                &local_scene.backdrop_layers,
-                &local_backdrop_hashes,
-                cursor_z,
-                local_scene.next_z,
-                None,
-                width,
-                height,
-                target_scale,
+        render_nested_range(
+            backend,
+            &target,
+            local_scene,
+            &prior_child_contributions,
+            cursor_z,
+            local_scene.next_z,
+            (width, height),
+            target_scale,
+            NestedBackdropContext {
                 backdrop_underlay,
-                next_load_op,
-            )?;
-        }
+                baked,
+                underlay_identity,
+            },
+            &mut PendingQueues {
+                composites: &mut pending_composites,
+                composite_load_op: &mut pending_composite_load_op,
+                shader_composites: &mut pending_shader_composites,
+                shader_load_op: &mut pending_shader_load_op,
+                next_load_op: &mut next_load_op,
+                composite_seq: &mut composite_seq,
+            },
+        )?;
     } else if matches!(next_load_op, wgpu::LoadOp::Clear(_)) {
         backend.clear_target_view_with_load_op(&target.view, next_load_op);
     } else {

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -103,6 +103,10 @@ fn prefix_snapshot_enabled() -> bool {
     crate::debug_toggles::debug_toggle("CRANPOSE_DISABLE_PREFIX_SNAPSHOT").is_none()
 }
 
+fn deferred_direct_run_enabled() -> bool {
+    crate::debug_toggles::debug_toggle("CRANPOSE_NO_DEFERRED_RUN").as_deref() != Some("1")
+}
+
 fn direct_scene_range_coalesce_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| {
@@ -119,6 +123,12 @@ struct DirectChunkRunCoalescer {
 impl DirectChunkRunCoalescer {
     fn absorb(&mut self, chunk_start: usize) {
         self.run_start.get_or_insert(chunk_start);
+    }
+
+    fn peek(&self, boundary: usize) -> Option<(usize, usize)> {
+        self.run_start
+            .filter(|start| *start < boundary)
+            .map(|start| (start, boundary))
     }
 
     fn flush_at(&mut self, boundary: usize) -> Option<(usize, usize)> {
@@ -1502,6 +1512,26 @@ fn draw_op_visible_bounds(scene: &CompositorScene, draw_op: DrawOp) -> Option<Re
     }
 }
 
+/// Every pixel a deferred range can write, shadows included: a blurred
+/// shadow reaches beyond its shapes by the blur extent, so it is bounded by
+/// its expanded, clipped rectangle rather than skipped like the chunk cache
+/// skips it.
+fn deferred_range_bounds(scene: &CompositorScene, z_start: usize, z_end: usize) -> Option<Rect> {
+    let mut bounds = None;
+    for op in scene_range_draw_ops(&scene.draw_ops, z_start, z_end) {
+        let rect = match op.kind {
+            DrawOpKind::Shadow(index) => scene.shadow_draws.get(index).and_then(|shadow| {
+                crate::normalized_scene::shadow_draws_bounds(std::slice::from_ref(shadow))
+            }),
+            _ => draw_op_visible_bounds(scene, *op),
+        };
+        if let Some(rect) = rect {
+            bounds = union_rect(bounds, rect);
+        }
+    }
+    bounds
+}
+
 fn scene_range_visible_bounds(
     scene: &CompositorScene,
     z_start: usize,
@@ -1656,11 +1686,11 @@ struct ChildUnderlay {
 
 /// The parent target a child's underlay is sampled from, with the composite
 /// queues still waiting to land on it.
-struct UnderlayCaptureSource<'a, 'q> {
+struct UnderlayCaptureSource<'a, 'q, 's> {
     target_view: &'a wgpu::TextureView,
     viewport: (u32, u32),
     dependency_rect: Rect,
-    queues: &'a mut PendingQueues<'q>,
+    queues: &'a mut PendingQueues<'q, 's>,
 }
 
 /// The pixels beneath a child that carries nested backdrops. A whole-pixel
@@ -1681,7 +1711,7 @@ fn sample_child_underlay<B: SurfaceExecutionBackend>(
     underlay_identity: Option<u64>,
     parent_scale: f32,
     translation_context: TranslationRenderContext,
-    source: UnderlayCaptureSource<'_, '_>,
+    source: UnderlayCaptureSource<'_, '_, '_>,
 ) -> Result<ChildUnderlay, String> {
     let child_scale = child_surface_target_scale(child, parent_scale, translation_context);
     let device_origin = (backend.underlay_bake_enabled()
@@ -1701,6 +1731,15 @@ fn sample_child_underlay<B: SurfaceExecutionBackend>(
             )
         })
         .flatten();
+    flush_deferred_run_for_dependency(
+        backend,
+        source.target_view,
+        source.viewport,
+        parent_scale,
+        source.dependency_rect,
+        child.z_index,
+        source.queues,
+    )?;
     let dependency_pixels = surface_pixel_rect(source.dependency_rect, parent_scale);
     let conflicts = pending_capture_conflicts(
         source.queues.composites,
@@ -1722,7 +1761,7 @@ fn sample_child_underlay<B: SurfaceExecutionBackend>(
             conflicts.shaders,
         );
     }
-    let flush_queues = |backend: &mut B, queues: &mut PendingQueues<'_>| {
+    let flush_queues = |backend: &mut B, queues: &mut PendingQueues<'_, '_>| {
         flush_pending_queues_for_backdrop_capture(
             backend,
             queues.composites,
@@ -2532,6 +2571,7 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
         let mut pending_shader_load_op = None;
         let mut composite_seq = 0usize;
         let mut prior_child_contributions = Vec::new();
+        let mut deferred = DeferredDirectRun::new(&local_scene);
         for mut child in child_layers {
             if cursor_z < child.z_index {
                 let range_has_events = range_contains_layer_events(
@@ -2541,6 +2581,19 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                     child.z_index,
                 );
                 if range_has_events {
+                    flush_deferred_run(
+                        backend,
+                        surface_view,
+                        (width, height),
+                        root_scale,
+                        cursor_z,
+                        &mut deferred,
+                        &mut pending_composites,
+                        &mut pending_composite_load_op,
+                        &mut pending_shader_composites,
+                        &mut pending_shader_load_op,
+                        &mut next_load_op,
+                    )?;
                     render_non_effect_range_with_pending_composites(
                         backend,
                         surface_view,
@@ -2593,9 +2646,13 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                         &mut pending_shader_composites,
                         &mut pending_shader_load_op,
                         &mut next_load_op,
+                        &mut deferred.run,
+                        !deferred_direct_run_enabled(),
                     )?;
+                    if !deferred_direct_run_enabled() {
+                        next_load_op = wgpu::LoadOp::Load;
+                    }
                 }
-                next_load_op = wgpu::LoadOp::Load;
             }
 
             let resolved_child = resolved_child_surface_composite(&child);
@@ -2622,6 +2679,19 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
 
             let child_backdrop_reads_target = child.backdrop.is_some() && root_target.is_some();
             if !resolved_child.shadow_draws.is_empty() && !child_backdrop_reads_target {
+                flush_deferred_run(
+                    backend,
+                    surface_view,
+                    (width, height),
+                    root_scale,
+                    child.z_index,
+                    &mut deferred,
+                    &mut pending_composites,
+                    &mut pending_composite_load_op,
+                    &mut pending_shader_composites,
+                    &mut pending_shader_load_op,
+                    &mut next_load_op,
+                )?;
                 render_non_effect_range_with_pending_composites(
                     backend,
                     surface_view,
@@ -2675,8 +2745,21 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                     shader_load_op: &mut pending_shader_load_op,
                     next_load_op: &mut next_load_op,
                     composite_seq: &mut composite_seq,
+                    deferred: &mut deferred,
                 },
             )?;
+            if child_is_bare_backdrop(&child) {
+                let scissor = child
+                    .visual_clip
+                    .and_then(|clip| scissor_rect_for_rect(clip, root_scale, width, height));
+                prior_child_contributions.push(bare_backdrop_child_contribution(
+                    &child,
+                    &resolved_child,
+                    scissor,
+                ));
+                cursor_z = child.z_index.saturating_add(1);
+                continue;
+            }
             let mut bake_underlay = false;
             let child_underlay = if wants_underlay {
                 Some(match root_target {
@@ -2707,6 +2790,7 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                                     shader_load_op: &mut pending_shader_load_op,
                                     next_load_op: &mut next_load_op,
                                     composite_seq: &mut composite_seq,
+                                    deferred: &mut deferred,
                                 },
                             },
                         )?;
@@ -2766,6 +2850,19 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                         pending_shader_composites.len()
                     );
                 }
+                flush_deferred_run(
+                    backend,
+                    surface_view,
+                    (width, height),
+                    root_scale,
+                    child.z_index,
+                    &mut deferred,
+                    &mut pending_composites,
+                    &mut pending_composite_load_op,
+                    &mut pending_shader_composites,
+                    &mut pending_shader_load_op,
+                    &mut next_load_op,
+                )?;
                 flush_pending_composite_queues_fused(
                     backend,
                     &mut pending_composites,
@@ -2844,6 +2941,19 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
                         next_load_op = wgpu::LoadOp::Load;
                     }
                     Err(child_surface) => {
+                        flush_deferred_run(
+                            backend,
+                            surface_view,
+                            (width, height),
+                            root_scale,
+                            child.z_index,
+                            &mut deferred,
+                            &mut pending_composites,
+                            &mut pending_composite_load_op,
+                            &mut pending_shader_composites,
+                            &mut pending_shader_load_op,
+                            &mut next_load_op,
+                        )?;
                         render_non_effect_range_with_pending_composites(
                             backend,
                             surface_view,
@@ -2878,109 +2988,182 @@ pub(crate) fn render_root_direct<B: SurfaceExecutionBackend>(
             cursor_z = child.z_index.saturating_add(1);
         }
 
-        if cursor_z < local_scene.next_z {
-            let range_has_events = range_contains_layer_events(
-                &local_scene.effect_layers,
-                &local_scene.backdrop_layers,
-                cursor_z,
-                local_scene.next_z,
-            );
-            if range_has_events {
-                render_non_effect_range_with_pending_composites(
-                    backend,
-                    surface_view,
-                    &local_scene,
-                    cursor_z,
-                    cursor_z,
-                    width,
-                    height,
-                    root_scale,
-                    &mut pending_composites,
-                    &mut pending_composite_load_op,
-                    &mut pending_shader_composites,
-                    &mut pending_shader_load_op,
-                    &mut next_load_op,
-                )?;
-                let backdrop_input_hashes = scene_backdrop_input_hashes(
-                    &local_scene,
-                    &prior_child_contributions,
-                    (width, height),
-                    root_scale,
-                );
-                render_range_with_layer_events_to_view(
-                    backend,
-                    surface_view,
-                    root_target,
-                    &backdrop_input_hashes,
-                    &local_scene,
-                    cursor_z,
-                    local_scene.next_z,
-                    None,
-                    width,
-                    height,
-                    root_scale,
-                    next_load_op,
-                )?;
-            } else {
-                render_direct_scene_range_with_pending_composites(
-                    backend,
-                    surface_view,
-                    root_target,
-                    &local_scene,
-                    cursor_z,
-                    local_scene.next_z,
-                    width,
-                    height,
-                    root_scale,
-                    &mut pending_composites,
-                    &mut composite_seq,
-                    &mut pending_composite_load_op,
-                    &mut pending_shader_composites,
-                    &mut pending_shader_load_op,
-                    &mut next_load_op,
-                )?;
-                render_non_effect_range_with_pending_composites(
-                    backend,
-                    surface_view,
-                    &local_scene,
-                    local_scene.next_z,
-                    local_scene.next_z,
-                    width,
-                    height,
-                    root_scale,
-                    &mut pending_composites,
-                    &mut pending_composite_load_op,
-                    &mut pending_shader_composites,
-                    &mut pending_shader_load_op,
-                    &mut next_load_op,
-                )?;
-            }
-        } else if matches!(next_load_op, wgpu::LoadOp::Clear(_)) {
-            backend.clear_target_view_with_load_op(surface_view, next_load_op);
-        } else {
-            render_non_effect_range_with_pending_composites(
-                backend,
-                surface_view,
-                &local_scene,
-                local_scene.next_z,
-                local_scene.next_z,
-                width,
-                height,
-                root_scale,
-                &mut pending_composites,
-                &mut pending_composite_load_op,
-                &mut pending_shader_composites,
-                &mut pending_shader_load_op,
-                &mut next_load_op,
-            )?;
-        }
-
+        finish_root_ranges(
+            backend,
+            surface_view,
+            root_target,
+            &local_scene,
+            &prior_child_contributions,
+            cursor_z,
+            width,
+            height,
+            root_scale,
+            &mut deferred,
+            &mut pending_composites,
+            &mut composite_seq,
+            &mut pending_composite_load_op,
+            &mut pending_shader_composites,
+            &mut pending_shader_load_op,
+            &mut next_load_op,
+        )?;
         Ok(())
     })();
     match result {
         Ok(()) => Ok(local_scene),
         Err(error) => Err((error, local_scene)),
     }
+}
+
+/// Draws whatever the root walk left after its last child: the trailing
+/// range, the deferred run and every pending composite, as one fused pass
+/// where the scene allows it.
+#[allow(clippy::too_many_arguments)]
+fn finish_root_ranges<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    surface_view: &wgpu::TextureView,
+    root_target: Option<&OffscreenTarget>,
+    local_scene: &CompositorScene,
+    prior_child_contributions: &[BackdropPrefixChildContribution],
+    cursor_z: usize,
+    width: u32,
+    height: u32,
+    root_scale: f32,
+    deferred: &mut DeferredDirectRun<'_>,
+    pending_composites: &mut Vec<PendingLayerComposite>,
+    composite_seq: &mut usize,
+    pending_composite_load_op: &mut Option<wgpu::LoadOp<wgpu::Color>>,
+    pending_shader_composites: &mut Vec<PendingShaderLayerComposite>,
+    pending_shader_load_op: &mut Option<wgpu::LoadOp<wgpu::Color>>,
+    next_load_op: &mut wgpu::LoadOp<wgpu::Color>,
+) -> Result<(), String> {
+    if cursor_z < local_scene.next_z {
+        let range_has_events = range_contains_layer_events(
+            &local_scene.effect_layers,
+            &local_scene.backdrop_layers,
+            cursor_z,
+            local_scene.next_z,
+        );
+        if range_has_events {
+            flush_deferred_run(
+                backend,
+                surface_view,
+                (width, height),
+                root_scale,
+                cursor_z,
+                deferred,
+                pending_composites,
+                pending_composite_load_op,
+                pending_shader_composites,
+                pending_shader_load_op,
+                next_load_op,
+            )?;
+            render_non_effect_range_with_pending_composites(
+                backend,
+                surface_view,
+                local_scene,
+                cursor_z,
+                cursor_z,
+                width,
+                height,
+                root_scale,
+                pending_composites,
+                pending_composite_load_op,
+                pending_shader_composites,
+                pending_shader_load_op,
+                next_load_op,
+            )?;
+            let backdrop_input_hashes = scene_backdrop_input_hashes(
+                local_scene,
+                prior_child_contributions,
+                (width, height),
+                root_scale,
+            );
+            render_range_with_layer_events_to_view(
+                backend,
+                surface_view,
+                root_target,
+                &backdrop_input_hashes,
+                local_scene,
+                cursor_z,
+                local_scene.next_z,
+                None,
+                width,
+                height,
+                root_scale,
+                *next_load_op,
+            )?;
+        } else {
+            render_direct_scene_range_with_pending_composites(
+                backend,
+                surface_view,
+                root_target,
+                local_scene,
+                cursor_z,
+                local_scene.next_z,
+                width,
+                height,
+                root_scale,
+                pending_composites,
+                composite_seq,
+                pending_composite_load_op,
+                pending_shader_composites,
+                pending_shader_load_op,
+                next_load_op,
+                &mut deferred.run,
+                true,
+            )?;
+            render_non_effect_range_with_pending_composites(
+                backend,
+                surface_view,
+                local_scene,
+                local_scene.next_z,
+                local_scene.next_z,
+                width,
+                height,
+                root_scale,
+                pending_composites,
+                pending_composite_load_op,
+                pending_shader_composites,
+                pending_shader_load_op,
+                next_load_op,
+            )?;
+        }
+    } else {
+        flush_deferred_run(
+            backend,
+            surface_view,
+            (width, height),
+            root_scale,
+            local_scene.next_z,
+            deferred,
+            pending_composites,
+            pending_composite_load_op,
+            pending_shader_composites,
+            pending_shader_load_op,
+            next_load_op,
+        )?;
+        if matches!(*next_load_op, wgpu::LoadOp::Clear(_)) {
+            backend.clear_target_view_with_load_op(surface_view, *next_load_op);
+        } else {
+            render_non_effect_range_with_pending_composites(
+                backend,
+                surface_view,
+                local_scene,
+                local_scene.next_z,
+                local_scene.next_z,
+                width,
+                height,
+                root_scale,
+                pending_composites,
+                pending_composite_load_op,
+                pending_shader_composites,
+                pending_shader_load_op,
+                next_load_op,
+            )?;
+        }
+    }
+
+    Ok(())
 }
 
 pub(crate) fn render_layer_surface<B: SurfaceExecutionBackend>(
@@ -3431,6 +3614,38 @@ fn backdrop_prefix_child_contribution(
         composite_alpha_bits: surface.composite_alpha.to_bits(),
         blend_mode: surface.blend_mode,
         sample_mode: surface.sample_mode,
+    }
+}
+
+fn child_is_bare_backdrop(child: &ChildLayerComposite) -> bool {
+    child.backdrop.is_some() && child.source.is_empty()
+}
+
+/// The contribution of a backdrop child that draws nothing over its effect
+/// output: only the effect output reaches later captures, so no surface is
+/// rendered or composited for it.
+fn bare_backdrop_child_contribution(
+    child: &ChildLayerComposite,
+    resolved_child: &ResolvedChildSurfaceComposite,
+    scissor: Option<(u32, u32, u32, u32)>,
+) -> BackdropPrefixChildContribution {
+    BackdropPrefixChildContribution {
+        z_index: child.z_index,
+        node_id: child.node_id,
+        content_hash: child.target_content_hash,
+        effect_hash: child.effect_hash,
+        backdrop_hash: child
+            .backdrop
+            .as_ref()
+            .map(retained_render_effect_hash)
+            .unwrap_or(0),
+        deferred_effect_hash: 0,
+        logical_rect: resolved_child.logical_rect,
+        dest_quad: resolved_child.dest_quad,
+        scissor,
+        composite_alpha_bits: 1.0f32.to_bits(),
+        blend_mode: BlendMode::SrcOver,
+        sample_mode: CompositeSampleMode::Linear,
     }
 }
 
@@ -4007,6 +4222,13 @@ fn hash_shadow_draw<H: Hasher>(shadow: &ShadowDraw, state: &mut H) {
     }
     hash_f32_bits(shadow.blur_radius, state);
     hash_optional_rect(shadow.clip, state);
+    shadow.rounded_clip.is_some().hash(state);
+    if let Some(rounded_clip) = shadow.rounded_clip {
+        hash_rect(rounded_clip.rect, state);
+        for radius in rounded_clip.radii {
+            hash_f32_bits(radius, state);
+        }
+    }
     shadow.z_index.hash(state);
 }
 
@@ -4496,13 +4718,103 @@ fn take_ordered_pending_composite_load_op(
 
 /// The composite queues a render loop batches between passes, lent to the
 /// helpers that push into them or flush them.
-struct PendingQueues<'a> {
+struct PendingQueues<'a, 's> {
     composites: &'a mut Vec<PendingLayerComposite>,
     composite_load_op: &'a mut Option<wgpu::LoadOp<wgpu::Color>>,
     shader_composites: &'a mut Vec<PendingShaderLayerComposite>,
     shader_load_op: &'a mut Option<wgpu::LoadOp<wgpu::Color>>,
     next_load_op: &'a mut wgpu::LoadOp<wgpu::Color>,
     composite_seq: &'a mut usize,
+    deferred: &'a mut DeferredDirectRun<'s>,
+}
+
+/// The direct draw ops of a scene that have been walked but not drawn: they
+/// stay pending alongside the composites so that one fused pass draws every
+/// z-ordered range and composite together, instead of one pass per child.
+/// A capture that reads their pixels, an immediate draw that must land above
+/// them, or the end of the walk flushes the run.
+struct DeferredDirectRun<'s> {
+    scene: &'s CompositorScene,
+    run: DirectChunkRunCoalescer,
+}
+
+impl<'s> DeferredDirectRun<'s> {
+    fn new(scene: &'s CompositorScene) -> Self {
+        Self {
+            scene,
+            run: DirectChunkRunCoalescer::default(),
+        }
+    }
+
+    fn intersects(&self, dependency_rect: Rect, boundary: usize) -> bool {
+        self.run.peek(boundary).is_some_and(|(start, end)| {
+            deferred_range_bounds(self.scene, start, end)
+                .is_some_and(|bounds| rects_intersect(bounds, dependency_rect))
+        })
+    }
+}
+
+/// Draws the deferred run up to `boundary` fused with every pending composite,
+/// so nothing drawn into the target afterwards can land beneath it.
+#[allow(clippy::too_many_arguments)]
+fn flush_deferred_run<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    target_view: &wgpu::TextureView,
+    viewport: (u32, u32),
+    root_scale: f32,
+    boundary: usize,
+    deferred: &mut DeferredDirectRun<'_>,
+    pending_composites: &mut Vec<PendingLayerComposite>,
+    pending_composite_load_op: &mut Option<wgpu::LoadOp<wgpu::Color>>,
+    pending_shader_composites: &mut Vec<PendingShaderLayerComposite>,
+    pending_shader_load_op: &mut Option<wgpu::LoadOp<wgpu::Color>>,
+    next_load_op: &mut wgpu::LoadOp<wgpu::Color>,
+) -> Result<(), String> {
+    let Some((run_start, run_end)) = deferred.run.flush_at(boundary) else {
+        return Ok(());
+    };
+    render_non_effect_range_with_pending_composites(
+        backend,
+        target_view,
+        deferred.scene,
+        run_start,
+        run_end,
+        viewport.0,
+        viewport.1,
+        root_scale,
+        pending_composites,
+        pending_composite_load_op,
+        pending_shader_composites,
+        pending_shader_load_op,
+        next_load_op,
+    )
+}
+
+fn flush_deferred_run_for_dependency<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    target_view: &wgpu::TextureView,
+    viewport: (u32, u32),
+    root_scale: f32,
+    dependency_rect: Rect,
+    boundary: usize,
+    queues: &mut PendingQueues<'_, '_>,
+) -> Result<(), String> {
+    if !queues.deferred.intersects(dependency_rect, boundary) {
+        return Ok(());
+    }
+    flush_deferred_run(
+        backend,
+        target_view,
+        viewport,
+        root_scale,
+        boundary,
+        queues.deferred,
+        queues.composites,
+        queues.composite_load_op,
+        queues.shader_composites,
+        queues.shader_load_op,
+        queues.next_load_op,
+    )
 }
 
 /// Composites a root child's own backdrop into the root target: capture,
@@ -4523,7 +4835,7 @@ fn composite_root_child_backdrop<B: SurfaceExecutionBackend>(
     resolved_child: &ResolvedChildSurfaceComposite,
     viewport: (u32, u32),
     root_scale: f32,
-    queues: &mut PendingQueues<'_>,
+    queues: &mut PendingQueues<'_, '_>,
 ) -> Result<(), String> {
     let (width, height) = viewport;
     if let Some(backdrop) = child.backdrop.clone() {
@@ -4688,7 +5000,7 @@ fn composite_nested_child_backdrop<B: SurfaceExecutionBackend>(
     viewport: (u32, u32),
     target_scale: f32,
     context: NestedBackdropContext<'_>,
-    queues: &mut PendingQueues<'_>,
+    queues: &mut PendingQueues<'_, '_>,
 ) -> Result<(), String> {
     let (width, height) = viewport;
 
@@ -5516,10 +5828,11 @@ fn render_direct_scene_range_with_pending_composites<B: SurfaceExecutionBackend>
     pending_shader_composites: &mut Vec<PendingShaderLayerComposite>,
     pending_shader_load_op: &mut Option<wgpu::LoadOp<wgpu::Color>>,
     next_load_op: &mut wgpu::LoadOp<wgpu::Color>,
+    direct_run: &mut DirectChunkRunCoalescer,
+    flush_at_end: bool,
 ) -> Result<(), String> {
     let cache_enabled = direct_scene_range_cache_enabled();
     let mut cursor_z = z_start;
-    let mut direct_run = DirectChunkRunCoalescer::default();
     if cache_enabled {
         cursor_z = stage_prefix_snapshot_into_walk(
             backend,
@@ -5534,7 +5847,7 @@ fn render_direct_scene_range_with_pending_composites<B: SurfaceExecutionBackend>
             composite_seq,
             pending_composite_load_op,
             next_load_op,
-            &mut direct_run,
+            direct_run,
         )?;
     }
     while cursor_z < z_end {
@@ -5615,7 +5928,7 @@ fn render_direct_scene_range_with_pending_composites<B: SurfaceExecutionBackend>
             )?;
         }
     }
-    if let Some((run_start, run_end)) = direct_run.flush_at(z_end) {
+    if flush_at_end && let Some((run_start, run_end)) = direct_run.flush_at(z_end) {
         render_non_effect_range_with_pending_composites(
             backend,
             target_view,
@@ -5706,7 +6019,7 @@ fn render_nested_range<B: SurfaceExecutionBackend>(
     viewport: (u32, u32),
     target_scale: f32,
     context: NestedBackdropContext<'_>,
-    queues: &mut PendingQueues<'_>,
+    queues: &mut PendingQueues<'_, '_>,
 ) -> Result<(), String> {
     let (width, height) = viewport;
     if !range_contains_layer_events(
@@ -5812,6 +6125,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
     let mut pending_shader_load_op = None;
     let mut composite_seq = 0usize;
     let mut prior_child_contributions = Vec::new();
+    let mut deferred = DeferredDirectRun::new(local_scene);
     for mut child in child_layers {
         let resolved_child = resolved_child_surface_composite(&child);
         let child_dest_quad = if let Some(anchor) = resolved_child.snap_anchor {
@@ -5866,6 +6180,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                     shader_load_op: &mut pending_shader_load_op,
                     next_load_op: &mut next_load_op,
                     composite_seq: &mut composite_seq,
+                    deferred: &mut deferred,
                 },
             )?;
             cursor_z = child.z_index;
@@ -5912,9 +6227,22 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                 shader_load_op: &mut pending_shader_load_op,
                 next_load_op: &mut next_load_op,
                 composite_seq: &mut composite_seq,
+                deferred: &mut deferred,
             },
         )?;
         let mut child_bake_underlay = false;
+        if child_is_bare_backdrop(&child) {
+            let scissor = child
+                .visual_clip
+                .and_then(|clip| scissor_rect_for_rect(clip, target_scale, width, height));
+            prior_child_contributions.push(bare_backdrop_child_contribution(
+                &child,
+                &resolved_child,
+                scissor,
+            ));
+            cursor_z = child.z_index.saturating_add(1);
+            continue;
+        }
         let child_underlay = if wants_underlay {
             let underlay = sample_child_underlay(
                 backend,
@@ -5942,6 +6270,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                         shader_load_op: &mut pending_shader_load_op,
                         next_load_op: &mut next_load_op,
                         composite_seq: &mut composite_seq,
+                        deferred: &mut deferred,
                     },
                 },
             )?;
@@ -6065,6 +6394,8 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                                 shader_load_op: &mut pending_shader_load_op,
                                 next_load_op: &mut next_load_op,
                                 composite_seq: &mut composite_seq,
+
+                                deferred: &mut deferred,
                             },
                         )?;
                         cursor_z = child.z_index;
@@ -6125,6 +6456,7 @@ fn render_layer_source_uncached<B: SurfaceExecutionBackend>(
                 shader_load_op: &mut pending_shader_load_op,
                 next_load_op: &mut next_load_op,
                 composite_seq: &mut composite_seq,
+                deferred: &mut deferred,
             },
         )?;
     } else if matches!(next_load_op, wgpu::LoadOp::Clear(_)) {
@@ -6787,8 +7119,17 @@ fn prepare_capture_source<B: SurfaceExecutionBackend>(
     dependency_rect: Rect,
     viewport: (u32, u32),
     scale: f32,
-    queues: &mut PendingQueues<'_>,
+    queues: &mut PendingQueues<'_, '_>,
 ) -> Result<Option<Rect>, String> {
+    flush_deferred_run_for_dependency(
+        backend,
+        &target.view,
+        viewport,
+        scale,
+        dependency_rect,
+        layer.z_index,
+        queues,
+    )?;
     let dependency_pixels = surface_pixel_rect(dependency_rect, scale);
     let conflicts = pending_capture_conflicts(
         queues.composites,

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -1750,7 +1750,7 @@ fn sample_child_underlay<B: SurfaceExecutionBackend>(
             parent_scale,
         ) {
             if replay && conflicts.any() {
-                replay_pending_into_underlay(
+                replay_pending_into_copy(
                     backend,
                     &target,
                     origin,
@@ -1826,11 +1826,11 @@ fn replayed_write(
     })
 }
 
-/// Draws the pending composites that touch `dependency_pixels` into the
-/// underlay copy, in the order they will later land on the parent, without
-/// consuming them: the copy then holds what the parent will show beneath the
-/// child, and the parent's own batch stays intact.
-fn replay_pending_into_underlay<B: SurfaceExecutionBackend>(
+/// Draws the pending composites that touch `dependency_pixels` into a copy
+/// taken out of the parent at `origin`, in the order they will later land on
+/// the parent, without consuming them: the copy then holds what the parent
+/// will show there, and the parent's own batch stays intact.
+fn replay_pending_into_copy<B: SurfaceExecutionBackend>(
     backend: &mut B,
     underlay: &OffscreenTarget,
     origin: (u32, u32),
@@ -4538,26 +4538,24 @@ fn composite_root_child_backdrop<B: SurfaceExecutionBackend>(
             effect: backdrop,
             z_index: child.z_index,
         };
-        if let Some(dependency_rect) = backdrop_dependency_rect(
+        let replay_pixels = match backdrop_dependency_rect(
             resolved_child.backdrop_rect,
             child.visual_clip,
             &backdrop_layer.effect,
             root_scale,
             (width, height),
         ) {
-            flush_pending_queues_for_backdrop_capture(
+            Some(dependency_rect) => prepare_capture_source(
                 backend,
-                queues.composites,
-                queues.composite_load_op,
-                queues.shader_composites,
-                queues.shader_load_op,
-                surface_view,
-                (width, height),
-                queues.next_load_op,
+                root_target,
+                &backdrop_layer,
                 dependency_rect,
+                (width, height),
                 root_scale,
-            )?;
-        }
+                queues,
+            )?,
+            None => None,
+        };
         let backdrop_input_hash = child_backdrop_input_hash(
             local_scene,
             prior_child_contributions,
@@ -4585,6 +4583,11 @@ fn composite_root_child_backdrop<B: SurfaceExecutionBackend>(
             root_scale,
             Some(backdrop_input_hash),
             !child.needs_nested_underlay,
+            replay_pixels.map(|dependency_pixels| PendingReplaySource {
+                composites: queues.composites,
+                shader_composites: queues.shader_composites,
+                dependency_pixels,
+            }),
         )? {
             let PreparedBackdropComposite {
                 surface: prepared_surface,
@@ -4634,6 +4637,18 @@ fn composite_root_child_backdrop<B: SurfaceExecutionBackend>(
                 *queues.next_load_op = wgpu::LoadOp::Load;
             }
         } else {
+            if replay_pixels.is_some() {
+                flush_pending_composite_queues_fused(
+                    backend,
+                    queues.composites,
+                    queues.composite_load_op,
+                    queues.shader_composites,
+                    queues.shader_load_op,
+                    surface_view,
+                    (width, height),
+                    queues.next_load_op,
+                )?;
+            }
             apply_backdrop_layer_to_target(
                 backend,
                 root_target,
@@ -4692,26 +4707,6 @@ fn composite_nested_child_backdrop<B: SurfaceExecutionBackend>(
     }
 
     if let Some(backdrop) = &child.backdrop {
-        if let Some(dependency_rect) = backdrop_dependency_rect(
-            resolved_child.backdrop_rect,
-            child.visual_clip,
-            backdrop,
-            target_scale,
-            (width, height),
-        ) {
-            flush_pending_queues_for_backdrop_capture(
-                backend,
-                queues.composites,
-                queues.composite_load_op,
-                queues.shader_composites,
-                queues.shader_load_op,
-                &target.view,
-                (width, height),
-                queues.next_load_op,
-                dependency_rect,
-                target_scale,
-            )?;
-        }
         let backdrop_layer = BackdropLayer {
             node_id: child.node_id,
             rect: resolved_child.backdrop_rect,
@@ -4719,6 +4714,24 @@ fn composite_nested_child_backdrop<B: SurfaceExecutionBackend>(
             snap_anchor: resolved_child.snap_anchor,
             effect: backdrop.clone(),
             z_index: child.z_index,
+        };
+        let replay_pixels = match backdrop_dependency_rect(
+            resolved_child.backdrop_rect,
+            child.visual_clip,
+            backdrop,
+            target_scale,
+            (width, height),
+        ) {
+            Some(dependency_rect) => prepare_capture_source(
+                backend,
+                target,
+                &backdrop_layer,
+                dependency_rect,
+                (width, height),
+                target_scale,
+                queues,
+            )?,
+            None => None,
         };
         let backdrop_input_hash = nested_child_backdrop_input_hash(
             local_scene,
@@ -4756,6 +4769,11 @@ fn composite_nested_child_backdrop<B: SurfaceExecutionBackend>(
             target_scale,
             Some(backdrop_input_hash),
             false,
+            replay_pixels.map(|dependency_pixels| PendingReplaySource {
+                composites: queues.composites,
+                shader_composites: queues.shader_composites,
+                dependency_pixels,
+            }),
         )? {
             if queues.composites.is_empty() {
                 *queues.composite_load_op = Some(*queues.next_load_op);
@@ -4769,6 +4787,18 @@ fn composite_nested_child_backdrop<B: SurfaceExecutionBackend>(
             });
             *queues.next_load_op = wgpu::LoadOp::Load;
         } else {
+            if replay_pixels.is_some() {
+                flush_pending_composite_queues_fused(
+                    backend,
+                    queues.composites,
+                    queues.composite_load_op,
+                    queues.shader_composites,
+                    queues.shader_load_op,
+                    &target.view,
+                    (width, height),
+                    queues.next_load_op,
+                )?;
+            }
             apply_backdrop_layer_to_target(
                 backend,
                 target,
@@ -6647,6 +6677,156 @@ pub(crate) fn render_effect_layer_to_target<B: SurfaceExecutionBackend>(
     composite_result
 }
 
+/// The device geometry of a backdrop capture: what of the layer is visible,
+/// the padded rect its effect reads, the scale the capture renders at and,
+/// when that scale is the target's own, the whole-pixel copy that samples it.
+struct BackdropCaptureGeometry {
+    layer_rect: Rect,
+    layer_clip: Option<Rect>,
+    visible_rect: Rect,
+    capture_rect: Rect,
+    backdrop_scale: f32,
+    copy_plan: Option<BackdropSnapshotCopyPlan>,
+}
+
+fn backdrop_capture_geometry(
+    layer: &BackdropLayer,
+    root_scale: f32,
+    width: u32,
+    height: u32,
+    target_size: (u32, u32),
+    max_texture_dim: u32,
+) -> Option<BackdropCaptureGeometry> {
+    let (layer_rect, layer_clip) = snapped_backdrop_geometry(layer, root_scale);
+    let visible_rect = visible_layer_rect(layer_rect, layer_clip, root_scale, width, height)?;
+    let capture_rect = backdrop_capture_rect(
+        visible_rect,
+        layer_clip,
+        &layer.effect,
+        root_scale,
+        (width, height),
+    );
+    let backdrop_scale =
+        clamp_effect_surface_scale(capture_rect, root_scale, root_scale, max_texture_dim);
+    let copy_plan = ((backdrop_scale - root_scale).abs() <= 0.01)
+        .then(|| {
+            axis_aligned_backdrop_snapshot_copy_plan(
+                capture_rect,
+                layer_rect,
+                root_scale,
+                target_size,
+                max_texture_dim,
+            )
+        })
+        .flatten();
+    Some(BackdropCaptureGeometry {
+        layer_rect,
+        layer_clip,
+        visible_rect,
+        capture_rect,
+        backdrop_scale,
+        copy_plan,
+    })
+}
+
+/// The composites still queued for the target when a capture copies out of
+/// it: the ones touching `dependency_pixels` are replayed into the copy.
+struct PendingReplaySource<'a> {
+    composites: &'a [PendingLayerComposite],
+    shader_composites: &'a [PendingShaderLayerComposite],
+    dependency_pixels: Rect,
+}
+
+/// Copies the capture's whole-pixel window out of the target and replays the
+/// queued composites that touch it into the copy. A capture that was promised
+/// a replay cannot fall back to sampling the target, which lacks them.
+fn copy_backdrop_capture<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    target: &OffscreenTarget,
+    copy_plan: Option<&BackdropSnapshotCopyPlan>,
+    destination: &OffscreenTarget,
+    replay: Option<&PendingReplaySource<'_>>,
+) -> Result<bool, String> {
+    let Some(plan) = copy_plan else {
+        if replay.is_some() {
+            return Err("a backdrop capture promised a replay has no copy plan".to_string());
+        }
+        return Ok(false);
+    };
+    let copied =
+        backend.copy_texture_region_to_target(target, plan.source_origin, destination, plan.size);
+    match replay {
+        Some(source) if copied => replay_pending_into_copy(
+            backend,
+            destination,
+            plan.source_origin,
+            source.composites,
+            source.shader_composites,
+            source.dependency_pixels,
+        )?,
+        Some(_) => {
+            return Err(
+                "a backdrop capture promised a replay could not copy its window".to_string(),
+            );
+        }
+        None => {}
+    }
+    Ok(copied)
+}
+
+/// Decides how a backdrop capture of `layer` sees the composites queued for
+/// `target`. With a whole-pixel copy plan and no clear held by a queue, the
+/// queues stay pending and the capture replays the conflicting ones into its
+/// copy; otherwise the queues flush first. Returns the dependency pixels the
+/// capture must replay, when it must.
+#[allow(clippy::too_many_arguments)]
+fn prepare_capture_source<B: SurfaceExecutionBackend>(
+    backend: &mut B,
+    target: &OffscreenTarget,
+    layer: &BackdropLayer,
+    dependency_rect: Rect,
+    viewport: (u32, u32),
+    scale: f32,
+    queues: &mut PendingQueues<'_>,
+) -> Result<Option<Rect>, String> {
+    let dependency_pixels = surface_pixel_rect(dependency_rect, scale);
+    let conflicts = pending_capture_conflicts(
+        queues.composites,
+        queues.composite_load_op,
+        queues.shader_composites,
+        queues.shader_load_op,
+        dependency_pixels,
+    );
+    let can_replay = backend.underlay_replay_enabled()
+        && !conflicts.clear_held
+        && backdrop_capture_geometry(
+            layer,
+            scale,
+            viewport.0,
+            viewport.1,
+            (target.width, target.height),
+            backend.max_texture_dim(),
+        )
+        .is_some_and(|geometry| geometry.copy_plan.is_some());
+    if !can_replay {
+        flush_pending_queues_for_backdrop_capture(
+            backend,
+            queues.composites,
+            queues.composite_load_op,
+            queues.shader_composites,
+            queues.shader_load_op,
+            &target.view,
+            viewport,
+            queues.next_load_op,
+            dependency_rect,
+            scale,
+        )?;
+        return Ok(None);
+    }
+    flush_pending_clear(backend, &target.view, queues.next_load_op);
+    Ok(conflicts.any().then_some(dependency_pixels))
+}
+
 #[allow(clippy::too_many_arguments)]
 fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
     backend: &mut B,
@@ -6658,15 +6838,29 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
     root_scale: f32,
     input_content_hash: Option<u64>,
     allow_deferred_tail: bool,
+    replay: Option<PendingReplaySource<'_>>,
 ) -> Result<Option<PreparedBackdropComposite>, String> {
     let diag = backdrop_diag_enabled();
-    let (layer_rect, layer_clip) = snapped_backdrop_geometry(layer, root_scale);
-    let Some(visible_rect) = visible_layer_rect(layer_rect, layer_clip, root_scale, width, height)
+    let Some(BackdropCaptureGeometry {
+        layer_rect,
+        layer_clip,
+        visible_rect,
+        capture_rect,
+        backdrop_scale,
+        copy_plan,
+    }) = backdrop_capture_geometry(
+        layer,
+        root_scale,
+        width,
+        height,
+        (target.width, target.height),
+        backend.max_texture_dim(),
+    )
     else {
         if diag {
             eprintln!(
                 "[backdrop-diag] prepare SKIP: no visible rect for {:?}",
-                layer_rect
+                layer.rect
             );
         }
         return Ok(None);
@@ -6688,38 +6882,15 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
         }
         return Ok(None);
     };
-    let capture_rect = backdrop_capture_rect(
-        visible_rect,
-        layer_clip,
-        &layer.effect,
-        root_scale,
-        (width, height),
-    );
     if diag {
         eprintln!(
-            "[backdrop-diag] prepare node={:?} visible={visible_rect:?} capture={capture_rect:?} scissor={scissor:?} in_pad={} out_pad={}",
+            "[backdrop-diag] prepare node={:?} visible={visible_rect:?} capture={capture_rect:?} scissor={scissor:?} in_pad={} out_pad={} replay={}",
             layer.node_id,
             layer.effect.input_padding(),
             layer.effect.output_padding(),
+            replay.is_some(),
         );
     }
-    let backdrop_scale = clamp_effect_surface_scale(
-        capture_rect,
-        root_scale,
-        root_scale,
-        backend.max_texture_dim(),
-    );
-    let copy_plan = if (backdrop_scale - root_scale).abs() <= 0.01 {
-        axis_aligned_backdrop_snapshot_copy_plan(
-            capture_rect,
-            layer_rect,
-            root_scale,
-            (target.width, target.height),
-            backend.max_texture_dim(),
-        )
-    } else {
-        None
-    };
     let (backdrop_width, backdrop_height) = copy_plan.map(|plan| plan.size).unwrap_or_else(|| {
         surface_target_size(capture_rect, backdrop_scale, backend.max_texture_dim())
     });
@@ -6765,14 +6936,13 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
         let effect_target = backend.acquire_retained_surface(backdrop_width, backdrop_height);
         if let Some(effect) = materialized_effect {
             let snapshot = backend.acquire_frame_surface(backdrop_width, backdrop_height);
-            let copied_snapshot = copy_plan.is_some_and(|plan| {
-                backend.copy_texture_region_to_target(
-                    target,
-                    plan.source_origin,
-                    &snapshot,
-                    plan.size,
-                )
-            });
+            let copied_snapshot = copy_backdrop_capture(
+                backend,
+                target,
+                copy_plan.as_ref(),
+                &snapshot,
+                replay.as_ref(),
+            )?;
             if !copied_snapshot {
                 copy_projective_backdrop_inputs_to_view(
                     backend,
@@ -6815,14 +6985,13 @@ fn prepare_cached_backdrop_layer_composite<B: SurfaceExecutionBackend>(
             )?;
             backend.release_frame_surface(snapshot);
         } else {
-            let copied_capture = copy_plan.is_some_and(|plan| {
-                backend.copy_texture_region_to_target(
-                    target,
-                    plan.source_origin,
-                    &effect_target,
-                    plan.size,
-                )
-            });
+            let copied_capture = copy_backdrop_capture(
+                backend,
+                target,
+                copy_plan.as_ref(),
+                &effect_target,
+                replay.as_ref(),
+            )?;
             if !copied_capture {
                 copy_projective_backdrop_inputs_to_view(
                     backend,
@@ -6916,6 +7085,7 @@ pub(crate) fn apply_backdrop_layer_to_target<B: SurfaceExecutionBackend>(
         root_scale,
         input_content_hash,
         false,
+        None,
     )? {
         if backdrop_diag_enabled() {
             eprintln!(

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -1522,28 +1522,26 @@ fn draw_op_visible_bounds(scene: &CompositorScene, draw_op: DrawOp) -> Option<Re
 /// shadow reaches beyond its shapes by the blur extent, so it is bounded by
 /// its expanded, clipped rectangle rather than skipped like the chunk cache
 /// skips it.
-fn deferred_range_bounds(
+/// Whether any draw op of the range that is not excluded touches
+/// `dependency_rect`. Ops are tested one by one: the union of a run's bounds
+/// would make every capture depend on everything walked before it.
+fn deferred_range_intersects(
     scene: &CompositorScene,
     z_start: usize,
     z_end: usize,
     excluded: &[Range<usize>],
-) -> Option<Rect> {
-    let mut bounds = None;
-    for op in scene_range_draw_ops(&scene.draw_ops, z_start, z_end) {
-        if is_in_effect_range(op.z_index, excluded) {
-            continue;
-        }
-        let rect = match op.kind {
+    dependency_rect: Rect,
+) -> bool {
+    scene_range_draw_ops(&scene.draw_ops, z_start, z_end)
+        .iter()
+        .filter(|op| !is_in_effect_range(op.z_index, excluded))
+        .filter_map(|op| match op.kind {
             DrawOpKind::Shadow(index) => scene.shadow_draws.get(index).and_then(|shadow| {
                 crate::normalized_scene::shadow_draws_bounds(std::slice::from_ref(shadow))
             }),
             _ => draw_op_visible_bounds(scene, *op),
-        };
-        if let Some(rect) = rect {
-            bounds = union_rect(bounds, rect);
-        }
-    }
-    bounds
+        })
+        .any(|rect| rects_intersect(rect, dependency_rect))
 }
 
 fn scene_range_visible_bounds(
@@ -4774,18 +4772,24 @@ impl<'s> DeferredDirectRun<'s> {
         self.excluded.push(z_index..z_index.saturating_add(1));
     }
 
-    fn next_excluded_after(&self, z_index: usize) -> Option<usize> {
-        self.excluded
+    /// The end of the chunk that may start at `cursor_z`: `None` when the op
+    /// there is excluded, otherwise the caller's end cut at the next exclusion.
+    fn chunk_end_from(&self, cursor_z: usize, chunk_end: usize) -> Option<usize> {
+        if is_in_effect_range(cursor_z, &self.excluded) {
+            return None;
+        }
+        let next_excluded = self
+            .excluded
             .iter()
             .map(|range| range.start)
-            .filter(|start| *start > z_index)
-            .min()
+            .filter(|start| *start > cursor_z)
+            .min();
+        Some(next_excluded.map_or(chunk_end, |next| chunk_end.min(next)))
     }
 
     fn intersects(&self, dependency_rect: Rect, boundary: usize) -> bool {
         self.run.peek(boundary).is_some_and(|(start, end)| {
-            deferred_range_bounds(self.scene, start, end, &self.excluded)
-                .is_some_and(|bounds| rects_intersect(bounds, dependency_rect))
+            deferred_range_intersects(self.scene, start, end, &self.excluded, dependency_rect)
         })
     }
 }
@@ -5980,14 +5984,13 @@ fn render_direct_scene_range_with_pending_composites<B: SurfaceExecutionBackend>
         deferred,
     );
     while cursor_z < z_end {
-        if is_in_effect_range(cursor_z, &deferred.excluded) {
+        let Some(mut chunk_end) = deferred.chunk_end_from(
+            cursor_z,
+            direct_scene_range_cache_chunk_end(scene, cursor_z, z_end, root_scale),
+        ) else {
             cursor_z = cursor_z.saturating_add(1);
             continue;
-        }
-        let mut chunk_end = direct_scene_range_cache_chunk_end(scene, cursor_z, z_end, root_scale);
-        if let Some(next_excluded) = deferred.next_excluded_after(cursor_z) {
-            chunk_end = chunk_end.min(next_excluded);
-        }
+        };
         if chunk_end <= cursor_z {
             return Err("direct scene cache chunk did not advance".to_string());
         }

--- a/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
+++ b/crates/cranpose-render/wgpu/src/surface_executor/render_paths.rs
@@ -3427,8 +3427,12 @@ fn minimum_surface_scale_for_composite(
     }
 }
 
-fn can_materialize_cached_effect(effect: &RenderEffect, backdrop: Option<&RenderEffect>) -> bool {
-    backdrop.is_none() && !effect.contains_runtime_shader()
+/// Whether a layer's effect output can live in the layer cache: every input
+/// of the effect (its parameters, a runtime shader's source and uniforms,
+/// the layer rect) is in the cache key, so only an effect reading the
+/// backdrop is excluded.
+fn can_materialize_cached_effect(_effect: &RenderEffect, backdrop: Option<&RenderEffect>) -> bool {
+    backdrop.is_none()
 }
 
 fn materialize_render_effect_to_target<B: SurfaceExecutionBackend>(

--- a/crates/cranpose-render/wgpu/src/surface_plan.rs
+++ b/crates/cranpose-render/wgpu/src/surface_plan.rs
@@ -553,6 +553,7 @@ mod tests {
     fn test_layer(local_bounds: Rect) -> LayerNode {
         LayerNode {
             node_id: None,
+            wraps: None,
             local_bounds,
             transform_to_parent: ProjectiveTransform::identity(),
             motion_context_animated: false,

--- a/crates/cranpose-render/wgpu/src/surface_requirements.rs
+++ b/crates/cranpose-render/wgpu/src/surface_requirements.rs
@@ -65,6 +65,23 @@ impl SurfaceRequirementSet {
             != 0
     }
 
+    /// Whether the only isolating requirement is the backdrop itself, so the
+    /// layer's own content could render into its parent once the backdrop
+    /// effect has been composited there: no group opacity, blend mode,
+    /// render effect, explicit offscreen, text mask or resampling transform.
+    /// A shape clip is allowed because the caller proves the content stays
+    /// inside the shape.
+    pub(crate) fn isolates_only_for_backdrop(self) -> bool {
+        self.contains(SurfaceRequirement::Backdrop)
+            && (self.bits
+                & !(Self::BACKDROP
+                    | Self::SHAPE_CLIP
+                    | Self::MIXED_DIRECT_CONTENT
+                    | Self::IMMEDIATE_SHADOW
+                    | Self::PIXEL_STABLE_COMPOSITE))
+                == 0
+    }
+
     pub(crate) fn has_renderer_forced_surface(self) -> bool {
         self.contains(SurfaceRequirement::TextMaterialMask)
             || self.contains(SurfaceRequirement::NonTranslationTransform)

--- a/crates/cranpose-render/wgpu/src/test_support.rs
+++ b/crates/cranpose-render/wgpu/src/test_support.rs
@@ -12,6 +12,7 @@ pub fn layer_node(
 ) -> LayerNode {
     LayerNode {
         node_id: None,
+        wraps: None,
         local_bounds,
         transform_to_parent,
         motion_context_animated: false,

--- a/crates/cranpose-render/wgpu/tests/arc_mesh_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/arc_mesh_parity.rs
@@ -118,6 +118,7 @@ fn build_sequence(node_id: usize) -> Vec<RenderGraph> {
             };
             RenderGraph::new(LayerNode {
                 node_id: None,
+                wraps: None,
                 local_bounds: bounds,
                 transform_to_parent: ProjectiveTransform::identity(),
                 content_offset: Point::default(),

--- a/crates/cranpose-render/wgpu/tests/backdrop_flatten_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/backdrop_flatten_parity.rs
@@ -21,6 +21,9 @@ const TOGGLE: &str = "CRANPOSE_NO_BACKDROP_FLATTEN";
 const NESTED: u8 = 0;
 const SIBLINGS: u8 = 1;
 const NO_BUTTON: u8 = 2;
+const CORNER_CIRCLE: u8 = 3;
+const CORNER_CIRCLE_SIBLINGS: u8 = 4;
+const CIRCLE: [f32; 4] = [226.0, 28.0, 40.0, 40.0];
 
 static SCENE: Mutex<()> = Mutex::new(());
 static ARRANGEMENT: AtomicU8 = AtomicU8::new(NESTED);
@@ -85,6 +88,20 @@ fn CardButton(offset: (f32, f32)) {
 
 #[composable]
 #[allow(non_snake_case)]
+fn CornerCircle() {
+    GlassSurface(
+        rect_modifier(CIRCLE),
+        Glass::regular()
+            .shape(LiquidShape::Circle)
+            .blur_radius(24.0)
+            .shadow(false)
+            .no_clip(),
+        || {},
+    );
+}
+
+#[composable]
+#[allow(non_snake_case)]
 fn GlassCardsPage() {
     LiquidTheme(LiquidThemeSpec::default(), || {
         FramePage(
@@ -111,6 +128,25 @@ fn GlassCardsPage() {
                                     CardButton(offset);
                                 },
                             );
+                        }
+                        CORNER_CIRCLE => {
+                            GlassSurface(rect_modifier(card), card_glass(), move || {
+                                Box(
+                                    rect_modifier([0.0, 0.0, card[2], card[3]]),
+                                    BoxSpec::new(),
+                                    || {
+                                        CardText();
+                                        CornerCircle();
+                                    },
+                                );
+                            })
+                        }
+                        CORNER_CIRCLE_SIBLINGS => {
+                            GlassSurface(rect_modifier(card), card_glass(), || {});
+                            Box(rect_modifier(card).clip_to_bounds(), BoxSpec::new(), || {
+                                CardText();
+                                CornerCircle();
+                            });
                         }
                         _ => GlassSurface(rect_modifier(card), card_glass(), || {
                             CardText();
@@ -352,5 +388,37 @@ fn a_flattened_cards_corner_shadow_stays_inside_the_rounded_clip() {
         "a shadow drawn into the parent leaked {} levels into a corner outside the card's \
          rounded clip",
         leaked.max
+    );
+}
+
+#[test]
+fn a_nested_glass_whose_reach_enters_the_corner_cut_still_flattens_the_card_exactly() {
+    let _scene = SCENE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(flattened) = capture(CORNER_CIRCLE, false) else {
+        return;
+    };
+    let isolated = capture(CORNER_CIRCLE, true).expect("headless WGPU init failed mid-suite");
+    assert!(
+        flattened.cold_passes < isolated.cold_passes,
+        "a nested glass only reads through the parent's clip, so its reach never blocks \
+         flattening: {} vs {} passes",
+        flattened.cold_passes,
+        isolated.cold_passes
+    );
+    let siblings =
+        capture(CORNER_CIRCLE_SIBLINGS, false).expect("headless WGPU init failed mid-suite");
+    let inside = delta_where(&flattened.pixels, &siblings.pixels, |_, _| true);
+    eprintln!(
+        "corner circle: max delta {} over {} pixels, {} differing",
+        inside.max, inside.compared, inside.differing
+    );
+    assert!(
+        inside.max <= 1 && inside.differing * 50 < inside.compared,
+        "a flattened card with a round glass near its corner must draw like the sibling \
+         arrangement: max delta {} over {} differing pixels",
+        inside.max,
+        inside.differing
     );
 }

--- a/crates/cranpose-render/wgpu/tests/backdrop_flatten_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/backdrop_flatten_parity.rs
@@ -1,0 +1,356 @@
+mod support;
+
+use std::sync::{
+    Mutex,
+    atomic::{AtomicU8, Ordering},
+};
+
+use cranpose_liquid::{
+    Glass, GlassButton, GlassButtonSpec, GlassSurface, LiquidShape, LiquidTheme, LiquidThemeSpec,
+};
+use cranpose_ui::Alignment;
+use support::page::*;
+
+const FRAME_WIDTH: u32 = 320;
+const FRAME_HEIGHT: u32 = 260;
+const CARD_RADIUS: f32 = 20.0;
+const CARDS: [[f32; 4]; 2] = [[20.0, 24.0, 280.0, 96.0], [20.0, 140.0, 280.0, 96.0]];
+const TEXT_OFFSET: [f32; 2] = [18.0, 18.0];
+const TOGGLE: &str = "CRANPOSE_NO_BACKDROP_FLATTEN";
+
+const NESTED: u8 = 0;
+const SIBLINGS: u8 = 1;
+const NO_BUTTON: u8 = 2;
+
+static SCENE: Mutex<()> = Mutex::new(());
+static ARRANGEMENT: AtomicU8 = AtomicU8::new(NESTED);
+static BUTTON_OFFSET: [AtomicU8; 2] = [AtomicU8::new(72), AtomicU8::new(0)];
+
+fn card_glass() -> Glass {
+    Glass::regular()
+        .shape(LiquidShape::RoundedRect(CARD_RADIUS))
+        .blur_radius(0.0)
+        .dispersion(1.0)
+        .adaptive_frost(Color::WHITE, 0.42)
+}
+
+fn button_offset() -> (f32, f32) {
+    (
+        f32::from(BUTTON_OFFSET[0].load(Ordering::Relaxed)),
+        f32::from(BUTTON_OFFSET[1].load(Ordering::Relaxed)),
+    )
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn Dots() {
+    for i in 0..14u32 {
+        let x = (i as f32 * 61.0) % 300.0;
+        let y = (i as f32 * 37.0) % 240.0;
+        Box(
+            rect_modifier([x, y, 16.0, 16.0])
+                .background(Color(0.95, 0.7 - (i % 4) as f32 * 0.15, 0.35, 1.0))
+                .rounded_corners(8.0),
+            BoxSpec::new(),
+            || {},
+        );
+    }
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn CardText() {
+    Text(
+        "Flattened card",
+        Modifier::empty().offset(TEXT_OFFSET[0], TEXT_OFFSET[1]),
+        TextStyle::default(),
+    );
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn CardButton(offset: (f32, f32)) {
+    let spec = if std::env::var("FLATTEN_NO_BUTTON_SHADOW").is_ok() {
+        GlassButtonSpec::glass().with_glass(Glass::regular().shadow(false))
+    } else {
+        GlassButtonSpec::glass()
+    };
+    GlassButton(
+        Modifier::empty().offset(offset.0, offset.1),
+        spec,
+        || {},
+        || {},
+    );
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn GlassCardsPage() {
+    LiquidTheme(LiquidThemeSpec::default(), || {
+        FramePage(
+            FRAME_WIDTH,
+            FRAME_HEIGHT,
+            Color(0.06, 0.05, 0.12, 1.0),
+            || {
+                Dots();
+                let arrangement = ARRANGEMENT.load(Ordering::Relaxed);
+                let offset = button_offset();
+                for card in CARDS {
+                    match arrangement {
+                        NESTED => GlassSurface(rect_modifier(card), card_glass(), move || {
+                            CardText();
+                            CardButton(offset);
+                        }),
+                        SIBLINGS => {
+                            GlassSurface(rect_modifier(card), card_glass(), || {});
+                            Box(
+                                rect_modifier(card),
+                                BoxSpec::new().content_alignment(Alignment::CENTER),
+                                move || {
+                                    CardText();
+                                    CardButton(offset);
+                                },
+                            );
+                        }
+                        _ => GlassSurface(rect_modifier(card), card_glass(), || {
+                            CardText();
+                        }),
+                    }
+                }
+            },
+        );
+    });
+}
+
+struct Frame {
+    pixels: Vec<u8>,
+    cold_passes: u32,
+}
+
+fn capture(arrangement: u8, no_flatten: bool) -> Option<Frame> {
+    ARRANGEMENT.store(arrangement, Ordering::Relaxed);
+    cranpose_render_wgpu::set_debug_toggle(TOGGLE, no_flatten.then_some("1"));
+    let captured = capture_with_current_toggles();
+    cranpose_render_wgpu::set_debug_toggle(TOGGLE, None);
+    captured
+}
+
+fn capture_with_current_toggles() -> Option<Frame> {
+    let (_lock, mut shell) = support::app_shell_for(
+        GlassCardsPage,
+        FRAME_WIDTH,
+        FRAME_HEIGHT,
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+        |_| {},
+    )?;
+    shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("warm-up capture should succeed");
+    let cold_passes = shell
+        .renderer()
+        .last_frame_stats()
+        .expect("frame stats")
+        .pass_count;
+    let frame = shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("frame capture should succeed");
+    assert_eq!(shell.renderer().device_error_count_for_tests(), 0);
+    Some(Frame {
+        pixels: frame.pixels,
+        cold_passes,
+    })
+}
+
+struct Delta {
+    max: u8,
+    differing: usize,
+    compared: usize,
+}
+
+fn delta_where(a: &[u8], b: &[u8], mut include: impl FnMut(usize, usize) -> bool) -> Delta {
+    assert_eq!(a.len(), b.len());
+    let mut delta = Delta {
+        max: 0,
+        differing: 0,
+        compared: 0,
+    };
+    for (index, (p, q)) in a
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .zip(b.as_chunks::<4>().0)
+        .enumerate()
+    {
+        let (x, y) = (index % FRAME_WIDTH as usize, index / FRAME_WIDTH as usize);
+        if !include(x, y) {
+            continue;
+        }
+        let d = p
+            .iter()
+            .zip(q)
+            .map(|(u, v)| u.abs_diff(*v))
+            .max()
+            .unwrap_or(0);
+        delta.max = delta.max.max(d);
+        delta.differing += usize::from(d > 0);
+        delta.compared += 1;
+    }
+    delta
+}
+
+fn dump_delta_map(a: &[u8], b: &[u8]) {
+    let mut rows = vec![String::new(); FRAME_HEIGHT as usize / 4];
+    for (index, (p, q)) in a
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .zip(b.as_chunks::<4>().0)
+        .enumerate()
+    {
+        let (x, y) = (index % FRAME_WIDTH as usize, index / FRAME_WIDTH as usize);
+        if x % 4 != 0 || y % 4 != 0 {
+            continue;
+        }
+        let d = p
+            .iter()
+            .zip(q)
+            .map(|(u, v)| u.abs_diff(*v))
+            .max()
+            .unwrap_or(0);
+        rows[y / 4].push(match d {
+            0 => '.',
+            1..=2 => ':',
+            3..=16 => '+',
+            _ => '#',
+        });
+    }
+    for row in rows {
+        eprintln!("{row}");
+    }
+}
+
+fn inside_a_card(x: usize, y: usize) -> bool {
+    let (x, y) = (x as f32, y as f32);
+    CARDS.iter().any(|card| {
+        (card[0]..card[0] + card[2]).contains(&x) && (card[1]..card[1] + card[3]).contains(&y)
+    })
+}
+
+fn in_a_corner_triangle(x: usize, y: usize) -> bool {
+    let (px, py) = (x as f32 + 0.5, y as f32 + 0.5);
+    CARDS.iter().any(|card| {
+        let (left, top) = (card[0], card[1]);
+        let (right, bottom) = (card[0] + card[2], card[1] + card[3]);
+        [
+            (left + CARD_RADIUS, top + CARD_RADIUS),
+            (right - CARD_RADIUS, top + CARD_RADIUS),
+            (left + CARD_RADIUS, bottom - CARD_RADIUS),
+            (right - CARD_RADIUS, bottom - CARD_RADIUS),
+        ]
+        .iter()
+        .any(|&(cx, cy)| {
+            let in_square = (px - cx).abs() <= CARD_RADIUS
+                && (py - cy).abs() <= CARD_RADIUS
+                && (px < left + CARD_RADIUS || px > right - CARD_RADIUS)
+                && (py < top + CARD_RADIUS || py > bottom - CARD_RADIUS);
+            in_square && (px - cx).hypot(py - cy) > CARD_RADIUS + 1.0
+        })
+    })
+}
+
+#[test]
+fn a_flattened_card_draws_its_content_like_siblings_and_drops_its_surface_passes() {
+    let _scene = SCENE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    BUTTON_OFFSET[0].store(72, Ordering::Relaxed);
+    BUTTON_OFFSET[1].store(0, Ordering::Relaxed);
+    let Some(flattened) = capture(NESTED, false) else {
+        return;
+    };
+    let siblings = capture(SIBLINGS, false).expect("headless WGPU init failed mid-suite");
+    let isolated = capture(NESTED, true).expect("headless WGPU init failed mid-suite");
+
+    if std::env::var("FLATTEN_DUMP").is_ok() {
+        dump_delta_map(&flattened.pixels, &siblings.pixels);
+    }
+    if let Ok(row) = std::env::var("FLATTEN_ROW") {
+        let y: usize = row.parse().expect("row");
+        for (label, frame) in [("flat", &flattened.pixels), ("sibl", &siblings.pixels)] {
+            let line: Vec<String> = (200..260)
+                .map(|x| {
+                    let p = &frame[(y * FRAME_WIDTH as usize + x) * 4..][..3];
+                    format!("{:3}", (p[0] as u32 + p[1] as u32 + p[2] as u32) / 3)
+                })
+                .collect();
+            eprintln!("{label} y={y}: {}", line.join(" "));
+        }
+    }
+    let delta = delta_where(&flattened.pixels, &siblings.pixels, |_, _| true);
+    eprintln!(
+        "flattened vs siblings: max delta {}, differing {} of {}; cold passes flattened {} \
+         isolated {}",
+        delta.max, delta.differing, delta.compared, flattened.cold_passes, isolated.cold_passes
+    );
+    assert!(
+        delta.max <= 1,
+        "content flattened into the parent must draw like the same content placed as a \
+         sibling over a bare card; a pixel moved by {} levels",
+        delta.max
+    );
+    assert!(
+        delta.differing * 50 < delta.compared,
+        "{} of {} pixels differ from the sibling arrangement; rounding noise touches only \
+         anti-aliased edges",
+        delta.differing,
+        delta.compared
+    );
+    assert!(
+        flattened.cold_passes + 2 * CARDS.len() as u32 <= isolated.cold_passes,
+        "flattening must drop at least the content surface's own passes per card: {} vs {}",
+        flattened.cold_passes,
+        isolated.cold_passes
+    );
+}
+
+#[test]
+fn a_flattened_cards_corner_shadow_stays_inside_the_rounded_clip() {
+    let _scene = SCENE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    BUTTON_OFFSET[0].store(90, Ordering::Relaxed);
+    BUTTON_OFFSET[1].store(6, Ordering::Relaxed);
+    let Some(flattened) = capture(NESTED, false) else {
+        return;
+    };
+    let bare = capture(NO_BUTTON, false).expect("headless WGPU init failed mid-suite");
+    let isolated = capture(NESTED, true).expect("headless WGPU init failed mid-suite");
+    assert!(
+        flattened.cold_passes < isolated.cold_passes,
+        "the corner-hugging button must still flatten: {} vs {} passes",
+        flattened.cold_passes,
+        isolated.cold_passes
+    );
+
+    let shadowed = delta_where(&flattened.pixels, &bare.pixels, |x, y| {
+        inside_a_card(x, y) && !in_a_corner_triangle(x, y)
+    });
+    assert!(
+        shadowed.differing > 200,
+        "the button and its shadow must show inside the card: {} pixels differ",
+        shadowed.differing
+    );
+    let leaked = delta_where(&flattened.pixels, &bare.pixels, in_a_corner_triangle);
+    eprintln!(
+        "corner triangles: max delta {} over {} pixels; shadowed pixels {}",
+        leaked.max, leaked.compared, shadowed.differing
+    );
+    assert!(
+        leaked.max <= 1,
+        "a shadow drawn into the parent leaked {} levels into a corner outside the card's \
+         rounded clip",
+        leaked.max
+    );
+}

--- a/crates/cranpose-render/wgpu/tests/backdrop_pass_batching.rs
+++ b/crates/cranpose-render/wgpu/tests/backdrop_pass_batching.rs
@@ -347,3 +347,174 @@ fn an_overlapping_capture_still_sees_the_glass_below_it() {
          {differing}/{total} sampled pixels differ from the red-less scene"
     );
 }
+
+#[composable]
+#[allow(non_snake_case)]
+fn DeferredContentUnderGlass(overlap: bool) {
+    Box(
+        Modifier::empty()
+            .size_points(FRAME_WIDTH as f32, FRAME_HEIGHT as f32)
+            .background(Color(0.05, 0.06, 0.08, 1.0)),
+        BoxSpec::new(),
+        move || {
+            Box(
+                Modifier::empty()
+                    .offset(24.0, 24.0)
+                    .width(220.0)
+                    .height(88.0)
+                    .rounded_corners(14.0)
+                    .backdrop_effect(chain_glass_effect(220.0, 88.0, Color(0.9, 0.9, 0.95, 0.1))),
+                BoxSpec::new(),
+                || {},
+            );
+            Box(
+                Modifier::empty()
+                    .offset(40.0, 200.0)
+                    .width(200.0)
+                    .height(60.0)
+                    .background(Color(1.0, 0.0, 0.0, 1.0)),
+                BoxSpec::new(),
+                || {},
+            );
+            let y = if overlap { 210.0 } else { 400.0 };
+            Box(
+                Modifier::empty()
+                    .offset(60.0, y)
+                    .width(160.0)
+                    .height(40.0)
+                    .rounded_corners(10.0)
+                    .backdrop_effect(chain_glass_effect(160.0, 40.0, Color(0.9, 0.9, 0.95, 0.1))),
+                BoxSpec::new(),
+                || {},
+            );
+        },
+    );
+}
+
+fn deferred_frame(overlap: bool) -> (cranpose_render_wgpu::CapturedFrame, u32) {
+    let (_lock, renderer) = support::headless_renderer_parts().expect("headless renderer");
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(renderer, root_key, move || {
+        DeferredContentUnderGlass(overlap)
+    });
+    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
+    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+    shell.update();
+    let frame = shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("frame capture should succeed");
+    let passes = shell
+        .renderer()
+        .last_frame_stats()
+        .expect("frame stats")
+        .pass_count;
+    (frame, passes)
+}
+
+#[test]
+fn a_direct_draw_between_two_glasses_is_captured_by_the_glass_that_covers_it() {
+    let (frame, _) = deferred_frame(true);
+    let pixel = |x: usize, y: usize| {
+        let index = (y * FRAME_WIDTH as usize + x) * 4;
+        [
+            frame.pixels[index],
+            frame.pixels[index + 1],
+            frame.pixels[index + 2],
+        ]
+    };
+    let under_glass = pixel(140, 230);
+    let beside_glass = pixel(40 + 8, 205);
+    assert!(
+        beside_glass[0] > 200 && beside_glass[1] < 40,
+        "the red box draws where nothing covers it: {beside_glass:?}"
+    );
+    assert!(
+        under_glass[0] > 120 && under_glass[0] > under_glass[1] + 60,
+        "the glass covering the red box must have captured it after it was drawn, not the \
+         empty page beneath: {under_glass:?}"
+    );
+}
+
+#[test]
+fn direct_draws_between_non_overlapping_glasses_share_one_fused_pass() {
+    let (_, overlapping_passes) = deferred_frame(true);
+    let (_, disjoint_passes) = deferred_frame(false);
+    assert!(
+        disjoint_passes < overlapping_passes,
+        "a draw no later capture reads must ride the frame's single fused pass; disjoint \
+         {disjoint_passes} vs overlapping {overlapping_passes}"
+    );
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn ShadowedGlassAfterAnotherGlass() {
+    Box(
+        Modifier::empty()
+            .size_points(FRAME_WIDTH as f32, FRAME_HEIGHT as f32)
+            .background(Color(0.92, 0.92, 0.94, 1.0)),
+        BoxSpec::new(),
+        || {
+            Box(
+                Modifier::empty()
+                    .offset(60.0, 20.0)
+                    .width(200.0)
+                    .height(40.0)
+                    .rounded_corners(12.0)
+                    .backdrop_effect(chain_glass_effect(200.0, 40.0, Color(1.0, 1.0, 1.0, 0.05))),
+                BoxSpec::new(),
+                || {},
+            );
+            Box(
+                Modifier::empty()
+                    .offset(60.0, 120.0)
+                    .width(200.0)
+                    .height(90.0)
+                    .rounded_corners(16.0)
+                    .drop_shadow(
+                        cranpose_ui::LayerShape::Rounded(cranpose_ui::RoundedCornerShape::uniform(
+                            16.0,
+                        )),
+                        |scope| {
+                            scope.radius = 24.0;
+                            scope.offset.y = 12.0;
+                            scope.color = Color(0.0, 0.0, 0.0, 0.9);
+                        },
+                    )
+                    .backdrop_effect(chain_glass_effect(200.0, 90.0, Color(1.0, 1.0, 1.0, 0.05))),
+                BoxSpec::new(),
+                || {},
+            );
+        },
+    );
+}
+
+#[test]
+fn a_glass_captures_its_own_drop_shadow_when_that_shadow_is_all_that_is_pending() {
+    let (_lock, renderer) = support::headless_renderer_parts().expect("headless renderer");
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(renderer, root_key, ShadowedGlassAfterAnotherGlass);
+    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
+    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+    shell.update();
+    let frame = shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("frame capture should succeed");
+    let luma = |x: usize, y: usize| {
+        let index = (y * FRAME_WIDTH as usize + x) * 4;
+        (u32::from(frame.pixels[index])
+            + u32::from(frame.pixels[index + 1])
+            + u32::from(frame.pixels[index + 2]))
+            / 3
+    };
+    let bottom_inside = luma(160, 204);
+    let top_inside = luma(160, 126);
+    assert!(
+        top_inside > bottom_inside + 20,
+        "the second glass must read its own shadow off the page below it while the first \
+         glass already consumed everything else pending: top {top_inside} vs bottom \
+         {bottom_inside}"
+    );
+}

--- a/crates/cranpose-render/wgpu/tests/backdrop_pass_batching.rs
+++ b/crates/cranpose-render/wgpu/tests/backdrop_pass_batching.rs
@@ -659,3 +659,116 @@ fn a_shadow_composited_from_its_cache_matches_the_shadow_drawn_in_the_segment() 
          direct {direct_passes}"
     );
 }
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SpreadBoxes {
+    None,
+    Apart,
+    UnderGlass,
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn SpreadContentUnderGlass(boxes: SpreadBoxes) {
+    Box(
+        Modifier::empty()
+            .size_points(FRAME_WIDTH as f32, FRAME_HEIGHT as f32)
+            .background(Color(0.05, 0.06, 0.08, 1.0)),
+        BoxSpec::new(),
+        move || {
+            Box(
+                Modifier::empty()
+                    .offset(24.0, 24.0)
+                    .width(220.0)
+                    .height(60.0)
+                    .rounded_corners(14.0)
+                    .backdrop_effect(chain_glass_effect(220.0, 60.0, Color(0.9, 0.9, 0.95, 0.1))),
+                BoxSpec::new(),
+                || {},
+            );
+            if boxes != SpreadBoxes::None {
+                let right_x = if boxes == SpreadBoxes::UnderGlass {
+                    260.0
+                } else {
+                    440.0
+                };
+                Box(
+                    Modifier::empty()
+                        .offset(40.0, 200.0)
+                        .width(160.0)
+                        .height(60.0)
+                        .background(Color(1.0, 0.0, 0.0, 1.0)),
+                    BoxSpec::new(),
+                    || {},
+                );
+                Box(
+                    Modifier::empty()
+                        .offset(right_x, 200.0)
+                        .width(160.0)
+                        .height(60.0)
+                        .background(Color(0.0, 0.0, 1.0, 1.0)),
+                    BoxSpec::new(),
+                    || {},
+                );
+            }
+            Box(
+                Modifier::empty()
+                    .offset(250.0, 210.0)
+                    .width(140.0)
+                    .height(40.0)
+                    .rounded_corners(10.0)
+                    .backdrop_effect(chain_glass_effect(140.0, 40.0, Color(0.9, 0.9, 0.95, 0.1))),
+                BoxSpec::new(),
+                || {},
+            );
+        },
+    );
+}
+
+fn spread_frame(boxes: SpreadBoxes) -> (cranpose_render_wgpu::CapturedFrame, u32) {
+    let (_lock, renderer) = support::headless_renderer_parts().expect("headless renderer");
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(renderer, root_key, move || SpreadContentUnderGlass(boxes));
+    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
+    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+    shell.update();
+    let frame = shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("frame capture should succeed");
+    let passes = shell
+        .renderer()
+        .last_frame_stats()
+        .expect("frame stats")
+        .pass_count;
+    (frame, passes)
+}
+
+#[test]
+fn a_glass_between_two_direct_draws_it_does_not_cover_leaves_them_in_the_fused_pass() {
+    let (_, bare_passes) = spread_frame(SpreadBoxes::None);
+    let (_, apart_passes) = spread_frame(SpreadBoxes::Apart);
+    assert_eq!(
+        apart_passes, bare_passes,
+        "a capture depends on the draws it reads, not on the bounding box of everything the \
+         run has walked so far"
+    );
+}
+
+#[test]
+fn a_glass_over_one_of_two_direct_draws_still_captures_it() {
+    let (frame, _) = spread_frame(SpreadBoxes::UnderGlass);
+    let pixel = |x: usize, y: usize| {
+        let index = (y * FRAME_WIDTH as usize + x) * 4;
+        [
+            frame.pixels[index],
+            frame.pixels[index + 1],
+            frame.pixels[index + 2],
+        ]
+    };
+    let under_glass = pixel(320, 230);
+    assert!(
+        under_glass[2] > 120 && under_glass[2] > under_glass[0] + 60,
+        "the glass over the blue box must read it after it was drawn: {under_glass:?}"
+    );
+}

--- a/crates/cranpose-render/wgpu/tests/backdrop_pass_batching.rs
+++ b/crates/cranpose-render/wgpu/tests/backdrop_pass_batching.rs
@@ -518,3 +518,144 @@ fn a_glass_captures_its_own_drop_shadow_when_that_shadow_is_all_that_is_pending(
          {bottom_inside}"
     );
 }
+
+const SHADOWED_CARD_COUNT: usize = 3;
+const SHADOWED_CARD_PITCH: f32 = 160.0;
+const SHADOWED_CARD_TOP: f32 = 40.0;
+const SHADOWED_CARD_HEIGHT: f32 = 100.0;
+
+#[composable]
+#[allow(non_snake_case)]
+fn ShadowedGlassColumn(shadowed: bool, scroll: f32) {
+    Box(
+        Modifier::empty()
+            .size_points(FRAME_WIDTH as f32, FRAME_HEIGHT as f32)
+            .background(Color(0.92, 0.92, 0.94, 1.0)),
+        BoxSpec::new(),
+        move || {
+            for index in 0..SHADOWED_CARD_COUNT {
+                let y = SHADOWED_CARD_TOP + index as f32 * SHADOWED_CARD_PITCH - scroll;
+                let modifier = Modifier::empty()
+                    .offset(60.0, y)
+                    .width(220.0)
+                    .height(SHADOWED_CARD_HEIGHT)
+                    .rounded_corners(16.0);
+                let modifier = if shadowed {
+                    modifier.drop_shadow(
+                        cranpose_ui::LayerShape::Rounded(cranpose_ui::RoundedCornerShape::uniform(
+                            16.0,
+                        )),
+                        |scope| {
+                            scope.radius = 24.0;
+                            scope.offset.y = 12.0;
+                            scope.color = Color(0.0, 0.0, 0.0, 0.9);
+                        },
+                    )
+                } else {
+                    modifier
+                };
+                Box(
+                    modifier.backdrop_effect(chain_glass_effect(
+                        220.0,
+                        SHADOWED_CARD_HEIGHT,
+                        Color(1.0, 1.0, 1.0, 0.05),
+                    )),
+                    BoxSpec::new(),
+                    || {},
+                );
+            }
+        },
+    );
+}
+
+fn scrolled_column_frame(
+    shadowed: bool,
+    queue_shadows: bool,
+) -> (cranpose_render_wgpu::CapturedFrame, u32) {
+    let (_lock, renderer) = support::headless_renderer_parts().expect("headless renderer");
+    cranpose_render_wgpu::set_debug_toggle(
+        "CRANPOSE_NO_SHADOW_COMPOSITE_QUEUE",
+        (!queue_shadows).then_some("1"),
+    );
+    let root_key = location_key(file!(), line!(), column!());
+    let scroll = Rc::new(std::cell::Cell::new(0.0f32));
+    let scroll_for_app = Rc::clone(&scroll);
+    let mut shell = AppShell::new(renderer, root_key, move || {
+        ShadowedGlassColumn(shadowed, scroll_for_app.get())
+    });
+    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
+    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+    let mut passes = 0;
+    let mut frame = None;
+    for step in 0..WARMUP_FRAMES + 1 {
+        scroll.set(step as f32 * 2.0);
+        shell.update();
+        frame = Some(
+            shell
+                .renderer()
+                .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+                .expect("frame capture should succeed"),
+        );
+        passes = shell
+            .renderer()
+            .last_frame_stats()
+            .expect("frame stats")
+            .pass_count;
+    }
+    cranpose_render_wgpu::set_debug_toggle("CRANPOSE_NO_SHADOW_COMPOSITE_QUEUE", None);
+    (frame.expect("a frame was captured"), passes)
+}
+
+#[test]
+fn drop_shadows_under_a_column_of_glass_cards_ride_the_frames_fused_pass() {
+    let (plain, plain_passes) = scrolled_column_frame(false, true);
+    let (shadowed, shadowed_passes) = scrolled_column_frame(true, true);
+    let luma = |frame: &cranpose_render_wgpu::CapturedFrame, x: usize, y: usize| {
+        let index = (y * FRAME_WIDTH as usize + x) * 4;
+        (u32::from(frame.pixels[index])
+            + u32::from(frame.pixels[index + 1])
+            + u32::from(frame.pixels[index + 2]))
+            / 3
+    };
+    let scroll = WARMUP_FRAMES as f32 * 2.0;
+    for index in 0..SHADOWED_CARD_COUNT {
+        let below = (SHADOWED_CARD_TOP + index as f32 * SHADOWED_CARD_PITCH + SHADOWED_CARD_HEIGHT
+            - scroll) as usize
+            + 6;
+        let plain_luma = luma(&plain, 170, below);
+        let shadowed_luma = luma(&shadowed, 170, below);
+        assert!(
+            shadowed_luma + 20 < plain_luma,
+            "card {index} must cast its shadow onto the page: shadowed {shadowed_luma} vs plain \
+             {plain_luma}"
+        );
+    }
+    assert_eq!(
+        shadowed_passes, plain_passes,
+        "a cached drop shadow is a composite the glass above it replays, not a direct draw that \
+         splits the frame's fused pass before every card"
+    );
+}
+
+#[test]
+fn a_shadow_composited_from_its_cache_matches_the_shadow_drawn_in_the_segment() {
+    let (direct, direct_passes) = scrolled_column_frame(true, false);
+    let (queued, queued_passes) = scrolled_column_frame(true, true);
+    let max_delta = direct
+        .pixels
+        .iter()
+        .zip(&queued.pixels)
+        .map(|(a, b)| a.abs_diff(*b))
+        .max()
+        .unwrap_or(0);
+    assert!(
+        max_delta <= 1,
+        "the queued shadow composite must land the same texels as the segment's own composite \
+         of the same cached shadow: max delta {max_delta}"
+    );
+    assert!(
+        queued_passes < direct_passes,
+        "queuing the shadows must remove the per-card run flushes: queued {queued_passes} vs \
+         direct {direct_passes}"
+    );
+}

--- a/crates/cranpose-render/wgpu/tests/box4_lowering_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/box4_lowering_parity.rs
@@ -1,12 +1,6 @@
 mod support;
 
-use cranpose_app_shell::AppShell;
-use cranpose_core::location_key;
-use cranpose_ui::{
-    Color, Modifier, RenderEffect, TextStyle, composable,
-    widgets::{Box, BoxSpec, Text},
-};
-use support::{FramePage, rect_modifier};
+use support::page::*;
 
 const FRAME_WIDTH: u32 = 320;
 const FRAME_HEIGHT: u32 = 240;
@@ -64,19 +58,13 @@ fn capture(keep_box4: bool) -> Option<Vec<u8>> {
 }
 
 fn capture_with_current_toggles() -> Option<Vec<u8>> {
-    let (_lock, renderer) = match support::headless_renderer_parts() {
-        Ok(parts) => parts,
-        Err(err) => {
-            eprintln!("skipping (headless WGPU init failed): {err}");
-            return None;
-        }
-    };
-    let root_key = location_key(file!(), line!(), column!());
-    let mut shell = AppShell::new(renderer, root_key, CardsPage);
-    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
-    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
-    shell.update();
-    shell.update();
+    let (_lock, mut shell) = support::app_shell_for(
+        CardsPage,
+        FRAME_WIDTH,
+        FRAME_HEIGHT,
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+        |_| {},
+    )?;
     let frame = shell
         .renderer()
         .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
@@ -91,25 +79,11 @@ fn a_lowered_box_resolve_matches_the_full_walk_byte_for_byte() {
         return;
     };
     let kept = capture(true).expect("headless WGPU init failed mid-suite");
-    assert_eq!(lowered.len(), kept.len());
-    let mut differing = 0usize;
-    let mut worst = 0u8;
-    let mut first = None;
-    for (index, (a, b)) in lowered.iter().zip(&kept).enumerate() {
-        let diff = a.abs_diff(*b);
-        if diff > 0 {
-            differing += 1;
-            worst = worst.max(diff);
-            first.get_or_insert((
-                index / 4 % FRAME_WIDTH as usize,
-                index / 4 / FRAME_WIDTH as usize,
-            ));
-        }
-    }
-    assert_eq!(
-        differing, 0,
-        "{differing} bytes diverged (worst {worst}, first at {first:?}) between a lowered \
-         texel fetch and the box resolve it replaced — the lowering may only fire when the \
-         box covers exactly one texel with weight one"
+    support::assert_same_bytes(
+        "lowered texel fetch vs box resolve, which may only be lowered where the box covers \
+         exactly one texel with weight one",
+        FRAME_WIDTH,
+        &lowered,
+        &kept,
     );
 }

--- a/crates/cranpose-render/wgpu/tests/box4_lowering_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/box4_lowering_parity.rs
@@ -1,0 +1,115 @@
+mod support;
+
+use cranpose_app_shell::AppShell;
+use cranpose_core::location_key;
+use cranpose_ui::{
+    Color, Modifier, RenderEffect, TextStyle, composable,
+    widgets::{Box, BoxSpec, Text},
+};
+use support::{FramePage, rect_modifier};
+
+const FRAME_WIDTH: u32 = 320;
+const FRAME_HEIGHT: u32 = 240;
+const TOGGLE: &str = "CRANPOSE_KEEP_BOX4";
+
+#[composable]
+#[allow(non_snake_case)]
+fn CardsPage() {
+    FramePage(
+        FRAME_WIDTH,
+        FRAME_HEIGHT,
+        Color(0.06, 0.05, 0.12, 1.0),
+        || {
+            for i in 0..12u32 {
+                let x = (i as f32 * 71.0) % 300.0;
+                let y = (i as f32 * 43.0) % 220.0;
+                Box(
+                    rect_modifier([x, y, 18.0, 18.0])
+                        .background(Color(0.9, 0.8 - (i % 3) as f32 * 0.2, 0.4, 1.0))
+                        .rounded_corners(9.0),
+                    BoxSpec::new(),
+                    || {},
+                );
+            }
+            for row in 0..2u32 {
+                let card = [24.0, 30.0 + row as f32 * 100.0, 272.0, 80.0];
+                Box(
+                    rect_modifier(card)
+                        .backdrop_effect(RenderEffect::blur(6.0))
+                        .background(Color(1.0, 1.0, 1.0, 0.16))
+                        .rounded_corners(14.0),
+                    BoxSpec::new(),
+                    move || {
+                        Text(
+                            if row == 0 {
+                                "Box resolve"
+                            } else {
+                                "Texel fetch"
+                            },
+                            Modifier::empty().offset(16.0, 14.0),
+                            TextStyle::default(),
+                        );
+                    },
+                );
+            }
+        },
+    );
+}
+
+fn capture(keep_box4: bool) -> Option<Vec<u8>> {
+    cranpose_render_wgpu::set_debug_toggle(TOGGLE, keep_box4.then_some("1"));
+    let captured = capture_with_current_toggles();
+    cranpose_render_wgpu::set_debug_toggle(TOGGLE, None);
+    captured
+}
+
+fn capture_with_current_toggles() -> Option<Vec<u8>> {
+    let (_lock, renderer) = match support::headless_renderer_parts() {
+        Ok(parts) => parts,
+        Err(err) => {
+            eprintln!("skipping (headless WGPU init failed): {err}");
+            return None;
+        }
+    };
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(renderer, root_key, CardsPage);
+    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
+    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+    shell.update();
+    shell.update();
+    let frame = shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("frame capture should succeed");
+    assert_eq!(shell.renderer().device_error_count_for_tests(), 0);
+    Some(frame.pixels)
+}
+
+#[test]
+fn a_lowered_box_resolve_matches_the_full_walk_byte_for_byte() {
+    let Some(lowered) = capture(false) else {
+        return;
+    };
+    let kept = capture(true).expect("headless WGPU init failed mid-suite");
+    assert_eq!(lowered.len(), kept.len());
+    let mut differing = 0usize;
+    let mut worst = 0u8;
+    let mut first = None;
+    for (index, (a, b)) in lowered.iter().zip(&kept).enumerate() {
+        let diff = a.abs_diff(*b);
+        if diff > 0 {
+            differing += 1;
+            worst = worst.max(diff);
+            first.get_or_insert((
+                index / 4 % FRAME_WIDTH as usize,
+                index / 4 / FRAME_WIDTH as usize,
+            ));
+        }
+    }
+    assert_eq!(
+        differing, 0,
+        "{differing} bytes diverged (worst {worst}, first at {first:?}) between a lowered \
+         texel fetch and the box resolve it replaced — the lowering may only fire when the \
+         box covers exactly one texel with weight one"
+    );
+}

--- a/crates/cranpose-render/wgpu/tests/cancellation_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/cancellation_contract.rs
@@ -85,25 +85,21 @@ fn command_for(node_id: usize) -> DrawCommandId {
     }
 }
 
-fn target_view(renderer: &support::LockedRenderer, width: u32, height: u32) -> wgpu::TextureView {
+fn target_view(
+    renderer: &support::LockedRenderer,
+    width: u32,
+    height: u32,
+) -> (wgpu::Texture, wgpu::TextureView) {
     let device = renderer
         .try_device()
         .expect("renderer GPU device was not initialized");
-    let texture = device.create_texture(&wgpu::TextureDescriptor {
-        label: Some("Cancellation Contract Render Target"),
-        size: wgpu::Extent3d {
-            width,
-            height,
-            depth_or_array_layers: 1,
-        },
-        mip_level_count: 1,
-        sample_count: 1,
-        dimension: wgpu::TextureDimension::D2,
-        format: wgpu::TextureFormat::Bgra8UnormSrgb,
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-        view_formats: &[],
-    });
-    texture.create_view(&wgpu::TextureViewDescriptor::default())
+    support::render_target(
+        device,
+        width,
+        height,
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+        wgpu::TextureUsages::RENDER_ATTACHMENT,
+    )
 }
 
 #[test]
@@ -123,9 +119,9 @@ fn renderer_replacement_cancels_in_flight_packet() {
         .expect("direct graph must lower into a packet");
     support::reinit_gpu(&mut renderer).expect("GPU reinit failed");
 
-    let view = target_view(&renderer, WIDTH, HEIGHT);
+    let (texture, view) = target_view(&renderer, WIDTH, HEIGHT);
     let outcome = renderer
-        .render_held_packet_for_tests(&view, WIDTH, HEIGHT, packet)
+        .render_held_packet_for_tests(&texture, &view, WIDTH, HEIGHT, packet)
         .expect("a cancel is a protocol outcome, not a draw error");
     assert_eq!(
         outcome,
@@ -155,7 +151,7 @@ fn renderer_replacement_cancels_in_flight_packet() {
         .build_frame_packet_for_tests(WIDTH, HEIGHT)
         .expect("the next build must lower normally");
     let outcome = renderer
-        .render_held_packet_for_tests(&view, WIDTH, HEIGHT, packet)
+        .render_held_packet_for_tests(&texture, &view, WIDTH, HEIGHT, packet)
         .expect("the post-replacement packet must draw");
     assert_eq!(
         outcome,
@@ -180,9 +176,9 @@ fn surface_reconfigure_cancels_waiting_packet() {
         .expect("direct graph must lower into a packet");
     renderer.note_surface_reconfigured();
 
-    let view = target_view(&renderer, WIDTH, HEIGHT);
+    let (texture, view) = target_view(&renderer, WIDTH, HEIGHT);
     let outcome = renderer
-        .render_held_packet_for_tests(&view, WIDTH, HEIGHT, packet)
+        .render_held_packet_for_tests(&texture, &view, WIDTH, HEIGHT, packet)
         .expect("a cancel is a protocol outcome, not a draw error");
     assert_eq!(
         outcome,
@@ -198,7 +194,7 @@ fn surface_reconfigure_cancels_waiting_packet() {
         .build_frame_packet_for_tests(WIDTH, HEIGHT)
         .expect("the next build must lower normally");
     let outcome = renderer
-        .render_held_packet_for_tests(&view, WIDTH, HEIGHT, packet)
+        .render_held_packet_for_tests(&texture, &view, WIDTH, HEIGHT, packet)
         .expect("the post-reconfigure packet must draw");
     assert_eq!(outcome, PresentOutcome::Presented);
 }
@@ -217,9 +213,9 @@ fn viewport_mismatch_cancels_packet() {
     let packet = renderer
         .build_frame_packet_for_tests(WIDTH, HEIGHT)
         .expect("direct graph must lower into a packet");
-    let view = target_view(&renderer, WIDTH / 2, HEIGHT / 2);
+    let (texture, view) = target_view(&renderer, WIDTH / 2, HEIGHT / 2);
     let outcome = renderer
-        .render_held_packet_for_tests(&view, WIDTH / 2, HEIGHT / 2, packet)
+        .render_held_packet_for_tests(&texture, &view, WIDTH / 2, HEIGHT / 2, packet)
         .expect("a cancel is a protocol outcome, not a draw error");
     assert_eq!(
         outcome,
@@ -251,9 +247,9 @@ fn cancelled_packet_returns_scene_and_replay_buffers() {
     );
 
     renderer.note_surface_reconfigured();
-    let view = target_view(&renderer, WIDTH, HEIGHT);
+    let (texture, view) = target_view(&renderer, WIDTH, HEIGHT);
     let outcome = renderer
-        .render_held_packet_for_tests(&view, WIDTH, HEIGHT, packet)
+        .render_held_packet_for_tests(&texture, &view, WIDTH, HEIGHT, packet)
         .expect("a cancel is a protocol outcome, not a draw error");
     assert_eq!(
         outcome,
@@ -285,7 +281,7 @@ fn cancelled_packet_returns_scene_and_replay_buffers() {
         "the next build must take the recycled scene from the pool"
     );
     let outcome = renderer
-        .render_held_packet_for_tests(&view, WIDTH, HEIGHT, packet)
+        .render_held_packet_for_tests(&texture, &view, WIDTH, HEIGHT, packet)
         .expect("the next packet must draw");
     assert_eq!(outcome, PresentOutcome::Presented);
 }

--- a/crates/cranpose-render/wgpu/tests/cancellation_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/cancellation_contract.rs
@@ -21,6 +21,7 @@ const HEIGHT: u32 = 96;
 fn test_layer(node_id: Option<NodeId>, children: Vec<RenderNode>) -> LayerNode {
     LayerNode {
         node_id,
+        wraps: None,
         local_bounds: Rect {
             x: 0.0,
             y: 0.0,

--- a/crates/cranpose-render/wgpu/tests/command_feed_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/command_feed_parity.rs
@@ -115,6 +115,7 @@ fn build_sequence(bypass: &mut dyn FnMut(u32) -> bool) -> Vec<RenderGraph> {
             };
             RenderGraph::new(LayerNode {
                 node_id: None,
+                wraps: None,
                 local_bounds: bounds,
                 transform_to_parent: ProjectiveTransform::identity(),
                 content_offset: Point::default(),

--- a/crates/cranpose-render/wgpu/tests/device_error_survival.rs
+++ b/crates/cranpose-render/wgpu/tests/device_error_survival.rs
@@ -43,25 +43,21 @@ fn direct_graph() -> RenderGraph {
     ))
 }
 
-fn target_view(renderer: &support::LockedRenderer, width: u32, height: u32) -> wgpu::TextureView {
+fn target_view(
+    renderer: &support::LockedRenderer,
+    width: u32,
+    height: u32,
+) -> (wgpu::Texture, wgpu::TextureView) {
     let device = renderer
         .try_device()
         .expect("renderer GPU device was not initialized");
-    let texture = device.create_texture(&wgpu::TextureDescriptor {
-        label: Some("Device Error Survival Render Target"),
-        size: wgpu::Extent3d {
-            width,
-            height,
-            depth_or_array_layers: 1,
-        },
-        mip_level_count: 1,
-        sample_count: 1,
-        dimension: wgpu::TextureDimension::D2,
-        format: wgpu::TextureFormat::Bgra8UnormSrgb,
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-        view_formats: &[],
-    });
-    texture.create_view(&wgpu::TextureViewDescriptor::default())
+    support::render_target(
+        device,
+        width,
+        height,
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+        wgpu::TextureUsages::RENDER_ATTACHMENT,
+    )
 }
 
 #[test]
@@ -74,13 +70,13 @@ fn uncaptured_device_error_poisons_one_frame_then_recovers() {
         }
     };
     renderer.scene_mut().graph = Some(direct_graph());
-    let view = target_view(&renderer, WIDTH, HEIGHT);
+    let (texture, view) = target_view(&renderer, WIDTH, HEIGHT);
 
     let packet = renderer
         .build_frame_packet_for_tests(WIDTH, HEIGHT)
         .expect("direct graph must lower into a packet");
     let outcome = renderer
-        .render_held_packet_for_tests(&view, WIDTH, HEIGHT, packet)
+        .render_held_packet_for_tests(&texture, &view, WIDTH, HEIGHT, packet)
         .expect("the pre-error packet must draw");
     assert_eq!(outcome, PresentOutcome::Presented);
     assert_eq!(
@@ -115,7 +111,7 @@ fn uncaptured_device_error_poisons_one_frame_then_recovers() {
         .build_frame_packet_for_tests(WIDTH, HEIGHT)
         .expect("the post-error build must lower normally");
     let outcome = renderer
-        .render_held_packet_for_tests(&view, WIDTH, HEIGHT, packet)
+        .render_held_packet_for_tests(&texture, &view, WIDTH, HEIGHT, packet)
         .expect("a device-error skip is a protocol outcome, not a draw error");
     assert_eq!(
         outcome,
@@ -131,7 +127,7 @@ fn uncaptured_device_error_poisons_one_frame_then_recovers() {
         .build_frame_packet_for_tests(WIDTH, HEIGHT)
         .expect("the recovery build must lower normally");
     let outcome = renderer
-        .render_held_packet_for_tests(&view, WIDTH, HEIGHT, packet)
+        .render_held_packet_for_tests(&texture, &view, WIDTH, HEIGHT, packet)
         .expect("the recovery packet must draw");
     assert_eq!(
         outcome,

--- a/crates/cranpose-render/wgpu/tests/direct_surface_root_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/direct_surface_root_parity.rs
@@ -1,0 +1,203 @@
+mod support;
+
+use std::{sync::mpsc, time::Duration};
+
+use support::page::*;
+
+const FRAME_WIDTH: u32 = 320;
+const FRAME_HEIGHT: u32 = 240;
+const NO_DIRECT: &str = "CRANPOSE_NO_DIRECT_SURFACE";
+
+#[composable]
+#[allow(non_snake_case)]
+fn CardsPage() {
+    FramePage(
+        FRAME_WIDTH,
+        FRAME_HEIGHT,
+        Color(0.05, 0.06, 0.14, 1.0),
+        || {
+            for i in 0..10u32 {
+                let x = (i as f32 * 67.0) % 300.0;
+                let y = (i as f32 * 41.0) % 220.0;
+                Box(
+                    rect_modifier([x, y, 22.0, 22.0])
+                        .background(Color(0.9, 0.5 + (i % 4) as f32 * 0.1, 0.3, 1.0))
+                        .rounded_corners(11.0),
+                    BoxSpec::new(),
+                    || {},
+                );
+            }
+            Box(
+                rect_modifier([24.0, 40.0, 272.0, 90.0])
+                    .backdrop_effect(RenderEffect::blur(7.0))
+                    .background(Color(1.0, 1.0, 1.0, 0.18))
+                    .rounded_corners(16.0),
+                BoxSpec::new(),
+                || {
+                    Text(
+                        "Direct surface",
+                        Modifier::empty().offset(16.0, 16.0),
+                        TextStyle::default(),
+                    );
+                },
+            );
+        },
+    );
+}
+
+struct Frames {
+    captured: Vec<u8>,
+    presented: Vec<u8>,
+    presented_passes: u32,
+}
+
+fn read_texture(device: &wgpu::Device, queue: &wgpu::Queue, texture: &wgpu::Texture) -> Vec<u8> {
+    let width = texture.width();
+    let height = texture.height();
+    let unpadded = width * 4;
+    let padded =
+        unpadded.div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT) * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("direct surface readback"),
+        size: u64::from(padded) * u64::from(height),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &buffer,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded),
+                rows_per_image: Some(height),
+            },
+        },
+        wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+    );
+    let submission = queue.submit([encoder.finish()]);
+    let slice = buffer.slice(..);
+    let (tx, rx) = mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = tx.send(result);
+    });
+    let _ = device.poll(wgpu::PollType::Wait {
+        submission_index: Some(submission),
+        timeout: None,
+    });
+    rx.recv_timeout(Duration::from_secs(3))
+        .expect("readback timed out")
+        .expect("readback map failed");
+    let mapped = slice.get_mapped_range();
+    let mut pixels = Vec::with_capacity((unpadded * height) as usize);
+    for row in 0..height as usize {
+        let start = row * padded as usize;
+        pixels.extend_from_slice(&mapped[start..start + unpadded as usize]);
+    }
+    pixels
+}
+
+fn render_frames(disable_direct: bool) -> Option<Frames> {
+    cranpose_render_wgpu::set_debug_toggle("CRANPOSE_COMPOSITION_8BIT", Some("1"));
+    cranpose_render_wgpu::set_debug_toggle(NO_DIRECT, disable_direct.then_some("1"));
+    let frames = render_frames_with_current_toggles();
+    cranpose_render_wgpu::set_debug_toggle(NO_DIRECT, None);
+    frames
+}
+
+fn render_frames_with_current_toggles() -> Option<Frames> {
+    let (_lock, mut shell) = support::app_shell_for(
+        CardsPage,
+        FRAME_WIDTH,
+        FRAME_HEIGHT,
+        wgpu::TextureFormat::Rgba8Unorm,
+        |_| {},
+    )?;
+    shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("warm-up capture should succeed");
+    let captured = shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("capture should succeed");
+
+    let device = shell.renderer().try_device().expect("device").clone();
+    let queue = shell
+        .renderer()
+        .try_queue_for_tests()
+        .expect("queue")
+        .clone();
+    let (texture, view) = support::render_target(
+        &device,
+        FRAME_WIDTH,
+        FRAME_HEIGHT,
+        wgpu::TextureFormat::Rgba8Unorm,
+        wgpu::TextureUsages::RENDER_ATTACHMENT
+            | wgpu::TextureUsages::TEXTURE_BINDING
+            | wgpu::TextureUsages::COPY_SRC
+            | wgpu::TextureUsages::COPY_DST,
+    );
+    for _ in 0..2 {
+        shell
+            .renderer()
+            .render(&texture, &view, FRAME_WIDTH, FRAME_HEIGHT)
+            .expect("presentable render should succeed");
+    }
+    let presented_passes = shell
+        .renderer()
+        .last_frame_stats()
+        .expect("stats")
+        .pass_count;
+    assert_eq!(shell.renderer().device_error_count_for_tests(), 0);
+    Some(Frames {
+        captured: captured.pixels,
+        presented: read_texture(&device, &queue, &texture),
+        presented_passes,
+    })
+}
+
+#[test]
+fn a_frame_rendered_straight_into_the_presentable_image_matches_the_converted_capture() {
+    let Some(frames) = render_frames(false) else {
+        return;
+    };
+    assert!(
+        frames
+            .captured
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .any(|px| px[0] > 200 && px[2] < 120),
+        "the scene must show its orange dots"
+    );
+    support::assert_same_bytes(
+        "direct vs captured",
+        FRAME_WIDTH,
+        &frames.presented,
+        &frames.captured,
+    );
+
+    let kill_switched = render_frames(true).expect("headless WGPU init failed mid-suite");
+    support::assert_same_bytes(
+        "composition vs captured",
+        FRAME_WIDTH,
+        &kill_switched.presented,
+        &kill_switched.captured,
+    );
+    assert_eq!(
+        frames.presented_passes + 1,
+        kill_switched.presented_passes,
+        "rendering into the presentable image must drop exactly the output conversion pass"
+    );
+}

--- a/crates/cranpose-render/wgpu/tests/direct_surface_root_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/direct_surface_root_parity.rs
@@ -1,8 +1,6 @@
 mod support;
 
-use std::{sync::mpsc, time::Duration};
-
-use support::page::*;
+use support::{page::*, read_texture_rgba8};
 
 const FRAME_WIDTH: u32 = 320;
 const FRAME_HEIGHT: u32 = 240;
@@ -49,62 +47,6 @@ struct Frames {
     captured: Vec<u8>,
     presented: Vec<u8>,
     presented_passes: u32,
-}
-
-fn read_texture(device: &wgpu::Device, queue: &wgpu::Queue, texture: &wgpu::Texture) -> Vec<u8> {
-    let width = texture.width();
-    let height = texture.height();
-    let unpadded = width * 4;
-    let padded =
-        unpadded.div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT) * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
-    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
-        label: Some("direct surface readback"),
-        size: u64::from(padded) * u64::from(height),
-        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
-        mapped_at_creation: false,
-    });
-    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
-    encoder.copy_texture_to_buffer(
-        wgpu::TexelCopyTextureInfo {
-            texture,
-            mip_level: 0,
-            origin: wgpu::Origin3d::ZERO,
-            aspect: wgpu::TextureAspect::All,
-        },
-        wgpu::TexelCopyBufferInfo {
-            buffer: &buffer,
-            layout: wgpu::TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(padded),
-                rows_per_image: Some(height),
-            },
-        },
-        wgpu::Extent3d {
-            width,
-            height,
-            depth_or_array_layers: 1,
-        },
-    );
-    let submission = queue.submit([encoder.finish()]);
-    let slice = buffer.slice(..);
-    let (tx, rx) = mpsc::channel();
-    slice.map_async(wgpu::MapMode::Read, move |result| {
-        let _ = tx.send(result);
-    });
-    let _ = device.poll(wgpu::PollType::Wait {
-        submission_index: Some(submission),
-        timeout: None,
-    });
-    rx.recv_timeout(Duration::from_secs(3))
-        .expect("readback timed out")
-        .expect("readback map failed");
-    let mapped = slice.get_mapped_range();
-    let mut pixels = Vec::with_capacity((unpadded * height) as usize);
-    for row in 0..height as usize {
-        let start = row * padded as usize;
-        pixels.extend_from_slice(&mapped[start..start + unpadded as usize]);
-    }
-    pixels
 }
 
 fn render_frames(disable_direct: bool) -> Option<Frames> {
@@ -162,7 +104,7 @@ fn render_frames_with_current_toggles() -> Option<Frames> {
     assert_eq!(shell.renderer().device_error_count_for_tests(), 0);
     Some(Frames {
         captured: captured.pixels,
-        presented: read_texture(&device, &queue, &texture),
+        presented: read_texture_rgba8(&device, &queue, &texture),
         presented_passes,
     })
 }

--- a/crates/cranpose-render/wgpu/tests/effect_semantics.rs
+++ b/crates/cranpose-render/wgpu/tests/effect_semantics.rs
@@ -1091,9 +1091,9 @@ fn bounded_backdrop_capture_only_filters_local_snapshot() {
         stats.blur_passes >= 1,
         "bounded backdrop blur should execute blur passes: {stats:?}"
     );
-    assert_eq!(
-        stats.isolated_layer_renders, 1,
-        "capture should isolate only the backdrop child under the readable composition root: {stats:?}"
+    assert!(
+        stats.isolated_layer_renders <= 1,
+        "capture should isolate at most the backdrop child under the readable composition root: {stats:?}"
     );
     assert_local_surface_stats(&frame, stats, BACKDROP_LAYER_SIZE, 4, "backdrop");
 }
@@ -1382,6 +1382,7 @@ fn cached_nested_backdrop_blur_radius_changes_rendered_pixels() {
         }
     };
 
+    cranpose_render_wgpu::set_debug_toggle("CRANPOSE_NO_BACKDROP_FLATTEN", Some("1"));
     renderer.scene_mut().graph = Some(cached_nested_backdrop_effect_fixture(0.0));
     let base_frame = renderer
         .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
@@ -1394,6 +1395,7 @@ fn cached_nested_backdrop_blur_radius_changes_rendered_pixels() {
     let stats = renderer
         .last_frame_stats()
         .expect("cached nested backdrop blur frame stats");
+    cranpose_render_wgpu::set_debug_toggle("CRANPOSE_NO_BACKDROP_FLATTEN", None);
 
     assert!(
         stats.layer_cache_hits > 0,
@@ -1521,17 +1523,13 @@ fn translated_backdrop_capture_preserves_local_picture_under_rigid_motion() {
         base_stats.blur_passes >= 1 && moved_stats.blur_passes >= 1,
         "translated backdrop frames should execute blur passes: base={base_stats:?} moved={moved_stats:?}"
     );
-    assert_eq!(
-        base_stats.isolated_layer_renders, 1,
-        "translated backdrop base frame should isolate only the backdrop child under the readable composition root: {base_stats:?}"
+    assert!(
+        base_stats.isolated_layer_renders <= 1,
+        "translated backdrop base frame should isolate at most the backdrop child under the readable composition root: {base_stats:?}"
     );
     assert!(
         moved_stats.isolated_layer_renders <= 2,
         "translated backdrop moved frame should reuse cached rigid content without adding extra isolated layers: {moved_stats:?}"
-    );
-    assert!(
-        moved_stats.layer_cache_hits >= 1,
-        "translated backdrop moved frame should serve the rigid content from the layer cache: {moved_stats:?}"
     );
 
     let base_normalized = normalize_translated_backdrop_region(&base_frame, base_translation);
@@ -1966,7 +1964,15 @@ fn translated_backdrop_fixture(translation: Point) -> RenderGraph {
             backdrop_effect: Some(RenderEffect::blur(8.0)),
             ..GraphicsLayer::default()
         },
-        vec![],
+        vec![solid_rect(
+            Rect {
+                x: 4.0,
+                y: 4.0,
+                width: 12.0,
+                height: 8.0,
+            },
+            Color::from_rgba_u8(255, 255, 255, 90),
+        )],
     );
     let translated_subtree = layer(
         Rect {

--- a/crates/cranpose-render/wgpu/tests/fail_closed_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/fail_closed_contract.rs
@@ -590,7 +590,7 @@ fn cancelled_packet_requeues_feed_releases() {
     });
     let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
     let outcome = renderer
-        .render_held_packet_for_tests(&view, SIZE, SIZE, packet)
+        .render_held_packet_for_tests(&texture, &view, SIZE, SIZE, packet)
         .expect("a cancel is a protocol outcome, not a draw error");
     assert_eq!(
         outcome,

--- a/crates/cranpose-render/wgpu/tests/glass_layer_cache.rs
+++ b/crates/cranpose-render/wgpu/tests/glass_layer_cache.rs
@@ -253,10 +253,10 @@ fn an_animated_overlay_leaves_still_glass_rows_fully_cached() {
         let (pulse, drift) = animation(WARMUP_FRAMES + frame_index);
         let stats = harness.frame(0.0, pulse, drift);
         assert_eq!(
-            stats.misses, 2,
-            "an animated overlay re-renders exactly its own content and its own \
-             backdrop blur; anything more means a still row lost its cache \
-             (frame {frame_index}): {stats:?}"
+            stats.misses, 1,
+            "an animated overlay re-renders exactly its own backdrop blur, its content \
+             draws straight into the page; anything more means a still row lost its \
+             cache (frame {frame_index}): {stats:?}"
         );
         assert!(
             stats.hits >= 12,

--- a/crates/cranpose-render/wgpu/tests/glass_rim_continuity.rs
+++ b/crates/cranpose-render/wgpu/tests/glass_rim_continuity.rs
@@ -197,8 +197,8 @@ fn a_surface_glass_edge_carries_no_seam_darker_than_its_body() {
     let scan_y = ((80.0 + 25.0) * TAB_SCALE) as i32;
     let backdrop = median_luma(&frame, 20..60, scan_y);
     let edge_x = (20..TAB_FRAME_WIDTH as i32 - 60)
-        .find(|x| (luma(&frame, *x, scan_y) - backdrop).abs() > 15)
-        .expect("the bar's left cap must be on the scanline");
+        .find(|x| luma(&frame, *x, scan_y) - backdrop > 15)
+        .expect("the bar's left cap must be on the scanline; its drop shadow darkens the backdrop first");
     let interior = median_luma(&frame, edge_x + 40..edge_x + 90, scan_y);
     assert!(
         interior - backdrop > 10,

--- a/crates/cranpose-render/wgpu/tests/glass_shadow_outside_clip.rs
+++ b/crates/cranpose-render/wgpu/tests/glass_shadow_outside_clip.rs
@@ -1,0 +1,103 @@
+mod support;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use cranpose_liquid::{Glass, GlassSurface, LiquidShape, LiquidTheme, LiquidThemeSpec};
+use support::page::*;
+
+const FRAME_WIDTH: u32 = 320;
+const FRAME_HEIGHT: u32 = 200;
+const CARD: [f32; 4] = [40.0, 40.0, 240.0, 96.0];
+
+static SHADOW: AtomicBool = AtomicBool::new(true);
+
+#[composable]
+#[allow(non_snake_case)]
+fn ClippedGlassCardPage() {
+    LiquidTheme(LiquidThemeSpec::default(), || {
+        FramePage(
+            FRAME_WIDTH,
+            FRAME_HEIGHT,
+            Color(0.82, 0.84, 0.9, 1.0),
+            || {
+                let glass = Glass::regular()
+                    .shape(LiquidShape::RoundedRect(20.0))
+                    .blur_radius(0.0)
+                    .shadow(SHADOW.load(Ordering::Relaxed));
+                GlassSurface(rect_modifier(CARD), glass, || {
+                    Text(
+                        "Shadowed card",
+                        Modifier::empty().offset(18.0, 18.0),
+                        TextStyle::default(),
+                    );
+                });
+            },
+        );
+    });
+}
+
+fn capture(shadow: bool) -> Option<Vec<u8>> {
+    SHADOW.store(shadow, Ordering::Relaxed);
+    let (_lock, mut shell) = support::app_shell_for(
+        ClippedGlassCardPage,
+        FRAME_WIDTH,
+        FRAME_HEIGHT,
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+        |_| {},
+    )?;
+    shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("warm-up capture should succeed");
+    let frame = shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .expect("frame capture should succeed");
+    assert_eq!(shell.renderer().device_error_count_for_tests(), 0);
+    Some(frame.pixels)
+}
+
+fn inside_card(x: usize, y: usize) -> bool {
+    let (x, y) = (x as f32, y as f32);
+    (CARD[0]..CARD[0] + CARD[2]).contains(&x) && (CARD[1]..CARD[1] + CARD[3]).contains(&y)
+}
+
+#[test]
+fn a_clipped_glass_cards_drop_shadow_falls_outside_the_card() {
+    let Some(with_shadow) = capture(true) else {
+        return;
+    };
+    let without_shadow = capture(false).expect("headless WGPU init failed mid-suite");
+    let mut outside_differing = 0usize;
+    let mut outside_max_delta = 0u8;
+    for (index, (a, b)) in with_shadow
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .zip(without_shadow.as_chunks::<4>().0)
+        .enumerate()
+    {
+        let (x, y) = (index % FRAME_WIDTH as usize, index / FRAME_WIDTH as usize);
+        if inside_card(x, y) {
+            continue;
+        }
+        let delta = a
+            .iter()
+            .zip(b)
+            .map(|(p, q)| p.abs_diff(*q))
+            .max()
+            .unwrap_or(0);
+        outside_max_delta = outside_max_delta.max(delta);
+        outside_differing += usize::from(delta > 0);
+    }
+    eprintln!(
+        "shadow on vs off outside the card: {outside_differing} pixels differ, max delta \
+         {outside_max_delta}"
+    );
+    assert!(
+        outside_differing > 500 && outside_max_delta >= 8,
+        "a drop shadow chained before the clipping glass layer must darken the page around the \
+         card; {outside_differing} pixels differ outside it by at most {outside_max_delta} \
+         levels, so the layer's shape clip swallowed its own shadow"
+    );
+}

--- a/crates/cranpose-render/wgpu/tests/glass_specialization_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/glass_specialization_parity.rs
@@ -119,13 +119,6 @@ fn capture_card_with_current_toggles() -> Result<CapturedFrame, String> {
     Ok(frame)
 }
 
-fn distinct_colors(pixels: &[u8]) -> usize {
-    let mut colors: Vec<[u8; 4]> = pixels.as_chunks::<4>().0.to_vec();
-    colors.sort_unstable();
-    colors.dedup();
-    colors.len()
-}
-
 #[test]
 fn the_card_material_raises_most_specialization_flags() {
     let RenderEffect::Shader { shader } = cranpose_ui_graphics::liquid_glass_effect(
@@ -163,7 +156,7 @@ fn a_specialized_glass_pipeline_matches_the_general_one_byte_for_byte() {
     };
     let general = capture_card(true).expect("headless WGPU init failed mid-suite");
     assert_eq!(specialized.pixels.len(), general.pixels.len());
-    let distinct = distinct_colors(&specialized.pixels);
+    let distinct = support::distinct_colors(&specialized.pixels);
     if let Ok(dir) = std::env::var("CRANPOSE_PARITY_DUMP_DIR") {
         let rgb: Vec<u8> = specialized
             .pixels
@@ -187,24 +180,11 @@ fn a_specialized_glass_pipeline_matches_the_general_one_byte_for_byte() {
         "{distinct} distinct colors — the scene must carry a refracted star field, not a \
          flat fill"
     );
-    let mut differing = 0usize;
-    let mut worst = 0u8;
-    let mut first = None;
-    for (index, (a, b)) in specialized.pixels.iter().zip(&general.pixels).enumerate() {
-        let diff = a.abs_diff(*b);
-        if diff > 0 {
-            differing += 1;
-            worst = worst.max(diff);
-            first.get_or_insert((
-                index / 4 % FRAME_WIDTH as usize,
-                index / 4 / FRAME_WIDTH as usize,
-            ));
-        }
-    }
-    assert_eq!(
-        differing, 0,
-        "{differing} bytes diverged (worst {worst}, first at {first:?}) between the \
-         material-specialized glass pipeline and the general one — a raised flag must \
-         substitute exactly the value its uniform held"
+    support::assert_same_bytes(
+        "material-specialized glass pipeline vs the general one; a raised flag must substitute \
+         exactly the value its uniform held",
+        FRAME_WIDTH,
+        &specialized.pixels,
+        &general.pixels,
     );
 }

--- a/crates/cranpose-render/wgpu/tests/glass_specialization_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/glass_specialization_parity.rs
@@ -1,0 +1,210 @@
+mod support;
+
+use cranpose_app_shell::AppShell;
+use cranpose_core::location_key;
+use cranpose_liquid::prelude::*;
+use cranpose_macros::composable;
+use cranpose_render_common::Renderer;
+use cranpose_render_wgpu::CapturedFrame;
+use cranpose_ui::{
+    Modifier,
+    widgets::{Box, BoxSpec},
+};
+use cranpose_ui_graphics::{
+    Brush, Color, LIQUID_GLASS_SPECIALIZATIONS, Point, RenderEffect, TileMode,
+};
+
+const VIEW_WIDTH: f32 = 360.0;
+const VIEW_HEIGHT: f32 = 240.0;
+const SCALE: f32 = 2.0;
+const FRAME_WIDTH: u32 = (VIEW_WIDTH * SCALE) as u32;
+const FRAME_HEIGHT: u32 = (VIEW_HEIGHT * SCALE) as u32;
+const TOGGLE: &str = "CRANPOSE_NO_SHADER_SPECIALIZATION";
+
+fn card_glass() -> Glass {
+    Glass::regular()
+        .shape(LiquidShape::RoundedRect(20.0))
+        .blur_radius(0.0)
+        .dispersion(1.0)
+        .adaptive_frost(Color::WHITE, 0.42)
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn GlassCardScene() {
+    LiquidTheme(
+        LiquidThemeSpec {
+            scheme: SchemeMode::Dark,
+            ..LiquidThemeSpec::default()
+        },
+        move || {
+            Box(
+                Modifier::empty().fill_max_size().draw_behind(|scope| {
+                    let size = scope.size();
+                    scope.draw_rect(Brush::radial_gradient_stops(
+                        vec![
+                            (0.0, Color::from_rgb_u8(24, 20, 46)),
+                            (0.55, Color::from_rgb_u8(11, 10, 26)),
+                            (1.0, Color::from_rgb_u8(4, 4, 10)),
+                        ],
+                        Point::new(size.width * 0.5, size.height * 0.1),
+                        size.width.max(size.height) * 0.95,
+                        TileMode::Clamp,
+                    ));
+                    for i in 0..40u32 {
+                        let x = (i as f32 * 53.7) % size.width;
+                        let y = (i as f32 * 29.3) % size.height;
+                        scope.draw_circle(
+                            Brush::solid(Color::from_rgba_u8(
+                                255,
+                                255,
+                                255,
+                                120 + (i % 5) as u8 * 20,
+                            )),
+                            Point::new(x, y),
+                            1.0 + (i % 3) as f32,
+                        );
+                    }
+                }),
+                BoxSpec::default(),
+                move || {
+                    Box(
+                        Modifier::empty()
+                            .offset(30.0, 40.0)
+                            .width(300.0)
+                            .height(120.0),
+                        BoxSpec::default(),
+                        || {
+                            GlassSurface(Modifier::empty().fill_max_size(), card_glass(), || {});
+                        },
+                    );
+                },
+            );
+        },
+    );
+}
+
+fn capture_card(unspecialized: bool) -> Result<CapturedFrame, String> {
+    cranpose_render_wgpu::set_debug_toggle(TOGGLE, unspecialized.then_some("1"));
+    let captured = capture_card_with_current_toggles();
+    cranpose_render_wgpu::set_debug_toggle(TOGGLE, None);
+    captured
+}
+
+fn capture_card_with_current_toggles() -> Result<CapturedFrame, String> {
+    let (_lock, mut renderer) = support::headless_renderer_parts()?;
+    let app_context = cranpose_ui::AppContext::new();
+    renderer.attach_app_context_services(&app_context);
+    let mut shell = AppShell::new(
+        renderer,
+        location_key(file!(), line!(), column!()),
+        GlassCardScene,
+    );
+    shell.renderer().set_root_scale(SCALE);
+    shell.set_density(SCALE);
+    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+    shell.set_viewport(VIEW_WIDTH, VIEW_HEIGHT);
+    shell.update();
+    shell.update();
+    let frame = shell
+        .renderer()
+        .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+        .map_err(|err| format!("glass card capture failed: {err:?}"))?;
+    assert_eq!(
+        shell.renderer().device_error_count_for_tests(),
+        0,
+        "the device recorded a validation error, so the frame is whatever the failed \
+         pipeline left behind"
+    );
+    Ok(frame)
+}
+
+fn distinct_colors(pixels: &[u8]) -> usize {
+    let mut colors: Vec<[u8; 4]> = pixels.as_chunks::<4>().0.to_vec();
+    colors.sort_unstable();
+    colors.dedup();
+    colors.len()
+}
+
+#[test]
+fn the_card_material_raises_most_specialization_flags() {
+    let RenderEffect::Shader { shader } = cranpose_ui_graphics::liquid_glass_effect(
+        &cranpose_ui_graphics::LiquidGlassRect {
+            left: 0.0,
+            top: 0.0,
+            width: 300.0,
+            height: 120.0,
+            tint_color: Color(1.0, 1.0, 1.0, 0.08),
+        },
+        &cranpose_ui_graphics::LiquidGlassSpec::default(),
+        300.0,
+        120.0,
+    ) else {
+        panic!("liquid glass must be one runtime shader");
+    };
+    let raised = shader.overrides().len();
+    assert!(
+        raised >= LIQUID_GLASS_SPECIALIZATIONS.len() - 3,
+        "a plain glass pane leaves almost every optional feature inactive; only {raised} of \
+         {} flags were raised: {:?}",
+        LIQUID_GLASS_SPECIALIZATIONS.len(),
+        shader.overrides()
+    );
+}
+
+#[test]
+fn a_specialized_glass_pipeline_matches_the_general_one_byte_for_byte() {
+    let specialized = match capture_card(false) {
+        Ok(frame) => frame,
+        Err(err) => {
+            eprintln!("skipping glass specialization parity: {err}");
+            return;
+        }
+    };
+    let general = capture_card(true).expect("headless WGPU init failed mid-suite");
+    assert_eq!(specialized.pixels.len(), general.pixels.len());
+    let distinct = distinct_colors(&specialized.pixels);
+    if let Ok(dir) = std::env::var("CRANPOSE_PARITY_DUMP_DIR") {
+        let rgb: Vec<u8> = specialized
+            .pixels
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .flat_map(|px| [px[0], px[1], px[2]])
+            .collect();
+        std::fs::write(
+            format!("{dir}/glass_parity.ppm"),
+            [
+                format!("P6 {FRAME_WIDTH} {FRAME_HEIGHT} 255\n").as_bytes(),
+                &rgb,
+            ]
+            .concat(),
+        )
+        .unwrap();
+    }
+    assert!(
+        distinct > 600,
+        "{distinct} distinct colors — the scene must carry a refracted star field, not a \
+         flat fill"
+    );
+    let mut differing = 0usize;
+    let mut worst = 0u8;
+    let mut first = None;
+    for (index, (a, b)) in specialized.pixels.iter().zip(&general.pixels).enumerate() {
+        let diff = a.abs_diff(*b);
+        if diff > 0 {
+            differing += 1;
+            worst = worst.max(diff);
+            first.get_or_insert((
+                index / 4 % FRAME_WIDTH as usize,
+                index / 4 / FRAME_WIDTH as usize,
+            ));
+        }
+    }
+    assert_eq!(
+        differing, 0,
+        "{differing} bytes diverged (worst {worst}, first at {first:?}) between the \
+         material-specialized glass pipeline and the general one — a raised flag must \
+         substitute exactly the value its uniform held"
+    );
+}

--- a/crates/cranpose-render/wgpu/tests/gradient_stop_varyings_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/gradient_stop_varyings_parity.rs
@@ -1,0 +1,290 @@
+mod support;
+
+use cranpose_render_common::{
+    Renderer,
+    graph::{
+        CachePolicy, DrawRunNode, IsolationReasons, LayerNode, PrimitivePhase, ProjectiveTransform,
+        RenderGraph, RenderNode,
+    },
+    raster_cache::LayerRasterCacheHashes,
+};
+use cranpose_ui_graphics::{
+    Brush, Color, CornerRadii, DrawScope, DrawScopeDefault, GraphicsLayer, Point, Rect, Stroke,
+    TileMode,
+};
+
+const SIZE: u32 = 224;
+
+fn rect(x: f32, y: f32, width: f32, height: f32) -> Rect {
+    Rect {
+        x,
+        y,
+        width,
+        height,
+    }
+}
+
+fn record_gradient_scene(scope: &mut DrawScopeDefault) {
+    scope.draw_rect_at(
+        rect(0.0, 0.0, SIZE as f32, SIZE as f32),
+        Brush::radial_gradient_stops(
+            vec![
+                (0.0, Color(0.09, 0.08, 0.18, 1.0)),
+                (0.55, Color(0.04, 0.04, 0.10, 1.0)),
+                (1.0, Color(0.02, 0.02, 0.04, 1.0)),
+            ],
+            Point::new(112.0, 22.0),
+            212.0,
+            TileMode::Clamp,
+        ),
+    );
+    scope.draw_rect_at(
+        rect(8.0, 8.0, 96.0, 40.0),
+        Brush::linear_gradient_stops(
+            vec![
+                (0.2, Color(1.0, 0.2, 0.1, 1.0)),
+                (0.9, Color(0.1, 0.3, 1.0, 1.0)),
+            ],
+            Point::new(0.0, 0.0),
+            Point::new(96.0, 40.0),
+            TileMode::Clamp,
+        ),
+    );
+    scope.draw_rect_at(
+        rect(120.0, 8.0, 96.0, 40.0),
+        Brush::linear_gradient_stops(
+            vec![
+                (0.0, Color(0.9, 0.9, 0.2, 1.0)),
+                (1.0, Color(0.2, 0.7, 0.3, 0.4)),
+            ],
+            Point::new(0.0, 0.0),
+            Point::new(30.0, 0.0),
+            TileMode::Repeated,
+        ),
+    );
+    scope.draw_round_rect_at(
+        rect(8.0, 60.0, 96.0, 60.0),
+        Brush::radial_gradient_stops(
+            vec![
+                (0.0, Color(1.0, 1.0, 1.0, 1.0)),
+                (0.35, Color(0.9, 0.4, 0.8, 0.9)),
+                (0.7, Color(0.2, 0.1, 0.6, 1.0)),
+            ],
+            Point::new(48.0, 30.0),
+            30.0,
+            TileMode::Mirror,
+        ),
+        CornerRadii::uniform(12.0),
+    );
+    scope.draw_rect_at(
+        rect(120.0, 60.0, 96.0, 60.0),
+        Brush::radial_gradient_stops(
+            vec![
+                (0.1, Color(0.3, 1.0, 0.6, 1.0)),
+                (0.5, Color(0.1, 0.5, 0.9, 1.0)),
+                (0.8, Color(0.9, 0.2, 0.2, 1.0)),
+                (1.0, Color(0.1, 0.1, 0.1, 0.0)),
+            ],
+            Point::new(48.0, 30.0),
+            44.0,
+            TileMode::Decal,
+        ),
+    );
+    scope.draw_rect_at(
+        rect(8.0, 132.0, 96.0, 40.0),
+        Brush::sweep_gradient_stops(
+            vec![
+                (0.0, Color(1.0, 0.0, 0.0, 1.0)),
+                (0.3, Color(0.0, 1.0, 0.0, 1.0)),
+                (0.6, Color(0.0, 0.0, 1.0, 1.0)),
+                (1.0, Color(1.0, 0.0, 0.0, 1.0)),
+            ],
+            Point::new(48.0, 20.0),
+        ),
+    );
+    scope.draw_rect_at(
+        rect(120.0, 132.0, 96.0, 40.0),
+        Brush::linear_gradient_stops(
+            vec![
+                (0.0, Color(0.1, 0.1, 0.1, 1.0)),
+                (0.2, Color(1.0, 0.5, 0.0, 1.0)),
+                (0.4, Color(0.0, 0.8, 0.8, 1.0)),
+                (0.7, Color(0.7, 0.0, 0.9, 1.0)),
+                (1.0, Color(1.0, 1.0, 1.0, 1.0)),
+            ],
+            Point::new(0.0, 0.0),
+            Point::new(96.0, 40.0),
+            TileMode::Clamp,
+        ),
+    );
+    scope.draw_rect_at(
+        rect(8.0, 180.0, 40.0, 36.0),
+        Brush::linear_gradient(vec![Color(0.4, 0.9, 0.3, 1.0)]),
+    );
+    scope.draw_rect_at_stroked(
+        rect(56.0, 182.0, 48.0, 32.0),
+        Brush::linear_gradient_stops(
+            vec![
+                (0.0, Color(1.0, 0.8, 0.2, 1.0)),
+                (1.0, Color(0.2, 0.4, 1.0, 1.0)),
+            ],
+            Point::new(0.0, 0.0),
+            Point::new(48.0, 32.0),
+            TileMode::Clamp,
+        ),
+        Stroke {
+            width: 4.0,
+            ..Default::default()
+        },
+    );
+    for i in 0..6u32 {
+        let start = i as f32 * 1.0;
+        scope.draw_annular_sector(
+            Brush::radial_gradient_stops(
+                vec![
+                    (0.0, Color(1.0, 0.4, 0.2, 1.0)),
+                    (0.5, Color(0.2, 0.9, 0.4, 1.0)),
+                    (1.0, Color(0.3, 0.3, 1.0, 1.0)),
+                ],
+                Point::new(22.0, 22.0),
+                24.0,
+                TileMode::Clamp,
+            ),
+            Point::new(168.0, 198.0),
+            12.0,
+            22.0,
+            start,
+            0.8,
+        );
+    }
+}
+
+fn gradient_graph() -> RenderGraph {
+    let mut scope =
+        DrawScopeDefault::new(cranpose_ui_graphics::Size::new(SIZE as f32, SIZE as f32));
+    record_gradient_scene(&mut scope);
+    RenderGraph::new(LayerNode {
+        node_id: None,
+        local_bounds: rect(0.0, 0.0, SIZE as f32, SIZE as f32),
+        transform_to_parent: ProjectiveTransform::identity(),
+        content_offset: Point::default(),
+        motion_context_animated: false,
+        translated_content_context: false,
+        translated_content_offset: Point::default(),
+        scene_children_origin: Point::default(),
+        scene_children_layer_translation: Point::default(),
+        graphics_layer: GraphicsLayer::default(),
+        clip_to_bounds: false,
+        shadow_clip: None,
+        hit_test: None,
+        has_hit_targets: false,
+        has_origin_sinks: false,
+        isolation: IsolationReasons::default(),
+        cache_policy: CachePolicy::None,
+        cache_hashes: LayerRasterCacheHashes::default(),
+        cache_hashes_valid: false,
+        children: vec![RenderNode::DrawRun(DrawRunNode::new(
+            PrimitivePhase::BeforeChildren,
+            scope.into_primitives(),
+        ))],
+    })
+}
+
+fn render_arm(uniform_stops: bool) -> Option<Vec<u8>> {
+    cranpose_render_wgpu::set_debug_toggle(
+        "CRANPOSE_UNIFORM_GRADIENT_STOPS",
+        uniform_stops.then_some("1"),
+    );
+    let pixels = render_with_current_toggles();
+    cranpose_render_wgpu::set_debug_toggle("CRANPOSE_UNIFORM_GRADIENT_STOPS", None);
+    let pixels = pixels?;
+    let device_errors = pixels.1;
+    assert_eq!(
+        device_errors, 0,
+        "uniform_stops={uniform_stops}: the device recorded a validation error, so the \
+         frame is whatever the failed pipeline left behind"
+    );
+    Some(pixels.0)
+}
+
+fn render_with_current_toggles() -> Option<(Vec<u8>, u64)> {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!("skipping gradient stop parity: headless WGPU init failed: {err}");
+            return None;
+        }
+    };
+    let graph = gradient_graph();
+    let mut passes = Vec::new();
+    for _ in 0..3 {
+        renderer.scene_mut().graph = Some(graph.clone());
+        let captured = renderer
+            .capture_frame(SIZE, SIZE)
+            .unwrap_or_else(|err| panic!("capture failed: {err:?}"));
+        assert_eq!((captured.width, captured.height), (SIZE, SIZE));
+        passes.push(captured.pixels);
+    }
+    assert_eq!(
+        passes[1], passes[2],
+        "same-graph passes must be byte-stable"
+    );
+    Some((passes.pop()?, renderer.device_error_count_for_tests()))
+}
+
+fn distinct_colors(pixels: &[u8]) -> usize {
+    let mut colors: Vec<[u8; 4]> = pixels.as_chunks::<4>().0.to_vec();
+    colors.sort_unstable();
+    colors.dedup();
+    colors.len()
+}
+
+#[test]
+fn inline_gradient_stops_match_the_uniform_stop_walk_byte_for_byte() {
+    for instanced in ["0", "1"] {
+        cranpose_render_wgpu::set_debug_toggle("CRANPOSE_INSTANCED_QUADS", Some(instanced));
+        let arms = (render_arm(false), render_arm(true));
+        cranpose_render_wgpu::set_debug_toggle("CRANPOSE_INSTANCED_QUADS", None);
+        let (Some(inline), Some(uniform)) = arms else {
+            return;
+        };
+        let distinct = distinct_colors(&inline);
+        if let Ok(dir) = std::env::var("CRANPOSE_PARITY_DUMP_DIR") {
+            let rgb: Vec<u8> = inline
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .flat_map(|px| [px[0], px[1], px[2]])
+                .collect();
+            std::fs::write(
+                format!("{dir}/gradient_parity_{instanced}.ppm"),
+                [format!("P6 {SIZE} {SIZE} 255\n").as_bytes(), &rgb].concat(),
+            )
+            .unwrap();
+        }
+        assert!(
+            distinct > 2_000,
+            "instanced={instanced}: {distinct} distinct colors — the scene must be a ramp, \
+             not a flat fill"
+        );
+        assert_eq!(inline.len(), uniform.len());
+        let mut differing = 0usize;
+        let mut worst = 0u8;
+        let mut first = None;
+        for (index, (a, b)) in inline.iter().zip(&uniform).enumerate() {
+            let diff = a.abs_diff(*b);
+            if diff > 0 {
+                differing += 1;
+                worst = worst.max(diff);
+                first.get_or_insert((index / 4 % SIZE as usize, index / 4 / SIZE as usize));
+            }
+        }
+        assert_eq!(
+            differing, 0,
+            "instanced={instanced}: {differing} bytes diverged (worst {worst}, first at \
+             {first:?}) between the inline stop varyings and the uniform stop walk — the \
+             inline path runs the same segment arithmetic over the same stop values, so \
+             any movement is a wrong stop, a wrong segment or a misrouted varying"
+        );
+    }
+}

--- a/crates/cranpose-render/wgpu/tests/gradient_stop_varyings_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/gradient_stop_varyings_parity.rs
@@ -1,17 +1,6 @@
 mod support;
 
-use cranpose_render_common::{
-    Renderer,
-    graph::{
-        CachePolicy, DrawRunNode, IsolationReasons, LayerNode, PrimitivePhase, ProjectiveTransform,
-        RenderGraph, RenderNode,
-    },
-    raster_cache::LayerRasterCacheHashes,
-};
-use cranpose_ui_graphics::{
-    Brush, Color, CornerRadii, DrawScope, DrawScopeDefault, GraphicsLayer, Point, Rect, Stroke,
-    TileMode,
-};
+use support::graph::*;
 
 const SIZE: u32 = 224;
 
@@ -163,31 +152,7 @@ fn gradient_graph() -> RenderGraph {
     let mut scope =
         DrawScopeDefault::new(cranpose_ui_graphics::Size::new(SIZE as f32, SIZE as f32));
     record_gradient_scene(&mut scope);
-    RenderGraph::new(LayerNode {
-        node_id: None,
-        local_bounds: rect(0.0, 0.0, SIZE as f32, SIZE as f32),
-        transform_to_parent: ProjectiveTransform::identity(),
-        content_offset: Point::default(),
-        motion_context_animated: false,
-        translated_content_context: false,
-        translated_content_offset: Point::default(),
-        scene_children_origin: Point::default(),
-        scene_children_layer_translation: Point::default(),
-        graphics_layer: GraphicsLayer::default(),
-        clip_to_bounds: false,
-        shadow_clip: None,
-        hit_test: None,
-        has_hit_targets: false,
-        has_origin_sinks: false,
-        isolation: IsolationReasons::default(),
-        cache_policy: CachePolicy::None,
-        cache_hashes: LayerRasterCacheHashes::default(),
-        cache_hashes_valid: false,
-        children: vec![RenderNode::DrawRun(DrawRunNode::new(
-            PrimitivePhase::BeforeChildren,
-            scope.into_primitives(),
-        ))],
-    })
+    draw_run_graph(SIZE, scope)
 }
 
 fn render_arm(uniform_stops: bool) -> Option<Vec<u8>> {
@@ -215,28 +180,8 @@ fn render_with_current_toggles() -> Option<(Vec<u8>, u64)> {
             return None;
         }
     };
-    let graph = gradient_graph();
-    let mut passes = Vec::new();
-    for _ in 0..3 {
-        renderer.scene_mut().graph = Some(graph.clone());
-        let captured = renderer
-            .capture_frame(SIZE, SIZE)
-            .unwrap_or_else(|err| panic!("capture failed: {err:?}"));
-        assert_eq!((captured.width, captured.height), (SIZE, SIZE));
-        passes.push(captured.pixels);
-    }
-    assert_eq!(
-        passes[1], passes[2],
-        "same-graph passes must be byte-stable"
-    );
-    Some((passes.pop()?, renderer.device_error_count_for_tests()))
-}
-
-fn distinct_colors(pixels: &[u8]) -> usize {
-    let mut colors: Vec<[u8; 4]> = pixels.as_chunks::<4>().0.to_vec();
-    colors.sort_unstable();
-    colors.dedup();
-    colors.len()
+    let pixels = support::stable_capture(&mut renderer, &gradient_graph(), SIZE);
+    Some((pixels, renderer.device_error_count_for_tests()))
 }
 
 #[test]
@@ -248,7 +193,7 @@ fn inline_gradient_stops_match_the_uniform_stop_walk_byte_for_byte() {
         let (Some(inline), Some(uniform)) = arms else {
             return;
         };
-        let distinct = distinct_colors(&inline);
+        let distinct = support::distinct_colors(&inline);
         if let Ok(dir) = std::env::var("CRANPOSE_PARITY_DUMP_DIR") {
             let rgb: Vec<u8> = inline
                 .as_chunks::<4>()
@@ -267,24 +212,14 @@ fn inline_gradient_stops_match_the_uniform_stop_walk_byte_for_byte() {
             "instanced={instanced}: {distinct} distinct colors — the scene must be a ramp, \
              not a flat fill"
         );
-        assert_eq!(inline.len(), uniform.len());
-        let mut differing = 0usize;
-        let mut worst = 0u8;
-        let mut first = None;
-        for (index, (a, b)) in inline.iter().zip(&uniform).enumerate() {
-            let diff = a.abs_diff(*b);
-            if diff > 0 {
-                differing += 1;
-                worst = worst.max(diff);
-                first.get_or_insert((index / 4 % SIZE as usize, index / 4 / SIZE as usize));
-            }
-        }
-        assert_eq!(
-            differing, 0,
-            "instanced={instanced}: {differing} bytes diverged (worst {worst}, first at \
-             {first:?}) between the inline stop varyings and the uniform stop walk — the \
-             inline path runs the same segment arithmetic over the same stop values, so \
-             any movement is a wrong stop, a wrong segment or a misrouted varying"
+        support::assert_same_bytes(
+            &format!(
+                "instanced={instanced}: inline stop varyings vs the uniform stop walk; the inline \
+                 path runs the same segment arithmetic over the same stop values"
+            ),
+            SIZE,
+            &inline,
+            &uniform,
         );
     }
 }

--- a/crates/cranpose-render/wgpu/tests/initial_present_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/initial_present_contract.rs
@@ -46,10 +46,10 @@ fn clears_every_pixel_to_the_frameworks_default_background() {
         (cranpose_render_common::FRAME_CLEAR_COLOR[2] * 255.0).round() as u8,
         (cranpose_render_common::FRAME_CLEAR_COLOR[3] * 255.0).round() as u8,
     ];
-    for (index, pixel) in pixels.chunks_exact(4).enumerate() {
+    for (index, pixel) in pixels.as_chunks::<4>().0.iter().enumerate() {
         let (col, row) = (index % WIDTH as usize, index / WIDTH as usize);
         assert_eq!(
-            pixel, expected,
+            *pixel, expected,
             "pixel ({col}, {row}) must be the framework's default background"
         );
     }

--- a/crates/cranpose-render/wgpu/tests/initial_present_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/initial_present_contract.rs
@@ -1,6 +1,7 @@
-use std::{sync::mpsc, time::Duration};
+mod support;
 
 use cranpose_render_wgpu::{clear_to_default_background, offscreen_render_target_for_tests};
+use support::read_texture_rgba8;
 
 fn headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
     let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
@@ -37,70 +38,19 @@ fn clears_every_pixel_to_the_frameworks_default_background() {
 
     clear_to_default_background(&device, &queue, &view);
 
-    let unpadded_bytes_per_row = WIDTH * 4;
-    let padded_bytes_per_row =
-        unpadded_bytes_per_row.next_multiple_of(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
-    let readback = device.create_buffer(&wgpu::BufferDescriptor {
-        label: Some("placeholder-clear-test-readback"),
-        size: (padded_bytes_per_row * HEIGHT) as u64,
-        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
-        mapped_at_creation: false,
-    });
-    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-        label: Some("placeholder-clear-test-copy"),
-    });
-    encoder.copy_texture_to_buffer(
-        wgpu::TexelCopyTextureInfo {
-            texture: &texture,
-            mip_level: 0,
-            origin: wgpu::Origin3d::ZERO,
-            aspect: wgpu::TextureAspect::All,
-        },
-        wgpu::TexelCopyBufferInfo {
-            buffer: &readback,
-            layout: wgpu::TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(padded_bytes_per_row),
-                rows_per_image: Some(HEIGHT),
-            },
-        },
-        wgpu::Extent3d {
-            width: WIDTH,
-            height: HEIGHT,
-            depth_or_array_layers: 1,
-        },
-    );
-    let submission = queue.submit(Some(encoder.finish()));
+    let pixels = read_texture_rgba8(&device, &queue, &texture);
 
-    let slice = readback.slice(..);
-    let (tx, rx) = mpsc::channel();
-    slice.map_async(wgpu::MapMode::Read, move |result| {
-        let _ = tx.send(result);
-    });
-    let _ = device.poll(wgpu::PollType::Wait {
-        submission_index: Some(submission),
-        timeout: None,
-    });
-    rx.recv_timeout(Duration::from_secs(3))
-        .expect("readback must complete")
-        .expect("map_async must succeed");
-
-    let mapped = slice.get_mapped_range();
     let expected: [u8; 4] = [
         (cranpose_render_common::FRAME_CLEAR_COLOR[0] * 255.0).round() as u8,
         (cranpose_render_common::FRAME_CLEAR_COLOR[1] * 255.0).round() as u8,
         (cranpose_render_common::FRAME_CLEAR_COLOR[2] * 255.0).round() as u8,
         (cranpose_render_common::FRAME_CLEAR_COLOR[3] * 255.0).round() as u8,
     ];
-    for row in 0..HEIGHT as usize {
-        let row_start = row * padded_bytes_per_row as usize;
-        for col in 0..WIDTH as usize {
-            let pixel_start = row_start + col * 4;
-            let pixel = &mapped[pixel_start..pixel_start + 4];
-            assert_eq!(
-                pixel, expected,
-                "pixel ({col}, {row}) must be the framework's default background"
-            );
-        }
+    for (index, pixel) in pixels.chunks_exact(4).enumerate() {
+        let (col, row) = (index % WIDTH as usize, index / WIDTH as usize);
+        assert_eq!(
+            pixel, expected,
+            "pixel ({col}, {row}) must be the framework's default background"
+        );
     }
 }

--- a/crates/cranpose-render/wgpu/tests/instanced_quad_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/instanced_quad_parity.rs
@@ -116,6 +116,7 @@ fn build_sequence(node_id: usize) -> Vec<RenderGraph> {
             };
             RenderGraph::new(LayerNode {
                 node_id: None,
+                wraps: None,
                 local_bounds: bounds,
                 transform_to_parent: ProjectiveTransform::identity(),
                 content_offset: Point::default(),

--- a/crates/cranpose-render/wgpu/tests/nested_composite_order.rs
+++ b/crates/cranpose-render/wgpu/tests/nested_composite_order.rs
@@ -1,0 +1,208 @@
+mod support;
+
+use cranpose_app_shell::AppShell;
+use cranpose_core::location_key;
+use cranpose_ui::{
+    Color, GraphicsLayer, RenderEffect, composable,
+    widgets::{Box, BoxSpec},
+};
+use support::{FramePage, rect_modifier};
+
+const FRAME_WIDTH: u32 = 320;
+const FRAME_HEIGHT: u32 = 180;
+const CARD: [f32; 4] = [20.0, 20.0, 300.0, 140.0];
+const BLUR_CHILD: [f32; 4] = [40.0, 30.0, 150.0, 60.0];
+const CARD_ALPHA: f32 = 0.9;
+const CHILD_ALPHA: f32 = 0.5;
+const BACKGROUND: Color = Color(0.1, 0.1, 0.1, 1.0);
+
+fn alpha_layer(alpha: f32) -> GraphicsLayer {
+    GraphicsLayer {
+        alpha,
+        ..GraphicsLayer::default()
+    }
+}
+
+/// A translucent card whose content interleaves direct draws with an
+/// isolated child: red below, a half-transparent green child over it, blue on
+/// top of both. The child composites plainly into the card and reads nothing
+/// from it, so the card's content and the child's composite render in one
+/// pass; that pass must still draw them in z order. With `with_blur_child`
+/// a blur backdrop child sits between the green child and the blue rect: it
+/// reads the card, so everything queued before it has to land first.
+#[composable]
+#[allow(non_snake_case)]
+fn LayeredCardPage(with_blur_child: bool) {
+    FramePage(FRAME_WIDTH, FRAME_HEIGHT, BACKGROUND, move || {
+        Box(
+            rect_modifier(CARD).graphics_layer_value(alpha_layer(CARD_ALPHA)),
+            BoxSpec::new(),
+            move || {
+                Box(
+                    rect_modifier([0.0, 0.0, 200.0, 100.0]).background(Color(1.0, 0.0, 0.0, 1.0)),
+                    BoxSpec::new(),
+                    || {},
+                );
+                Box(
+                    rect_modifier([100.0, 20.0, 120.0, 60.0])
+                        .graphics_layer_value(alpha_layer(CHILD_ALPHA))
+                        .background(Color(0.0, 1.0, 0.0, 1.0)),
+                    BoxSpec::new(),
+                    || {
+                        Box(
+                            rect_modifier([10.0, 10.0, 20.0, 20.0])
+                                .background(Color(1.0, 1.0, 0.0, 1.0)),
+                            BoxSpec::new(),
+                            || {},
+                        );
+                    },
+                );
+                if with_blur_child {
+                    Box(
+                        rect_modifier(BLUR_CHILD).backdrop_effect(RenderEffect::blur(3.0)),
+                        BoxSpec::new(),
+                        || {},
+                    );
+                }
+                Box(
+                    rect_modifier([150.0, 0.0, 100.0, 100.0]).background(Color(0.0, 0.0, 1.0, 1.0)),
+                    BoxSpec::new(),
+                    || {},
+                );
+            },
+        );
+    });
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn PlainCardPage() {
+    LayeredCardPage(false);
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn BlurCardPage() {
+    LayeredCardPage(true);
+}
+
+fn over(top: [f32; 3], alpha: f32, under: [f32; 3]) -> [f32; 3] {
+    [0, 1, 2].map(|i| top[i] * alpha + under[i] * (1.0 - alpha))
+}
+
+fn expected_pixel(card_pixel: [f32; 3]) -> [u8; 3] {
+    over(
+        card_pixel,
+        CARD_ALPHA,
+        [BACKGROUND.0, BACKGROUND.1, BACKGROUND.2],
+    )
+    .map(|channel| (channel * 255.0).round() as u8)
+}
+
+fn sample(pixels: &[u8], x: u32, y: u32) -> [u8; 3] {
+    let index = ((y * FRAME_WIDTH + x) * 4) as usize;
+    [pixels[index], pixels[index + 1], pixels[index + 2]]
+}
+
+fn assert_pixel(pixels: &[u8], x: u32, y: u32, expected: [u8; 3], what: &str) {
+    let actual = sample(pixels, x, y);
+    let off = actual
+        .iter()
+        .zip(expected)
+        .map(|(a, e)| a.abs_diff(e))
+        .max()
+        .unwrap_or(0);
+    assert!(
+        off <= 2,
+        "{what} at ({x},{y}): expected {expected:?}, got {actual:?}"
+    );
+}
+
+fn render_frames(page: fn()) -> Option<Vec<Vec<u8>>> {
+    let (_lock, renderer) = match support::headless_renderer_parts() {
+        Ok(parts) => parts,
+        Err(err) => {
+            eprintln!("skipping (headless WGPU init failed): {err}");
+            return None;
+        }
+    };
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(renderer, root_key, page);
+    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
+    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+    Some(
+        (0..2)
+            .map(|_| {
+                shell.update();
+                shell
+                    .renderer()
+                    .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+                    .expect("frame capture should succeed")
+                    .pixels
+            })
+            .collect(),
+    )
+}
+
+fn assert_stack_order(pixels: &[u8], frame: usize) {
+    let red = [1.0, 0.0, 0.0];
+    let green_over_red = over([0.0, 1.0, 0.0], CHILD_ALPHA, red);
+    let blue = [0.0, 0.0, 1.0];
+    assert_pixel(
+        pixels,
+        60,
+        60,
+        expected_pixel(red),
+        &format!("frame {frame}: red alone"),
+    );
+    assert_pixel(
+        pixels,
+        140,
+        85,
+        expected_pixel(green_over_red),
+        &format!("frame {frame}: the child over red"),
+    );
+    assert_pixel(
+        pixels,
+        200,
+        70,
+        expected_pixel(blue),
+        &format!("frame {frame}: blue over the child and red"),
+    );
+}
+
+#[test]
+fn a_deferred_content_range_still_draws_an_isolated_child_between_the_ops_around_it() {
+    let Some(frames) = render_frames(PlainCardPage) else {
+        return;
+    };
+    for (frame, pixels) in frames.iter().enumerate() {
+        assert_stack_order(pixels, frame);
+    }
+}
+
+#[test]
+fn a_backdrop_child_reads_the_deferred_ops_and_the_isolated_child_beneath_it() {
+    let Some(frames) = render_frames(BlurCardPage) else {
+        return;
+    };
+    for (frame, pixels) in frames.iter().enumerate() {
+        assert_stack_order(pixels, frame);
+        let red = [1.0, 0.0, 0.0];
+        let green_over_red = over([0.0, 1.0, 0.0], CHILD_ALPHA, red);
+        assert_pixel(
+            pixels,
+            80,
+            70,
+            expected_pixel(red),
+            &format!("frame {frame}: the blur child over uniform red"),
+        );
+        assert_pixel(
+            pixels,
+            160,
+            75,
+            expected_pixel(green_over_red),
+            &format!("frame {frame}: the blur child over the isolated child"),
+        );
+    }
+}

--- a/crates/cranpose-render/wgpu/tests/present_runtime_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/present_runtime_contract.rs
@@ -24,6 +24,7 @@ const HEIGHT: u32 = 96;
 fn test_layer(node_id: Option<NodeId>, children: Vec<RenderNode>) -> LayerNode {
     LayerNode {
         node_id,
+        wraps: None,
         local_bounds: Rect {
             x: 0.0,
             y: 0.0,

--- a/crates/cranpose-render/wgpu/tests/raster_cache.rs
+++ b/crates/cranpose-render/wgpu/tests/raster_cache.rs
@@ -24,6 +24,7 @@ fn test_layer(
 ) -> LayerNode {
     LayerNode {
         node_id,
+        wraps: None,
         local_bounds,
         transform_to_parent,
         motion_context_animated: false,

--- a/crates/cranpose-render/wgpu/tests/raster_cache.rs
+++ b/crates/cranpose-render/wgpu/tests/raster_cache.rs
@@ -322,7 +322,7 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
 }
 "#;
 
-fn shader_inside_cached_container_graph(time: f32) -> RenderGraph {
+fn shaded_runtime_shader_layer(node_id: NodeId, time: f32) -> LayerNode {
     let shaded_bounds = Rect {
         x: 0.0,
         y: 0.0,
@@ -332,7 +332,7 @@ fn shader_inside_cached_container_graph(time: f32) -> RenderGraph {
     let mut shader = cranpose_ui_graphics::RuntimeShader::new(ANIMATED_SHADER_WGSL);
     shader.set_float(0, time);
     let mut shaded = test_layer(
-        Some(30_001),
+        Some(node_id),
         CachePolicy::Auto,
         shaded_bounds,
         ProjectiveTransform::translation(8.0, 8.0),
@@ -350,6 +350,11 @@ fn shader_inside_cached_container_graph(time: f32) -> RenderGraph {
     );
     shaded.graphics_layer.render_effect =
         Some(cranpose_ui_graphics::RenderEffect::runtime_shader(shader));
+    shaded
+}
+
+fn shader_inside_cached_container_graph(time: f32) -> RenderGraph {
+    let shaded = shaded_runtime_shader_layer(30_001, time);
 
     let mut container = test_layer(
         Some(30_000),
@@ -378,6 +383,66 @@ fn shader_inside_cached_container_graph(time: f32) -> RenderGraph {
         ProjectiveTransform::identity(),
         vec![RenderNode::Layer(Box::new(container))],
     ))
+}
+
+fn shader_layer_graph(time: f32) -> RenderGraph {
+    let shaded = shaded_runtime_shader_layer(30_101, time);
+    RenderGraph::new(test_layer(
+        Some(30_102),
+        CachePolicy::None,
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 128.0,
+            height: 96.0,
+        },
+        ProjectiveTransform::identity(),
+        vec![RenderNode::Layer(Box::new(shaded))],
+    ))
+}
+
+#[test]
+fn a_runtime_shader_layer_with_stable_uniforms_is_served_from_the_layer_cache() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!(
+                "skipping runtime-shader cache assertion because headless WGPU init failed: {}",
+                err
+            );
+            return;
+        }
+    };
+
+    renderer.scene_mut().graph = Some(shader_layer_graph(0.25));
+    let first = renderer
+        .capture_frame(128, 96)
+        .expect("first shader capture should succeed");
+    renderer.scene_mut().graph = Some(shader_layer_graph(0.25));
+    renderer
+        .capture_frame(128, 96)
+        .expect("the second sighting admits the layer into the cache");
+    renderer.scene_mut().graph = Some(shader_layer_graph(0.25));
+    let second = renderer
+        .capture_frame(128, 96)
+        .expect("second shader capture should succeed");
+    let stats = renderer.last_frame_stats().expect("frame stats");
+    assert_eq!(second.pixels, first.pixels);
+    assert!(
+        stats.layer_cache_hits >= 1 && stats.isolated_layer_renders == 0,
+        "a runtime shader's output depends only on its uniforms, source and layer rect, all in \
+         the cache key, so a repeated frame must not re-run it: {stats:?}"
+    );
+
+    renderer.scene_mut().graph = Some(shader_layer_graph(0.75));
+    let third = renderer
+        .capture_frame(128, 96)
+        .expect("third shader capture should succeed");
+    let stats = renderer.last_frame_stats().expect("frame stats");
+    assert!(
+        third.pixels != second.pixels && stats.isolated_layer_renders >= 1,
+        "a changed uniform must re-run the shader: {stats:?}"
+    );
 }
 
 #[test]

--- a/crates/cranpose-render/wgpu/tests/render_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/render_contract.rs
@@ -538,20 +538,19 @@ fn first_child_composite_consumes_pending_clear_load_op() {
             && source.contains("composite_load_op,"),
         "first child surface composites should consume the pending clear load-op instead of forcing a standalone clear submit"
     );
-    let nested_underlay_start = source
-        .find(
-            "if child.needs_nested_underlay {\n            flush_pending_composite_queues_fused(\n                backend,\n                &mut pending_composites,",
-        )
-        .expect("nested underlay branch must initialize target before child capture");
-    let nested_underlay_end = source[nested_underlay_start..]
-        .find("let underlay = sample_child_underlay(")
-        .map(|offset| nested_underlay_start + offset)
-        .expect("nested underlay capture should follow target initialization");
-    let nested_underlay_body = &source[nested_underlay_start..nested_underlay_end];
+    let underlay_start = source
+        .find("fn sample_child_underlay<")
+        .expect("child underlays must be sampled through the shared helper");
+    let underlay_end = source[underlay_start..]
+        .find("\nstruct ReplayedWrite")
+        .map(|offset| underlay_start + offset)
+        .expect("the underlay helper must be followed by the replay write");
+    let underlay_body = &source[underlay_start..underlay_end];
     let backdrop_body = block_after(&source, "if let Some(backdrop) = &child.backdrop");
     let shadow_body = block_after(&source, "if !resolved_child.shadow_draws.is_empty()");
     assert!(
-        nested_underlay_body.contains("flush_pending_clear")
+        underlay_body.contains("flush_pending_clear")
+            && underlay_body.contains("flush_pending_queues_for_backdrop_capture")
             && backdrop_body.contains("flush_pending_queues_for_backdrop_capture")
             && shadow_body.contains("flush_pending_clear"),
         "target readers such as underlays, backdrop snapshots, and shadow draws must still initialize the target before reading/compositing"

--- a/crates/cranpose-render/wgpu/tests/render_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/render_contract.rs
@@ -546,12 +546,21 @@ fn first_child_composite_consumes_pending_clear_load_op() {
         .map(|offset| underlay_start + offset)
         .expect("the underlay helper must be followed by the replay write");
     let underlay_body = &source[underlay_start..underlay_end];
-    let backdrop_body = block_after(&source, "if let Some(backdrop) = &child.backdrop");
+    let capture_source_start = source
+        .find("fn prepare_capture_source<")
+        .expect("backdrop captures must decide their source through the shared helper");
+    let capture_source_end = source[capture_source_start..]
+        .find("\n#[allow(clippy::too_many_arguments)]\nfn prepare_cached_backdrop_layer_composite<")
+        .map(|offset| capture_source_start + offset)
+        .expect("the capture source helper must be followed by the prepare function");
+    let capture_source_body = &source[capture_source_start..capture_source_end];
     let shadow_body = block_after(&source, "if !resolved_child.shadow_draws.is_empty()");
     assert!(
         underlay_body.contains("flush_pending_clear")
             && underlay_body.contains("flush_pending_queues_for_backdrop_capture")
-            && backdrop_body.contains("flush_pending_queues_for_backdrop_capture")
+            && capture_source_body.contains("flush_pending_queues_for_backdrop_capture")
+            && capture_source_body.contains("flush_pending_clear")
+            && source.matches("prepare_capture_source(").count() >= 2
             && shadow_body.contains("flush_pending_clear"),
         "target readers such as underlays, backdrop snapshots, and shadow draws must still initialize the target before reading/compositing"
     );

--- a/crates/cranpose-render/wgpu/tests/render_contract.rs
+++ b/crates/cranpose-render/wgpu/tests/render_contract.rs
@@ -1444,7 +1444,10 @@ fn shadow_temporary_surfaces_are_frame_recorder_transients() {
     assert!(
         shape_body.contains(
             "let scratch = frame_encoder.acquire_transient_offscreen(&device, scratch_descriptor);"
-        ) && shape_body.contains("let source_is_cacheable = cache_key.is_some();")
+        ) && shape_body.contains("let source = if retained {")
+            && shape_body.contains("self.acquire_retained_surface(bounds_w, bounds_h)")
+            && shape_body
+                .contains("frame_encoder.acquire_transient_offscreen(&device, source_descriptor)")
             && shape_body
                 .contains("frame_encoder.release_transient_offscreen(scratch_descriptor, scratch)")
             && shape_body

--- a/crates/cranpose-render/wgpu/tests/retained_bundle_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/retained_bundle_parity.rs
@@ -119,6 +119,7 @@ fn build_sequence(node_id: usize) -> Vec<RenderGraph> {
             };
             RenderGraph::new(LayerNode {
                 node_id: None,
+                wraps: None,
                 local_bounds: bounds,
                 transform_to_parent: ProjectiveTransform::identity(),
                 content_offset: Point::default(),

--- a/crates/cranpose-render/wgpu/tests/rim_mesh_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/rim_mesh_parity.rs
@@ -1,16 +1,6 @@
 mod support;
 
-use cranpose_render_common::{
-    Renderer,
-    graph::{
-        CachePolicy, DrawRunNode, IsolationReasons, LayerNode, PrimitivePhase, ProjectiveTransform,
-        RenderGraph, RenderNode,
-    },
-    raster_cache::LayerRasterCacheHashes,
-};
-use cranpose_ui_graphics::{
-    Brush, Color, CornerRadii, DrawScope, DrawScopeDefault, GraphicsLayer, Point, Rect, Stroke,
-};
+use support::graph::*;
 
 const SIZE: u32 = 400;
 const RIM_RECT: Rect = Rect {
@@ -76,54 +66,11 @@ fn rim_graph() -> RenderGraph {
     let mut scope =
         DrawScopeDefault::new(cranpose_ui_graphics::Size::new(SIZE as f32, SIZE as f32));
     record_scene(&mut scope);
-    let bounds = Rect {
-        x: 0.0,
-        y: 0.0,
-        width: SIZE as f32,
-        height: SIZE as f32,
-    };
-    RenderGraph::new(LayerNode {
-        node_id: None,
-        local_bounds: bounds,
-        transform_to_parent: ProjectiveTransform::identity(),
-        content_offset: Point::default(),
-        motion_context_animated: false,
-        translated_content_context: false,
-        translated_content_offset: Point::default(),
-        scene_children_origin: Point::default(),
-        scene_children_layer_translation: Point::default(),
-        graphics_layer: GraphicsLayer::default(),
-        clip_to_bounds: false,
-        shadow_clip: None,
-        hit_test: None,
-        has_hit_targets: false,
-        has_origin_sinks: false,
-        isolation: IsolationReasons::default(),
-        cache_policy: CachePolicy::None,
-        cache_hashes: LayerRasterCacheHashes::default(),
-        cache_hashes_valid: false,
-        children: vec![RenderNode::DrawRun(DrawRunNode::new(
-            PrimitivePhase::BeforeChildren,
-            scope.into_primitives(),
-        ))],
-    })
+    draw_run_graph(SIZE, scope)
 }
 
 fn render_arm(renderer: &mut support::LockedRenderer, graph: &RenderGraph) -> Vec<u8> {
-    let mut passes = Vec::new();
-    for _ in 0..3 {
-        renderer.scene_mut().graph = Some(graph.clone());
-        let captured = renderer
-            .capture_frame(SIZE, SIZE)
-            .unwrap_or_else(|err| panic!("capture failed: {err:?}"));
-        assert_eq!((captured.width, captured.height), (SIZE, SIZE));
-        passes.push(captured.pixels);
-    }
-    assert_eq!(
-        passes[1], passes[2],
-        "same-graph control passes must be byte-stable before the cross-arm compare"
-    );
-    passes.pop().unwrap()
+    support::stable_capture(renderer, graph, SIZE)
 }
 
 #[test]

--- a/crates/cranpose-render/wgpu/tests/round_cull_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/round_cull_parity.rs
@@ -94,6 +94,7 @@ fn graph_from(record: impl FnOnce(&mut DrawScopeDefault)) -> RenderGraph {
     };
     RenderGraph::new(LayerNode {
         node_id: None,
+        wraps: None,
         local_bounds: bounds,
         transform_to_parent: ProjectiveTransform::identity(),
         content_offset: Point::default(),

--- a/crates/cranpose-render/wgpu/tests/scene_range_cache_exactness.rs
+++ b/crates/cranpose-render/wgpu/tests/scene_range_cache_exactness.rs
@@ -15,6 +15,7 @@ use cranpose_render_common::{
     graph::{
         DrawPrimitiveNode, PrimitiveEntry, PrimitiveNode, PrimitivePhase, RenderGraph, RenderNode,
     },
+    raster_cache::{LayerRasterCacheKey, ScaleBucket},
 };
 use cranpose_ui_graphics::{Brush, Color, CornerRadii, DrawPrimitive, Rect};
 
@@ -192,6 +193,108 @@ fn a_prefix_snapshot_replays_the_direct_bytes_in_every_cache_phase() {
             );
         }
     }
+}
+
+fn prefix_kind_slot() -> usize {
+    LayerRasterCacheKey::prefix_snapshot(
+        0,
+        0,
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 1.0,
+            height: 1.0,
+        },
+        (1, 1),
+        ScaleBucket::from_scale(1.0),
+    )
+    .kind_slot()
+}
+
+fn prefix_traffic(renderer: &support::LockedRenderer) -> (u32, u32) {
+    let stats = renderer.last_frame_stats().expect("frame stats");
+    let slot = prefix_kind_slot();
+    (
+        stats.layer_cache_hits_by_kind[slot],
+        stats.layer_cache_misses_by_kind[slot],
+    )
+}
+
+/// A prefix that holds still for two frames and then moves on passes the
+/// repeat check on every second frame, so without a backoff each such
+/// frame renders and stores a full-target snapshot that the next frame
+/// replaces unserved: one store per two frames. The bytes stay exact either
+/// way; what must drop is the store traffic, to the streak that arms the
+/// backoff plus one store per doubling window. Once the content settles the
+/// snapshot is served again.
+#[test]
+fn a_prefix_that_holds_for_two_frames_stops_being_snapshotted_and_recovers_when_still() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!("skipping prefix snapshot backoff: headless WGPU init failed: {err}");
+            return;
+        }
+    };
+    let region = Rect {
+        x: 5.0,
+        y: 5.0,
+        width: 590.0,
+        height: 590.0,
+    };
+    const STEPPED_FRAMES: usize = 40;
+    const SETTLED_FRAMES: usize = 80;
+    const MAX_STEPPED_STORES: u32 = (STEPPED_FRAMES / 8) as u32;
+    let stepped: Vec<RenderGraph> = (0..STEPPED_FRAMES)
+        .map(|frame| layered_graph(30_200, region, frame / 2))
+        .collect();
+
+    cranpose_render_wgpu::set_debug_toggle("CRANPOSE_DISABLE_PREFIX_SNAPSHOT", Some("1"));
+    let (truth, _) = render_pass(&mut renderer, &stepped);
+    cranpose_render_wgpu::set_debug_toggle("CRANPOSE_DISABLE_PREFIX_SNAPSHOT", None);
+
+    let mut frames = Vec::with_capacity(STEPPED_FRAMES);
+    let mut stores = Vec::with_capacity(STEPPED_FRAMES);
+    for graph in &stepped {
+        renderer.scene_mut().graph = Some(graph.clone());
+        let captured = renderer
+            .capture_frame(SIZE, SIZE)
+            .expect("stepped frame capture");
+        frames.push(captured.pixels);
+        stores.push(prefix_traffic(&renderer).1);
+    }
+    assert_byte_exact("stepped prefix", &truth, &frames);
+    assert!(
+        stores.iter().take(4).any(|stores| *stores > 0),
+        "the repeat check must still admit a first snapshot: {stores:?}"
+    );
+    let total_stores: u32 = stores.iter().sum();
+    assert!(
+        total_stores <= MAX_STEPPED_STORES,
+        "a prefix that never repeats after its second sighting kept being snapshotted {total_stores} times in {STEPPED_FRAMES} frames: {stores:?}"
+    );
+
+    let settled = stepped.last().expect("stepped frames").clone();
+    let mut served = false;
+    for _ in 0..SETTLED_FRAMES {
+        renderer.scene_mut().graph = Some(settled.clone());
+        let captured = renderer
+            .capture_frame(SIZE, SIZE)
+            .expect("settled frame capture");
+        assert_byte_exact(
+            "settled prefix",
+            &truth[STEPPED_FRAMES - 1..],
+            &[captured.pixels],
+        );
+        if prefix_traffic(&renderer).0 > 0 {
+            served = true;
+            break;
+        }
+    }
+    assert!(
+        served,
+        "once the prefix holds still the snapshot must be admitted again and served within {SETTLED_FRAMES} frames"
+    );
 }
 
 /// The small flatten class's inexactness has to stay small and stable:

--- a/crates/cranpose-render/wgpu/tests/segment_surface_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/segment_surface_parity.rs
@@ -161,6 +161,7 @@ fn build_sequence(
             };
             RenderGraph::new(LayerNode {
                 node_id: None,
+                wraps: None,
                 local_bounds: bounds,
                 transform_to_parent: ProjectiveTransform::identity(),
                 content_offset: Point::default(),

--- a/crates/cranpose-render/wgpu/tests/sized_retained_mesh_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/sized_retained_mesh_parity.rs
@@ -129,6 +129,7 @@ fn build_sequence(node_id: usize) -> Vec<RenderGraph> {
             };
             RenderGraph::new(LayerNode {
                 node_id: None,
+                wraps: None,
                 local_bounds: bounds,
                 transform_to_parent: ProjectiveTransform::identity(),
                 content_offset: Point::default(),

--- a/crates/cranpose-render/wgpu/tests/solid_fs_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/solid_fs_parity.rs
@@ -98,6 +98,7 @@ fn graph_for(with_gradient: bool) -> RenderGraph {
     };
     RenderGraph::new(LayerNode {
         node_id: None,
+        wraps: None,
         local_bounds: bounds,
         transform_to_parent: ProjectiveTransform::identity(),
         content_offset: Point::default(),

--- a/crates/cranpose-render/wgpu/tests/stale_transition_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/stale_transition_parity.rs
@@ -106,6 +106,7 @@ fn build_graphs(node_id: usize, flips: &[usize]) -> Vec<RenderGraph> {
             };
             RenderGraph::new(LayerNode {
                 node_id: None,
+                wraps: None,
                 local_bounds: bounds,
                 transform_to_parent: ProjectiveTransform::identity(),
                 content_offset: Point::default(),

--- a/crates/cranpose-render/wgpu/tests/static_span_cache_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/static_span_cache_parity.rs
@@ -83,6 +83,7 @@ fn scene_graph(frame: u32, bg: Color, vignette: Color, glow: Option<Color>) -> R
     };
     RenderGraph::new(LayerNode {
         node_id: None,
+        wraps: None,
         local_bounds: bounds,
         transform_to_parent: ProjectiveTransform::identity(),
         content_offset: Point::default(),

--- a/crates/cranpose-render/wgpu/tests/support.rs
+++ b/crates/cranpose-render/wgpu/tests/support.rs
@@ -45,7 +45,28 @@ pub fn gpu_test_lock() -> MutexGuard<'static, ()> {
     lock_gpu_test()
 }
 
+struct StderrWarnings;
+
+impl log::Log for StderrWarnings {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        metadata.level() <= log::Level::Warn
+    }
+
+    fn log(&self, record: &log::Record) {
+        if self.enabled(record.metadata()) {
+            eprintln!("[{}] {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+static STDERR_WARNINGS: StderrWarnings = StderrWarnings;
+
 fn lock_gpu_test() -> MutexGuard<'static, ()> {
+    if log::set_logger(&STDERR_WARNINGS).is_ok() {
+        log::set_max_level(log::LevelFilter::Warn);
+    }
     GPU_TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())

--- a/crates/cranpose-render/wgpu/tests/support.rs
+++ b/crates/cranpose-render/wgpu/tests/support.rs
@@ -12,7 +12,10 @@ use cranpose_render_common::{
     software_text_raster::DEFAULT_SOFTWARE_TEXT_FONT_BYTES,
 };
 use cranpose_render_wgpu::{CapturedFrame, RenderStatsSnapshot, WgpuRenderer};
-use cranpose_ui::AppContext;
+use cranpose_ui::{
+    AppContext, Color, Modifier, Size, composable,
+    widgets::{Box, BoxSpec},
+};
 use cranpose_ui_graphics::Rect;
 
 pub static TEST_FONT: &[u8] = DEFAULT_SOFTWARE_TEXT_FONT_BYTES;
@@ -241,4 +244,28 @@ fn create_headless_renderer_with_format(
         adapter.get_downlevel_capabilities().flags,
     );
     Ok(renderer)
+}
+
+pub fn rect_modifier(rect: [f32; 4]) -> Modifier {
+    Modifier::empty().offset(rect[0], rect[1]).size(Size {
+        width: rect[2],
+        height: rect[3],
+    })
+}
+
+/// A page filling the whole frame with one background color, the root every
+/// parity scene composes its content into.
+#[composable]
+#[allow(non_snake_case)]
+pub fn FramePage(width: u32, height: u32, background: Color, content: impl Fn() + 'static) {
+    Box(
+        Modifier::empty()
+            .size(Size {
+                width: width as f32,
+                height: height as f32,
+            })
+            .background(background),
+        BoxSpec::new(),
+        content,
+    );
 }

--- a/crates/cranpose-render/wgpu/tests/support.rs
+++ b/crates/cranpose-render/wgpu/tests/support.rs
@@ -5,10 +5,11 @@ use std::{
     sync::{Arc, Mutex, MutexGuard},
 };
 
+use cranpose_app_shell::AppShell;
 use cranpose_core::NodeId;
 use cranpose_render_common::{
     Renderer,
-    graph::{LayerNode, RenderNode},
+    graph::{LayerNode, RenderGraph, RenderNode},
     software_text_raster::DEFAULT_SOFTWARE_TEXT_FONT_BYTES,
 };
 use cranpose_render_wgpu::{CapturedFrame, RenderStatsSnapshot, WgpuRenderer};
@@ -103,23 +104,15 @@ impl LockedRenderer {
                 .renderer
                 .try_device()
                 .ok_or_else(|| "renderer GPU device was not initialized".to_string())?;
-            let texture = device.create_texture(&wgpu::TextureDescriptor {
-                label: Some("WGPU contract render target"),
-                size: wgpu::Extent3d {
-                    width,
-                    height,
-                    depth_or_array_layers: 1,
-                },
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: wgpu::TextureDimension::D2,
-                format: wgpu::TextureFormat::Bgra8UnormSrgb,
-                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                view_formats: &[],
-            });
-            let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+            let (texture, view) = render_target(
+                device,
+                width,
+                height,
+                wgpu::TextureFormat::Bgra8UnormSrgb,
+                wgpu::TextureUsages::RENDER_ATTACHMENT,
+            );
             self.renderer
-                .render(&view, width, height)
+                .render(&texture, &view, width, height)
                 .map_err(|err| format!("{err:?}"))?;
             self.renderer
                 .last_frame_stats()
@@ -182,6 +175,14 @@ pub fn headless_renderer_unencoded() -> Result<LockedRenderer, String> {
 pub fn headless_renderer_parts() -> Result<(MutexGuard<'static, ()>, WgpuRenderer), String> {
     let lock = lock_gpu_test();
     let renderer = create_headless_renderer()?;
+    Ok((lock, renderer))
+}
+
+pub fn headless_renderer_parts_with_display_format(
+    format: wgpu::TextureFormat,
+) -> Result<(MutexGuard<'static, ()>, WgpuRenderer), String> {
+    let lock = lock_gpu_test();
+    let renderer = create_headless_renderer_with_format(format)?;
     Ok((lock, renderer))
 }
 
@@ -265,6 +266,149 @@ fn create_headless_renderer_with_format(
         adapter.get_downlevel_capabilities().flags,
     );
     Ok(renderer)
+}
+
+/// Composes `page` in an app shell over a fresh headless renderer, laid out
+/// and updated twice so caches are warm, or `None` when no GPU is available.
+/// Everything a composable page test imports: the page widgets and the
+/// frame helpers below.
+#[allow(unused_imports)]
+pub mod page {
+    pub use cranpose_ui::{
+        Color, Modifier, RenderEffect, TextStyle, composable,
+        widgets::{Box, BoxSpec, Text},
+    };
+
+    pub use super::{FramePage, rect_modifier};
+}
+
+/// Everything a raw render-graph test imports: the graph node types and the
+/// drawing primitives that fill a draw run.
+#[allow(unused_imports)]
+pub mod graph {
+    pub use cranpose_render_common::{
+        Renderer,
+        graph::{RenderGraph, RenderNode},
+    };
+    pub use cranpose_ui_graphics::{
+        Brush, Color, CornerRadii, DrawScope, DrawScopeDefault, Point, Rect, Stroke, TileMode,
+    };
+
+    pub use super::draw_run_graph;
+}
+
+/// A root layer of `size` square pixels holding one draw run of `scope`'s
+/// primitives.
+pub fn draw_run_graph(size: u32, scope: cranpose_ui_graphics::DrawScopeDefault) -> RenderGraph {
+    use cranpose_render_common::graph::{DrawRunNode, PrimitivePhase};
+    use cranpose_ui_graphics::DrawScope;
+    RenderGraph::new(layer_node(
+        None,
+        size as f32,
+        size as f32,
+        vec![RenderNode::DrawRun(DrawRunNode::new(
+            PrimitivePhase::BeforeChildren,
+            scope.into_primitives(),
+        ))],
+    ))
+}
+
+/// A render-attachment texture of `format` and its default view, the shape
+/// every presentable-target test hands to the renderer.
+pub fn render_target(
+    device: &wgpu::Device,
+    width: u32,
+    height: u32,
+    format: wgpu::TextureFormat,
+    usage: wgpu::TextureUsages,
+) -> (wgpu::Texture, wgpu::TextureView) {
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Test Render Target"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format,
+        usage,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    (texture, view)
+}
+
+pub fn app_shell_for(
+    page: fn(),
+    width: u32,
+    height: u32,
+    display_format: wgpu::TextureFormat,
+    configure: impl FnOnce(&mut WgpuRenderer),
+) -> Option<(MutexGuard<'static, ()>, AppShell<WgpuRenderer>)> {
+    let (lock, mut renderer) = match headless_renderer_parts_with_display_format(display_format) {
+        Ok(parts) => parts,
+        Err(err) => {
+            eprintln!("skipping (headless WGPU init failed): {err}");
+            return None;
+        }
+    };
+    configure(&mut renderer);
+    let root_key = cranpose_core::location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(renderer, root_key, page);
+    shell.set_viewport(width as f32, height as f32);
+    shell.set_buffer_size(width, height);
+    shell.update();
+    shell.update();
+    Some((lock, shell))
+}
+
+/// Captures `graph` three times and returns the last frame, after checking
+/// that repeated captures of one graph are byte-stable.
+pub fn stable_capture(renderer: &mut LockedRenderer, graph: &RenderGraph, size: u32) -> Vec<u8> {
+    let mut passes = Vec::new();
+    for _ in 0..3 {
+        renderer.scene_mut().graph = Some(graph.clone());
+        let captured = renderer
+            .capture_frame(size, size)
+            .unwrap_or_else(|err| panic!("capture failed: {err:?}"));
+        assert_eq!((captured.width, captured.height), (size, size));
+        passes.push(captured.pixels);
+    }
+    assert_eq!(
+        passes[1], passes[2],
+        "same-graph control passes must be byte-stable before the cross-arm compare"
+    );
+    passes.pop().expect("three captures")
+}
+
+pub fn distinct_colors(pixels: &[u8]) -> usize {
+    let mut colors: Vec<[u8; 4]> = pixels.as_chunks::<4>().0.to_vec();
+    colors.sort_unstable();
+    colors.dedup();
+    colors.len()
+}
+
+/// Asserts two RGBA frames of `width` pixels per row are identical, naming
+/// the first differing pixel otherwise.
+pub fn assert_same_bytes(label: &str, width: u32, a: &[u8], b: &[u8]) {
+    assert_eq!(a.len(), b.len(), "{label}: capture sizes differ");
+    let mut differing = 0usize;
+    let mut worst = 0u8;
+    let mut first = None;
+    for (index, (x, y)) in a.iter().zip(b).enumerate() {
+        let diff = x.abs_diff(*y);
+        if diff > 0 {
+            differing += 1;
+            worst = worst.max(diff);
+            first.get_or_insert((index / 4 % width as usize, index / 4 / width as usize));
+        }
+    }
+    assert_eq!(
+        differing, 0,
+        "{label}: {differing} bytes diverged (worst {worst}, first at {first:?})"
+    );
 }
 
 pub fn rect_modifier(rect: [f32; 4]) -> Modifier {

--- a/crates/cranpose-render/wgpu/tests/support.rs
+++ b/crates/cranpose-render/wgpu/tests/support.rs
@@ -2,7 +2,8 @@
 
 use std::{
     ops::{Deref, DerefMut},
-    sync::{Arc, Mutex, MutexGuard},
+    sync::{Arc, Mutex, MutexGuard, mpsc},
+    time::Duration,
 };
 
 use cranpose_app_shell::AppShell;
@@ -315,6 +316,65 @@ pub fn draw_run_graph(size: u32, scope: cranpose_ui_graphics::DrawScopeDefault) 
 
 /// A render-attachment texture of `format` and its default view, the shape
 /// every presentable-target test hands to the renderer.
+pub fn read_texture_rgba8(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    texture: &wgpu::Texture,
+) -> Vec<u8> {
+    let width = texture.width();
+    let height = texture.height();
+    let unpadded = width * 4;
+    let padded = unpadded.next_multiple_of(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
+    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("test readback"),
+        size: u64::from(padded) * u64::from(height),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &buffer,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded),
+                rows_per_image: Some(height),
+            },
+        },
+        wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+    );
+    let submission = queue.submit([encoder.finish()]);
+    let slice = buffer.slice(..);
+    let (tx, rx) = mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = tx.send(result);
+    });
+    let _ = device.poll(wgpu::PollType::Wait {
+        submission_index: Some(submission),
+        timeout: None,
+    });
+    rx.recv_timeout(Duration::from_secs(3))
+        .expect("readback timed out")
+        .expect("readback map failed");
+    let mapped = slice.get_mapped_range();
+    let mut pixels = Vec::with_capacity((unpadded * height) as usize);
+    for row in 0..height as usize {
+        let start = row * padded as usize;
+        pixels.extend_from_slice(&mapped[start..start + unpadded as usize]);
+    }
+    pixels
+}
+
 pub fn render_target(
     device: &wgpu::Device,
     width: u32,

--- a/crates/cranpose-render/wgpu/tests/surface_packet.rs
+++ b/crates/cranpose-render/wgpu/tests/surface_packet.rs
@@ -24,6 +24,7 @@ fn test_layer(
 ) -> LayerNode {
     LayerNode {
         node_id,
+        wraps: None,
         local_bounds,
         transform_to_parent,
         motion_context_animated: false,

--- a/crates/cranpose-render/wgpu/tests/underlay_bake_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/underlay_bake_parity.rs
@@ -3,33 +3,23 @@ mod support;
 use cranpose_app_shell::AppShell;
 use cranpose_core::location_key;
 use cranpose_ui::{
-    Color, Modifier, RenderEffect, Size, TextStyle, composable,
+    Color, Modifier, RenderEffect, TextStyle, composable,
     widgets::{Box, BoxSpec, Text},
 };
+use support::{FramePage, rect_modifier};
 
 const FRAME_WIDTH: u32 = 320;
 const FRAME_HEIGHT: u32 = 240;
 const CARD: [f32; 4] = [24.0, 40.0, 272.0, 120.0];
 const BUTTON: [f32; 4] = [236.0, 80.0, 40.0, 40.0];
 
-fn rect_modifier(rect: [f32; 4]) -> Modifier {
-    Modifier::empty().offset(rect[0], rect[1]).size(Size {
-        width: rect[2],
-        height: rect[3],
-    })
-}
-
 #[composable]
 #[allow(non_snake_case)]
 fn GradientPage() {
-    Box(
-        Modifier::empty()
-            .size(Size {
-                width: FRAME_WIDTH as f32,
-                height: FRAME_HEIGHT as f32,
-            })
-            .background(Color(0.08, 0.12, 0.30, 1.0)),
-        BoxSpec::new(),
+    FramePage(
+        FRAME_WIDTH,
+        FRAME_HEIGHT,
+        Color(0.08, 0.12, 0.30, 1.0),
         || {
             Box(
                 rect_modifier([0.0, 0.0, 160.0, 240.0]).background(Color(0.55, 0.20, 0.12, 1.0)),

--- a/crates/cranpose-render/wgpu/tests/underlay_bake_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/underlay_bake_parity.rs
@@ -52,6 +52,7 @@ fn GradientPage() {
 }
 
 fn cold_capture(bake: bool) -> Option<(Vec<u8>, cranpose_render_wgpu::RenderStatsSnapshot)> {
+    cranpose_render_wgpu::set_debug_toggle("CRANPOSE_NO_BACKDROP_FLATTEN", Some("1"));
     let (_lock, mut shell) = support::app_shell_for(
         GradientPage,
         FRAME_WIDTH,

--- a/crates/cranpose-render/wgpu/tests/underlay_bake_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/underlay_bake_parity.rs
@@ -1,12 +1,6 @@
 mod support;
 
-use cranpose_app_shell::AppShell;
-use cranpose_core::location_key;
-use cranpose_ui::{
-    Color, Modifier, RenderEffect, TextStyle, composable,
-    widgets::{Box, BoxSpec, Text},
-};
-use support::{FramePage, rect_modifier};
+use support::page::*;
 
 const FRAME_WIDTH: u32 = 320;
 const FRAME_HEIGHT: u32 = 240;
@@ -58,19 +52,13 @@ fn GradientPage() {
 }
 
 fn cold_capture(bake: bool) -> Option<(Vec<u8>, cranpose_render_wgpu::RenderStatsSnapshot)> {
-    let (_lock, mut renderer) = match support::headless_renderer_parts() {
-        Ok(parts) => parts,
-        Err(err) => {
-            eprintln!("skipping (headless WGPU init failed): {err}");
-            return None;
-        }
-    };
-    renderer.set_underlay_bake_enabled(bake);
-    let root_key = location_key(file!(), line!(), column!());
-    let mut shell = AppShell::new(renderer, root_key, GradientPage);
-    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
-    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
-    shell.update();
+    let (_lock, mut shell) = support::app_shell_for(
+        GradientPage,
+        FRAME_WIDTH,
+        FRAME_HEIGHT,
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+        |renderer| renderer.set_underlay_bake_enabled(bake),
+    )?;
     let frame = shell
         .renderer()
         .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)

--- a/crates/cranpose-render/wgpu/tests/underlay_replay_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/underlay_replay_parity.rs
@@ -15,6 +15,7 @@ const FRAME_WIDTH: u32 = 320;
 const FRAME_HEIGHT: u32 = 300;
 const CARDS: [[f32; 4]; 2] = [[24.0, 30.0, 272.0, 110.0], [24.0, 160.0, 272.0, 110.0]];
 const BUTTON_IN_CARD: [f32; 4] = [212.0, 36.0, 40.0, 40.0];
+const BAR: [f32; 4] = [0.0, 120.0, 320.0, 60.0];
 
 #[composable]
 #[allow(non_snake_case)]
@@ -82,6 +83,37 @@ fn card_glass() -> Glass {
         .dispersion(1.0)
         .transmission_refraction(0.72)
         .highlight(0.72)
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn BarredGlassCardsPage() {
+    LiquidTheme(LiquidThemeSpec::default(), || {
+        FramePage(
+            FRAME_WIDTH,
+            FRAME_HEIGHT,
+            Color(0.08, 0.12, 0.30, 1.0),
+            || {
+                Stripes();
+                for card in CARDS {
+                    GlassSurface(rect_modifier(card), card_glass(), || {
+                        Text(
+                            "Under a bar",
+                            Modifier::empty().offset(16.0, 16.0),
+                            TextStyle::default(),
+                        );
+                    });
+                }
+                Box(
+                    rect_modifier(BAR)
+                        .backdrop_effect(RenderEffect::blur(6.0))
+                        .background(Color(1.0, 1.0, 1.0, 0.2)),
+                    BoxSpec::new(),
+                    || {},
+                );
+            },
+        );
+    });
 }
 
 #[composable]
@@ -242,4 +274,9 @@ fn replaying_blur_cards_into_their_underlay_copies_matches_the_flushed_render_ex
 #[test]
 fn replaying_glass_cards_into_their_underlay_copies_matches_the_flushed_render_exactly() {
     parity("glass cards", GlassCardsPage);
+}
+
+#[test]
+fn a_bar_capturing_over_pending_cards_replays_them_instead_of_flushing_the_target() {
+    parity("barred glass cards", BarredGlassCardsPage);
 }

--- a/crates/cranpose-render/wgpu/tests/underlay_replay_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/underlay_replay_parity.rs
@@ -87,59 +87,55 @@ fn card_glass() -> Glass {
 
 #[composable]
 #[allow(non_snake_case)]
-fn BarredGlassCardsPage() {
-    LiquidTheme(LiquidThemeSpec::default(), || {
-        FramePage(
-            FRAME_WIDTH,
-            FRAME_HEIGHT,
-            Color(0.08, 0.12, 0.30, 1.0),
-            || {
-                Stripes();
-                for card in CARDS {
-                    GlassSurface(rect_modifier(card), card_glass(), || {
-                        Text(
-                            "Under a bar",
-                            Modifier::empty().offset(16.0, 16.0),
-                            TextStyle::default(),
-                        );
-                    });
-                }
-                Box(
-                    rect_modifier(BAR)
-                        .backdrop_effect(RenderEffect::blur(6.0))
-                        .background(Color(1.0, 1.0, 1.0, 0.2)),
-                    BoxSpec::new(),
-                    || {},
-                );
-            },
-        );
-    });
+fn GlassCardsPage() {
+    GlassCards(false);
 }
 
 #[composable]
 #[allow(non_snake_case)]
-fn GlassCardsPage() {
-    LiquidTheme(LiquidThemeSpec::default(), || {
+fn BarredGlassCardsPage() {
+    GlassCards(true);
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn GlassCards(barred: bool) {
+    LiquidTheme(LiquidThemeSpec::default(), move || {
         FramePage(
             FRAME_WIDTH,
             FRAME_HEIGHT,
             Color(0.08, 0.12, 0.30, 1.0),
-            || {
+            move || {
                 Stripes();
                 for card in CARDS {
-                    GlassSurface(rect_modifier(card), card_glass(), || {
+                    GlassSurface(rect_modifier(card), card_glass(), move || {
                         Text(
-                            "Replayed glass",
+                            if barred {
+                                "Under a bar"
+                            } else {
+                                "Replayed glass"
+                            },
                             Modifier::empty().offset(16.0, 16.0),
                             TextStyle::default(),
                         );
-                        GlassButton(
-                            rect_modifier(BUTTON_IN_CARD),
-                            GlassButtonSpec::glass(),
-                            || {},
-                            || {},
-                        );
+                        if !barred {
+                            GlassButton(
+                                rect_modifier(BUTTON_IN_CARD),
+                                GlassButtonSpec::glass(),
+                                || {},
+                                || {},
+                            );
+                        }
                     });
+                }
+                if barred {
+                    Box(
+                        rect_modifier(BAR)
+                            .backdrop_effect(RenderEffect::blur(6.0))
+                            .background(Color(1.0, 1.0, 1.0, 0.2)),
+                        BoxSpec::new(),
+                        || {},
+                    );
                 }
             },
         );

--- a/crates/cranpose-render/wgpu/tests/underlay_replay_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/underlay_replay_parity.rs
@@ -6,21 +6,15 @@ use cranpose_liquid::{
     Glass, GlassButton, GlassButtonSpec, GlassSurface, LiquidShape, LiquidTheme, LiquidThemeSpec,
 };
 use cranpose_ui::{
-    Color, Modifier, RenderEffect, Size, TextStyle, composable,
+    Color, Modifier, RenderEffect, TextStyle, composable,
     widgets::{Box, BoxSpec, Text},
 };
+use support::{FramePage, rect_modifier};
 
 const FRAME_WIDTH: u32 = 320;
 const FRAME_HEIGHT: u32 = 300;
 const CARDS: [[f32; 4]; 2] = [[24.0, 30.0, 272.0, 110.0], [24.0, 160.0, 272.0, 110.0]];
 const BUTTON_IN_CARD: [f32; 4] = [212.0, 36.0, 40.0, 40.0];
-
-fn rect_modifier(rect: [f32; 4]) -> Modifier {
-    Modifier::empty().offset(rect[0], rect[1]).size(Size {
-        width: rect[2],
-        height: rect[3],
-    })
-}
 
 #[composable]
 #[allow(non_snake_case)]
@@ -45,14 +39,10 @@ fn Stripes() {
 #[composable]
 #[allow(non_snake_case)]
 fn BlurCardsPage() {
-    Box(
-        Modifier::empty()
-            .size(Size {
-                width: FRAME_WIDTH as f32,
-                height: FRAME_HEIGHT as f32,
-            })
-            .background(Color(0.08, 0.12, 0.30, 1.0)),
-        BoxSpec::new(),
+    FramePage(
+        FRAME_WIDTH,
+        FRAME_HEIGHT,
+        Color(0.08, 0.12, 0.30, 1.0),
         || {
             Stripes();
             for card in CARDS {
@@ -98,14 +88,10 @@ fn card_glass() -> Glass {
 #[allow(non_snake_case)]
 fn GlassCardsPage() {
     LiquidTheme(LiquidThemeSpec::default(), || {
-        Box(
-            Modifier::empty()
-                .size(Size {
-                    width: FRAME_WIDTH as f32,
-                    height: FRAME_HEIGHT as f32,
-                })
-                .background(Color(0.08, 0.12, 0.30, 1.0)),
-            BoxSpec::new(),
+        FramePage(
+            FRAME_WIDTH,
+            FRAME_HEIGHT,
+            Color(0.08, 0.12, 0.30, 1.0),
             || {
                 Stripes();
                 for card in CARDS {

--- a/crates/cranpose-render/wgpu/tests/underlay_replay_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/underlay_replay_parity.rs
@@ -148,6 +148,7 @@ struct Capture {
 }
 
 fn cold_capture(replay: bool, page: fn(), frames: usize) -> Option<Vec<Capture>> {
+    cranpose_render_wgpu::set_debug_toggle("CRANPOSE_NO_BACKDROP_FLATTEN", Some("1"));
     let (_lock, mut renderer) = match support::headless_renderer_parts() {
         Ok(parts) => parts,
         Err(err) => {

--- a/crates/cranpose-render/wgpu/tests/underlay_replay_parity.rs
+++ b/crates/cranpose-render/wgpu/tests/underlay_replay_parity.rs
@@ -1,0 +1,259 @@
+mod support;
+
+use cranpose_app_shell::AppShell;
+use cranpose_core::location_key;
+use cranpose_liquid::{
+    Glass, GlassButton, GlassButtonSpec, GlassSurface, LiquidShape, LiquidTheme, LiquidThemeSpec,
+};
+use cranpose_ui::{
+    Color, Modifier, RenderEffect, Size, TextStyle, composable,
+    widgets::{Box, BoxSpec, Text},
+};
+
+const FRAME_WIDTH: u32 = 320;
+const FRAME_HEIGHT: u32 = 300;
+const CARDS: [[f32; 4]; 2] = [[24.0, 30.0, 272.0, 110.0], [24.0, 160.0, 272.0, 110.0]];
+const BUTTON_IN_CARD: [f32; 4] = [212.0, 36.0, 40.0, 40.0];
+
+fn rect_modifier(rect: [f32; 4]) -> Modifier {
+    Modifier::empty().offset(rect[0], rect[1]).size(Size {
+        width: rect[2],
+        height: rect[3],
+    })
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn Stripes() {
+    Box(
+        rect_modifier([0.0, 0.0, 160.0, FRAME_HEIGHT as f32])
+            .background(Color(0.55, 0.20, 0.12, 1.0)),
+        BoxSpec::new(),
+        || {},
+    );
+    for row in 0..15 {
+        let y = row as f32 * 20.0;
+        let shade = 0.2 + 0.05 * row as f32;
+        Box(
+            rect_modifier([120.0, y, 200.0, 10.0]).background(Color(shade, 0.9 - shade, 0.5, 1.0)),
+            BoxSpec::new(),
+            || {},
+        );
+    }
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn BlurCardsPage() {
+    Box(
+        Modifier::empty()
+            .size(Size {
+                width: FRAME_WIDTH as f32,
+                height: FRAME_HEIGHT as f32,
+            })
+            .background(Color(0.08, 0.12, 0.30, 1.0)),
+        BoxSpec::new(),
+        || {
+            Stripes();
+            for card in CARDS {
+                Box(
+                    rect_modifier(card)
+                        .backdrop_effect(RenderEffect::blur(8.0))
+                        .background(Color(1.0, 1.0, 1.0, 0.18))
+                        .rounded_corners(14.0),
+                    BoxSpec::new(),
+                    || {
+                        Text(
+                            "Replayed blur",
+                            Modifier::empty().offset(16.0, 16.0),
+                            TextStyle::default(),
+                        );
+                        Box(
+                            rect_modifier(BUTTON_IN_CARD)
+                                .backdrop_effect(RenderEffect::blur(5.0))
+                                .background(Color(1.0, 1.0, 1.0, 0.24))
+                                .rounded_corners(20.0),
+                            BoxSpec::new(),
+                            || {},
+                        );
+                    },
+                );
+            }
+        },
+    );
+}
+
+fn card_glass() -> Glass {
+    Glass::regular()
+        .shape(LiquidShape::RoundedRect(20.0))
+        .blur_radius(0.0)
+        .refraction_depth(0.58)
+        .refraction_curve(0.62)
+        .dispersion(1.0)
+        .transmission_refraction(0.72)
+        .highlight(0.72)
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn GlassCardsPage() {
+    LiquidTheme(LiquidThemeSpec::default(), || {
+        Box(
+            Modifier::empty()
+                .size(Size {
+                    width: FRAME_WIDTH as f32,
+                    height: FRAME_HEIGHT as f32,
+                })
+                .background(Color(0.08, 0.12, 0.30, 1.0)),
+            BoxSpec::new(),
+            || {
+                Stripes();
+                for card in CARDS {
+                    GlassSurface(rect_modifier(card), card_glass(), || {
+                        Text(
+                            "Replayed glass",
+                            Modifier::empty().offset(16.0, 16.0),
+                            TextStyle::default(),
+                        );
+                        GlassButton(
+                            rect_modifier(BUTTON_IN_CARD),
+                            GlassButtonSpec::glass(),
+                            || {},
+                            || {},
+                        );
+                    });
+                }
+            },
+        );
+    });
+}
+
+struct Capture {
+    pixels: Vec<u8>,
+    stats: cranpose_render_wgpu::RenderStatsSnapshot,
+}
+
+fn cold_capture(replay: bool, page: fn(), frames: usize) -> Option<Vec<Capture>> {
+    let (_lock, mut renderer) = match support::headless_renderer_parts() {
+        Ok(parts) => parts,
+        Err(err) => {
+            eprintln!("skipping (headless WGPU init failed): {err}");
+            return None;
+        }
+    };
+    renderer.set_underlay_replay_enabled(replay);
+    let root_key = location_key(file!(), line!(), column!());
+    let mut shell = AppShell::new(renderer, root_key, page);
+    shell.set_viewport(FRAME_WIDTH as f32, FRAME_HEIGHT as f32);
+    shell.set_buffer_size(FRAME_WIDTH, FRAME_HEIGHT);
+    let mut captures = Vec::with_capacity(frames);
+    for _ in 0..frames {
+        shell.update();
+        let frame = shell
+            .renderer()
+            .capture_frame(FRAME_WIDTH, FRAME_HEIGHT)
+            .expect("frame capture should succeed");
+        let stats = shell.renderer().last_frame_stats().expect("frame stats");
+        captures.push(Capture {
+            pixels: frame.pixels,
+            stats,
+        });
+    }
+    Some(captures)
+}
+
+struct PixelDifference {
+    max_delta: u8,
+    differing: usize,
+    bounds: Option<[u32; 4]>,
+}
+
+fn pixel_difference(reference: &[u8], replayed: &[u8]) -> PixelDifference {
+    assert_eq!(reference.len(), replayed.len());
+    let mut max_delta = 0u8;
+    let mut differing = 0usize;
+    let mut bounds: Option<[u32; 4]> = None;
+    for (index, (a, b)) in reference
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .zip(replayed.as_chunks::<4>().0)
+        .enumerate()
+    {
+        let delta = a
+            .iter()
+            .zip(b)
+            .map(|(x, y)| x.abs_diff(*y))
+            .max()
+            .unwrap_or(0);
+        max_delta = max_delta.max(delta);
+        if delta > 0 {
+            differing += 1;
+            let x = index as u32 % FRAME_WIDTH;
+            let y = index as u32 / FRAME_WIDTH;
+            bounds = Some(match bounds {
+                None => [x, y, x, y],
+                Some([left, top, right, bottom]) => {
+                    [left.min(x), top.min(y), right.max(x), bottom.max(y)]
+                }
+            });
+        }
+    }
+    PixelDifference {
+        max_delta,
+        differing,
+        bounds,
+    }
+}
+
+fn parity(label: &str, page: fn()) {
+    let Some(reference) = cold_capture(false, page, 2) else {
+        return;
+    };
+    let Some(replayed) = cold_capture(true, page, 2) else {
+        return;
+    };
+    for (frame, (reference, replayed)) in reference.iter().zip(&replayed).enumerate() {
+        let difference = pixel_difference(&reference.pixels, &replayed.pixels);
+        println!(
+            "{label} frame {frame}: {} pixels within {:?} differ by up to {}",
+            difference.differing, difference.bounds, difference.max_delta
+        );
+        assert!(
+            difference.max_delta <= 1,
+            "{label} frame {frame}: replaying the pending composites into the underlay copy is the same blend on the same pixels as flushing them first, but {} pixels within {:?} differ by up to {}",
+            difference.differing,
+            difference.bounds,
+            difference.max_delta
+        );
+        let card_pixels = CARDS.len() * (CARDS[0][2] * CARDS[0][3]) as usize;
+        assert!(
+            difference.differing * 20 < card_pixels,
+            "{label} frame {frame}: a shader composite interpolates its uv at the moved viewport, which may round a sparse few samples one LSB apart, but {} of {card_pixels} card pixels differ",
+            difference.differing
+        );
+    }
+    let root_area = u64::from(FRAME_WIDTH) * u64::from(FRAME_HEIGHT);
+    let card_area = (CARDS[0][2] * CARDS[0][3]) as u64;
+    let least_saving = root_area - card_area * CARDS.len() as u64;
+    let reference_pixels = reference[0].stats.pass_pixels;
+    let replayed_pixels = replayed[0].stats.pass_pixels;
+    println!(
+        "{label}: pass pixels reference={reference_pixels} replayed={replayed_pixels} passes {} vs {}",
+        reference[0].stats.pass_count, replayed[0].stats.pass_count
+    );
+    assert!(
+        reference_pixels >= replayed_pixels + least_saving,
+        "{label}: the cards' self-flushes must leave the full target, at the price of one card-sized replay each, so the frame's pass pixels drop by at least {least_saving}: {reference_pixels} before, {replayed_pixels} after"
+    );
+}
+
+#[test]
+fn replaying_blur_cards_into_their_underlay_copies_matches_the_flushed_render_exactly() {
+    parity("blur cards", BlurCardsPage);
+}
+
+#[test]
+fn replaying_glass_cards_into_their_underlay_copies_matches_the_flushed_render_exactly() {
+    parity("glass cards", GlassCardsPage);
+}

--- a/crates/cranpose-ui-graphics/shaders/liquid_glass.wgsl
+++ b/crates/cranpose-ui-graphics/shaders/liquid_glass.wgsl
@@ -31,6 +31,44 @@ fn get_vec4(index: u32) -> vec4<f32> {
     return vec4<f32>(get_float(index), get_float(index + 1u), get_float(index + 2u), get_float(index + 3u));
 }
 
+// Material specialization. Every optional feature of this program is gated
+// by a uniform, and on a tiler the gates that are OFF still cost: their
+// dead branches hold registers and their uniforms are fetched per fragment.
+// Each flag below is a pipeline-overridable constant the renderer sets to
+// `true` when the uniform it covers holds the feature's inactive value
+// (`LIQUID_GLASS_SPECIALIZATIONS` on the Rust side is the one table of
+// flags, slots and inactive values). A raised flag replaces the uniform read
+// with that value — the same number the uniform carried, so every
+// downstream expression is unchanged and the specialized pipeline is
+// byte-identical to the general one; the compiler then removes the dead
+// feature. Measured on Mali-G76: the showcase card material fell from
+// 47 ms to 21 ms of isolated effect-pass time per frame.
+override GLASS_LOUPE_OFF: bool = false;
+override GLASS_FOLD_OFF: bool = false;
+override GLASS_SCENE_SHAPES_OFF: bool = false;
+override GLASS_WOBBLE_OFF: bool = false;
+override GLASS_ELLIPSE_BLEND_OFF: bool = false;
+override GLASS_STRAIN_OFF: bool = false;
+override GLASS_ZOOM_ANCHOR_OFF: bool = false;
+override GLASS_TOUCH_OFF: bool = false;
+override GLASS_CONTENT_MASK_OFF: bool = false;
+override GLASS_OPTICAL_BLUR_OFF: bool = false;
+override GLASS_SHADOW_OFF: bool = false;
+override GLASS_ZOOM_OFF: bool = false;
+override GLASS_PHYSICAL_REFRACTION_OFF: bool = false;
+override GLASS_FULL_TRANSMISSION: bool = false;
+override GLASS_DISPERSION_OFF: bool = false;
+override GLASS_ADAPTIVE_FROST_OFF: bool = false;
+override GLASS_INK_OFF: bool = false;
+
+fn fixed_or(value: f32, fixed: f32, is_fixed: bool) -> f32 {
+    return select(value, fixed, is_fixed);
+}
+
+fn fixed_or_vec2(value: vec2<f32>, fixed: vec2<f32>, is_fixed: bool) -> vec2<f32> {
+    return select(value, fixed, is_fixed);
+}
+
 // SDF for rounded rectangle
 fn sd_round_rect(p: vec2<f32>, half_size: vec2<f32>, radius: f32) -> f32 {
     let q = abs(p) - half_size + vec2<f32>(radius);
@@ -477,7 +515,7 @@ fn primary_scene_distance(
     );
     let rounded_d = sd_round_rect(strained_p, half_a, r_a);
     let ellipse_d = sd_ellipse_approx(strained_p, half_a);
-    return mix(rounded_d, ellipse_d, clamp(get_float(110u), 0.0, 1.0))
+    return mix(rounded_d, ellipse_d, clamp(fixed_or(get_float(110u), 0.0, GLASS_ELLIPSE_BLEND_OFF), 0.0, 1.0))
         * min(strain_along, strain_across);
 }
 
@@ -617,21 +655,21 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     // Liquid scene: float 30 = extra shape count (shapes at 36+, 5 floats
     // each); 31 = glue radius for the smooth union; 32/33 = wobble
     // amplitude px / phase.
-    let shape_count = u32(max(get_float(30u), 0.0));
+    let shape_count = u32(max(fixed_or(get_float(30u), 0.0, GLASS_SCENE_SHAPES_OFF), 0.0));
     let glue = get_float(31u) * s;
-    let wobble_amp = get_float(32u) * s;
+    let wobble_amp = fixed_or(get_float(32u), 0.0, GLASS_WOBBLE_OFF) * s;
     let wobble_phase = get_float(33u);
-    let bulge_amp = get_float(26u) * s;
+    let bulge_amp = fixed_or(get_float(26u), 0.0, GLASS_WOBBLE_OFF) * s;
     let bulge_dir = get_float(27u);
-    var strain_axis = get_vec2(106u);
+    var strain_axis = fixed_or_vec2(get_vec2(106u), vec2<f32>(1.0, 0.0), GLASS_STRAIN_OFF);
     let strain_axis_length = length(strain_axis);
     if strain_axis_length > 0.001 {
         strain_axis = strain_axis / strain_axis_length;
     } else {
         strain_axis = vec2<f32>(1.0, 0.0);
     }
-    var strain_along = get_float(108u);
-    var strain_across = get_float(109u);
+    var strain_along = fixed_or(get_float(108u), 1.0, GLASS_STRAIN_OFF);
+    var strain_across = fixed_or(get_float(109u), 1.0, GLASS_STRAIN_OFF);
     if strain_along <= 0.0 || strain_across <= 0.0 {
         strain_along = 1.0;
         strain_across = 1.0;
@@ -655,7 +693,7 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
         select(
             inradius * refraction_depth,
             physical_refraction_depth,
-            get_float(101u) > 0.5,
+            fixed_or(get_float(101u), 0.0, GLASS_PHYSICAL_REFRACTION_OFF) > 0.5,
         ),
         0.001,
     );
@@ -685,7 +723,7 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     // A morphing glass node uses this same scene SDF as the alpha mask for
     // its foreground content. Keeping the mask in this shader guarantees
     // that blurred children and the refracted backdrop share one silhouette.
-    if get_float(112u) > 0.5 {
+    if fixed_or(get_float(112u), 0.0, GLASS_CONTENT_MASK_OFF) > 0.5 {
         return textureSample(input_texture, input_sampler, input.uv)
             * coverage
             * material_activity;
@@ -703,7 +741,7 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     if material_activity <= 0.0 {
         return resting_output;
     }
-    let shadow_strength = clamp(get_float(102u), 0.0, 1.0);
+    let shadow_strength = clamp(fixed_or(get_float(102u), 0.0, GLASS_SHADOW_OFF), 0.0, 1.0);
     var shadow_alpha = 0.0;
     if shadow_strength > 0.0 {
         let shadow_offset = vec2<f32>(0.0, get_float(104u) * s);
@@ -749,8 +787,8 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     let rim_style = clamp(get_float(28u), 0.0, 1.0);
     // Materials may push past 1 for stronger chromatic splits (the toggle
     // hold runs 1.1); the spread factor keeps the split proportional.
-    let dispersion_strength = clamp(get_float(95u), 0.0, 2.0);
-    let loupe_mode = get_float(80u);
+    let dispersion_strength = clamp(fixed_or(get_float(95u), 0.0, GLASS_DISPERSION_OFF), 0.0, 2.0);
+    let loupe_mode = fixed_or(get_float(80u), 0.0, GLASS_LOUPE_OFF);
     var refraction_curve = get_float(94u);
     if refraction_curve <= 0.0 {
         refraction_curve = 0.25;
@@ -779,7 +817,7 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     );
     let interior = optical_sample.interior;
 
-    let transmission_refraction = clamp(get_float(96u), 0.0, 1.0);
+    let transmission_refraction = clamp(fixed_or(get_float(96u), 1.0, GLASS_FULL_TRANSMISSION), 0.0, 1.0);
     // Uniform face magnification (uniform 89, dp-free ratio): the riding
     // lens projects its backdrop enlarged across the whole face. Blended by
     // the channel interior so the rim band keeps the wcKSRD edge mapping,
@@ -791,8 +829,8 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     // it rides (the toggle thumb) — anchoring the magnification there keeps
     // the face filled by the ridden content instead of pulling in the well
     // beyond it.
-    let optical_zoom = max(get_float(89u), 1.0);
-    let zoom_anchor = get_vec2(128u) * dp_scale;
+    let optical_zoom = max(fixed_or(get_float(89u), 1.0, GLASS_ZOOM_OFF), 1.0);
+    let zoom_anchor = fixed_or_vec2(get_vec2(128u), vec2<f32>(0.0), GLASS_ZOOM_ANCHOR_OFF) * dp_scale;
     // Displacement that translates the image without bending the ray (the
     // loupe's focus offset — optically a flat-slab shift). Translation does
     // not disperse; only the ray-bend components built per channel below
@@ -835,7 +873,7 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     // a PURE displacement — the band replays the interior mirrored toward
     // the rim, the reference toggle's "U". No color terms ride on it, so
     // white surround mirrors white and colored tracks mirror themselves.
-    let fold_depth_px = get_float(88u) * optical_scale;
+    let fold_depth_px = fixed_or(get_float(88u), 0.0, GLASS_FOLD_OFF) * optical_scale;
     var fold_displacement = vec2<f32>(0.0);
     var fold_absorb = 0.0;
     if loupe_mode <= 0.5 && fold_depth_px > 0.0 {
@@ -874,7 +912,7 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     );
 
     // wcKSRD owns source mapping and backdrop blur.
-    let wcksrd_blur_radius = max(max(get_float(93u), 0.0), loupe_rim_softening);
+    let wcksrd_blur_radius = max(max(fixed_or(get_float(93u), 0.0, GLASS_OPTICAL_BLUR_OFF), 0.0), loupe_rim_softening);
     let transmitted_path = sample_wcksrd_path(
         uv,
         tex_size,
@@ -949,7 +987,7 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     // untouched and only glyph ink takes the color. This lives in the
     // MATERIAL: recoloring the elements instead refracts their accent
     // into smears around the bubble rim (live report).
-    let ink_recolor_strength = clamp(get_float(127u), 0.0, 1.0);
+    let ink_recolor_strength = clamp(fixed_or(get_float(127u), 0.0, GLASS_INK_OFF), 0.0, 1.0);
     if ink_recolor_strength > 0.0 {
         let ink_color = vec3<f32>(get_float(124u), get_float(125u), get_float(126u));
         let transmitted_luma = dot(rgb, vec3<f32>(0.2126, 0.7152, 0.0722));
@@ -1204,7 +1242,7 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     // gradient UNDER THE FINGER — never a flat surface recolor. Saturation
     // of white is white and the light is a small screen-ish add, so bright
     // backdrops stay safe.
-    let touch_strength = clamp(get_float(120u), 0.0, 1.0);
+    let touch_strength = clamp(fixed_or(get_float(120u), 0.0, GLASS_TOUCH_OFF), 0.0, 1.0);
     if touch_strength > 0.0 {
         let touch_px = vec2<f32>(get_float(118u), get_float(119u)) * dp_scale;
         let touch_reach = 58.0 * optical_scale;
@@ -1222,7 +1260,7 @@ fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
     // background and its detail. A per-fragment decision classifies thin
     // light/dark backdrop glyphs as a new background polarity and inverts
     // them, even though the surrounding card already has safe contrast.
-    let adaptive_frost = clamp(get_float(91u), 0.0, 1.0);
+    let adaptive_frost = clamp(fixed_or(get_float(91u), 0.0, GLASS_ADAPTIVE_FROST_OFF), 0.0, 1.0);
     if adaptive_frost > 0.0 {
         let foreground_luma = clamp(get_float(97u), 0.0, 1.0);
         let adaptive_sample = sample_adaptive_neighborhood(

--- a/crates/cranpose-ui-graphics/shaders/shape.wgsl
+++ b/crates/cranpose-ui-graphics/shaders/shape.wgsl
@@ -22,6 +22,11 @@ struct VertexOutput {
     @location(7) @interpolate(flat) stroke_params: vec4<f32>,
     @location(8) @interpolate(flat) arc_params: vec4<f32>,
     @location(9) @interpolate(flat) brush: vec4<u32>,
+    @location(10) @interpolate(flat) stop_offsets: vec4<f32>,
+    @location(11) @interpolate(flat) stop_color0: vec4<f32>,
+    @location(12) @interpolate(flat) stop_color1: vec4<f32>,
+    @location(13) @interpolate(flat) stop_color2: vec4<f32>,
+    @location(14) @interpolate(flat) stop_color3: vec4<f32>,
 }
 
 struct Uniforms {
@@ -126,6 +131,12 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
         shape.gradient_count,
         shape.gradient_tile_mode,
     );
+    let stops = load_inline_gradient_stops(shape.gradient_start, shape.gradient_count);
+    output.stop_offsets = stops.offsets;
+    output.stop_color0 = stops.color0;
+    output.stop_color1 = stops.color1;
+    output.stop_color2 = stops.color2;
+    output.stop_color3 = stops.color3;
 
     return output;
 }
@@ -194,6 +205,12 @@ fn vs_shape_instanced(
         shape.gradient_count,
         shape.gradient_tile_mode,
     );
+    let stops = load_inline_gradient_stops(shape.gradient_start, shape.gradient_count);
+    output.stop_offsets = stops.offsets;
+    output.stop_color0 = stops.color0;
+    output.stop_color1 = stops.color1;
+    output.stop_color2 = stops.color2;
+    output.stop_color3 = stops.color3;
 
     return output;
 }
@@ -252,6 +269,12 @@ fn vs_mesh(in: MeshVertexInput) -> VertexOutput {
         shape.gradient_count,
         shape.gradient_tile_mode,
     );
+    let stops = load_inline_gradient_stops(shape.gradient_start, shape.gradient_count);
+    output.stop_offsets = stops.offsets;
+    output.stop_color0 = stops.color0;
+    output.stop_color1 = stops.color1;
+    output.stop_color2 = stops.color2;
+    output.stop_color3 = stops.color3;
 
     return output;
 }
@@ -474,6 +497,96 @@ fn gradient_dither(device_pos: vec2<f32>) -> f32 {
     return f32(m) * (1.0 / 16.0) - (15.0 / 32.0);
 }
 
+// Gradients of up to `INLINE_GRADIENT_STOPS` stops travel to the fragment
+// stage as flat varyings, read once per vertex; longer ramps keep the
+// per-fragment walk over `gradient_stops`. On a tiler the walk is several
+// dynamically indexed uniform loads per fragment, which is what a full-screen
+// three-stop radial cost on Mali (`CRANPOSE_UNIFORM_GRADIENT_STOPS` rewrites
+// this to 0 and routes every gradient back through the walk; the parity test
+// holds the two at zero differing bytes).
+const INLINE_GRADIENT_STOPS: u32 = 4u;
+
+struct InlineGradientStops {
+    offsets: vec4<f32>,
+    color0: vec4<f32>,
+    color1: vec4<f32>,
+    color2: vec4<f32>,
+    color3: vec4<f32>,
+}
+
+fn load_inline_gradient_stops(gradient_start: u32, count: u32) -> InlineGradientStops {
+    var stops: InlineGradientStops;
+    if (count == 0u || count > INLINE_GRADIENT_STOPS) {
+        return stops;
+    }
+    let first = gradient_stops[gradient_start];
+    stops.offsets.x = first.position.x;
+    stops.color0 = first.color;
+    if (count > 1u) {
+        let second = gradient_stops[gradient_start + 1u];
+        stops.offsets.y = second.position.x;
+        stops.color1 = second.color;
+    }
+    if (count > 2u) {
+        let third = gradient_stops[gradient_start + 2u];
+        stops.offsets.z = third.position.x;
+        stops.color2 = third.color;
+    }
+    if (count > 3u) {
+        let fourth = gradient_stops[gradient_start + 3u];
+        stops.offsets.w = fourth.position.x;
+        stops.color3 = fourth.color;
+    }
+    return stops;
+}
+
+fn gradient_segment(
+    from_offset: f32,
+    from_color: vec4<f32>,
+    to_offset: f32,
+    to_color: vec4<f32>,
+    clamped: f32,
+) -> vec4<f32> {
+    let denom = max(to_offset - from_offset, 0.00001);
+    let local_t = clamp((clamped - from_offset) / denom, 0.0, 1.0);
+    return mix(from_color, to_color, local_t);
+}
+
+fn sample_inline_gradient(input: VertexOutput, count: u32, t: f32) -> vec4<f32> {
+    if (count == 1u) {
+        return input.stop_color0;
+    }
+    let offsets = input.stop_offsets;
+    let clamped = clamp(t, 0.0, 1.0);
+    if (clamped <= offsets.x) {
+        return input.stop_color0;
+    }
+    if (clamped <= offsets.y) {
+        return gradient_segment(offsets.x, input.stop_color0, offsets.y, input.stop_color1, clamped);
+    }
+    if (count == 2u) {
+        return input.stop_color1;
+    }
+    if (clamped <= offsets.z) {
+        return gradient_segment(offsets.y, input.stop_color1, offsets.z, input.stop_color2, clamped);
+    }
+    if (count == 3u) {
+        return input.stop_color2;
+    }
+    if (clamped <= offsets.w) {
+        return gradient_segment(offsets.z, input.stop_color2, offsets.w, input.stop_color3, clamped);
+    }
+    return input.stop_color3;
+}
+
+fn gradient_color(input: VertexOutput, t: f32) -> vec4<f32> {
+    let count = input.brush.z;
+    if (count > 0u && count <= INLINE_GRADIENT_STOPS) {
+        return sample_inline_gradient(input, count, t);
+    }
+    return sample_gradient(input.brush.y, count, t);
+}
+
 fn sample_gradient(gradient_start: u32, count: u32, t: f32) -> vec4<f32> {
     if (count == 0u) {
         return vec4<f32>(0.0);
@@ -496,9 +609,9 @@ fn sample_gradient(gradient_start: u32, count: u32, t: f32) -> vec4<f32> {
         let current = gradient_stops[gradient_start + i];
         let next = gradient_stops[gradient_start + i + 1u];
         if (clamped <= next.position.x) {
-            let denom = max(next.position.x - current.position.x, 0.00001);
-            let local_t = clamp((clamped - current.position.x) / denom, 0.0, 1.0);
-            return mix(current.color, next.color, local_t);
+            return gradient_segment(
+                current.position.x, current.color, next.position.x, next.color, clamped,
+            );
         }
         i = i + 1u;
     }
@@ -613,8 +726,6 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
 
     // Apply gradient if needed
     let brush_type = input.brush.x;
-    let gradient_start = input.brush.y;
-    let gradient_count = input.brush.z;
     let gradient_tile_mode = input.brush.w;
     if (brush_type == 1u) {
         // Linear gradient projected from start.xy to end.xy
@@ -627,7 +738,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         if (!sample.valid) {
             color = vec4<f32>(0.0);
         } else {
-            color = sample_gradient(gradient_start, gradient_count, sample.t);
+            color = gradient_color(input, sample.t);
             is_gradient = true;
         }
     } else if (brush_type == 2u) {
@@ -640,7 +751,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         if (!sample.valid) {
             color = vec4<f32>(0.0);
         } else {
-            color = sample_gradient(gradient_start, gradient_count, sample.t);
+            color = gradient_color(input, sample.t);
             is_gradient = true;
         }
     } else if (brush_type == 3u) {
@@ -655,7 +766,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         if (!sample.valid) {
             color = vec4<f32>(0.0);
         } else {
-            color = sample_gradient(gradient_start, gradient_count, sample.t);
+            color = gradient_color(input, sample.t);
             is_gradient = true;
         }
     }

--- a/crates/cranpose-ui-graphics/shaders/shape_solid_trim.wgsl
+++ b/crates/cranpose-ui-graphics/shaders/shape_solid_trim.wgsl
@@ -13,7 +13,7 @@
 //
 // LOCATION DISCIPLINE — the rule this file exists to encode: the surviving
 // varyings KEEP the location indices they hold in `VertexOutput`, and
-// locations 5 and 9 stay VACANT. The first attempt at this trim (16a5d312,
+// locations 5, 9 and 10-14 stay VACANT. The first attempt at this trim (16a5d312,
 // reverted in 371dd06a) renumbered the survivors densely (clip_rect 6 -> 5,
 // stroke_params 7 -> 6, arc_params 8 -> 7) and a watch died with it on; the
 // crash was never diagnosed and the renumbering was suspect #1. With the
@@ -36,8 +36,9 @@
 //   against the occluder like every other content pipeline.
 
 // The solid pipelines' inter-stage interface: `VertexOutput` minus
-// `gradient_params` (its location 5 left vacant) and `brush` (its location 9
-// left vacant). See LOCATION DISCIPLINE above before touching an index.
+// `gradient_params` (its location 5 left vacant), `brush` (its location 9
+// left vacant) and the inline gradient stops (locations 10-14 left vacant).
+// See LOCATION DISCIPLINE above before touching an index.
 struct VertexOutputSolid {
     @builtin(position) clip_position: vec4<f32>,
     @location(0) color: vec4<f32>,
@@ -50,6 +51,7 @@ struct VertexOutputSolid {
     @location(7) @interpolate(flat) stroke_params: vec4<f32>,
     @location(8) @interpolate(flat) arc_params: vec4<f32>,
     // location 9 is `brush`'s slot in `VertexOutput` — VACANT.
+    // locations 10-14 are the inline gradient stops' slots — VACANT.
 }
 
 // BIT-EXACTNESS REQUIREMENT: every expression below is copied verbatim from

--- a/crates/cranpose-ui-graphics/src/liquid_glass.rs
+++ b/crates/cranpose-ui-graphics/src/liquid_glass.rs
@@ -8,6 +8,152 @@
 
 use crate::{Color, RenderEffect, RuntimeShader};
 
+/// One pipeline-overridable flag of `liquid_glass.wgsl` and the uniform
+/// slots it folds away.
+///
+/// The shader gates each optional feature on a uniform; a raised flag
+/// replaces that uniform read with the feature's inactive value, which is
+/// the value the uniform holds when `inactive` reports true, so the
+/// specialized pipeline computes exactly what the general one did and the
+/// compiler removes the dead feature. See [`specialize_liquid_glass`].
+#[derive(Clone, Copy, Debug)]
+pub struct LiquidGlassSpecialization {
+    /// The `override NAME: bool` declared by the shader.
+    pub flag: &'static str,
+    /// Uniform slots the flag replaces.
+    pub slots: &'static [usize],
+    /// Whether the uniforms hold the feature's inactive value.
+    pub inactive: fn(&[f32]) -> bool,
+}
+
+fn slot(uniforms: &[f32], index: usize) -> f32 {
+    uniforms.get(index).copied().unwrap_or(0.0)
+}
+
+/// Every specialization flag of `liquid_glass.wgsl`, the single table the
+/// shader's `override` declarations, [`specialize_liquid_glass`] and the
+/// contract tests share.
+pub const LIQUID_GLASS_SPECIALIZATIONS: &[LiquidGlassSpecialization] = &[
+    LiquidGlassSpecialization {
+        flag: "GLASS_LOUPE_OFF",
+        slots: &[80],
+        inactive: |u| slot(u, 80) == 0.0,
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_FOLD_OFF",
+        slots: &[GLASS_FOLD_DEPTH_UNIFORM],
+        inactive: |u| slot(u, GLASS_FOLD_DEPTH_UNIFORM) == 0.0,
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_SCENE_SHAPES_OFF",
+        slots: &[30],
+        inactive: |u| slot(u, 30) == 0.0,
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_WOBBLE_OFF",
+        slots: &[32, 26],
+        inactive: |u| slot(u, 32) == 0.0 && slot(u, 26) == 0.0,
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_ELLIPSE_BLEND_OFF",
+        slots: &[110],
+        inactive: |u| slot(u, 110) == 0.0,
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_STRAIN_OFF",
+        slots: &[106, 107, 108, 109],
+        inactive: |u| {
+            let axis_identity = (slot(u, 106) == 0.0 && slot(u, 107) == 0.0)
+                || (slot(u, 106) == 1.0 && slot(u, 107) == 0.0);
+            let ratio_identity = slot(u, 108) <= 0.0
+                || slot(u, 109) <= 0.0
+                || (slot(u, 108) == 1.0 && slot(u, 109) == 1.0);
+            axis_identity && ratio_identity
+        },
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_ZOOM_ANCHOR_OFF",
+        slots: &[
+            GLASS_OPTICAL_ZOOM_ANCHOR_UNIFORM,
+            GLASS_OPTICAL_ZOOM_ANCHOR_UNIFORM + 1,
+        ],
+        inactive: |u| {
+            slot(u, GLASS_OPTICAL_ZOOM_ANCHOR_UNIFORM) == 0.0
+                && slot(u, GLASS_OPTICAL_ZOOM_ANCHOR_UNIFORM + 1) == 0.0
+        },
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_TOUCH_OFF",
+        slots: &[120],
+        inactive: |u| slot(u, 120) <= 0.0,
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_CONTENT_MASK_OFF",
+        slots: &[112],
+        inactive: |u| slot(u, 112) <= 0.5,
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_OPTICAL_BLUR_OFF",
+        slots: &[GLASS_BLUR_RADIUS_UNIFORM],
+        inactive: |u| slot(u, GLASS_BLUR_RADIUS_UNIFORM) <= 0.0,
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_SHADOW_OFF",
+        slots: &[102],
+        inactive: |u| slot(u, 102) <= 0.0,
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_ZOOM_OFF",
+        slots: &[GLASS_OPTICAL_ZOOM_UNIFORM],
+        inactive: |u| slot(u, GLASS_OPTICAL_ZOOM_UNIFORM) <= 1.0,
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_PHYSICAL_REFRACTION_OFF",
+        slots: &[GLASS_PHYSICAL_REFRACTION_DEPTH_ENABLED_UNIFORM],
+        inactive: |u| slot(u, GLASS_PHYSICAL_REFRACTION_DEPTH_ENABLED_UNIFORM) <= 0.5,
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_FULL_TRANSMISSION",
+        slots: &[GLASS_TRANSMISSION_REFRACTION_UNIFORM],
+        inactive: |u| slot(u, GLASS_TRANSMISSION_REFRACTION_UNIFORM) >= 1.0,
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_DISPERSION_OFF",
+        slots: &[GLASS_DISPERSION_UNIFORM],
+        inactive: |u| slot(u, GLASS_DISPERSION_UNIFORM) <= 0.0,
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_ADAPTIVE_FROST_OFF",
+        slots: &[91],
+        inactive: |u| slot(u, 91) <= 0.0,
+    },
+    LiquidGlassSpecialization {
+        flag: "GLASS_INK_OFF",
+        slots: &[127],
+        inactive: |u| slot(u, 127) <= 0.0,
+    },
+];
+
+/// Raises every specialization flag whose feature the shader's uniforms
+/// leave inactive, so the pipeline compiled for this material carries only
+/// the features it uses. Byte-exact: a raised flag substitutes the value the
+/// uniform already holds.
+pub fn specialize_liquid_glass(shader: &mut RuntimeShader) {
+    let uniforms: Vec<f32> = shader.uniforms().to_vec();
+    for specialization in LIQUID_GLASS_SPECIALIZATIONS {
+        if (specialization.inactive)(&uniforms) {
+            shader.set_override(specialization.flag, 1.0);
+        }
+    }
+}
+
+/// Wraps a fully configured `liquid_glass.wgsl` shader as a render effect,
+/// specialized to the features its uniforms enable.
+pub fn liquid_glass_runtime_effect(mut shader: RuntimeShader) -> RenderEffect {
+    specialize_liquid_glass(&mut shader);
+    RenderEffect::runtime_shader(shader)
+}
+
 /// Uniform slot containing wcKSRD-owned backdrop blur reach in physical pixels.
 pub const GLASS_BLUR_RADIUS_UNIFORM: usize = 93;
 /// Uniform slot containing the normalized wcKSRD ray-return exponent.
@@ -194,7 +340,7 @@ pub fn liquid_glass_effect(
     shader.set_float(GLASS_ACTIVITY_UNIFORM, 1.0);
     shader.set_input_padding(liquid_glass_input_padding(spec));
 
-    RenderEffect::runtime_shader(shader)
+    liquid_glass_runtime_effect(shader)
 }
 
 /// How far the shader's refracted and internally reflected samples can reach
@@ -283,7 +429,7 @@ pub fn liquid_loupe_effect(node_size: (f32, f32), spec: &LiquidLoupeSpec) -> Ren
     shader.set_float(90, activity);
     let focus_reach = (spec.focus_offset.0.powi(2) + spec.focus_offset.1.powi(2)).sqrt();
     shader.set_input_padding((focus_reach + 8.0).ceil());
-    RenderEffect::runtime_shader(shader)
+    liquid_glass_runtime_effect(shader)
 }
 
 /// The text edit-menu material measured from the reference: a 44 dp glass
@@ -330,7 +476,7 @@ pub fn liquid_menu_glass_effect(
     };
     shader.set_float(GLASS_BLUR_RADIUS_UNIFORM, wcksrd_blur);
     shader.set_input_padding(12.0 + requested_blur);
-    let optical = RenderEffect::runtime_shader(shader);
+    let optical = liquid_glass_runtime_effect(shader);
     if gaussian_blur > f32::EPSILON {
         RenderEffect::blur_with_edge_treatment(gaussian_blur, crate::TileMode::Mirror).then(optical)
     } else {
@@ -370,6 +516,114 @@ mod tests {
             height: 100.0,
             tint_color: Color(0.5, 0.5, 1.0, 0.1),
         }
+    }
+
+    fn shader_lines_reading(slot: usize) -> Vec<&'static str> {
+        let needles = [format!("get_float({slot}u)"), format!("get_vec2({slot}u)")];
+        LIQUID_GLASS_WGSL
+            .lines()
+            .filter(|line| needles.iter().any(|needle| line.contains(needle)))
+            .collect()
+    }
+
+    #[test]
+    fn every_specialization_flag_is_a_shader_override_and_guards_all_of_its_slot_reads() {
+        for specialization in LIQUID_GLASS_SPECIALIZATIONS {
+            let declaration = format!("override {}: bool = false;", specialization.flag);
+            assert!(
+                LIQUID_GLASS_WGSL.contains(&declaration),
+                "`{declaration}` missing from liquid_glass.wgsl"
+            );
+            let mut guarded_reads = 0;
+            for slot in specialization.slots {
+                for line in shader_lines_reading(*slot) {
+                    assert!(
+                        line.contains(specialization.flag),
+                        "slot {slot} is read outside its `{}` guard: `{}`",
+                        specialization.flag,
+                        line.trim()
+                    );
+                    guarded_reads += 1;
+                }
+            }
+            assert!(
+                guarded_reads > 0,
+                "`{}` guards no uniform read; the flag would fold nothing",
+                specialization.flag
+            );
+        }
+        let declared: Vec<&str> = LIQUID_GLASS_WGSL
+            .lines()
+            .filter_map(|line| line.strip_prefix("override "))
+            .filter_map(|rest| rest.split(':').next())
+            .collect();
+        for flag in &declared {
+            assert!(
+                LIQUID_GLASS_SPECIALIZATIONS
+                    .iter()
+                    .any(|specialization| specialization.flag == *flag),
+                "shader override `{flag}` is missing from LIQUID_GLASS_SPECIALIZATIONS, so \
+                 nothing ever raises it"
+            );
+        }
+        assert_eq!(declared.len(), LIQUID_GLASS_SPECIALIZATIONS.len());
+    }
+
+    fn raised_flags(effect: &RenderEffect) -> Vec<&'static str> {
+        let RenderEffect::Shader { shader } = effect else {
+            panic!("liquid glass must be one runtime shader");
+        };
+        shader.overrides().iter().map(|(flag, _)| *flag).collect()
+    }
+
+    #[test]
+    fn a_plain_pane_raises_every_flag() {
+        let flags = raised_flags(&liquid_glass_effect(
+            &rect(),
+            &LiquidGlassSpec::default(),
+            800.0,
+            600.0,
+        ));
+        let every_flag: Vec<&str> = LIQUID_GLASS_SPECIALIZATIONS
+            .iter()
+            .map(|specialization| specialization.flag)
+            .collect();
+        let mut sorted = every_flag.clone();
+        sorted.sort_unstable();
+        assert_eq!(
+            flags, sorted,
+            "a plain pane uses no optional feature, so every flag folds"
+        );
+    }
+
+    #[test]
+    fn a_blurred_dispersive_loupe_keeps_its_features_live() {
+        let flags = raised_flags(&liquid_loupe_effect(
+            (200.0, 120.0),
+            &LiquidLoupeSpec::default(),
+        ));
+        for live in ["GLASS_LOUPE_OFF", "GLASS_DISPERSION_OFF"] {
+            assert!(
+                !flags.contains(&live),
+                "{live} must stay live for a loupe: {flags:?}"
+            );
+        }
+        assert!(flags.contains(&"GLASS_FOLD_OFF"));
+        assert!(flags.contains(&"GLASS_SCENE_SHAPES_OFF"));
+
+        let blurred = liquid_glass_effect(
+            &rect(),
+            &LiquidGlassSpec {
+                blur_radius: 1.5,
+                ..LiquidGlassSpec::default()
+            },
+            800.0,
+            600.0,
+        );
+        assert!(
+            !raised_flags(&blurred).contains(&"GLASS_OPTICAL_BLUR_OFF"),
+            "an optical blur radius keeps the wcKSRD footprint live"
+        );
     }
 
     #[test]

--- a/crates/cranpose-ui-graphics/src/render_effect.rs
+++ b/crates/cranpose-ui-graphics/src/render_effect.rs
@@ -91,6 +91,7 @@ pub struct RuntimeShader {
     source: Arc<str>,
     source_hash: u64,
     uniforms: RuntimeShaderUniforms,
+    overrides: Vec<(&'static str, f64)>,
     input_padding: f32,
     output_padding: f32,
 }
@@ -190,6 +191,7 @@ impl RuntimeShader {
             source,
             source_hash,
             uniforms: RuntimeShaderUniforms::new(),
+            overrides: Vec::new(),
             input_padding: 0.0,
             output_padding: 0.0,
         }
@@ -205,9 +207,46 @@ impl RuntimeShader {
             source,
             source_hash,
             uniforms: RuntimeShaderUniforms::new(),
+            overrides: Vec::new(),
             input_padding: 0.0,
             output_padding: 0.0,
         }
+    }
+
+    /// Fixes a pipeline-overridable constant (`override NAME: T = ...;` in
+    /// the WGSL) for every pipeline compiled from this shader. The value is
+    /// converted to the constant's declared scalar type the way WebGPU does
+    /// (a `bool` is `value != 0`). Each distinct override set compiles its
+    /// own pipeline; renderers use this to fold a material's inactive
+    /// features away without changing the shader text.
+    pub fn set_override(&mut self, name: &'static str, value: f64) {
+        match self
+            .overrides
+            .binary_search_by(|(existing, _)| existing.cmp(&name))
+        {
+            Ok(index) => self.overrides[index].1 = value,
+            Err(index) => self.overrides.insert(index, (name, value)),
+        }
+    }
+
+    /// The pipeline-overridable constants fixed by [`Self::set_override`],
+    /// ordered by name.
+    pub fn overrides(&self) -> &[(&'static str, f64)] {
+        &self.overrides
+    }
+
+    /// Hash of the fixed override set; zero when no override is fixed.
+    pub fn overrides_hash(&self) -> u64 {
+        if self.overrides.is_empty() {
+            return 0;
+        }
+        let mut bytes = Vec::new();
+        for (name, value) in &self.overrides {
+            bytes.extend_from_slice(name.as_bytes());
+            bytes.push(0);
+            bytes.extend_from_slice(&value.to_bits().to_le_bytes());
+        }
+        hash_shader_bytes(&bytes)
     }
 
     /// Declares how far the shader may sample outside its effect rect, in
@@ -363,21 +402,28 @@ impl PartialEq for RuntimeShader {
             && (Arc::ptr_eq(&self.source, &other.source)
                 || self.source.as_ref() == other.source.as_ref())
             && self.uniforms == other.uniforms
+            && self.overrides.len() == other.overrides.len()
+            && self
+                .overrides
+                .iter()
+                .zip(&other.overrides)
+                .all(|(a, b)| a.0 == b.0 && a.1.to_bits() == b.1.to_bits())
             && self.input_padding.to_bits() == other.input_padding.to_bits()
             && self.output_padding.to_bits() == other.output_padding.to_bits()
     }
 }
 
 fn hash_shader_source(source: &str) -> u64 {
+    hash_shader_bytes(source.as_bytes())
+}
+
+fn hash_shader_bytes(bytes: &[u8]) -> u64 {
     const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
     const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
 
-    source
-        .as_bytes()
-        .iter()
-        .fold(FNV_OFFSET_BASIS, |hash, byte| {
-            (hash ^ u64::from(*byte)).wrapping_mul(FNV_PRIME)
-        })
+    bytes.iter().fold(FNV_OFFSET_BASIS, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(FNV_PRIME)
+    })
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -573,6 +619,29 @@ impl RenderEffect {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn overrides_stay_sorted_and_replace_by_name() {
+        let mut shader = super::RuntimeShader::new("// overrides");
+        shader.set_override("ZETA", 1.0);
+        shader.set_override("ALPHA", 0.0);
+        shader.set_override("ZETA", 2.0);
+        assert_eq!(shader.overrides(), &[("ALPHA", 0.0), ("ZETA", 2.0)]);
+    }
+
+    #[test]
+    fn overrides_distinguish_otherwise_equal_shaders() {
+        let plain = super::RuntimeShader::new("// overrides-eq");
+        let mut raised = plain.clone();
+        raised.set_override("FLAG", 1.0);
+        assert_eq!(plain.overrides_hash(), 0);
+        assert_ne!(plain.overrides_hash(), raised.overrides_hash());
+        assert_ne!(plain, raised);
+        let mut lowered = raised.clone();
+        lowered.set_override("FLAG", 0.0);
+        assert_ne!(raised.overrides_hash(), lowered.overrides_hash());
+        assert_ne!(raised, lowered);
+    }
+
     use super::*;
     use crate::RoundedCornerShape;
 

--- a/crates/cranpose-ui-graphics/src/render_hash.rs
+++ b/crates/cranpose-ui-graphics/src/render_hash.rs
@@ -240,6 +240,7 @@ fn hash_color_filter<H: Hasher>(filter: ColorFilter, state: &mut H) {
 
 fn hash_runtime_shader<H: Hasher>(shader: &RuntimeShader, state: &mut H) {
     shader.source_hash().hash(state);
+    shader.overrides_hash().hash(state);
     hash_f32_bits(shader.input_padding(), state);
     hash_f32_bits(shader.output_padding(), state);
     shader.uniforms().len().hash(state);
@@ -430,6 +431,19 @@ fn hash_shadow_primitive<H: Hasher>(shadow: &ShadowPrimitive, state: &mut H) {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn runtime_shader_overrides_change_the_render_hash() {
+        let plain = crate::RuntimeShader::new("// hash-overrides");
+        let mut raised = plain.clone();
+        raised.set_override("FLAG", 1.0);
+        assert_ne!(
+            crate::RenderEffect::runtime_shader(plain).render_hash(),
+            crate::RenderEffect::runtime_shader(raised).render_hash(),
+            "a specialized pipeline renders through different code, so cached output keyed \
+             without the overrides would serve the wrong program"
+        );
+    }
+
     use super::*;
     use crate::render_effect::TileMode;
 

--- a/crates/cranpose-ui/src/modifier/slices.rs
+++ b/crates/cranpose-ui/src/modifier/slices.rs
@@ -25,6 +25,7 @@ use crate::{
 #[derive(Default)]
 pub struct ModifierNodeSlices {
     draw_commands: Vec<DrawCommand>,
+    layer_draw_boundary: Option<usize>,
     pointer_inputs: Vec<Rc<dyn Fn(PointerEvent)>>,
     pointer_input_sizes: Vec<Rc<std::cell::Cell<cranpose_ui_graphics::Size>>>,
     click_handlers: Vec<Rc<dyn Fn(Point)>>,
@@ -71,6 +72,7 @@ impl Clone for ModifierNodeSlices {
     fn clone(&self) -> Self {
         Self {
             draw_commands: self.draw_commands.clone(),
+            layer_draw_boundary: self.layer_draw_boundary,
             pointer_inputs: self.pointer_inputs.clone(),
             pointer_input_sizes: self.pointer_input_sizes.clone(),
             click_handlers: self.click_handlers.clone(),
@@ -145,6 +147,35 @@ fn compose_color_filters(
 impl ModifierNodeSlices {
     pub fn draw_commands(&self) -> &[DrawCommand] {
         &self.draw_commands
+    }
+
+    /// How many leading [`draw_commands`](Self::draw_commands) come from
+    /// modifiers chained before the node's graphics layer or clip. Those draw
+    /// around the layer in the parent's space, outside its clip, alpha and
+    /// transform, exactly as an outer `drawBehind` wraps a `graphicsLayer`.
+    pub fn outer_draw_command_count(&self) -> usize {
+        self.layer_draw_boundary.unwrap_or(0)
+    }
+
+    fn insert_background_draw(
+        &mut self,
+        insert_index: Option<usize>,
+        precedes_layer: bool,
+        command: DrawCommand,
+    ) {
+        let insert_index = insert_index.unwrap_or(0).min(self.draw_commands.len());
+        self.draw_commands.insert(insert_index, command);
+        if let Some(boundary) = self.layer_draw_boundary.as_mut()
+            && precedes_layer
+        {
+            *boundary += 1;
+        }
+    }
+
+    fn mark_layer_draw_boundary(&mut self) {
+        if self.layer_draw_boundary.is_none() {
+            self.layer_draw_boundary = Some(self.draw_commands.len());
+        }
     }
 
     pub fn pointer_inputs(&self) -> &[Rc<dyn Fn(PointerEvent)>] {
@@ -340,6 +371,7 @@ impl ModifierNodeSlices {
     /// Resets the slice collection for reuse, retaining vector capacity.
     pub fn clear(&mut self) {
         self.draw_commands.clear();
+        self.layer_draw_boundary = None;
         self.pointer_inputs.clear();
         self.pointer_input_sizes.clear();
         self.click_handlers.clear();
@@ -419,6 +451,7 @@ pub fn collect_modifier_slices_into(chain: &ModifierNodeChain, slices: &mut Modi
 
     let mut background_color = None;
     let mut background_insert_index = None::<usize>;
+    let mut background_precedes_layer = false;
     let mut corner_shape = None;
     let mut padding = EdgeInsets::default();
 
@@ -444,6 +477,7 @@ pub fn collect_modifier_slices_into(chain: &ModifierNodeChain, slices: &mut Modi
                 if let Some(bg_node) = any.downcast_ref::<BackgroundNode>() {
                     background_color = Some(bg_node.color());
                     background_insert_index = Some(slices.draw_commands.len());
+                    background_precedes_layer = slices.layer_draw_boundary.is_none();
                     if bg_node.shape().is_some() {
                         corner_shape = bg_node.shape();
                     }
@@ -486,6 +520,7 @@ pub fn collect_modifier_slices_into(chain: &ModifierNodeChain, slices: &mut Modi
                 }
 
                 if let Some(layer_node) = any.downcast_ref::<GraphicsLayerNode>() {
+                    slices.mark_layer_draw_boundary();
                     slices.push_graphics_layer(
                         layer_node.layer_snapshot(),
                         layer_node.layer_resolver(),
@@ -493,6 +528,7 @@ pub fn collect_modifier_slices_into(chain: &ModifierNodeChain, slices: &mut Modi
                 }
 
                 if any.is::<ClipToBoundsNode>() {
+                    slices.mark_layer_draw_boundary();
                     slices.clip_to_bounds = true;
                 }
             }
@@ -565,12 +601,11 @@ pub fn collect_modifier_slices_into(chain: &ModifierNodeChain, slices: &mut Modi
             }
         });
 
-        let insert_index = background_insert_index
-            .unwrap_or(0)
-            .min(slices.draw_commands.len());
-        slices
-            .draw_commands
-            .insert(insert_index, DrawCommand::Behind(draw_cmd));
+        slices.insert_background_draw(
+            background_insert_index,
+            background_precedes_layer,
+            DrawCommand::Behind(draw_cmd),
+        );
     }
 }
 

--- a/crates/cranpose-ui/src/modifier/slices.rs
+++ b/crates/cranpose-ui/src/modifier/slices.rs
@@ -2,7 +2,7 @@ use std::{fmt, mem::size_of, rc::Rc};
 
 use cranpose_foundation::{ModifierNodeChain, NodeCapabilities, PointerEvent};
 use cranpose_ui_graphics::{
-    ColorFilter, EdgeInsets, GraphicsLayer, RenderEffect, RoundedCornerShape,
+    ColorFilter, EdgeInsets, GraphicsLayer, LayerShape, RenderEffect, RoundedCornerShape,
 };
 
 use super::{ModifierChainHandle, Point};
@@ -112,13 +112,27 @@ fn merge_graphics_layers(base: GraphicsLayer, overlay: GraphicsLayer) -> Graphic
         shadow_elevation: overlay.shadow_elevation,
         ambient_shadow_color: overlay.ambient_shadow_color,
         spot_shadow_color: overlay.spot_shadow_color,
-        shape: overlay.shape,
+        shape: merged_layer_shape(&base, &overlay),
         clip: base.clip || overlay.clip,
         compositing_strategy: overlay.compositing_strategy,
         blend_mode: overlay.blend_mode,
         color_filter: compose_color_filters(base.color_filter, overlay.color_filter),
         render_effect: compose_render_effects(base.render_effect, overlay.render_effect),
         backdrop_effect: overlay.backdrop_effect.or(base.backdrop_effect),
+    }
+}
+
+/// The shape of two stacked layers merged into one: the layer that clips
+/// owns it, else the layer that carries the backdrop (its effect covers that
+/// shape), else the later layer, whose default resets it like every other
+/// parent-local field.
+fn merged_layer_shape(base: &GraphicsLayer, overlay: &GraphicsLayer) -> LayerShape {
+    if overlay.clip || (!base.clip && overlay.backdrop_effect.is_some()) {
+        overlay.shape
+    } else if base.clip || base.backdrop_effect.is_some() {
+        base.shape
+    } else {
+        overlay.shape
     }
 }
 

--- a/crates/cranpose-ui/src/modifier/tests/modifier_tests.rs
+++ b/crates/cranpose-ui/src/modifier/tests/modifier_tests.rs
@@ -1052,6 +1052,51 @@ fn first_inner_cutout_x(primitives: &[DrawPrimitive]) -> Option<f32> {
 }
 
 #[test]
+fn draw_commands_chained_before_the_graphics_layer_are_outer() {
+    let _app_context = crate::render_state::app_context_test_scope();
+    let shape = LayerShape::Rounded(RoundedCornerShape::uniform(8.0));
+    let modifier = Modifier::empty()
+        .drop_shadow(shape, |_| {})
+        .graphics_layer(|| GraphicsLayer {
+            clip: true,
+            ..Default::default()
+        })
+        .background(Color(1.0, 0.0, 0.0, 1.0));
+    let slices = collect_slices_from_modifier(&modifier);
+
+    assert_eq!(slices.draw_commands().len(), 2);
+    assert_eq!(
+        slices.outer_draw_command_count(),
+        1,
+        "the shadow precedes the layer and draws around it; the background follows it and is \
+         clipped by it"
+    );
+
+    let inner_only = collect_slices_from_modifier(
+        &Modifier::empty()
+            .graphics_layer(|| GraphicsLayer {
+                clip: true,
+                ..Default::default()
+            })
+            .drop_shadow(shape, |_| {}),
+    );
+    assert_eq!(inner_only.outer_draw_command_count(), 0);
+
+    let background_before_clip = collect_slices_from_modifier(
+        &Modifier::empty()
+            .background(Color(1.0, 0.0, 0.0, 1.0))
+            .clip_to_bounds(),
+    );
+    assert_eq!(background_before_clip.outer_draw_command_count(), 1);
+    assert_eq!(
+        collect_slices_from_modifier(&Modifier::empty().drop_shadow(shape, |_| {}))
+            .outer_draw_command_count(),
+        0,
+        "without a layer or clip nothing is outer"
+    );
+}
+
+#[test]
 fn drop_shadow_cutout_knocks_element_shape_out_of_silhouette() {
     let _app_context = crate::render_state::app_context_test_scope();
     let modifier = Modifier::empty().drop_shadow_value(

--- a/crates/cranpose-ui/src/modifier/tests/modifier_tests.rs
+++ b/crates/cranpose-ui/src/modifier/tests/modifier_tests.rs
@@ -1052,6 +1052,71 @@ fn first_inner_cutout_x(primitives: &[DrawPrimitive]) -> Option<f32> {
 }
 
 #[test]
+fn a_transform_layer_after_a_shaped_layer_keeps_the_shape() {
+    let _app_context = crate::render_state::app_context_test_scope();
+    let shape = LayerShape::Rounded(RoundedCornerShape::uniform(8.0));
+    let modifier = Modifier::empty()
+        .graphics_layer(move || GraphicsLayer {
+            clip: true,
+            shape,
+            ..Default::default()
+        })
+        .graphics_layer(|| GraphicsLayer {
+            scale_x: 1.2,
+            scale_y: 1.2,
+            ..Default::default()
+        });
+    let layer = collect_slices_from_modifier(&modifier)
+        .graphics_layer()
+        .expect("the stacked layers merge into one");
+    assert!(layer.clip);
+    assert_eq!(
+        layer.shape, shape,
+        "a later layer that declares no shape must not turn the clip rectangular"
+    );
+    assert_eq!(layer.scale_x, 1.2);
+
+    let glass_then_scale = collect_slices_from_modifier(
+        &Modifier::empty()
+            .graphics_layer(move || GraphicsLayer {
+                shape,
+                backdrop_effect: Some(RenderEffect::blur(4.0)),
+                ..Default::default()
+            })
+            .graphics_layer(|| GraphicsLayer {
+                scale: 1.1,
+                ..Default::default()
+            }),
+    )
+    .graphics_layer()
+    .expect("the stacked layers merge into one");
+    assert_eq!(
+        glass_then_scale.shape, shape,
+        "the layer carrying the backdrop keeps the shape its effect covers"
+    );
+
+    let reshaped = collect_slices_from_modifier(
+        &Modifier::empty()
+            .graphics_layer(move || GraphicsLayer {
+                shape,
+                ..Default::default()
+            })
+            .graphics_layer(|| GraphicsLayer {
+                clip: true,
+                shape: LayerShape::Rounded(RoundedCornerShape::uniform(2.0)),
+                ..Default::default()
+            }),
+    )
+    .graphics_layer()
+    .expect("the stacked layers merge into one");
+    assert_eq!(
+        reshaped.shape,
+        LayerShape::Rounded(RoundedCornerShape::uniform(2.0)),
+        "a later layer that declares a shape wins"
+    );
+}
+
+#[test]
 fn draw_commands_chained_before_the_graphics_layer_are_outer() {
     let _app_context = crate::render_state::app_context_test_scope();
     let shape = LayerShape::Rounded(RoundedCornerShape::uniform(8.0));

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -666,9 +666,10 @@ fn render_once(
             });
             let (width, height) = shell.buffer_size();
 
-            if let Err(e) = shell
-                .renderer()
-                .render_surface_texture(&view, width, height)
+            if let Err(e) =
+                shell
+                    .renderer()
+                    .render_surface_texture(&frame.texture, &view, width, height)
             {
                 log::error!("Render error: {:?}", e);
             }
@@ -1336,14 +1337,17 @@ fn create_android_surface_config(
     let desired_maximum_frame_latency = android_frame_latency(
         crate::android_frame_telemetry::system_property("debug.cranpose.frame_latency").as_deref(),
     );
+    let usage = cranpose_render_wgpu::presentable_root_usages(surface_caps.usages);
     log::info!(
-        "Android surface: supported present modes {:?}, selected {:?}, desired_maximum_frame_latency {}",
+        "Android surface: formats {:?}, usages {:?} (configured {usage:?}), supported present modes {:?}, selected {:?}, desired_maximum_frame_latency {}",
+        surface_caps.formats,
+        surface_caps.usages,
         surface_caps.present_modes,
         present_mode,
         desired_maximum_frame_latency,
     );
     Ok(wgpu::SurfaceConfiguration {
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        usage,
         format: surface_format,
         width,
         height,

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -32,7 +32,7 @@ fn property_flag(name: &str) -> bool {
     }
 }
 
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 56] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 57] = [
     ("debug.cranpose.root_direct", "CRANPOSE_ROOT_DIRECT_DIAG"),
     ("debug.cranpose.recomp_diag", "CRANPOSE_RECOMP_DIAG"),
     (
@@ -171,6 +171,10 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 56] = [
         "CRANPOSE_NO_BACKDROP_FLATTEN",
     ),
     ("debug.cranpose.no_deferred_run", "CRANPOSE_NO_DEFERRED_RUN"),
+    (
+        "debug.cranpose.no_shadow_composite_queue",
+        "CRANPOSE_NO_SHADOW_COMPOSITE_QUEUE",
+    ),
     (
         "debug.cranpose.survive_gpu_errors",
         "CRANPOSE_SURVIVE_GPU_ERRORS",

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -32,7 +32,7 @@ fn property_flag(name: &str) -> bool {
     }
 }
 
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 47] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 50] = [
     ("debug.cranpose.root_direct", "CRANPOSE_ROOT_DIRECT_DIAG"),
     ("debug.cranpose.recomp_diag", "CRANPOSE_RECOMP_DIAG"),
     (
@@ -41,6 +41,10 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 47] = [
     ),
     ("debug.cranpose.core_pin", "CRANPOSE_CORE_PIN"),
     ("debug.cranpose.gpu_stats", "CRANPOSE_GPU_STATS"),
+    (
+        "debug.cranpose.gpu_fence_profile",
+        "CRANPOSE_GPU_FENCE_PROFILE",
+    ),
     ("debug.cranpose.pass_timing", "CRANPOSE_GPU_PASS_TIMING"),
     (
         "debug.cranpose.composition_8bit",
@@ -89,6 +93,14 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 47] = [
         "CRANPOSE_SCENE_UPDATE_DIAG",
     ),
     ("debug.cranpose.backdrop_diag", "CRANPOSE_BACKDROP_DIAG"),
+    (
+        "debug.cranpose.no_underlay_bake",
+        "CRANPOSE_DISABLE_UNDERLAY_BAKE",
+    ),
+    (
+        "debug.cranpose.no_underlay_replay",
+        "CRANPOSE_DISABLE_UNDERLAY_REPLAY",
+    ),
     (
         "debug.cranpose.render_stage_ms",
         "CRANPOSE_WGPU_RENDER_STAGE_TELEMETRY_MS",

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -32,7 +32,7 @@ fn property_flag(name: &str) -> bool {
     }
 }
 
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 50] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 52] = [
     ("debug.cranpose.root_direct", "CRANPOSE_ROOT_DIRECT_DIAG"),
     ("debug.cranpose.recomp_diag", "CRANPOSE_RECOMP_DIAG"),
     (
@@ -153,6 +153,14 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 50] = [
         "CRANPOSE_PIPELINE_PREWARM",
     ),
     ("debug.cranpose.solid_trim", "CRANPOSE_SOLID_TRIM_VARYINGS"),
+    (
+        "debug.cranpose.uniform_gradient_stops",
+        "CRANPOSE_UNIFORM_GRADIENT_STOPS",
+    ),
+    (
+        "debug.cranpose.no_shader_specialization",
+        "CRANPOSE_NO_SHADER_SPECIALIZATION",
+    ),
     (
         "debug.cranpose.survive_gpu_errors",
         "CRANPOSE_SURVIVE_GPU_ERRORS",

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -32,7 +32,7 @@ fn property_flag(name: &str) -> bool {
     }
 }
 
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 55] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 56] = [
     ("debug.cranpose.root_direct", "CRANPOSE_ROOT_DIRECT_DIAG"),
     ("debug.cranpose.recomp_diag", "CRANPOSE_RECOMP_DIAG"),
     (

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -32,7 +32,7 @@ fn property_flag(name: &str) -> bool {
     }
 }
 
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 54] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 55] = [
     ("debug.cranpose.root_direct", "CRANPOSE_ROOT_DIRECT_DIAG"),
     ("debug.cranpose.recomp_diag", "CRANPOSE_RECOMP_DIAG"),
     (
@@ -166,6 +166,11 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 54] = [
         "debug.cranpose.no_direct_surface",
         "CRANPOSE_NO_DIRECT_SURFACE",
     ),
+    (
+        "debug.cranpose.no_backdrop_flatten",
+        "CRANPOSE_NO_BACKDROP_FLATTEN",
+    ),
+    ("debug.cranpose.no_deferred_run", "CRANPOSE_NO_DEFERRED_RUN"),
     (
         "debug.cranpose.survive_gpu_errors",
         "CRANPOSE_SURVIVE_GPU_ERRORS",

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -32,7 +32,7 @@ fn property_flag(name: &str) -> bool {
     }
 }
 
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 52] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 53] = [
     ("debug.cranpose.root_direct", "CRANPOSE_ROOT_DIRECT_DIAG"),
     ("debug.cranpose.recomp_diag", "CRANPOSE_RECOMP_DIAG"),
     (
@@ -161,6 +161,7 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 52] = [
         "debug.cranpose.no_shader_specialization",
         "CRANPOSE_NO_SHADER_SPECIALIZATION",
     ),
+    ("debug.cranpose.keep_box4", "CRANPOSE_KEEP_BOX4"),
     (
         "debug.cranpose.survive_gpu_errors",
         "CRANPOSE_SURVIVE_GPU_ERRORS",

--- a/crates/cranpose/src/android_frame_telemetry.rs
+++ b/crates/cranpose/src/android_frame_telemetry.rs
@@ -32,7 +32,7 @@ fn property_flag(name: &str) -> bool {
     }
 }
 
-const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 53] = [
+const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 54] = [
     ("debug.cranpose.root_direct", "CRANPOSE_ROOT_DIRECT_DIAG"),
     ("debug.cranpose.recomp_diag", "CRANPOSE_RECOMP_DIAG"),
     (
@@ -162,6 +162,10 @@ const PROPERTY_BACKED_ENV_VARS: [(&str, &str); 53] = [
         "CRANPOSE_NO_SHADER_SPECIALIZATION",
     ),
     ("debug.cranpose.keep_box4", "CRANPOSE_KEEP_BOX4"),
+    (
+        "debug.cranpose.no_direct_surface",
+        "CRANPOSE_NO_DIRECT_SURFACE",
+    ),
     (
         "debug.cranpose.survive_gpu_errors",
         "CRANPOSE_SURVIVE_GPU_ERRORS",

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -2603,6 +2603,7 @@ impl App {
             ..Default::default()
         });
         if let Err(error) = native.app.renderer().render_surface_texture(
+            &output.texture,
             &view,
             native.surface_config.width,
             native.surface_config.height,
@@ -4693,6 +4694,7 @@ impl ApplicationHandler for App {
                     });
 
                     if let Err(err) = app.renderer().render_surface_texture(
+                        &output.texture,
                         &view,
                         surface_config.width,
                         surface_config.height,

--- a/crates/cranpose/src/ios.rs
+++ b/crates/cranpose/src/ios.rs
@@ -234,9 +234,10 @@ impl<F: FnMut() + 'static> IosApp<F> {
                     ..Default::default()
                 });
                 let (width, height) = shell.buffer_size();
-                if let Err(error) = shell
-                    .renderer()
-                    .render_surface_texture(&view, width, height)
+                if let Err(error) =
+                    shell
+                        .renderer()
+                        .render_surface_texture(&frame.texture, &view, width, height)
                 {
                     log::error!("iOS render error: {error:?}");
                 }

--- a/crates/cranpose/src/web.rs
+++ b/crates/cranpose/src/web.rs
@@ -860,6 +860,7 @@ pub async fn run(
                     {
                         let mut app_mut = app.borrow_mut();
                         if let Err(err) = app_mut.renderer().render_surface_texture(
+                            &output.texture,
                             &view,
                             render_width,
                             render_height,

--- a/scripts/ci/with_host_lock.sh
+++ b/scripts/ci/with_host_lock.sh
@@ -7,6 +7,14 @@ set -euo pipefail
 #   --shared     a build. Any number may hold this at once.
 #   --exclusive  a measurement. One at a time, and no build while it runs.
 #
+# The wrapper is reentrant: a command that already runs under a lock which
+# covers the requested mode (shared under shared or exclusive, exclusive
+# under exclusive) runs directly. A nested take would otherwise queue behind
+# the turnstile an exclusive waiter holds while it waits for the outer
+# holder, and the two would wait for each other until the job timeout, which
+# is how `just budgets` (shared) calling `size-budget` (shared) parked the
+# architecture-budgets job for 45 minutes beside a queued robot suite.
+#
 # One Linux machine serves every `[self-hosted, Linux, cranpose-heavy]` job.
 # Two runners are registered on it, so two heavy jobs land there at once, and
 # a heavy job here means twelve rustc processes. The robot suite's per-frame
@@ -71,6 +79,10 @@ if ! host_capacity_lock_available; then
   echo "with_host_lock: no flock on this host; running without the $mode lock"
   exec "$@"
 fi
+if [[ "${CRANPOSE_HOST_LOCK_HELD:-}" == "exclusive" || ( "${CRANPOSE_HOST_LOCK_HELD:-}" == "shared" && "$mode" == "shared" ) ]]; then
+  echo "with_host_lock: already inside the $CRANPOSE_HOST_LOCK_HELD lock; running the nested $mode command under it"
+  exec "$@"
+fi
 
 # Before the lock fd below exists, not after: this wrapper's whole job is to
 # run a build (`--shared`) or a measurement (`--exclusive`) underneath it,
@@ -117,4 +129,4 @@ fi
 # 8) closed in that CHILD ONLY -- so nothing it spawns, sccache's daemon
 # included, can inherit a copy either -- while this process keeps fd 9 open
 # until the child actually exits, then exits with its status.
-"$@" 7>&- 8>&- 9>&-
+CRANPOSE_HOST_LOCK_HELD="$mode" "$@" 7>&- 8>&- 9>&-

--- a/scripts/ci/with_host_lock_test.sh
+++ b/scripts/ci/with_host_lock_test.sh
@@ -234,6 +234,30 @@ case_writer_is_not_starved_by_a_reader_stream() {
 
 # --- run -------------------------------------------------------------------
 
+case_nested_shared_take_inside_a_shared_holder_does_not_wait_for_a_queued_exclusive() {
+    local max_secs=4 elapsed
+    local started=$SECONDS
+    with_lock --shared bash -c '
+        "$0" --exclusive true &
+        sleep 1
+        "$0" --shared true
+    ' "$WITH_HOST_LOCK" &
+    local holder_pid=$!
+    local acquired=1
+    wait "$holder_pid" || acquired=0
+    elapsed=$((SECONDS - started))
+    if [ "$acquired" = 0 ]; then
+        fail "a nested shared take inside a shared holder does not deadlock behind a queued exclusive" \
+            "the nested take failed after ${elapsed}s" \
+            "the exclusive waiter holds the turnstile until the outer holder releases, and the outer holder waits on the nested take"
+    elif [ "$elapsed" -le "$max_secs" ]; then
+        pass "a nested shared take inside a shared holder does not deadlock behind a queued exclusive (${elapsed}s)"
+    else
+        fail "a nested shared take inside a shared holder does not deadlock behind a queued exclusive" \
+            "took ${elapsed}s, over the ${max_secs}s bound"
+    fi
+}
+
 echo "host lock suite: locks under $SCRATCH_DIR"
 
 case_default_paths
@@ -243,6 +267,7 @@ if command -v flock >/dev/null 2>&1; then
     case_lock_lands_on_the_overridden_file
     case_exclusive_waits_for_a_shared_holder
     case_writer_is_not_starved_by_a_reader_stream
+    case_nested_shared_take_inside_a_shared_holder_does_not_wait_for_a_queued_exclusive
 else
     skip "the lock cases" "no flock(1) on this host, so the wrapper runs unlocked here"
 fi


### PR DESCRIPTION
## Why

The showcase list screen on the Mate 20 X (Mali-G76) spent its frame on render passes, not pixels: each glass card flushed the root target's pending composites just to read its own backdrop back, and every card's content split into several small passes around its children. On that GPU a pass costs ~0.3 ms whatever it draws, and a frame carried 37-58 of them.

## What

- **Underlay replay** (`c576ad35`): a child that bakes an underlay draws the overlapping pending composites into its underlay copy, shifted by the copy's whole-pixel origin, and leaves them queued for the parent's batch. Same blend on the same pixels; the unconditional flushes ahead of such children are gone. Kill switch `CRANPOSE_DISABLE_UNDERLAY_REPLAY` / `debug.cranpose.no_underlay_replay`.
- **Materialized effects** for those children: replay and root composite are two blits of one effect result; a cache hit runs no shader.
- **Backdrop fold removed**: it lacked the effect's input padding and failed its own parity; the replay covers it.
- **Deferred direct ranges** (`dd396a87`): inside a surface the ops before a child accumulate until a child reads the target (capture, nested underlay, shadows, layer events) or the tail, then render once with the composites queued in between, ordered by z. The nested loop's cross-flushes between its blit and shader queues are gone.
- Earlier on this branch: the cold-render glass oracle for the scroll robot test, the unrewarded-store admission ledger, idle-only warmup frames, per-kind cache stats.

## Instruments

`FrameStatsSnapshot::pass_pixels` (tile traffic), `hit_by_kind`/`pass_px` on the GPU stats line, `CRANPOSE_GPU_FENCE_PROFILE` (per-frame pass inventory by label, target and load op for adapters without timestamp queries; its times are isolated latencies, see TIME_WASTERS), and backdrop-diag lines for the capture-flush decision, shadow flushes and prefix-snapshot bail reasons.

## Tests

- `underlay_replay_parity`: blur cards bit-exact, glass cards within one LSB on a sparse few samples of the moved viewport, pass pixels drop by at least one full-target pass net of the card-sized replays. Red with the replay draw disabled.
- `nested_composite_order`: a red rect, a half-transparent isolated child and a blue rect, with and without a blur backdrop child between them, checked at absolute colors. Red when the helper flushes composites ahead of the deferred ops.
- `render_contract` updated to the shared underlay helper.

## Measured (Mate 20 X, back-to-back runs)

| | before | after |
|---|---|---|
| idle list, quiet frame passes | 37 | 27 |
| idle list, star-step frame passes | 58 | 47 |
| idle present p50 | 41 ms | 35 ms |
| pass pixels per frame | 32 MP | 21 MP |
| scroll | 14.3 fps | 15.4 fps |

The presented rate on the idle screen is capped by the showcase's stepped animations (planets 20 Hz, stars 5-10 Hz), so 60 fps only means scrolling there, where a frame still shades ~3 MP of liquid glass and recaptures a 2.3 MP prefix; those are the next levers and both change what is drawn, so they need a decision.

## Second round: what the fragment stage and the passes were wasting

- **Gradient stops as flat varyings** (`c6f6fda4`): up to four stops travel from the vertex stage instead of a per-fragment walk over a dynamically indexed uniform array. Byte-exact against the walk (`gradient_stop_varyings_parity`, `CRANPOSE_UNIFORM_GRADIENT_STOPS`); about 3 ms off an 11 ms full-screen radial on Mali, where a flat varying fetch costs what a uniform load did.
- **Glass pipeline specialized per material** (`bea949d9`): `liquid_glass.wgsl` gates a dozen optional features on uniforms, and on Mali the inactive ones still held registers and fetched their uniforms per fragment; the showcase cards' four effect passes cost 47 ms isolated for a 19-tap material. Each gate is now an `override` that `specialize_liquid_glass` raises when the uniform holds the feature's inactive value, substituting exactly that value, so the specialized pipeline is byte-identical (`glass_specialization_parity`, `CRANPOSE_NO_SHADER_SPECIALIZATION`). The same passes cost 21 ms.
- **Box resolve lowered to one texel fetch** (`e10bd086`) where a pixel-stable composite maps destination pixels onto source texels one to one with integer origins, which is every snapped layer composite in the showcase; the 6x6 walk returned that texel unchanged (`box4_lowering_parity`, `CRANPOSE_KEEP_BOX4`). Root composite 14 -> 10 ms isolated.
- **Direct-surface root** (`b60025b0`): on Android the swapchain is Rgba8Unorm with sample and copy usages, the same bytes as the 8-bit composition target, so the output conversion pass was an identity copy of the screen. The frame renders into the presentable image when its format equals the composition format and it carries the capture usages (`presentable_root_usages` asks the surface for them); `direct_surface_root_parity` holds the two byte-identical and pins the dropped pass (`CRANPOSE_NO_DIRECT_SURFACE`). Every render entry now takes the texture with its view.

| Mate 20 X, scroll | fps |
|---|---|
| after the first round | 14.3 |
| + glass specialization | 18.5 |
| + box resolve lowering | 19.9 |
| + direct-surface root | 20.0 |

Per-pass inventory (`debug.cranpose.gpu_fence_profile 1`, isolated ms per frame): 158.6 -> 114.8. The remaining frame is the glass effect passes (~33), three root full-screen passes (~30), each card's own surface passes (~24) and blurs (~10); flattening the card surfaces into the root pass is the next structural change.

## Third round: outer draws, flattened cards, deferred root run

- **Draw modifiers before a graphics layer draw outside it** (`5af90ba1`). A `drop_shadow` chained before `graphics_layer(clip)` was lowered inside the clipped layer, so every clipped glass surface's shadow was masked away. Modifier slices now record the outer draw count; the scene builder wraps the node's layer in a synthetic layer (`LayerNode.wraps`) holding those draws at the layout placement. Guarded by `glass_shadow_outside_clip`, slice/wrapper unit tests, and a scroll fast-path test for wrapped rows.
- **Backdrop layers flatten into their parent.** A glass card whose only reason to isolate is its backdrop draws its content straight into the page when nothing rect-clipped enters the rounded clip's corner squares. Blurred drop shadows it brings along are masked with the card's rounded clip through the composite pipeline (`ShadowDraw.rounded_clip`); a bare backdrop child renders no surface at all. Parity is checked against the same content placed as siblings (max delta 0) and a corner-hugging shadow against the no-button frame (corner triangles delta 0). Kill switch `CRANPOSE_NO_BACKDROP_FLATTEN` / `debug.cranpose.no_backdrop_flatten`.
- **The root walk defers direct ranges.** Direct draw ops between child composites no longer force one fused pass per child; they stay pending with the composites and flush only when a capture depends on them, before an immediate draw, or at the end. Two red-first guards: a draw under a later glass is captured (red without the dependency check), and draws between non-overlapping glasses share one pass (red when eager). A third guard covers a glass whose only pending op is its own shadow. Kill switch `CRANPOSE_NO_DEFERRED_RUN` / `debug.cranpose.no_deferred_run`.

## Fourth round: shadows as pending composites, cards that actually flatten

- **Blurred drop shadows are pending composites.** A card's shadow was a direct draw op its own capture depended on, so the deferred root run flushed into the full target once per card. The walk now prepares each cacheable blurred drop shadow (rendering it into the shadow cache when it is not resident) and queues its bands as pending composites at the op's z, excluded from the segment draws and from the run's dependency bounds; captures replay them into their copies. Guards: `drop_shadows_under_a_column_of_glass_cards_ride_the_frames_fused_pass` (6 vs 4 passes before), `a_shadow_composited_from_its_cache_matches_the_shadow_drawn_in_the_segment` (pinned direct path via `CRANPOSE_NO_SHADOW_COMPOSITE_QUEUE`, max delta <= 1).
- **Stacked graphics layers keep their shape.** `merge_graphics_layers` took the later layer's shape unconditionally, so the list row's press-scale layer after the icon's glass reported a rectangle (and a rounded clip followed by any transform layer went rectangular). The merged shape follows the layer that clips, else the one carrying the backdrop, else the later layer. Guard: `a_transform_layer_after_a_shaped_layer_keeps_the_shape`.
- **A nested glass near a corner no longer blocks flattening.** The predicate refused any nested backdrop whose padded capture rect entered a corner square or left the card. Its capture is clamped by the inherited visual clip exactly as a clipped sibling's is, so flattening is exact regardless of the reach. Guard: `a_nested_glass_whose_reach_enters_the_corner_cut_still_flattens_the_card_exactly` (40 px circle, 14 px from the edge, 26 px reach, delta 0 against the clipped sibling oracle).
- **Precise run dependencies.** The deferred run's dependency check tests each op's bounds instead of the union of the run. Guards: `a_glass_between_two_direct_draws_it_does_not_cover_leaves_them_in_the_fused_pass` (9 vs 8 before), `a_glass_over_one_of_two_direct_draws_still_captures_it`.
- **Runtime-shader layers cache their effect output.** Flattening exposed a card's runtime-shader child as a root child, and effects containing a runtime shader were never cached, so it re-ran every frame (`robot_nested_glass_cache`). Every input of a runtime shader is in the layer cache key, so only backdrop-reading effects stay uncached. Guard: `a_runtime_shader_layer_with_stable_uniforms_is_served_from_the_layer_cache`; the robot runner allows one settle tick after a toggle (a runtime-shader subtree is admitted on the repeated key) and asserts the pass budget and pixel contracts.
- **Reentrant host lock wrapper.** `just budgets` (shared) calling `size-budget` (shared) parked the architecture-budgets job for 45 minutes beside a queued robot suite: the exclusive waiter holds the turnstile the nested shared take must pass, while it waits for the outer holder. The wrapper exports the held mode and runs a covered nested command directly. Guard in `with_host_lock_test.sh` (red on samarch-1 before, green after).
- **Ordered pass log.** `[wgpu-render-stage:submit]` (Android: `debug.cranpose.render_stage_ms 0`) now lists render passes in frame order with target size and load op.

Phone (Mate 20 X, list scroll, steady windows): the visible outer shadows from the third round had cost 20 -> 16.5 fps; this round takes the frame from 56 to 30 passes and 16.5 -> 24.4 fps, with the GPU clock no longer parked at 490 MHz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

