### PR TITLE
Record that a release is a bare tag, not a hand-pushed bump

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@
 - Install hooks once per clone with `just hooks`; stage new files before `just precommit` so diff checks include them.
 - Follow the user's validation plan; otherwise run affected checks and batch full suites after related fixes, with zero warnings.
 - Use the exact CI recipes and shipped features; change checks in `justfile`, never inline in workflows.
+- Release: push a bare `v*` tag at green main; never hand-bump or commit `release:`.
 - `just web` always uses release mode; `just android` assembles the Android demo release; root `perf*.sh` scripts run performance checks.
 - Prefer SSH builds on `samarch-1` or `macm3`; see [host details](docs/development_troubleshooting.md).
 - Both SSH hosts use zsh: upload a script and run it with Bash, or quote `bash -lc` without premature variable expansion.


### PR DESCRIPTION
## What this changes

Three lines in `AGENTS.md` saying what a release actually is.

Every agent asked to "tag a release" reconstructs the flow from scratch, because
nothing in the repo says what it is — there is no runbook in `docs/` either. The
reconstruction that keeps coming back is "bump the versions, commit
`release: v0.1.N`, push to main, then tag", and that is the one shape that
reddens CI.

`publish.yml`'s `sync_versions` already does the bump itself:

> A bare web-UI tag on an unbumped main is the NORMAL release flow: land the
> bump on the default branch and move the tag onto it so the tag tree matches
> the published crates.

It commits `release: ${tag} [skip ci]`, and that `[skip ci]` is load-bearing —
it stops any workflow running on the commit where the workspace is bumped but
`apps/isolated-demo` still pins the previous release. A hand-pushed bump commit
carries no `[skip ci]`, so CI runs on exactly that tree and three steps of
`fmt + tests + clippy (mac)` fail on one cause: `Check Cranpose package
versions`, `Test the quality gates' diff-scoping logic` and `Run workspace
tests` (xtask's `check_versions_passes_against_the_real_workspace`).

That is what happened cutting v0.1.117. The release published fine; the red was
avoidable noise.

Hand-fixing the isolated-demo pin is never the answer either — it resolves the
*published* crates, so pinning it before the version is on crates.io leaves an
unresolvable lock. `bump_isolated_demo` lands it after publish.

Part of #641, which asks for the fuller runbook and for the version gate to stop
being failable mid-release.

## Checklist

- [x] `just ci` passes in full.
- [x] A bug fix starts with a test that fails without the fix.
- [x] New public API carries a `///` doc comment with an example. Internal code
      does not: good names beat narration.
- [x] No half-migrated state, deprecation shim, or "legacy" path left behind.
- [x] I used AI assistance (Claude, Copilot, etc.) to write this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)