### PR TITLE
Let the host page lay out the web canvas

### DIFF
--- a/apps/isolated-demo/index.html
+++ b/apps/isolated-demo/index.html
@@ -59,7 +59,8 @@
 
         canvas {
             width: 100%;
-            height: 600px;
+            height: min(600px, 70vh);
+            height: min(600px, 70dvh);
             border-radius: 16px;
             background: #0b0f14;
             border: 1px solid rgba(255, 255, 255, 0.06);

--- a/crates/cranpose/src/app_launcher.rs
+++ b/crates/cranpose/src/app_launcher.rs
@@ -65,14 +65,14 @@ pub struct AppSettings {
     pub initial_height: u32,
     /// Whether the initial size was explicitly supplied by the app.
     pub initial_size_explicit: bool,
-    /// Web only: size the canvas to the full browser viewport instead of
-    /// capping it at `initial_width`/`initial_height`.
+    /// Web only: give the canvas the full browser viewport instead of the box
+    /// the host page lays it out in.
     ///
-    /// The default keeps the historical behavior — a canvas that shrinks to
-    /// fit a narrow viewport but never grows past the requested size,
-    /// centered on the page. An app that wants the canvas to fill and track
-    /// the browser window (resizing live as the window does) opts in here;
-    /// other platforms ignore this field.
+    /// The default leaves the canvas box to the page's own stylesheet, so a
+    /// canvas nested in a phone frame, a card or any clipping container keeps
+    /// the size that container gives it. An app that owns the whole page opts
+    /// in here and the canvas fills the dynamic viewport, tracking the browser
+    /// window as it resizes; other platforms ignore this field.
     pub web_fill_viewport: bool,
     /// Fonts loaded for text rendering (ordered: primary first, fallbacks last).
     pub fonts: Option<&'static [&'static [u8]]>,
@@ -427,8 +427,9 @@ impl AppLauncher {
     /// in a multi-window mode (freeform / desktop windowing such as DeX);
     /// fullscreen activities ignore it and keep the display-sized,
     /// edge-to-edge surface, because shrinking the fullscreen window would
-    /// leave uncovered (black) strips of display around the surface.
-    /// Maximized Web canvases still keep platform-controlled bounds.
+    /// leave uncovered (black) strips of display around the surface. Web
+    /// ignores it: the canvas takes the box the host page lays it out in, or
+    /// the viewport under [`Self::with_web_fill_viewport`].
     ///
     /// # Arguments
     ///
@@ -442,9 +443,9 @@ impl AppLauncher {
     }
 
     /// Web only: size the canvas to the full browser viewport and keep it
-    /// tracking that viewport's size as the window resizes, instead of
-    /// capping it at the size passed to [`Self::with_size`]. Other platforms
-    /// ignore this.
+    /// tracking that viewport's size as the window resizes, instead of taking
+    /// the box the host page's stylesheet lays the canvas out in. Other
+    /// platforms ignore this.
     pub fn with_web_fill_viewport(mut self, fill: bool) -> Self {
         self.settings.web_fill_viewport = fill;
         self

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -554,6 +554,12 @@ pub mod web;
     all(feature = "web", feature = "renderer-wgpu", target_arch = "wasm32"),
     test
 ))]
+mod web_canvas_layout;
+
+#[cfg(any(
+    all(feature = "web", feature = "renderer-wgpu", target_arch = "wasm32"),
+    test
+))]
 mod web_surface_scale;
 
 #[cfg(any(

--- a/crates/cranpose/src/web.rs
+++ b/crates/cranpose/src/web.rs
@@ -191,13 +191,6 @@ impl PlatformFrameDriver for WebPlatformFrameDriver<'_> {
     }
 }
 
-fn set_height_to_dynamic_viewport_height_with_static_fallback(
-    style: &web_sys::CssStyleDeclaration,
-) -> Result<(), JsValue> {
-    style.set_property("height", "100vh")?;
-    style.set_property("height", "100dvh")
-}
-
 /// Runs a web Compose application with wgpu rendering.
 ///
 /// Called by `AppLauncher::run_web()`. This is the framework-level
