### PR TITLE
Keep the docs-only filter fixtures unsigned

### DIFF
--- a/scripts/ci/docs_only_change_test.sh
+++ b/scripts/ci/docs_only_change_test.sh
@@ -56,6 +56,7 @@ mkdir -p "$repo"
 git -C "$repo" init -q -b main
 git -C "$repo" config user.email ci@example.invalid
 git -C "$repo" config user.name ci
+git -C "$repo" config commit.gpgsign false
 mkdir -p "$repo/docs/render-reference" "$repo/crates/foo/src" \
          "$repo/crates/foo/shaders" "$repo/tools/api-surface/src" \
          "$repo/.github/workflows"


### PR DESCRIPTION
`scripts/ci/docs_only_change_test.sh` builds a throwaway repo and lands a dozen commits in it. It sets a throwaway identity for those commits but never a signing policy, so a host configured with `commit.gpgsign = true` tries to sign them. On a runner nobody can answer pinentry: signing is cancelled and the recipe dies with `fatal: failed to write commit object`, so the `fmt + tests + clippy (mac)` job fails on every pull request regardless of the diff ([example](https://github.com/samoylenkodmitry/Cranpose/actions/runs/34484430136/job/102908432974)).

Turn signing off in the fixture repo, on the line after the identity it already sets. `scripts/dev/target_gc_test.sh` already does the same for its throwaway commits.

Proof, with `gpg.program` pointed at a missing binary so signing cannot succeed:

- before: `fatal: failed to write commit object`, exit 128
- after: `all docs-only filter cases pass, and every negative assertion is load-bearing`, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)