### PR TITLE
Keep the driver's compiled pipelines between launches

### DIFF
--- a/crates/cranpose-render/wgpu/src/lib.rs
+++ b/crates/cranpose-render/wgpu/src/lib.rs
@@ -32,7 +32,7 @@ mod output_conversion;
 pub(crate) mod pass_timing;
 mod pipeline;
 #[cfg(not(target_arch = "wasm32"))]
-mod pipeline_disk_cache;
+pub mod pipeline_disk_cache;
 #[cfg(not(target_arch = "wasm32"))]
 mod present_runtime;
 mod record_columns;

--- a/crates/cranpose-render/wgpu/src/pipeline_disk_cache.rs
+++ b/crates/cranpose-render/wgpu/src/pipeline_disk_cache.rs
@@ -1,6 +1,9 @@
 use std::{
     path::{Path, PathBuf},
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use web_time::Instant;
@@ -13,13 +16,26 @@ fn disk_cache_enabled() -> bool {
     !DISK_CACHE.equals("0")
 }
 
+static HOST_FILE: OnceLock<PathBuf> = OnceLock::new();
+
+/// Names the file the driver's compiled pipelines are kept in between runs.
+///
+/// This crate renders and does not know where an application may write, so the
+/// platform backend passes the path in once, before the first device is
+/// created. Without it the cache lives and dies with the process, and every
+/// launch pays the driver's compile again. A later call is ignored: the
+/// loaded blob and the watcher that writes it back must name one file.
+pub fn set_file_path(path: PathBuf) {
+    let _ = HOST_FILE.set(path);
+}
+
 pub(crate) fn file_path() -> Option<PathBuf> {
     if !disk_cache_enabled() {
         return None;
     }
     match crate::debug_toggles::debug_toggle_os("CRANPOSE_PIPELINE_CACHE_FILE") {
         Some(path) if !path.is_empty() => Some(PathBuf::from(path)),
-        _ => None,
+        _ => HOST_FILE.get().cloned(),
     }
 }
 

--- a/crates/cranpose/src/android_host.rs
+++ b/crates/cranpose/src/android_host.rs
@@ -102,6 +102,7 @@ pub(crate) fn install(app: android_activity::AndroidApp) {
         log::warn!("cranpose: the Android package name is not a usable application id: {error}");
     }
     set_host_controller(Arc::new(AndroidHost { app }));
+    crate::pipeline_cache_file::publish();
 }
 
 #[unsafe(no_mangle)]

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -5824,7 +5824,9 @@ fn register_application_id(configured: Option<&str>) {
     };
     if let Err(error) = cranpose_services::set_application_id(application_id) {
         log::warn!("cranpose: `{application_id}` is not a usable application id: {error}");
+        return;
     }
+    crate::pipeline_cache_file::publish();
 }
 
 /// Runs a desktop application and exits the process on success.

--- a/crates/cranpose/src/ios_host.rs
+++ b/crates/cranpose/src/ios_host.rs
@@ -54,4 +54,5 @@ pub(crate) fn register() {
         log::warn!("cranpose: the iOS bundle identifier is not a usable application id: {error}");
     }
     set_host_controller(Arc::new(IosHost));
+    crate::pipeline_cache_file::publish();
 }

--- a/crates/cranpose/src/lib.rs
+++ b/crates/cranpose/src/lib.rs
@@ -403,6 +403,9 @@ pub mod prelude {
 ))]
 pub(crate) mod platform_env;
 
+#[cfg(not(target_arch = "wasm32"))]
+mod pipeline_cache_file;
+
 #[cfg(all(feature = "android", feature = "renderer-wgpu", target_os = "android"))]
 pub mod android;
 #[cfg(feature = "renderer-wgpu")]

