### PR TITLE
Allow two queued frames for desktop VSync

### DIFF
--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -7,6 +7,7 @@
 - Put Android measurement details in [device measurement](docs/device_measurement.md).
 - Put experiment results in [mobile performance evidence](docs/mobile_watch_performance.md), with one conclusion and evidence link per row.
 - Fix Cargo output discovery in [#618](https://github.com/samoylenkodmitry/Cranpose/issues/618).
+- Deduplicate nested Cargo targets during GC in [#622](https://github.com/samoylenkodmitry/Cranpose/issues/622).
 - Version the Android measurement tools in [#619](https://github.com/samoylenkodmitry/Cranpose/issues/619).
 - Track macOS FPS limits in [#505](https://github.com/samoylenkodmitry/Cranpose/issues/505).
 - Track repeated robot scroll input in [#544](https://github.com/samoylenkodmitry/Cranpose/issues/544).

--- a/crates/cranpose-render/wgpu/tests/queued_surface_frames.rs
+++ b/crates/cranpose-render/wgpu/tests/queued_surface_frames.rs
@@ -1,0 +1,94 @@
+mod support;
+
+use cranpose_render_common::{Renderer, graph::RenderGraph};
+use cranpose_ui_graphics::{Color, Rect};
+
+const WIDTH: u32 = 128;
+const HEIGHT: u32 = 96;
+const FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+
+fn frame_graph(index: usize) -> RenderGraph {
+    let bounds = Rect {
+        x: 0.0,
+        y: 0.0,
+        width: WIDTH as f32,
+        height: HEIGHT as f32,
+    };
+    RenderGraph::new(support::layer_node(
+        Some(71),
+        WIDTH as f32,
+        HEIGHT as f32,
+        vec![
+            support::rect_primitive(bounds, Color::BLACK),
+            support::rect_primitive(
+                Rect {
+                    x: 8.0 + index as f32 * 9.0,
+                    y: 16.0,
+                    width: 24.0,
+                    height: 48.0,
+                },
+                if index.is_multiple_of(2) {
+                    Color::RED
+                } else {
+                    Color::BLUE
+                },
+            ),
+        ],
+    ))
+}
+
+#[test]
+fn queued_surface_images_keep_their_own_complete_frame_after_image_reuse() {
+    let (_lock, mut renderer) = support::headless_renderer_parts_with_display_format(FORMAT)
+        .expect("queued surface guard requires a GPU adapter");
+    let device = renderer.try_device().expect("device").clone();
+    let queue = renderer.try_queue_for_tests().expect("queue").clone();
+    let target = || {
+        support::render_target(
+            &device,
+            WIDTH,
+            HEIGHT,
+            FORMAT,
+            wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST,
+        )
+    };
+    let images: Vec<_> = (0..3).map(|_| target()).collect();
+    let mut snapshots = Vec::new();
+    for index in 0..9 {
+        renderer.scene_mut().graph = Some(frame_graph(index));
+        let (texture, view) = &images[index % images.len()];
+        renderer
+            .render_surface_texture(texture, view, WIDTH, HEIGHT)
+            .expect("queued surface render");
+        let (snapshot, _) = target();
+        let mut encoder = device.create_command_encoder(&Default::default());
+        encoder.copy_texture_to_texture(
+            texture.as_image_copy(),
+            snapshot.as_image_copy(),
+            texture.size(),
+        );
+        queue.submit([encoder.finish()]);
+        snapshots.push(snapshot);
+    }
+    for (index, snapshot) in snapshots.iter().enumerate() {
+        let presented = support::read_texture(&device, &queue, snapshot);
+        renderer.scene_mut().graph = Some(frame_graph(index));
+        let expected = renderer.capture_frame(WIDTH, HEIGHT).expect("serial frame");
+        assert!(expected.pixels.as_chunks::<4>().0.iter().any(|pixel| {
+            if index.is_multiple_of(2) {
+                pixel[0] > 240 && pixel[2] < 10
+            } else {
+                pixel[2] > 240 && pixel[0] < 10
+            }
+        }));
+        support::assert_same_bytes(
+            &format!("queued surface frame {index}"),
+            WIDTH,
+            &presented,
+            &expected.pixels,
+        );
+    }
+    assert_eq!(renderer.device_error_count_for_tests(), 0);
+}

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -2781,8 +2781,8 @@ fn log_desktop_present_mode(
 
 fn desired_frame_latency(mode: FramePacingMode) -> u32 {
     match mode {
-        FramePacingMode::Vsync | FramePacingMode::Hard60 | FramePacingMode::Hard120 => 1,
-        FramePacingMode::NoVsync => 2,
+        FramePacingMode::Vsync | FramePacingMode::NoVsync => 2,
+        FramePacingMode::Hard60 | FramePacingMode::Hard120 => 1,
     }
 }
 

--- a/docs/desktop_vsync_performance.md
+++ b/docs/desktop_vsync_performance.md
@@ -1,0 +1,16 @@
+# Desktop VSync
+
+- Two queued VSync frames allow CPU and GPU work to overlap; a one-frame queue serializes them on Metal.
+
+| App and device | Main FPS | SOTA FPS | Change |
+| --- | ---: | ---: | ---: |
+| LeetCodeDaily · M3 Pro · 60 Hz | 43.95 | 59.76 | +36.0% |
+
+- Protocol: identical app sources, assets and release profile; ABAB BABA; eight 20-second runs with 1,200 scroll inputs each and no cooling waits.
+- Route: 960 logical pixels inside scroll bounds; all returns differ by less than 0.001 pixels and all checked endpoint bodies match exactly.
+- Guard: nine changing frames across three reused output images; suppressing later surface renders fails at frame 1; restored rendering passes on Metal and Vulkan.
+- Footage: [main](https://github.com/user-attachments/assets/01df0b92-7d85-4081-b451-7721e69b66d1) and [SOTA](https://github.com/user-attachments/assets/dc4dd965-0f82-48ac-8f17-110979e8afc2); 1,161 robot readbacks checked separately from FPS measurements.
+- Runs, endpoints and thermal snapshots: [legs 1–4](https://github.com/user-attachments/files/31928040/fps-v116-endpoints-1.zip), [legs 5–8](https://github.com/user-attachments/files/31928039/fps-v116-endpoints-2.zip); CPU temperature unavailable, battery sensors retained as raw readings.
+- Source inventories, build hashes, red/green logs, frame analysis and reproduction scripts: [measurement data](https://github.com/user-attachments/files/31928167/fps-v116-measurement-data.zip).
+- Validation: 4,874 tests, 163 GPU robots and four screenshot robots pass; clippy and precommit pass; [logs and source hashes](https://github.com/user-attachments/files/31928377/fps-v116-verification.zip).
+- Tradeoff: one additional pending frame is permitted; input-to-photon latency is unmeasured; explicit Hard60/Hard120 modes keep a one-frame queue.

--- a/docs/render_verification.md
+++ b/docs/render_verification.md
@@ -1,5 +1,7 @@
 # Render verification
 
+- Keep measured wheel routes inside scroll bounds; elastic overscroll consumes reverse input, so verify the actual start and return positions.
+
 ## Harness and capture
 
 - Start from [robot testing](ROBOT_TESTING.md); run placement-sensitive runners through `run_robot_test.sh`.


### PR DESCRIPTION
Allow two queued desktop VSync frames so CPU preparation overlaps GPU rendering instead of missing display refreshes on Metal.

| App / device | Main FPS | SOTA FPS | Change |
| --- | ---: | ---: | ---: |
| LeetCodeDaily · M3 Pro · 60 Hz | 43.95 | 59.76 | +36.0% |

- ABAB BABA; identical app, data and release profile; eight 20-second runs with 1,200 inputs each.
- Nine-frame GPU guard proven red/green; 1,161 recorded frames checked; all measured endpoint bodies match exactly.
- One additional frame may queue; input-to-photon latency is unmeasured; Hard60/Hard120 retain their existing queue depth.
- [Measurements, source hashes and frame analysis](https://github.com/user-attachments/files/31928167/fps-v116-measurement-data.zip) · [legs 1–4](https://github.com/user-attachments/files/31928040/fps-v116-endpoints-1.zip) · [legs 5–8](https://github.com/user-attachments/files/31928039/fps-v116-endpoints-2.zip).
- Validation: 4,874 tests, 163 GPU robots and four screenshot robots pass; clippy and precommit pass with zero warnings; [logs and source hashes](https://github.com/user-attachments/files/31928377/fps-v116-verification.zip).