@@ -233,24 +226,13 @@ pub async fn run(
 
     let scale_factor = window.device_pixel_ratio();
 
-    let requested_width = settings.initial_width;
-    let requested_height = settings.initial_height;
     if let Some(html_element) = canvas.dyn_ref::<web_sys::HtmlElement>() {
         let style = html_element.style();
-        if settings.web_fill_viewport {
-            style.set_property("width", "100vw")?;
-            set_height_to_dynamic_viewport_height_with_static_fallback(&style)?;
-        } else {
-            style.set_property(
-                "width",
-                &format!("min({requested_width}px, calc(100vw - 36px))"),
-            )?;
-            style.set_property(
-                "height",
-                &format!("min({requested_height}px, calc(100vh - 36px))"),
-            )?;
+        for (property, value) in
+            crate::web_canvas_layout::canvas_inline_styles(settings.web_fill_viewport)
+        {
+            style.set_property(property, value)?;
         }
-        style.set_property("touch-action", "none")?;
     }
     let width = canvas.client_width().max(1) as u32;
     let height = canvas.client_height().max(1) as u32;

--- a/crates/cranpose/src/web_canvas_layout.rs
+++ b/crates/cranpose/src/web_canvas_layout.rs
@@ -1,0 +1,65 @@
+type CanvasStyle = (&'static str, &'static str);
+
+const VIEWPORT_FILLING_CANVAS_STYLES: [CanvasStyle; 4] = [
+    ("width", "100vw"),
+    ("height", "100vh"),
+    ("height", "100dvh"),
+    ("touch-action", "none"),
+];
+
+const PAGE_LAID_OUT_CANVAS_STYLES: [CanvasStyle; 1] = [("touch-action", "none")];
+
+pub(crate) fn canvas_inline_styles(fill_viewport: bool) -> &'static [CanvasStyle] {
+    if fill_viewport {
+        &VIEWPORT_FILLING_CANVAS_STYLES
+    } else {
+        &PAGE_LAID_OUT_CANVAS_STYLES
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::canvas_inline_styles;
+
+    fn properties(fill_viewport: bool) -> Vec<&'static str> {
+        canvas_inline_styles(fill_viewport)
+            .iter()
+            .map(|(property, _)| *property)
+            .collect()
+    }
+
+    #[test]
+    fn page_laid_out_canvases_keep_the_box_their_container_gives_them() {
+        assert_eq!(properties(false), vec!["touch-action"]);
+    }
+
+    #[test]
+    fn viewport_filling_canvases_take_the_whole_viewport() {
+        assert_eq!(
+            canvas_inline_styles(true),
+            [
+                ("width", "100vw"),
+                ("height", "100vh"),
+                ("height", "100dvh"),
+                ("touch-action", "none"),
+            ]
+        );
+    }
+
+    #[test]
+    fn viewport_filling_heights_end_on_the_dynamic_unit() {
+        let heights: Vec<&str> = canvas_inline_styles(true)
+            .iter()
+            .filter(|(property, _)| *property == "height")
+            .map(|(_, value)| *value)
+            .collect();
+        assert_eq!(heights, vec!["100vh", "100dvh"]);
+    }
+
+    #[test]
+    fn every_mode_takes_pointer_gestures_from_the_browser() {
+        for fill_viewport in [false, true] {
+            assert!(canvas_inline_styles(fill_viewport).contains(&("touch-action", "none")));
+        }
+    }
+}


### PR DESCRIPTION
The web backend wrote `min({initial_width}px, calc(100vw - 36px))` — and the matching height — as **inline** styles on the canvas. Inline styles beat the page stylesheet, so every host page lost the box it had authored, and the `36px` was a guess at one particular page's body padding.

On [cranpose-showcase](https://samoylenkodmitry.github.io/cranpose-showcase/) at a 375x812 mobile viewport that produced a **776px canvas inside a 763px `overflow: hidden` phone frame** — the bottom navigation bar lived in the 13px that got clipped. `100vh` is the *large* viewport on mobile too, so the canvas outgrew the visible area again whenever the URL bar was showing.

## Change

The page owns the canvas box. `with_web_fill_viewport(true)` still opts an app into filling the dynamic viewport; the default now writes nothing but `touch-action: none`, and the existing `resize` path already reads the laid-out size, so the buffer follows the page.

`web_canvas_layout` holds the property table, so the decision is unit tested on the host target (the `wasm32`-only `web` module cannot be). Reintroducing a framework-imposed width/height in the default mode turns `page_laid_out_canvases_keep_the_box_their_container_gives_them` red — verified by putting the old formula back.

`apps/isolated-demo` kept a flat `height: 600px` that only fitted short viewports because the framework was capping it; it caps itself now.

## Verified

Showcase built against this branch and measured in a 375x812 browser:

| | before | after |
|---|---|---|
| canvas inline style | `width: min(412px, -36px + 100vw); height: min(915px, -36px + 100vh)` | `touch-action: none` |
| canvas height | 776px | 747px |
| `.stage` height | 763px | 747px |
| clipped below the frame | 13px | 0 |
| page scroll overflow | 20px | 0 |

Nav bar fully visible; also checked at an 800x450 short viewport.

Gates: `just fmt`, `just clippy`, `just clippy-wasm`, `just precommit`, `cargo test -p cranpose --lib` (107 passed).

Downstream pages need the matching `vh` -> `dvh` hardening once this releases; showcase and cranscan `index.html` are ready to land behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)