### PR TITLE
Let a touched control's surface carry the shadow back to the page

### DIFF
--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -299,6 +299,11 @@ path = "robot-runners/robot_liquid_nav_bar_backdrop.rs"
 required-features = ["robot-app"]
 
 [[example]]
+name = "robot_liquid_touched_shadow"
+path = "robot-runners/robot_liquid_touched_shadow.rs"
+required-features = ["robot-app"]
+
+[[example]]
 name = "robot_double_click"
 path = "robot-runners/robot_double_click.rs"
 required-features = ["robot-app"]

--- a/apps/desktop-demo/robot-runners/liquid_page.rs
+++ b/apps/desktop-demo/robot-runners/liquid_page.rs
@@ -1,0 +1,61 @@
+#![allow(dead_code)]
+
+use std::time::Duration;
+
+use cranpose::Robot;
+use desktop_app::app::{DemoTab, TEST_ACTIVE_TAB_STATE, TEST_LIQUID_SCROLL_STATE};
+
+const SETTLE_ROUNDS: usize = 6;
+const SETTLE_FRAMES: u32 = 12;
+const SETTLE_MS: u64 = 250;
+
+/// The Liquid UI page's robot hooks: select the tab, and drive the page's own
+/// scroll state so a runner places content exactly instead of flinging a drag
+/// at it and landing wherever the settle policy snaps.
+pub(crate) fn app_hook(name: String, argument: String) -> Result<Option<String>, String> {
+    match name.as_str() {
+        "set-tab" => {
+            TEST_ACTIVE_TAB_STATE
+                .with(|cell| cell.borrow().as_ref().copied())
+                .ok_or_else(|| "active tab state was not installed".to_string())?
+                .set(DemoTab::Liquid);
+            Ok(None)
+        }
+        "scroll-liquid-to" => {
+            let offset: f32 = argument
+                .parse()
+                .map_err(|err| format!("invalid liquid scroll offset '{argument}': {err}"))?;
+            let scroll = TEST_LIQUID_SCROLL_STATE
+                .with(|cell| *cell.borrow())
+                .ok_or_else(|| "liquid scroll state was not installed".to_string())?;
+            scroll.scroll_to(offset);
+            Ok(Some(scroll.value_non_reactive().to_string()))
+        }
+        other => Err(format!("unsupported robot app hook {other}({argument})")),
+    }
+}
+
+/// Opens the Liquid UI tab and waits for it to come to rest.
+pub(crate) fn open(robot: &Robot) {
+    robot
+        .invoke_app_hook("set-tab", "liquid")
+        .expect("select the liquid tab");
+    settle(robot);
+}
+
+/// Scrolls the page to an absolute offset and waits for it to come to rest.
+pub(crate) fn scroll_to(robot: &Robot, offset: f32) {
+    robot
+        .invoke_app_hook("scroll-liquid-to", &offset.to_string())
+        .expect("scroll the liquid page");
+    settle(robot);
+}
+
+/// Pumps until animations and scrolling have stopped.
+pub(crate) fn settle(robot: &Robot) {
+    for _ in 0..SETTLE_ROUNDS {
+        robot.pump_frames(SETTLE_FRAMES).expect("pump frames");
+    }
+    std::thread::sleep(Duration::from_millis(SETTLE_MS));
+    robot.pump_frames(SETTLE_FRAMES).expect("pump frames");
+}

--- a/apps/desktop-demo/robot-runners/robot_liquid_nav_bar_backdrop.rs
+++ b/apps/desktop-demo/robot-runners/robot_liquid_nav_bar_backdrop.rs
@@ -1,3 +1,4 @@
+mod liquid_page;
 mod robot_exit;
 mod robot_shot;
 
@@ -5,16 +6,11 @@ use std::{path::PathBuf, process::ExitCode, time::Duration};
 
 use cranpose::{AppLauncher, Robot, RobotScreenshot};
 use cranpose_testing::{find_in_semantics, find_text_exact};
