### PR TITLE
Add a raymarched metal controls demo

### DIFF
--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -544,6 +544,11 @@ path = "robot-runners/robot_tabbar_drag.rs"
 required-features = ["robot-app"]
 
 [[example]]
+name = "robot_controls_grid"
+path = "robot-runners/robot_controls_grid.rs"
+required-features = ["robot-app"]
+
+[[example]]
 name = "robot_regression_tabbar_contract"
 path = "robot-runners/robot_regression_tabbar_contract.rs"
 required-features = ["robot-app"]

--- a/apps/desktop-demo/examples/robot_tab_screenshot_dump.rs
+++ b/apps/desktop-demo/examples/robot_tab_screenshot_dump.rs
@@ -84,33 +84,7 @@ fn dump_tab(robot: &cranpose::Robot, tab: DemoTab, shot_dir: &Path) {
 }
 
 fn tab_slug(tab: DemoTab) -> &'static str {
-    match tab {
-        DemoTab::Counter => "counter",
-        DemoTab::CompositionLocal => "composition-local",
-        DemoTab::Async => "async",
-        DemoTab::Animations => "animations",
-        DemoTab::InteractiveAnim => "interactive-anim",
-        DemoTab::WebFetch => "web-fetch",
-        DemoTab::TextInput => "text-input",
-        DemoTab::Layout => "layout",
-        DemoTab::ModifierShowcase => "modifier-showcase",
-        DemoTab::LazyList => "lazy-list",
-        DemoTab::Mineswapper2 => "mineswapper2",
-        DemoTab::HackerNews => "hacker-news",
-        DemoTab::Images => "images",
-        DemoTab::Text => "text",
-        DemoTab::Winamp => "winamp",
-        DemoTab::Xkcd => "xkcd",
-        DemoTab::Shaders => "shaders",
-        DemoTab::ShaderRect => "shader-rect",
-        DemoTab::MarkdownViewer => "markdown-viewer",
-        DemoTab::Liquid => "liquid-ui",
-        DemoTab::GlassFeed => "glass-feed",
-        DemoTab::FilePicker => "file-picker",
-        DemoTab::Rotary => "rotary",
-        DemoTab::RecompositionLab => "recomposition-lab",
-        DemoTab::Wear => "wear-watch",
-    }
+    tab.slug()
 }
 
 fn set_tab_hook(name: String, argument: String) -> Result<Option<String>, String> {

--- a/apps/desktop-demo/robot-runners/robot_controls_grid.rs
+++ b/apps/desktop-demo/robot-runners/robot_controls_grid.rs
@@ -1,0 +1,184 @@
+mod robot_exit;
+
+use std::time::Duration;
+
+use cranpose::{AppLauncher, Robot, SemanticElement};
+use cranpose_testing::changed_pixel_count_in_region;
+use desktop_app::app;
+
+const WINDOW_WIDTH: u32 = 760;
+const WINDOW_HEIGHT: u32 = 900;
+/// How much of the stage a press has to move for the dip to count as drawn.
+const MIN_PRESSED_PIXELS: usize = 400;
+
+/// The card whose accessibility name is `title`, as `(reading, bounds)`. The
+/// footer prints the same name, so the stage is the one that also publishes a
+/// state description.
+fn find_card(element: &SemanticElement, title: &str) -> Option<(String, (f32, f32, f32, f32))> {
+    if element.text.as_deref() == Some(title) {
+        if let Some(reading) = &element.state_description {
+            let bounds = element.bounds;
+            return Some((
+                reading.clone(),
+                (bounds.x, bounds.y, bounds.width, bounds.height),
+            ));
+        }
+    }
+    element
+        .children
+        .iter()
+        .find_map(|child| find_card(child, title))
+}
+
+fn card(robot: &Robot, title: &str) -> (String, (f32, f32, f32, f32)) {
+    let semantics = robot.get_semantics().expect("semantics");
+    semantics
+        .iter()
+        .find_map(|element| find_card(element, title))
+        .unwrap_or_else(|| {
+            robot_exit::fail_without_shutdown(&format!(
+                "no card named '{title}' publishes a reading"
+            ));
+        })
+}
+
+fn reading(robot: &Robot, title: &str) -> String {
+    card(robot, title).0
+}
+
+fn click_stage(robot: &Robot, title: &str) {
+    let (_, (x, y, width, height)) = card(robot, title);
+    robot
+        .click(x + width * 0.5, y + height * 0.5)
+        .expect("click the control stage");
+    std::thread::sleep(Duration::from_millis(220));
+    let _ = robot.wait_for_idle();
+}
+
+fn expect_reading(robot: &Robot, title: &str, want: &str, why: &str) {
+    let got = reading(robot, title);
+    if got != want {
+        robot_exit::fail_without_shutdown(&format!(
+            "{title} reads '{got}', expected '{want}': {why}"
+        ));
+    }
+}
+
+fn main() {
+    let _ = env_logger::try_init();
+
+    AppLauncher::new()
+        .with_title("Controls Grid Contract")
+        .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
+        .with_fonts(desktop_app::fonts::DEMO_FONTS)
+        .with_headless(std::env::var("CRANPOSE_HEADLESS").as_deref() != Ok("0"))
+        .with_test_driver(move |robot| {
+            std::thread::sleep(Duration::from_millis(600));
+            let _ = robot.wait_for_idle();
+
+            expect_reading(
+                &robot,
+                "Checkmark",
+                "Checked",
+                "the grid starts at its initial state",
+            );
+            expect_reading(
+                &robot,
+                "Toggle",
+                "Off",
+                "the grid starts at its initial state",
+            );
+            expect_reading(
+                &robot,
+                "Push button",
+                "0 presses",
+                "the grid starts at its initial state",
+            );
+            expect_reading(
+                &robot,
+                "Lever switch",
+                "Off",
+                "the grid starts at its initial state",
+            );
+
+            click_stage(&robot, "Checkmark");
+            click_stage(&robot, "Toggle");
+            click_stage(&robot, "Push button");
+            click_stage(&robot, "Lever switch");
+
+            expect_reading(
+                &robot,
+                "Checkmark",
+                "Unchecked",
+                "the first grid row takes a click",
+            );
+            expect_reading(
+                &robot,
+                "Toggle",
+                "On",
+                "a card in the middle grid row takes a click; a two-column window put the \
+                 toggle and the button there and neither answered one",
+            );
+            expect_reading(
+                &robot,
+                "Push button",
+                "1 press",
+                "the other middle-row card takes a click",
+            );
+            expect_reading(
+                &robot,
+                "Lever switch",
+                "On",
+                "the last grid row takes a click",
+            );
+
+            expect_reading(
+                &robot,
+                "Slider",
+                "35 %",
+                "clicking other cards leaves this one alone",
+            );
+            expect_reading(
+                &robot,
+                "Volume dial",
+                "40 %",
+                "clicking other cards leaves this one alone",
+            );
+
+            let (_, stage) = card(&robot, "Toggle");
+            let idle = robot.screenshot().expect("idle screenshot");
+            robot
+                .mouse_move(stage.0 + stage.2 * 0.25, stage.1 + stage.3 * 0.3)
+                .expect("move onto the middle-row stage away from its centre");
+            std::thread::sleep(Duration::from_millis(260));
+            let _ = robot.wait_for_idle();
+            let hovered = robot.screenshot().expect("hover screenshot");
+            robot.mouse_down().expect("press the middle-row stage");
+            std::thread::sleep(Duration::from_millis(140));
+            let _ = robot.wait_for_idle();
+            let pressed = robot.screenshot().expect("press screenshot");
+            robot.mouse_up().expect("release the middle-row stage");
+            std::thread::sleep(Duration::from_millis(360));
+            let _ = robot.wait_for_idle();
+
+            let hover_pixels = changed_pixel_count_in_region(&idle, &hovered, stage, 6);
+            let press_pixels = changed_pixel_count_in_region(&hovered, &pressed, stage, 6);
+            println!("hover_pixels={hover_pixels} press_pixels={press_pixels}");
+            if hover_pixels < MIN_PRESSED_PIXELS {
+                robot_exit::fail_without_shutdown(&format!(
+                    "hovering a middle-row stage moved {hover_pixels} pixels: its gesture \
+                     handler never ran"
+                ));
+            }
+            if press_pixels < MIN_PRESSED_PIXELS {
+                robot_exit::fail_without_shutdown(&format!(
+                    "pressing a middle-row stage moved {press_pixels} pixels: the press dip never \
+                     reached the shader"
+                ));
+            }
+
+            println!("PASS: every row of the controls grid takes a click and shows its press");
+            robot.exit().expect("exit");
+        })
+        .run(app::ControlsUiRobotApp);
+}

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -818,6 +818,14 @@ pub fn combined_app_with_startup(startup: StartupSelection) {
     );
 }
 
