### PR TITLE
Fix Android accessibility tree updates after reconnect

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,6 +93,10 @@ jobs:
         # before the heavy job ever spends a build on it.
         run: just test-robot-discovery
 
+      - name: Test Android robot result validation
+        if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
+        run: just test-android-accessibility-contract
+
       - name: Test the shell helpers
         if: ${{ !cancelled() && steps.provision.conclusion == 'success' }}
         run: just test-shell-helpers

--- a/TIME_WASTERS.md
+++ b/TIME_WASTERS.md
@@ -6,9 +6,3 @@
 - Put robot and image-check details in [render verification](docs/render_verification.md).
 - Put Android measurement details in [device measurement](docs/device_measurement.md).
 - Put experiment results in [mobile performance evidence](docs/mobile_watch_performance.md), with one conclusion and evidence link per row.
-- Fix Cargo output discovery in [#618](https://github.com/samoylenkodmitry/Cranpose/issues/618).
-- Deduplicate nested Cargo targets during GC in [#622](https://github.com/samoylenkodmitry/Cranpose/issues/622).
-- Version the Android measurement tools in [#619](https://github.com/samoylenkodmitry/Cranpose/issues/619).
-- Track macOS FPS limits in [#505](https://github.com/samoylenkodmitry/Cranpose/issues/505).
-- Track repeated robot scroll input in [#544](https://github.com/samoylenkodmitry/Cranpose/issues/544).
-- Track Android scroll cost in [#500](https://github.com/samoylenkodmitry/Cranpose/issues/500).

--- a/apps/android-demo/android/app/build.gradle.kts
+++ b/apps/android-demo/android/app/build.gradle.kts
@@ -33,6 +33,7 @@ cranpose {
 android {
     namespace = "com.compose_rs.demo"
     compileSdk = 36
+    testBuildType = "release"
 
     defaultConfig {
         applicationId = "com.compose_rs.demo"
@@ -45,6 +46,9 @@ android {
 
     buildTypes {
         release {
+            if (providers.gradleProperty("cranposeRobot").orNull == "true") {
+                applicationIdSuffix = ".robot"
+            }
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/apps/android-demo/android/app/src/androidTest/java/com/compose_rs/demo/CranposeAccessibilityNavigationTest.java
+++ b/apps/android-demo/android/app/src/androidTest/java/com/compose_rs/demo/CranposeAccessibilityNavigationTest.java
@@ -1,0 +1,131 @@
+package com.compose_rs.demo;
+
+import android.app.Instrumentation;
+import android.app.UiAutomation;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.Color;
+import android.graphics.Rect;
+import android.os.SystemClock;
+import android.view.MotionEvent;
+import android.view.accessibility.AccessibilityManager;
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import dev.cranpose.android.CranposeActivity;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public final class CranposeAccessibilityNavigationTest {
+    private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+
+    @Test
+    public void reconnectPublishesThePageRenderedWhileAccessibilityWasDisabled() throws Exception {
+        UiAutomation automation = instrumentation.getUiAutomation();
+        Context context = instrumentation.getTargetContext();
+        try (ActivityScenario<CranposeActivity> scenario = launchScreen()) {
+            Rect target = awaitPage(automation, "Library page", "Settings page");
+            automation = instrumentation.getUiAutomation(UiAutomation.FLAG_DONT_USE_ACCESSIBILITY);
+            awaitAccessibilityDisabled(context);
+            tap(target.centerX(), target.centerY());
+            SystemClock.sleep(500);
+            Bitmap frame = automation.takeScreenshot();
+            assertNotNull("The rendered page must be captured", frame);
+            try {
+                int background = frame.getPixel(frame.getWidth() / 2, frame.getHeight() / 4);
+                assertTrue("Settings must render green before its hierarchy is checked",
+                        Color.green(background) > 240 && Color.blue(background) < 15);
+            } finally {
+                frame.recycle();
+            }
+            automation = instrumentation.getUiAutomation();
+            awaitPage(automation, "Settings page", "Library page");
+        }
+    }
+
+    @Test
+    public void connectedAccessibilityTracksPageChangesInBothDirections() {
+        UiAutomation automation = instrumentation.getUiAutomation();
+        try (ActivityScenario<CranposeActivity> scenario = launchScreen()) {
+            for (String expected : new String[] {"Settings page", "Library page"}) {
+                String previous = expected.equals("Settings page") ? "Library page" : "Settings page";
+                Rect target = awaitPage(automation, previous, expected);
+                tap(target.centerX(), target.centerY());
+                awaitPage(automation, expected, previous);
+            }
+        }
+    }
+
+    private ActivityScenario<CranposeActivity> launchScreen() {
+        Intent intent = new Intent(instrumentation.getTargetContext(), CranposeActivity.class)
+                .putExtra("test_screen", "accessibility_navigation");
+        ActivityScenario<CranposeActivity> scenario = ActivityScenario.launch(intent);
+        scenario.onActivity(activity -> activity.cranposeSetKeepScreenOn(true));
+        return scenario;
+    }
+
+    private static void awaitAccessibilityDisabled(Context context) {
+        AccessibilityManager manager = context.getSystemService(AccessibilityManager.class);
+        long deadline = SystemClock.uptimeMillis() + 3000;
+        while (manager.isEnabled() && SystemClock.uptimeMillis() < deadline) {
+            SystemClock.sleep(25);
+        }
+        assertFalse("The test must navigate with accessibility disconnected", manager.isEnabled());
+    }
+
+    private Rect awaitPage(UiAutomation automation, String expected, String absent) {
+        long deadline = SystemClock.uptimeMillis() + 3000;
+        List<String> labels = new ArrayList<>();
+        do {
+            labels.clear();
+            AccessibilityNodeInfo root = automation.getRootInActiveWindow();
+            Rect bounds = visit(root, expected, labels);
+            if (bounds != null && !labels.contains(absent)) return bounds;
+            SystemClock.sleep(50);
+        } while (SystemClock.uptimeMillis() < deadline);
+        throw new AssertionError("Expected " + expected + " without " + absent + "; hierarchy=" + labels);
+    }
+
+    private static Rect visit(AccessibilityNodeInfo node, String expected, List<String> labels) {
+        if (node == null) return null;
+        Rect found = null;
+        CharSequence description = node.getContentDescription();
+        String label = description == null ? "" : description.toString();
+        labels.add(label);
+        if (label.equals(expected)) {
+            Rect bounds = new Rect();
+            node.getBoundsInScreen(bounds);
+            if (!bounds.isEmpty()) found = bounds;
+        }
+        for (int index = 0; index < node.getChildCount(); index++) {
+            Rect child = visit(node.getChild(index), expected, labels);
+            if (child != null) found = child;
+        }
+        return found;
+    }
+
+    private void tap(float x, float y) {
+        long down = SystemClock.uptimeMillis();
+        for (int action : new int[] {MotionEvent.ACTION_DOWN, MotionEvent.ACTION_UP}) {
+            MotionEvent event = MotionEvent.obtain(down, SystemClock.uptimeMillis(), action, x, y, 0);
+            try {
+                instrumentation.sendPointerSync(event);
+            } finally {
+                event.recycle();
+            }
+        }
+    }
+}

--- a/apps/desktop-demo-platform/src/lib.rs
+++ b/apps/desktop-demo-platform/src/lib.rs
@@ -9,7 +9,7 @@ use cranpose::AppLauncher;
     all(feature = "web", target_arch = "wasm32", feature = "renderer-wgpu")
 ))]
 fn create_app() -> AppLauncher {
-    let dev_controls = cranpose::launch_args().string("test_screen") != Some("surface_prefix");
+    let dev_controls = cranpose::launch_args().string("test_screen").is_none();
     AppLauncher::new()
         .with_title("Cranpose Demo")
         .with_size(800, 600)
@@ -26,10 +26,14 @@ cranpose::android_main! {
 
 #[cfg(all(feature = "android", target_os = "android", feature = "renderer-wgpu"))]
 fn android_content() {
-    if cranpose::launch_args().string("test_screen") == Some("surface_prefix") {
-        desktop_demo::test_screens::surface_prefix_repro::SurfacePrefixReproScreen();
-    } else {
-        desktop_demo::app::combined_app();
+    match cranpose::launch_args().string("test_screen") {
+        Some("surface_prefix") => {
+            desktop_demo::test_screens::surface_prefix_repro::SurfacePrefixReproScreen();
+        }
+        Some("accessibility_navigation") => {
+            desktop_demo::test_screens::accessibility_navigation::AccessibilityNavigationScreen();
+        }
+        _ => desktop_demo::app::combined_app(),
     }
 }
 

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -967,3 +967,8 @@ required-features = ["desktop", "robot-app"]
 name = "robot_android_resume"
 path = "robot-runners/robot_android_resume.rs"
 required-features = ["desktop", "robot-app"]
+
+[[example]]
+name = "robot_glass_feed_wheel"
+path = "robot-runners/robot_glass_feed_wheel.rs"
+required-features = ["robot-app"]

--- a/apps/desktop-demo/robot-runners/perf_presentation_probe.rs
+++ b/apps/desktop-demo/robot-runners/perf_presentation_probe.rs
@@ -1,0 +1,164 @@
+use std::{cell::RefCell, thread, time::Duration};
+
+use cranpose::Robot;
+use cranpose_animation::{
+    infiniteRepeatable, rememberInfiniteTransition, AnimationSpec, RepeatMode, StartOffset,
+};
+use cranpose_app_shell::FpsStats;
+use cranpose_core::{rememberMutableStateOf, MutableState};
+use cranpose_ui::{composable, Box, BoxSpec, Color, Modifier};
+
+pub(super) const FINISH_HOOK: &str = "perf.finish_calibration";
+const SAMPLE_DURATION: Duration = Duration::from_secs(2);
+
+thread_local! {
+    static ACTIVE: RefCell<Option<MutableState<bool>>> = const { RefCell::new(None) };
+}
+
+pub(super) fn requested(min_fps: f32, max_p95_ms: f32, max_stalls: u32) -> bool {
+    min_fps > 0.0 || max_p95_ms > 0.0 || max_stalls != u32::MAX
+}
+
+pub(super) fn active(initial: bool) -> bool {
+    let state = rememberMutableStateOf(|| initial);
+    ACTIVE.with(|slot| *slot.borrow_mut() = Some(state));
+    state.get()
+}
+
+pub(super) fn finish() -> Result<Option<String>, String> {
+    ACTIVE.with(|slot| {
+        let state = slot
+            .borrow()
+            .ok_or("presentation probe is not initialized")?;
+        state.set(false);
+        Ok(None)
+    })
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn PresentationProbe() {
+    let transition = rememberInfiniteTransition("presentation_probe");
+    let pulse = transition.animateFloat(
+        0.0,
+        1.0,
+        infiniteRepeatable(
+            AnimationSpec::linear(1_379),
+            RepeatMode::Restart,
+            StartOffset::default(),
+        ),
+        "probe_color",
+    );
+    Box(
+        Modifier::empty().fill_max_size().background(Color(
+            0.1 + pulse.get() * 0.1,
+            0.12,
+            0.18,
+            1.0,
+        )),
+        BoxSpec::new(),
+        || {},
+    );
+}
+
+pub(super) fn content() {
+    PresentationProbe();
+}
+
+fn has_headroom(stats: FpsStats, min_fps: f32, max_p95_ms: f32, max_stalls: u32) -> bool {
+    stats.interval_count > 0
+        && stats.work_fps.is_finite()
+        && stats.work_fps > min_fps
+        && stats.work_p95_ms.is_finite()
+        && (max_p95_ms <= 0.0 || stats.work_p95_ms <= max_p95_ms)
+        && stats.work_stalled_50ms_frames <= max_stalls
+}
+
+pub(super) fn verify(
+    robot: &Robot,
+    min_fps: f32,
+    max_p95_ms: f32,
+    max_stalls: u32,
+) -> Result<(), String> {
+    robot.wait_for_present_frame()?;
+    thread::sleep(SAMPLE_DURATION);
+    let first = robot.screenshot()?;
+    robot.reset_fps_stats()?;
+    thread::sleep(SAMPLE_DURATION);
+    let stats = robot.fps_stats()?;
+    let render = robot
+        .get_render_stats()?
+        .ok_or("presentation probe did not render")?;
+    let rendered = render.submits > 0 && render.draw_calls > 0;
+    let last = robot.screenshot()?;
+    let changed =
+        first.width == last.width && first.height == last.height && first.pixels != last.pixels;
+    let accepted = rendered && changed && has_headroom(stats, min_fps, max_p95_ms, max_stalls);
+    println!(
+        "PERF_PRESENTATION_CALIBRATION cadence_fps={:.2} work_fps={:.2} work_p95_ms={:.2} intervals={} rendered={} changed={} min_fps={:.2} max_p95_ms={:.2} work_stalls={} max_stalls={} headroom={}",
+        stats.fps, stats.work_fps, stats.work_p95_ms, stats.interval_count,
+        rendered, changed, min_fps, max_p95_ms, stats.work_stalled_50ms_frames, max_stalls, accepted,
+    );
+    if !accepted {
+        return Err("cannot measure throughput: the animated single-quad presentation probe has no headroom for this budget; use --report-only to measure this surface's cadence".into());
+    }
+    robot.invoke_app_hook(FINISH_HOOK, "")?;
+    robot.wait_for_present_frame()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calibration_rejects_paced_empty_frames_before_gating_a_workload() {
+        let paced = FpsStats {
+            interval_count: 60,
+            work_fps: 60.0,
+            work_p95_ms: 16.67,
+            ..Default::default()
+        };
+        assert!(!has_headroom(paced, 120.0, 0.0, u32::MAX));
+        assert!(!has_headroom(paced, 0.0, 8.33, u32::MAX));
+        assert!(has_headroom(paced, 1.0, 0.0, u32::MAX));
+        assert!(!has_headroom(
+            FpsStats {
+                work_stalled_50ms_frames: 1,
+                ..paced
+            },
+            0.0,
+            0.0,
+            0
+        ));
+        assert!(!has_headroom(FpsStats::default(), 1.0, 0.0, u32::MAX));
+        assert!(!has_headroom(
+            FpsStats {
+                work_fps: f32::NAN,
+                ..paced
+            },
+            1.0,
+            0.0,
+            u32::MAX
+        ));
+        assert!(!has_headroom(
+            FpsStats {
+                work_p95_ms: f32::NAN,
+                ..paced
+            },
+            1.0,
+            0.0,
+            u32::MAX
+        ));
+        assert!(has_headroom(
+            FpsStats {
+                work_fps: 240.0,
+                work_p95_ms: 4.3,
+                ..paced
+            },
+            120.0,
+            8.33,
+            u32::MAX
+        ));
+    }
+}

--- a/apps/desktop-demo/robot-runners/robot_glass_feed_wheel.rs
+++ b/apps/desktop-demo/robot-runners/robot_glass_feed_wheel.rs
@@ -1,0 +1,93 @@
+mod robot_exit;
+mod robot_launch;
+
+use cranpose::{Robot, SemanticElement};
+use cranpose_testing::{changed_pixel_count_in_region, find_element_by_text_exact};
+use desktop_app::app::{self, DemoTab, GLASS_FEED_LIST_TAG};
+
+fn receipts(elements: &[SemanticElement]) -> Vec<(usize, f32)> {
+    fn collect(element: &SemanticElement, values: &mut Vec<(usize, f32)>) {
+        if let Some(index) = element
+            .text
+            .as_deref()
+            .and_then(|text| text.strip_prefix("Receipt #"))
+            .and_then(|text| text.split_whitespace().next())
+            .and_then(|index| index.parse().ok())
+        {
+            values.push((index, element.bounds.y));
+        }
+        for child in &element.children {
+            collect(child, values);
+        }
+    }
+    let mut values = Vec::new();
+    for element in elements {
+        collect(element, &mut values);
+    }
+    values.sort_by_key(|&(index, _)| index);
+    values.dedup_by_key(|value| value.0);
+    values
+}
+
+fn check_scroll(robot: &Robot) {
+    robot.wait_for_idle().expect("initial layout");
+    let semantics = robot.get_semantics().expect("initial semantics");
+    let viewport = find_element_by_text_exact(&semantics, GLASS_FEED_LIST_TAG)
+        .expect("Glass Feed viewport")
+        .bounds;
+    robot
+        .mouse_move(
+            viewport.x + viewport.width * 0.5,
+            viewport.y + viewport.height * 0.8,
+        )
+        .expect("hover the unobscured list");
+    let initial = receipts(&semantics);
+    assert!(initial.len() >= 2, "expected multiple receipt anchors");
+    let stride = (initial[1].1 - initial[0].1) / (initial[1].0 - initial[0].0) as f32;
+    assert!(stride > 0.0);
+    let region = (
+        viewport.x,
+        viewport.y + viewport.height * 0.5,
+        viewport.width,
+        viewport.height * 0.4,
+    );
+    let mut previous = robot.screenshot().expect("initial frame");
+    let mut expected_scroll = 0.0;
+    for (step, delta) in [-300.0, 300.0, -40.0, -1.0, -50.0, -77.0]
+        .into_iter()
+        .chain(std::iter::repeat_n(-50.0, 16))
+        .chain(std::iter::repeat_n(50.0, 16))
+        .enumerate()
+    {
+        robot.mouse_scroll(0.0, delta).expect("dispatch wheel");
+        robot.wait_for_idle().expect("settle wheel");
+        let frame = robot.screenshot().expect("wheel frame");
+        let anchors = receipts(&robot.get_semantics().expect("wheel semantics"));
+        let &(index, y) = anchors.first().expect("receipt anchor after wheel");
+        expected_scroll -= delta;
+        let observed_scroll = initial[0].1 + (index - initial[0].0) as f32 * stride - y;
+        let changed = changed_pixel_count_in_region(&previous, &frame, region, 0);
+        println!(
+            "wheel step={step} delta={delta} expected={expected_scroll} observed={observed_scroll} changed_pixels={changed}"
+        );
+        if (observed_scroll - expected_scroll).abs() > 0.1 || changed == 0 {
+            robot_exit::fail(
+                robot,
+                "wheel input did not move receipt geometry and pixels",
+            );
+        }
+        previous = frame;
+    }
+}
+
+fn main() {
+    env_logger::init();
+    robot_exit::arm_timeout(90);
+    robot_launch::launch("Glass Feed Wheel", 800, 800)
+        .with_test_driver(|robot| {
+            check_scroll(&robot);
+            println!("PASS: large, one-pixel and repeated wheel inputs move Glass Feed");
+            robot.exit().expect("exit");
+        })
+        .run(|| app::combined_app_with_initial_tab(Some(DemoTab::GlassFeed)));
+}

--- a/apps/desktop-demo/robot-runners/robot_perf_harness.rs
+++ b/apps/desktop-demo/robot-runners/robot_perf_harness.rs
@@ -1,4 +1,5 @@
 mod markdown_fixture_client;
+mod perf_presentation_probe;
 mod perf_robot_stats;
 
 use std::{
@@ -993,6 +994,74 @@ impl FpsPacingAccumulator {
     }
 }
 
+fn verify_presentation_budget(
+    robot: &cranpose::Robot,
+    scenario: PerfScenario,
+    min_fps: f32,
+    max_p95_frame_ms: f32,
+    max_50ms_stalls: u32,
+) {
+    let presentation = robot
+        .presentation_info()
+        .unwrap_or_else(|err| fatal(robot, err));
+    println!(
+        "PERF_PRESENTATION_SUMMARY scenario={} requested={:?} resolved={:?} supported={:?} pacing={} display_hz={:.3} configuration_unpaced={} work_includes_surface_acquire=true",
+        scenario.name(), presentation.requested_mode, presentation.present_mode,
+        presentation.supported_modes, presentation.frame_pacing_mode.label(),
+        presentation.refresh_rate_hz, presentation.uses_unpaced_configuration(),
+    );
+    if perf_presentation_probe::requested(min_fps, max_p95_frame_ms, max_50ms_stalls)
+        && !presentation.uses_unpaced_configuration()
+    {
+        fatal(robot, "cannot measure throughput: presentation or scheduling is VSync-limited; use --report-only to measure cadence");
+    }
+}
+
+#[composable]
+#[allow(non_snake_case)]
+fn PresentedPerfHarness(scenario: PerfScenario, calibrate: bool) {
+    if perf_presentation_probe::active(calibrate) {
+        perf_presentation_probe::content();
+    } else {
+        PerfHarnessApp(scenario);
+    }
+}
+
+fn perf_app_hook(name: String, _argument: String) -> Result<Option<String>, String> {
+    match name.as_str() {
+        LAZY_STATS_HOOK => Ok(lazy_summary_from_app_thread()),
+        perf_presentation_probe::FINISH_HOOK => perf_presentation_probe::finish(),
+        _ => Err(format!("unknown robot app hook: {name}")),
+    }
+}
+
+fn initialize_perf_scenario(
+    robot: &cranpose::Robot,
+    scenario: PerfScenario,
+    min_fps: f32,
+    max_p95_frame_ms: f32,
+    max_50ms_stalls: u32,
+) {
+    let calibrate = perf_presentation_probe::requested(min_fps, max_p95_frame_ms, max_50ms_stalls);
+    std::thread::sleep(Duration::from_millis(500));
+    if !calibrate {
+        wait_for_perf_idle(robot);
+    }
+    verify_presentation_budget(robot, scenario, min_fps, max_p95_frame_ms, max_50ms_stalls);
+    if calibrate {
+        if env_bool("CRANPOSE_HEADLESS", true) {
+            fatal(
+                robot,
+                "cannot measure GPU throughput through a hidden update-only host",
+            );
+        }
+        perf_presentation_probe::verify(robot, min_fps, max_p95_frame_ms, max_50ms_stalls)
+            .unwrap_or_else(|err| fatal(robot, err));
+        wait_for_perf_idle(robot);
+    }
+    prepare_perf_scenario(robot, scenario);
+}
+
 fn main() {
     env_logger::init();
     let scenario = PerfScenario::from_env();
@@ -1043,14 +1112,12 @@ fn main() {
         println!("50ms stall budget: <= {max_50ms_stalls}");
     }
 
+    let calibrate = perf_presentation_probe::requested(min_fps, max_p95_frame_ms, max_50ms_stalls);
     AppLauncher::new()
         .with_title(format!("Robot Perf Harness - {}", scenario.title()))
         .with_size(900, 700)
         .with_headless(env_bool("CRANPOSE_HEADLESS", true))
-        .with_robot_app_hook(|name, _argument| match name.as_str() {
-            LAZY_STATS_HOOK => Ok(lazy_summary_from_app_thread()),
-            _ => Err(format!("unknown robot app hook: {name}")),
-        })
+        .with_robot_app_hook(perf_app_hook)
         .with_test_driver(move |robot| {
             let timeout_secs = timeout_budget_secs(duration_secs, warmup_secs, timeout_slack_secs);
             std::thread::spawn(move || {
@@ -1059,9 +1126,7 @@ fn main() {
                 std::process::exit(1);
             });
 
-            std::thread::sleep(Duration::from_millis(500));
-            wait_for_perf_idle(&robot);
-            prepare_perf_scenario(&robot, scenario);
+            initialize_perf_scenario(&robot, scenario, min_fps, max_p95_frame_ms, max_50ms_stalls);
 
             let total_duration = Duration::from_secs(duration_secs + warmup_secs);
             let warmup_duration = Duration::from_secs(warmup_secs);
@@ -1125,6 +1190,7 @@ fn main() {
                         .unwrap_or_else(|err| fatal(&robot, err));
                     pacing_stats = FpsPacingAccumulator::default();
                     measurement_started = true;
+                    continue;
                 }
 
                 if baseline_rss_kb.is_none() && measurement_started {
@@ -1341,9 +1407,7 @@ fn main() {
 
             robot.exit().ok();
         })
-        .run(move || {
-            PerfHarnessApp(scenario);
-        });
+        .run(move || PresentedPerfHarness(scenario, calibrate));
 }
 
 #[cfg(test)]

--- a/apps/desktop-demo/src/test_screens/accessibility_navigation.rs
+++ b/apps/desktop-demo/src/test_screens/accessibility_navigation.rs
@@ -1,0 +1,32 @@
+use cranpose::{
+    composable, rememberMutableStateOf, Alignment, Box, BoxSpec, Color, Modifier, SpanStyle, Text,
+    TextStyle,
+};
+
+#[allow(non_snake_case)]
+#[composable]
+pub fn AccessibilityNavigationScreen() {
+    let settings = rememberMutableStateOf(|| false);
+    let selected = settings.get();
+    Box(
+        Modifier::empty()
+            .fill_max_size()
+            .background(if selected { Color::GREEN } else { Color::BLUE })
+            .clickable(move |_| settings.set(!settings.get())),
+        BoxSpec::default().content_alignment(Alignment::CENTER),
+        move || {
+            Text(
+                if selected {
+                    "Settings page"
+                } else {
+                    "Library page"
+                },
+                Modifier::empty(),
+                TextStyle::from_span_style(SpanStyle {
+                    color: Some(Color::WHITE),
+                    ..SpanStyle::default()
+                }),
+            );
+        },
+    );
+}

--- a/apps/desktop-demo/src/test_screens/mod.rs
+++ b/apps/desktop-demo/src/test_screens/mod.rs
@@ -1,3 +1,4 @@
+pub mod accessibility_navigation;
 pub mod nested_glass_cache_repro;
 pub mod pressed_state_repro;
 pub mod scroll_repro;

--- a/crates/cranpose/src/android.rs
+++ b/crates/cranpose/src/android.rs
@@ -2367,18 +2367,14 @@ pub fn run(
                 }
             } else {
                 frame_telemetry.note_idle_iteration();
-                if accessibility_policy
-                    .wake_deadline()
-                    .is_some_and(|deadline| deadline <= std::time::Instant::now())
-                    && let Err(error) = crate::android_accessibility::sync(
-                        &app,
-                        shell,
-                        android_platform.scale_factor(),
-                        &mut accessibility_elements,
-                        &mut accessibility_revision,
-                        &mut accessibility_policy,
-                    )
-                {
+                if let Err(error) = crate::android_accessibility::sync(
+                    &app,
+                    shell,
+                    android_platform.scale_factor(),
+                    &mut accessibility_elements,
+                    &mut accessibility_revision,
+                    &mut accessibility_policy,
+                ) {
                     log::warn!("{error}");
                 }
             }

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -2735,6 +2735,38 @@ fn robot_scroll_present_target(
     ))
 }
 
+#[cfg(feature = "robot")]
+fn robot_frame_diagnostics(
+    command: &RobotCommand,
+    app: &mut AppShell<WgpuRenderer>,
+    config: Option<&wgpu::SurfaceConfiguration>,
+    caps: Option<&wgpu::SurfaceCapabilities>,
+    interval: Duration,
+) -> RobotResponse {
+    match command {
+        RobotCommand::GetRenderStats => {
+            RobotResponse::RenderStats(Box::new(app.renderer().last_frame_stats()))
+        }
+        RobotCommand::GetFpsStats => RobotResponse::FpsStats(app.fps_stats()),
+        RobotCommand::GetPresentationInfo => match (config, caps) {
+            (Some(config), Some(caps)) => {
+                RobotResponse::PresentationInfo(crate::RobotPresentationInfo {
+                    requested_mode: std::env::var("CRANPOSE_PRESENT_MODE").ok(),
+                    present_mode: crate::present_mode::resolved_present_mode(
+                        config.present_mode,
+                        caps,
+                    ),
+                    supported_modes: caps.present_modes.clone(),
+                    frame_pacing_mode: app.frame_pacing_mode(),
+                    refresh_rate_hz: 1.0 / interval.as_secs_f64(),
+                })
+            }
+            _ => RobotResponse::Error("Window presentation is not configured".into()),
+        },
+        _ => RobotResponse::Error("Command is not a frame diagnostics query".into()),
+    }
+}
+
 fn apply_frame_pacing_mode(
     app: &mut AppShell<WgpuRenderer>,
     surface: &wgpu::Surface<'static>,
@@ -5115,13 +5147,17 @@ impl ApplicationHandler for App {
                             None => RobotResponse::Screenshots(shots),
                         });
                     }
-                    RobotCommand::GetRenderStats => {
-                        let _ = controller.tx.send(RobotResponse::RenderStats(Box::new(
-                            app.renderer().last_frame_stats(),
-                        )));
-                    }
-                    RobotCommand::GetFpsStats => {
-                        let _ = controller.tx.send(RobotResponse::FpsStats(app.fps_stats()));
+                    RobotCommand::GetRenderStats
+                    | RobotCommand::GetFpsStats
+                    | RobotCommand::GetPresentationInfo => {
+                        let response = robot_frame_diagnostics(
+                            &cmd,
+                            app,
+                            self.surface_config.as_ref(),
+                            self.surface_caps.as_ref(),
+                            self.vsync_interval,
+                        );
+                        let _ = controller.tx.send(response);
                     }
                     RobotCommand::GetPacingControlCenter(mode) => {
                         let center = app.dev_overlay_control_center(mode);

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -592,7 +592,8 @@ pub use cranpose_app_shell::{DevOptions, FpsStats, FramePacingMode};
     feature = "renderer-wgpu"
 ))]
 pub use robot::{
-    Robot, RobotScreenshot, RobotTimelineAction, RobotTimelineStep, SemanticElement, SemanticRect,
+    Robot, RobotPresentationInfo, RobotScreenshot, RobotTimelineAction, RobotTimelineStep,
+    SemanticElement, SemanticRect,
 };
 
 #[cfg(all(test, feature = "desktop-shell", feature = "renderer-wgpu"))]

--- a/crates/cranpose/src/present_mode.rs
+++ b/crates/cranpose/src/present_mode.rs
@@ -86,6 +86,26 @@ fn is_auto_present_mode(mode: wgpu::PresentMode) -> bool {
     )
 }
 
+#[cfg(any(test, feature = "robot"))]
+pub(crate) fn resolved_present_mode(
+    mode: wgpu::PresentMode,
+    caps: &wgpu::SurfaceCapabilities,
+) -> wgpu::PresentMode {
+    let fallbacks: &[wgpu::PresentMode] = match mode {
+        wgpu::PresentMode::AutoNoVsync => &[
+            wgpu::PresentMode::Immediate,
+            wgpu::PresentMode::Mailbox,
+            wgpu::PresentMode::Fifo,
+        ],
+        wgpu::PresentMode::AutoVsync => &[
+            wgpu::PresentMode::FifoRelaxed,
+            wgpu::PresentMode::Fifo,
+        ],
+        _ => return mode,
+    };
+    fallbacks.iter().copied().find(|mode| caps.present_modes.contains(mode)).unwrap_or(mode)
+}
+
 fn parse_present_mode(value: &str) -> Option<wgpu::PresentMode> {
     match value.trim().to_ascii_lowercase().as_str() {
         "auto_no_vsync" | "autonovsync" | "no_vsync" | "novsync" => {
@@ -108,6 +128,19 @@ mod tests {
         parse_present_mode, select_android_present_mode_for_request,
         select_present_mode_for_frame_pacing, select_present_mode_for_request,
     };
+
+    #[test]
+    fn automatic_presentation_reports_the_backend_fallback() {
+        for (requested, supported, resolved) in [
+            (PresentMode::AutoNoVsync, vec![PresentMode::Fifo], PresentMode::Fifo),
+            (PresentMode::AutoNoVsync, vec![PresentMode::Fifo, PresentMode::Mailbox], PresentMode::Mailbox),
+            (PresentMode::AutoNoVsync, vec![PresentMode::Mailbox, PresentMode::Immediate], PresentMode::Immediate),
+            (PresentMode::AutoVsync, vec![PresentMode::Fifo, PresentMode::FifoRelaxed], PresentMode::FifoRelaxed),
+            (PresentMode::Immediate, vec![PresentMode::Fifo, PresentMode::Immediate], PresentMode::Immediate),
+        ] {
+            assert_eq!(super::resolved_present_mode(requested, &caps(&supported)), resolved);
+        }
+    }
 
     fn caps(present_modes: &[PresentMode]) -> SurfaceCapabilities {
         SurfaceCapabilities {

--- a/crates/cranpose/src/robot.rs
+++ b/crates/cranpose/src/robot.rs
@@ -10,6 +10,36 @@ use cranpose_render_common::Renderer;
 use cranpose_render_wgpu::{DebugCpuAllocationStats, RenderStatsSnapshot};
 use cranpose_ui::{SemanticsAction, SemanticsNode, SemanticsRole};
 
+/// Presentation constraints of the window controlled by a robot.
+#[cfg(feature = "renderer-wgpu")]
+#[derive(Debug, Clone)]
+pub struct RobotPresentationInfo {
+    /// Explicit environment request, if one was provided.
+    pub requested_mode: Option<String>,
+    /// Concrete surface mode after resolving automatic fallback choices.
+    pub present_mode: wgpu::PresentMode,
+    /// Concrete modes advertised by this surface.
+    pub supported_modes: Vec<wgpu::PresentMode>,
+    /// Application scheduling policy.
+    pub frame_pacing_mode: cranpose_app_shell::FramePacingMode,
+    /// Display refresh estimate used by the window scheduler.
+    pub refresh_rate_hz: f64,
+}
+
+#[cfg(feature = "renderer-wgpu")]
+impl RobotPresentationInfo {
+    /// Whether the configured scheduling and presentation modes request unpaced rendering.
+    ///
+    /// This does not establish measured throughput; surface acquisition can still block.
+    pub fn uses_unpaced_configuration(&self) -> bool {
+        self.frame_pacing_mode == cranpose_app_shell::FramePacingMode::NoVsync
+            && matches!(
+                self.present_mode,
+                wgpu::PresentMode::Immediate | wgpu::PresentMode::Mailbox
+            )
+    }
+}
+
 /// Serializable semantic element combining semantics + geometry
 ///
 /// This structure combines semantic information (role, text, actions) with
@@ -194,6 +224,8 @@ pub(crate) enum RobotCommand {
     #[cfg(feature = "renderer-wgpu")]
     GetRenderStats,
     GetFpsStats,
+    #[cfg(feature = "renderer-wgpu")]
+    GetPresentationInfo,
     GetPacingControlCenter(cranpose_app_shell::FramePacingMode),
     ResetFpsStats,
     GetLastFlingVelocity,
@@ -226,6 +258,8 @@ pub(crate) enum RobotResponse {
     #[cfg(feature = "renderer-wgpu")]
     RenderStats(Box<Option<RenderStatsSnapshot>>),
     FpsStats(cranpose_app_shell::FpsStats),
+    #[cfg(feature = "renderer-wgpu")]
+    PresentationInfo(RobotPresentationInfo),
     PacingControlCenter(Option<(f32, f32)>),
     F32(f32),
     #[cfg(feature = "renderer-wgpu")]
@@ -872,6 +906,26 @@ impl Robot {
             .map_err(|e| format!("Failed to send FPS stats command: {}", e))?;
         self.recv_response(|response| match response {
             RobotResponse::FpsStats(stats) => Some(stats),
+            _ => None,
+        })
+    }
+
+    /// Read the active window's resolved presentation and scheduling constraints.
+    ///
+    /// ```no_run
+    /// # fn inspect(robot: &cranpose::Robot) -> Result<(), String> {
+    /// let presentation = robot.presentation_info()?;
+    /// println!("{:?} at {} Hz", presentation.present_mode, presentation.refresh_rate_hz);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "renderer-wgpu")]
+    pub fn presentation_info(&self) -> Result<RobotPresentationInfo, String> {
+        self.tx
+            .send(RobotCommand::GetPresentationInfo)
+            .map_err(|err| format!("Failed to send presentation info command: {err}"))?;
+        self.recv_response(|response| match response {
+            RobotResponse::PresentationInfo(info) => Some(info),
             _ => None,
         })
     }
@@ -1619,6 +1673,64 @@ mod tests {
         semantics_node_clickable, semantics_node_text, semantics_text_matches,
         subtree_contains_matching_text,
     };
+
+    #[cfg(feature = "renderer-wgpu")]
+    #[test]
+    fn presentation_info_reports_constraints_and_channel_errors() {
+        use cranpose_app_shell::FramePacingMode;
+
+        use super::{RobotChannel, RobotCommand, RobotPresentationInfo, RobotResponse};
+        for mode in [
+            wgpu::PresentMode::Immediate,
+            wgpu::PresentMode::Mailbox,
+            wgpu::PresentMode::Fifo,
+            wgpu::PresentMode::FifoRelaxed,
+            wgpu::PresentMode::AutoNoVsync,
+        ] {
+            for pacing in [
+                FramePacingMode::NoVsync,
+                FramePacingMode::Vsync,
+                FramePacingMode::Hard60,
+                FramePacingMode::Hard120,
+            ] {
+                let info = RobotPresentationInfo {
+                    requested_mode: Some("immediate".into()),
+                    present_mode: mode,
+                    supported_modes: vec![mode],
+                    frame_pacing_mode: pacing,
+                    refresh_rate_hz: 60.0,
+                };
+                let expected = pacing == FramePacingMode::NoVsync
+                    && matches!(
+                        mode,
+                        wgpu::PresentMode::Immediate | wgpu::PresentMode::Mailbox
+                    );
+                assert_eq!(info.uses_unpaced_configuration(), expected);
+                let (channel, robot) = RobotChannel::new(|| {});
+                channel
+                    .tx
+                    .send(RobotResponse::PresentationInfo(info))
+                    .unwrap();
+                let response = robot.presentation_info().unwrap();
+                assert!(matches!(
+                    channel.rx.recv().unwrap(),
+                    RobotCommand::GetPresentationInfo
+                ));
+                assert_eq!(response.present_mode, mode);
+                assert_eq!(response.uses_unpaced_configuration(), expected);
+                channel
+                    .tx
+                    .send(RobotResponse::Error("surface unavailable".into()))
+                    .unwrap();
+                assert_eq!(
+                    robot.presentation_info().unwrap_err(),
+                    "surface unavailable"
+                );
+                drop(channel);
+                assert!(robot.presentation_info().is_err());
+            }
+        }
+    }
 
     fn find_text_in_trees(
         sem_node: &SemanticsNode,

--- a/docs/android_benchmark.md
+++ b/docs/android_benchmark.md
@@ -1,0 +1,15 @@
+# Android benchmark tooling
+
+- Requires Python 3.11+, Pillow, adb, cargo-ndk and the app’s Android NDK; video capture also requires ffmpeg and screenrecord or scrcpy.
+- Build immutable source archives and native provenance with `python3 scripts/android_benchmark_build.py --help`; keep reports outside the disposable build cache.
+- Package one verified native ABI into an isolated signed APK with `python3 scripts/android_benchmark_package.py --help`; both revisions must share their application payload and build settings.
+- Compile the device input helper with `./perf_android.sh build-route --android-jar SDK/android.jar --d8 BUILD_TOOLS/d8 --output OUTPUT`.
+- Configure display size, density, input timing and distinct visible endpoints in a route JSON; examples live in [scripts/android/routes](../scripts/android/routes).
+- Use `./perf_android.sh build-ocr --output OUTPUT` on macOS for image endpoint checks; restrict heading regions to exclude persistent navigation labels.
+- Run `./perf_android.sh measure --serial SERIAL --route ROUTE --dex HELPER/classes.dex --a A/apk.json --b B/apk.json --output OUTPUT` for one locked ABAB BABA sequence.
+- Add `--record --record-backend scrcpy` for comparison videos; recording runs and their nested windows are ineligible for FPS acceptance.
+- Matching installed APK hashes reuse the on-device payload and skip redundant installation; differing payloads are transferred and verified before use.
+- Each leg verifies the installed APK, first-gesture motion, both endpoints, foreground PID, input timing and device temperature; captures sit outside the measurement window.
+- Reports preserve command output, failed legs and cleanup errors; diagnostic properties are restored before any performance result becomes eligible.
+- `just gc` and `just gc-apply` include disposable benchmark snapshots under `${XDG_CACHE_HOME:-$HOME/.cache}/cranpose/benchmarks`; nested caches count once and recent descendants protect their parent.
+- `just test-shell-helpers` covers archive integrity, provenance, sequence locking, route validation, cleanup, reporting and cache collection.

--- a/docs/cranscan_render_regression.md
+++ b/docs/cranscan_render_regression.md
@@ -19,3 +19,5 @@
 - Guard validation: `just test-android-surface-contract` accepts every row offset and rejects marker cutouts, card cutouts and blank frames.
 - Evidence: [per-frame results and build hashes](https://github.com/user-attachments/files/31923864/pr617-renderer-frames.zip) and [before/after videos](https://github.com/samoylenkodmitry/Cranpose/pull/617#issuecomment-5573688025) retain the failing recordings.
 - Acceptance: Huawei motion verification passes; [fresh FPS measurements](https://github.com/user-attachments/files/31923866/pr617-fixed-sota-fps.zip) remain below 60 FPS.
+
+- Huawei verification for #620 checks 1,309 recorded frames across 171 scroll positions with zero missing card or marker pixels; the merged compositor fix remains covered by `robot-android-surface`.

--- a/docs/device_measurement.md
+++ b/docs/device_measurement.md
@@ -1,5 +1,6 @@
 # Device measurement
 
+- Use the [versioned Android benchmark tooling](android_benchmark.md) for reproducible device sequences.
 - Follow the [mobile acceptance protocol](mobile_60fps_architecture.md) and retain results in [mobile performance evidence](mobile_watch_performance.md).
 - Hold the shared sequence lock for all eight ABAB BABA runs; per-command locks and reservation messages cannot protect a whole comparison.
 - Install both revisions over one isolated benchmark package; keep its data, assets, signer, ABI, app revision and feature set identical.
@@ -44,3 +45,5 @@
 - Build the Android robot with `just android-robot-build`; run `just robot-android-accessibility SERIAL OUTPUT` to verify page changes with accessibility connected and after reconnecting.
 - iOS system-dialog tests require USB and enabled UI Automation; network-paired runner timeouts can occur before any test starts.
 - Prefer in-process iOS telemetry for repeated profiles; use unique Instruments trace paths when a trace is needed.
+- Desktop FPS reports include resolved presentation mode; throughput gates require an animated single-quad probe to pass the requested budget, while `--report-only` permits display cadence.
+- Verify the rendered Library heading before the Watch Settings tap; its persistent navigation label does not establish which page is ready.

--- a/docs/device_measurement.md
+++ b/docs/device_measurement.md
@@ -3,6 +3,7 @@
 - Follow the [mobile acceptance protocol](mobile_60fps_architecture.md) and retain results in [mobile performance evidence](mobile_watch_performance.md).
 - Hold the shared sequence lock for all eight ABAB BABA runs; per-command locks and reservation messages cannot protect a whole comparison.
 - Install both revisions over one isolated benchmark package; keep its data, assets, signer, ABI, app revision and feature set identical.
+- If `adb install` times out, compare the installed APK hash before retrying; installation can finish before the client returns.
 - Record the consuming workspace's effective release profile, full toolchain, resolved framework paths and packaged native hashes.
 - Refresh extracted source timestamps and verify the complete inventory; matching source hashes alone do not prove Cargo rebuilt the library.
 - Compare the actual packaged native payloads; Gradle stripping can legitimately change a build-output hash.
@@ -40,5 +41,6 @@
 - Capture temperatures and SurfaceFlinger results before profiler finalization; label profiled timings as diagnostics.
 - Android worker tests must call the API directly on a worker; `ActivityScenario.onActivity` always dispatches onto the UI thread.
 - Use the AndroidX instrumentation runner on the watch and test both enable and disable paths.
+- Build the Android robot with `just android-robot-build`; run `just robot-android-accessibility SERIAL OUTPUT` to verify page changes with accessibility connected and after reconnecting.
 - iOS system-dialog tests require USB and enabled UI Automation; network-paired runner timeouts can occur before any test starts.
 - Prefer in-process iOS telemetry for repeated profiles; use unique Instruments trace paths when a trace is needed.

--- a/docs/render_verification.md
+++ b/docs/render_verification.md
@@ -43,3 +43,4 @@
 - Make invalidation bypasses impossible through ownership and private fields; test moved solid siblings without full-rebuild fallback.
 - Proc-macro-generated syntax uses the macro crate's edition; mixed-site hygiene does not isolate bindings from call-site constants.
 - Test composable doctests with their required crate-root imports and explicit main; downstream examples have a different expansion context.
+- Run `just robot-one robot_glass_feed_wheel` to check receipt positions and pixels after large, one-pixel and repeated wheel input.

--- a/justfile
+++ b/justfile
@@ -216,6 +216,8 @@ test-shell-helpers:
     bash scripts/ci/sccache_lifetime_test.sh
     scripts/wait_until_quiet_test.sh
     scripts/dev/target_gc_test.sh
+    python3 scripts/android_benchmark_test.py
+    python3 scripts/perf_report_test.py
 
 # Covers the shared/exclusive lock that keeps builds off the machine while a
 # measurement runs, and the turnstile that keeps a stream of builds from
@@ -415,6 +417,9 @@ robot-android-accessibility serial output:
 test-android-accessibility-contract:
     python3 scripts/android_accessibility_robot_test.py
 
+test-presentation-policy binary output:
+    scripts/ci/with_host_lock.sh --exclusive python3 scripts/perf_presentation_test.py --binary {{quote(binary)}} --output {{quote(output)}}
+
 test-android-surface-contract:
     python3 scripts/android_surface_frames_test.py
 
@@ -491,15 +496,15 @@ perf-heap *args:
 
 # Report what the sweep would reclaim. Removes nothing.
 gc:
-    scripts/dev/target_gc.sh
+    scripts/dev/target_gc.sh --root "${XDG_CACHE_HOME:-$HOME/.cache}/cranpose/benchmarks"
 
 # Reclaim least-recently-built worktree target dirs to the free-space target.
 gc-apply:
-    scripts/dev/target_gc.sh --apply
+    scripts/dev/target_gc.sh --apply --root "${XDG_CACHE_HOME:-$HOME/.cache}/cranpose/benchmarks"
 
 # Current free space and the per-worktree target dirs behind it.
 disk:
-    @scripts/dev/target_gc.sh --min-free-gb 0
+    @scripts/dev/target_gc.sh --min-free-gb 0 --root "${XDG_CACHE_HOME:-$HOME/.cache}/cranpose/benchmarks"
 
 # Refuse to start a heavy recipe the disk cannot finish. Sweeps first.
 _disk-guard:

--- a/justfile
+++ b/justfile
@@ -405,6 +405,16 @@ robot-one example:
 robot-android-surface serial output:
     python3 scripts/android_surface_robot.py --serial {{quote(serial)}} --output {{quote(output)}}
 
+android-robot-build: _disk-guard
+    cd apps/android-demo/android && ../../../scripts/ci/with_host_lock.sh --shared \
+      ./gradlew --no-daemon -PcranposeRobot=true :app:assembleRelease :app:assembleReleaseAndroidTest
+
+robot-android-accessibility serial output:
+    python3 scripts/android_accessibility_robot.py --serial {{quote(serial)}} --output {{quote(output)}}
+
+test-android-accessibility-contract:
+    python3 scripts/android_accessibility_robot_test.py
+
 test-android-surface-contract:
     python3 scripts/android_surface_frames_test.py
 
@@ -512,7 +522,7 @@ _disk-guard:
 # all seven on every pull request.
 
 # What a pull request is gated on. Run this before pushing.
-ci: fmt-check typos versions test clippy clippy-optional-backends clippy-svg clippy-hyphenation clippy-robot clippy-wasm doc budgets test-quality-gates complexity-gate duplication-gate test-robot-discovery test-shell-helpers test-host-lock test-ci-filters test-features test-property bench-smoke test-ci-gate-reachability test-robot-suite-partition
+ci: fmt-check typos versions test clippy clippy-optional-backends clippy-svg clippy-hyphenation clippy-robot clippy-wasm doc budgets test-quality-gates complexity-gate duplication-gate test-robot-discovery test-shell-helpers test-host-lock test-ci-filters test-features test-property bench-smoke test-ci-gate-reachability test-robot-suite-partition test-android-accessibility-contract
 
 # Needs a Linux box with the X11 stack, an Android SDK and (on macOS) Xcode.
 

--- a/perf_android.sh
+++ b/perf_android.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec python3 "$(dirname "${BASH_SOURCE[0]}")/scripts/android_benchmark.py" "$@"

--- a/perf_robot_fps.sh
+++ b/perf_robot_fps.sh
@@ -37,8 +37,9 @@ usage() {
 Usage: $0 [--dev|--release|--profile NAME] [--example NAME] [--duration SECS] [--warmup SECS] [--min-fps FPS] [--max-p95-ms MS] [--max-50ms-stalls COUNT] [--output PATH] [--scenario NAME] [--report-only]
 
 Runs the robot performance harness and fails when any selected scenario is not above the FPS budget.
-Default budget: >120 FPS. Presents with vsync off (present_mode=immediate), so the
-numbers are what the renderer can reach rather than what the display accepts.
+Default budget: >120 FPS of frame work, including surface acquisition waits.
+Requests immediate presentation, reports the resolved mode, and rejects throughput
+gates unless an animated single-quad probe demonstrates headroom for the requested budget.
 
 --report-only drops the budgets and just measures. Use it to read a ceiling,
 not to gate: an unbudgeted number cannot fail, so it cannot protect anything.
@@ -124,7 +125,8 @@ fi
 
 "${CARGO_RUNNER[@]}" build "${BUILD_ARGS[@]}"
 
-BIN="target/${PROFILE_DIR}/examples/${EXAMPLE}"
+TARGET_DIR="$("${CARGO_RUNNER[@]}" metadata --no-deps --format-version 1 | python3 -c 'import json, sys; print(json.load(sys.stdin)["target_directory"])')"
+BIN="${TARGET_DIR}/${PROFILE_DIR}/examples/${EXAMPLE}"
 if [[ ! -x "$BIN" ]]; then
     echo "Binary not found: $BIN"
     exit 1
@@ -133,10 +135,9 @@ fi
 OUTPUT_DIR="$(dirname "$OUTPUT")"
 mkdir -p "$OUTPUT_DIR"
 if [[ "$REPORT_ONLY" == "1" ]]; then
-    # No floor, no p95 ceiling, no stall ceiling: measure and print.
     MIN_FPS="0"
-    MAX_P95_FRAME_MS="100000"
-    MAX_50MS_STALLS="1000000"
+    MAX_P95_FRAME_MS="0"
+    MAX_50MS_STALLS="4294967295"
 fi
 
 OUTPUT_BASE="${OUTPUT%.*}"
@@ -155,7 +156,7 @@ fi
     echo "max_p95_frame_ms=$MAX_P95_FRAME_MS"
     echo "max_50ms_stalls=$MAX_50MS_STALLS"
     echo "headless=$HEADLESS"
-    echo "present_mode=$PRESENT_MODE"
+    echo "requested_present_mode=$PRESENT_MODE"
     echo "wait_idle_after_drag=$WAIT_IDLE_AFTER_DRAG"
     echo "host=$(host_state_summary)"
     echo "scenarios=${PERF_SCENARIOS[*]}"
@@ -167,6 +168,7 @@ for scenario in "${PERF_SCENARIOS[@]}"; do
 
     wait_for_host_capacity "fps perf scenario $scenario"
     echo "Running FPS perf scenario: $scenario"
+    scenario_status=0
     CRANPOSE_PERF_SCENARIO="$scenario" \
     CRANPOSE_PERF_DURATION_SECS="$DURATION_SECS" \
     CRANPOSE_PERF_WARMUP_SECS="$WARMUP_SECS" \
@@ -178,13 +180,16 @@ for scenario in "${PERF_SCENARIOS[@]}"; do
     CRANPOSE_PRESENT_MODE="$PRESENT_MODE" \
     CRANPOSE_HEADLESS="$HEADLESS" \
     CRANPOSE_PERF_WAIT_IDLE_AFTER_DRAG="$WAIT_IDLE_AFTER_DRAG" \
-    "$BIN" 2>&1 | tee "$LOG_FILE"
+    "$BIN" 2>&1 | tee "$LOG_FILE" || scenario_status=$?
 
     append_perf_summary_block "$OUTPUT" "$scenario" "$LOG_FILE"
     {
         echo "app_log=$LOG_FILE"
         echo
     } >> "$OUTPUT"
+    if [[ "$scenario_status" != 0 ]]; then
+        exit "$scenario_status"
+    fi
 done
 
 echo "report: $OUTPUT"

--- a/scripts/android/CranposeBenchmarkRoute.java
+++ b/scripts/android/CranposeBenchmarkRoute.java
@@ -1,0 +1,100 @@
+import android.os.SystemClock;
+import android.view.InputEvent;
+import android.view.InputDevice;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import java.lang.reflect.Method;
+
+public final class CranposeBenchmarkRoute {
+    private final Object manager;
+    private final Method inject;
+
+    private CranposeBenchmarkRoute() throws Exception {
+        Class<?> type = Class.forName(android.os.Build.VERSION.SDK_INT >= 34
+            ? "android.hardware.input.InputManagerGlobal" : "android.hardware.input.InputManager");
+        manager = type.getMethod("getInstance").invoke(null);
+        inject = type.getMethod("injectInputEvent", InputEvent.class, int.class);
+    }
+
+    private void send(InputEvent event) throws Exception {
+        if (!(Boolean) inject.invoke(manager, event, 0)) {
+            throw new IllegalStateException("Input injection refused");
+        }
+    }
+
+    private void touch(long down, int action, float x, float y) throws Exception {
+        MotionEvent event = MotionEvent.obtain(down, SystemClock.uptimeMillis(), action, x, y, 0);
+        try {
+            event.setSource(InputDevice.SOURCE_TOUCHSCREEN);
+            send(event);
+        } finally {
+            event.recycle();
+        }
+    }
+
+    private static void waitUntil(long deadline) {
+        long remaining = deadline - SystemClock.uptimeMillis();
+        if (remaining > 0) SystemClock.sleep(remaining);
+    }
+
+    private static void command(String... command) throws Exception {
+        if (new ProcessBuilder(command).inheritIO().start().waitFor() != 0) {
+            throw new IllegalStateException("Device command failed");
+        }
+    }
+
+    private void gesture(float x, float y1, float y2, int duration) throws Exception {
+        send(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_WAKEUP));
+        send(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_WAKEUP));
+        long down = SystemClock.uptimeMillis();
+        touch(down, MotionEvent.ACTION_DOWN, x, y1);
+        try {
+            for (int elapsed = 16; elapsed < duration; elapsed += 16) {
+                waitUntil(down + elapsed);
+                float fraction = Math.min(1f, (SystemClock.uptimeMillis() - down) / (float) duration);
+                touch(down, MotionEvent.ACTION_MOVE, x, y1 + (y2 - y1) * fraction);
+            }
+            waitUntil(down + duration);
+            touch(down, MotionEvent.ACTION_UP, x, y2);
+        } catch (Exception error) {
+            touch(down, MotionEvent.ACTION_CANCEL, x, y2);
+            throw error;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        float x = Float.parseFloat(args[0]);
+        float y1 = Float.parseFloat(args[1]);
+        float y2 = Float.parseFloat(args[2]);
+        int count = Integer.parseInt(args[3]);
+        int duration = Integer.parseInt(args[4]);
+        int period = Integer.parseInt(args[5]);
+        int window = Integer.parseInt(args[6]);
+        if (count < 0 || duration < 1 || period < duration || window < 1 || (long) count * period > window) {
+            throw new IllegalArgumentException("Invalid measurement timing");
+        }
+        CranposeBenchmarkRoute driver = new CranposeBenchmarkRoute();
+        System.out.println("route_pid=" + android.os.Process.myPid() + " run_id=" + args[7]);
+        System.out.flush();
+        command("dumpsys", "SurfaceFlinger", "--timestats", "-clear", "-enable");
+        long elapsed;
+        try {
+            long start = SystemClock.uptimeMillis();
+            for (int step = 0; step < count; step++) {
+                waitUntil(start + (long) step * period);
+                long gestureStart = SystemClock.uptimeMillis();
+                driver.gesture(x, y1, y2, duration);
+                System.out.println("gesture=" + step + " start=" + (gestureStart - start)
+                    + " end=" + (SystemClock.uptimeMillis() - start));
+            }
+            waitUntil(start + window);
+            elapsed = SystemClock.uptimeMillis() - start;
+        } finally {
+            command("dumpsys", "SurfaceFlinger", "--timestats", "-disable");
+        }
+        System.out.println("elapsed_ms=" + elapsed);
+        System.out.println("SF_BEGIN");
+        command("dumpsys", "SurfaceFlinger", "--timestats", "-dump");
+        System.out.println("SF_END");
+    }
+}

--- a/scripts/android/recognize_text.swift
+++ b/scripts/android/recognize_text.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Vision
+
+let request = VNRecognizeTextRequest()
+request.recognitionLevel = .accurate
+request.usesLanguageCorrection = false
+let handler = VNImageRequestHandler(url: URL(fileURLWithPath: CommandLine.arguments[1]), options: [:])
+try handler.perform([request])
+let rows = (request.results ?? []).compactMap { observation -> [String: Any]? in
+    guard let candidate = observation.topCandidates(1).first else { return nil }
+    let box = observation.boundingBox
+    return ["text": candidate.string, "confidence": candidate.confidence, "bounds": [box.minX, box.minY, box.width, box.height]]
+}
+let data = try JSONSerialization.data(withJSONObject: rows, options: [.prettyPrinted])
+print(String(decoding: data, as: UTF8.self))

--- a/scripts/android/routes/huawei-showcase.json
+++ b/scripts/android/routes/huawei-showcase.json
@@ -1,0 +1,26 @@
+{
+  "kind": "scroll",
+  "package": "com.cranpose.showcase",
+  "activity": "dev.cranpose.android.CranposeActivity",
+  "size": [
+    1080,
+    2244
+  ],
+  "density": 480,
+  "x": 300,
+  "y_start": 1770,
+  "y_end": 620,
+  "count": 3,
+  "duration_ms": 1660,
+  "period_ms": 1666,
+  "window_ms": 4998,
+  "timing_tolerance_ms": 100,
+  "start_text": "Search the",
+  "end_text": "Proxima Centauri b",
+  "motion_region": [
+    80,
+    380,
+    900,
+    1800
+  ]
+}

--- a/scripts/android/routes/watch-settings.json
+++ b/scripts/android/routes/watch-settings.json
@@ -1,0 +1,60 @@
+{
+  "kind": "scroll",
+  "package": "com.cranscan.app.codex",
+  "activity": "dev.cranpose.android.CranposeActivity",
+  "size": [
+    408,
+    408
+  ],
+  "density": 320,
+  "x": 100,
+  "y_start": 260,
+  "y_end": 60,
+  "count": 50,
+  "duration_ms": 170,
+  "period_ms": 200,
+  "window_ms": 10000,
+  "timing_tolerance_ms": 100,
+  "start_text": "Settings",
+  "end_text": "CranScan 1.0.22",
+  "motion_region": [
+    60,
+    60,
+    300,
+    280
+  ],
+  "setup": [
+    {
+      "visible_text": "CranScan",
+      "region": [
+        0,
+        0,
+        350,
+        135
+      ],
+      "text_source": "image",
+      "tap": [
+        348,
+        312
+      ]
+    }
+  ],
+  "start_region": [
+    0,
+    100,
+    408,
+    260
+  ],
+  "end_region": [
+    0,
+    0,
+    408,
+    275
+  ],
+  "return": {
+    "y_start": 60,
+    "y_end": 260
+  },
+  "text_source": "image",
+  "endpoint_timeout_s": 4
+}

--- a/scripts/android_accessibility_robot.py
+++ b/scripts/android_accessibility_robot.py
@@ -1,0 +1,54 @@
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+
+from android_robot_device import locked_device
+
+
+def completed_tests(output):
+    result = re.search(r'^OK \((\d+) tests?\)$', output, re.M)
+    if (result is None or int(result[1]) < 1 or 'FAILURES!!!' in output
+            or 'INSTRUMENTATION_FAILED' in output):
+        raise RuntimeError('Android accessibility robot did not pass; inspect instrumentation.log')
+    return int(result[1])
+
+
+def main():
+    root = Path(__file__).resolve().parents[1]
+    apk_root = root / 'apps/android-demo/android/app/build/outputs/apk'
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--serial', required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--app-apk', type=Path, default=apk_root / 'release/app-release.apk')
+    parser.add_argument('--test-apk', type=Path,
+                        default=apk_root / 'androidTest/release/app-release-androidTest.apk')
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=False)
+    report = {'serial': args.serial, 'status': 'running', 'apks': {}}
+    try:
+        with locked_device(args.serial) as device:
+            for apk in [args.app_apk, args.test_apk]:
+                with apk.open('rb') as source:
+                    report['apks'][str(apk)] = hashlib.file_digest(source, 'sha256').hexdigest()
+                device.wake()
+                device.command('install', '-r', '-t', str(apk), timeout=180)
+            device.wake()
+            output = device.command(
+                'shell', 'am', 'instrument', '-w', '-r', '-e', 'class',
+                'com.compose_rs.demo.CranposeAccessibilityNavigationTest',
+                'com.compose_rs.demo.robot.test/androidx.test.runner.AndroidJUnitRunner', timeout=120)
+            (args.output / 'instrumentation.log').write_text(output)
+            report['tests_passed'] = completed_tests(output)
+            report['status'] = 'passed'
+            print(output)
+    except BaseException as error:
+        report.update(status='failed', error=str(error))
+        raise
+    finally:
+        (args.output / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/android_accessibility_robot_test.py
+++ b/scripts/android_accessibility_robot_test.py
@@ -1,0 +1,19 @@
+import unittest
+
+from android_accessibility_robot import completed_tests
+
+
+class InstrumentationResultTest(unittest.TestCase):
+    def test_accepts_completed_robot_tests(self):
+        self.assertEqual(completed_tests('Time: 2.5\nOK (2 tests)\nINSTRUMENTATION_CODE: -1\n'), 2)
+
+    def test_rejects_empty_failed_and_incomplete_instrumentation(self):
+        for result in ['OK (0 tests)\n', 'INSTRUMENTATION_CODE: -1\n',
+                       'FAILURES!!!\nTests run: 1,  Failures: 1\n',
+                       'OK (1 test)\nINSTRUMENTATION_FAILED: runner crashed\n']:
+            with self.subTest(result=result), self.assertRaises(RuntimeError):
+                completed_tests(result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/android_benchmark.py
+++ b/scripts/android_benchmark.py
@@ -1,0 +1,368 @@
+import argparse
+import json
+import math
+from pathlib import Path
+import re
+import signal
+import statistics
+import subprocess
+import time
+import uuid
+
+from android_benchmark_artifacts import snapshot_source, source_inventory, verify_apk, verify_build
+from android_benchmark_device import AndroidDevice, surface_frames, verify_route_window
+from android_benchmark_support import checked_command, device_lock, digest, error_details, interrupted, run_reported, write_report
+from android_benchmark_video import AndroidRecording, ScrcpyRecording
+
+
+def validate_pair(proofs):
+    first, second = proofs
+    for key in ['payload']:
+        if first[key] != second[key]:
+            raise ValueError('Compared APKs differ in ' + key)
+    for key in ['abi', 'features', 'toolchain', 'cargo', 'ndk', 'settings', 'lock_sha256']:
+        if first['build'][key] != second['build'][key]:
+            raise ValueError('Compared builds differ in ' + key)
+    if first['build']['sources']['app']['inventory'] != second['build']['sources']['app']['inventory']:
+        raise ValueError('Compared builds differ in application sources')
+
+
+def validate_route(route):
+    if route['kind'] not in {'scroll', 'game'} or not route['package'] or not route['activity']:
+        raise ValueError('Route needs a supported scene and explicit component')
+    if route['kind'] == 'scroll' and (not route['start_text'] or not route['end_text']
+                                     or route['start_text'] == route['end_text'] or route['count'] <= 0):
+        raise ValueError('Scroll route needs distinct positive start/end checks and input')
+    if route['kind'] == 'game' and (not route['ready_log'] or route['count'] != 0):
+        raise ValueError('Game window requires a positive launch marker and no injected gestures')
+    if (route['duration_ms'] < 1 or route['period_ms'] < route['duration_ms']
+            or route['window_ms'] <= 0 or route['window_ms'] < route['count'] * route['period_ms']
+            or not 0 <= route['timing_tolerance_ms'] < route['period_ms']):
+        raise ValueError('Invalid route timing')
+    for x, y in [(route['x'], route['y_start']), (route['x'], route['y_end']),
+                 *[step['tap'] for step in route.get('setup', [])]]:
+        if not 0 <= x < route['size'][0] or not 0 <= y < route['size'][1]:
+            raise ValueError('Route input falls outside the verified display')
+    left, top, right, bottom = route['motion_region']
+    if not 0 <= left < right <= route['size'][0] or not 0 <= top < bottom <= route['size'][1]:
+        raise ValueError('Motion region falls outside the verified display')
+
+
+def wait_ready(device, route, output):
+    deadline = time.monotonic() + route.get('startup_timeout_s', 30)
+    failure = None
+    while time.monotonic() < deadline:
+        try:
+            if route['kind'] == 'scroll':
+                return device.endpoint(route['package'], route['start_text'], route['size'],
+                                       route.get('start_region'), route.get('text_source', 'accessibility'))
+            logs = device.shell('logcat', '-d', '--pid=' + output['pid'], '-T', output['launch_time'])
+            match = re.search(route['ready_log'], logs)
+            if match:
+                return match[0]
+            failure = ValueError('Game startup marker was not observed')
+        except (ValueError, subprocess.CalledProcessError) as error:
+            failure = error
+        time.sleep(0.25)
+    raise RuntimeError('Application did not reach its verified start state') from failure
+
+
+def stage_apk(device, package, apk, remote, expected_hash, timeout):
+    device.wake()
+    installed = device.installed_apk(package)
+    if installed and installed['sha256'] == expected_hash:
+        device.shell('cp', installed['path'], remote)
+    else:
+        device.run('push', str(apk), remote, timeout=timeout)
+    if device.shell('sha256sum', remote).split()[0] != expected_hash:
+        raise ValueError('Staged APK differs from its build proof')
+
+
+def install_staged(device, package, source, expected_hash, report):
+    device.wake()
+    installed = device.installed_apk(package)
+    report['installation'] = {'reused': bool(installed and installed['sha256'] == expected_hash)}
+    if not report['installation']['reused']:
+        try:
+            result = device.shell('pm', 'install', '-r', source, timeout=120)
+            report['installation']['output'] = result
+            if 'Success' not in result:
+                raise ValueError('APK installation did not report success: ' + result)
+        except subprocess.TimeoutExpired as error:
+            report['installation']['timeout'] = error_details(error)
+        installed = device.installed_apk(package)
+    actual = installed['sha256'] if installed else None
+    report['installation']['installed_sha256'] = actual
+    if actual != expected_hash:
+        raise ValueError('Installed APK does not match the measured build')
+
+
+def launch_route(device, route, report):
+    package = route['package']
+    device.shell('am', 'force-stop', package)
+    report['launch_time'] = device.shell('date', '+%m-%d %H:%M:%S.000').strip()
+    device.wake()
+    device.shell('am', 'start', '-W', '-n', package + '/' + route['activity'], *route.get('launch_args', []))
+    report['pid'] = device.wait_for_pid(package, timeout=route.get('startup_timeout_s', 30))
+    report['setup_validation'] = []
+    for step in route.get('setup', []):
+        ready = route | {'kind': 'scroll', 'start_text': step['visible_text'], 'start_region': step.get('region'),
+                         'text_source': step.get('text_source', 'accessibility')}
+        report['setup_validation'].append(wait_ready(device, ready, report))
+        device.wake()
+        device.shell('input', 'tap', *step['tap'])
+    report['start_validation'] = wait_ready(device, route, report)
+
+
+def verify_first_gesture(device, route, destination, report):
+    probe = {'before': device.screenshot(destination / 'first-gesture-before.png', route['motion_region'])}
+    report['first_gesture'] = probe
+    device.wake()
+    device.shell('input', 'swipe', route['x'], route['y_start'], route['x'], route['y_end'], route['duration_ms'])
+    probe['after'] = device.screenshot(destination / 'first-gesture-after.png', route['motion_region'])
+    probe['changed'] = probe['before']['motion_pixels_sha256'] != probe['after']['motion_pixels_sha256']
+    if not probe['changed']:
+        raise ValueError('The first gesture did not move visible content')
+
+
+def run_leg(device, route, apk, proof, dex, destination, report, installed_source, recorder=None):
+    package = route['package']
+    report.update(apk_sha256=proof['apk_sha256'], native_sha256=proof['build']['native_sha256'], route=route)
+    verify_apk(apk, proof, proof['native_member'])
+    install_staged(device, package, installed_source, proof['apk_sha256'], report)
+    launch_route(device, route, report)
+    report['start_image'] = device.screenshot(destination / 'start.png', route['motion_region'])
+    if report['start_image']['size'] != route['size']:
+        raise ValueError('Device display size differs from the verified route')
+    density = device.shell('wm', 'density')
+    if int(re.findall(r'density: (\d+)', density)[-1]) != route['density']:
+        raise ValueError('Device density differs from the verified route')
+    if route['kind'] == 'scroll':
+        verify_first_gesture(device, route, destination, report)
+        launch_route(device, route, report)
+    if recorder:
+        recorder.start()
+    windows = [route]
+    if 'return' in route:
+        windows.append(route | {'start_text': route['end_text'], 'end_text': route['start_text'],
+                                'start_region': route.get('end_region'), 'end_region': route.get('start_region')}
+                       | route['return'])
+    report['windows'] = []
+    for index, window_route in enumerate(windows, 1):
+        validate_route(window_route)
+        directory = destination / f'window-{index}'
+        directory.mkdir()
+        window = {'pid': report['pid'], 'launch_time': report['launch_time'], 'route': window_route,
+                  'recording': recorder is not None}
+        report['windows'].append(window)
+        run_reported(directory / 'report.json', window,
+                     lambda: run_window(device, window_route, dex, directory, window),
+                     [lambda: stop_route(device, directory, window),
+                      lambda: device.shell('dumpsys', 'SurfaceFlinger', '--timestats', '-disable')])
+    elapsed = sum(window['elapsed_s'] for window in report['windows'])
+    frames = sum(window['layer']['frames'] for window in report['windows'])
+    report.update(elapsed_s=elapsed, frames=frames, fps=frames / elapsed,
+                  before=report['windows'][0]['before'], after=report['windows'][-1]['after'],
+                  acceptance_eligible=recorder is None)
+
+
+def run_window(device, route, dex, destination, report):
+    package = route['package']
+    report['start_validation'] = wait_ready(device, route, report)
+    report['start_image'] = device.screenshot(destination / 'start.png', route['motion_region'])
+    report['foreground_before'] = device.require_foreground(package, report['pid'])
+    report['before'] = device.state()
+    remote_dex = '/data/local/tmp/cranpose-benchmark-' + digest(dex) + '.dex'
+    device.run('push', str(dex), remote_dex)
+    if device.shell('sha256sum', remote_dex).split()[0] != digest(dex):
+        raise ValueError('Device route bytecode differs from the verified helper')
+    report['run_id'] = uuid.uuid4().hex
+    command = ['env', 'CLASSPATH=' + remote_dex, 'app_process', '/system/bin', 'CranposeBenchmarkRoute',
+               *[route[key] for key in ['x', 'y_start', 'y_end', 'count', 'duration_ms', 'period_ms', 'window_ms']],
+               report['run_id']]
+    device.wake()
+    output = device.shell(*command, timeout=route['window_ms'] / 1000 + 30,
+                          output=destination / 'device-route.log')
+    report['after'] = device.state()
+    report['foreground_after'] = device.require_foreground(package, report['pid'])
+    capture_end(device, route, destination, report)
+    if report['start_image']['motion_pixels_sha256'] == report['end_image']['motion_pixels_sha256']:
+        raise ValueError('Scene did not change during the measurement')
+    elapsed, stats = verify_route_window(output, *[route[key] for key in [
+        'count', 'duration_ms', 'period_ms', 'window_ms', 'timing_tolerance_ms']])
+    (destination / 'surfaceflinger.txt').write_text(stats)
+    layer = surface_frames(stats, package)
+    report.update(elapsed_s=elapsed, layer=layer, fps=layer['frames'] / elapsed,
+                  acceptance_eligible=not report['recording'],
+                  timing='device uptime; excludes SurfaceFlinger control IPC')
+
+
+def capture_end(device, route, destination, report):
+    timeout = route.get('endpoint_timeout_s', 0)
+    if not math.isfinite(timeout) or timeout < 0:
+        raise ValueError('Endpoint timeout must be finite and nonnegative')
+    started = time.monotonic()
+    deadline = started + timeout
+    report['endpoint_attempts'] = []
+    while True:
+        index = len(report['endpoint_attempts']) + 1
+        path = destination / ('end.png' if index == 1 else f'end-{index}.png')
+        report['end_image'] = device.screenshot(path, route['motion_region'])
+        attempt = {'image': str(path), 'pixels': report['end_image']}
+        report['endpoint_attempts'].append(attempt)
+        report['endpoint_settle_elapsed_s'] = time.monotonic() - started
+        if route['kind'] != 'scroll':
+            return
+        try:
+            report['end_validation'] = device.endpoint(route['package'], route['end_text'], route['size'],
+                                                       route.get('end_region'), route.get('text_source', 'accessibility'),
+                                                       image_path=path)
+            return
+        except ValueError as error:
+            attempt['error'] = str(error)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise
+            time.sleep(min(0.25, remaining))
+
+
+def stop_route(device, directory, report):
+    log = directory / 'device-route.log'
+    if not log.exists() or 'run_id' not in report:
+        return
+    match = re.search(r'route_pid=(\d+) run_id=' + re.escape(report['run_id']), log.read_text())
+    if not match:
+        return
+    device.stop_owned_process(match[1], report['run_id'])
+
+
+def sequence(args, report):
+    if args.transfer_timeout_seconds <= 0:
+        raise ValueError('Transfer timeout must be positive')
+    report['transfer_timeout_seconds'] = args.transfer_timeout_seconds
+    tooling = Path(__file__).parent
+    report['tooling'] = {'archive': 'tooling.tar.gz',
+                         'sha256': snapshot_source(tooling, args.output / 'tooling.tar.gz'),
+                         'inventory': source_inventory(tooling)}
+    route = json.loads(args.route.read_text())
+    validate_route(route)
+    helper = json.loads(args.dex.with_name('route.json').read_text())
+    if (helper['dex_sha256'] != digest(args.dex)
+            or helper['source_sha256'] != digest(Path(__file__).parent / 'android/CranposeBenchmarkRoute.java')):
+        raise ValueError('Route helper does not match the versioned source and build proof')
+    inputs = [path.resolve() for path in [args.a, args.b]]
+    proofs = [json.loads(path.read_text()) for path in inputs]
+    for path, proof in zip(inputs, proofs):
+        if proof['status'] != 'complete':
+            raise ValueError('APK provenance did not complete')
+        verify_build(proof['build'], Path(proof['build_directory']))
+        verify_apk(path.parent / proof['apk'], proof, proof['native_member'])
+    validate_pair(proofs)
+    report.update(serial=args.serial, route_sha256=digest(args.route), helper=helper, legs=[])
+    if args.ocr:
+        proof = json.loads(args.ocr.with_suffix('.json').read_text())
+        if (proof['executable_sha256'] != digest(args.ocr)
+                or proof['source_sha256'] != digest(tooling / 'android/recognize_text.swift')):
+            raise ValueError('OCR helper does not match its source build')
+        report['ocr'] = proof
+    device = AndroidDevice(args.serial, args.adb, args.ocr, args.output / 'endpoints')
+    remote_apks = {proof['apk_sha256']: (path.parent / proof['apk'],
+                                         '/data/local/tmp/cranpose-benchmark-' + uuid.uuid4().hex + '.apk')
+                   for path, proof in zip(inputs, proofs)}
+    with device_lock(args.serial):
+        def measure():
+            for sha256, (apk, remote) in remote_apks.items():
+                stage_apk(device, route['package'], apk, remote, sha256, args.transfer_timeout_seconds)
+            try:
+                device.configure_properties({})
+            finally:
+                report['saved_properties'] = device.saved_properties
+            for index, slot in enumerate('AB' if args.record else 'ABABBABA', 1):
+                source = 0 if slot == 'A' else 1
+                destination = args.output / f'{index}-{slot}'
+                destination.mkdir()
+                leg = {'slot': slot, 'index': index}
+                report['legs'].append(leg)
+                recorder = None
+                if args.record:
+                    recording_type = ScrcpyRecording if args.record_backend == 'scrcpy' else AndroidRecording
+                    options = {'duration_seconds': args.video_seconds} if args.record_backend == 'scrcpy' else {}
+                    recorder = recording_type(device, destination, route['size'], leg, args.video_bit_rate, **options)
+                run_reported(destination / 'report.json', leg,
+                             lambda: run_leg(device, route, inputs[source].parent / proofs[source]['apk'],
+                                             proofs[source], args.dex, destination, leg,
+                                             remote_apks[proofs[source]['apk_sha256']][1], recorder),
+                             [lambda: stop_route(device, destination, leg),
+                              lambda: device.shell('dumpsys', 'SurfaceFlinger', '--timestats', '-disable'),
+                              lambda: recorder.finish() if recorder else None,
+                              lambda: device.shell('am', 'force-stop', route['package'])])
+                write_report(args.output / 'report.json', report)
+                print(json.dumps({key: leg[key] for key in ['slot', 'index', 'fps', 'elapsed_s']}), flush=True)
+            report['mean_fps'] = {slot: statistics.mean(leg['fps'] for leg in report['legs'] if leg['slot'] == slot)
+                                  for slot in ['A', 'B']}
+            if source_inventory(tooling) != report['tooling']['inventory']:
+                raise ValueError('Measurement tooling changed during the sequence')
+            report['acceptance_eligible'] = not args.record
+        run_reported(args.output / 'report.json', report, measure,
+                     [device.restore_properties, *[lambda path=path: device.shell('rm', '-f', path)
+                                                    for _, path in remote_apks.values()]])
+
+
+def build_route(args):
+    args.output.mkdir(parents=True, exist_ok=False)
+    source = Path(__file__).parent / 'android/CranposeBenchmarkRoute.java'
+    classes = args.output / 'classes'
+    classes.mkdir()
+    checked_command(['javac', '--release', '8', '-classpath', str(args.android_jar), '-d', str(classes), str(source)])
+    checked_command([str(args.d8), '--output', str(args.output), str(classes / 'CranposeBenchmarkRoute.class')])
+    write_report(args.output / 'route.json', {'source_sha256': digest(source),
+                                             'dex_sha256': digest(args.output / 'classes.dex'),
+                                             'android_jar_sha256': digest(args.android_jar)})
+
+
+def build_ocr(args):
+    args.output.mkdir(parents=True, exist_ok=False)
+    source = Path(__file__).parent / 'android/recognize_text.swift'
+    executable = args.output / 'recognize-text'
+    checked_command(['swiftc', '-O', str(source), '-o', str(executable)], timeout=120)
+    write_report(executable.with_suffix('.json'), {'source_sha256': digest(source),
+                                                  'executable_sha256': digest(executable)})
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest='command', required=True)
+    route = commands.add_parser('build-route')
+    route.add_argument('--android-jar', type=Path, required=True)
+    route.add_argument('--d8', type=Path, required=True)
+    route.add_argument('--output', type=Path, required=True)
+    ocr = commands.add_parser('build-ocr')
+    ocr.add_argument('--output', type=Path, required=True)
+    measure = commands.add_parser('measure')
+    measure.add_argument('--serial', required=True)
+    measure.add_argument('--adb', default='adb')
+    measure.add_argument('--transfer-timeout-seconds', type=int, default=120)
+    measure.add_argument('--route', type=Path, required=True)
+    measure.add_argument('--dex', type=Path, required=True)
+    measure.add_argument('--ocr', type=Path)
+    measure.add_argument('--record', action='store_true')
+    measure.add_argument('--record-backend', choices=['screenrecord', 'scrcpy'], default='screenrecord')
+    measure.add_argument('--video-seconds', type=int, choices=range(1, 181), default=60, metavar='1..180')
+    measure.add_argument('--video-bit-rate', type=int, default=2_000_000)
+    measure.add_argument('--a', type=Path, required=True)
+    measure.add_argument('--b', type=Path, required=True)
+    measure.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    signal.signal(signal.SIGTERM, interrupted)
+    if args.command == 'build-route':
+        build_route(args)
+    elif args.command == 'build-ocr':
+        build_ocr(args)
+    else:
+        args.output.mkdir(parents=True, exist_ok=False)
+        report = {}
+        run_reported(args.output / 'report.json', report, lambda: sequence(args, report))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/android_benchmark_artifacts.py
+++ b/scripts/android_benchmark_artifacts.py
@@ -1,0 +1,139 @@
+import gzip
+import hashlib
+import io
+import json
+import os
+from pathlib import Path, PurePosixPath
+import tarfile
+import tempfile
+import zipfile
+
+from android_benchmark_support import digest
+
+
+CACHE_SIGNATURE = 'Signature: 8a477f597d28d172789f06886806bc55'
+INVENTORY = '.cranpose-source.json'
+
+
+def source_inventory(root):
+    root = Path(root)
+    result = {}
+    for directory, children, files in os.walk(root):
+        base = Path(directory)
+        children[:] = sorted(child for child in children
+                             if child not in {'.git', '.gradle', 'target', 'build', '__pycache__'}
+                             and not (base / child / 'CACHEDIR.TAG').exists())
+        for name in sorted(children + files):
+            if (base / name).is_symlink():
+                raise ValueError('Source symlink requires an explicit materialized input: ' + str(base / name))
+        for name in sorted(files):
+            path = base / name
+            if name in {INVENTORY, '.git'}:
+                continue
+            result[path.relative_to(root).as_posix()] = {
+                'sha256': digest(path), 'executable': bool(path.stat().st_mode & 0o111),
+            }
+    return dict(sorted(result.items()))
+
+
+def snapshot_source(root, destination):
+    root, destination = Path(root), Path(destination)
+    if destination.resolve().is_relative_to(root.resolve()):
+        raise ValueError('Source archives must live outside their input tree')
+    inventory = source_inventory(root)
+    with destination.open('xb') as output, gzip.GzipFile(fileobj=output, mode='wb', mtime=0, filename='') as compressed:
+        with tarfile.open(fileobj=compressed, mode='w|') as archive:
+            for name, entry in [*inventory.items(), (INVENTORY, {'executable': False})]:
+                data = (json.dumps(inventory, sort_keys=True).encode() if name == INVENTORY
+                        else (root / name).read_bytes())
+                if name != INVENTORY and hashlib.sha256(data).hexdigest() != entry['sha256']:
+                    raise ValueError('Source changed while archiving: ' + name)
+                member = tarfile.TarInfo(name)
+                member.size = len(data)
+                member.mode = 0o755 if entry['executable'] else 0o644
+                archive.addfile(member, io.BytesIO(data))
+    if source_inventory(root) != inventory:
+        raise ValueError('Source inventory changed while archiving')
+    destination.chmod(0o444)
+    return digest(destination)
+
+
+def extract_source(archive_path, destination):
+    destination = Path(destination)
+    if destination.exists():
+        raise ValueError('Source extraction requires a fresh directory')
+    with tarfile.open(archive_path) as archive:
+        members = archive.getmembers()
+        names = [member.name for member in members]
+        if len(set(names)) != len(names):
+            raise ValueError('Archive contains duplicate entries')
+        for member in members:
+            path = PurePosixPath(member.name)
+            if not member.isfile() or path.is_absolute() or '..' in path.parts or str(path) != member.name:
+                raise ValueError('Invalid source archive entry: ' + member.name)
+        manifest = json.load(archive.extractfile(INVENTORY))
+        if set(names) != set(manifest) | {INVENTORY}:
+            raise ValueError('Archive inventory does not match its members')
+        for member in members:
+            if member.name != INVENTORY:
+                actual = hashlib.file_digest(archive.extractfile(member), 'sha256').hexdigest()
+                if actual != manifest[member.name]['sha256']:
+                    raise ValueError('Archive source hash mismatch: ' + member.name)
+        destination.mkdir(parents=True)
+        for member in members:
+            path = destination / member.name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(archive.extractfile(member).read())
+            executable = member.name != INVENTORY and manifest[member.name]['executable']
+            path.chmod(0o755 if executable else 0o644)
+    if source_inventory(destination) != manifest:
+        raise ValueError('Extracted source inventory mismatch')
+    return manifest
+
+
+def build_cache(cache_root):
+    root = Path(cache_root).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    directory = Path(tempfile.mkdtemp(prefix='android-', dir=root))
+    (directory / 'CACHEDIR.TAG').write_text(CACHE_SIGNATURE + '\n')
+    return directory
+
+
+def verify_apk(apk, proof, native_member):
+    if digest(apk) != proof['apk_sha256']:
+        raise ValueError('APK differs from its build provenance')
+    with zipfile.ZipFile(apk) as archive:
+        if len(archive.namelist()) != len(set(archive.namelist())):
+            raise ValueError('APK contains duplicate members')
+        native_hash = hashlib.sha256(archive.read(native_member)).hexdigest()
+        if native_hash != proof['build']['native_sha256']:
+            raise ValueError('APK native library differs from its source build')
+        libraries = [name for name in archive.namelist()
+                     if name.startswith('lib/') and name.endswith('/' + Path(native_member).name)]
+        if libraries != [native_member]:
+            raise ValueError('APK contains another ABI of the measured library')
+        payload = apk_payload(archive, native_member)
+    if payload != proof['payload']:
+        raise ValueError('APK application payload differs from its provenance')
+    return native_hash
+
+
+def apk_payload(archive, native_member):
+    return {name: hashlib.sha256(archive.read(name)).hexdigest()
+            for name in archive.namelist()
+            if not name.startswith('META-INF/')
+            and not (name.startswith('lib/') and name.endswith('/' + Path(native_member).name))}
+
+
+def verify_build(proof, directory):
+    if proof['status'] != 'complete':
+        raise ValueError('Native build did not complete')
+    if digest(directory / proof['native']) != proof['native_sha256']:
+        raise ValueError('Native artifact differs from its build report')
+    for source in proof['sources'].values():
+        archive = directory / source['archive']
+        if digest(archive) != source['sha256']:
+            raise ValueError('Source archive differs from its build report')
+        with tarfile.open(archive) as contents:
+            if json.load(contents.extractfile(INVENTORY)) != source['inventory']:
+                raise ValueError('Source inventory differs from its build report')

--- a/scripts/android_benchmark_build.py
+++ b/scripts/android_benchmark_build.py
@@ -1,0 +1,145 @@
+import argparse
+import json
+import signal
+import os
+from pathlib import Path
+import shutil
+import tomllib
+
+from android_benchmark_artifacts import build_cache, extract_source, snapshot_source, source_inventory
+from android_benchmark_support import checked_command, digest, interrupted, run_reported
+
+
+def framework_packages(root):
+    packages = {}
+    for manifest in (root / 'crates').rglob('Cargo.toml'):
+        name = tomllib.loads(manifest.read_text()).get('package', {}).get('name')
+        if name:
+            packages[name] = manifest.parent
+    return packages
+
+
+def native_artifact(exported, package, abi, build_output):
+    warnings = [line for line in build_output.decode(errors='replace').splitlines()
+                if line.startswith('warning:')]
+    if warnings:
+        raise ValueError('Build emitted warnings: ' + '\n'.join(warnings))
+    names = {target['name'] for target in package['targets'] if 'cdylib' in target['crate_types']}
+    if len(names) != 1:
+        raise ValueError('Expected one native library target in Cargo metadata')
+    artifact = exported / abi / ('lib' + names.pop() + '.so')
+    if not artifact.is_file():
+        raise ValueError('cargo-ndk did not export the selected library: ' + str(artifact))
+    return artifact
+
+
+def build_settings(args, environment):
+    names = {'RUSTFLAGS', 'CARGO_ENCODED_RUSTFLAGS', 'RUSTC_WRAPPER', 'RUSTC_WORKSPACE_WRAPPER',
+             'CC', 'CXX', 'AR', 'CFLAGS', 'CXXFLAGS', 'CPPFLAGS', 'LDFLAGS'}
+    flags = {name: value for name, value in environment.items()
+             if name in names or name.startswith(('CARGO_PROFILE_', 'CARGO_TARGET_'))
+             and name != 'CARGO_TARGET_DIR'}
+    cargo_home = Path(environment.get('CARGO_HOME', Path.home() / '.cargo'))
+    configs = {name: digest(cargo_home / name) for name in ['config', 'config.toml']
+               if (cargo_home / name).is_file()}
+    ndk = Path(environment['ANDROID_NDK_HOME'])
+    return {'package': args.package, 'platform': args.platform, 'profile': 'release',
+            'flags': flags, 'cargo_config_sha256': configs,
+            'ndk_properties_sha256': digest(ndk / 'source.properties')}
+
+
+def write_framework_overrides(destination, packages, selected):
+    destination.write_text('[patch.crates-io]\n' + ''.join(
+        json.dumps(name) + ' = { path = ' + json.dumps(str(packages[name])) + ' }\n'
+        for name in sorted(selected)))
+
+
+def build(args, report):
+    cache = build_cache(args.cache)
+    report['cache'] = str(cache)
+    sources = {}
+    for name, original in [('framework', args.framework), ('app', args.app)]:
+        archive = (args.output if name == 'framework' else cache) / f'{name}.tar.gz'
+        source_hash = snapshot_source(original, archive)
+        inventory = extract_source(archive, cache / name)
+        sources[name] = {'archive': archive.name, 'sha256': source_hash, 'inventory': inventory}
+    report['sources'] = sources
+    app = cache / 'app'
+    environment = dict(os.environ, CARGO_TARGET_DIR=str(args.target_dir.resolve()))
+    common = ['--locked', '--no-default-features', '--features', args.features]
+    packages = framework_packages(cache / 'framework')
+    selected = set()
+    for manifest in [app / 'Cargo.toml', app / '.cargo/config.toml', app / '.cargo/config']:
+        if manifest.is_file():
+            patches = tomllib.loads(manifest.read_text()).get('patch', {}).get('crates-io', {})
+            selected |= patches.keys() & packages.keys()
+    overrides = cache / 'framework.toml'
+    write_framework_overrides(overrides, packages, selected)
+    metadata_command = ['cargo', 'metadata', '--format-version=1', *common, '--config', str(overrides)]
+    if selected:
+        metadata_command.remove('--locked')
+    initial_metadata = json.loads(checked_command(metadata_command, cwd=app, env=environment,
+                                                 output=args.output / 'initial-metadata.log'))
+    selected |= {package['name'] for package in initial_metadata['packages']} & packages.keys()
+    if not selected:
+        raise ValueError('Application resolves no framework packages')
+    write_framework_overrides(overrides, packages, selected)
+    if '--locked' in metadata_command:
+        metadata_command.remove('--locked')
+    metadata_command.append('--offline')
+    metadata = json.loads(checked_command(metadata_command, cwd=app, env=environment,
+                                          output=args.output / 'resolved-metadata.log'))
+    resolved = {package['name']: package['manifest_path'] for package in metadata['packages']
+                if package['source'] is None}
+    if any(not Path(path).is_relative_to(cache) for path in resolved.values()):
+        raise ValueError('Application resolves source outside its immutable snapshot: ' + str(resolved))
+    if any(Path(resolved[name]).parent != packages[name] for name in selected & resolved.keys()):
+        raise ValueError('Application does not resolve the archived framework')
+    app_archive = args.output / 'app.tar.gz'
+    sources['app'] = {'archive': app_archive.name, 'sha256': snapshot_source(app, app_archive),
+                      'inventory': source_inventory(app)}
+    package = next(package for package in metadata['packages'] if package['name'] == args.package)
+    exported = cache / 'native'
+    command = ['cargo', 'ndk', '--platform', str(args.platform), '-t', args.abi,
+               '--output-dir', str(exported),
+               'build', *common, '--release', '-p', args.package, '--lib',
+               '--config', str(overrides)]
+    report.update(command=command, resolved=resolved,
+                  toolchain=checked_command(['rustc', '-Vv'], cwd=app, env=environment).decode(),
+                  cargo=checked_command(['cargo', '-V'], cwd=app, env=environment).decode(),
+                  settings=build_settings(args, environment),
+                  ndk=environment['ANDROID_NDK_HOME'], features=args.features, abi=args.abi)
+    log = args.output / 'build.log'
+    checked_command(command, cwd=app, env=environment, timeout=args.timeout, output=log)
+    artifact = native_artifact(exported, package, args.abi, log.read_bytes())
+    for name, source in sources.items():
+        if source_inventory(cache / name) != source['inventory']:
+            raise ValueError('Build changed archived sources: ' + name)
+    native = args.output / artifact.name
+    shutil.copyfile(artifact, native)
+    report.update(native=artifact.name, native_sha256=digest(native),
+                  lock_sha256=digest(app / 'Cargo.lock'))
+
+
+def main():
+    signal.signal(signal.SIGTERM, interrupted)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--framework', type=Path, required=True)
+    parser.add_argument('--app', type=Path, required=True)
+    parser.add_argument('--package', required=True)
+    parser.add_argument('--features', required=True)
+    parser.add_argument('--abi', required=True, choices=['arm64-v8a', 'armeabi-v7a', 'x86_64', 'x86'])
+    parser.add_argument('--platform', type=int, required=True)
+    parser.add_argument('--cache', type=Path, default=Path(os.environ.get('XDG_CACHE_HOME', Path.home() / '.cache')) / 'cranpose/benchmarks')
+    parser.add_argument('--target-dir', type=Path, required=True)
+    parser.add_argument('--timeout', type=int, default=1800)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    args.output = args.output.resolve()
+    args.output.mkdir(parents=True, exist_ok=False)
+    report = {}
+    run_reported(args.output / 'build.json', report, lambda: build(args, report))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/android_benchmark_device.py
+++ b/scripts/android_benchmark_device.py
@@ -1,0 +1,227 @@
+import hashlib
+import io
+import json
+import re
+import shlex
+import subprocess
+import time
+import xml.etree.ElementTree as ET
+import uuid
+
+from PIL import Image
+
+from android_benchmark_support import checked_command
+
+
+class AndroidDevice:
+    def __init__(self, serial, adb='adb', ocr=None, evidence=None):
+        self.command = [adb, '-s', serial]
+        self.serial = serial
+        self.saved_properties = {}
+        self.desired_properties = {}
+        self.ocr = ocr
+        self.evidence = evidence
+
+    def run(self, *parts, **options):
+        return checked_command(self.command + list(parts), **options)
+
+    def shell(self, *parts, **options):
+        return self.run('shell', shlex.join([str(part) for part in parts]), **options).decode()
+
+    def wake(self):
+        self.shell('input', 'keyevent', 'KEYCODE_WAKEUP')
+        if 'mWakefulness=Awake' not in self.shell('dumpsys', 'power'):
+            raise ValueError('Device is not awake')
+
+    def properties(self):
+        return dict(re.findall(r'^\[(debug\.cranpose\.[^\]]+)\]: \[([^\]]*)\]$',
+                               self.shell('getprop'), re.M))
+
+    def configure_properties(self, overrides):
+        if any(not name.startswith('debug.cranpose.') for name in overrides):
+            raise ValueError('Only Cranpose diagnostic properties can be changed')
+        current = self.properties()
+        self.desired_properties = dict.fromkeys(current, '') | overrides
+        self.saved_properties = {name: current.get(name, '') for name in self.desired_properties}
+        for name, value in self.desired_properties.items():
+            if current.get(name, '') != value:
+                self.shell('setprop', name, value)
+        effective = self.properties()
+        if any(effective.get(name, '') != value for name, value in self.desired_properties.items()):
+            raise ValueError('Diagnostic property setup did not take effect')
+
+    def restore_properties(self):
+        if not self.saved_properties:
+            return
+        current = self.properties()
+        errors = []
+        for name, original in self.saved_properties.items():
+            try:
+                if current.get(name, '') not in {original, self.desired_properties[name]}:
+                    raise ValueError('Diagnostic property changed outside the sequence: ' + name)
+                if current.get(name, '') != original:
+                    self.shell('setprop', name, original)
+            except Exception as error:
+                errors.append(error)
+        restored = self.properties()
+        if any(restored.get(name, '') != value for name, value in self.saved_properties.items()):
+            errors.append(ValueError('Diagnostic property restoration did not match saved values'))
+        if errors:
+            raise ExceptionGroup('Diagnostic property restoration failed', errors)
+
+    def screenshot(self, path, region):
+        self.wake()
+        data = self.run('exec-out', 'screencap', '-p')
+        path.write_bytes(data)
+        return screenshot_pixels(data, region)
+
+    def endpoint(self, package, expected, size, region=None, text_source='accessibility', image_path=None):
+        if not expected.strip():
+            raise ValueError('Endpoint checks require nonempty text')
+        if text_source == 'image':
+            return self.visual_endpoint(expected, size, region, image_path)
+        if text_source != 'accessibility':
+            raise ValueError('Unsupported endpoint text source')
+        self.wake()
+        path = '/data/local/tmp/cranpose-endpoint-' + uuid.uuid4().hex + '.xml'
+        try:
+            self.shell('uiautomator', 'dump', '--compressed', path)
+            text = self.shell('cat', path)
+        finally:
+            self.shell('rm', '-f', path)
+        start = text.find('<?xml')
+        end = text.rfind('</hierarchy>')
+        if start < 0 or end < 0:
+            raise ValueError('Accessibility hierarchy was not returned')
+        hierarchy = ET.fromstring(text[start:end + len('</hierarchy>')])
+        matches = []
+        for node in hierarchy.iter('node'):
+            label = node.get('text', '') + ' ' + node.get('content-desc', '')
+            bounds = [int(value) for value in re.findall(r'-?\d+', node.get('bounds', ''))]
+            if expected.casefold() not in label.casefold() or node.get('package') != package or len(bounds) != 4:
+                continue
+            left, top, right, bottom = bounds
+            if region is not None and not (region[0] <= (left + right) / 2 <= region[2]
+                                          and region[1] <= (top + bottom) / 2 <= region[3]):
+                continue
+            if min(right, size[0]) > max(left, 0) and min(bottom, size[1]) > max(top, 0):
+                matches.append({'label': label, 'bounds': bounds})
+        if not matches:
+            raise ValueError('Visible route endpoint was not reached: ' + expected)
+        return matches
+
+    def visual_endpoint(self, expected, size, region, image_path):
+        if self.ocr is None or self.evidence is None or region is None:
+            raise ValueError('Image endpoints require a verified OCR helper, evidence directory and region')
+        self.evidence.mkdir(parents=True, exist_ok=True)
+        path = image_path or self.evidence / (uuid.uuid4().hex + '.png')
+        pixels = screenshot_pixels(path.read_bytes(), region) if image_path else self.screenshot(path, region)
+        if pixels['size'] != size:
+            raise ValueError('Image endpoint has an unexpected display size')
+        cropped = path.with_suffix('.crop.png')
+        with Image.open(path) as image:
+            image.crop(region).save(cropped)
+        rows = json.loads(checked_command([str(self.ocr), str(cropped)]))
+        path.with_suffix('.json').write_text(json.dumps(rows, indent=2) + '\n')
+        text = ' '.join(row['text'] for row in rows)
+        if expected.casefold() not in text.casefold():
+            raise ValueError('Visible image endpoint was not reached: ' + expected)
+        return {'image': str(path), 'pixels': pixels, 'text': text, 'rows': rows}
+
+    def state(self):
+        battery = self.shell('dumpsys', 'battery')
+        temperature = re.search(r'temperature:\s*(-?\d+)', battery)
+        if not temperature:
+            raise ValueError('Device temperature was not reported')
+        return {'battery': battery, 'temperature_c': int(temperature[1]) / 10,
+                'thermal': self.shell('dumpsys', 'thermalservice'),
+                'background_cpu': self.shell('dumpsys', 'cpuinfo')}
+
+    def installed_apk(self, package):
+        paths = self.shell('pm', 'path', package).splitlines()
+        if not paths:
+            return None
+        if len(paths) != 1 or not paths[0].startswith('package:'):
+            raise ValueError('Benchmark requires a single installed APK')
+        path = paths[0].removeprefix('package:')
+        return {'path': path, 'sha256': self.shell('sha256sum', path).split()[0]}
+
+    def wait_for_pid(self, package, timeout=30):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                pid = self.shell('pidof', package).strip()
+                if pid.isdigit() and int(pid) > 1:
+                    return pid
+            except subprocess.CalledProcessError:
+                pass
+            time.sleep(0.2)
+        raise ValueError('Application did not report a PID before the launch deadline')
+
+    def require_foreground(self, package, pid):
+        current = self.shell('pidof', package).strip()
+        activities = self.shell('dumpsys', 'activity', 'activities')
+        resumed = [line for line in activities.splitlines() if 'ResumedActivity' in line or 'mResumed' in line]
+        if current != pid or not any(package + '/' in line for line in resumed):
+            raise ValueError('Measured application restarted or left the foreground')
+        return resumed
+
+    def stop_owned_process(self, pid, marker, first_signal='TERM'):
+        if not str(pid).isdigit() or int(pid) <= 1 or not marker:
+            raise ValueError('Process cleanup requires a positive PID and unique ownership marker')
+        def owned():
+            command = self.shell('sh', '-c', f'if test -d /proc/{pid}; then cat /proc/{pid}/cmdline; fi')
+            return marker in command
+        for signal_name, timeout in [(first_signal, 5), ('KILL', 2)]:
+            if not owned():
+                return
+            self.shell('kill', '-' + signal_name, str(pid))
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                if not owned():
+                    return
+                time.sleep(0.1)
+        raise RuntimeError('Owned device process did not terminate: ' + str(pid))
+
+
+def screenshot_pixels(data, region):
+    with Image.open(io.BytesIO(data)) as image:
+        image.load()
+        colors = image.convert('RGB')
+        if max(max(channel) for channel in colors.getextrema()) < 16:
+            raise ValueError('Device screenshot is black')
+        left, top, right, bottom = region
+        if not 0 <= left < right <= image.width or not 0 <= top < bottom <= image.height:
+            raise ValueError('Motion region falls outside the screenshot')
+        return {'sha256': hashlib.sha256(data).hexdigest(), 'size': list(image.size),
+                'motion_pixels_sha256': hashlib.sha256(colors.crop(region).tobytes()).hexdigest()}
+
+
+def surface_frames(text, package):
+    layers = []
+    for block in re.split(r'(?=layerName = )', text):
+        name = re.search(r'layerName = (.*)', block)
+        frames = re.search(r'totalFrames = (\d+)', block)
+        if name and frames and package + '/' in name[1]:
+            layers.append({'name': name[1], 'frames': int(frames[1])})
+    if len(layers) != 1 or layers[0]['frames'] == 0:
+        raise ValueError('Expected one active presentation surface: ' + str(layers))
+    return layers[0]
+
+
+def verify_route_window(output, count, duration_ms, period_ms, window_ms, tolerance_ms):
+    gestures = [tuple(map(int, match)) for match in re.findall(r'gesture=(\d+) start=(\d+) end=(\d+)', output)]
+    elapsed = re.search(r'elapsed_ms=(\d+)', output)
+    if not elapsed or len(gestures) != count:
+        raise ValueError('Device input sequence was incomplete')
+    if any(index != expected or abs(start - expected * period_ms) > tolerance_ms
+           or end - start < duration_ms
+           for expected, (index, start, end) in enumerate(gestures)):
+        raise ValueError('Device input sequence missed its timing contract')
+    elapsed_ms = int(elapsed[1])
+    if not window_ms <= elapsed_ms <= window_ms + tolerance_ms:
+        raise ValueError('Device measurement window overran its timing contract')
+    stats = re.search(r'SF_BEGIN\n(.*?)SF_END', output, re.S)
+    if not stats:
+        raise ValueError('Device did not return presentation statistics')
+    return elapsed_ms / 1000, stats[1]

--- a/scripts/android_benchmark_package.py
+++ b/scripts/android_benchmark_package.py
@@ -1,0 +1,57 @@
+import argparse
+import json
+import signal
+from pathlib import Path
+import zipfile
+
+from android_benchmark_artifacts import apk_payload, verify_apk, verify_build
+from android_benchmark_support import checked_command, digest, interrupted, run_reported
+
+
+def package(args, report):
+    build = json.loads(args.build_report.read_text())
+    verify_build(build, args.build_report.parent)
+    native = args.build_report.parent / build['native']
+    member = f'lib/{build["abi"]}/{native.name}'
+    unsigned = args.output / 'unaligned.apk'
+    apk = args.output / 'app.apk'
+    with zipfile.ZipFile(args.template) as source, zipfile.ZipFile(unsigned, 'w') as target:
+        if len(source.namelist()) != len(set(source.namelist())):
+            raise ValueError('Template APK contains duplicate members')
+        payload = apk_payload(source, member)
+        for item in source.infolist():
+            if item.filename in payload:
+                target.writestr(item, source.read(item))
+        target.write(native, member, compress_type=zipfile.ZIP_STORED)
+    zipalign = str(args.build_tools / 'zipalign')
+    apksigner = str(args.build_tools / 'apksigner')
+    checked_command([zipalign, '-P', '16', '4', str(unsigned), str(apk)])
+    checked_command([apksigner, 'sign', '--ks', str(args.keystore),
+                     '--ks-key-alias', args.key_alias, '--ks-pass', 'env:' + args.password_env,
+                     '--key-pass', 'env:' + args.password_env, str(apk)])
+    checked_command([apksigner, 'verify', str(apk)])
+    checked_command([zipalign, '-c', '-P', '16', '4', str(apk)])
+    report.update(apk='app.apk', apk_sha256=digest(apk), template_sha256=digest(args.template),
+                  native_member=member, build=build, build_directory=str(args.build_report.parent.resolve()),
+                  payload=payload)
+    verify_apk(apk, report, member)
+
+
+def main():
+    signal.signal(signal.SIGTERM, interrupted)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--build-report', type=Path, required=True)
+    parser.add_argument('--template', type=Path, required=True)
+    parser.add_argument('--build-tools', type=Path, required=True)
+    parser.add_argument('--keystore', type=Path, required=True)
+    parser.add_argument('--key-alias', required=True)
+    parser.add_argument('--password-env', required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=False)
+    report = {}
+    run_reported(args.output / 'apk.json', report, lambda: package(args, report))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/android_benchmark_support.py
+++ b/scripts/android_benchmark_support.py
@@ -1,0 +1,102 @@
+import hashlib
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import tempfile
+
+from android_robot_device import device_lock
+
+
+def digest(path):
+    with Path(path).open('rb') as source:
+        return hashlib.file_digest(source, 'sha256').hexdigest()
+
+
+def write_report(path, report):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(mode='w', dir=path.parent, delete=False) as output:
+        json.dump(report, output, indent=2)
+        output.write('\n')
+        output.flush()
+        os.fsync(output.fileno())
+    os.replace(output.name, path)
+
+
+def checked_command(command, *, cwd=None, env=None, timeout=60, output=None):
+    with subprocess.Popen(command, cwd=cwd, env=env, stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE, start_new_session=True) as process:
+        try:
+            data, diagnostics = process.communicate(timeout=timeout)
+        except BaseException:
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                data, diagnostics = process.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                data, diagnostics = process.communicate(timeout=5)
+            if output:
+                Path(output).write_bytes(diagnostics + data)
+            raise
+    if output:
+        Path(output).write_bytes(diagnostics + data)
+    if process.returncode:
+        raise subprocess.CalledProcessError(process.returncode, command, output=diagnostics + data)
+    return data
+
+
+def error_details(error):
+    result = {'type': type(error).__name__, 'message': str(error)}
+    if isinstance(error, BaseExceptionGroup):
+        result['children'] = [error_details(child) for child in error.exceptions]
+    if isinstance(error, (subprocess.CalledProcessError, subprocess.TimeoutExpired)):
+        result['command'] = error.cmd
+        output = error.output
+        result['output'] = output.decode(errors='replace') if isinstance(output, bytes) else output
+    return result
+
+
+def run_reported(path, report, work, cleanup=()):
+    report.update(status='running', acceptance_eligible=False)
+    write_report(path, report)
+    errors = []
+    try:
+        work()
+    except BaseException as error:
+        errors.append(error)
+        report['invalid_reason'] = f'{type(error).__name__}: {error}'
+    finally:
+        eligible = report.get('acceptance_eligible', False)
+        report['acceptance_eligible'] = False
+        try:
+            write_report(path, report)
+        except BaseException as error:
+            errors.append(error)
+            report['report_error'] = str(error)
+        for finish in cleanup:
+            try:
+                finish()
+            except BaseException as error:
+                errors.append(error)
+                report.setdefault('cleanup_errors', []).append(f'{type(error).__name__}: {error}')
+        report['status'] = 'failed' if errors else 'complete'
+        report['acceptance_eligible'] = eligible and not errors
+        if errors:
+            report['acceptance_eligible'] = False
+            report.setdefault('invalid_reason', 'cleanup failed')
+            report['errors'] = [error_details(error) for error in errors]
+        try:
+            write_report(path, report)
+        except BaseException as error:
+            errors.append(error)
+    if errors:
+        raise BaseExceptionGroup('Benchmark failed; evidence retained in ' + str(path), errors)
+
+
+def interrupted(number, _frame):
+    raise KeyboardInterrupt(f'Signal {number}')

--- a/scripts/android_benchmark_test.py
+++ b/scripts/android_benchmark_test.py
@@ -1,0 +1,755 @@
+import io
+import json
+import os
+import signal
+import time
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from unittest.mock import Mock, patch
+from types import SimpleNamespace
+
+import android_benchmark as benchmark
+import android_benchmark_artifacts as artifacts
+import android_benchmark_support as support
+from android_benchmark_device import AndroidDevice, surface_frames, verify_route_window
+from android_benchmark_build import build, native_artifact
+from android_benchmark import run_leg, sequence, validate_pair, validate_route
+from android_benchmark_video import AndroidRecording, ScrcpyRecording, inspect_recording
+
+
+class BenchmarkContracts(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.report = self.root / 'report.json'
+
+    def source(self):
+        source = self.root / 'source'
+        source.mkdir()
+        (source / 'app.rs').write_text('fn main() {}')
+        (source / 'run.sh').write_text('exit 0\n')
+        (source / 'run.sh').chmod(0o755)
+        return source
+
+    def test_archives_are_deterministic_complete_and_extract_into_fresh_sources(self):
+        source = self.source()
+        archives = [self.root / f'{index}.tar.gz' for index in range(2)]
+        hashes = [artifacts.snapshot_source(source, path) for path in archives]
+        self.assertEqual(hashes[0], hashes[1])
+        extracted = self.root / 'extracted'
+        inventory = artifacts.extract_source(archives[0], extracted)
+        self.assertEqual(inventory, artifacts.source_inventory(source))
+        self.assertTrue(os.access(extracted / 'run.sh', os.X_OK))
+        (extracted / 'unexpected.rs').write_text('stale input')
+        with self.assertRaisesRegex(ValueError, 'fresh directory'):
+            artifacts.extract_source(archives[0], extracted)
+
+    def test_archive_rejects_symlinks_and_self_inclusion(self):
+        source = self.source()
+        with self.assertRaisesRegex(ValueError, 'outside'):
+            artifacts.snapshot_source(source, source / 'self.tar.gz')
+        (source / 'alias.rs').symlink_to(source / 'app.rs')
+        with self.assertRaisesRegex(ValueError, 'symlink'):
+            artifacts.snapshot_source(source, self.root / 'link.tar.gz')
+
+    def test_archive_rejects_paths_duplicates_and_corrupt_inventory_before_extraction(self):
+        valid = self.root / 'valid.tar.gz'
+        artifacts.snapshot_source(self.source(), valid)
+        for index, mutation in enumerate(['../escape', '/absolute', 'duplicate', 'corrupt', 'extra']):
+            archive = self.root / f'bad-{index}.tar'
+            with tarfile.open(valid) as original, tarfile.open(archive, 'w') as modified:
+                for member in original.getmembers():
+                    data = original.extractfile(member).read()
+                    if mutation == 'corrupt' and member.name == 'app.rs':
+                        data = b'changed bytes'
+                    member.size = len(data)
+                    modified.addfile(member, io.BytesIO(data))
+                if mutation != 'corrupt':
+                    extra = tarfile.TarInfo('app.rs' if mutation == 'duplicate' else mutation)
+                    extra.size = 1
+                    modified.addfile(extra, io.BytesIO(b'x'))
+            destination = self.root / f'rejected-{index}'
+            with self.assertRaises(ValueError):
+                artifacts.extract_source(archive, destination)
+            self.assertFalse(destination.exists())
+        self.assertFalse((self.root / 'escape').exists())
+
+    def test_work_and_cleanup_failures_are_retained_and_every_cleanup_runs(self):
+        report, calls = {}, []
+
+        def work():
+            raise subprocess.CalledProcessError(3, ['broken-input'], output=b'injection refused')
+
+        def cleanup():
+            self.assertEqual(json.loads(self.report.read_text())['status'], 'running')
+            raise RuntimeError('restore failed')
+
+        with self.assertRaises(BaseExceptionGroup):
+            support.run_reported(self.report, report, work, [cleanup, lambda: calls.append('last')])
+        saved = json.loads(self.report.read_text())
+        self.assertEqual(calls, ['last'])
+        self.assertEqual(saved['status'], 'failed')
+        self.assertFalse(saved['acceptance_eligible'])
+        self.assertEqual(saved['errors'][0]['output'], 'injection refused')
+        self.assertIn('restore failed', saved['cleanup_errors'][0])
+
+    def test_reporting_failure_does_not_skip_device_cleanup(self):
+        calls = []
+        original = support.write_report
+        writes = 0
+
+        def fail_second_write(path, report):
+            nonlocal writes
+            writes += 1
+            if writes == 2:
+                raise OSError('disk full')
+            original(path, report)
+
+        with patch.object(support, 'write_report', side_effect=fail_second_write):
+            with self.assertRaises(BaseException):
+                support.run_reported(self.report, {}, lambda: None, [lambda: calls.append('restored')])
+        self.assertEqual(calls, ['restored'])
+        self.assertEqual(json.loads(self.report.read_text())['status'], 'failed')
+
+    def test_nested_command_failures_keep_their_diagnostics(self):
+        def work():
+            raise ExceptionGroup('recording', [subprocess.CalledProcessError(
+                2, ['ffprobe', 'video.mp4'], output=b'invalid container')])
+        with self.assertRaises(BaseExceptionGroup):
+            support.run_reported(self.report, {}, work)
+        failure = json.loads(self.report.read_text())['errors'][0]['children'][0]
+        self.assertEqual(failure['command'], ['ffprobe', 'video.mp4'])
+        self.assertEqual(failure['output'], 'invalid container')
+
+    def test_success_does_not_implicitly_authorize_a_performance_number(self):
+        report = {}
+        support.run_reported(self.report, report, lambda: report.update(fps=60))
+        self.assertEqual(report['status'], 'complete')
+        self.assertFalse(report['acceptance_eligible'])
+
+    def test_performance_is_not_eligible_until_cleanup_succeeds(self):
+        report = {}
+        def cleanup():
+            saved = json.loads(self.report.read_text())
+            self.assertEqual(saved['status'], 'running')
+            self.assertFalse(saved['acceptance_eligible'])
+        support.run_reported(self.report, report, lambda: report.update(acceptance_eligible=True), [cleanup])
+        self.assertTrue(report['acceptance_eligible'])
+
+    def test_timeout_preserves_command_output_and_stops_the_child(self):
+        log = self.root / 'command.log'
+        with self.assertRaises(subprocess.TimeoutExpired):
+            support.checked_command([sys.executable, '-c',
+                                     'import os,time; print(os.getpid(), flush=True); time.sleep(60)'],
+                                    timeout=1, output=log)
+        pid = int(log.read_text())
+        with self.assertRaises(ProcessLookupError):
+            os.kill(pid, 0)
+
+    def test_sigterm_interrupts_pending_commands_and_retains_failure_report(self):
+        marker = self.root / 'command.pid'
+        sleeper = f'import os,time; from pathlib import Path; Path({str(marker)!r}).write_text(str(os.getpid())); time.sleep(60)'
+        driver = ('import signal,sys; import android_benchmark as b; import android_benchmark_support as s; '
+                  'signal.signal(signal.SIGTERM,b.interrupted); '
+                  f's.run_reported({str(self.report)!r}, {{}}, lambda: s.checked_command([sys.executable,"-c",{sleeper!r}],timeout=60))')
+        with (self.root / 'driver.log').open('wb') as log:
+            process = subprocess.Popen([sys.executable, '-c', driver], cwd=Path(__file__).parent,
+                                       stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+            try:
+                deadline = time.monotonic() + 5
+                while not marker.exists() and time.monotonic() < deadline:
+                    time.sleep(0.02)
+                self.assertTrue(marker.exists(), 'Child command did not start')
+                process.send_signal(signal.SIGTERM)
+                self.assertNotEqual(process.wait(timeout=3), 0)
+                result = json.loads(self.report.read_text())
+                self.assertEqual(result['status'], 'failed')
+                self.assertFalse(result['acceptance_eligible'])
+                with self.assertRaises(ProcessLookupError):
+                    os.kill(int(marker.read_text()), 0)
+            finally:
+                if process.poll() is None:
+                    process.kill()
+                    process.wait(timeout=5)
+                if marker.exists():
+                    try:
+                        os.kill(int(marker.read_text()), signal.SIGTERM)
+                    except ProcessLookupError:
+                        pass
+
+    def test_device_lock_is_shared_between_processes_and_released_after_failure(self):
+        serial = 'fixture-' + str(self.root)
+        marker = self.root / 'acquired'
+        code = ('from android_robot_device import locked_device; from pathlib import Path; '
+                'import sys\nwith locked_device(sys.argv[1]): Path(sys.argv[2]).touch()')
+        with support.device_lock(serial):
+            child = subprocess.Popen([sys.executable, '-c', code, serial, str(marker)],
+                                     cwd=Path(__file__).parent)
+            try:
+                with self.assertRaises(subprocess.TimeoutExpired):
+                    child.wait(timeout=0.2)
+                self.assertFalse(marker.exists())
+            except BaseException:
+                child.terminate()
+                child.wait(timeout=5)
+                raise
+        self.assertEqual(child.wait(timeout=5), 0)
+        self.assertTrue(marker.exists())
+
+    def test_partial_property_setup_is_restored_and_conflicts_are_not_overwritten(self):
+        class Device(AndroidDevice):
+            def __init__(self):
+                super().__init__('test')
+                self.values = {'debug.cranpose.a': 'original', 'debug.cranpose.b': 'saved'}
+                self.fail = True
+
+            def properties(self):
+                return self.values.copy()
+
+            def shell(self, *parts):
+                _, name, value = parts
+                if self.fail and name.endswith('.b'):
+                    self.fail = False
+                    raise RuntimeError('property write refused')
+                self.values[name] = value
+
+        device = Device()
+        original = device.values.copy()
+        with self.assertRaisesRegex(RuntimeError, 'refused'):
+            device.configure_properties({})
+        device.restore_properties()
+        self.assertEqual(device.values, original)
+        device.configure_properties({'debug.cranpose.new': '1'})
+        device.values['debug.cranpose.a'] = 'external change'
+        with self.assertRaises(ExceptionGroup):
+            device.restore_properties()
+        self.assertEqual(device.values['debug.cranpose.a'], 'external change')
+        self.assertEqual(device.values['debug.cranpose.b'], 'saved')
+        self.assertEqual(device.values['debug.cranpose.new'], '')
+
+    def test_status_bar_changes_do_not_prove_application_motion(self):
+        from PIL import Image
+        device = AndroidDevice('test')
+        device.wake = lambda: None
+        captures = []
+        image = Image.new('RGB', (100, 100), 'white')
+        for index, point in enumerate([(0, 0), (1, 0), (50, 50)]):
+            image.putpixel(point, (0, 0, 0))
+            encoded = io.BytesIO()
+            image.save(encoded, format='PNG')
+            device.run = lambda *parts: encoded.getvalue()
+            captures.append(device.screenshot(self.root / f'{index}.png', [10, 10, 90, 90]))
+        self.assertNotEqual(captures[0]['sha256'], captures[1]['sha256'])
+        self.assertEqual(captures[0]['motion_pixels_sha256'], captures[1]['motion_pixels_sha256'])
+        self.assertNotEqual(captures[1]['motion_pixels_sha256'], captures[2]['motion_pixels_sha256'])
+
+    def test_surface_counts_reject_missing_or_restarted_application_layers(self):
+        valid = 'layerName = SurfaceView - com.example.app/Main\ntotalFrames = 300\n'
+        self.assertEqual(surface_frames(valid, 'com.example.app')['frames'], 300)
+        for text in ['', valid + valid, valid.replace('300', '0'), valid.replace('example.app', 'other')]:
+            with self.assertRaises(ValueError):
+                surface_frames(text, 'com.example.app')
+
+    def test_route_accepts_completed_motion_and_rejects_dropped_input_and_overruns(self):
+        valid = ('gesture=0 start=0 end=1500\ngesture=1 start=1666 end=3166\n'
+                 'elapsed_ms=3332\nSF_BEGIN\nframes\nSF_END\n')
+        self.assertEqual(verify_route_window(valid, 2, 1500, 1666, 3332, 30), (3.332, 'frames\n'))
+        for text in [valid.replace('gesture=1', 'dropped=1'), valid.replace('3332', '3999'),
+                     valid.replace('end=1500', 'end=30'), valid.replace('start=1666', 'start=2000'),
+                     valid.replace('SF_END', 'missing')]:
+            with self.assertRaises(ValueError):
+                verify_route_window(text, 2, 1500, 1666, 3332, 30)
+
+    def test_native_artifact_comes_from_the_selected_cargo_package(self):
+        exported = self.root / 'native/arm64-v8a'
+        exported.mkdir(parents=True)
+        library = exported / 'libapp.so'
+        library.write_bytes(b'compiled library')
+        (exported / 'libdependency.so').write_bytes(b'dependency')
+        package = {'targets': [{'name': 'app', 'crate_types': ['cdylib']},
+                               {'name': 'build-script-build', 'crate_types': ['bin']}]}
+        self.assertEqual(native_artifact(exported.parent, package, 'arm64-v8a', b''), library)
+        with self.assertRaisesRegex(ValueError, 'did not export'):
+            native_artifact(exported.parent, package, 'armeabi-v7a', b'')
+        with self.assertRaisesRegex(ValueError, 'warnings'):
+            native_artifact(exported.parent, package, 'arm64-v8a', b'warning: build warning\n')
+
+    def test_build_resolves_archived_framework_before_reading_unavailable_host_paths(self):
+        framework = self.root / 'framework'
+        package = framework / 'crates/benchmark-fixture'
+        package.mkdir(parents=True)
+        (package / 'Cargo.toml').write_text('[package]\nname="benchmark-fixture"\nversion="1.0.0"\nedition="2021"\n[lib]\npath="lib.rs"\n')
+        (package / 'lib.rs').write_text('pub fn value() -> u32 { 1 }\n')
+        app = self.root / 'app'
+        (app / '.cargo').mkdir(parents=True)
+        (app / 'Cargo.toml').write_text('[package]\nname="benchmark-app"\nversion="1.0.0"\nedition="2021"\n[lib]\npath="lib.rs"\ncrate-type=["cdylib"]\n[dependencies]\nbenchmark-fixture="1.0.0"\n')
+        (app / 'lib.rs').write_text('pub fn value() -> u32 { benchmark_fixture::value() }\n')
+        config = app / '.cargo/config.toml'
+        config.write_text('[patch.crates-io]\nbenchmark-fixture={path=' + json.dumps(str(package)) + '}\n')
+        support.checked_command(['cargo', 'generate-lockfile', '--offline'], cwd=app)
+        config.write_text('[patch.crates-io]\nbenchmark-fixture={path=' + json.dumps(str(self.root / 'unavailable-host')) + '}\n')
+        output = self.root / 'build'
+        output.mkdir()
+        ndk = self.root / 'ndk'
+        ndk.mkdir()
+        (ndk / 'source.properties').write_text('Pkg.Revision=27.0.12077973\n')
+        args = SimpleNamespace(framework=framework, app=app, cache=self.root / 'cache',
+                               target_dir=self.root / 'target', output=output, features='',
+                               package='benchmark-app', platform=24, abi='arm64-v8a', timeout=30)
+        report = {}
+
+        def checked(command, **options):
+            if command[:2] == ['cargo', 'ndk']:
+                raise RuntimeError('native build reached with archived sources')
+            try:
+                return support.checked_command(command, **options)
+            except subprocess.CalledProcessError as error:
+                sys.stderr.write(error.output.decode())
+                raise
+
+        with patch.dict(os.environ, {'ANDROID_NDK_HOME': str(ndk)}), patch('android_benchmark_build.checked_command', side_effect=checked):
+            with self.assertRaisesRegex(RuntimeError, 'native build reached'):
+                build(args, report)
+        self.assertTrue(Path(report['resolved']['benchmark-fixture']).is_relative_to(Path(report['cache']) / 'framework'))
+        self.assertIn('unavailable-host', config.read_text())
+
+    def test_endpoint_reads_the_dump_file_and_rejects_offscreen_or_other_apps(self):
+        device = AndroidDevice('fixture')
+        calls = []
+        document = ('<?xml version="1.0"?><hierarchy><node package="com.scene" '
+                    'text="Last row" bounds="[10,20][90,80]"/></hierarchy>')
+
+        def shell(*parts):
+            calls.append(parts)
+            if parts[0] == 'cat':
+                return document
+            if parts[0] == 'uiautomator':
+                return 'UI hierchary dumped to: ' + parts[-1]
+            return ''
+
+        with patch.object(device, 'wake'), patch.object(device, 'shell', side_effect=shell):
+            self.assertEqual(device.endpoint('com.scene', 'Last row', [100, 100])[0]['bounds'], [10, 20, 90, 80])
+            for invalid in ['package="other.app"', 'bounds="[0,150][100,180]"']:
+                document = document.replace('package="com.scene"', invalid) if invalid.startswith('package') else (
+                    document.replace('package="other.app"', 'package="com.scene"').replace('bounds="[10,20][90,80]"', invalid))
+                with self.assertRaisesRegex(ValueError, 'endpoint'):
+                    device.endpoint('com.scene', 'Last row', [100, 100])
+        dumps = [parts[-1] for parts in calls if parts[0] == 'uiautomator']
+        self.assertEqual(len(set(dumps)), 3)
+        self.assertEqual([parts[-1] for parts in calls if parts[0] == 'rm'], dumps)
+
+    def test_device_cleanup_waits_for_its_process_and_never_signals_a_reused_pid(self):
+        device = AndroidDevice('fixture')
+        calls = []
+        running = 'route-unique-token'
+
+        def shell(*parts):
+            nonlocal running
+            calls.append(parts)
+            if parts[0] == 'kill':
+                running = 'different-owner'
+                return ''
+            return running
+
+        with patch.object(device, 'shell', side_effect=shell):
+            device.stop_owned_process('123', 'route-unique-token')
+            device.stop_owned_process('123', 'route-unique-token')
+        self.assertEqual([parts for parts in calls if parts[0] == 'kill'], [('kill', '-TERM', '123')])
+        with patch.object(device, 'shell', return_value='route-unique-token'), patch('android_benchmark_device.time.monotonic', side_effect=[0, 6, 6, 9]):
+            with self.assertRaisesRegex(RuntimeError, 'did not terminate'):
+                device.stop_owned_process('123', 'route-unique-token')
+        for pid in ['0', '1', '-123', '123; echo wrong']:
+            with self.assertRaises(ValueError):
+                device.stop_owned_process(pid, 'route-unique-token')
+
+    def test_pair_rejects_different_build_settings_and_app_sources(self):
+        build = dict.fromkeys(['abi', 'features', 'toolchain', 'cargo', 'ndk', 'settings', 'lock_sha256'], 'same')
+        build['sources'] = {'app': {'inventory': {'scene': 'same'}}}
+        first = {'build': build, 'payload': {'assets': 'same'}}
+        validate_pair([first, first])
+        for key in build:
+            second = json.loads(json.dumps(first))
+            if key == 'sources':
+                second['build'][key]['app']['inventory']['scene'] = 'different'
+            else:
+                second['build'][key] = 'different'
+            with self.assertRaises(ValueError):
+                validate_pair([first, second])
+        with self.assertRaisesRegex(ValueError, 'payload'):
+            validate_pair([first, first | {'payload': {}}])
+
+    def test_roundtrip_uses_independent_start_checks_and_accumulates_only_motion_windows(self):
+        route = {'kind': 'scroll', 'package': 'com.scene', 'activity': 'Activity', 'size': [100, 100],
+                 'density': 160, 'motion_region': [10, 10, 80, 80], 'x': 20, 'y_start': 70, 'y_end': 20,
+                 'count': 2, 'duration_ms': 10, 'period_ms': 20, 'window_ms': 40, 'timing_tolerance_ms': 10,
+                 'start_text': 'Heading', 'end_text': 'Footer', 'start_region': [0, 0, 100, 50],
+                 'setup': [{'visible_text': 'Navigation', 'tap': [90, 90]}],
+                 'return': {'y_start': 20, 'y_end': 70}}
+        device = Mock(spec=AndroidDevice)
+        device.run.return_value = b'Success'
+        device.wait_for_pid.return_value = '123'
+        device.installed_apk.return_value = {'path': '/installed.apk', 'sha256': 'hash'}
+        device.screenshot.return_value = {'size': [100, 100]}
+        device.shell.side_effect = lambda *parts, **_options: {
+            'pm': 'package:/installed.apk' if parts[1] == 'path' else 'Success', 'sha256sum': 'hash /installed.apk',
+            'pidof': '123', 'date': 'launch-time', 'wm': 'Physical density: 160',
+        }.get(parts[0], '')
+        measured = []
+
+        def window(_device, selected, _dex, _directory, report):
+            measured.append(selected)
+            self.assertEqual(report['launch_time'], 'launch-time')
+            report.update(elapsed_s=0.04, layer={'frames': 2}, before={}, after={}, acceptance_eligible=True)
+
+        proof = {'apk_sha256': 'hash', 'build': {'native_sha256': 'native'}, 'native_member': 'libapp.so'}
+        report = {}
+        with patch('android_benchmark.verify_apk'), patch('android_benchmark.wait_ready') as ready, patch('android_benchmark.run_window', side_effect=window), patch('android_benchmark.verify_first_gesture') as motion:
+            run_leg(device, route, self.root / 'app.apk', proof, self.root / 'classes.dex', self.root, report, '/staged.apk')
+        motion.assert_called_once()
+        self.assertIsNone(ready.call_args_list[0].args[1]['start_region'])
+        self.assertEqual(ready.call_args_list[1].args[1]['start_region'], route['start_region'])
+        self.assertEqual([(r['start_text'], r['end_text']) for r in measured], [('Heading', 'Footer'), ('Footer', 'Heading')])
+        self.assertEqual(report['fps'], 50)
+        self.assertEqual(report['elapsed_s'], 0.08)
+        self.assertEqual(len(report['windows']), 2)
+        self.assertTrue(all(w['status'] == 'complete' for w in report['windows']))
+
+    def test_endpoint_region_rejects_a_persistent_navigation_label(self):
+        device = AndroidDevice('fixture')
+        document = ('<?xml version="1.0"?><hierarchy><node package="com.scene" '
+                    'text="Settings" bounds="[10,75][90,100]"/></hierarchy>')
+        with patch.object(device, 'wake'), patch.object(device, 'shell', return_value=document):
+            self.assertTrue(device.endpoint('com.scene', 'Settings', [100, 100]))
+            with self.assertRaisesRegex(ValueError, 'endpoint'):
+                device.endpoint('com.scene', 'Settings', [100, 100], [0, 0, 100, 60])
+
+    def test_image_endpoint_checks_rendered_text_inside_the_requested_region(self):
+        from PIL import Image
+        image = Image.new('RGB', (100, 100), 'white')
+        image.paste('blue', (0, 70, 100, 100))
+        encoded = io.BytesIO()
+        image.save(encoded, format='PNG')
+        device = AndroidDevice('fixture', ocr=self.root / 'ocr', evidence=self.root / 'endpoints')
+        crops = []
+
+        def recognize(command):
+            with Image.open(command[1]) as crop:
+                crops.append((crop.size, crop.getpixel((0, 0))))
+            return b'[{"text":"Settings","confidence":1.0}]'
+
+        with patch.object(device, 'wake'), patch.object(device, 'run', return_value=encoded.getvalue()), patch('android_benchmark_device.checked_command', side_effect=recognize):
+            proof = device.endpoint('com.scene', 'Settings', [100, 100], [0, 0, 100, 60], 'image')
+            self.assertTrue(Path(proof['image']).is_file())
+            with self.assertRaisesRegex(ValueError, 'image endpoint'):
+                device.endpoint('com.scene', 'Library', [100, 100], [0, 0, 100, 60], 'image')
+        self.assertEqual(crops, [((100, 60), (255, 255, 255))] * 2)
+
+    def test_image_endpoint_validates_the_motion_capture_without_recapturing(self):
+        from PIL import Image
+        path = self.root / 'end.png'
+        Image.new('RGB', (100, 100), 'white').save(path)
+        device = AndroidDevice('fixture', ocr=self.root / 'ocr', evidence=self.root)
+        with patch.object(device, 'run', side_effect=AssertionError('must not recapture')), patch('android_benchmark_device.checked_command', return_value=b'[{"text":"Settings"}]'):
+            proof = device.endpoint('com.scene', 'Settings', [100, 100], [0, 0, 100, 60], 'image', image_path=path)
+        self.assertEqual(proof['image'], str(path))
+        self.assertEqual(proof['pixels']['sha256'], support.digest(path))
+
+    def test_end_capture_retains_transient_overlays_and_validates_the_same_frame(self):
+        route = {'kind': 'scroll', 'package': 'com.scene', 'end_text': 'Settings', 'size': [100, 100],
+                 'motion_region': [0, 0, 100, 100], 'end_region': [0, 0, 100, 60],
+                 'text_source': 'image', 'endpoint_timeout_s': 2}
+        device = Mock(spec=AndroidDevice)
+        device.screenshot.side_effect = [{'sha256': 'covered'}, {'sha256': 'clear'}]
+        device.endpoint.side_effect = [ValueError('Visible image endpoint was not reached: Settings'), {'text': 'Settings'}]
+        report = {}
+        with patch('android_benchmark.time.sleep'):
+            benchmark.capture_end(device, route, self.root, report)
+        self.assertEqual(report['end_image']['sha256'], 'clear')
+        self.assertEqual(len(report['endpoint_attempts']), 2)
+        for capture, validation in zip(device.screenshot.call_args_list, device.endpoint.call_args_list):
+            self.assertEqual(capture.args[0], validation.kwargs['image_path'])
+        self.assertIn('error', report['endpoint_attempts'][0])
+        device.screenshot.side_effect = None
+        device.endpoint.side_effect = ValueError('endpoint absent')
+        with self.assertRaisesRegex(ValueError, 'endpoint absent'):
+            benchmark.capture_end(device, route | {'endpoint_timeout_s': 0}, self.root, {})
+        for invalid in [-1, float('inf'), float('nan')]:
+            with self.assertRaisesRegex(ValueError, 'finite and nonnegative'):
+                benchmark.capture_end(device, route | {'endpoint_timeout_s': invalid}, self.root, {})
+
+    def test_sequence_rejects_nonpositive_transfer_timeout(self):
+        for timeout in [0, -1]:
+            with self.assertRaisesRegex(ValueError, 'Transfer timeout'):
+                sequence(SimpleNamespace(transfer_timeout_seconds=timeout), {})
+
+    def test_sequence_stages_each_apk_once_and_cleans_up_success_and_failure(self):
+        helper = self.root / 'helper'
+        helper.mkdir()
+        dex = helper / 'classes.dex'
+        dex.write_bytes(b'route')
+        (helper / 'route.json').write_text(json.dumps({
+            'dex_sha256': support.digest(dex), 'source_sha256': support.digest(
+                Path(__file__).parent / 'android/CranposeBenchmarkRoute.java')}))
+        route = Path(__file__).parent / 'android/routes/huawei-showcase.json'
+        proofs = []
+        for name in ['a', 'b']:
+            apk = self.root / f'{name}.apk'
+            apk.write_bytes(name.encode())
+            build = dict.fromkeys(['abi', 'features', 'toolchain', 'cargo', 'ndk', 'settings', 'lock_sha256'], 'same')
+            build['sources'] = {'app': {'inventory': {}}}
+            proof = self.root / f'{name}.json'
+            proof.write_text(json.dumps({'status': 'complete', 'apk': apk.name,
+                                         'apk_sha256': support.digest(apk), 'native_member': 'library',
+                                         'build_directory': str(self.root), 'build': build, 'payload': {}}))
+            proofs.append(proof)
+        for fail in [False, True]:
+            with self.subTest(fail=fail):
+                output = self.root / str(fail)
+                output.mkdir()
+                args = SimpleNamespace(serial='fixture-' + str(self.root), adb='adb', route=route,
+                                       dex=dex, ocr=None, record=False, video_bit_rate=2_000_000, a=proofs[0], b=proofs[1], output=output, transfer_timeout_seconds=600)
+                device = Mock(spec=AndroidDevice)
+                device.saved_properties = {}
+                device.installed_apk.return_value = None
+                uploaded, removed, slots = {}, [], []
+
+                def push(*parts, **options):
+                    self.assertEqual(device.wake.call_count, len(uploaded) + 1)
+                    self.assertEqual(options['timeout'], 600)
+                    self.assertEqual(parts[0], 'push')
+                    self.assertNotIn(parts[2], uploaded)
+                    uploaded[parts[2]] = support.digest(parts[1])
+                    return b''
+
+                def shell(*parts, **_options):
+                    if parts[0] == 'sha256sum':
+                        return uploaded[parts[1]] + ' ' + parts[1]
+                    if parts[0] == 'rm':
+                        removed.append(parts[-1])
+                    return ''
+
+                def leg(_device, _route, _apk, proof, _dex, _directory, report, remote, recorder):
+                    self.assertIsNone(recorder)
+                    self.assertEqual(uploaded[remote], proof['apk_sha256'])
+                    slots.append(report['slot'])
+                    if fail and len(slots) == 3:
+                        raise RuntimeError('input refused')
+                    report.update(fps=10 if report['slot'] == 'A' else 20,
+                                  elapsed_s=1, acceptance_eligible=True)
+
+                device.run.side_effect = push
+                device.shell.side_effect = shell
+                report = {}
+                with patch('android_benchmark.AndroidDevice', return_value=device), patch('android_benchmark.verify_apk'), patch('android_benchmark.verify_build'), patch('android_benchmark.snapshot_source', return_value='hash'), patch('android_benchmark.source_inventory', return_value={}), patch('android_benchmark.run_leg', side_effect=leg), patch('builtins.print'):
+                    if fail:
+                        with self.assertRaises(BaseExceptionGroup):
+                            sequence(args, report)
+                    else:
+                        sequence(args, report)
+                self.assertEqual(''.join(slots), 'ABA' if fail else 'ABABBABA')
+                self.assertEqual(len(uploaded), 2)
+                self.assertEqual(set(removed), set(uploaded))
+                device.restore_properties.assert_called_once()
+                self.assertEqual(report['status'], 'failed' if fail else 'complete')
+                self.assertEqual(report['acceptance_eligible'], not fail)
+                if not fail:
+                    self.assertEqual(report['mean_fps'], {'A': 10, 'B': 20})
+
+    def test_recorded_windows_never_pass_fps_acceptance(self):
+        route = json.loads((Path(__file__).parent / 'android/routes/huawei-showcase.json').read_text())
+        dex = self.root / 'route.dex'
+        dex.write_bytes(b'route')
+        for recording in [False, True]:
+            with self.subTest(recording=recording):
+                device = Mock(spec=AndroidDevice)
+                device.screenshot.return_value = {'motion_pixels_sha256': 'start'}
+                device.state.return_value = {'temperature_c': 30}
+                device.shell.side_effect = lambda *parts, **_options: support.digest(dex) if parts[0] == 'sha256sum' else 'route output'
+                report = {'pid': '123', 'launch_time': 'start', 'recording': recording}
+                def end(_device, _route, _directory, report):
+                    report['end_image'] = {'motion_pixels_sha256': 'end'}
+                stats = 'layerName = ' + route['package'] + '/Activity\ntotalFrames = 60'
+                with patch('android_benchmark.wait_ready'), patch('android_benchmark.capture_end', side_effect=end), patch('android_benchmark.verify_route_window', return_value=(1.0, stats)):
+                    benchmark.run_window(device, route, dex, self.root, report)
+                self.assertEqual(report['fps'], 60)
+                self.assertEqual(report['acceptance_eligible'], not recording)
+
+    def test_install_timeout_accepts_only_the_expected_installed_apk(self):
+        for installed in ['expected', 'different']:
+            with self.subTest(installed=installed):
+                device = Mock(spec=AndroidDevice)
+                device.installed_apk.side_effect = [None, {'path': '/installed.apk', 'sha256': installed}]
+                def shell(*parts, **_options):
+                    if parts[:2] == ('pm', 'install'):
+                        raise subprocess.TimeoutExpired(['pm', 'install'], 120, output=b'pending')
+                    if parts[:2] == ('pm', 'path'):
+                        return 'package:/installed.apk'
+                    return installed + ' /installed.apk'
+                device.shell.side_effect = shell
+                report = {}
+                if installed == 'expected':
+                    benchmark.install_staged(device, 'com.scene', '/staged.apk', 'expected', report)
+                    self.assertIn('timeout', report['installation'])
+                else:
+                    with self.assertRaisesRegex(ValueError, 'Installed APK'):
+                        benchmark.install_staged(device, 'com.scene', '/staged.apk', 'expected', report)
+
+    def test_matching_installed_apk_skips_installation_and_transfer(self):
+        device = Mock(spec=AndroidDevice)
+        device.installed_apk.return_value = {'path': '/installed.apk', 'sha256': 'expected'}
+        report = {}
+        benchmark.install_staged(device, 'com.scene', '/staged.apk', 'expected', report)
+        device.shell.assert_not_called()
+        device.shell.return_value = 'expected /staged.apk'
+        benchmark.stage_apk(device, 'com.scene', self.root / 'app.apk', '/staged.apk', 'expected', 120)
+        device.run.assert_not_called()
+        device.shell.assert_any_call('cp', '/installed.apk', '/staged.apk')
+
+    def test_installed_apk_rejects_split_packages_and_reads_exact_hash(self):
+        device = AndroidDevice('fixture')
+        with patch.object(device, 'shell', side_effect=['package:/base.apk', 'hash /base.apk']):
+            self.assertEqual(device.installed_apk('com.scene'), {'path': '/base.apk', 'sha256': 'hash'})
+        with patch.object(device, 'shell', return_value=''):
+            self.assertIsNone(device.installed_apk('com.scene'))
+        with patch.object(device, 'shell', return_value='package:/base.apk\npackage:/split.apk'):
+            with self.assertRaisesRegex(ValueError, 'single'):
+                device.installed_apk('com.scene')
+
+    def test_launch_pid_is_polled_with_a_deadline(self):
+        device = AndroidDevice('fixture')
+        with patch.object(device, 'shell', side_effect=['', subprocess.CalledProcessError(1, ['pidof']), '123']), patch('android_benchmark_device.time.sleep'):
+            self.assertEqual(device.wait_for_pid('com.scene', timeout=1), '123')
+        with patch.object(device, 'shell', return_value=''), patch('android_benchmark_device.time.monotonic', side_effect=[0, 0, 2]), patch('android_benchmark_device.time.sleep'):
+            with self.assertRaisesRegex(ValueError, 'PID'):
+                device.wait_for_pid('com.scene', timeout=1)
+
+    def test_first_gesture_requires_visible_content_motion(self):
+        route = json.loads((Path(__file__).parent / 'android/routes/huawei-showcase.json').read_text())
+        for changed in [False, True]:
+            with self.subTest(changed=changed):
+                device = Mock(spec=AndroidDevice)
+                device.screenshot.side_effect = [{'motion_pixels_sha256': 'start'},
+                                                {'motion_pixels_sha256': 'end' if changed else 'start'}]
+                report = {}
+                if changed:
+                    benchmark.verify_first_gesture(device, route, self.root, report)
+                    self.assertTrue(report['first_gesture']['changed'])
+                else:
+                    with self.assertRaisesRegex(ValueError, 'first gesture'):
+                        benchmark.verify_first_gesture(device, route, self.root, report)
+                device.shell.assert_called_once_with('input', 'swipe', route['x'], route['y_start'],
+                                                    route['x'], route['y_end'], route['duration_ms'])
+
+    def test_recorder_rejects_early_exit_and_recovers_its_pid_before_cleanup(self):
+        for early in [False, True]:
+            with self.subTest(early=early):
+                device = Mock(spec=AndroidDevice)
+                device.command = ['adb', '-s', 'fixture']
+                process = Mock()
+                process.poll.side_effect = [0 if early else None, 0]
+                process.communicate.return_value = (b'recorder output', None)
+                process.returncode = 0
+                report = {}
+                recording = AndroidRecording(device, self.root, [100, 100], report, 2_000_000)
+                recording.process = process
+                device.shell.return_value = '123'
+                device.run.side_effect = lambda *parts, **_options: Path(parts[-1]).write_bytes(b'video')
+                probe = {'streams': [{'width': 100, 'height': 100, 'nb_read_frames': '30'}]}
+                with patch('android_benchmark_video.checked_command', return_value=json.dumps(probe).encode()):
+                    if early:
+                        with self.assertRaisesRegex(BaseExceptionGroup, 'Recording failed'):
+                            recording.finish()
+                    else:
+                        recording.finish()
+                device.stop_owned_process.assert_called_once_with('123', recording.remote, first_signal='INT')
+                removed = {call.args[-1] for call in device.shell.call_args_list if call.args[0] == 'rm'}
+                self.assertEqual(removed, {recording.remote, recording.pid_file})
+                self.assertTrue(Path(report['video']['path']).is_file())
+
+    def test_unavailable_device_recorder_is_rejected_before_launch(self):
+        device = Mock(spec=AndroidDevice)
+        device.command = ['adb', '-s', 'fixture']
+        device.shell.side_effect = subprocess.CalledProcessError(127, ['screenrecord'])
+        recording = AndroidRecording(device, self.root, [100, 100], {}, 2_000_000)
+        reader, writer = os.pipe()
+        os.write(writer, b'123\n')
+        os.close(writer)
+        with os.fdopen(reader, 'rb') as output:
+            with patch('android_benchmark_video.subprocess.Popen', return_value=Mock(stdout=output)) as launch:
+                with self.assertRaises(subprocess.CalledProcessError):
+                    recording.start()
+                launch.assert_not_called()
+
+    def test_scrcpy_recording_waits_for_readiness_and_child_completion(self):
+        executable = self.root / 'scrcpy'
+        executable.write_text('#!' + sys.executable + '\n' + '''
+import sys,time
+from pathlib import Path
+output=next(argument.split('=',1)[1] for argument in sys.argv if argument.startswith('--record='))
+Path(output).write_bytes(bytes.fromhex('000000206674797069736f6d0000020069736f6d69736f32617663316d7034310000000866726565000000006d646174'))
+time.sleep(0.3)
+''')
+        executable.chmod(0o755)
+        report = {}
+        recording = ScrcpyRecording(SimpleNamespace(serial='fixture'), self.root, [100, 100], report, 2_000_000)
+        with patch.dict(os.environ, {'PATH': str(self.root) + os.pathsep + os.environ['PATH']}):
+            recording.start()
+        self.assertIsNone(recording.process.poll())
+        probe = {'streams': [{'width': 100, 'height': 100, 'nb_read_frames': '30'}]}
+        with patch('android_benchmark_video.checked_command', return_value=json.dumps(probe).encode()):
+            recording.finish()
+        self.assertEqual(recording.process.returncode, 0)
+        self.assertTrue(recording.log.closed)
+        self.assertEqual(report['video']['sha256'], support.digest(self.root / 'scroll.mp4'))
+
+    def test_scrcpy_early_exit_and_wrong_dimensions_reject_recordings(self):
+        recording = ScrcpyRecording(SimpleNamespace(serial='fixture'), self.root, [100, 100], {}, 2_000_000)
+        recording.process = Mock(returncode=0)
+        recording.started_at = 0
+        recording.process.poll.return_value = 0
+        with patch('android_benchmark_video.inspect_recording'):
+            with self.assertRaisesRegex(BaseExceptionGroup, 'Recording failed'):
+                recording.finish()
+        recording.process.terminate.assert_not_called()
+        video = self.root / 'scroll.mp4'
+        video.write_bytes(b'video')
+        for streams in [[], [{'width': 100, 'height': 99, 'nb_read_frames': '30'}],
+                        [{'width': 100, 'height': 100, 'nb_read_frames': '1'}]]:
+            with self.subTest(streams=streams):
+                with patch('android_benchmark_video.checked_command', return_value=json.dumps({'streams': streams}).encode()):
+                    with self.assertRaisesRegex(ValueError, 'full-size route frames'):
+                        inspect_recording(video, [100, 100], {})
+
+    def test_apk_provenance_rejects_modified_code_assets_and_unmeasured_abis(self):
+        apk = self.root / 'app.apk'
+        member = 'lib/arm64-v8a/libapp.so'
+        with zipfile.ZipFile(apk, 'w') as archive:
+            archive.writestr(member, b'native')
+            archive.writestr('assets/scene', b'picture')
+        with zipfile.ZipFile(apk) as archive:
+            proof = {'apk_sha256': support.digest(apk), 'build': {
+                'native_sha256': artifacts.hashlib.sha256(b'native').hexdigest()},
+                'payload': artifacts.apk_payload(archive, member)}
+        artifacts.verify_apk(apk, proof, member)
+        for changed in ['native', 'asset', 'abi']:
+            modified = self.root / f'{changed}.apk'
+            with zipfile.ZipFile(modified, 'w') as archive:
+                archive.writestr(member, b'wrong' if changed == 'native' else b'native')
+                archive.writestr('assets/scene', b'wrong' if changed == 'asset' else b'picture')
+                if changed == 'abi':
+                    archive.writestr('lib/armeabi-v7a/libapp.so', b'unmeasured')
+            with self.assertRaises(ValueError):
+                artifacts.verify_apk(modified, proof, member)
+            updated = proof | {'apk_sha256': support.digest(modified)}
+            with self.assertRaises(ValueError):
+                artifacts.verify_apk(modified, updated, member)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/android_benchmark_video.py
+++ b/scripts/android_benchmark_video.py
@@ -1,0 +1,152 @@
+import json
+import os
+import select
+import shlex
+import signal
+import subprocess
+import time
+import uuid
+
+from android_benchmark_support import checked_command, digest
+
+
+def inspect_recording(video, size, report):
+    probe = json.loads(checked_command([
+        'ffprobe', '-v', 'error', '-count_frames', '-select_streams', 'v:0',
+        '-show_entries', 'stream=width,height,nb_read_frames', '-of', 'json', str(video)]))
+    streams = probe.get('streams', [])
+    if (len(streams) != 1 or int(streams[0].get('nb_read_frames', '0')) < 2
+            or [streams[0]['width'], streams[0]['height']] != size):
+        raise ValueError('Recording did not contain full-size route frames')
+    report.setdefault('video', {}).update(path=str(video), sha256=digest(video), probe=probe)
+
+
+class AndroidRecording:
+    def __init__(self, device, directory, size, report, bit_rate):
+        self.device = device
+        self.directory = directory
+        self.size = size
+        self.report = report
+        self.bit_rate = bit_rate
+        self.remote = '/data/local/tmp/cranpose-recording-' + uuid.uuid4().hex + '.mp4'
+        self.pid_file = self.remote + '.pid'
+        self.process = None
+        self.pid = None
+
+    def start(self):
+        self.device.shell('screenrecord', '--help')
+        command = 'echo $$ > ' + shlex.quote(self.pid_file) + ' && echo $$ && exec ' + shlex.join([
+            'screenrecord', '--bit-rate', str(self.bit_rate), '--time-limit', '180', self.remote])
+        self.process = subprocess.Popen(
+            self.device.command + ['shell', shlex.join(['sh', '-c', command])],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, start_new_session=True)
+        ready, _, _ = select.select([self.process.stdout], [], [], 10)
+        if not ready:
+            raise RuntimeError('Device recorder did not report its process ID')
+        line = self.process.stdout.readline().decode().strip()
+        if not line.isdigit() or int(line) <= 1:
+            raise ValueError('Invalid device recorder response: ' + line)
+        self.pid = line
+        self.report['video'] = {'remote': self.remote, 'pid': self.pid, 'bit_rate': self.bit_rate,
+                                'purpose': 'Recording adds load; FPS is ineligible'}
+
+    def finish(self):
+        if self.process is None:
+            return
+        errors = []
+        try:
+            if self.pid is None:
+                saved = self.device.shell('cat', self.pid_file).strip()
+                if not saved.isdigit() or int(saved) <= 1:
+                    raise ValueError('Recorder ownership file has no valid PID')
+                self.pid = saved
+            if self.process.poll() is not None:
+                errors.append(RuntimeError('Device recording ended before route completion'))
+            if self.pid:
+                self.device.stop_owned_process(self.pid, self.remote, first_signal='INT')
+            else:
+                self.process.terminate()
+            output, _ = self.process.communicate(timeout=15)
+            (self.directory / 'recorder.log').write_bytes(output)
+            if self.process.returncode not in {0, 130}:
+                errors.append(RuntimeError('Device recorder failed: ' + output.decode(errors='replace')))
+            video = self.directory / 'scroll.mp4'
+            self.device.run('pull', self.remote, str(video), timeout=120)
+            inspect_recording(video, self.size, self.report)
+        except BaseException as error:
+            errors.append(error)
+        finally:
+            try:
+                if self.process.poll() is None:
+                    self.process.terminate()
+                    self.process.communicate(timeout=10)
+            except BaseException as error:
+                errors.append(error)
+            for path in [self.remote, self.pid_file]:
+                try:
+                    self.device.shell('rm', '-f', path)
+                except BaseException as error:
+                    errors.append(error)
+        if errors:
+            raise BaseExceptionGroup('Recording failed; partial evidence retained', errors)
+
+
+class ScrcpyRecording:
+    def __init__(self, device, directory, size, report, bit_rate, duration_seconds=60):
+        self.device = device
+        self.directory = directory
+        self.size = size
+        self.report = report
+        self.bit_rate = bit_rate
+        self.duration_seconds = duration_seconds
+        self.process = None
+        self.log = None
+        self.started_at = None
+
+    def start(self):
+        self.log = (self.directory / 'recorder.log').open('wb')
+        command = ['scrcpy', '--serial=' + self.device.serial, '--no-playback', '--no-audio',
+                   '--no-control', '--video-bit-rate=' + str(self.bit_rate),
+                   '--time-limit=' + str(self.duration_seconds),
+                   '--record=' + str(self.directory / 'scroll.mp4')]
+        self.process = subprocess.Popen(command, stdout=self.log, stderr=subprocess.STDOUT,
+                                        start_new_session=True)
+        self.started_at = time.monotonic()
+        self.report['video'] = {'command': command, 'pid': self.process.pid,
+                                'purpose': 'Recording adds load; FPS is ineligible'}
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            if self.process.poll() is not None:
+                raise RuntimeError('scrcpy exited before recording became ready')
+            video = self.directory / 'scroll.mp4'
+            if video.is_file():
+                with video.open('rb') as file:
+                    header = file.read(64)
+                if header[4:8] == b'ftyp' and b'mdat' in header:
+                    return
+            time.sleep(0.1)
+        raise TimeoutError('scrcpy did not initialize the recording container')
+
+    def finish(self):
+        errors = []
+        try:
+            if self.process is not None:
+                if self.process.poll() is not None:
+                    errors.append(RuntimeError('scrcpy ended before route completion'))
+                try:
+                    remaining = max(0, self.started_at + self.duration_seconds - time.monotonic())
+                    self.process.wait(timeout=remaining + 15)
+                except subprocess.TimeoutExpired as error:
+                    errors.append(error)
+                    os.killpg(self.process.pid, signal.SIGKILL)
+                    self.process.wait(timeout=5)
+                if self.process.returncode != 0:
+                    errors.append(RuntimeError('scrcpy recording failed; see recorder.log'))
+                inspect_recording(self.directory / 'scroll.mp4', self.size, self.report)
+        except BaseException as error:
+            errors.append(error)
+        finally:
+            if self.log is not None:
+                self.log.close()
+        if errors:
+            raise BaseExceptionGroup('Recording failed; partial evidence retained', errors)

--- a/scripts/android_robot_device.py
+++ b/scripts/android_robot_device.py
@@ -1,0 +1,29 @@
+from contextlib import contextmanager
+import fcntl
+import hashlib
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+class AndroidRobotDevice:
+    def __init__(self, serial):
+        self.adb = ['adb', '-s', serial]
+
+    def command(self, *parts, timeout=60):
+        return subprocess.check_output(self.adb + list(parts), text=True,
+                                       stderr=subprocess.STDOUT, timeout=timeout)
+
+    def wake(self):
+        self.command('shell', 'input', 'keyevent', 'KEYCODE_WAKEUP')
+        if 'mWakefulness=Awake' not in self.command('shell', 'dumpsys', 'power'):
+            raise RuntimeError('Device screen is not awake')
+
+
+@contextmanager
+def locked_device(serial):
+    key = hashlib.sha256(serial.encode()).hexdigest()[:16]
+    path = Path(tempfile.gettempdir()) / ('cranpose-device-' + key + '.lock')
+    with path.open('a+') as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        yield AndroidRobotDevice(serial)

--- a/scripts/android_robot_device.py
+++ b/scripts/android_robot_device.py
@@ -21,9 +21,15 @@ class AndroidRobotDevice:
 
 
 @contextmanager
-def locked_device(serial):
+def device_lock(serial):
     key = hashlib.sha256(serial.encode()).hexdigest()[:16]
     path = Path(tempfile.gettempdir()) / ('cranpose-device-' + key + '.lock')
     with path.open('a+') as lock:
         fcntl.flock(lock, fcntl.LOCK_EX)
+        yield
+
+
+@contextmanager
+def locked_device(serial):
+    with device_lock(serial):
         yield AndroidRobotDevice(serial)

--- a/scripts/android_surface_robot.py
+++ b/scripts/android_surface_robot.py
@@ -1,30 +1,22 @@
 import argparse
-import fcntl
-import hashlib
 import json
 from pathlib import Path
 import re
 import subprocess
-import tempfile
 import time
 
 from PIL import Image
 
 from android_surface_frames import inspect_video
+from android_robot_device import locked_device
 
 
-def run_device(args):
+def run_device(args, device):
     output = args.output
     output.mkdir(parents=True, exist_ok=False)
-    adb = ['adb', '-s', args.serial]
-
-    def command(*parts):
-        return subprocess.check_output(adb + list(parts), text=True, stderr=subprocess.STDOUT, timeout=60)
-
-    def wake():
-        command('shell', 'input', 'keyevent', 'KEYCODE_WAKEUP')
-        if 'mWakefulness=Awake' not in command('shell', 'dumpsys', 'power'):
-            raise RuntimeError('Device screen is not awake')
+    adb = device.adb
+    command = device.command
+    wake = device.wake
 
     density = command('shell', 'wm', 'density')
     scale = int(re.findall(r'density: (\d+)', density)[-1]) / 160
@@ -84,11 +76,8 @@ def main():
     else:
         if not args.serial:
             parser.error('device robot requires --serial')
-        device_key = hashlib.sha256(args.serial.encode()).hexdigest()[:16]
-        lock_path = Path(tempfile.gettempdir()) / ('cranpose-device-' + device_key + '.lock')
-        with lock_path.open('a+') as lock:
-            fcntl.flock(lock, fcntl.LOCK_EX)
-            run_device(args)
+        with locked_device(args.serial) as device:
+            run_device(args, device)
 
 
 if __name__ == '__main__':

--- a/scripts/dev/target_gc.sh
+++ b/scripts/dev/target_gc.sh
@@ -145,7 +145,11 @@ target_last_build() {
     newest="$(mtime_of "$dir")"
     for entry in "$dir"/*; do
         [ -d "$entry" ] || continue
-        candidate="$(mtime_of "$entry")"
+        if [ ! -L "$entry" ] && is_cargo_target_dir "$entry"; then
+            candidate="$(target_last_build "$entry")"
+        else
+            candidate="$(mtime_of "$entry")"
+        fi
         [ "$candidate" -gt "$newest" ] 2>/dev/null && newest="$candidate"
         if [ -d "$entry/.fingerprint" ]; then
             candidate="$(mtime_of "$entry/.fingerprint")"
@@ -333,7 +337,6 @@ emit_candidate() {
     worktree_has_live_process "$wt" && live=1
     size_mb="$(dir_size_mb "$target")"
     [ -n "$size_mb" ] || size_mb=0
-    [ "$size_mb" -ge "$min_size_mb" ] || return 0
 
     last="$(target_last_build "$target")"
     now="$(date +%s)"
@@ -360,12 +363,36 @@ emit_candidate() {
     # $target empty, which the display loop then skips -- every genuine eviction
     # candidate disappears and only protected ones survive, which reads exactly
     # like "nothing is reclaimable".
-    printf '%s\t%s\t%s\t%s\n' "$last" "$size_mb" "${protect:--}" "$target"
+    printf '%s\t%s\t%s\t%s\n' "$last" "$size_mb" "${protect:--}" "$target_real"
+}
+
+collapse_candidates() {
+    awk -F '\t' -v minimum="$min_size_mb" '
+        { last[NR] = $1; size[NR] = $2; protect[NR] = $3; path[NR] = $4 }
+        END {
+            for (i = 1; i <= NR; i++) {
+                owner[i] = i
+                for (j = 1; j <= NR; j++) {
+                    if (index(path[i], path[j] "/") == 1 &&
+                        length(path[j]) < length(path[owner[i]])) owner[i] = j
+                }
+            }
+            for (i = 1; i <= NR; i++) {
+                root = owner[i]
+                if (last[i] > last[root]) last[root] = last[i]
+                if (protect[i] != "-" && protect[root] == "-") protect[root] = protect[i]
+            }
+            for (i = 1; i <= NR; i++) {
+                if (owner[i] == i && size[i] >= minimum)
+                    printf "%s\t%s\t%s\t%s\n", last[i], size[i], protect[i], path[i]
+            }
+        }
+    '
 }
 
 [ "$apply" -eq 1 ] && reap_orphans
 
-candidates="$(collect_candidates | sort -n)"
+candidates="$(collect_candidates | collapse_candidates | sort -n)"
 if [ -z "$candidates" ]; then
     echo "No cargo target directories above ${min_size_mb}MB found."
     exit 0

--- a/scripts/dev/target_gc_test.sh
+++ b/scripts/dev/target_gc_test.sh
@@ -138,5 +138,31 @@ check "--repo rejects a non-repository" \
     "$("$GC" --repo "$root" >/dev/null 2>&1; echo $?)" "2"
 
 echo
+nested="$root/nested/target"
+cross="$nested/aarch64-unknown-linux-gnu"
+make_target "$nested" 202608010000
+make_target "$cross" 202608010000
+make_target "$cross/nested-cache" 202608010000
+touch -t 202608010000 "$cross" "$nested"
+listing="$(gc --root "$cross" --root "$nested" --min-free-gb 999999 --busy-minutes 0 2>&1)"
+check "nested target caches are reported once regardless of root order" \
+    "$(printf '%s\n' "$listing" | grep -c 'would reclaim')" "3"
+check "nested target capacity is counted once" \
+    "$(printf '%s\n' "$listing" | grep -c 'Would reclaim 0.6G')" "1"
+
+touch "$cross/nested-cache/ci/.fingerprint"
+listing="$(gc --root "$nested" --min-free-gb 999999 --busy-minutes 15 2>&1)"
+check "recent nested writes protect their entire parent cache" \
+    "$(printf '%s\n' "$listing" | grep '^nested ' | grep -c 'protected: live build')" "1"
+listing="$(gc --root "$root/nested" --min-free-gb 999999 --busy-minutes 15 2>&1)"
+check "activity below candidate discovery depth protects the parent cache" \
+    "$(printf '%s\n' "$listing" | grep '^nested ' | grep -c 'protected: live build')" "1"
+
+listing="$(gc --root "$nested" --apply --min-free-gb 999999 --busy-minutes 0 2>&1)"
+check "reclaiming a parent never retries its removed descendants" \
+    "$(printf '%s\n' "$listing" | grep -c 'FAILED to reclaim' || true)" "0"
+check "nested target root is reclaimed" \
+    "$([ -d "$nested" ] && echo present || echo gone)" "gone"
+
 echo "$passed passed, $failed failed"
 [ "$failed" -eq 0 ]

--- a/scripts/perf_presentation_test.py
+++ b/scripts/perf_presentation_test.py
@@ -1,0 +1,38 @@
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--binary', type=Path, required=True)
+parser.add_argument('--output', type=Path, required=True)
+args = parser.parse_args()
+root = args.output
+root.mkdir(parents=True, exist_ok=False)
+binary = str(args.binary.resolve())
+results = []
+for name, mode, budget, expected_code in [('capped', 'fifo', '120', 1), ('cadence', 'fifo', '0', 0), ('headroom', 'immediate', '1', 0), ('no-headroom', 'immediate', '1000000', 1)]:
+    environment = dict(os.environ, CRANPOSE_PRESENT_MODE=mode, CRANPOSE_PERF_MIN_FPS=budget,
+                       CRANPOSE_PERF_MAX_P95_FRAME_MS='0', CRANPOSE_PERF_MAX_50MS_STALLS='4294967295',
+                       CRANPOSE_PERF_SCENARIO='glass_lazy_scroll', CRANPOSE_PERF_DURATION_SECS='1',
+                       CRANPOSE_PERF_WARMUP_SECS='1', CRANPOSE_HEADLESS='0', CRANPOSE_MEM_VALIDATE='0')
+    result = subprocess.run([binary], env=environment, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=90)
+    text = result.stdout.decode(errors='replace')
+    (root / f'{name}.log').write_text(text)
+    assert result.returncode == expected_code, (name, result.returncode, text[-3000:])
+    assert 'PERF_PRESENTATION_SUMMARY' in text
+    if name == 'capped':
+        assert 'resolved=Fifo' in text and 'configuration_unpaced=false' in text
+        assert 'cannot measure throughput' in text and 'PERF_FPS_SUMMARY' not in text
+    elif name == 'no-headroom':
+        assert 'PERF_PRESENTATION_CALIBRATION' in text
+        assert 'cannot measure throughput' in text and 'PERF_FPS_SUMMARY' not in text
+    else:
+        if name == 'headroom':
+            assert 'changed=true' in text and 'headroom=true' in text
+        assert 'PERF_FPS_SUMMARY' in text and 'PERF_SCENARIO_COMPLETE' in text
+    results.append({'case': name, 'exit': result.returncode,
+                    'presentation': next(line for line in text.splitlines() if line.startswith('PERF_PRESENTATION_SUMMARY'))})
+    print(results[-1], flush=True)
+(root / 'results.json').write_text(json.dumps(results, indent=2))

--- a/scripts/perf_report_test.py
+++ b/scripts/perf_report_test.py
@@ -1,0 +1,47 @@
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+class PerfReportContracts(unittest.TestCase):
+    def test_success_and_failure_keep_presentation_evidence_and_exit_status(self):
+        repository = Path(__file__).resolve().parent.parent
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / 'scripts').mkdir()
+            for name in ['perf_robot_fps.sh', 'scripts/dev_build_common.sh', 'scripts/perf_robot_common.sh']:
+                shutil.copy2(repository / name, root / name)
+            runner = root / 'cargo-dev.sh'
+            metadata = shlex.quote(json.dumps({'target_directory': str(root / 'configured artifacts')}))
+            runner.write_text('#!/bin/sh\nif [ "$1" = metadata ]; then printf \'%s\\n\' ' + metadata + '; fi\n')
+            runner.chmod(0o755)
+            binary = root / 'configured artifacts/ci/examples/robot_perf_harness'
+            binary.parent.mkdir(parents=True)
+            binary.write_text('''#!/bin/sh
+printf '%s\\n' 'PERF_PRESENTATION_SUMMARY configuration_unpaced=true'
+printf '%s\\n' 'PERF_PRESENTATION_CALIBRATION headroom=false'
+exit "$FIXTURE_EXIT"
+''')
+            binary.chmod(0o755)
+            for status in [0, 7]:
+                with self.subTest(status=status):
+                    report = root / f'report-{status}.txt'
+                    result = subprocess.run(['bash', str(root / 'perf_robot_fps.sh'), '--profile', 'ci',
+                                             '--scenario', 'glass_lazy_scroll', '--output', str(report)],
+                                            cwd=root, env=dict(os.environ, CI='1', FIXTURE_EXIT=str(status),
+                                                               CRANPOSE_USE_SCCACHE='0'),
+                                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=20)
+                    self.assertEqual(result.returncode, status, result.stdout.decode())
+                    text = report.read_text()
+                    self.assertIn('PERF_PRESENTATION_SUMMARY configuration_unpaced=true', text)
+                    self.assertIn('PERF_PRESENTATION_CALIBRATION headroom=false', text)
+                    self.assertIn('app_log=', text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/perf_robot_common.sh
+++ b/scripts/perf_robot_common.sh
@@ -51,6 +51,8 @@ append_perf_summary_block() {
 
     {
         echo "=== ${scenario} ==="
+        extract_perf_summary_line "PERF_PRESENTATION_SUMMARY" "$log_file"
+        extract_perf_summary_line "PERF_PRESENTATION_CALIBRATION" "$log_file"
         local render_line
         render_line=$(extract_perf_summary_line "PERF_RENDER_SUMMARY" "$log_file")
         local memory_line

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -739,7 +739,7 @@ fn bundle_macos(options: BundleMacosOptions) -> Result<(), String> {
         build_binary(&workspace, &binary_options)?;
     }
 
-    let binary = built_binary_path(&workspace, &binary_options);
+    let binary = built_binary_path(&workspace, &binary_options)?;
     if !binary.exists() {
         return Err(format!(
             "built binary `{}` does not exist; run without --no-build or check --profile/--target",
@@ -771,7 +771,7 @@ fn report_built_binary(
     binary_options: &CargoBinaryOptions,
     max_bytes: Option<u64>,
 ) -> Result<(), String> {
-    let binary = built_binary_path(workspace, binary_options);
+    let binary = built_binary_path(workspace, binary_options)?;
     let metadata = fs::metadata(&binary)
         .map_err(|error| format!("failed to inspect `{}`: {error}", binary.display()))?;
     let bytes = metadata.len();
@@ -1280,24 +1280,33 @@ fn read_dir_entries(path: &Path) -> Result<Vec<fs::DirEntry>, String> {
         .map_err(read)
 }
 
-fn built_binary_path(workspace: &Path, options: &CargoBinaryOptions) -> PathBuf {
-    let mut path = cargo_target_root(workspace, options);
+fn built_binary_path(workspace: &Path, options: &CargoBinaryOptions) -> Result<PathBuf, String> {
+    let mut path = cargo_target_root(workspace, options)?;
     if let Some(target) = options.target.as_deref() {
         path.push(target);
     }
     path.push(cargo_profile_dir(&options.profile));
     path.push(binary_file_name(&options.bin));
-    path
+    Ok(path)
 }
 
-fn cargo_target_root(workspace: &Path, options: &CargoBinaryOptions) -> PathBuf {
-    let Some(manifest_path) = options.manifest_path.as_deref() else {
-        return workspace.join("target");
+fn cargo_target_root(workspace: &Path, options: &CargoBinaryOptions) -> Result<PathBuf, String> {
+    let manifest = match options.manifest_path.as_deref() {
+        Some(path) => absolute_path(
+            &env::current_dir()
+                .map_err(|error| format!("failed to resolve working directory: {error}"))?,
+            path,
+        ),
+        None => workspace.join("Cargo.toml"),
     };
-    absolute_path(workspace, manifest_path)
-        .parent()
-        .map(|parent| parent.join("target"))
-        .unwrap_or_else(|| workspace.join("target"))
+    let metadata = cargo_metadata_json(Some(&manifest))?;
+    let metadata: serde_json::Value = serde_json::from_str(&metadata)
+        .map_err(|error| format!("cargo metadata returned invalid JSON: {error}"))?;
+    metadata["target_directory"]
+        .as_str()
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| "cargo metadata did not include target_directory".to_owned())
 }
 
 fn absolute_path(workspace: &Path, path: &Path) -> PathBuf {
@@ -5451,11 +5460,6 @@ cranpose v0.1.0
         assert!(
             !staged_dir.join("android").exists(),
             "staging must copy cargo targets, not another build system's output"
-        );
-        assert_eq!(
-            built_binary_path(&workspace, &staged),
-            staged_dir.join("target/release-small/isolated-demo"),
-            "the measured binary must come from the staged target directory"
         );
     }
 

--- a/xtask/tests/cargo_outputs.rs
+++ b/xtask/tests/cargo_outputs.rs
@@ -1,0 +1,129 @@
+use std::{fs, path::Path, process::Command};
+
+fn successful(command: &mut Command) -> String {
+    let output = command.output().expect("run command");
+    assert!(
+        output.status.success(),
+        "{command:?}:\n{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("UTF-8 output")
+}
+
+fn verify_binary_lookup(configured: bool, custom: bool, cross_target: bool, member_cwd: bool) {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let root = fixture.path();
+    fs::create_dir_all(root.join("member/src")).expect("member directory");
+    fs::write(
+        root.join("Cargo.toml"),
+        "[workspace]\nmembers = [\"member\"]\nresolver = \"2\"\n",
+    )
+    .expect("workspace manifest");
+    fs::write(
+        root.join("member/Cargo.toml"),
+        "[package]\nname = \"artifact-fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .expect("member manifest");
+    fs::write(root.join("member/src/main.rs"), "fn main() {}\n").expect("source");
+    if configured {
+        fs::create_dir(root.join(".cargo")).expect("Cargo configuration directory");
+        fs::write(
+            root.join(".cargo/config.toml"),
+            "[build]\ntarget-dir = \"configured artifacts\"\n",
+        )
+        .expect("Cargo configuration");
+    }
+    let host = cross_target.then(|| {
+        successful(Command::new("rustc").arg("-vV"))
+            .lines()
+            .find_map(|line| line.strip_prefix("host: "))
+            .expect("host triple")
+            .to_owned()
+    });
+    let configure = |command: &mut Command| {
+        command
+            .current_dir(if member_cwd {
+                root.join("member")
+            } else {
+                root.to_path_buf()
+            })
+            .env_remove("CARGO_TARGET_DIR")
+            .env_remove("CARGO_BUILD_TARGET");
+        if custom {
+            command.env("CARGO_TARGET_DIR", "environment artifacts");
+        }
+        command.args([
+            "--manifest-path",
+            if member_cwd {
+                "../member/Cargo.toml"
+            } else {
+                "member/Cargo.toml"
+            },
+        ]);
+        if let Some(host) = &host {
+            command.args(["--target", host]);
+        }
+    };
+    let mut build = Command::new("cargo");
+    build.arg("build").arg("--offline");
+    configure(&mut build);
+    successful(&mut build);
+    let mut report = Command::new(env!("CARGO_BIN_EXE_xtask"));
+    report.args([
+        "binary-size",
+        "--package",
+        "artifact-fixture",
+        "--bin",
+        "artifact-fixture",
+        "--profile",
+        "dev",
+        "--no-build",
+    ]);
+    configure(&mut report);
+    let output = successful(&mut report);
+    let mut expected = if custom && member_cwd {
+        root.join("member")
+    } else {
+        root.to_path_buf()
+    }
+    .join(if custom {
+        "environment artifacts"
+    } else if configured {
+        "configured artifacts"
+    } else {
+        "target"
+    });
+    if let Some(host) = host {
+        expected.push(host);
+    }
+    expected.push(Path::new("debug"));
+    expected.push(format!("artifact-fixture{}", std::env::consts::EXE_SUFFIX));
+    let bytes = fs::metadata(expected).expect("Cargo artifact").len();
+    assert!(output.contains(&format!("{bytes} bytes")), "{output}");
+}
+
+#[test]
+fn workspace_member_uses_the_workspace_target_directory() {
+    verify_binary_lookup(false, false, false, false);
+}
+
+#[test]
+fn cargo_configuration_selects_the_target_directory() {
+    verify_binary_lookup(true, false, false, false);
+}
+
+#[test]
+fn environment_target_directory_overrides_cargo_configuration() {
+    verify_binary_lookup(true, true, false, false);
+}
+
+#[test]
+fn explicit_target_uses_cargos_target_specific_output_directory() {
+    verify_binary_lookup(true, true, true, false);
+}
+
+#[test]
+fn member_invocation_resolves_relative_environment_directory() {
+    verify_binary_lookup(true, true, true, true);
+}


### PR DESCRIPTION
## What this changes

Publish Android accessibility updates on idle wakeups so reconnecting after navigation exposes the rendered page.

| Pixel Watch check | Main | Fix |
| --- | --- | --- |
| Framework robot: reconnect after navigation | Settings renders; hierarchy stays Library | Pass |
| Framework robot: connected navigation in both directions | Pass | Pass |
| CranScan Settings heading and hierarchy | Mismatch | Match; Library content absent |

The robot test APK is identical between runs; the app APKs differ only in their native library.

## Checklist

- [x] Regression robot fails before the fix and passes after it.
- [x] `just test` passes: 4,876 tests.
- [x] `just fmt`, `just clippy`, `just web`, `just android`, `just clippy-android`, and `just precommit` pass.
- [x] Android builds and Clippy pass for all four ABIs; the final APK retains the tested Watch library and test APK byte for byte.
- [x] Robot result validation and CI gate reachability tests pass.
- [ ] `just ci` passes in full (not run locally).
- [x] No new published API or compatibility paths.
- [x] AI assistance used.
