### PR TITLE
Sign nothing when the release bot commits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,6 +78,11 @@ jobs:
             git diff --stat -- Cargo.toml Cargo.lock
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
+            # A runner whose git carries commit.gpgsign=true makes this bot
+            # commit reach for a human's key: gpg launches pinentry, nobody is
+            # there to answer it, and the release stops at "gpg: signing
+            # failed: Operation cancelled". The bot has no key and wants none.
+            git config commit.gpgsign false
             git add Cargo.toml Cargo.lock
             git commit -m "release: ${tag} [skip ci]"
             if ! git push origin "HEAD:$DEFAULT_BRANCH"; then
@@ -232,6 +237,7 @@ jobs:
           git diff --stat -- apps/isolated-demo
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config commit.gpgsign false
           git add apps/isolated-demo
           git commit -m "chore: point isolated demo at ${TAG_NAME}"
           # Pushes made with GITHUB_TOKEN do not retrigger workflows, so this


### PR DESCRIPTION
`v0.1.118`'s publish stopped here:

```
Running `target/debug/xtask bump-release-version v0.1.118`
 Cargo.lock | 46 +++++++++---------
 Cargo.toml | 44 ++++++++--------
error: gpg failed to sign the data:
[GNUPG:] PINENTRY_LAUNCHED 92490 mac 1.3.1.1
gpg: signing failed: Operation cancelled
fatal: failed to write commit object
```

The bump itself was right. Writing it was not possible.

## Why

`sync_versions` sets the bot's name and email and leaves signing alone, so on a runner whose git carries `commit.gpgsign = true` the commit reaches for a human's GPG key. gpg launches pinentry, nothing answers it in a headless job, and the release ends before a single crate is published.

Two things kept this hidden:

- **It depends on which runner takes the job.** The macOS pool is not uniform, and the setting is machine-global, not in the repo.
- **Only this path commits.** `v0.1.117` was cut with a hand-pushed bump, which walks straight past `sync_versions`' commit and so never touched it. The flow that #646 documented as the correct one is the flow that exercises this.

## Change

Both bot commits — the release bump and the isolated-demo re-pin — now turn signing off in the workspace's own config. That leaves the machine's global setting untouched. `github-actions[bot]` has no key and needs none: the commit is attributed by the token that pushes it.

## State after the failed cut

Nothing to unwind, verified before touching anything:

| | |
|---|---|
| crates.io `cranpose` max_version | `0.1.117` (unchanged) |
| GitHub Release `v0.1.118` | not found |
| `main` HEAD | `03e6abfb` (never moved) |
| workflows run for the tag | Publish (failed), Deploy to GitHub Pages (succeeded) |

The `v0.1.118` tag is pushed but stale — it points at a tree whose `publish.yml` still has the bug, and a tag push runs the workflow from the tag's own ref. It gets moved onto this fix once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)