--- a/crates/cranpose/src/pipeline_cache_file.rs
+++ b/crates/cranpose/src/pipeline_cache_file.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+
+use cranpose_services::PlatformDirectories;
+
+const PIPELINE_CACHE_FILE_NAME: &str = "pipeline-cache.bin";
+
+fn cache_file(directories: &PlatformDirectories) -> PathBuf {
+    directories.data.join(PIPELINE_CACHE_FILE_NAME)
+}
+
+pub(crate) fn publish() {
+    let Ok(directories) = cranpose_services::application_directories() else {
+        return;
+    };
+    hand_to_renderer(cache_file(&directories));
+}
+
+#[cfg(feature = "renderer-wgpu")]
+fn hand_to_renderer(path: PathBuf) {
+    cranpose_render_wgpu::pipeline_disk_cache::set_file_path(path);
+}
+
+#[cfg(not(feature = "renderer-wgpu"))]
+fn hand_to_renderer(_path: PathBuf) {}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use cranpose_services::PlatformDirectories;
+
+    use super::cache_file;
+
+    fn directories() -> PlatformDirectories {
+        PlatformDirectories {
+            data: PathBuf::from("/data/com.example.app"),
+            config: PathBuf::from("/config/com.example.app"),
+            cache: PathBuf::from("/cache/com.example.app"),
+            documents: None,
+            temporary: PathBuf::from("/tmp/com.example.app"),
+            shared: None,
+        }
+    }
+
+    #[test]
+    fn the_blob_sits_under_the_application_data_directory() {
+        assert_eq!(
+            cache_file(&directories()),
+            PathBuf::from("/data/com.example.app/pipeline-cache.bin")
+        );
+    }
+
+    #[test]
+    fn the_blob_avoids_directories_the_platform_may_empty() {
+        let directories = directories();
+        let path = cache_file(&directories);
+        assert!(
+            !path.starts_with(&directories.cache),
+            "Android empties the cache directory under storage pressure, and a \
+             compile paid once per install must outlive that"
+        );
+        assert!(!path.starts_with(&directories.temporary));
+    }
+}

--- a/crates/cranpose/src/pipeline_cache_file.rs
+++ b/crates/cranpose/src/pipeline_cache_file.rs
@@ -37,7 +37,7 @@ mod tests {
             config: PathBuf::from("/config/com.example.app"),
             cache: PathBuf::from("/cache/com.example.app"),
             documents: None,
-            temporary: PathBuf::from("/tmp/com.example.app"),
+            temporary: PathBuf::from("/temporary/com.example.app"),
             shared: None,
         }
     }


### PR DESCRIPTION
Item 1 of #639.

## The cache is finished and inert

`pipeline_disk_cache` already wraps `wgpu::PipelineCache`: it loads a blob at device creation, and a watcher persists it once a burst of compiles settles. All four platforms already ask for `Features::PIPELINE_CACHE` through `optional_device_features`.

None of it runs. `file_path()` answers `None` unless `CRANPOSE_PIPELINE_CACHE_FILE` names a file, so a shipped app creates an empty cache, loads nothing and writes nothing. The driver's compile is paid again on every launch, and the user sees the stall inside the frame that needs the variant.

## The renderer cannot pick the file

It does not know where an application may write. So the platform backend passes one in: `set_file_path` takes it once, and the three places that register the application id hand over `data/pipeline-cache.bin` from the directories that id scopes. `CRANPOSE_PIPELINE_CACHE_FILE` still wins for a run that wants its own file.

**`data`, not `cache`.** Android empties the cache directory under storage pressure, and a compile paid once per install has to outlive that. Two unit tests pin that choice, including one that fails if the path ever moves under `cache` or `temporary`.

## Checked on hardware

Intel UHD Graphics 730 / Mesa on samarch-1, `desktop-app` built `--features desktop,logging`, three launches against one `XDG_DATA_HOME`:

| launch | log | blob |
|---|---|---|
| **cold**, no blob | `[pipeline-cache] cold (no blob on disk)` then `persisted 247631 B in 0.7 ms` | created, 247631 B |
| **warm**, blob present | **`[pipeline-cache] loaded 247631 B from disk`** then `persisted 247631 B in 0.9 ms` | unchanged |
| **control**, `CRANPOSE_PIPELINE_DISK_CACHE=0`, blob present | `[pipeline-cache] cold (no blob on disk)` | ignored |

The control matters: with the cache switched off the same build reports cold *while the blob sits on disk*, so the warm run's load came from this path and not from the driver's own blob cache. On `main` the first line of all three would be `cold`, because no blob is ever written.

A first attempt at this measurement built `desktop-app` without its `logging` feature and printed nothing at all. That proves nothing — the app links `env_logger` only behind that feature, so every `log::` line is discarded. The runs above have a live instrument.

## What this does not fix

`persist()` runs only from the watcher thread on a 2 second tick. There is no write at shutdown, so a process killed inside that window pays the compile again. Ordinary use clears the tick long before the app closes, and the 20 second benchmark routes in #639 clear it easily, but "once per install" is not yet unconditional. Items 2 to 4 of #639 (pre-warming, shipping SPIR-V, cutting the variant count) are untouched.

## Gates

`just fmt`, `cargo clippy --workspace --all-targets -D warnings`, `just clippy-wasm`, `just precommit`, `cargo check --target aarch64-linux-android` with `android` and with `android,renderer-wgpu`, `cargo test -p cranpose --lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)