+/// The controls tab on its own, for tests that drive its cards without the
+/// demo shell's tab bar around them.
+#[allow(non_snake_case)]
+#[composable]
+pub fn ControlsUiRobotApp() {
+    ControlsUiTab();
+}
+
 #[allow(non_snake_case)]
 #[composable]
 pub fn MarkdownViewerRobotApp() {

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -22,6 +22,7 @@ use cranpose_ui::{
 };
 
 mod animations;
+mod controls_ui;
 mod glass_feed;
 mod hacker_news;
 mod images;
@@ -43,6 +44,7 @@ mod winamp;
 mod xkcd;
 
 use animations::AnimationsTab;
+use controls_ui::ControlsUiTab;
 use glass_feed::GlassFeedTab;
 pub use glass_feed::GLASS_FEED_LIST_TAG;
 pub use hacker_news::HACKER_NEWS_SCROLL_STABILITY_TARGET_TITLE;
@@ -109,6 +111,7 @@ pub enum DemoTab {
     Xkcd,
     Shaders,
     ShaderRect,
+    Controls,
     Liquid,
     GlassFeed,
     MarkdownViewer,
@@ -119,35 +122,227 @@ pub enum DemoTab {
 
 pub const DESKTOP_INITIAL_TAB: DemoTab = DemoTab::HackerNews;
 
+/// Everything the demo shell needs to know about one tab besides how to draw
+/// it: the tab bar's label, the robot runners' slug, the source file the "view
+/// source" pane fetches, and the names a startup request may use.
+pub struct DemoTabInfo {
+    pub tab: DemoTab,
+    pub label: &'static str,
+    pub slug: &'static str,
+    pub source_path: &'static str,
+    pub startup_aliases: &'static [&'static str],
+}
+
+pub const DEMO_TAB_INFO: [DemoTabInfo; 26] = [
+    DemoTabInfo {
+        tab: DemoTab::Counter,
+        label: "Counter App",
+        slug: "counter",
+        source_path: "apps/desktop-demo/src/app.rs",
+        startup_aliases: &["counter", "counterapp"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::CompositionLocal,
+        label: "CompositionLocal Test",
+        slug: "composition-local",
+        source_path: "apps/desktop-demo/src/app.rs",
+        startup_aliases: &["compositionlocal", "compositionlocaltest"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::Async,
+        label: "Async Runtime",
+        slug: "async",
+        source_path: "apps/desktop-demo/src/app.rs",
+        startup_aliases: &["async", "asyncruntime"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::Animations,
+        label: "Animations",
+        slug: "animations",
+        source_path: "apps/desktop-demo/src/app/animations.rs",
+        startup_aliases: &["animations"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::InteractiveAnim,
+        label: "Interactive Anim",
+        slug: "interactive-anim",
+        source_path: "apps/desktop-demo/src/app/interactive_anim.rs",
+        startup_aliases: &[
+            "interactiveanim",
+            "interactiveanimation",
+            "interactiveanimations",
+        ],
+    },
+    DemoTabInfo {
+        tab: DemoTab::WebFetch,
+        label: "Web Fetch",
+        slug: "web-fetch",
+        source_path: "apps/desktop-demo/src/app/web_fetch.rs",
+        startup_aliases: &["webfetch"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::TextInput,
+        label: "Text Input",
+        slug: "text-input",
+        source_path: "apps/desktop-demo/src/app.rs",
+        startup_aliases: &["textinput"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::Layout,
+        label: "Recursive Layout",
+        slug: "layout",
+        source_path: "apps/desktop-demo/src/app.rs",
+        startup_aliases: &["layout", "recursivelayout"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::ModifierShowcase,
+        label: "Modifiers Showcase",
+        slug: "modifier-showcase",
+        source_path: "apps/desktop-demo/src/app.rs",
+        startup_aliases: &["modifiers", "modifiersshowcase", "modifiershowcase"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::LazyList,
+        label: "Lazy List",
+        slug: "lazy-list",
+        source_path: "apps/desktop-demo/src/app/lazy_list.rs",
+        startup_aliases: &["lazylist"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::Mineswapper2,
+        label: "Mineswapper2",
+        slug: "mineswapper2",
+        source_path: "apps/desktop-demo/src/app/mineswapper2.rs",
+        startup_aliases: &["mineswapper2"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::RecompositionLab,
+        label: "Recomposition Lab",
+        slug: "recomposition-lab",
+        source_path: "apps/desktop-demo/src/app/recomposition_lab.rs",
+        startup_aliases: &["recompositionlab"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::HackerNews,
+        label: "Hacker News",
+        slug: "hacker-news",
+        source_path: "apps/desktop-demo/src/app/hacker_news.rs",
+        startup_aliases: &["hackernews"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::Images,
+        label: "Images",
+        slug: "images",
+        source_path: "apps/desktop-demo/src/app/images.rs",
+        startup_aliases: &["images"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::Text,
+        label: "Text",
+        slug: "text",
+        source_path: "apps/desktop-demo/src/app/text_showcase.rs",
+        startup_aliases: &["text"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::Winamp,
+        label: "Winamp",
+        slug: "winamp",
+        source_path: "apps/desktop-demo/src/app/winamp/mod.rs",
+        startup_aliases: &["winamp"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::Xkcd,
+        label: "XKCD",
+        slug: "xkcd",
+        source_path: "apps/desktop-demo/src/app/xkcd.rs",
+        startup_aliases: &["xkcd"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::Shaders,
+        label: "Shaders",
+        slug: "shaders",
+        source_path: "apps/desktop-demo/src/app/shaders.rs",
+        startup_aliases: &["shaders"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::ShaderRect,
+        label: "Shader Rect",
+        slug: "shader-rect",
+        source_path: "apps/desktop-demo/src/app/shader_rect.rs",
+        startup_aliases: &["shaderrect"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::Controls,
+        label: "Controls UI",
+        slug: "controls-ui",
+        source_path: "apps/desktop-demo/src/app/controls_ui.rs",
+        startup_aliases: &["controls", "controlsui"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::Liquid,
+        label: "Liquid UI",
+        slug: "liquid-ui",
+        source_path: "apps/desktop-demo/src/app/liquid_ui.rs",
+        startup_aliases: &["liquid", "liquidui"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::GlassFeed,
+        label: "Receipts",
+        slug: "glass-feed",
+        source_path: "apps/desktop-demo/src/app/glass_feed.rs",
+        startup_aliases: &["glassfeed", "receipts"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::MarkdownViewer,
+        label: "Markdown",
+        slug: "markdown-viewer",
+        source_path: "apps/desktop-demo/src/app/markdown.rs",
+        startup_aliases: &["markdown", "markdownviewer"],
+    },
+    DemoTabInfo {
+        tab: DemoTab::FilePicker,
+        label: "File Picker",
+        slug: "file-picker",
+        source_path: "apps/desktop-demo/src/app.rs",
+        startup_aliases: &[],
+    },
+    DemoTabInfo {
+        tab: DemoTab::Rotary,
+        label: "Rotary Input",
+        slug: "rotary",
+        source_path: "apps/desktop-demo/src/app/rotary.rs",
+        startup_aliases: &[],
+    },
+    DemoTabInfo {
+        tab: DemoTab::Wear,
+        label: "Wear (watch)",
+        slug: "wear-watch",
+        source_path: "apps/desktop-demo/src/app/wear.rs",
+        startup_aliases: &[],
+    },
+];
+
 impl DemoTab {
+    fn info(self) -> &'static DemoTabInfo {
+        DEMO_TAB_INFO
+            .iter()
+            .find(|info| info.tab == self)
+            .expect("every DemoTab needs a DEMO_TAB_INFO row")
+    }
+
     pub fn label(self) -> &'static str {
-        match self {
-            DemoTab::Counter => "Counter App",
-            DemoTab::CompositionLocal => "CompositionLocal Test",
-            DemoTab::Async => "Async Runtime",
-            DemoTab::Animations => "Animations",
-            DemoTab::InteractiveAnim => "Interactive Anim",
-            DemoTab::WebFetch => "Web Fetch",
-            DemoTab::TextInput => "Text Input",
-            DemoTab::Layout => "Recursive Layout",
-            DemoTab::ModifierShowcase => "Modifiers Showcase",
-            DemoTab::LazyList => "Lazy List",
-            DemoTab::Mineswapper2 => "Mineswapper2",
-            DemoTab::RecompositionLab => "Recomposition Lab",
-            DemoTab::HackerNews => "Hacker News",
-            DemoTab::Images => "Images",
-            DemoTab::Text => "Text",
-            DemoTab::Winamp => "Winamp",
-            DemoTab::Xkcd => "XKCD",
-            DemoTab::Shaders => "Shaders",
-            DemoTab::ShaderRect => "Shader Rect",
-            DemoTab::Liquid => "Liquid UI",
-            DemoTab::GlassFeed => "Receipts",
-            DemoTab::MarkdownViewer => "Markdown",
-            DemoTab::FilePicker => "File Picker",
-            DemoTab::Rotary => "Rotary Input",
-            DemoTab::Wear => "Wear (watch)",
-        }
+        self.info().label
+    }
+
+    /// The stable identifier robot runners and screenshot dumps address this
+    /// tab by.
+    pub fn slug(self) -> &'static str {
+        self.info().slug
+    }
+
+    /// The repository path of the file that implements this tab.
+    pub fn source_path(self) -> &'static str {
+        self.info().source_path
     }
 
     #[cfg(any(test, target_arch = "wasm32"))]
@@ -157,37 +352,14 @@ impl DemoTab {
             .filter(|ch| ch.is_ascii_alphanumeric())
             .map(|ch| ch.to_ascii_lowercase())
             .collect::<String>();
-        match normalized.as_str() {
-            "counter" | "counterapp" => Some(Self::Counter),
-            "compositionlocal" | "compositionlocaltest" => Some(Self::CompositionLocal),
-            "async" | "asyncruntime" => Some(Self::Async),
-            "animations" => Some(Self::Animations),
-            "interactiveanim" | "interactiveanimation" | "interactiveanimations" => {
-                Some(Self::InteractiveAnim)
-            }
-            "webfetch" => Some(Self::WebFetch),
-            "textinput" => Some(Self::TextInput),
-            "layout" | "recursivelayout" => Some(Self::Layout),
-            "modifiers" | "modifiersshowcase" | "modifiershowcase" => Some(Self::ModifierShowcase),
-            "lazylist" => Some(Self::LazyList),
-            "mineswapper2" => Some(Self::Mineswapper2),
-            "recompositionlab" => Some(Self::RecompositionLab),
-            "hackernews" => Some(Self::HackerNews),
-            "images" => Some(Self::Images),
-            "text" => Some(Self::Text),
-            "winamp" => Some(Self::Winamp),
-            "xkcd" => Some(Self::Xkcd),
-            "shaders" => Some(Self::Shaders),
-            "shaderrect" => Some(Self::ShaderRect),
-            "markdown" | "markdownviewer" => Some(Self::MarkdownViewer),
-            "liquid" | "liquidui" => Some(Self::Liquid),
-            "glassfeed" | "receipts" => Some(Self::GlassFeed),
-            _ => None,
-        }
+        DEMO_TAB_INFO
+            .iter()
+            .find(|info| info.startup_aliases.contains(&normalized.as_str()))
+            .map(|info| info.tab)
     }
 }
 
-pub const DEMO_TABS: [DemoTab; 25] = [
+pub const DEMO_TABS: [DemoTab; 26] = [
     DemoTab::Counter,
     DemoTab::Liquid,
     DemoTab::CompositionLocal,
@@ -207,6 +379,7 @@ pub const DEMO_TABS: [DemoTab; 25] = [
     DemoTab::Xkcd,
     DemoTab::Shaders,
     DemoTab::ShaderRect,
+    DemoTab::Controls,
     DemoTab::MarkdownViewer,
     DemoTab::InteractiveAnim,
     DemoTab::FilePicker,
@@ -702,6 +875,30 @@ fn render_active_tab(active: DemoTab, startup: StartupSelection, winamp_tab_stat
         DemoTab::LazyList => lazy_list_example(),
         DemoTab::Mineswapper2 => mineswapper2::mineswapper2_tab(),
         DemoTab::RecompositionLab => RecompositionLabTab(),
+        DemoTab::FilePicker => file_picker_tab(),
+        DemoTab::Rotary => rotary_tab(),
+        DemoTab::Wear => wear::wear_tab(),
+        DemoTab::HackerNews
+        | DemoTab::Images
+        | DemoTab::Text
+        | DemoTab::Winamp
+        | DemoTab::Xkcd
+        | DemoTab::Shaders
+        | DemoTab::ShaderRect
+        | DemoTab::Controls
+        | DemoTab::MarkdownViewer
+        | DemoTab::Liquid
+        | DemoTab::GlassFeed => render_showcase_tab(active, startup, winamp_tab_state),
+    }
+}
+
+#[composable]
+fn render_showcase_tab(
+    active: DemoTab,
+    startup: StartupSelection,
+    winamp_tab_state: WinampTabState,
+) {
+    match active {
         DemoTab::HackerNews => HackerNewsTab(),
         DemoTab::Images => images_tab(),
         DemoTab::Text => TextShowcaseTab(),
@@ -709,12 +906,25 @@ fn render_active_tab(active: DemoTab, startup: StartupSelection, winamp_tab_stat
         DemoTab::Xkcd => xkcd_tab(),
         DemoTab::Shaders => ShadersTab(startup.initial_shader_section),
         DemoTab::ShaderRect => ShaderRectTab(),
+        DemoTab::Controls => ControlsUiTab(),
         DemoTab::MarkdownViewer => markdown_viewer_tab(),
-        DemoTab::FilePicker => file_picker_tab(),
-        DemoTab::Rotary => rotary_tab(),
-        DemoTab::Wear => wear::wear_tab(),
         DemoTab::Liquid => LiquidUiTab(),
         DemoTab::GlassFeed => GlassFeedTab(),
+        DemoTab::Counter
+        | DemoTab::CompositionLocal
+        | DemoTab::Async
+        | DemoTab::Animations
+        | DemoTab::InteractiveAnim
+        | DemoTab::WebFetch
+        | DemoTab::TextInput
+        | DemoTab::Layout
+        | DemoTab::ModifierShowcase
+        | DemoTab::LazyList
+        | DemoTab::Mineswapper2
+        | DemoTab::RecompositionLab
+        | DemoTab::FilePicker
+        | DemoTab::Rotary
+        | DemoTab::Wear => {}
     }
 }
 

--- a/apps/desktop-demo/src/app/controls_ui.rs
+++ b/apps/desktop-demo/src/app/controls_ui.rs
@@ -1,21 +1,21 @@
 #![allow(non_snake_case)]
 
 use std::{
-    cell::Cell,
     f32::consts::{PI, TAU},
     sync::{Arc, OnceLock},
 };
 
 use cranpose_animation::{animateFloatAsState, spring, Animatable, AnimationType, Spring};
 use cranpose_core::{
-    remember, rememberMutableStateOf, with_current_composer, MutableState, Owned, State,
+    key, rememberMutableStateOf, with_current_composer, MutableState, Owned, State,
 };
+use cranpose_foundation::SemanticsWidgetRole;
 use cranpose_ui::{
     composable,
     text::{FontWeight, SpanStyle, TextUnit},
     Box, BoxSpec, Brush, Color, Column, ColumnSpec, CornerRadii, GraphicsLayer, LinearArrangement,
-    Modifier, Point, PointerEvent, PointerEventKind, PointerInputScope, Row, RowSpec, Size, Text,
-    TextStyle, VerticalAlignment,
+    Modifier, Point, PointerEventKind, PointerInputScope, Row, RowSpec, SemanticsConfiguration,
+    Size, Text, TextStyle, VerticalAlignment,
 };
 use cranpose_ui_graphics::{
     CompositingStrategy, RenderEffect, RuntimeShader, RUNTIME_SHADER_PRELUDE_WGSL,
@@ -53,7 +53,7 @@ static CONTROL_KINDS: [ControlKind; 6] = [
     ControlKind::LeverSwitch,
 ];
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 enum ControlKind {
     Checkmark,
     Slider,
@@ -91,6 +91,22 @@ impl ControlKind {
             self,
             ControlKind::Checkmark | ControlKind::Toggle | ControlKind::LeverSwitch
         )
+    }
+
+    /// What a screen reader announces this control as, mirroring Compose's
+    /// `Role`.
+    fn role(self) -> Option<SemanticsWidgetRole> {
+        match self {
+            ControlKind::Checkmark => Some(SemanticsWidgetRole::Checkbox),
+            ControlKind::Toggle | ControlKind::LeverSwitch => Some(SemanticsWidgetRole::Switch),
+            ControlKind::PushButton => Some(SemanticsWidgetRole::Button),
+            ControlKind::Slider | ControlKind::VolumeDial => None,
+        }
+    }
+
+    /// Whether a drag on the stage moves this control's value.
+    fn is_continuous(self) -> bool {
+        matches!(self, ControlKind::Slider | ControlKind::VolumeDial)
     }
 
     fn value_animation(self) -> AnimationType {
@@ -144,6 +160,24 @@ impl ControlState {
             }
         } else {
             self.value
+        }
+    }
+
+    fn toggled(self, on: bool) -> Self {
+        Self { on, ..self }
+    }
+
+    fn pressed_once(self) -> Self {
+        Self {
+            presses: self.presses.saturating_add(1),
+            ..self
+        }
+    }
+
+    fn with_value(self, value: f32) -> Self {
+        Self {
+            value: value.clamp(0.0, 1.0),
+            ..self
         }
     }
 
@@ -279,26 +313,17 @@ fn pointer_tilt(position: Point, size: Size) -> (f32, f32) {
     (-x * TILT_YAW, -y * TILT_PITCH)
 }
 
-fn press_state(
+/// The value a press at `position` starts a drag from, for the controls a
+/// drag moves. Compose's `Slider` jumps to the tapped position the same way.
+fn drag_start_value(
     kind: ControlKind,
     state: ControlState,
     position: Point,
     size: Size,
 ) -> ControlState {
     match kind {
-        ControlKind::Checkmark | ControlKind::Toggle | ControlKind::LeverSwitch => ControlState {
-            on: !state.on,
-            ..state
-        },
-        ControlKind::Slider => ControlState {
-            value: slider_value_at(position, size),
-            ..state
-        },
-        ControlKind::PushButton => ControlState {
-            presses: state.presses.saturating_add(1),
-            ..state
-        },
-        ControlKind::VolumeDial => state,
+        ControlKind::Slider => state.with_value(slider_value_at(position, size)),
+        _ => state,
     }
 }
 
@@ -310,19 +335,10 @@ fn drag_state(
     size: Size,
 ) -> (ControlState, DragTracking) {
     match kind {
-        ControlKind::Slider => (
-            ControlState {
-                value: slider_value_at(position, size),
-                ..state
-            },
-            tracking,
-        ),
+        ControlKind::Slider => (state.with_value(slider_value_at(position, size)), tracking),
         ControlKind::VolumeDial => match pointer_angle(position, size) {
             Some(angle) => (
-                ControlState {
-                    value: dial_value_after(state.value, tracking.angle, angle),
-                    ..state
-                },
+                state.with_value(dial_value_after(state.value, tracking.angle, angle)),
                 DragTracking {
                     active: tracking.active,
                     angle,
@@ -425,7 +441,6 @@ struct StageUniforms {
     kind: f32,
     value: f32,
     press: f32,
-    hover: f32,
     dark: f32,
     tilt_yaw: f32,
     tilt_pitch: f32,
@@ -437,7 +452,6 @@ fn stage_effect(uniforms: &StageUniforms) -> RenderEffect {
     shader.set_float(0, uniforms.kind);
     shader.set_float(1, uniforms.value);
     shader.set_float(2, uniforms.press);
-    shader.set_float(3, uniforms.hover);
     shader.set_float(4, uniforms.dark);
     shader.set_float(5, uniforms.tilt_yaw);
     shader.set_float(6, uniforms.tilt_pitch);
@@ -483,7 +497,7 @@ pub(crate) fn ControlsUiTab() {
             );
 
             for row in CONTROL_KINDS.chunks(grid_columns(page_size.get().width)) {
-                ControlGridRow(row, is_dark);
+                key(row[0], || ControlGridRow(row, is_dark));
             }
         },
     );
@@ -504,7 +518,15 @@ fn ThemeSwitch(dark: MutableState<bool>, is_dark: bool) {
             .draw_behind(move |scope| {
                 scope.draw_round_rect(Brush::solid(background), CornerRadii::uniform(16.0));
             })
-            .clickable(move |_| dark.set(!dark.get()))
+            .toggleable(
+                is_dark,
+                Some(format!(
+                    "Dark theme, {}",
+                    if is_dark { "on" } else { "off" }
+                )),
+                Some(SemanticsWidgetRole::Switch),
+                move |next| dark.set(next),
+            )
             .padding_symmetric(16.0, 9.0),
         BoxSpec::default(),
         move || {
@@ -513,6 +535,12 @@ fn ThemeSwitch(dark: MutableState<bool>, is_dark: bool) {
     );
 }
 
+/// One row of the grid.
+///
+/// The rows and the cards inside them are emitted from a single call site, so
+/// each is wrapped in Compose's `key`: identity comes from the control a card
+/// draws rather than from where the loop happened to reach it, and a reflow
+/// between column counts moves a card's state with it.
 #[composable]
 fn ControlGridRow(kinds: &'static [ControlKind], dark: bool) {
     Row(
@@ -520,37 +548,12 @@ fn ControlGridRow(kinds: &'static [ControlKind], dark: bool) {
         RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(GRID_SPACING)),
         move || {
             for kind in kinds {
-                ControlCard(*kind, dark, Modifier::empty().weight(1.0));
+                key(*kind, || {
+                    ControlCard(*kind, dark, Modifier::empty().weight(1.0))
+                });
             }
         },
     );
-}
-
-#[derive(Clone, Copy, PartialEq, Debug)]
-struct CardMemory {
-    kind: ControlKind,
-    control: ControlState,
-    hovered: bool,
-    tilt: (f32, f32),
-}
-
-impl CardMemory {
-    fn initial(kind: ControlKind) -> Self {
-        Self {
-            kind,
-            control: ControlState::initial(kind),
-            hovered: false,
-            tilt: (0.0, 0.0),
-        }
-    }
-
-    fn for_kind(self, kind: ControlKind) -> Self {
-        if self.kind == kind {
-            self
-        } else {
-            Self::initial(kind)
-        }
-    }
 }
 
 /// What a pointer event does to the press depth.
@@ -587,86 +590,41 @@ fn remember_press_depth() -> Owned<Animatable<f32>> {
     })
 }
 
-#[derive(Clone, Copy)]
-struct CardInput {
-    kind: ControlKind,
-    memory: MutableState<CardMemory>,
+fn apply_press(depth: &Owned<Animatable<f32>>, kind: PointerEventKind) {
+    match press_response(kind) {
+        PressResponse::Snap => depth.update(|animatable| animatable.snapTo(1.0)),
+        PressResponse::Release => {
+            depth.update(|animatable| animatable.animateTo(0.0, press_release_animation()))
+        }
+        PressResponse::Hold => {}
+    }
 }
 
-impl CardInput {
-    /// The remembered state of this card, replaced with a fresh one when a
-    /// grid reflow hands this slot a different control.
-    fn read(&self) -> CardMemory {
-        self.memory.get().for_kind(self.kind)
-    }
-
-    fn handle(
-        &self,
-        event: &PointerEvent,
-        size: Size,
-        tracking: &Cell<DragTracking>,
-        depth: &Owned<Animatable<f32>>,
-    ) {
-        match press_response(event.kind) {
-            PressResponse::Snap => depth.update(|animatable| animatable.snapTo(1.0)),
-            PressResponse::Release => {
-                depth.update(|animatable| animatable.animateTo(0.0, press_release_animation()))
-            }
-            PressResponse::Hold => {}
+/// The click behaviour and accessibility of one control: the switches are
+/// `Modifier.toggleable`, the button is `Modifier.clickable`, and every card
+/// names itself and publishes its reading the way Compose's
+/// `contentDescription` / `stateDescription` pair does.
+fn control_action(kind: ControlKind, state: MutableState<ControlState>) -> Modifier {
+    let current = state.get();
+    let action = match kind {
+        ControlKind::Checkmark | ControlKind::Toggle | ControlKind::LeverSwitch => {
+            Modifier::empty().toggleable(current.on, None, kind.role(), move |next| {
+                state.set(state.get().toggled(next))
+            })
         }
-
-        let memory = self.read();
-        match event.kind {
-            PointerEventKind::Enter => self.memory.set(CardMemory {
-                hovered: true,
-                ..memory
-            }),
-            PointerEventKind::Exit => {
-                self.memory.set(CardMemory {
-                    hovered: false,
-                    ..memory
-                });
-                tracking.set(DragTracking::default());
-            }
-            PointerEventKind::Down => {
-                self.memory.set(CardMemory {
-                    control: press_state(self.kind, memory.control, event.position, size),
-                    hovered: true,
-                    ..memory
-                });
-                tracking.set(DragTracking {
-                    active: true,
-                    angle: pointer_angle(event.position, size).unwrap_or_default(),
-                });
-                event.consume();
-            }
-            PointerEventKind::Move => {
-                let tilt = pointer_tilt(event.position, size);
-                if tracking.get().active {
-                    let (control, tracked) = drag_state(
-                        self.kind,
-                        memory.control,
-                        tracking.get(),
-                        event.position,
-                        size,
-                    );
-                    self.memory.set(CardMemory {
-                        control,
-                        tilt,
-                        ..memory
-                    });
-                    tracking.set(tracked);
-                    event.consume();
-                } else {
-                    self.memory.set(CardMemory { tilt, ..memory });
-                }
-            }
-            PointerEventKind::Up | PointerEventKind::Cancel => {
-                tracking.set(DragTracking::default());
-            }
-            _ => {}
+        ControlKind::PushButton => {
+            Modifier::empty().clickable(move |_position| state.set(state.get().pressed_once()))
         }
-    }
+        ControlKind::Slider | ControlKind::VolumeDial => Modifier::empty(),
+    };
+    let reading = current.label(kind);
+    action.semantics(move |config: &mut SemanticsConfiguration| {
+        config.content_description = Some(kind.title().to_string());
+        config.state_description = Some(reading.clone());
+        if let Some(role) = kind.role() {
+            config.role = Some(role);
+        }
+    })
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -676,25 +634,10 @@ struct StageTargets {
     tilt: (f32, f32),
 }
 
-impl StageTargets {
-    fn of(kind: ControlKind, memory: CardMemory) -> Self {
-        Self {
-            value: memory.control.scene_value(kind),
-            hovered: memory.hovered,
-            tilt: if memory.hovered {
-                memory.tilt
-            } else {
-                (0.0, 0.0)
-            },
-        }
-    }
-}
-
 #[derive(Clone, Copy)]
 struct StageAnimation {
     value: State<f32>,
     press: State<f32>,
-    hover: State<f32>,
     yaw: State<f32>,
     pitch: State<f32>,
 }
@@ -705,7 +648,6 @@ impl StageAnimation {
             kind: kind.scene_index(),
             value: self.value.value(),
             press: self.press.value().clamp(0.0, 1.0),
-            hover: self.hover.value(),
             dark: if dark { 1.0 } else { 0.0 },
             tilt_yaw: self.yaw.value(),
             tilt_pitch: self.pitch.value(),
@@ -714,34 +656,42 @@ impl StageAnimation {
     }
 }
 
+#[allow(non_snake_case)]
 #[composable]
-fn stageAnimation(kind: ControlKind, targets: StageTargets, press: State<f32>) -> StageAnimation {
+fn animateStageAsState(
+    kind: ControlKind,
+    targets: StageTargets,
+    press: State<f32>,
+) -> StageAnimation {
     let settle = spring(Spring::DampingRatioNoBouncy, Spring::StiffnessLow);
+    let (yaw, pitch) = if targets.hovered {
+        targets.tilt
+    } else {
+        (0.0, 0.0)
+    };
     StageAnimation {
         value: animateFloatAsState(targets.value, kind.value_animation(), "controls_value"),
         press,
-        hover: animateFloatAsState(
-            if targets.hovered { 1.0 } else { 0.0 },
-            spring(Spring::DampingRatioNoBouncy, Spring::StiffnessMediumLow),
-            "controls_hover",
-        ),
-        yaw: animateFloatAsState(targets.tilt.0, settle, "controls_yaw"),
-        pitch: animateFloatAsState(targets.tilt.1, settle, "controls_pitch"),
+        yaw: animateFloatAsState(yaw, settle, "controls_yaw"),
+        pitch: animateFloatAsState(pitch, settle, "controls_pitch"),
     }
 }
 
 #[composable]
 fn ControlCard(kind: ControlKind, dark: bool, modifier: Modifier) {
-    let input = CardInput {
-        kind,
-        memory: rememberMutableStateOf(move || CardMemory::initial(kind)),
-    };
-    let tracking = remember(|| Cell::new(DragTracking::default()));
+    let state = rememberMutableStateOf(move || ControlState::initial(kind));
+    let hovered = rememberMutableStateOf(|| false);
+    let tilt = rememberMutableStateOf(|| (0.0f32, 0.0f32));
     let depth = remember_press_depth();
-    let memory = input.read();
-    let animation = stageAnimation(
+
+    let current = state.get();
+    let animation = animateStageAsState(
         kind,
-        StageTargets::of(kind, memory),
+        StageTargets {
+            value: current.scene_value(kind),
+            hovered: hovered.get(),
+            tilt: tilt.get(),
+        },
         depth.with(|animatable| animatable.state()),
     );
     let background = card_color(dark);
@@ -754,12 +704,12 @@ fn ControlCard(kind: ControlKind, dark: bool, modifier: Modifier) {
             }),
         ColumnSpec::default(),
         move || {
-            let tracking = tracking.clone();
             let depth = depth.clone();
             Box(
                 Modifier::empty()
                     .fill_max_width()
                     .height(STAGE_HEIGHT)
+                    .then(control_action(kind, state))
                     .graphics_layer(move || GraphicsLayer {
                         render_effect: Some(stage_effect(
                             &animation.uniforms(kind, dark, background),
@@ -768,16 +718,58 @@ fn ControlCard(kind: ControlKind, dark: bool, modifier: Modifier) {
                         ..Default::default()
                     })
                     .pointer_input((), move |scope: PointerInputScope| {
-                        let tracking = tracking.clone();
                         let depth = depth.clone();
                         async move {
                             scope
-                                .await_pointer_event_scope(|await_scope| async move {
+                                .await_pointer_event_scope(|events| async move {
+                                    let mut drag = DragTracking::default();
                                     loop {
-                                        let event = await_scope.await_pointer_event().await;
-                                        let size = await_scope.size();
-                                        tracking
-                                            .with(|cell| input.handle(&event, size, cell, &depth));
+                                        let event = events.await_pointer_event().await;
+                                        let size = events.size();
+                                        apply_press(&depth, event.kind);
+                                        match event.kind {
+                                            PointerEventKind::Enter => hovered.set(true),
+                                            PointerEventKind::Exit => {
+                                                hovered.set(false);
+                                                drag = DragTracking::default();
+                                            }
+                                            PointerEventKind::Down => {
+                                                hovered.set(true);
+                                                drag = DragTracking {
+                                                    active: kind.is_continuous(),
+                                                    angle: pointer_angle(event.position, size)
+                                                        .unwrap_or_default(),
+                                                };
+                                                if kind.is_continuous() {
+                                                    state.set(drag_start_value(
+                                                        kind,
+                                                        state.get(),
+                                                        event.position,
+                                                        size,
+                                                    ));
+                                                    event.consume();
+                                                }
+                                            }
+                                            PointerEventKind::Move => {
+                                                tilt.set(pointer_tilt(event.position, size));
+                                                if drag.active {
+                                                    let (next, tracked) = drag_state(
+                                                        kind,
+                                                        state.get(),
+                                                        drag,
+                                                        event.position,
+                                                        size,
+                                                    );
+                                                    state.set(next);
+                                                    drag = tracked;
+                                                    event.consume();
+                                                }
+                                            }
+                                            PointerEventKind::Up | PointerEventKind::Cancel => {
+                                                drag = DragTracking::default();
+                                            }
+                                            _ => {}
+                                        }
                                     }
                                 })
                                 .await;
@@ -786,7 +778,8 @@ fn ControlCard(kind: ControlKind, dark: bool, modifier: Modifier) {
                 BoxSpec::default(),
                 || {},
             );
-            ControlFooter(kind, memory.control, dark);
+
+            ControlFooter(kind, current, dark);
         },
     );
 }
@@ -932,29 +925,6 @@ mod tests {
     }
 
     #[test]
-    fn a_reflowed_slot_does_not_hand_a_control_another_kinds_state() {
-        let slider = CardMemory {
-            kind: ControlKind::Slider,
-            control: ControlState {
-                value: 0.9,
-                on: true,
-                presses: 4,
-            },
-            hovered: true,
-            tilt: (0.2, 0.1),
-        };
-        assert_eq!(slider.for_kind(ControlKind::Slider), slider);
-        assert_eq!(
-            slider.for_kind(ControlKind::Toggle),
-            CardMemory::initial(ControlKind::Toggle)
-        );
-        assert_eq!(
-            slider.for_kind(ControlKind::VolumeDial).control.value,
-            ControlState::initial(ControlKind::VolumeDial).value
-        );
-    }
-
-    #[test]
     fn wrap_angle_folds_full_turns() {
         assert!((wrap_angle(0.4) - 0.4).abs() < 1e-5);
         assert!((wrap_angle(0.4 + TAU) - 0.4).abs() < 1e-4);
@@ -995,37 +965,66 @@ mod tests {
     }
 
     #[test]
-    fn press_toggles_switches_and_counts_button_presses() {
-        let toggle = ControlState::initial(ControlKind::Toggle);
-        let flipped = press_state(ControlKind::Toggle, toggle, Point::default(), STAGE);
-        assert!(flipped.on);
-        assert!(!press_state(ControlKind::Toggle, flipped, Point::default(), STAGE).on);
+    fn a_switch_takes_the_value_its_toggleable_hands_over() {
+        let off = ControlState::initial(ControlKind::Toggle);
+        assert!(!off.on);
+        assert!(off.toggled(true).on);
+        assert!(!off.toggled(true).toggled(false).on);
+    }
 
+    #[test]
+    fn a_click_counts_one_press() {
         let button = ControlState::initial(ControlKind::PushButton);
-        let pressed = press_state(ControlKind::PushButton, button, Point::default(), STAGE);
-        assert_eq!(pressed.presses, 1);
+        assert_eq!(button.presses, 0);
+        assert_eq!(button.pressed_once().presses, 1);
+        assert_eq!(button.pressed_once().pressed_once().presses, 2);
         assert_eq!(
-            press_state(ControlKind::PushButton, pressed, Point::default(), STAGE).presses,
-            2
+            ControlState {
+                presses: u32::MAX,
+                ..button
+            }
+            .pressed_once()
+            .presses,
+            u32::MAX
         );
     }
 
     #[test]
-    fn press_moves_the_slider_but_leaves_the_dial_alone() {
+    fn a_drag_starts_the_slider_at_the_pressed_position_and_leaves_the_dial() {
         let right = project([SLIDER_TRAVEL, SLIDER_LIFT, 0.0], STAGE);
-        let slider = press_state(
-            ControlKind::Slider,
-            ControlState::initial(ControlKind::Slider),
-            right,
-            STAGE,
+        let slider = ControlState::initial(ControlKind::Slider);
+        assert_eq!(
+            drag_start_value(ControlKind::Slider, slider, right, STAGE).value,
+            1.0
         );
-        assert_eq!(slider.value, 1.0);
-
         let dial = ControlState::initial(ControlKind::VolumeDial);
         assert_eq!(
-            press_state(ControlKind::VolumeDial, dial, right, STAGE),
+            drag_start_value(ControlKind::VolumeDial, dial, right, STAGE),
             dial
         );
+    }
+
+    #[test]
+    fn only_the_dragged_controls_are_continuous() {
+        assert!(ControlKind::Slider.is_continuous());
+        assert!(ControlKind::VolumeDial.is_continuous());
+        for kind in [
+            ControlKind::Checkmark,
+            ControlKind::Toggle,
+            ControlKind::LeverSwitch,
+            ControlKind::PushButton,
+        ] {
+            assert!(!kind.is_continuous(), "{kind:?} is clicked, not dragged");
+            assert!(kind.role().is_some(), "{kind:?} needs a semantics role");
+        }
+    }
+
+    #[test]
+    fn a_value_is_clamped_to_its_track() {
+        let slider = ControlState::initial(ControlKind::Slider);
+        assert_eq!(slider.with_value(1.4).value, 1.0);
+        assert_eq!(slider.with_value(-0.3).value, 0.0);
+        assert_eq!(slider.with_value(0.42).value, 0.42);
     }
 
     #[test]

--- a/apps/desktop-demo/src/app/controls_ui.rs
+++ b/apps/desktop-demo/src/app/controls_ui.rs
@@ -1,0 +1,1058 @@
+#![allow(non_snake_case)]
+
+use std::{
+    cell::Cell,
+    f32::consts::{PI, TAU},
+    sync::{Arc, OnceLock},
+};
+
+use cranpose_animation::{animateFloatAsState, spring, AnimationType, Spring};
+use cranpose_core::{remember, rememberMutableStateOf, MutableState, State};
+use cranpose_ui::{
+    composable,
+    text::{FontWeight, SpanStyle, TextUnit},
+    Box, BoxSpec, Brush, Color, Column, ColumnSpec, CornerRadii, GraphicsLayer, LinearArrangement,
+    Modifier, Point, PointerEvent, PointerEventKind, PointerInputScope, Row, RowSpec, Size, Text,
+    TextStyle, VerticalAlignment,
+};
+use cranpose_ui_graphics::{
+    CompositingStrategy, RenderEffect, RuntimeShader, RUNTIME_SHADER_PRELUDE_WGSL,
+};
+
+const STAGE_HEIGHT: f32 = 208.0;
+const CARD_RADIUS: f32 = 22.0;
+const GRID_SPACING: f32 = 16.0;
+const FOOTER_HORIZONTAL_PADDING: f32 = 18.0;
+const FOOTER_VERTICAL_PADDING: f32 = 13.0;
+
+const CAMERA_YAW: f32 = 0.46;
+const CAMERA_PITCH: f32 = 0.60;
+const CAMERA_DISTANCE: f32 = 4.05;
+const CAMERA_FOCAL: f32 = 2.62;
+const CAMERA_TARGET_Y: f32 = 0.19;
+
+const SLIDER_TRAVEL: f32 = 0.66;
+const SLIDER_LIFT: f32 = 0.148;
+const DIAL_PIVOT_Y: f32 = 0.33;
+const DIAL_SWEEP: f32 = 4.72;
+const DIAL_DEAD_ZONE_PX: f32 = 14.0;
+const TILT_YAW: f32 = 0.17;
+const TILT_PITCH: f32 = 0.11;
+const STAGE_DESIGN_ASPECT: f32 = 1.78;
+const WIDE_GRID_MIN_WIDTH: f32 = 900.0;
+const MEDIUM_GRID_MIN_WIDTH: f32 = 620.0;
+
+static CONTROL_KINDS: [ControlKind; 6] = [
+    ControlKind::Checkmark,
+    ControlKind::Slider,
+    ControlKind::Toggle,
+    ControlKind::PushButton,
+    ControlKind::VolumeDial,
+    ControlKind::LeverSwitch,
+];
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ControlKind {
+    Checkmark,
+    Slider,
+    Toggle,
+    PushButton,
+    VolumeDial,
+    LeverSwitch,
+}
+
+impl ControlKind {
+    fn title(self) -> &'static str {
+        match self {
+            ControlKind::Checkmark => "Checkmark",
+            ControlKind::Slider => "Slider",
+            ControlKind::Toggle => "Toggle",
+            ControlKind::PushButton => "Push button",
+            ControlKind::VolumeDial => "Volume dial",
+            ControlKind::LeverSwitch => "Lever switch",
+        }
+    }
+
+    fn scene_index(self) -> f32 {
+        match self {
+            ControlKind::Checkmark => 0.0,
+            ControlKind::Slider => 1.0,
+            ControlKind::Toggle => 2.0,
+            ControlKind::PushButton => 3.0,
+            ControlKind::VolumeDial => 4.0,
+            ControlKind::LeverSwitch => 5.0,
+        }
+    }
+
+    fn is_switch(self) -> bool {
+        matches!(
+            self,
+            ControlKind::Checkmark | ControlKind::Toggle | ControlKind::LeverSwitch
+        )
+    }
+
+    fn value_animation(self) -> AnimationType {
+        if self.is_switch() {
+            spring(Spring::DampingRatioMediumBouncy, Spring::StiffnessMedium)
+        } else {
+            spring(Spring::DampingRatioNoBouncy, Spring::StiffnessHigh)
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+struct ControlState {
+    value: f32,
+    on: bool,
+    presses: u32,
+}
+
+impl ControlState {
+    fn initial(kind: ControlKind) -> Self {
+        match kind {
+            ControlKind::Checkmark => Self {
+                value: 0.0,
+                on: true,
+                presses: 0,
+            },
+            ControlKind::Slider => Self {
+                value: 0.35,
+                on: false,
+                presses: 0,
+            },
+            ControlKind::VolumeDial => Self {
+                value: 0.40,
+                on: false,
+                presses: 0,
+            },
+            _ => Self {
+                value: 0.0,
+                on: false,
+                presses: 0,
+            },
+        }
+    }
+
+    fn scene_value(self, kind: ControlKind) -> f32 {
+        if kind.is_switch() {
+            if self.on {
+                1.0
+            } else {
+                0.0
+            }
+        } else {
+            self.value
+        }
+    }
+
+    fn label(self, kind: ControlKind) -> String {
+        match kind {
+            ControlKind::Checkmark => {
+                if self.on {
+                    "Checked".to_string()
+                } else {
+                    "Unchecked".to_string()
+                }
+            }
+            ControlKind::Slider | ControlKind::VolumeDial => {
+                format!("{} %", (self.value * 100.0).round() as i32)
+            }
+            ControlKind::PushButton => {
+                if self.presses == 1 {
+                    "1 press".to_string()
+                } else {
+                    format!("{} presses", self.presses)
+                }
+            }
+            ControlKind::Toggle | ControlKind::LeverSwitch => {
+                if self.on {
+                    "On".to_string()
+                } else {
+                    "Off".to_string()
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct DragTracking {
+    active: bool,
+    angle: f32,
+}
+
+fn sub(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+fn dot(a: [f32; 3], b: [f32; 3]) -> f32 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+fn cross(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+fn normalize(a: [f32; 3]) -> [f32; 3] {
+    let length = dot(a, a).sqrt().max(1e-6);
+    [a[0] / length, a[1] / length, a[2] / length]
+}
+
+fn camera_eye() -> [f32; 3] {
+    [
+        CAMERA_YAW.sin() * CAMERA_PITCH.cos() * CAMERA_DISTANCE,
+        CAMERA_TARGET_Y + CAMERA_PITCH.sin() * CAMERA_DISTANCE,
+        CAMERA_YAW.cos() * CAMERA_PITCH.cos() * CAMERA_DISTANCE,
+    ]
+}
+
+fn stage_unit(size: Size) -> f32 {
+    size.height.min(size.width / STAGE_DESIGN_ASPECT)
+}
+
+fn grid_columns(width: f32) -> usize {
+    if width <= 1.0 || width >= WIDE_GRID_MIN_WIDTH {
+        3
+    } else if width >= MEDIUM_GRID_MIN_WIDTH {
+        2
+    } else {
+        1
+    }
+}
+
+fn project(point: [f32; 3], size: Size) -> Point {
+    let eye = camera_eye();
+    let forward = normalize(sub([0.0, CAMERA_TARGET_Y, 0.0], eye));
+    let right = normalize(cross(forward, [0.0, 1.0, 0.0]));
+    let up = cross(right, forward);
+    let offset = sub(point, eye);
+    let depth = dot(offset, forward).max(1e-3);
+    let unit = stage_unit(size);
+    let x = dot(offset, right) * CAMERA_FOCAL / depth;
+    let y = dot(offset, up) * CAMERA_FOCAL / depth;
+    Point {
+        x: x * unit + size.width * 0.5,
+        y: -y * unit + size.height * 0.5,
+    }
+}
+
+fn slider_value_at(position: Point, size: Size) -> f32 {
+    let left = project([-SLIDER_TRAVEL, SLIDER_LIFT, 0.0], size).x;
+    let right = project([SLIDER_TRAVEL, SLIDER_LIFT, 0.0], size).x;
+    let span = right - left;
+    if span.abs() < 1e-3 {
+        return 0.0;
+    }
+    ((position.x - left) / span).clamp(0.0, 1.0)
+}
+
+fn pointer_angle(position: Point, size: Size) -> Option<f32> {
+    let pivot = project([0.0, DIAL_PIVOT_Y, 0.0], size);
+    let dx = position.x - pivot.x;
+    let dy = position.y - pivot.y;
+    if dx * dx + dy * dy < DIAL_DEAD_ZONE_PX * DIAL_DEAD_ZONE_PX {
+        return None;
+    }
+    Some(dy.atan2(dx))
+}
+
+fn wrap_angle(angle: f32) -> f32 {
+    (angle + PI).rem_euclid(TAU) - PI
+}
+
+fn dial_value_after(value: f32, previous: f32, current: f32) -> f32 {
+    (value + wrap_angle(current - previous) / DIAL_SWEEP).clamp(0.0, 1.0)
+}
+
+fn pointer_tilt(position: Point, size: Size) -> (f32, f32) {
+    if size.width <= 1.0 || size.height <= 1.0 {
+        return (0.0, 0.0);
+    }
+    let x = ((position.x / size.width) - 0.5).clamp(-0.5, 0.5) * 2.0;
+    let y = ((position.y / size.height) - 0.5).clamp(-0.5, 0.5) * 2.0;
+    (-x * TILT_YAW, -y * TILT_PITCH)
+}
+
+fn press_state(
+    kind: ControlKind,
+    state: ControlState,
+    position: Point,
+    size: Size,
+) -> ControlState {
+    match kind {
+        ControlKind::Checkmark | ControlKind::Toggle | ControlKind::LeverSwitch => ControlState {
+            on: !state.on,
+            ..state
+        },
+        ControlKind::Slider => ControlState {
+            value: slider_value_at(position, size),
+            ..state
+        },
+        ControlKind::PushButton => ControlState {
+            presses: state.presses.saturating_add(1),
+            ..state
+        },
+        ControlKind::VolumeDial => state,
+    }
+}
+
+fn drag_state(
+    kind: ControlKind,
+    state: ControlState,
+    tracking: DragTracking,
+    position: Point,
+    size: Size,
+) -> (ControlState, DragTracking) {
+    match kind {
+        ControlKind::Slider => (
+            ControlState {
+                value: slider_value_at(position, size),
+                ..state
+            },
+            tracking,
+        ),
+        ControlKind::VolumeDial => match pointer_angle(position, size) {
+            Some(angle) => (
+                ControlState {
+                    value: dial_value_after(state.value, tracking.angle, angle),
+                    ..state
+                },
+                DragTracking {
+                    active: tracking.active,
+                    angle,
+                },
+            ),
+            None => (state, tracking),
+        },
+        _ => (state, tracking),
+    }
+}
+
+fn page_color(dark: bool) -> Color {
+    if dark {
+        Color(0.043, 0.047, 0.058, 1.0)
+    } else {
+        Color(0.898, 0.898, 0.890, 1.0)
+    }
+}
+
+fn card_color(dark: bool) -> Color {
+    if dark {
+        Color(0.086, 0.092, 0.106, 1.0)
+    } else {
+        Color(0.851, 0.851, 0.843, 1.0)
+    }
+}
+
+fn divider_color(dark: bool) -> Color {
+    if dark {
+        Color(1.0, 1.0, 1.0, 0.10)
+    } else {
+        Color(0.0, 0.0, 0.0, 0.10)
+    }
+}
+
+fn ink_color(dark: bool) -> Color {
+    if dark {
+        Color(0.94, 0.95, 0.97, 1.0)
+    } else {
+        Color(0.09, 0.10, 0.11, 1.0)
+    }
+}
+
+fn muted_color(dark: bool) -> Color {
+    if dark {
+        Color(0.62, 0.65, 0.70, 1.0)
+    } else {
+        Color(0.38, 0.39, 0.41, 1.0)
+    }
+}
+
+fn title_style(dark: bool) -> TextStyle {
+    TextStyle {
+        span_style: SpanStyle {
+            color: Some(ink_color(dark)),
+            font_size: TextUnit::Sp(30.0),
+            font_weight: Some(FontWeight::BOLD),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn card_title_style(dark: bool) -> TextStyle {
+    TextStyle {
+        span_style: SpanStyle {
+            color: Some(ink_color(dark)),
+            font_size: TextUnit::Sp(15.0),
+            font_weight: Some(FontWeight::BOLD),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn card_value_style(dark: bool) -> TextStyle {
+    TextStyle {
+        span_style: SpanStyle {
+            color: Some(muted_color(dark)),
+            font_size: TextUnit::Sp(14.0),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn controls_wgsl() -> Arc<str> {
+    static SOURCE: OnceLock<Arc<str>> = OnceLock::new();
+    SOURCE
+        .get_or_init(|| {
+            Arc::<str>::from(format!(
+                "{RUNTIME_SHADER_PRELUDE_WGSL}{}",
+                include_str!("controls_ui.wgsl")
+            ))
+        })
+        .clone()
+}
+
+struct StageUniforms {
+    kind: f32,
+    value: f32,
+    press: f32,
+    hover: f32,
+    dark: f32,
+    tilt_yaw: f32,
+    tilt_pitch: f32,
+    background: Color,
+}
+
+fn stage_effect(uniforms: &StageUniforms) -> RenderEffect {
+    let mut shader = RuntimeShader::from_shared_source(controls_wgsl());
+    shader.set_float(0, uniforms.kind);
+    shader.set_float(1, uniforms.value);
+    shader.set_float(2, uniforms.press);
+    shader.set_float(3, uniforms.hover);
+    shader.set_float(4, uniforms.dark);
+    shader.set_float(5, uniforms.tilt_yaw);
+    shader.set_float(6, uniforms.tilt_pitch);
+    shader.set_float(8, uniforms.background.0);
+    shader.set_float(9, uniforms.background.1);
+    shader.set_float(10, uniforms.background.2);
+    shader.set_float(12, CAMERA_YAW);
+    shader.set_float(13, CAMERA_PITCH);
+    shader.set_float(14, CAMERA_DISTANCE);
+    shader.set_float(15, CAMERA_FOCAL);
+    shader.set_float(16, CAMERA_TARGET_Y);
+    shader.set_float(17, SLIDER_TRAVEL);
+    shader.set_float(18, SLIDER_LIFT);
+    shader.set_float(19, STAGE_DESIGN_ASPECT);
+    RenderEffect::runtime_shader(shader)
+}
+
+#[composable]
+pub(crate) fn ControlsUiTab() {
+    let dark = rememberMutableStateOf(|| false);
+    let page_size = rememberMutableStateOf(Size::default);
+    let is_dark = dark.get();
+
+    Column(
+        Modifier::empty()
+            .fill_max_width()
+            .report_size_state(page_size)
+            .background(page_color(is_dark))
+            .padding_symmetric(2.0, 6.0),
+        ColumnSpec::new().vertical_arrangement(LinearArrangement::SpacedBy(GRID_SPACING)),
+        move || {
+            Row(
+                Modifier::empty()
+                    .fill_max_width()
+                    .padding_symmetric(6.0, 4.0),
+                RowSpec::new()
+                    .horizontal_arrangement(LinearArrangement::SpaceBetween)
+                    .vertical_alignment(VerticalAlignment::CenterVertically),
+                move || {
+                    Text("Controls UI", Modifier::empty(), title_style(is_dark));
+                    ThemeSwitch(dark, is_dark);
+                },
+            );
+
+            for row in CONTROL_KINDS.chunks(grid_columns(page_size.get().width)) {
+                ControlGridRow(row, is_dark);
+            }
+        },
+    );
+}
+
+#[composable]
+fn ThemeSwitch(dark: MutableState<bool>, is_dark: bool) {
+    let label = if is_dark { "Light" } else { "Dark" };
+    let background = if is_dark {
+        Color(1.0, 1.0, 1.0, 0.10)
+    } else {
+        Color(0.0, 0.0, 0.0, 0.06)
+    };
+
+    Box(
+        Modifier::empty()
+            .rounded_corners(16.0)
+            .draw_behind(move |scope| {
+                scope.draw_round_rect(Brush::solid(background), CornerRadii::uniform(16.0));
+            })
+            .clickable(move |_| dark.set(!dark.get()))
+            .padding_symmetric(16.0, 9.0),
+        BoxSpec::default(),
+        move || {
+            Text(label, Modifier::empty(), card_value_style(is_dark));
+        },
+    );
+}
+
+#[composable]
+fn ControlGridRow(kinds: &'static [ControlKind], dark: bool) {
+    Row(
+        Modifier::empty().fill_max_width(),
+        RowSpec::new().horizontal_arrangement(LinearArrangement::SpacedBy(GRID_SPACING)),
+        move || {
+            for kind in kinds {
+                ControlCard(*kind, dark, Modifier::empty().weight(1.0));
+            }
+        },
+    );
+}
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+struct CardMemory {
+    kind: ControlKind,
+    control: ControlState,
+    hovered: bool,
+    pressed: bool,
+    tilt: (f32, f32),
+}
+
+impl CardMemory {
+    fn initial(kind: ControlKind) -> Self {
+        Self {
+            kind,
+            control: ControlState::initial(kind),
+            hovered: false,
+            pressed: false,
+            tilt: (0.0, 0.0),
+        }
+    }
+
+    fn for_kind(self, kind: ControlKind) -> Self {
+        if self.kind == kind {
+            self
+        } else {
+            Self::initial(kind)
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct CardInput {
+    kind: ControlKind,
+    memory: MutableState<CardMemory>,
+}
+
+impl CardInput {
+    /// The remembered state of this card, replaced with a fresh one when a
+    /// grid reflow hands this slot a different control.
+    fn read(&self) -> CardMemory {
+        self.memory.get().for_kind(self.kind)
+    }
+
+    fn handle(&self, event: &PointerEvent, size: Size, tracking: &Cell<DragTracking>) {
+        let memory = self.read();
+        match event.kind {
+            PointerEventKind::Enter => self.memory.set(CardMemory {
+                hovered: true,
+                ..memory
+            }),
+            PointerEventKind::Exit => {
+                self.memory.set(CardMemory {
+                    hovered: false,
+                    pressed: false,
+                    ..memory
+                });
+                tracking.set(DragTracking::default());
+            }
+            PointerEventKind::Down => {
+                self.memory.set(CardMemory {
+                    control: press_state(self.kind, memory.control, event.position, size),
+                    hovered: true,
+                    pressed: true,
+                    ..memory
+                });
+                tracking.set(DragTracking {
+                    active: true,
+                    angle: pointer_angle(event.position, size).unwrap_or_default(),
+                });
+                event.consume();
+            }
+            PointerEventKind::Move => {
+                let tilt = pointer_tilt(event.position, size);
+                if tracking.get().active {
+                    let (control, tracked) = drag_state(
+                        self.kind,
+                        memory.control,
+                        tracking.get(),
+                        event.position,
+                        size,
+                    );
+                    self.memory.set(CardMemory {
+                        control,
+                        tilt,
+                        ..memory
+                    });
+                    tracking.set(tracked);
+                    event.consume();
+                } else {
+                    self.memory.set(CardMemory { tilt, ..memory });
+                }
+            }
+            PointerEventKind::Up | PointerEventKind::Cancel => {
+                self.memory.set(CardMemory {
+                    pressed: false,
+                    ..memory
+                });
+                tracking.set(DragTracking::default());
+            }
+            _ => {}
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+struct StageTargets {
+    value: f32,
+    pressed: bool,
+    hovered: bool,
+    tilt: (f32, f32),
+}
+
+impl StageTargets {
+    fn of(kind: ControlKind, memory: CardMemory) -> Self {
+        Self {
+            value: memory.control.scene_value(kind),
+            pressed: memory.pressed,
+            hovered: memory.hovered,
+            tilt: if memory.hovered {
+                memory.tilt
+            } else {
+                (0.0, 0.0)
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct StageAnimation {
+    value: State<f32>,
+    press: State<f32>,
+    hover: State<f32>,
+    yaw: State<f32>,
+    pitch: State<f32>,
+}
+
+impl StageAnimation {
+    fn uniforms(self, kind: ControlKind, dark: bool, background: Color) -> StageUniforms {
+        StageUniforms {
+            kind: kind.scene_index(),
+            value: self.value.value(),
+            press: self.press.value(),
+            hover: self.hover.value(),
+            dark: if dark { 1.0 } else { 0.0 },
+            tilt_yaw: self.yaw.value(),
+            tilt_pitch: self.pitch.value(),
+            background,
+        }
+    }
+}
+
+#[composable]
+fn stageAnimation(kind: ControlKind, targets: StageTargets) -> StageAnimation {
+    let settle = spring(Spring::DampingRatioNoBouncy, Spring::StiffnessLow);
+    StageAnimation {
+        value: animateFloatAsState(targets.value, kind.value_animation(), "controls_value"),
+        press: animateFloatAsState(
+            if targets.pressed { 1.0 } else { 0.0 },
+            spring(Spring::DampingRatioNoBouncy, Spring::StiffnessHigh),
+            "controls_press",
+        ),
+        hover: animateFloatAsState(
+            if targets.hovered { 1.0 } else { 0.0 },
+            spring(Spring::DampingRatioNoBouncy, Spring::StiffnessMediumLow),
+            "controls_hover",
+        ),
+        yaw: animateFloatAsState(targets.tilt.0, settle, "controls_yaw"),
+        pitch: animateFloatAsState(targets.tilt.1, settle, "controls_pitch"),
+    }
+}
+
+#[composable]
+fn ControlCard(kind: ControlKind, dark: bool, modifier: Modifier) {
+    let input = CardInput {
+        kind,
+        memory: rememberMutableStateOf(move || CardMemory::initial(kind)),
+    };
+    let tracking = remember(|| Cell::new(DragTracking::default()));
+    let memory = input.read();
+    let animation = stageAnimation(kind, StageTargets::of(kind, memory));
+    let background = card_color(dark);
+
+    Column(
+        modifier
+            .rounded_corners(CARD_RADIUS)
+            .draw_behind(move |scope| {
+                scope.draw_round_rect(Brush::solid(background), CornerRadii::uniform(CARD_RADIUS));
+            }),
+        ColumnSpec::default(),
+        move || {
+            let tracking = tracking.clone();
+            Box(
+                Modifier::empty()
+                    .fill_max_width()
+                    .height(STAGE_HEIGHT)
+                    .graphics_layer(move || GraphicsLayer {
+                        render_effect: Some(stage_effect(
+                            &animation.uniforms(kind, dark, background),
+                        )),
+                        compositing_strategy: CompositingStrategy::Offscreen,
+                        ..Default::default()
+                    })
+                    .pointer_input((), move |scope: PointerInputScope| {
+                        let tracking = tracking.clone();
+                        async move {
+                            scope
+                                .await_pointer_event_scope(|await_scope| async move {
+                                    loop {
+                                        let event = await_scope.await_pointer_event().await;
+                                        let size = await_scope.size();
+                                        tracking.with(|cell| input.handle(&event, size, cell));
+                                    }
+                                })
+                                .await;
+                        }
+                    }),
+                BoxSpec::default(),
+                || {},
+            );
+            ControlFooter(kind, memory.control, dark);
+        },
+    );
+}
+
+#[composable]
+fn ControlFooter(kind: ControlKind, state: ControlState, dark: bool) {
+    Box(
+        Modifier::empty()
+            .fill_max_width()
+            .height(1.0)
+            .background(divider_color(dark)),
+        BoxSpec::default(),
+        || {},
+    );
+
+    Row(
+        Modifier::empty()
+            .fill_max_width()
+            .padding_symmetric(FOOTER_HORIZONTAL_PADDING, FOOTER_VERTICAL_PADDING),
+        RowSpec::new()
+            .horizontal_arrangement(LinearArrangement::SpaceBetween)
+            .vertical_alignment(VerticalAlignment::CenterVertically),
+        move || {
+            Text(kind.title(), Modifier::empty(), card_title_style(dark));
+            Text(state.label(kind), Modifier::empty(), card_value_style(dark));
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const STAGE: Size = Size {
+        width: 360.0,
+        height: STAGE_HEIGHT,
+    };
+
+    #[test]
+    fn projection_maps_scene_origin_near_stage_centre() {
+        let centre = project([0.0, CAMERA_TARGET_Y, 0.0], STAGE);
+        assert!((centre.x - STAGE.width * 0.5).abs() < 0.01);
+        assert!((centre.y - STAGE.height * 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn projection_keeps_rail_ends_inside_the_stage() {
+        let left = project([-SLIDER_TRAVEL, SLIDER_LIFT, 0.0], STAGE);
+        let right = project([SLIDER_TRAVEL, SLIDER_LIFT, 0.0], STAGE);
+        assert!(left.x > 0.0 && left.x < STAGE.width);
+        assert!(right.x > left.x && right.x < STAGE.width);
+    }
+
+    #[test]
+    fn slider_value_follows_pointer_across_the_rail() {
+        let left = project([-SLIDER_TRAVEL, SLIDER_LIFT, 0.0], STAGE);
+        let right = project([SLIDER_TRAVEL, SLIDER_LIFT, 0.0], STAGE);
+        assert_eq!(slider_value_at(left, STAGE), 0.0);
+        assert_eq!(slider_value_at(right, STAGE), 1.0);
+        let middle = Point {
+            x: (left.x + right.x) * 0.5,
+            y: left.y,
+        };
+        assert!((slider_value_at(middle, STAGE) - 0.5).abs() < 1e-4);
+    }
+
+    #[test]
+    fn slider_value_clamps_outside_the_rail() {
+        assert_eq!(slider_value_at(Point { x: -400.0, y: 0.0 }, STAGE), 0.0);
+        assert_eq!(slider_value_at(Point { x: 900.0, y: 0.0 }, STAGE), 1.0);
+    }
+
+    #[test]
+    fn slider_value_is_zero_for_a_stage_that_was_never_laid_out() {
+        assert_eq!(
+            slider_value_at(Point { x: 0.0, y: 0.0 }, Size::default()),
+            0.0
+        );
+    }
+
+    #[test]
+    fn grid_columns_narrow_to_one_and_assume_wide_before_the_first_layout() {
+        assert_eq!(grid_columns(0.0), 3);
+        assert_eq!(grid_columns(1200.0), 3);
+        assert_eq!(grid_columns(WIDE_GRID_MIN_WIDTH), 3);
+        assert_eq!(grid_columns(WIDE_GRID_MIN_WIDTH - 1.0), 2);
+        assert_eq!(grid_columns(MEDIUM_GRID_MIN_WIDTH), 2);
+        assert_eq!(grid_columns(MEDIUM_GRID_MIN_WIDTH - 1.0), 1);
+        assert_eq!(grid_columns(320.0), 1);
+    }
+
+    #[test]
+    fn every_grid_column_count_covers_all_six_controls() {
+        for width in [320.0, 700.0, 1200.0] {
+            let rows: Vec<&[ControlKind]> = CONTROL_KINDS.chunks(grid_columns(width)).collect();
+            let placed: Vec<ControlKind> = rows.concat();
+            assert_eq!(
+                placed,
+                CONTROL_KINDS.to_vec(),
+                "width {width} drops a control"
+            );
+        }
+    }
+
+    #[test]
+    fn a_stage_narrower_than_the_design_aspect_scales_the_scene_down() {
+        let wide = Size {
+            width: STAGE_HEIGHT * STAGE_DESIGN_ASPECT * 2.0,
+            height: STAGE_HEIGHT,
+        };
+        assert_eq!(stage_unit(wide), STAGE_HEIGHT);
+        let narrow = Size {
+            width: STAGE_HEIGHT,
+            height: STAGE_HEIGHT,
+        };
+        assert!(stage_unit(narrow) < STAGE_HEIGHT);
+        let rail_end = project([-SLIDER_TRAVEL, SLIDER_LIFT, 0.0], narrow);
+        assert!(
+            rail_end.x > 0.0,
+            "the rail must stay inside a square stage, got {}",
+            rail_end.x
+        );
+    }
+
+    #[test]
+    fn a_reflowed_slot_does_not_hand_a_control_another_kinds_state() {
+        let slider = CardMemory {
+            kind: ControlKind::Slider,
+            control: ControlState {
+                value: 0.9,
+                on: true,
+                presses: 4,
+            },
+            hovered: true,
+            pressed: true,
+            tilt: (0.2, 0.1),
+        };
+        assert_eq!(slider.for_kind(ControlKind::Slider), slider);
+        assert_eq!(
+            slider.for_kind(ControlKind::Toggle),
+            CardMemory::initial(ControlKind::Toggle)
+        );
+        assert_eq!(
+            slider.for_kind(ControlKind::VolumeDial).control.value,
+            ControlState::initial(ControlKind::VolumeDial).value
+        );
+    }
+
+    #[test]
+    fn wrap_angle_folds_full_turns() {
+        assert!((wrap_angle(0.4) - 0.4).abs() < 1e-5);
+        assert!((wrap_angle(0.4 + TAU) - 0.4).abs() < 1e-4);
+        assert!((wrap_angle(PI + 0.2) - (-PI + 0.2)).abs() < 1e-4);
+    }
+
+    #[test]
+    fn dial_value_turns_with_the_pointer_and_clamps() {
+        let quarter = DIAL_SWEEP * 0.25;
+        assert!((dial_value_after(0.4, 0.0, quarter) - 0.65).abs() < 1e-4);
+        assert!((dial_value_after(0.4, quarter, 0.0) - 0.15).abs() < 1e-4);
+        assert_eq!(dial_value_after(0.95, 0.0, quarter), 1.0);
+        assert_eq!(dial_value_after(0.05, quarter, 0.0), 0.0);
+    }
+
+    #[test]
+    fn pointer_angle_ignores_the_pivot_dead_zone() {
+        let pivot = project([0.0, DIAL_PIVOT_Y, 0.0], STAGE);
+        assert!(pointer_angle(pivot, STAGE).is_none());
+        let away = Point {
+            x: pivot.x + 60.0,
+            y: pivot.y,
+        };
+        assert!(pointer_angle(away, STAGE).expect("angle").abs() < 1e-5);
+    }
+
+    #[test]
+    fn pointer_tilt_is_centred_and_bounded() {
+        let centre = Point {
+            x: STAGE.width * 0.5,
+            y: STAGE.height * 0.5,
+        };
+        assert_eq!(pointer_tilt(centre, STAGE), (0.0, 0.0));
+        let corner = Point { x: 0.0, y: 0.0 };
+        assert!((pointer_tilt(corner, STAGE).0 - TILT_YAW).abs() < 1e-5);
+        assert!((pointer_tilt(corner, STAGE).1 - TILT_PITCH).abs() < 1e-5);
+        assert_eq!(pointer_tilt(centre, Size::default()), (0.0, 0.0));
+    }
+
+    #[test]
+    fn press_toggles_switches_and_counts_button_presses() {
+        let toggle = ControlState::initial(ControlKind::Toggle);
+        let flipped = press_state(ControlKind::Toggle, toggle, Point::default(), STAGE);
+        assert!(flipped.on);
+        assert!(!press_state(ControlKind::Toggle, flipped, Point::default(), STAGE).on);
+
+        let button = ControlState::initial(ControlKind::PushButton);
+        let pressed = press_state(ControlKind::PushButton, button, Point::default(), STAGE);
+        assert_eq!(pressed.presses, 1);
+        assert_eq!(
+            press_state(ControlKind::PushButton, pressed, Point::default(), STAGE).presses,
+            2
+        );
+    }
+
+    #[test]
+    fn press_moves_the_slider_but_leaves_the_dial_alone() {
+        let right = project([SLIDER_TRAVEL, SLIDER_LIFT, 0.0], STAGE);
+        let slider = press_state(
+            ControlKind::Slider,
+            ControlState::initial(ControlKind::Slider),
+            right,
+            STAGE,
+        );
+        assert_eq!(slider.value, 1.0);
+
+        let dial = ControlState::initial(ControlKind::VolumeDial);
+        assert_eq!(
+            press_state(ControlKind::VolumeDial, dial, right, STAGE),
+            dial
+        );
+    }
+
+    #[test]
+    fn drag_turns_the_dial_and_records_the_new_angle() {
+        let pivot = project([0.0, DIAL_PIVOT_Y, 0.0], STAGE);
+        let below = Point {
+            x: pivot.x,
+            y: pivot.y + 60.0,
+        };
+        let state = ControlState::initial(ControlKind::VolumeDial);
+        let tracking = DragTracking {
+            active: true,
+            angle: 0.0,
+        };
+        let (next, tracked) = drag_state(ControlKind::VolumeDial, state, tracking, below, STAGE);
+        assert!(next.value > state.value);
+        assert!((tracked.angle - PI * 0.5).abs() < 1e-4);
+        assert!(tracked.active);
+    }
+
+    #[test]
+    fn drag_leaves_switches_untouched() {
+        let state = ControlState::initial(ControlKind::Checkmark);
+        let tracking = DragTracking {
+            active: true,
+            angle: 0.2,
+        };
+        let (next, tracked) = drag_state(
+            ControlKind::Checkmark,
+            state,
+            tracking,
+            Point { x: 10.0, y: 10.0 },
+            STAGE,
+        );
+        assert_eq!(next, state);
+        assert_eq!(tracked.angle, 0.2);
+    }
+
+    #[test]
+    fn labels_report_the_state_the_footer_shows() {
+        assert_eq!(
+            ControlState::initial(ControlKind::Checkmark).label(ControlKind::Checkmark),
+            "Checked"
+        );
+        assert_eq!(
+            ControlState::initial(ControlKind::Slider).label(ControlKind::Slider),
+            "35 %"
+        );
+        assert_eq!(
+            ControlState::initial(ControlKind::VolumeDial).label(ControlKind::VolumeDial),
+            "40 %"
+        );
+        assert_eq!(
+            ControlState::initial(ControlKind::Toggle).label(ControlKind::Toggle),
+            "Off"
+        );
+        assert_eq!(
+            ControlState::initial(ControlKind::PushButton).label(ControlKind::PushButton),
+            "0 presses"
+        );
+        let once = ControlState {
+            presses: 1,
+            ..ControlState::initial(ControlKind::PushButton)
+        };
+        assert_eq!(once.label(ControlKind::PushButton), "1 press");
+    }
+
+    #[test]
+    fn switch_scene_values_are_binary_and_dials_are_continuous() {
+        let on = ControlState {
+            on: true,
+            value: 0.3,
+            presses: 0,
+        };
+        assert_eq!(on.scene_value(ControlKind::Toggle), 1.0);
+        assert_eq!(
+            ControlState { on: false, ..on }.scene_value(ControlKind::Toggle),
+            0.0
+        );
+        assert_eq!(on.scene_value(ControlKind::Slider), 0.3);
+    }
+
+    #[test]
+    fn every_kind_has_a_distinct_scene_index() {
+        let mut seen = Vec::new();
+        for kind in CONTROL_KINDS {
+            let index = kind.scene_index();
+            assert!(!seen.contains(&index.to_bits()));
+            seen.push(index.to_bits());
+        }
+        assert_eq!(seen.len(), 6);
+    }
+}

--- a/apps/desktop-demo/src/app/controls_ui.rs
+++ b/apps/desktop-demo/src/app/controls_ui.rs
@@ -6,8 +6,10 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use cranpose_animation::{animateFloatAsState, spring, AnimationType, Spring};
-use cranpose_core::{remember, rememberMutableStateOf, MutableState, State};
+use cranpose_animation::{animateFloatAsState, spring, Animatable, AnimationType, Spring};
+use cranpose_core::{
+    remember, rememberMutableStateOf, with_current_composer, MutableState, Owned, State,
+};
 use cranpose_ui::{
     composable,
     text::{FontWeight, SpanStyle, TextUnit},
@@ -529,7 +531,6 @@ struct CardMemory {
     kind: ControlKind,
     control: ControlState,
     hovered: bool,
-    pressed: bool,
     tilt: (f32, f32),
 }
 
@@ -539,7 +540,6 @@ impl CardMemory {
             kind,
             control: ControlState::initial(kind),
             hovered: false,
-            pressed: false,
             tilt: (0.0, 0.0),
         }
     }
@@ -551,6 +551,40 @@ impl CardMemory {
             Self::initial(kind)
         }
     }
+}
+
+/// What a pointer event does to the press depth.
+///
+/// `Down` snaps the depth to fully pressed instead of animating toward it:
+/// a click whose press and release land in the same input batch would
+/// otherwise leave a target that composition never observes as pressed, and
+/// the control would never visibly move.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum PressResponse {
+    Snap,
+    Release,
+    Hold,
+}
+
+fn press_response(kind: PointerEventKind) -> PressResponse {
+    match kind {
+        PointerEventKind::Down => PressResponse::Snap,
+        PointerEventKind::Up | PointerEventKind::Cancel | PointerEventKind::Exit => {
+            PressResponse::Release
+        }
+        _ => PressResponse::Hold,
+    }
+}
+
+fn press_release_animation() -> AnimationType {
+    spring(Spring::DampingRatioNoBouncy, Spring::StiffnessMedium)
+}
+
+fn remember_press_depth() -> Owned<Animatable<f32>> {
+    with_current_composer(|composer| {
+        let runtime = composer.runtime_handle();
+        composer.remember(|| Animatable::new(0.0, runtime))
+    })
 }
 
 #[derive(Clone, Copy)]
@@ -566,7 +600,21 @@ impl CardInput {
         self.memory.get().for_kind(self.kind)
     }
 
-    fn handle(&self, event: &PointerEvent, size: Size, tracking: &Cell<DragTracking>) {
+    fn handle(
+        &self,
+        event: &PointerEvent,
+        size: Size,
+        tracking: &Cell<DragTracking>,
+        depth: &Owned<Animatable<f32>>,
+    ) {
+        match press_response(event.kind) {
+            PressResponse::Snap => depth.update(|animatable| animatable.snapTo(1.0)),
+            PressResponse::Release => {
+                depth.update(|animatable| animatable.animateTo(0.0, press_release_animation()))
+            }
+            PressResponse::Hold => {}
+        }
+
         let memory = self.read();
         match event.kind {
             PointerEventKind::Enter => self.memory.set(CardMemory {
@@ -576,7 +624,6 @@ impl CardInput {
             PointerEventKind::Exit => {
                 self.memory.set(CardMemory {
                     hovered: false,
-                    pressed: false,
                     ..memory
                 });
                 tracking.set(DragTracking::default());
@@ -585,7 +632,6 @@ impl CardInput {
                 self.memory.set(CardMemory {
                     control: press_state(self.kind, memory.control, event.position, size),
                     hovered: true,
-                    pressed: true,
                     ..memory
                 });
                 tracking.set(DragTracking {
@@ -616,10 +662,6 @@ impl CardInput {
                 }
             }
             PointerEventKind::Up | PointerEventKind::Cancel => {
-                self.memory.set(CardMemory {
-                    pressed: false,
-                    ..memory
-                });
                 tracking.set(DragTracking::default());
             }
             _ => {}
@@ -630,7 +672,6 @@ impl CardInput {
 #[derive(Clone, Copy, PartialEq, Debug)]
 struct StageTargets {
     value: f32,
-    pressed: bool,
     hovered: bool,
     tilt: (f32, f32),
 }
@@ -639,7 +680,6 @@ impl StageTargets {
     fn of(kind: ControlKind, memory: CardMemory) -> Self {
         Self {
             value: memory.control.scene_value(kind),
-            pressed: memory.pressed,
             hovered: memory.hovered,
             tilt: if memory.hovered {
                 memory.tilt
@@ -664,7 +704,7 @@ impl StageAnimation {
         StageUniforms {
             kind: kind.scene_index(),
             value: self.value.value(),
-            press: self.press.value(),
+            press: self.press.value().clamp(0.0, 1.0),
             hover: self.hover.value(),
             dark: if dark { 1.0 } else { 0.0 },
             tilt_yaw: self.yaw.value(),
@@ -675,15 +715,11 @@ impl StageAnimation {
 }
 
 #[composable]
-fn stageAnimation(kind: ControlKind, targets: StageTargets) -> StageAnimation {
+fn stageAnimation(kind: ControlKind, targets: StageTargets, press: State<f32>) -> StageAnimation {
     let settle = spring(Spring::DampingRatioNoBouncy, Spring::StiffnessLow);
     StageAnimation {
         value: animateFloatAsState(targets.value, kind.value_animation(), "controls_value"),
-        press: animateFloatAsState(
-            if targets.pressed { 1.0 } else { 0.0 },
-            spring(Spring::DampingRatioNoBouncy, Spring::StiffnessHigh),
-            "controls_press",
-        ),
+        press,
         hover: animateFloatAsState(
             if targets.hovered { 1.0 } else { 0.0 },
             spring(Spring::DampingRatioNoBouncy, Spring::StiffnessMediumLow),
@@ -701,8 +737,13 @@ fn ControlCard(kind: ControlKind, dark: bool, modifier: Modifier) {
         memory: rememberMutableStateOf(move || CardMemory::initial(kind)),
     };
     let tracking = remember(|| Cell::new(DragTracking::default()));
+    let depth = remember_press_depth();
     let memory = input.read();
-    let animation = stageAnimation(kind, StageTargets::of(kind, memory));
+    let animation = stageAnimation(
+        kind,
+        StageTargets::of(kind, memory),
+        depth.with(|animatable| animatable.state()),
+    );
     let background = card_color(dark);
 
     Column(
@@ -714,6 +755,7 @@ fn ControlCard(kind: ControlKind, dark: bool, modifier: Modifier) {
         ColumnSpec::default(),
         move || {
             let tracking = tracking.clone();
+            let depth = depth.clone();
             Box(
                 Modifier::empty()
                     .fill_max_width()
@@ -727,13 +769,15 @@ fn ControlCard(kind: ControlKind, dark: bool, modifier: Modifier) {
                     })
                     .pointer_input((), move |scope: PointerInputScope| {
                         let tracking = tracking.clone();
+                        let depth = depth.clone();
                         async move {
                             scope
                                 .await_pointer_event_scope(|await_scope| async move {
                                     loop {
                                         let event = await_scope.await_pointer_event().await;
                                         let size = await_scope.size();
-                                        tracking.with(|cell| input.handle(&event, size, cell));
+                                        tracking
+                                            .with(|cell| input.handle(&event, size, cell, &depth));
                                     }
                                 })
                                 .await;
@@ -824,6 +868,26 @@ mod tests {
     }
 
     #[test]
+    fn a_press_snaps_down_so_a_click_inside_one_batch_still_shows() {
+        assert_eq!(press_response(PointerEventKind::Down), PressResponse::Snap);
+        assert_eq!(press_response(PointerEventKind::Up), PressResponse::Release);
+        assert_eq!(
+            press_response(PointerEventKind::Cancel),
+            PressResponse::Release
+        );
+        assert_eq!(
+            press_response(PointerEventKind::Exit),
+            PressResponse::Release
+        );
+        assert_eq!(press_response(PointerEventKind::Move), PressResponse::Hold);
+        assert_eq!(press_response(PointerEventKind::Enter), PressResponse::Hold);
+        assert_eq!(
+            press_response(PointerEventKind::Scroll),
+            PressResponse::Hold
+        );
+    }
+
+    #[test]
     fn grid_columns_narrow_to_one_and_assume_wide_before_the_first_layout() {
         assert_eq!(grid_columns(0.0), 3);
         assert_eq!(grid_columns(1200.0), 3);
@@ -877,7 +941,6 @@ mod tests {
                 presses: 4,
             },
             hovered: true,
-            pressed: true,
             tilt: (0.2, 0.1),
         };
         assert_eq!(slider.for_kind(ControlKind::Slider), slider);

--- a/apps/desktop-demo/src/app/controls_ui.wgsl
+++ b/apps/desktop-demo/src/app/controls_ui.wgsl
@@ -1,0 +1,485 @@
+const MAX_STEPS: i32 = 96;
+const SHADOW_STEPS: i32 = 26;
+const MAX_DIST: f32 = 9.0;
+const BOUND_RADIUS: f32 = 1.30;
+const BOUND_CENTER: vec3<f32> = vec3<f32>(0.0, 0.26, 0.0);
+
+fn get_float(index: u32) -> f32 {
+    return u[index / 4u][index % 4u];
+}
+
+fn scene_kind() -> i32 {
+    return i32(get_float(0u) + 0.5);
+}
+
+fn key_dir() -> vec3<f32> {
+    return normalize(vec3<f32>(-0.42, 0.86, 0.30));
+}
+
+fn rot_y(p: vec3<f32>, a: f32) -> vec3<f32> {
+    let s = sin(a);
+    let c = cos(a);
+    return vec3<f32>(c * p.x + s * p.z, p.y, c * p.z - s * p.x);
+}
+
+fn rot_z(p: vec3<f32>, a: f32) -> vec3<f32> {
+    let s = sin(a);
+    let c = cos(a);
+    return vec3<f32>(c * p.x - s * p.y, s * p.x + c * p.y, p.z);
+}
+
+fn sd_round_box(p: vec3<f32>, b: vec3<f32>, r: f32) -> f32 {
+    let q = abs(p) - b + vec3<f32>(r);
+    return length(max(q, vec3<f32>(0.0))) + min(max(q.x, max(q.y, q.z)), 0.0) - r;
+}
+
+fn sd_capsule(p: vec3<f32>, a: vec3<f32>, b: vec3<f32>, r: f32) -> f32 {
+    let offset_a = p - a;
+    let axis = b - a;
+    let h = clamp(dot(offset_a, axis) / max(dot(axis, axis), 1e-6), 0.0, 1.0);
+    return length(offset_a - axis * h) - r;
+}
+
+fn sd_round_cylinder(p: vec3<f32>, radius: f32, half_height: f32, edge: f32) -> f32 {
+    let d = vec2<f32>(length(p.xz) - (radius - edge), abs(p.y) - (half_height - edge));
+    return min(max(d.x, d.y), 0.0) + length(max(d, vec2<f32>(0.0))) - edge;
+}
+
+fn sd_sphere(p: vec3<f32>, r: f32) -> f32 {
+    return length(p) - r;
+}
+
+fn crowned(d: f32, p: vec3<f32>, top: f32, curve: f32) -> f32 {
+    return max(d, sd_sphere(p - vec3<f32>(0.0, top - curve, 0.0), curve));
+}
+
+fn sd_segment_2d(p: vec2<f32>, a: vec2<f32>, b: vec2<f32>) -> f32 {
+    let offset_a = p - a;
+    let axis = b - a;
+    let h = clamp(dot(offset_a, axis) / max(dot(axis, axis), 1e-6), 0.0, 1.0);
+    return length(offset_a - axis * h);
+}
+
+fn sd_round_rect_2d(p: vec2<f32>, b: vec2<f32>, r: f32) -> f32 {
+    let q = abs(p) - b + vec2<f32>(r);
+    return length(max(q, vec2<f32>(0.0))) + min(max(q.x, q.y), 0.0) - r;
+}
+
+fn smooth_min(a: f32, b: f32, k: f32) -> f32 {
+    let h = clamp(0.5 + 0.5 * (b - a) / k, 0.0, 1.0);
+    return mix(b, a, h) - k * h * (1.0 - h);
+}
+
+fn closer(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {
+    if (a.x < b.x) {
+        return a;
+    }
+    return b;
+}
+
+fn map_check(p: vec3<f32>, value: f32) -> vec2<f32> {
+    let r = 0.085 * smoothstep(0.0, 0.16, value);
+    if (r < 0.004) {
+        return vec2<f32>(MAX_DIST, 0.0);
+    }
+    let a = vec3<f32>(-0.48, 0.105, -0.10);
+    let b = vec3<f32>(-0.14, 0.105, 0.50);
+    let c = vec3<f32>(0.52, 0.105, -0.62);
+    let t1 = clamp(value / 0.40, 0.0, 1.0);
+    let t2 = clamp((value - 0.36) / 0.64, 0.0, 1.0);
+    var d = sd_capsule(p, a, mix(a, b, t1), r);
+    if (t2 > 0.0) {
+        d = min(d, sd_capsule(p, b, mix(b, c, t2), r));
+    }
+    return vec2<f32>(d, 0.0);
+}
+
+fn map_slider(p: vec3<f32>, value: f32, press: f32) -> vec2<f32> {
+    let travel = get_float(17u);
+    let rail = sd_capsule(
+        p,
+        vec3<f32>(-travel - 0.22, 0.052, 0.0),
+        vec3<f32>(travel + 0.22, 0.052, 0.0),
+        0.025,
+    );
+    let x = mix(-travel, travel, value);
+    let lift = get_float(18u) - press * 0.014;
+    let centre = p - vec3<f32>(x, lift, 0.0);
+    var puck = crowned(
+        sd_round_cylinder(centre, 0.285, 0.105, 0.058),
+        centre,
+        0.105,
+        2.4,
+    );
+    let groove = sd_round_box(
+        centre - vec3<f32>(0.0, 0.100, 0.0),
+        vec3<f32>(0.130, 0.018, 0.012),
+        0.010,
+    );
+    puck = max(puck, -groove);
+    return closer(vec2<f32>(rail, 1.0), vec2<f32>(puck, 0.0));
+}
+
+fn map_toggle(p: vec3<f32>, value: f32, press: f32) -> vec2<f32> {
+    let outline = abs(sd_segment_2d(p.xz, vec2<f32>(-0.26, 0.0), vec2<f32>(0.26, 0.0)) - 0.30);
+    let track = length(vec2<f32>(outline, p.y - 0.040)) - 0.026;
+    let x = mix(-0.26, 0.26, value);
+    let lift = 0.160 - press * 0.012;
+    let puck = sd_round_box(
+        p - vec3<f32>(x, lift, 0.0),
+        vec3<f32>(0.30, 0.115, 0.255),
+        0.115,
+    );
+    return closer(vec2<f32>(track, 1.0), vec2<f32>(puck, 0.0));
+}
+
+fn map_button(p: vec3<f32>, press: f32) -> vec2<f32> {
+    let body = sd_round_box(
+        p - vec3<f32>(0.0, 0.185 - press * 0.070, 0.0),
+        vec3<f32>(0.42, 0.135, 0.275),
+        0.135,
+    );
+    return vec2<f32>(body, 0.0);
+}
+
+fn map_dial(p: vec3<f32>, value: f32) -> vec2<f32> {
+    let centre = p - vec3<f32>(0.0, 0.168, 0.0);
+    let knob = crowned(
+        sd_round_cylinder(centre, 0.42, 0.168, 0.072),
+        centre,
+        0.168,
+        1.9,
+    );
+    let angle = mix(-2.36, 2.36, value);
+    let q = rot_y(centre, -angle);
+    let slot = sd_round_box(
+        q - vec3<f32>(0.0, 0.13, -0.285),
+        vec3<f32>(0.032, 0.09, 0.135),
+        0.024,
+    );
+    return vec2<f32>(max(knob, -slot), 0.0);
+}
+
+fn map_lever(p: vec3<f32>, value: f32) -> vec2<f32> {
+    let collar = sd_round_cylinder(p - vec3<f32>(0.0, 0.048, 0.0), 0.27, 0.048, 0.044);
+    let dome = sd_sphere(p - vec3<f32>(0.0, -0.02, 0.0), 0.19);
+    let angle = mix(-0.52, 0.52, value);
+    let q = rot_z(p - vec3<f32>(0.0, 0.09, 0.0), angle);
+    let stick = sd_capsule(q, vec3<f32>(0.0), vec3<f32>(0.0, 0.40, 0.0), 0.05);
+    let ball = sd_sphere(q - vec3<f32>(0.0, 0.45, 0.0), 0.105);
+    var d = smooth_min(stick, dome, 0.07);
+    d = min(d, ball);
+    return closer(vec2<f32>(d, 0.0), vec2<f32>(collar, 1.0));
+}
+
+fn map(p: vec3<f32>) -> vec2<f32> {
+    let kind = scene_kind();
+    let value = get_float(1u);
+    let press = get_float(2u);
+    if (kind == 0) {
+        return map_check(p, value);
+    }
+    if (kind == 1) {
+        return map_slider(p, value, press);
+    }
+    if (kind == 2) {
+        return map_toggle(p, value, press);
+    }
+    if (kind == 3) {
+        return map_button(p, press);
+    }
+    if (kind == 4) {
+        return map_dial(p, value);
+    }
+    return map_lever(p, value);
+}
+
+fn scene_normal(p: vec3<f32>) -> vec3<f32> {
+    let e = vec2<f32>(1.0, -1.0) * 0.0016;
+    return normalize(
+        e.xyy * map(p + e.xyy).x + e.yyx * map(p + e.yyx).x + e.yxy * map(p + e.yxy).x
+            + e.xxx * map(p + e.xxx).x,
+    );
+}
+
+fn ambient_occlusion(p: vec3<f32>, n: vec3<f32>) -> f32 {
+    var occ = 0.0;
+    var scale = 1.0;
+    for (var i = 0; i < 4; i = i + 1) {
+        let h = 0.015 + 0.09 * f32(i);
+        let d = map(p + n * h).x;
+        occ = occ + (h - d) * scale;
+        scale = scale * 0.72;
+    }
+    return clamp(1.0 - 2.4 * occ, 0.0, 1.0);
+}
+
+fn soft_shadow(origin: vec3<f32>, dir: vec3<f32>) -> f32 {
+    var res = 1.0;
+    var t = 0.035;
+    for (var i = 0; i < SHADOW_STEPS; i = i + 1) {
+        let h = map(origin + dir * t).x;
+        res = min(res, 12.0 * h / t);
+        t = t + clamp(h, 0.018, 0.22);
+        if (res < 0.005 || t > 3.4) {
+            break;
+        }
+    }
+    return clamp(res, 0.0, 1.0);
+}
+
+fn bound_span(ro: vec3<f32>, rd: vec3<f32>) -> vec2<f32> {
+    let oc = ro - BOUND_CENTER;
+    let b = dot(oc, rd);
+    let c = dot(oc, oc) - BOUND_RADIUS * BOUND_RADIUS;
+    let disc = b * b - c;
+    if (disc < 0.0) {
+        return vec2<f32>(-1.0, -1.0);
+    }
+    let s = sqrt(disc);
+    return vec2<f32>(-b - s, -b + s);
+}
+
+fn srgb_to_linear(c: vec3<f32>) -> vec3<f32> {
+    return pow(max(c, vec3<f32>(0.0)), vec3<f32>(2.2));
+}
+
+fn linear_to_srgb(c: vec3<f32>) -> vec3<f32> {
+    return pow(max(c, vec3<f32>(0.0)), vec3<f32>(1.0 / 2.2));
+}
+
+fn environment(dir: vec3<f32>, dark: f32) -> vec3<f32> {
+    let up = clamp(dir.y, -1.0, 1.0);
+    let ground = mix(vec3<f32>(0.034, 0.034, 0.038), vec3<f32>(0.006, 0.006, 0.009), dark);
+    let band = mix(vec3<f32>(1.18, 1.20, 1.26), vec3<f32>(0.26, 0.29, 0.38), dark);
+    let sky = mix(vec3<f32>(0.210, 0.213, 0.222), vec3<f32>(0.050, 0.054, 0.068), dark);
+    let ceiling = mix(vec3<f32>(0.128, 0.130, 0.138), vec3<f32>(0.030, 0.032, 0.040), dark);
+    var c = mix(ground, band, smoothstep(-0.22, 0.03, up));
+    c = mix(c, sky, smoothstep(0.07, 0.36, up));
+    c = mix(c, ceiling, smoothstep(0.52, 0.88, up));
+    let softbox = mix(vec3<f32>(5.6, 5.5, 5.3), vec3<f32>(3.6, 3.6, 3.8), dark);
+    c = c + softbox * smoothstep(0.930, 0.992, dot(dir, key_dir()));
+    let fill = normalize(vec3<f32>(0.74, 0.30, 0.60));
+    c = c + mix(vec3<f32>(0.85, 0.88, 0.98), vec3<f32>(0.34, 0.38, 0.50), dark)
+        * smoothstep(0.90, 0.995, dot(dir, fill));
+    let rim = normalize(vec3<f32>(-0.82, 0.08, -0.56));
+    c = c + mix(vec3<f32>(1.10, 1.12, 1.20), vec3<f32>(0.44, 0.50, 0.66), dark)
+        * smoothstep(0.88, 0.998, dot(dir, rim));
+    return c;
+}
+
+fn tonemap(c: vec3<f32>) -> vec3<f32> {
+    let x = max(c, vec3<f32>(0.0));
+    return clamp((x * (2.51 * x + 0.03)) / (x * (2.43 * x + 0.59) + 0.14), vec3<f32>(0.0), vec3<f32>(1.0));
+}
+
+fn tick_mark(xz: vec2<f32>, value: f32, width: f32) -> vec2<f32> {
+    let radius = length(xz);
+    if (radius < 0.50 || radius > 0.66) {
+        return vec2<f32>(0.0, 0.0);
+    }
+    let angle = atan2(xz.x, -xz.y);
+    let span = 2.36;
+    if (abs(angle) > span + 0.06) {
+        return vec2<f32>(0.0, 0.0);
+    }
+    let steps = 10.0;
+    let slot = clamp(round((angle + span) / (2.0 * span) * steps), 0.0, steps);
+    let centre = slot / steps * 2.0 * span - span;
+    let arc = abs(angle - centre) * radius;
+    let mask = 1.0 - smoothstep(0.007, 0.007 + width, arc);
+    let filled = step(slot / steps, value + 0.001);
+    return vec2<f32>(mask, filled);
+}
+
+fn lever_mark(xz: vec2<f32>, value: f32, width: f32) -> vec2<f32> {
+    let off = sd_round_rect_2d(xz - vec2<f32>(-0.50, -0.02), vec2<f32>(0.055, 0.013), 0.013);
+    let on = sd_round_rect_2d(xz - vec2<f32>(0.50, -0.02), vec2<f32>(0.055, 0.013), 0.013);
+    let mask_off = 1.0 - smoothstep(0.0, width, off);
+    let mask_on = 1.0 - smoothstep(0.0, width, on);
+    return vec2<f32>(max(mask_off, mask_on), mix(mask_off, mask_on, step(0.5, value)));
+}
+
+fn plate_distance(kind: i32, xz: vec2<f32>) -> f32 {
+    if (kind == 0) {
+        return sd_round_rect_2d(xz, vec2<f32>(0.74, 0.78), 0.22);
+    }
+    if (kind == 1) {
+        return sd_round_rect_2d(xz, vec2<f32>(1.02, 0.24), 0.24);
+    }
+    if (kind == 2) {
+        return sd_round_rect_2d(xz, vec2<f32>(0.72, 0.40), 0.38);
+    }
+    if (kind == 3) {
+        return sd_round_rect_2d(xz, vec2<f32>(0.78, 0.52), 0.26);
+    }
+    if (kind == 4) {
+        return sd_round_rect_2d(xz, vec2<f32>(0.78, 0.78), 0.78);
+    }
+    return sd_round_rect_2d(xz, vec2<f32>(0.70, 0.44), 0.22);
+}
+
+fn ground_decal(kind: i32, xz: vec2<f32>, value: f32, dark: f32, width: f32) -> vec4<f32> {
+    let w = max(width, 0.0016);
+    let d = plate_distance(kind, xz);
+    let fill = (1.0 - smoothstep(-w, w, d)) * mix(0.18, 0.07, dark);
+    let edge = (1.0 - smoothstep(0.004, 0.004 + w * 2.5, abs(d))) * mix(0.24, 0.22, dark);
+    let plate_alpha = clamp(fill + edge * (1.0 - fill), 0.0, 1.0);
+    let plate_colour = mix(vec3<f32>(1.0, 1.0, 1.0), vec3<f32>(0.74, 0.78, 0.88), dark);
+
+    var mark = vec2<f32>(0.0, 0.0);
+    if (kind == 4) {
+        mark = tick_mark(xz, value, w * 2.0 + 0.004);
+    } else if (kind == 5) {
+        mark = lever_mark(xz, value, w * 2.0 + 0.004);
+    }
+    if (mark.x <= 0.0) {
+        return vec4<f32>(plate_colour, plate_alpha);
+    }
+
+    let idle = mix(vec3<f32>(0.55, 0.56, 0.59), vec3<f32>(0.36, 0.38, 0.44), dark);
+    let live = mix(vec3<f32>(0.10, 0.11, 0.13), vec3<f32>(0.88, 0.90, 0.96), dark);
+    let mark_colour = mix(idle, live, mark.y);
+    let mark_alpha = clamp(mark.x * mix(0.8, 0.92, mark.y), 0.0, 1.0);
+    let alpha = mark_alpha + plate_alpha * (1.0 - mark_alpha);
+    let colour = (mark_colour * mark_alpha + plate_colour * plate_alpha * (1.0 - mark_alpha))
+        / max(alpha, 0.0001);
+    return vec4<f32>(colour, alpha);
+}
+
+fn ground_linear(kind: i32, xz: vec2<f32>, value: f32, dark: f32, background: vec3<f32>) -> vec3<f32> {
+    let decal = ground_decal(kind, xz, value, dark, 0.012);
+    return srgb_to_linear(mix(background, decal.rgb, decal.a));
+}
+
+fn power_glyph(icon: vec2<f32>) -> f32 {
+    let ring = abs(length(icon) - 0.082) - 0.013;
+    let gap = sd_round_rect_2d(icon - vec2<f32>(0.0, 0.075), vec2<f32>(0.026, 0.075), 0.0);
+    let bar = sd_round_rect_2d(icon - vec2<f32>(0.0, 0.052), vec2<f32>(0.012, 0.055), 0.012);
+    return min(max(ring, -gap), bar);
+}
+
+fn shade_surface(
+    p: vec3<f32>,
+    n: vec3<f32>,
+    rd: vec3<f32>,
+    material: f32,
+    kind: i32,
+    value: f32,
+    dark: f32,
+    background: vec3<f32>,
+) -> vec3<f32> {
+    let r = reflect(rd, n);
+    var col = environment(r, dark);
+    if (r.y < -0.02) {
+        let hit = p.xz + r.xz * (p.y / max(-r.y, 1e-4));
+        let ground = ground_linear(kind, hit, value, dark, background) * mix(0.62, 0.40, dark);
+        let fade = clamp(-r.y * 2.4, 0.0, 1.0) * clamp(2.0 - 0.7 * length(hit), 0.0, 1.0);
+        col = mix(col, ground, clamp(fade, 0.0, 0.92));
+    }
+
+    var tint = mix(vec3<f32>(0.94, 0.95, 0.97), vec3<f32>(0.62, 0.64, 0.68), material);
+    if (kind == 3 && material < 0.5 && n.y > 0.86) {
+        let mask = 1.0 - smoothstep(0.0, 0.006, power_glyph(vec2<f32>(p.x, -p.z)));
+        tint = mix(tint, vec3<f32>(0.10, 0.11, 0.13), mask);
+    }
+
+    let occlusion = ambient_occlusion(p, n);
+    let shadow = soft_shadow(p + n * 0.006, key_dir());
+    let fresnel = 0.90 + 0.10 * pow(1.0 - clamp(dot(n, -rd), 0.0, 1.0), 5.0);
+    return col * tint * fresnel * mix(0.34, 1.0, occlusion) * mix(0.66, 1.0, shadow);
+}
+
+@fragment
+fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {
+    let tex_size = vec2<f32>(textureDimensions(input_texture));
+    let effect_rect = vec4<f32>(get_float(248u), get_float(249u), get_float(250u), get_float(251u));
+    let size_px = max(effect_rect.zw, vec2<f32>(1.0));
+    let unit = min(size_px.y, size_px.x / max(get_float(19u), 0.1));
+    let local_px = input.uv * tex_size - effect_rect.xy;
+    let offset = (local_px - size_px * 0.5) / unit;
+    let screen = vec2<f32>(offset.x, -offset.y);
+
+    let kind = scene_kind();
+    let value = get_float(1u);
+    let dark = get_float(4u);
+    let yaw = get_float(12u) + get_float(5u);
+    let pitch = clamp(get_float(13u) + get_float(6u), 0.14, 1.30);
+    let distance = get_float(14u);
+    let focal = get_float(15u);
+    let background = vec3<f32>(get_float(8u), get_float(9u), get_float(10u));
+
+    let look_at = vec3<f32>(0.0, get_float(16u), 0.0);
+    let ro = look_at
+        + vec3<f32>(sin(yaw) * cos(pitch), sin(pitch), cos(yaw) * cos(pitch)) * distance;
+    let fwd = normalize(look_at - ro);
+    let right = normalize(cross(fwd, vec3<f32>(0.0, 1.0, 0.0)));
+    let up = cross(right, fwd);
+    let rd = normalize(screen.x * right + screen.y * up + focal * fwd);
+    let pixel_scale = 0.5 / (focal * unit);
+
+    var ground = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    if (rd.y < -0.0005) {
+        let t_ground = -ro.y / rd.y;
+        if (t_ground < MAX_DIST) {
+            let hit = ro + rd * t_ground;
+            let width = t_ground * pixel_scale / max(-rd.y, 0.12);
+            let decal = ground_decal(kind, hit.xz, value, dark, width);
+            var lit = 1.0;
+            if (length(hit.xz) < 2.1) {
+                let raw = soft_shadow(hit + vec3<f32>(0.0, 0.004, 0.0), key_dir());
+                lit = mix(1.0, raw, mix(0.44, 0.52, dark));
+            }
+            ground = vec4<f32>(
+                decal.rgb * decal.a * lit,
+                1.0 - lit * (1.0 - decal.a),
+            );
+        }
+    }
+
+    var object = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    let bounds = bound_span(ro, rd);
+    if (bounds.y > 0.0) {
+        var t = max(bounds.x, 0.02);
+        let t_max = min(bounds.y, MAX_DIST);
+        var hit = false;
+        var coverage = 1.0;
+        var best_t = t;
+        var material = 0.0;
+        for (var i = 0; i < MAX_STEPS; i = i + 1) {
+            if (t > t_max) {
+                break;
+            }
+            let probe = map(ro + rd * t);
+            let radius = max(t * pixel_scale, 1e-5);
+            let ratio = probe.x / radius;
+            if (ratio < coverage) {
+                coverage = ratio;
+                best_t = t;
+                material = probe.y;
+            }
+            if (ratio < 0.35) {
+                hit = true;
+                break;
+            }
+            t = t + max(probe.x * 0.8, radius * 0.35);
+        }
+
+        var alpha = 0.0;
+        if (hit) {
+            alpha = 1.0;
+        } else {
+            alpha = clamp(1.0 - coverage, 0.0, 1.0);
+        }
+        if (alpha > 0.002) {
+            let p = ro + rd * best_t;
+            let n = scene_normal(p);
+            let lit = shade_surface(p, n, rd, material, kind, value, dark, background);
+            object = vec4<f32>(linear_to_srgb(tonemap(lit)) * alpha, alpha);
+        }
+    }
+
+    let composed = object + ground * (1.0 - object.a);
+    let base = textureSample(input_texture, input_sampler, input.uv);
+    return composed + base * (1.0 - composed.a);
+}

--- a/apps/desktop-demo/src/app/controls_ui.wgsl
+++ b/apps/desktop-demo/src/app/controls_ui.wgsl
@@ -77,14 +77,15 @@ fn closer(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {
     return b;
 }
 
-fn map_check(p: vec3<f32>, value: f32) -> vec2<f32> {
+fn map_check(p: vec3<f32>, value: f32, press: f32) -> vec2<f32> {
     let r = 0.085 * smoothstep(0.0, 0.16, value);
     if (r < 0.004) {
         return vec2<f32>(MAX_DIST, 0.0);
     }
-    let a = vec3<f32>(-0.48, 0.105, -0.10);
-    let b = vec3<f32>(-0.14, 0.105, 0.50);
-    let c = vec3<f32>(0.52, 0.105, -0.62);
+    let y = 0.105 - press * 0.020;
+    let a = vec3<f32>(-0.48, y, -0.10);
+    let b = vec3<f32>(-0.14, y, 0.50);
+    let c = vec3<f32>(0.52, y, -0.62);
     let t1 = clamp(value / 0.40, 0.0, 1.0);
     let t2 = clamp((value - 0.36) / 0.64, 0.0, 1.0);
     var d = sd_capsule(p, a, mix(a, b, t1), r);
@@ -142,8 +143,8 @@ fn map_button(p: vec3<f32>, press: f32) -> vec2<f32> {
     return vec2<f32>(body, 0.0);
 }
 
-fn map_dial(p: vec3<f32>, value: f32) -> vec2<f32> {
-    let centre = p - vec3<f32>(0.0, 0.168, 0.0);
+fn map_dial(p: vec3<f32>, value: f32, press: f32) -> vec2<f32> {
+    let centre = p - vec3<f32>(0.0, 0.168 - press * 0.022, 0.0);
     let knob = crowned(
         sd_round_cylinder(centre, 0.42, 0.168, 0.072),
         centre,
@@ -151,7 +152,7 @@ fn map_dial(p: vec3<f32>, value: f32) -> vec2<f32> {
         1.9,
     );
     let angle = mix(-2.36, 2.36, value);
-    let q = rot_y(centre, -angle);
+    let q = rot_y(centre, angle);
     let slot = sd_round_box(
         q - vec3<f32>(0.0, 0.13, -0.285),
         vec3<f32>(0.032, 0.09, 0.135),
@@ -160,7 +161,8 @@ fn map_dial(p: vec3<f32>, value: f32) -> vec2<f32> {
     return vec2<f32>(max(knob, -slot), 0.0);
 }
 
-fn map_lever(p: vec3<f32>, value: f32) -> vec2<f32> {
+fn map_lever(p_in: vec3<f32>, value: f32, press: f32) -> vec2<f32> {
+    let p = p_in + vec3<f32>(0.0, press * 0.018, 0.0);
     let collar = sd_round_cylinder(p - vec3<f32>(0.0, 0.048, 0.0), 0.27, 0.048, 0.044);
     let dome = sd_sphere(p - vec3<f32>(0.0, -0.02, 0.0), 0.19);
     let angle = mix(-0.52, 0.52, value);
@@ -177,7 +179,7 @@ fn map(p: vec3<f32>) -> vec2<f32> {
     let value = get_float(1u);
     let press = get_float(2u);
     if (kind == 0) {
-        return map_check(p, value);
+        return map_check(p, value, press);
     }
     if (kind == 1) {
         return map_slider(p, value, press);
@@ -189,9 +191,9 @@ fn map(p: vec3<f32>) -> vec2<f32> {
         return map_button(p, press);
     }
     if (kind == 4) {
-        return map_dial(p, value);
+        return map_dial(p, value, press);
     }
-    return map_lever(p, value);
+    return map_lever(p, value, press);
 }
 
 fn scene_normal(p: vec3<f32>) -> vec3<f32> {

--- a/apps/desktop-demo/src/app/source_view.rs
+++ b/apps/desktop-demo/src/app/source_view.rs
@@ -16,33 +16,7 @@ use super::DemoTab;
 const REPOSITORY: &str = "https://raw.githubusercontent.com/samoylenkodmitry/cranpose";
 
 pub(crate) fn source_path(tab: DemoTab) -> &'static str {
-    match tab {
-        DemoTab::Counter
-        | DemoTab::CompositionLocal
-        | DemoTab::Async
-        | DemoTab::TextInput
-        | DemoTab::Layout
-        | DemoTab::ModifierShowcase
-        | DemoTab::FilePicker => "apps/desktop-demo/src/app.rs",
-        DemoTab::Animations => "apps/desktop-demo/src/app/animations.rs",
-        DemoTab::InteractiveAnim => "apps/desktop-demo/src/app/interactive_anim.rs",
-        DemoTab::WebFetch => "apps/desktop-demo/src/app/web_fetch.rs",
-        DemoTab::LazyList => "apps/desktop-demo/src/app/lazy_list.rs",
-        DemoTab::Mineswapper2 => "apps/desktop-demo/src/app/mineswapper2.rs",
-        DemoTab::RecompositionLab => "apps/desktop-demo/src/app/recomposition_lab.rs",
-        DemoTab::HackerNews => "apps/desktop-demo/src/app/hacker_news.rs",
-        DemoTab::Images => "apps/desktop-demo/src/app/images.rs",
-        DemoTab::Text => "apps/desktop-demo/src/app/text_showcase.rs",
-        DemoTab::Winamp => "apps/desktop-demo/src/app/winamp/mod.rs",
-        DemoTab::Xkcd => "apps/desktop-demo/src/app/xkcd.rs",
-        DemoTab::Shaders => "apps/desktop-demo/src/app/shaders.rs",
-        DemoTab::ShaderRect => "apps/desktop-demo/src/app/shader_rect.rs",
-        DemoTab::Liquid => "apps/desktop-demo/src/app/liquid_ui.rs",
-        DemoTab::GlassFeed => "apps/desktop-demo/src/app/glass_feed.rs",
-        DemoTab::MarkdownViewer => "apps/desktop-demo/src/app/markdown.rs",
-        DemoTab::Rotary => "apps/desktop-demo/src/app/rotary.rs",
-        DemoTab::Wear => "apps/desktop-demo/src/app/wear.rs",
-    }
+    tab.source_path()
 }
 
 pub(crate) fn source_ref() -> &'static str {

--- a/apps/desktop-demo/src/tests/main_tests.rs
+++ b/apps/desktop-demo/src/tests/main_tests.rs
@@ -520,3 +520,75 @@ fn the_wear_tab_lays_out_a_watch_screen_of_real_widgets() {
         .iter()
         .all(|rect| rect.width > 0.0 && rect.height > 0.0));
 }
+
+#[test]
+fn every_demo_tab_has_exactly_one_metadata_row() {
+    for tab in DEMO_TABS {
+        let rows = DEMO_TAB_INFO.iter().filter(|info| info.tab == tab).count();
+        assert_eq!(rows, 1, "{tab:?} needs exactly one DEMO_TAB_INFO row");
+    }
+    assert_eq!(
+        DEMO_TAB_INFO.len(),
+        DEMO_TABS.len(),
+        "DEMO_TAB_INFO and DEMO_TABS describe the same tabs"
+    );
+}
+
+#[test]
+fn tab_labels_slugs_and_startup_aliases_are_unique() {
+    let mut labels: Vec<&str> = DEMO_TAB_INFO.iter().map(|info| info.label).collect();
+    labels.sort_unstable();
+    let count = labels.len();
+    labels.dedup();
+    assert_eq!(labels.len(), count, "tab labels collide");
+
+    let mut slugs: Vec<&str> = DEMO_TAB_INFO.iter().map(|info| info.slug).collect();
+    slugs.sort_unstable();
+    slugs.dedup();
+    assert_eq!(slugs.len(), count, "tab slugs collide");
+
+    let mut aliases: Vec<&str> = DEMO_TAB_INFO
+        .iter()
+        .flat_map(|info| info.startup_aliases.iter().copied())
+        .collect();
+    let alias_count = aliases.len();
+    aliases.sort_unstable();
+    aliases.dedup();
+    assert_eq!(aliases.len(), alias_count, "startup aliases collide");
+}
+
+#[test]
+fn startup_names_round_trip_through_their_aliases() {
+    for info in &DEMO_TAB_INFO {
+        for alias in info.startup_aliases {
+            assert_eq!(
+                DemoTab::from_startup_name(alias),
+                Some(info.tab),
+                "'{alias}' should select {:?}",
+                info.tab
+            );
+        }
+    }
+    assert_eq!(
+        DemoTab::from_startup_name("Controls UI"),
+        Some(DemoTab::Controls)
+    );
+    assert_eq!(DemoTab::from_startup_name("no-such-tab"), None);
+}
+
+#[test]
+fn tab_source_paths_point_at_files_that_exist() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("workspace root");
+    for info in &DEMO_TAB_INFO {
+        let path = root.join(info.source_path);
+        assert!(
+            path.is_file(),
+            "{:?} points at {}, which is not a file",
+            info.tab,
+            path.display()
+        );
+    }
+}


### PR DESCRIPTION
A new **Controls UI** demo tab: six controls that are real 3D geometry, not artwork.

Each card's stage is one runtime WGSL shader that raymarches signed distance fields — a checkmark drawn as two capsules, a slider puck on its rail, a toggle pill inside a wire track, a push button with a power glyph, a crowned volume knob with tick marks, and a lever on a dome. They share one studio environment (bright horizon sweep, dark floor, sharp key softbox), a single-bounce planar ground reflection, soft contact shadows and coverage-based edge antialiasing, tonemapped through ACES.

Interaction drives the scene, not a picture of it: dragging slides the puck along the rail and turns the dial around its pivot, clicking flips the switches and depresses the button, hovering parallaxes the camera toward the pointer, and the light/dark switch swaps the environment the metal reflects.

Rust owns the camera and the geometry constants the pointer mapping needs (yaw, pitch, distance, focal, target, slider travel and lift, stage aspect) and passes them to the shader as uniforms, so the projection that turns a pointer position into a value cannot drift from the scene it addresses. The grid reflows from three columns to two and then one as the window narrows, and the stage fits its scene to a narrow card instead of cropping it.

### Controls that answer the way Compose's do

The three switches are `Modifier.toggleable`, which takes the value it moves to and publishes a `Switch` or `Checkbox` role; the push button is `Modifier.clickable`; every card names itself with a content description and prints its reading as a state description, so a screen reader and a robot read the same grid. The gesture handler keeps only what it is for — hover parallax, press depth, and the two drags — holds its drag in the gesture's own locals rather than a remembered cell, and consumes events only while a drag owns them, which is what lets the click modifiers see them at all. Rows and cards are wrapped in `key()`, so identity comes from the control a card draws rather than from where the loop reached it.

Two behaviours this replaced were wrong in the app but invisible to a headless harness that forces frames:

- **A fast click never moved the button.** Its press and release land in the same input batch, so composition never observed a pressed state and the spring had nothing to travel toward — the count rose while the metal stood still. The press depth is now an `Animatable` that snaps to fully pressed on the down event and animates back on release, so the shortest possible click plays a whole press and holding keeps the control down. Every control dips into its plate on press.
- **A two-column window left the middle grid row dead.** The toggle and the push button answered no click while the rows above and below them did. Each card ran its own pointer loop and kept its state behind a kind-stamped guard that reset the moment two cards in that row shared a composition slot, so a click flipped a value the next read threw away.

The dial's indicator and its filled ticks also turned counter-clockwise while a clockwise drag raised the value; the knob now turns with the drag.

### Tab metadata

Adding a tab pushed five parallel matches — label, slug, source path, startup aliases, tab dispatch — over the complexity ceiling. Four of them are now one `DEMO_TAB_INFO` table; the dispatch match is split in two, both halves still exhaustive. New tests cover the table: every tab has exactly one row, labels/slugs/aliases are unique, aliases round-trip through `from_startup_name`, and every source path names a file that exists.

### Verification

- `just precommit` (fmt, typos, complexity, duplication), `cargo clippy --workspace --all-targets -D warnings`, `just clippy-robot`, the robot-discovery predicate, and the wasm-target clippy the web demo ships are all clean.
- `cargo test -p desktop-app`: 21 test binaries green, including 23 unit tests for the projection, slider/dial mapping, state transitions, press response and grid breakpoints. Each was checked against a deliberately broken implementation and failed.
- `robot_controls_grid` drives the two-column window the failure needed: it clicks a card in every row, and requires the middle row to answer a hover with parallax and a press with its dip. It passes with and without `key()` — the modifier rewrite alone clears the failure, so the key stays as the correct idiom for loop identity rather than as a tested fix.
- Headless renders of all 26 tabs: the 24 deterministic ones are byte-identical across the metadata refactor (the two that differ print random numbers).
- Rough cost on an M-series Mac at 1200x800: one live card adds ~0.2 ms to a frame that already costs ~5.9 ms with GPU readback; idle cards do not re-run their shader.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)