### PR TITLE
Stop painting a lazy row that left the list

### DIFF
--- a/crates/cranpose-render/common/tests/lazy_trim_scene.rs
+++ b/crates/cranpose-render/common/tests/lazy_trim_scene.rs
@@ -1,0 +1,155 @@
+#![cfg(feature = "embedded-default-font")]
+#![allow(non_snake_case)]
+
+use std::{cell::RefCell, rc::Rc};
+
+use cranpose_core::{MemoryApplier, MutableState, NodeId};
+use cranpose_foundation::lazy::{LazyItems, LazyListScope, rememberLazyListState};
+use cranpose_render_common::scene_builder::{
+    build_graph_from_applier, update_graph_from_applier_report,
+};
+use cranpose_ui::{
+    LayoutEngine, LinearArrangement, Modifier, Size, Text, TextStyle,
+    widgets::{LazyColumn, LazyColumnSpec},
+};
+
+mod scene_probe;
+
+use scene_probe::painted_text;
+
+const VIEWPORT: Size = Size {
+    width: 320.0,
+    height: 480.0,
+};
+
+#[cranpose_ui::composable]
+fn TrimmableList(dropped: MutableState<usize>) {
+    let state = rememberLazyListState();
+    let visible: Vec<usize> = (dropped.get().min(3)..3).collect();
+    let keys = visible.clone();
+    LazyColumn(
+        Modifier::empty().fill_max_size(),
+        state,
+        LazyColumnSpec::default()
+            .content_padding(100.0, 128.0)
+            .vertical_arrangement(LinearArrangement::spaced_by(12.0)),
+        move |scope| {
+            let bodies = visible.clone();
+            let keys = keys.clone();
+            scope.item(|| {
+                Text(
+                    "Header".to_string(),
+                    Modifier::empty().fill_max_width().height(40.0),
+                    TextStyle::default(),
+                );
+            });
+            scope.items(
+                LazyItems::new(bodies.len())
+                    .key(move |order: usize| keys.get(order).copied().unwrap_or(order) as u64),
+                move |order| {
+                    let Some(&body) = bodies.get(order) else {
+                        return;
+                    };
+                    Text(
+                        format!("Body {body}"),
+                        Modifier::empty().fill_max_width().height(96.0),
+                        TextStyle::default(),
+                    );
+                },
+            );
+        },
+    );
+}
+
+/// The scope the app shell hands the scoped scene update: every node whose
+/// geometry the layout pass changed, plus every parent whose child set did.
+fn scoped_scene_nodes(applier: &mut MemoryApplier, root: NodeId) -> Vec<NodeId> {
+    let mut nodes = Vec::new();
+    for node in cranpose_ui::take_geometry_scene_nodes() {
+        if let Some(node) = applier.scene_node_attached_to(node, root)
+            && !nodes.contains(&node)
+        {
+            nodes.push(node);
+        }
+    }
+    for node in applier.take_structural_change_parents_attached_to(root) {
+        if !nodes.contains(&node) {
+            nodes.push(node);
+        }
+    }
+    nodes
+}
+
+#[test]
+fn dropping_leading_keyed_lazy_rows_one_at_a_time_repaints_the_survivors() {
+    let dropped_cell: Rc<RefCell<Option<MutableState<usize>>>> = Rc::new(RefCell::new(None));
+    let mut composition = cranpose_ui::run_test_composition({
+        let dropped_cell = Rc::clone(&dropped_cell);
+        move || {
+            let dropped = cranpose_core::rememberMutableStateOf(|| 0usize);
+            *dropped_cell.borrow_mut() = Some(dropped);
+            TrimmableList(dropped);
+        }
+    });
+
+    let root = composition.root().expect("list root");
+    let handle = composition.runtime_handle();
+    let mut graph = {
+        let mut applier = composition.applier_mut();
+        applier.set_runtime_handle(handle.clone());
+        applier.compute_layout(root, VIEWPORT).expect("layout");
+        let graph = build_graph_from_applier(&mut applier, root, 1.0).expect("render graph");
+        applier.clear_runtime_handle();
+        graph
+    };
+    let _ = scoped_scene_nodes(&mut composition.applier_mut(), root);
+
+    let mut painted = Vec::new();
+    painted_text(&graph.root, &mut painted);
+    assert_eq!(
+        painted,
+        vec![
+            "Header".to_string(),
+            "Body 0".to_string(),
+            "Body 1".to_string(),
+            "Body 2".to_string()
+        ],
+        "every row should paint before the first is dropped"
+    );
+
+    let dropped = dropped_cell.borrow().expect("state captured");
+    for count in 1..=2usize {
+        dropped.set(count);
+        while composition
+            .process_invalid_scopes()
+            .expect("drop the leading lazy row")
+        {}
+
+        {
+            let mut applier = composition.applier_mut();
+            applier.set_runtime_handle(handle.clone());
+            applier.compute_layout(root, VIEWPORT).expect("relayout");
+            let dirty = scoped_scene_nodes(&mut applier, root);
+            assert!(
+                !dirty.is_empty(),
+                "dropping row {} told the scene phase nothing had moved",
+                count - 1
+            );
+            if !update_graph_from_applier_report(&mut applier, &mut graph, &dirty, 1.0).applied() {
+                graph = build_graph_from_applier(&mut applier, root, 1.0)
+                    .expect("rebuilt render graph");
+            }
+            applier.clear_runtime_handle();
+        }
+
+        let mut painted = Vec::new();
+        painted_text(&graph.root, &mut painted);
+        let mut expected = vec!["Header".to_string()];
+        expected.extend((count..3).map(|body| format!("Body {body}")));
+        assert_eq!(
+            painted, expected,
+            "after dropping {count} leading row(s) the renderer must be handed exactly the \
+             rows that are left, in order"
+        );
+    }
+}

