### PR TITLE
Keep a rekeyed subtree in its place on a scoped recompose

### DIFF
--- a/crates/cranpose-core/src/composer.rs
+++ b/crates/cranpose-core/src/composer.rs
@@ -479,6 +479,7 @@ pub(crate) struct ComposerCore {
     pub(crate) phase: Cell<crate::Phase>,
     pub(crate) last_node_reused: Cell<Option<bool>>,
     pub(crate) recompose_parent_hint: Cell<Option<NodeId>>,
+    pub(crate) recompose_child_cursor: Cell<Option<usize>>,
     pub(crate) root_render_requested: Cell<bool>,
     pub(crate) _not_send: PhantomData<*const ()>,
 }
@@ -570,6 +571,7 @@ impl ComposerCore {
             phase: Cell::new(crate::Phase::Compose),
             last_node_reused: Cell::new(None),
             recompose_parent_hint: Cell::new(None),
+            recompose_child_cursor: Cell::new(None),
             root_render_requested: Cell::new(false),
             _not_send: PhantomData,
         }

--- a/crates/cranpose-core/src/emit.rs
+++ b/crates/cranpose-core/src/emit.rs
@@ -231,6 +231,12 @@ impl Composer {
         self.attach_to_parent_with_mode(id, false);
     }
 
