### PR TITLE
Write the release runbook and refuse a hand-written release commit

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,16 @@
+#!/bin/sh
+# `release: vX.Y.Z` is publish.yml's own commit, not a person's. The workflow
+# writes it with `[skip ci]` so no run ever sees the tree where the workspace
+# already carries the new version and `apps/isolated-demo` still pins the
+# previous one; a hand-written one carries no such marker and reddens the
+# version gate, the quality-gate diff test and the workspace tests at once.
+# See docs/release.md. Install once per clone with `just hooks`.
+if grep -qiE '^release:[[:space:]]*v?[0-9]+\.[0-9]+\.[0-9]+' "$1"; then
+    if ! grep -qF '[skip ci]' "$1"; then
+        echo "commit-msg: 'release: vX.Y.Z' is publish.yml's commit, not yours." >&2
+        echo "  A release is a bare v* tag at green main; sync_versions writes" >&2
+        echo "  the bump itself. See docs/release.md." >&2
+        exit 1
+    fi
+fi
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
 - Install hooks once per clone with `just hooks`; stage new files before `just precommit` so diff checks include them.
 - Follow the user's validation plan; otherwise run affected checks and batch full suites after related fixes, with zero warnings.
 - Use the exact CI recipes and shipped features; change checks in `justfile`, never inline in workflows.
-- Release: push a bare `v*` tag at green main; never hand-bump or commit `release:`.
+- Release: a bare `v*` tag at green main, never a hand bump: [runbook](docs/release.md).
 - `just web` always uses release mode; `just android` assembles the Android demo release; root `perf*.sh` scripts run performance checks.
 - Prefer SSH builds on `samarch-1` or `macm3`; see [host details](docs/development_troubleshooting.md).
 - Both SSH hosts use zsh: upload a script and run it with Bash, or quote `bash -lc` without premature variable expansion.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,51 @@
+# Releasing Cranpose
+
+A release is one action: create a `vX.Y.Z` tag on green `main` in the GitHub web
+UI. Nothing before it, nothing after it.
+
+## What the tag sets off
+
+`.github/workflows/publish.yml` takes it from there:
+
+1. `sync_versions` runs `cargo xtask bump-release-version "$tag"`, commits
+   `release: ${tag} [skip ci]`, pushes it to `main`, and moves the tag onto that
+   commit, so the tag's tree matches what gets published.
+2. The crates publish to crates.io in dependency order.
+3. `bump_isolated_demo` points `apps/isolated-demo` at the version that now
+   exists on crates.io.
+
+The workspace version on `main` therefore moves *during* the release, not
+before it.
+
+## Do not hand-push the bump
+
+The tempting reconstruction of the flow is "bump the version, commit
+`release: v0.1.N`, push, then tag". It is wrong, and it reddens `main`.
+
+`[skip ci]` on the workflow's own commit is load-bearing. Between step 1 and
+step 3 the workspace is at `0.1.N` while `apps/isolated-demo` still pins
+`0.1.N-1`, and that tree is not meant to be built. A hand-pushed commit carries
+no `[skip ci]`, so CI runs on exactly that tree. Cutting v0.1.117 this way
+reddened three steps of `fmt + tests + clippy (mac)` at once:
+
+- `Check Cranpose package versions`
+- `Test the quality gates' diff-scoping logic`
+- `Run workspace tests` (187 passed, 1 failed: xtask's
+  `check_versions_passes_against_the_real_workspace`)
+
+`.githooks/commit-msg` refuses a `release:` commit message without `[skip ci]`
+for this reason. Install the hooks once per clone with `just hooks`.
+
+## Do not hand-fix the isolated demo pin
+
+`apps/isolated-demo` resolves the *published* crates, so pinning it to `0.1.N`
+before `0.1.N` exists on crates.io leaves a lockfile cargo cannot resolve. It is
+the canary that proves a release is consumable from outside the workspace, and
+only `bump_isolated_demo`, after the publish, can move it.
+
+## If a release goes wrong
+
+Read `publish.yml` before fixing anything by hand: most release-time reds are a
+step the workflow already owns. `versions` failing on `main` right after a tag
+usually means the publish did not reach `bump_isolated_demo`, and the fix is to
+let that job finish or re-run it, not to edit the pin.


### PR DESCRIPTION
Addresses asks 1 and 3 of #641.

## What went wrong

A release is one action: a bare `vX.Y.Z` tag on green `main` in the web UI. `publish.yml`'s `sync_versions` writes the version bump itself, as `release: ${tag} [skip ci]`, and that marker is load-bearing — between the bump and `bump_isolated_demo` the workspace carries the new version while `apps/isolated-demo` still pins the previous one, and no run is meant to see that tree.

Nothing recorded this, so the flow got reconstructed as "bump by hand, commit `release: v0.1.N`, push, then tag". That commit carries no `[skip ci]`, CI runs on the misaligned tree, and three steps of `fmt + tests + clippy (mac)` go red at once. That is how v0.1.117 was cut.

## Ask 1 — the runbook

`docs/release.md`: what the tag sets off, why a hand-pushed bump reddens the board, why the isolated-demo pin cannot be hand-fixed (it resolves the *published* crates, so a pin ahead of crates.io does not resolve at all), and where to look when a release does go wrong. Linked from `AGENTS.md`, which keeps its one line at 88 characters.

## Ask 3 — the guard

`.githooks/commit-msg` refuses a `release: vX.Y.Z` message that carries no `[skip ci]`, so the wrong move stops before it reaches a branch. Checked by exit code on four message shapes:

| commit message | exit |
|---|---|
| `release: v0.1.118` | **1**, with the runbook pointer |
| `release: v0.1.118 [skip ci]` | 0 (the workflow's own form) |
| `Fix the release notes wording` | 0 |
| `release: not a version` | 0 |

## Ask 2 is deliberately not here

Ask 2 asks that the version gate not fail while a release is mid-flight, by comparing `apps/isolated-demo` against the latest *published* version instead of the workspace version.

Every offline way to write that weakens the canary. The gate's present strength is "the demo pins exactly what this workspace is", and that is what proves each release is consumable from outside. Relaxing it to "the demo pins something published and not ahead of the workspace" would pass a demo left five releases behind, which is the drift the gate exists to catch. Reading crates.io from the gate trades a deterministic offline check for a network dependency, and a network failure would red the same board.

Once `[skip ci]` covers the workflow's own commit and this hook covers the hand-written one, no CI run can observe the misaligned window at all, which meets #641's acceptance ("the version gate cannot fail merely because a release is mid-flight") without giving up the assertion. Leaving #641 open for that call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)