### PR TITLE
Pin winit and build the bare android feature

### DIFF
--- a/crates/cranpose-platform/desktop-winit/Cargo.toml
+++ b/crates/cranpose-platform/desktop-winit/Cargo.toml
@@ -24,6 +24,6 @@ x11 = ["winit/x11"]
 wayland = ["winit/wayland", "winit/wayland-dlopen", "winit/wayland-csd-adwaita"]
 
 [dependencies]
-winit = { version = "0.31.0-beta.2", default-features = false }
+winit = { version = "=0.31.0-beta.2", default-features = false }
 cranpose-foundation = { workspace = true }
 cranpose-ui-graphics = { workspace = true }

--- a/crates/cranpose/Cargo.toml
+++ b/crates/cranpose/Cargo.toml
@@ -164,7 +164,7 @@ cranpose-platform-web = { workspace = true, optional = true }
 cranpose-render-pixels = { workspace = true, optional = true }
 cranpose-render-wgpu = { workspace = true, optional = true }
 pollster = { version = "0.4", optional = true }
-winit = { version = "0.31.0-beta.2", optional = true, default-features = false }
+winit = { version = "=0.31.0-beta.2", optional = true, default-features = false }
 wasm-bindgen = { version = "0.2", optional = true }
 web-sys = { version = "0.3", optional = true, features = [
     "Window",

--- a/crates/cranpose/src/app_launcher.rs
+++ b/crates/cranpose/src/app_launcher.rs
@@ -1027,7 +1027,7 @@ impl AppLauncher {
     ///
     /// * `app` - The `AndroidApp` handle provided by `android_activity`.
     /// * `content` - The root composable function of your application.
-    #[cfg(all(feature = "android", target_os = "android"))]
+    #[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
     pub fn run(self, app: android_activity::AndroidApp, content: impl FnMut() + 'static) {
         crate::android::run(app, self.settings, content);
     }

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -63,7 +63,7 @@ mod android_keyboard;
 mod android_launch_args;
 #[cfg(all(feature = "android", feature = "media", target_os = "android"))]
 mod android_media;
-#[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
+#[cfg(all(feature = "android", target_os = "android"))]
 mod android_overlay_window;
 #[cfg(any(test, all(feature = "android", target_os = "android")))]
 mod android_panic_hook;

--- a/justfile
+++ b/justfile
@@ -135,8 +135,15 @@ clippy-robot:
 # written as `const {}` and on one that cannot be const at all
 # (`HashMap::default()`). It stays enabled everywhere else, so a genuine
 # non-const initializer is still caught by `just clippy`.
+#
+# The second line builds `android` with no renderer at all. Every other
+# android job pairs the feature with renderer-wgpu, which is how #631 stayed
+# hidden: two gates named `android` alone and reached for renderer-wgpu items,
+# so a configuration the manifest offers was one no build ever tried. One
+# crate, one ABI, `check` only.
 clippy-android:
     cargo ndk --platform 24 -t arm64-v8a -t armeabi-v7a -t x86 -t x86_64 clippy -p desktop-app-platform --lib --no-default-features --features android,renderer-wgpu -- -D warnings -A clippy::missing_const_for_thread_local
+    cargo check --target aarch64-linux-android -p cranpose --no-default-features --features android
 
 # --- code quality gates -----------------------------------------------------
 #


### PR DESCRIPTION
Two configurations the manifests offer did not compile.

## winit — closes #630, #632, #633

`cranpose` and `cranpose-platform-desktop-winit` both asked for `"0.31.0-beta.2"` as a caret range, and cargo's pre-release matching resolves that to **0.31.0-beta.3**. Downstream sees the break inside cranpose's own source after a plain `cargo update`; cranscan 1.0.23 and cranamp v0.1.51 each carry a hand-written lock pin to get past it.

**The three issues name one cause and it is not the whole one.** They point at the exhaustive match on `MouseScrollDelta`. That is where compilation stops, not where it ends — the first failing crate hides the rest. I added the wildcard arm, moved the lock to beta.3, and built the workspace:

```
error[E0026]: variant `DragDropped` does not have a field named `paths`
    --> crates/cranpose/src/desktop.rs:4434:44
error[E0004]: non-exhaustive patterns: `_` not covered      (winit::event::Ime)
    --> crates/cranpose/src/desktop.rs:4109:11
error[E0004]: non-exhaustive patterns: `&_` not covered     (ButtonSource)
    --> crates/cranpose/src/winit_pointer.rs:29:11
```

`Ime` and `ButtonSource` want wildcards too, but `DragDropped` is not a wildcard away: beta.3 dropped `paths: Vec<PathBuf>` and now hands over a `DataTransferId` to read back through `ActiveEventLoop::data_transfer`, a whole MIME-type negotiation. So a wildcard on `MouseScrollDelta` leaves every consumer exactly as pinned as before.

The beta.2 lock cannot hold the wildcards either — under beta.2 those enums are exhaustive, so the arm is an `unreachable_patterns` error under `-D warnings`. Verified:

```
error: unreachable pattern
   = note: `-D unreachable-patterns` implied by `-D warnings`
```

The root cause is the requirement, not the match: a caret range across a beta line whose betas break each other. Both manifests now say `"=0.31.0-beta.2"`. Checked:

```
$ cargo update -p winit                                  # lock unchanged
$ cargo update -p winit --precise 0.31.0-beta.3
error: failed to select a version ... required by package `cranpose`
```

Consumers can drop their own pins once this releases. Porting drag and drop to the beta.3 data-transfer API gets its own issue.

## android — closes #631

`cargo check --target aarch64-linux-android -p cranpose --no-default-features --features android` stopped on an unresolved `crate::android_overlay_window` and a missing `crate::android`.

- `android_overlay_window` names wgpu nowhere (`grep -c wgpu` → 0), so its `renderer-wgpu` gate was wrong. Removed.
- `AppLauncher::run` does call `crate::android::run`, which *is* `renderer-wgpu` gated, so that gate was missing. Added.

`android,renderer-wgpu` and `android,renderer-pixels` still check clean.

`clippy-android` now builds the bare feature as well. Every other android job pairs `android` with `renderer-wgpu`, which is why nothing ever tried this one. Putting the old gate back turns the new line red — verified.

## Gates

`just fmt`, `cargo clippy --workspace --all-targets -D warnings`, `just precommit`, `just versions`, `cargo test -p cranpose -p cranpose-platform-desktop-winit --lib` (103 + 3 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)