### PR TITLE
Keep a clip that meets nothing instead of lifting it

### DIFF
--- a/crates/cranpose-render/common/src/hit_graph.rs
+++ b/crates/cranpose-render/common/src/hit_graph.rs
@@ -98,10 +98,11 @@ fn collect_hits_from_graph_inner<S: HitGraphSink>(
     if let Some(local_clip) = layer.clip_rect() {
         let clip_quad = transform.map_rect(local_clip);
         let clip_bounds = quad_bounds(clip_quad);
-        let Some(resolved_clip_bounds) = resolve_clip(parent_hit_clip, Some(clip_bounds)) else {
+        let resolved_clip_bounds = resolve_clip(parent_hit_clip, Some(clip_bounds));
+        if resolved_clip_bounds.is_some_and(|clip| clip.is_empty()) {
             return;
-        };
-        hit_clip_bounds = Some(resolved_clip_bounds);
+        }
+        hit_clip_bounds = resolved_clip_bounds;
         hit_clips.push(HitClip {
             quad: clip_quad,
             bounds: clip_bounds,
@@ -250,6 +251,25 @@ mod tests {
         );
         assert_eq!(*clip, Some(*rect));
         assert_eq!(*clip_count, 1);
+    }
+
+    #[test]
+    fn a_child_clipped_away_by_its_parent_takes_no_hits() {
+        let mut list = test_layer(1, ProjectiveTransform::translation(0.0, 80.0));
+        let scrolled_out = test_layer(2, ProjectiveTransform::translation(4.0, -40.0));
+        list.children
+            .push(RenderNode::Layer(Box::new(scrolled_out)));
+        let mut sink = TestSink::default();
+
+        collect_hits_from_graph(&list, ProjectiveTransform::identity(), &mut sink, None);
+
+        let hit_ids: Vec<NodeId> = sink.hits.iter().map(|hit| hit.0).collect();
+        assert_eq!(
+            hit_ids,
+            vec![1],
+            "a child the list has scrolled past its edge lies outside the list's clip and \
+             takes no hits, however far inside the window it sits"
+        );
     }
 
     #[test]

--- a/crates/cranpose-render/common/src/primitive_emit.rs
+++ b/crates/cranpose-render/common/src/primitive_emit.rs
@@ -169,9 +169,13 @@ pub fn draw_shape_params_for_primitive(
     sink.shape
 }
 
+/// The clip a node paints within once its own clip meets the clips above
+/// it: `None` only when nothing clips at all. Two clips that do not overlap
+/// resolve to [`Rect::EMPTY`], never to `None` -- a list that has scrolled a
+/// control past its edge has clipped the control away, not set it free.
 pub fn resolve_clip(parent_clip: Option<Rect>, requested_clip: Option<Rect>) -> Option<Rect> {
     match (parent_clip, requested_clip) {
-        (Some(parent), Some(current)) => parent.intersect(current),
+        (Some(parent), Some(current)) => Some(parent.intersect(current).unwrap_or(Rect::EMPTY)),
         (Some(parent), None) => Some(parent),
         (None, Some(current)) => Some(current),
         (None, None) => None,
@@ -488,6 +492,37 @@ mod tests {
     use cranpose_ui_graphics::{Brush, Color, CornerRadii};
 
     use super::*;
+
+    #[test]
+    fn resolve_clip_keeps_a_clip_that_meets_nothing() {
+        let list = Rect {
+            x: 0.0,
+            y: 80.0,
+            width: 200.0,
+            height: 120.0,
+        };
+        let scrolled_out = Rect {
+            x: 40.0,
+            y: -60.0,
+            width: 120.0,
+            height: 120.0,
+        };
+        let shown = Rect {
+            x: 40.0,
+            y: 90.0,
+            width: 120.0,
+            height: 120.0,
+        };
+
+        assert_eq!(
+            resolve_clip(Some(list), Some(scrolled_out)),
+            Some(Rect::EMPTY)
+        );
+        assert_eq!(resolve_clip(Some(list), Some(shown)), list.intersect(shown));
+        assert_eq!(resolve_clip(Some(list), None), Some(list));
+        assert_eq!(resolve_clip(None, Some(shown)), Some(shown));
+        assert_eq!(resolve_clip(None, None), None);
+    }
 
     #[test]
     fn draw_shape_params_for_primitive_returns_transformed_rect_shape() {

--- a/crates/cranpose-render/pixels/src/pipeline.rs
+++ b/crates/cranpose-render/pixels/src/pipeline.rs
@@ -823,7 +823,7 @@ fn populate_draws_from_graph(
         }
     });
 
-    if content_clip_to_bounds && visual_clip.is_none() {
+    if visual_clip.is_some_and(|clip| clip.is_empty()) {
         return;
     }
 
@@ -951,7 +951,7 @@ fn render_graph_primitive(
                 context.visual_clip,
                 PrimitiveClipSpace::LayerTransformed,
             );
-            if draw.clip.is_some() && effective_clip.is_none() {
+            if effective_clip.is_some_and(|clip| clip.is_empty()) {
                 return;
             }
             push_draw_primitive(
@@ -998,7 +998,7 @@ fn render_graph_text(
         visual_clip,
         PrimitiveClipSpace::LayerTransformed,
     );
-    if text.clip.is_some() && text_clip.is_none() {
+    if text_clip.is_some_and(|clip| clip.is_empty()) {
         return;
     }
 
@@ -1674,6 +1674,63 @@ mod tests {
         assert_eq!(
             scene.texts[0].snap_anchor, expected_anchor,
             "rested scroll text should snap back to device pixels"
+        );
+    }
+
+    fn clipped_layer(placement: Point, children: Vec<RenderNode>) -> LayerNode {
+        LayerNode {
+            local_bounds: Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 120.0,
+                height: 120.0,
+            },
+            transform_to_parent: ProjectiveTransform::translation(placement.x, placement.y),
+            clip_to_bounds: true,
+            children,
+            ..Default::default()
+        }
+    }
+
+    fn red_fill() -> RenderNode {
+        RenderNode::Primitive(PrimitiveEntry {
+            phase: PrimitivePhase::BeforeChildren,
+            node: PrimitiveNode::Draw(DrawPrimitiveNode {
+                primitive: DrawPrimitive::Rect {
+                    rect: Rect {
+                        x: 0.0,
+                        y: 0.0,
+                        width: 120.0,
+                        height: 120.0,
+                    },
+                    brush: Brush::solid(Color(0.86, 0.12, 0.12, 1.0)),
+                    stroke: None,
+                },
+                clip: None,
+            }),
+        })
+    }
+
+    fn shapes_in_list(child: LayerNode) -> usize {
+        let mut list = clipped_layer(Point::new(0.0, 80.0), vec![]);
+        list.local_bounds.width = 200.0;
+        list.children.push(RenderNode::Layer(Box::new(child)));
+        build_raster_scene_for_test(&RenderGraph::new(list))
+            .shapes
+            .len()
+    }
+
+    #[test]
+    fn a_layer_clipped_away_by_its_parent_paints_nothing() {
+        let shown = shapes_in_list(clipped_layer(Point::new(40.0, 10.0), vec![red_fill()]));
+        assert_eq!(shown, 1, "the fill must paint while its layer is on show");
+
+        let scrolled_out =
+            shapes_in_list(clipped_layer(Point::new(40.0, -140.0), vec![red_fill()]));
+        assert_eq!(
+            scrolled_out, 0,
+            "a layer the list has scrolled past its edge lies outside the list's clip and \
+             paints nothing, however far inside the window it sits"
         );
     }
 

--- a/crates/cranpose-render/wgpu/src/collect.rs
+++ b/crates/cranpose-render/wgpu/src/collect.rs
@@ -503,7 +503,7 @@ fn collect_into(
         .clip_rect()
         .map(|clip| clip.translate(context.offset.x, context.offset.y));
     let visual_clip = resolve_clip(context.visual_clip, layer_clip);
-    if layer_clip.is_some() && context.visual_clip.is_some() && visual_clip.is_none() {
+    if visual_clip.is_some_and(|clip| clip.is_empty()) {
         return;
     }
     let translated = context.translated || layer.translated_content_context;
@@ -764,7 +764,7 @@ fn push_primitive(
                 visual_clip,
                 PrimitiveClipSpace::Local,
             );
-            if draw.clip.is_some() && clip.is_none() {
+            if clip.is_some_and(|clip| clip.is_empty()) {
                 return;
             }
             push_draw_primitive(
@@ -787,7 +787,7 @@ fn push_primitive(
                 visual_clip,
                 PrimitiveClipSpace::Local,
             );
-            if text.clip.is_some() && text_clip.is_none() {
+            if text_clip.is_some_and(|clip| clip.is_empty()) {
                 return;
             }
             push_text_style_draws(

--- a/crates/cranpose-render/wgpu/src/draw_pass.rs
+++ b/crates/cranpose-render/wgpu/src/draw_pass.rs
@@ -916,6 +916,7 @@ impl<'s, C: FrameCommandRecorder> PassPrep<'_, 's, C> {
                     alpha: *alpha,
                     blend_mode: supported_blend_mode(*blend_mode),
                     sample_mode: *sample_mode,
+                    scissor,
                 };
                 let prepared = renderer.effect_renderer.prepare_projective_composite_draw(
                     self.recorder,

--- a/crates/cranpose-render/wgpu/src/effect_renderer.rs
+++ b/crates/cranpose-render/wgpu/src/effect_renderer.rs
@@ -700,6 +700,10 @@ pub(crate) struct ProjectiveCompositeItem<'a> {
     pub alpha: f32,
     pub blend_mode: BlendMode,
     pub sample_mode: CompositeSampleMode,
+    /// The clip of the layers above the child, in target pixels. A tilted
+    /// child's quad reaches wherever its transform sends it; this is what
+    /// keeps it inside the layer that clips it.
+    pub scissor: Option<(u32, u32, u32, u32)>,
 }
 
 pub(crate) struct PreparedProjectiveComposite<'a> {
@@ -707,6 +711,7 @@ pub(crate) struct PreparedProjectiveComposite<'a> {
     uniform: UniformUpload,
     vertices: BufferUpload,
     blend_mode: BlendMode,
+    scissor: Option<(u32, u32, u32, u32)>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2274,6 +2279,7 @@ impl EffectRenderer {
             uniform,
             vertices,
             blend_mode: item.blend_mode,
+            scissor: item.scissor,
         }
     }
 
@@ -2287,7 +2293,11 @@ impl EffectRenderer {
         pass.set_bind_group(0, draw.texture_bind_group, &[]);
         pass.set_bind_group(1, &draw.uniform.bind_group, &[draw.uniform.offset]);
         pass.set_vertex_buffer(0, draw.vertices.slice());
-        pass.set_scissor_rect(0, 0, viewport.0, viewport.1);
+        if let Some((x, y, w, h)) = draw.scissor {
+            pass.set_scissor_rect(x, y, w, h);
+        } else {
+            pass.set_scissor_rect(0, 0, viewport.0, viewport.1);
+        }
         pass.draw(0..4, 0..1);
     }
 }

--- a/crates/cranpose-render/wgpu/tests/clipped_out_layer.rs
+++ b/crates/cranpose-render/wgpu/tests/clipped_out_layer.rs
@@ -1,0 +1,76 @@
+mod support;
+
+use cranpose_ui_graphics::{
+    GraphicsLayer, Point, RUNTIME_SHADER_PRELUDE_WGSL, RenderEffect, RuntimeShader,
+};
+use support::clip_band::{self, FRAME};
+
+/// Where a child sits when it is on show: inside the band.
+const SHOWN: Point = Point { x: 40.0, y: 10.0 };
+/// Where a child sits when the list has scrolled it out: wholly above the
+/// band's top, with 60 of its rows still inside the frame.
+const SCROLLED_OUT: Point = Point { x: 40.0, y: -140.0 };
+
+/// A backdrop shader that paints red wherever it is composited, so the
+/// composite's footprint is what the frame shows.
+fn red_backdrop() -> RenderEffect {
+    RenderEffect::runtime_shader(RuntimeShader::new(&format!(
+        "{RUNTIME_SHADER_PRELUDE_WGSL}
+         @fragment fn effect_fs(input: VertexOutput) -> @location(0) vec4<f32> {{
+             return vec4<f32>(0.86, 0.12, 0.12, 1.0);
+         }}"
+    )))
+}
+
+/// A glass control the way the liquid widgets build one: a backdrop effect
+/// under a layer that clips to its own bounds.
+fn glass() -> GraphicsLayer {
+    GraphicsLayer {
+        clip: true,
+        backdrop_effect: Some(red_backdrop()),
+        ..GraphicsLayer::default()
+    }
+}
+
+/// A glass control the list has scrolled wholly past its edge paints
+/// nothing, the way its neighbours' fills do once they leave the list.
+///
+/// The control's own clip lies outside the list's, and a clip that meets
+/// nothing must stay a clip: the frame's top rows are the tab bar above
+/// the list, and a control drawn there is the bug.
+#[test]
+fn a_glass_control_scrolled_out_of_its_list_paints_nothing() {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!("skipping clipped out layer: {err}");
+            return;
+        }
+    };
+    let shown = support::capture_graph(
+        &mut renderer,
+        clip_band::page(glass(), SHOWN, vec![]),
+        FRAME,
+        FRAME,
+    );
+    let (_, inside) = clip_band::red_pixels(&shown.pixels);
+    assert!(
+        inside > 1000,
+        "the glass control must paint inside the band when it is on show for this to test \
+         anything, painted {inside} pixels"
+    );
+
+    let scrolled = support::capture_graph(
+        &mut renderer,
+        clip_band::page(glass(), SCROLLED_OUT, vec![]),
+        FRAME,
+        FRAME,
+    );
+    let (above, inside) = clip_band::red_pixels(&scrolled.pixels);
+    assert_eq!(
+        (above, inside),
+        (0, 0),
+        "a glass control scrolled out of its list painted {above} pixels above the list and \
+         {inside} inside it"
+    );
+}

--- a/crates/cranpose-render/wgpu/tests/projective_layer_clip.rs
+++ b/crates/cranpose-render/wgpu/tests/projective_layer_clip.rs
@@ -1,0 +1,115 @@
+mod support;
+
+#[path = "../src/test_support.rs"]
+mod shared_test_support;
+
+use cranpose_render_common::{
+    graph::{ProjectiveTransform, RenderGraph, RenderNode},
+    layer_transform::layer_transform_to_parent,
+};
+use cranpose_ui_graphics::{Color, GraphicsLayer, Point, Rect};
+
+const FRAME: u32 = 200;
+/// The clipping band covers the frame below this row.
+const CLIP_TOP: usize = 80;
+const CHILD: Rect = Rect {
+    x: 0.0,
+    y: 0.0,
+    width: 120.0,
+    height: 120.0,
+};
+/// Where the child sits in the band: 60 of its 120 rows above the band's top.
+const PLACEMENT: Point = Point { x: 40.0, y: -60.0 };
+
+/// A clipped band holding one red child with `layer`, placed the way the
+/// graph builder places a `graphics_layer` node.
+fn page(layer: GraphicsLayer) -> RenderGraph {
+    let child = shared_test_support::layer_node(
+        CHILD,
+        layer_transform_to_parent(CHILD, PLACEMENT, &layer),
+        layer,
+        vec![support::solid_rect(CHILD, Color::from_rgb_u8(220, 30, 30))],
+    );
+    let band = shared_test_support::layer_node(
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: FRAME as f32,
+            height: FRAME as f32 - CLIP_TOP as f32,
+        },
+        ProjectiveTransform::translation(0.0, CLIP_TOP as f32),
+        GraphicsLayer {
+            clip: true,
+            ..GraphicsLayer::default()
+        },
+        vec![RenderNode::Layer(Box::new(child))],
+    );
+    support::page_graph(FRAME, FRAME, vec![RenderNode::Layer(Box::new(band))])
+}
+
+/// Red pixels above and inside the band.
+fn red_pixels(pixels: &[u8]) -> (usize, usize) {
+    pixels
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .enumerate()
+        .filter(|(_, px)| px[0] > 160 && px[1] < 90 && px[2] < 90)
+        .fold((0, 0), |(above, inside), (index, _)| {
+            if (index / FRAME as usize) < CLIP_TOP {
+                (above + 1, inside)
+            } else {
+                (above, inside + 1)
+            }
+        })
+}
+
+fn capture(layer: GraphicsLayer) -> Option<(usize, usize)> {
+    let mut renderer = match support::headless_renderer() {
+        Ok(renderer) => renderer,
+        Err(err) => {
+            eprintln!("skipping projective layer clip: {err}");
+            return None;
+        }
+    };
+    let frame = support::capture_graph(&mut renderer, page(layer), FRAME, FRAME);
+    let counted = red_pixels(&frame.pixels);
+    eprintln!("[probe] red (above, inside) = {counted:?}");
+    assert!(
+        counted.1 > 1000,
+        "the child must be drawn inside the band for this to test anything: {counted:?}"
+    );
+    Some(counted)
+}
+
+#[test]
+fn an_upright_child_reaching_past_the_band_is_clipped() {
+    let Some((above, _)) = capture(GraphicsLayer::default()) else {
+        return;
+    };
+    assert_eq!(
+        above, 0,
+        "an upright child is drawn past the top of the layer that clips it"
+    );
+}
+
+/// The plane from the demo's Shaders page: rotated about X and Y under a
+/// camera, so its quad is a true perspective.
+#[test]
+fn a_tilted_child_reaching_past_the_band_is_clipped() {
+    let tilted = GraphicsLayer {
+        rotation_x: 26.0,
+        rotation_y: -18.0,
+        camera_distance: 8.0,
+        ..GraphicsLayer::default()
+    };
+    let Some((above, _)) = capture(tilted) else {
+        return;
+    };
+    assert_eq!(
+        above, 0,
+        "{above} pixels of a child leaning out of the layer that clips it landed past the \
+         layer's edge: the plane a person tilts inside a scroll list is drawn over whatever \
+         sits above the list"
+    );
+}

--- a/crates/cranpose-render/wgpu/tests/projective_layer_clip.rs
+++ b/crates/cranpose-render/wgpu/tests/projective_layer_clip.rs
@@ -1,68 +1,10 @@
 mod support;
 
-#[path = "../src/test_support.rs"]
-mod shared_test_support;
+use cranpose_ui_graphics::{Color, GraphicsLayer, Point};
+use support::clip_band::{self, CHILD, FRAME};
 
-use cranpose_render_common::{
-    graph::{ProjectiveTransform, RenderGraph, RenderNode},
-    layer_transform::layer_transform_to_parent,
-};
-use cranpose_ui_graphics::{Color, GraphicsLayer, Point, Rect};
-
-const FRAME: u32 = 200;
-/// The clipping band covers the frame below this row.
-const CLIP_TOP: usize = 80;
-const CHILD: Rect = Rect {
-    x: 0.0,
-    y: 0.0,
-    width: 120.0,
-    height: 120.0,
-};
 /// Where the child sits in the band: 60 of its 120 rows above the band's top.
 const PLACEMENT: Point = Point { x: 40.0, y: -60.0 };
-
-/// A clipped band holding one red child with `layer`, placed the way the
-/// graph builder places a `graphics_layer` node.
-fn page(layer: GraphicsLayer) -> RenderGraph {
-    let child = shared_test_support::layer_node(
-        CHILD,
-        layer_transform_to_parent(CHILD, PLACEMENT, &layer),
-        layer,
-        vec![support::solid_rect(CHILD, Color::from_rgb_u8(220, 30, 30))],
-    );
-    let band = shared_test_support::layer_node(
-        Rect {
-            x: 0.0,
-            y: 0.0,
-            width: FRAME as f32,
-            height: FRAME as f32 - CLIP_TOP as f32,
-        },
-        ProjectiveTransform::translation(0.0, CLIP_TOP as f32),
-        GraphicsLayer {
-            clip: true,
-            ..GraphicsLayer::default()
-        },
-        vec![RenderNode::Layer(Box::new(child))],
-    );
-    support::page_graph(FRAME, FRAME, vec![RenderNode::Layer(Box::new(band))])
-}
-
-/// Red pixels above and inside the band.
-fn red_pixels(pixels: &[u8]) -> (usize, usize) {
-    pixels
-        .as_chunks::<4>()
-        .0
-        .iter()
-        .enumerate()
-        .filter(|(_, px)| px[0] > 160 && px[1] < 90 && px[2] < 90)
-        .fold((0, 0), |(above, inside), (index, _)| {
-            if (index / FRAME as usize) < CLIP_TOP {
-                (above + 1, inside)
-            } else {
-                (above, inside + 1)
-            }
-        })
-}
 
 fn capture(layer: GraphicsLayer) -> Option<(usize, usize)> {
     let mut renderer = match support::headless_renderer() {
@@ -72,8 +14,14 @@ fn capture(layer: GraphicsLayer) -> Option<(usize, usize)> {
             return None;
         }
     };
-    let frame = support::capture_graph(&mut renderer, page(layer), FRAME, FRAME);
-    let counted = red_pixels(&frame.pixels);
+    let fill = support::solid_rect(CHILD, Color::from_rgb_u8(220, 30, 30));
+    let frame = support::capture_graph(
+        &mut renderer,
+        clip_band::page(layer, PLACEMENT, vec![fill]),
+        FRAME,
+        FRAME,
+    );
+    let counted = clip_band::red_pixels(&frame.pixels);
     eprintln!("[probe] red (above, inside) = {counted:?}");
     assert!(
         counted.1 > 1000,

--- a/crates/cranpose-render/wgpu/tests/support.rs
+++ b/crates/cranpose-render/wgpu/tests/support.rs
@@ -612,6 +612,74 @@ pub fn page_graph(width: u32, height: u32, children: Vec<RenderNode>) -> RenderG
     RenderGraph::new(layer_node(None, width as f32, height as f32, children))
 }
 
+/// A clipped band across the lower part of a square frame holding one child
+/// placed the way the graph builder places a `graphics_layer` node: a list
+/// item at the list's top edge, with the frame's top rows standing in for
+/// whatever sits above the list.
+pub mod clip_band {
+    use cranpose_render_common::layer_transform::layer_transform_to_parent;
+    use cranpose_ui_graphics::GraphicsLayer;
+
+    use super::*;
+
+    pub const FRAME: u32 = 200;
+    /// The band covers the frame below this row.
+    pub const CLIP_TOP: usize = 80;
+    pub const CHILD: Rect = Rect {
+        x: 0.0,
+        y: 0.0,
+        width: 120.0,
+        height: 120.0,
+    };
+
+    pub fn page(layer: GraphicsLayer, placement: Point, children: Vec<RenderNode>) -> RenderGraph {
+        let child = LayerNode {
+            local_bounds: CHILD,
+            transform_to_parent: layer_transform_to_parent(CHILD, placement, &layer),
+            graphics_layer: layer,
+            children,
+            ..Default::default()
+        };
+        let band = LayerNode {
+            local_bounds: Rect {
+                x: 0.0,
+                y: 0.0,
+                width: FRAME as f32,
+                height: FRAME as f32 - CLIP_TOP as f32,
+            },
+            transform_to_parent: ProjectiveTransform::translation(0.0, CLIP_TOP as f32),
+            graphics_layer: GraphicsLayer {
+                clip: true,
+                ..GraphicsLayer::default()
+            },
+            children: vec![RenderNode::Layer(std::boxed::Box::new(child))],
+            ..Default::default()
+        };
+        page_graph(
+            FRAME,
+            FRAME,
+            vec![RenderNode::Layer(std::boxed::Box::new(band))],
+        )
+    }
+
+    /// Red pixels above and inside the band.
+    pub fn red_pixels(pixels: &[u8]) -> (usize, usize) {
+        pixels
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .enumerate()
+            .filter(|(_, px)| px[0] > 160 && px[1] < 90 && px[2] < 90)
+            .fold((0, 0), |(above, inside), (index, _)| {
+                if (index / FRAME as usize) < CLIP_TOP {
+                    (above + 1, inside)
+                } else {
+                    (above, inside + 1)
+                }
+            })
+    }
+}
+
 /// Renders `graph` through the renderer and captures a frame of the given size.
 pub fn capture_graph(
     renderer: &mut LockedRenderer,

--- a/crates/cranpose-ui-graphics/src/geometry.rs
+++ b/crates/cranpose-ui-graphics/src/geometry.rs
@@ -133,6 +133,16 @@ pub struct Rect {
 }
 
 impl Rect {
+    /// The rect that holds nothing: what two clips that do not overlap
+    /// resolve to, so a clip that meets nothing stays a clip instead of
+    /// lifting.
+    pub const EMPTY: Rect = Rect {
+        x: 0.0,
+        y: 0.0,
+        width: 0.0,
+        height: 0.0,
+    };
+
     pub fn from_origin_size(origin: Point, size: Size) -> Self {
         Self {
             x: origin.x,
@@ -162,6 +172,11 @@ impl Rect {
 
     pub fn contains(&self, x: f32, y: f32) -> bool {
         x >= self.x && y >= self.y && x <= self.x + self.width && y <= self.y + self.height
+    }
+
+    /// Whether the rect covers no area, so nothing clipped to it can paint.
+    pub fn is_empty(&self) -> bool {
+        self.width <= 0.0 || self.height <= 0.0
     }
 
     /// Returns the intersection of two rectangles, or `None` if they don't overlap.
@@ -1996,6 +2011,38 @@ mod tests {
             }
             other => panic!("expected blended circle primitive, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn rect_is_empty_without_area() {
+        assert!(Rect::EMPTY.is_empty());
+        assert!(
+            Rect {
+                x: 4.0,
+                y: 5.0,
+                width: 0.0,
+                height: 6.0,
+            }
+            .is_empty()
+        );
+        assert!(
+            Rect {
+                x: 4.0,
+                y: 5.0,
+                width: 6.0,
+                height: -1.0,
+            }
+            .is_empty()
+        );
+        assert!(
+            !Rect {
+                x: 4.0,
+                y: 5.0,
+                width: 0.5,
+                height: 0.5,
+            }
+            .is_empty()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Layers escaped their clip in the desktop demo: the Shaders page's rotated planes were drawn over the tab bar once the list scrolled them past its top, and on Receipts a list item's glass button was drawn over the "Show source" chip above the list.

Two causes, one commit each:

1. **Projected children ignored their clip.** The resolver computed `visible` for a projective composite, but the projective draw never set a scissor, so a tilted plane was drawn wherever its quad landed. `ProjectiveCompositeItem` now carries the scissor and the draw applies it.
2. **A clip that met nothing lifted.** `resolve_clip` returned `None` when a layer's own clip did not overlap the clips above it, and `None` means unclipped to every consumer. A glass control scrolled wholly out of its list was planned against the whole window; its backdrop, shadow and hit region followed. The content walk, the primitives, the pixels backend and the hit graph each guarded that `None` locally; the backdrop and shadow paths did not. Two clips that do not overlap now resolve to `Rect::EMPTY`, which every consumer intersects to nothing, and the guards prune on an empty clip.

Tests, each red before its fix:
- `projective_layer_clip`: an upright and a tilted child reaching past the band's top (tilted leaked before 5093e035).
- `clipped_out_layer`: a glass control scrolled wholly out of its list painted 7200 pixels above the list before a6a0d948; it paints nothing now, with a shown-position control proving the instrument is live.
- Unit tests for `resolve_clip`, `Rect::EMPTY`/`is_empty`, a clipped-away child taking no hits, and the pixels backend painting nothing for a clipped-away layer.

Verified on macm3 (Metal, 1013 passed) and samarch-1 (Vulkan, 1020 passed): unit tests of the touched crates, the full `cranpose-render-wgpu` suite including the glass parity suites, and `just clippy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