-use desktop_app::app::{
-    self, DemoTab, LIQUID_SCROLL_VIEWPORT_TAG, TEST_ACTIVE_TAB_STATE, TEST_LIQUID_SCROLL_STATE,
-};
+use desktop_app::app::{self, LIQUID_SCROLL_VIEWPORT_TAG};
 
 const WINDOW_WIDTH: u32 = 784;
 const WINDOW_HEIGHT: u32 = 620;
 const SHOT_SCALE: f32 = 2.0;
-const SETTLE_ROUNDS: usize = 6;
-const SETTLE_FRAMES: u32 = 12;
-const SETTLE_MS: u64 = 250;
 const COLLAPSED_OFFSET: f32 = 200.0;
 const CARD_TITLE: &str = "iPadOS";
 const CARD_SUBTITLE: &str = "Unlock the full potential of iPadOS.";
@@ -42,14 +38,11 @@ fn main() -> ExitCode {
         .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
         .with_fonts(desktop_app::fonts::DEMO_FONTS)
         .with_headless(std::env::var("CRANPOSE_HEADLESS").as_deref() != Ok("0"))
-        .with_robot_app_hook(app_hook)
+        .with_robot_app_hook(liquid_page::app_hook)
         .with_test_driver(move |robot| {
             robot_exit::arm_timeout(120);
             std::thread::sleep(Duration::from_millis(700));
-            robot
-                .invoke_app_hook("set-tab", "liquid")
-                .expect("select the liquid tab");
-            settle(&robot);
+            liquid_page::open(&robot);
 
             let page = find_in_semantics(&robot, |element| {
                 find_text_exact(element, LIQUID_SCROLL_VIEWPORT_TAG)
@@ -61,11 +54,11 @@ fn main() -> ExitCode {
             let icon_y_at_top = icon_centre_y(title, subtitle);
             let icon_left = title.0 - ICON_GAP - ICON_SIZE;
 
-            scroll_to(&robot, COLLAPSED_OFFSET);
+            liquid_page::scroll_to(&robot, COLLAPSED_OFFSET);
             let bar = text_bounds(&robot, BAR_TITLE);
             let bar_centre_y = bar.1 + bar.3 * 0.5;
 
-            scroll_to(&robot, icon_y_at_top - bar_centre_y);
+            liquid_page::scroll_to(&robot, icon_y_at_top - bar_centre_y);
             let landed = icon_centre_y(text_bounds(&robot, CARD_TITLE), subtitle);
             if (landed - bar_centre_y).abs() > LANDING_TOLERANCE {
                 robot_exit::fail(
@@ -130,22 +123,6 @@ fn text_bounds(robot: &Robot, text: &str) -> Bounds {
     bounds
 }
 
-fn scroll_to(robot: &Robot, offset: f32) {
-    let reached = robot
-        .invoke_app_hook("scroll-liquid-to", &offset.to_string())
-        .expect("scroll the liquid page");
-    println!("[nav-bar] scroll to {offset:.1} -> {reached:?}");
-    settle(robot);
-}
-
-fn settle(robot: &Robot) {
-    for _ in 0..SETTLE_ROUNDS {
-        robot.pump_frames(SETTLE_FRAMES).expect("pump frames");
-    }
-    std::thread::sleep(Duration::from_millis(SETTLE_MS));
-    robot.pump_frames(SETTLE_FRAMES).expect("pump frames");
-}
-
 fn mean_luma(shot: &RobotScreenshot, x: f32, y: f32) -> f32 {
     let sample = robot_shot::logical_sampler(shot);
     let mut total = 0.0;
@@ -156,27 +133,4 @@ fn mean_luma(shot: &RobotScreenshot, x: f32, y: f32) -> f32 {
         }
     }
     total / (SAMPLE_WIDTH * SAMPLE_HEIGHT) as f32
-}
-
-fn app_hook(name: String, argument: String) -> Result<Option<String>, String> {
-    match name.as_str() {
-        "set-tab" => {
-            TEST_ACTIVE_TAB_STATE
-                .with(|cell| cell.borrow().as_ref().copied())
-                .ok_or_else(|| "active tab state was not installed".to_string())?
-                .set(DemoTab::Liquid);
-            Ok(None)
-        }
-        "scroll-liquid-to" => {
-            let offset: f32 = argument
-                .parse()
-                .map_err(|err| format!("invalid liquid scroll offset '{argument}': {err}"))?;
-            let scroll = TEST_LIQUID_SCROLL_STATE
-                .with(|cell| *cell.borrow())
-                .ok_or_else(|| "liquid scroll state was not installed".to_string())?;
-            scroll.scroll_to(offset);
-            Ok(Some(scroll.value_non_reactive().to_string()))
-        }
-        other => Err(format!("unsupported robot app hook {other}({argument})")),
-    }
 }

--- a/apps/desktop-demo/robot-runners/robot_liquid_touched_shadow.rs
+++ b/apps/desktop-demo/robot-runners/robot_liquid_touched_shadow.rs
@@ -1,0 +1,142 @@
+mod liquid_page;
+mod robot_exit;
+mod robot_shot;
+
+use std::{path::PathBuf, process::ExitCode, time::Duration};
+
+use cranpose::{AppLauncher, Robot, RobotScreenshot};
+use cranpose_testing::{find_in_semantics, find_text_exact};
+use desktop_app::app;
+
+const WINDOW_WIDTH: u32 = 900;
+const WINDOW_HEIGHT: u32 = 700;
+const SHOT_SCALE: f32 = 2.0;
+/// The bottom bar's first and last destinations, which bound the row a press
+/// lands in.
+const FIRST: &str = "Discover";
+const LAST: &str = "Account";
+/// The band under the bar the shadow falls on, in dp below the bar's edge.
+const BAND_TOP: f32 = 4.0;
+const BAND_BOTTOM: f32 = 18.0;
+/// Holding a control must not change the page outside it by more than this.
+const TOLERANCE: f32 = 3.0;
+
+type Bounds = (f32, f32, f32, f32);
+
+fn main() -> ExitCode {
+    let _ = env_logger::try_init();
+    let shot_dir = PathBuf::from(
+        std::env::var("ROBOT_SHOT_DIR").unwrap_or_else(|_| "target/touched-shadow".into()),
+    );
+    std::fs::create_dir_all(&shot_dir).expect("create shot dir");
+    AppLauncher::new()
+        .with_title("Liquid Touched Shadow")
+        .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
+        .with_fonts(desktop_app::fonts::DEMO_FONTS)
+        .with_headless(std::env::var("CRANPOSE_HEADLESS").as_deref() != Ok("0"))
+        .with_robot_app_hook(liquid_page::app_hook)
+        .with_test_driver(move |robot| {
+            robot_exit::arm_timeout(180);
+            std::thread::sleep(Duration::from_millis(700));
+            liquid_page::open(&robot);
+
+            let first = text_bounds(&robot, FIRST);
+            let last = text_bounds(&robot, LAST);
+            let bottom = first.1 + first.3;
+            println!("[touched] {FIRST} {first:?} {LAST} {last:?} band {bottom:.0} dp");
+
+            let rest = robot
+                .screenshot_with_scale(SHOT_SCALE)
+                .expect("resting screenshot");
+            robot_shot::save(&rest, &shot_dir, "rest.png");
+            let resting = band(&rest, first.0, last.0 + last.2, bottom);
+            let darkest = resting.iter().copied().fold(f32::INFINITY, f32::min);
+            let lightest = resting.iter().copied().fold(0.0f32, f32::max);
+            if lightest - darkest < TOLERANCE * 2.0 {
+                robot_exit::fail(
+                    &robot,
+                    &format!(
+                        "the bar must cast a shadow on the band below it for this to test \
+                         anything: it reads {darkest:.1} to {lightest:.1}"
+                    ),
+                );
+            }
+
+            let (cx, cy) = (first.0 + first.2 * 0.5, first.1 + first.3 * 0.5);
+            robot.touch_down(cx, cy).expect("touch down");
+            for _ in 0..14 {
+                robot.pump_frames(4).expect("pump frames");
+            }
+            std::thread::sleep(Duration::from_millis(350));
+            robot.pump_frames(12).expect("pump frames");
+            let held = robot
+                .screenshot_with_scale(SHOT_SCALE)
+                .expect("held screenshot");
+            robot_shot::save(&held, &shot_dir, "held.png");
+            let pressed = band(&held, first.0, last.0 + last.2, bottom);
+            robot.touch_up(cx, cy).expect("touch up");
+
+            let mut worst = (0.0f32, 0usize);
+            for (index, (before, after)) in resting.iter().zip(pressed.iter()).enumerate() {
+                let lifted = after - before;
+                if lifted > worst.0 {
+                    worst = (lifted, index);
+                }
+            }
+            println!(
+                "[touched] band rest {:?} held {:?}",
+                &resting[..resting.len().min(8)],
+                &pressed[..pressed.len().min(8)]
+            );
+            if worst.0 > TOLERANCE {
+                robot_exit::fail(
+                    &robot,
+                    &format!(
+                        "holding a destination erased the bar's shadow beside it: the page \
+                         under the bar went from {:.1} to {:.1}, {:.1} lighter, at sample {} of \
+                         {}. A press must not repaint what lies outside the control.",
+                        resting[worst.1],
+                        pressed[worst.1],
+                        worst.0,
+                        worst.1,
+                        resting.len()
+                    ),
+                );
+            }
+            println!("✓ PASS: holding a destination leaves the shadow under the bar alone");
+            robot.exit().expect("exit");
+        })
+        .try_run(app::combined_app)
+        .expect("launch touched shadow runner");
+    ExitCode::SUCCESS
+}
+
+/// The page's luma across the band the bar's shadow falls on, sampled left
+/// to right under the row of destinations.
+fn band(shot: &RobotScreenshot, left: f32, right: f32, bar_bottom: f32) -> Vec<f32> {
+    let sample = robot_shot::logical_sampler(shot);
+    let luma = |x: f32, y: f32| {
+        let (r, g, b) = sample(x, y);
+        0.299 * f32::from(r) + 0.587 * f32::from(g) + 0.114 * f32::from(b)
+    };
+    let mut band = Vec::new();
+    let mut x = left;
+    while x <= right {
+        let mut total = 0.0;
+        let mut count = 0.0;
+        let mut y = bar_bottom + BAND_TOP;
+        while y <= bar_bottom + BAND_BOTTOM {
+            total += luma(x, y);
+            count += 1.0;
+            y += 2.0;
+        }
+        band.push(total / count);
+        x += 10.0;
+    }
+    band
+}
+
+fn text_bounds(robot: &Robot, text: &str) -> Bounds {
+    find_in_semantics(robot, |element| find_text_exact(element, text))
+        .unwrap_or_else(|| robot_exit::fail(robot, &format!("{text} must be on the page")))
+}

--- a/crates/cranpose-render/wgpu/src/frame.rs
+++ b/crates/cranpose-render/wgpu/src/frame.rs
@@ -1009,6 +1009,28 @@ fn child_device_placement(
     (dest, clipped.and_then(|rect| rect.intersect(target_rect)))
 }
 
+/// What bounds a child's rendered surface on the page: the child's clip
+/// within the target, and nothing narrower.
+///
+/// Not the child's own box. A surface holds what the child draws outside
+/// itself as well -- the shadow it casts -- and [`child_surface_rect`] sizes
+/// it to cover that. Scissoring the composite to the box instead drops the
+/// ring of shadow around the child, which is a rectangle of missing shadow
+/// exactly where the child sits.
+fn child_surface_bound(
+    child: &ChildLayer,
+    snap: Point,
+    scale: f32,
+    target_rect: DeviceRect,
+) -> Option<DeviceRect> {
+    match child.clip {
+        Some(clip) => {
+            DeviceRect::from_logical(clip.translate(snap.x, snap.y), scale).intersect(target_rect)
+        }
+        None => Some(target_rect),
+    }
+}
+
 /// Whether a child's runtime shader can draw in the final pass over the
 /// child's content: the shader must apply the child's clip and alpha itself
 /// unless the child has neither.
@@ -3197,11 +3219,15 @@ impl<'r, 'c, C: FrameCommandRecorder> FrameExecutor<'r, 'c, C> {
             }
             None => surface.source.clone(),
         };
+        let bound = child_surface_bound(child, snap, scale, pass.target_rect()).unwrap_or(visible);
         let composite = match surface.grid_dest {
-            Some(dest) => grid_child_composite(child, z, source, dest, snap, scale, visible),
+            Some(dest) => {
+                let visible = dest.intersect(bound).unwrap_or(visible);
+                grid_child_composite(child, z, source, dest, snap, scale, visible)
+            }
             None => {
                 let Some(composite) =
-                    projected_child_composite(child, z, source, &surface, snap, scale, visible)
+                    projected_child_composite(child, z, source, &surface, snap, scale, bound)
                 else {
                     return Ok(());
                 };


### PR DESCRIPTION
Every touchable glass surface wore a grey rectangle while it was held: the
shadow vanished inside a box the size of the control and stood unchanged
outside it. The untouched search accessory beside the bottom bar lost its
shadow at the same moment, so the repaint was not per-control.

# What it was

A control drawn straight onto the page casts its shadow onto the page.
Touch it and it is rendered into its own surface instead.

`child_surface_rect` already sizes that surface to hold what the child
draws outside itself. Instrumented on the liquid bottom bar:

| | rect |
|---|---|
| the layer's own box | `(0, 0, 320, 64)` |
| the surface it gets | `(-57, -53, 403, 170)` |

The extra is the reach of the shadow, and the surface is rendered with the
shadow in it. The composite that puts the surface back on the page took its
scissor from `child_device_placement`, which builds its rect from
`child.local_bounds` alone. So the surface was painted back through a hole
the size of the control and the ring of shadow around it was thrown away.

A child's surface composite is now bounded by the child's clip within the
target, never by the child's own box. A clip still cuts a shadow, which is
what a clip is for.

# Where it came from

`git bisect` over the 116 commits between the last clean point and the
release commit, driven by the measurement below, names **50d21533**, the
resolve-and-compose rewrite (#617), as the first bad commit. That is the
same rewrite whose backdrop capture reach #650 fixed.

# What holds it

`robot_liquid_touched_shadow` opens the Liquid UI page, samples the band of
page just under the row of destinations in the bottom bar, holds one
destination, and samples again. A press changes the control, never the page
beside it.

| band under the bar | before | after |
|---|---|---|
| at rest | 185 to 196 | 185 to 196 |
| held | flat 199, no shadow | 179 to 193 |

Red before the fix with "holding a destination erased the bar's shadow
beside it: the page under the bar went from 224.8 to 242.6, 17.8 lighter".
The same run on Vulkan failed with identical numbers, so this was never a
backend artefact.

The nav bar runner moves onto a shared `liquid_page` helper so both liquid
runners use one app hook instead of two copies of it.

# Verified

macm3 (Metal): the full `cranpose-render-wgpu` suite including the glass
parity suites, plus `cranpose-liquid`, `cranpose-render-common`,
`cranpose-render-pixels` and `cranpose-ui-graphics`; 33 test binaries, zero
failures; `just clippy` and `just clippy-robot` clean;
`robot_liquid_touched_shadow`, `robot_liquid_nav_bar_backdrop` and
`robot_nested_glass_animated` all green. samarch-1 (Vulkan): the same
renderer suite and this test.

Three earlier attempts were tried, measured, disproved and removed rather
than shipped: enabling the shadow on one widget's glued surface, granting
the material output room for its shadow, and resolving a shadow before the
backdrop at one depth. None of them moved the measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