+    fn advance_recompose_child_cursor(&self) -> Option<usize> {
+        let cursor = self.core.recompose_child_cursor.get()?;
+        self.core.recompose_child_cursor.set(Some(cursor + 1));
+        Some(cursor)
+    }
+
     pub(crate) fn attach_to_parent_with_mode(
         &self,
         id: NodeId,
@@ -283,6 +289,7 @@ impl Composer {
                     self.commands_mut().push(Command::AttachChild {
                         parent_id,
                         child_id: id,
+                        insert_index: None,
                         bubble: DirtyBubble::LAYOUT_AND_MEASURE,
                     });
                 }
@@ -326,11 +333,15 @@ impl Composer {
                     .unwrap_or(None)
             };
             match parent_status {
-                Some(existing) if existing == parent_hint => {}
+                Some(existing) if existing == parent_hint => {
+                    self.advance_recompose_child_cursor();
+                }
                 None => {
+                    let insert_index = self.advance_recompose_child_cursor();
                     self.commands_mut().push(Command::AttachChild {
                         parent_id: parent_hint,
                         child_id: id,
+                        insert_index,
                         bubble: DirtyBubble::LAYOUT_AND_MEASURE,
                     });
                 }

--- a/crates/cranpose-core/src/lib.rs
+++ b/crates/cranpose-core/src/lib.rs
@@ -1779,6 +1779,7 @@ pub(crate) enum Command {
     AttachChild {
         parent_id: NodeId,
         child_id: NodeId,
+        insert_index: Option<usize>,
         bubble: DirtyBubble,
     },
     InsertChild {
@@ -1922,18 +1923,10 @@ impl Command {
             Self::AttachChild {
                 parent_id,
                 child_id,
+                insert_index,
                 bubble,
             } => {
-                if insert_child_with_reparenting(applier, parent_id, child_id) {
-                    bubble.apply(applier, parent_id);
-                } else if let Ok(child) = applier.get_mut(child_id) {
-                    let dirty_bubble = DirtyBubble {
-                        layout: child.needs_layout(),
-                        measure: child.needs_measure(),
-                        semantics: false,
-                    };
-                    dirty_bubble.apply(applier, parent_id);
-                }
+                attach_child_at(applier, parent_id, child_id, insert_index, bubble);
                 Ok(())
             }
             Self::InsertChild {
@@ -2042,6 +2035,7 @@ struct UpdateTypedNodeCommand {
 struct AttachChildCommand {
     parent_id: NodeId,
     child_id: NodeId,
+    insert_index: Option<usize>,
     bubble: DirtyBubble,
 }
 
@@ -2137,11 +2131,13 @@ impl CommandQueue {
             Command::AttachChild {
                 parent_id,
                 child_id,
+                insert_index,
                 bubble,
             } => {
                 self.attach_children.push(AttachChildCommand {
                     parent_id,
                     child_id,
+                    insert_index,
                     bubble,
                 });
                 self.push_tag(CommandTag::AttachChild);
@@ -2391,11 +2387,13 @@ impl CommandQueue {
                         let AttachChildCommand {
                             parent_id,
                             child_id,
+                            insert_index,
                             bubble,
                         } = next_command_payload(&mut attach_children, tag)?;
                         Command::AttachChild {
                             parent_id,
                             child_id,
+                            insert_index,
                             bubble,
                         }
                         .apply_with_cleanup(applier, &mut deferred_cleanup)?;
@@ -2518,6 +2516,41 @@ fn update_typed_node<N: Node + 'static>(node: &mut dyn Node, id: NodeId) -> Resu
         })?;
     typed.update();
     Ok(())
+}
+
+fn attach_child_at(
+    applier: &mut dyn Applier,
+    parent_id: NodeId,
+    child_id: NodeId,
+    insert_index: Option<usize>,
+    bubble: DirtyBubble,
+) {
+    if insert_child_with_reparenting(applier, parent_id, child_id) {
+        if let Some(target) = insert_index {
+            move_appended_child_to(applier, parent_id, target);
+        }
+        bubble.apply(applier, parent_id);
+    } else if let Ok(child) = applier.get_mut(child_id) {
+        let dirty_bubble = DirtyBubble {
+            layout: child.needs_layout(),
+            measure: child.needs_measure(),
+            semantics: false,
+        };
+        dirty_bubble.apply(applier, parent_id);
+    }
+}
+
+fn move_appended_child_to(applier: &mut dyn Applier, parent_id: NodeId, target: usize) {
+    let Ok(parent_node) = applier.get_mut(parent_id) else {
+        return;
+    };
+    let mut owned: SmallVec<[NodeId; 8]> = SmallVec::new();
+    parent_node.collect_owned_children_into(&mut owned);
+    let appended_index = owned.len().saturating_sub(1);
+    if target < appended_index {
+        parent_node.move_child(appended_index, target);
+        note_structural_move(parent_id, appended_index, target);
+    }
 }
 
 fn insert_child_with_reparenting(

--- a/crates/cranpose-core/src/recompose.rs
+++ b/crates/cranpose-core/src/recompose.rs
@@ -1,11 +1,31 @@
 use std::rc::Rc;
 
+use smallvec::SmallVec;
+
 use crate::{
     Command, Composer, ComposerCore, DirtyBubble, NodeId, RecomposeScope,
     debug_scope_invalidation_sources, debug_scope_label,
 };
 
 impl Composer {
+    fn scope_child_cursor(
+        &self,
+        scope: &RecomposeScope,
+        parent_hint: Option<NodeId>,
+    ) -> Option<usize> {
+        let parent_hint = parent_hint?;
+        let roots =
+            self.with_slot_session_mut(|slots| slots.active_scope_root_node_ids(scope.id()));
+        let first = roots.first().copied()?;
+        let mut applier = self.borrow_applier();
+        let mut siblings: SmallVec<[NodeId; 8]> = SmallVec::new();
+        applier
+            .get_mut(parent_hint)
+            .ok()?
+            .collect_owned_children_into(&mut siblings);
+        siblings.iter().position(|&sibling| sibling == first)
+    }
+
     pub(crate) fn recompose_group(&self, scope: &RecomposeScope) {
         struct RecomposeGuard {
             composer: Composer,
@@ -50,19 +70,27 @@ impl Composer {
             debug_scope_invalidation_sources(scope.id()),
         );
         if started.is_some() {
-            let previous_hint = self.core.recompose_parent_hint.replace(scope.parent_hint());
+            let parent_hint = scope.parent_hint();
+            let previous_hint = self.core.recompose_parent_hint.replace(parent_hint);
+            let previous_cursor = self
+                .core
+                .recompose_child_cursor
+                .replace(self.scope_child_cursor(scope, parent_hint));
             struct HintGuard {
                 core: Rc<ComposerCore>,
                 previous: Option<NodeId>,
+                previous_cursor: Option<usize>,
             }
             impl Drop for HintGuard {
                 fn drop(&mut self) {
                     self.core.recompose_parent_hint.set(self.previous);
+                    self.core.recompose_child_cursor.set(self.previous_cursor);
                 }
             }
             let _hint_guard = HintGuard {
                 core: self.clone_core(),
                 previous: previous_hint,
+                previous_cursor,
             };
             {
                 let mut stack = self.scope_stack();

--- a/crates/cranpose-core/src/slot/writer/group.rs
+++ b/crates/cranpose-core/src/slot/writer/group.rs
@@ -5,7 +5,7 @@ use super::{
     },
     SlotWriteSessionState,
 };
-use crate::{AnchorId, ScopeId};
+use crate::{AnchorId, NodeId, ScopeId};
 
 enum ActiveChildResolution {
     ReuseExpected { anchor: AnchorId },
@@ -236,6 +236,16 @@ impl SlotWriteSession<'_> {
                 kind: GroupStartKind::Inserted,
             },
         }
+    }
+
+    pub(crate) fn active_scope_root_node_ids(&mut self, scope_id: ScopeId) -> Vec<NodeId> {
+        let Some(group) = self.table.active_group_for_scope(scope_id) else {
+            return Vec::new();
+        };
+        let Some(anchor) = self.table.try_active_group_anchor(group) else {
+            return Vec::new();
+        };
+        self.table.collect_subtree_root_node_ids(anchor)
     }
 
     pub(crate) fn begin_recompose_at_scope(&mut self, scope_id: ScopeId) -> Option<ActiveGroupId> {

--- a/crates/cranpose-core/src/tests/composer_applier_tests.rs
+++ b/crates/cranpose-core/src/tests/composer_applier_tests.rs
@@ -751,6 +751,7 @@ fn queued_sync_children_preserves_child_reparented_later_in_same_apply() {
     commands.push(Command::AttachChild {
         parent_id: new_parent,
         child_id: child,
+        insert_index: None,
         bubble: DirtyBubble::LAYOUT_AND_MEASURE,
     });
 
@@ -2091,6 +2092,7 @@ fn reattaching_a_dirty_child_still_bubbles_to_ancestors() {
     commands.push(Command::AttachChild {
         parent_id: parent,
         child_id: child,
+        insert_index: None,
         bubble: DirtyBubble::LAYOUT_AND_MEASURE,
     });
     commands
@@ -2118,6 +2120,7 @@ fn reattaching_a_clean_child_bubbles_nothing() {
     commands.push(Command::AttachChild {
         parent_id: parent,
         child_id: child,
+        insert_index: None,
         bubble: DirtyBubble::LAYOUT_AND_MEASURE,
     });
     commands

--- a/crates/cranpose-core/src/tests/composition_and_recompose_scope_tests.rs
+++ b/crates/cranpose-core/src/tests/composition_and_recompose_scope_tests.rs
@@ -4740,3 +4740,175 @@ fn sibling_key_blocks_with_different_keys_do_not_share_state() {
         "the second sibling key(..) block must keep its own state, not the first's"
     );
 }
+
+#[test]
+fn a_rekeyed_subtree_keeps_its_place_when_only_its_scope_recomposes() {
+    thread_local! {
+        static CONTAINER_ID: Cell<Option<NodeId>> = const { Cell::new(None) };
+        static LIST_ID: Cell<Option<NodeId>> = const { Cell::new(None) };
+        static DOCK_ID: Cell<Option<NodeId>> = const { Cell::new(None) };
+    }
+
+    #[composable]
+    fn tabbed_list(tab: MutableState<u8>) {
+        let tab = tab.value();
+        cranpose_core::with_key(&tab, || {
+            let id = with_current_composer(|composer| {
+                composer.emit_node(|| TrackingChild {
+                    label: format!("list {tab}"),
+                    ..TrackingChild::default()
+                })
+            });
+            LIST_ID.with(|slot| slot.set(Some(id)));
+        });
+    }
+
+    #[composable]
+    fn dock() {
+        let id = with_current_composer(|composer| {
+            composer.emit_node(|| TrackingChild {
+                label: "dock".to_string(),
+                ..TrackingChild::default()
+            })
+        });
+        DOCK_ID.with(|slot| slot.set(Some(id)));
+    }
+
+    #[composable]
+    fn pane(tab: MutableState<u8>) {
+        let id = with_current_composer(|composer| composer.emit_node(RecordingNode::default));
+        CONTAINER_ID.with(|slot| slot.set(Some(id)));
+        cranpose_core::push_parent(id);
+        tabbed_list(tab);
+        dock();
+        cranpose_core::pop_parent();
+    }
+
+    fn container_children(composition: &mut Composition<MemoryApplier>) -> Vec<NodeId> {
+        let container = CONTAINER_ID.with(Cell::get).expect("container id");
+        composition
+            .applier_mut()
+            .with_node::<RecordingNode, _>(container, |node| node.children.clone())
+            .expect("container should exist")
+    }
+
+    let mut composition = test_composition();
+    let runtime = composition.runtime_handle();
+    let tab = MutableState::with_runtime(0u8, runtime);
+    let root_key = location_key(file!(), line!(), column!());
+
+    composition
+        .render(root_key, || {
+            pane(tab);
+        })
+        .expect("initial render");
+
+    let first_list = LIST_ID.with(Cell::get).expect("list id");
+    let dock_id = DOCK_ID.with(Cell::get).expect("dock id");
+    assert_eq!(
+        container_children(&mut composition),
+        vec![first_list, dock_id],
+        "the list should start above the dock"
+    );
+
+    tab.set_value(1);
+    while composition
+        .process_invalid_scopes()
+        .expect("recompose the list's scope")
+    {}
+
+    let second_list = LIST_ID.with(Cell::get).expect("list id");
+    assert_ne!(
+        second_list, first_list,
+        "the rekeyed list must compose a fresh node"
+    );
+    assert_eq!(
+        container_children(&mut composition),
+        vec![second_list, dock_id],
+        "a scoped recompose must place the rekeyed list where the old one was, not behind the dock"
+    );
+    assert_composition_valid(&composition);
+}
+
+#[test]
+fn a_scope_that_grows_places_its_new_node_among_its_own_nodes() {
+    thread_local! {
+        static CONTAINER_ID: Cell<Option<NodeId>> = const { Cell::new(None) };
+        static HEAD_ID: Cell<Option<NodeId>> = const { Cell::new(None) };
+        static TAIL_ID: Cell<Option<NodeId>> = const { Cell::new(None) };
+        static DOCK_ID: Cell<Option<NodeId>> = const { Cell::new(None) };
+    }
+
+    fn emit_child(label: &'static str) -> NodeId {
+        with_current_composer(|composer| {
+            composer.emit_node(|| TrackingChild {
+                label: label.to_string(),
+                ..TrackingChild::default()
+            })
+        })
+    }
+
+    #[composable]
+    fn growing_list(grown: MutableState<bool>) {
+        HEAD_ID.with(|slot| slot.set(Some(emit_child("head"))));
+        if grown.value() {
+            TAIL_ID.with(|slot| slot.set(Some(emit_child("tail"))));
+        }
+    }
+
+    #[composable]
+    fn dock() {
+        DOCK_ID.with(|slot| slot.set(Some(emit_child("dock"))));
+    }
+
+    #[composable]
+    fn pane(grown: MutableState<bool>) {
+        let id = with_current_composer(|composer| composer.emit_node(RecordingNode::default));
+        CONTAINER_ID.with(|slot| slot.set(Some(id)));
+        cranpose_core::push_parent(id);
+        growing_list(grown);
+        dock();
+        cranpose_core::pop_parent();
+    }
+
+    fn container_children(composition: &mut Composition<MemoryApplier>) -> Vec<NodeId> {
+        let container = CONTAINER_ID.with(Cell::get).expect("container id");
+        composition
+            .applier_mut()
+            .with_node::<RecordingNode, _>(container, |node| node.children.clone())
+            .expect("container should exist")
+    }
+
+    let mut composition = test_composition();
+    let runtime = composition.runtime_handle();
+    let grown = MutableState::with_runtime(false, runtime);
+    let root_key = location_key(file!(), line!(), column!());
+
+    composition
+        .render(root_key, || {
+            pane(grown);
+        })
+        .expect("initial render");
+
+    let head_id = HEAD_ID.with(Cell::get).expect("head id");
+    let dock_id = DOCK_ID.with(Cell::get).expect("dock id");
+    assert_eq!(
+        container_children(&mut composition),
+        vec![head_id, dock_id],
+        "the list should start with one row above the dock"
+    );
+
+    grown.set_value(true);
+    while composition
+        .process_invalid_scopes()
+        .expect("recompose the list's scope")
+    {}
+
+    let tail_id = TAIL_ID.with(Cell::get).expect("tail id");
+    assert_eq!(
+        container_children(&mut composition),
+        vec![head_id, tail_id, dock_id],
+        "a node a scope gains must follow the scope's own nodes, not the dock"
+    );
+    assert_composition_valid(&composition);
+}


### PR DESCRIPTION
Reported against cranpose-showcase: the floating Explore/Saved tab bar stops absorbing its own presses — a card underneath takes the click and opens that body's detail page instead of switching tabs. It is neither a `LiquidTabBar` defect nor a missing consume in the showcase's dock: after one tab switch the bar is not on top any more, and the rows are painted over it.

## Cause

When a scope recomposes on its own, its nodes are attached through `recompose_parent_hint`, which carried no position: `Command::AttachChild` appended to the hint parent's child list. A scope that rekeys part of its content — `with_key(&tab)` around a list — drops its old nodes out of the middle of that list and gets the new ones appended behind every later sibling. In the showcase, `ListPane` emits the list and then the tab-bar dock; after a tab switch the order became dock-then-list, so the rows painted over the glass pill and took its presses.

## Fix

A scope's nodes occupy a contiguous run of the hint parent's children, so `recompose_group` reads the scope's current root nodes before running the body (`SlotWriteSession::active_scope_root_node_ids`) and records where that run starts. Each node the scope attaches takes the next place in the run; each node it keeps advances past one. A rekeyed block therefore lands where the old one was, and a block that grows keeps its new node among its own.

`Command::AttachChild` carries that position and resolves it when it applies — appending, then moving the child from the end to the target index, measured against the parent's **own** child list (`collect_owned_children_into`), because `SubcomposeLayoutNode::children()` answers with its placements rather than the list `move_child` indexes into. A scope with no previous nodes under the hint still appends, exactly as before.

`apply_with_cleanup` was already over the complexity limit, so its `AttachChild` arm moved into `attach_child_at`.

## Regression tests

`crates/cranpose-core/src/tests/composition_and_recompose_scope_tests.rs`:

- `a_rekeyed_subtree_keeps_its_place_when_only_its_scope_recomposes` — the reported shape. Red without the fix: `left: [2, 3]`, `right: [3, 2]`.
- `a_scope_that_grows_places_its_new_node_among_its_own_nodes` — the cursor must advance past nodes the scope keeps. Red without the fix: `left: [1, 2, 3]`, `right: [1, 3, 2]`.

Both were confirmed red by disabling the cursor and green again with it restored.

End to end, the showcase drives Saved → Explore → Saved with the tab bar over a card. Against this branch every press switches tabs; against `fix/crossfade-entry-skip` alone the third press opens Jupiter's page. The showcase side of that is `robot-tab-switch` in samoylenkodmitry/cranpose-showcase#8.

## Checks

`just fmt`, `just precommit`, `just clippy` and `just test` (190 binaries, exit 0) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)