--- a/crates/cranpose-render/common/tests/scaling_list_scene.rs
+++ b/crates/cranpose-render/common/tests/scaling_list_scene.rs
@@ -5,7 +5,7 @@ use std::{cell::RefCell, rc::Rc};
 use cranpose_foundation::lazy::LazyItems;
 use cranpose_render_common::{
     HitTestTarget, RenderScene,
-    graph::{LayerNode, PrimitiveNode, ProjectiveTransform, RenderNode},
+    graph::{LayerNode, ProjectiveTransform, RenderNode},
     graph_scene::Scene,
     hit_graph::collect_hits_from_graph,
     scene_builder::build_graph_from_applier,
@@ -22,6 +22,10 @@ use cranpose_ui::{
     },
 };
 
+mod scene_probe;
+
+use scene_probe::painted_text;
+
 const WATCH: f32 = 454.0;
 
 const ROWS: [&str; 6] = ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot"];
@@ -30,20 +34,6 @@ fn colors() -> WearColors {
     WearColors {
         content: Color::WHITE,
         ..WearColors::default()
-    }
-}
-
-fn painted_text(layer: &LayerNode, out: &mut Vec<String>) {
-    for child in &layer.children {
-        match child {
-            RenderNode::Primitive(primitive) => {
-                if let PrimitiveNode::Text(text) = &primitive.node {
-                    out.push(text.text.text.clone());
-                }
-            }
-            RenderNode::Layer(child) => painted_text(child, out),
-            RenderNode::DrawRun(_) => {}
-        }
     }
 }
 

--- a/crates/cranpose-render/common/tests/scene_probe/mod.rs
+++ b/crates/cranpose-render/common/tests/scene_probe/mod.rs
@@ -1,0 +1,26 @@
+//! What a built render graph actually paints, for tests that need to compare
+//! the scene against the tree it was built from.
+
+use cranpose_render_common::graph::{LayerNode, PrimitiveNode, RenderNode};
+use cranpose_ui_graphics::DrawPrimitive;
+
+/// Every string the layer and its descendants paint, in draw order.
+pub fn painted_text(layer: &LayerNode, out: &mut Vec<String>) {
+    for child in &layer.children {
+        match child {
+            RenderNode::Primitive(primitive) => {
+                if let PrimitiveNode::Text(text) = &primitive.node {
+                    out.push(text.text.text.clone());
+                }
+            }
+            RenderNode::Layer(child) => painted_text(child, out),
+            RenderNode::DrawRun(run) => {
+                for primitive in run.primitives() {
+                    if let DrawPrimitive::Text(text) = primitive {
+                        out.push(text.text.to_string());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/cranpose-ui/src/subcompose_layout.rs
+++ b/crates/cranpose-ui/src/subcompose_layout.rs
@@ -1253,7 +1253,11 @@ impl cranpose_core::Node for SubcomposeLayoutNode {
     fn set_node_id(&mut self, id: NodeId) {
         self.id.set(Some(id));
         self.layout_state.borrow_mut().set_node_id(id);
-        self.inner.borrow_mut().modifier_chain.set_node_id(Some(id));
+        {
+            let mut inner = self.inner.borrow_mut();
+            inner.node_id = Some(id);
+            inner.modifier_chain.set_node_id(Some(id));
+        }
         self.update_modifier_slices_cache();
     }
 
@@ -1488,7 +1492,9 @@ impl SubcomposeLayoutNodeHandle {
             inner.state = state;
             inner.placement_scratch = placement_scratch;
 
-            inner.last_placements = result.placements.iter().map(|p| p.node_id).collect();
+            inner.replace_placed_children(
+                result.placements.iter().map(|placement| placement.node_id),
+            );
         }
 
         Ok(result)
@@ -1506,9 +1512,7 @@ impl SubcomposeLayoutNodeHandle {
     where
         I: IntoIterator<Item = NodeId>,
     {
-        let mut inner = self.inner.borrow_mut();
-        inner.last_placements.clear();
-        inner.last_placements.extend(children);
+        self.inner.borrow_mut().replace_placed_children(children);
     }
 }
 
@@ -1527,6 +1531,7 @@ struct SubcomposeLayoutNodeInner {
     slots: Rc<SlotsHost>,
     debug_modifiers: bool,
     virtual_nodes: HashMap<NodeId, Rc<LayoutNode>>,
+    node_id: Option<NodeId>,
     last_placements: Vec<NodeId>,
     placement_scratch: Vec<Placement>,
     measured_children_scratch: Rc<RefCell<HashMap<NodeId, Rc<MeasuredNode>>>>,
@@ -1535,6 +1540,45 @@ struct SubcomposeLayoutNodeInner {
 }
 
 impl SubcomposeLayoutNodeInner {
+    /// Writes the children this node placed, self-reporting an actual change
+    /// to the scene phase the way [`LayoutState::place`] reports a move.
+    ///
+    /// These children *are* the node's render-graph children, and a
+    /// subcomposition changes them without the applier seeing an insert or a
+    /// remove: a lazy row that leaves the content keeps its nodes parked in
+    /// the reusable pool, still attached and still carrying the position it
+    /// was last placed at. Nothing else in the frame then says the child set
+    /// shrank, so a scoped scene update would keep the departed row's layer
+    /// and paint it under the row that took its place.
+    fn replace_placed_children<I>(&mut self, children: I)
+    where
+        I: IntoIterator<Item = NodeId>,
+    {
+        let mut changed = false;
+        let mut count = 0usize;
+        for child in children {
+            match self.last_placements.get(count) {
+                Some(&placed) if placed == child => {}
+                Some(_) => {
+                    self.last_placements[count] = child;
+                    changed = true;
+                }
+                None => {
+                    self.last_placements.push(child);
+                    changed = true;
+                }
+            }
+            count += 1;
+        }
+        if self.last_placements.len() > count {
+            self.last_placements.truncate(count);
+            changed = true;
+        }
+        if changed && let Some(id) = self.node_id {
+            crate::render_state::record_geometry_scene_node(id);
+        }
+    }
+
     fn new(measure_policy: Rc<MeasurePolicy>) -> Self {
         Self {
             modifier: Modifier::empty(),
@@ -1547,6 +1591,7 @@ impl SubcomposeLayoutNodeInner {
             slots: Rc::new(SlotsHost::new(SlotTable::default())),
             debug_modifiers: false,
             virtual_nodes: HashMap::new(),
+            node_id: None,
             last_placements: Vec::new(),
             placement_scratch: Vec::new(),
             measured_children_scratch: Rc::new(RefCell::new(HashMap::default())),


### PR DESCRIPTION
## The bug

Removing rows from a keyed lazy list leaves the departed rows drawn on
top of the row that takes their place. Un-star two of three saved bodies
in [cranpose-showcase](https://github.com/samoylenkodmitry/cranpose-showcase)
and the survivor's card carries all three titles, tags and taglines
stacked at the same offset. The semantics tree is correct throughout —
only the pixels are wrong — and the screen only comes right when
something else forces a full scene rebuild.

## Why

A `SubcomposeLayoutNode`'s children, as far as the render graph is
concerned, are the nodes it placed (`children()` returns
`last_placements`). A lazy list that drops a row does not remove those
nodes from the applier: the row's slot goes to the reusable pool, still
attached, still holding the position it was last placed at. So the frame
carries no structural change for the list — `structural_dirty_nodes=0` in
the shell's own diagnostics — and the scoped scene update has no reason to
touch the list's layer. It keeps the layer it has, departed rows and all.

## The fix

Writing the placed-children list now compares it against the one it
replaces and records a geometry scene node when it really changed — the
same self-reporting `LayoutState::place` already does for an actual move.
The comparison is in place over the existing `Vec`, so a list that places
the same children every frame allocates nothing and reports nothing.

## The test

`crates/cranpose-render/common/tests/lazy_trim_scene.rs` drives the scene
the way `cranpose-app-shell` does — geometry scene nodes plus structural
parents into `update_graph_from_applier_report`, falling back to a full
rebuild when the patch declines — and asserts the renderer is handed
exactly the rows that are left, in order. Deliberately disabling the new
report makes it fail:

```
left:  ["Header", "Body 0", "Body 1", "Body 2"]
right: ["Header", "Body 1", "Body 2"]
```

`painted_text` moved into a shared `tests/scene_probe/mod.rs` that
`scaling_list_scene.rs` now uses too.

## Verified

- `just fmt`, `just precommit`, `just clippy` — clean.
- `just test` — 190 test binaries, exit 0.
- The showcase driven headlessly against this worktree: the Saved list
  after two removals differs from the same list composed from scratch by a
  mean of 0.06 per channel, against 11.3 before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)