### PR TITLE
Render a touched control's surface for what the page shows, not its box

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 - No unsafe code.
 - Use KISS, DRY and SOLID; duplicated code of ten or more lines needs a shared abstraction.
 - Fix root causes completely; do not leave partial changes, deprecated paths or compatibility layers in this pre-alpha repository.
+- A wrong value fixed at one consumer is still wrong at the others; audit every consumer of that value before calling the bug fixed.
 - Review architecture, correctness and maintainability before completion; fix supported problems without inventing new ones.
 - Follow the [performance coding guide](docs/performance_coding_guide.md); reduce measured work and preserve exact pictures on shipped targets.
 - Use `cargo add` for dependencies and `cargo upgrade` for upgrades.

--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -304,6 +304,11 @@ path = "robot-runners/robot_liquid_touched_shadow.rs"
 required-features = ["robot-app"]
 
 [[example]]
+name = "robot_feed_touched_shadow"
+path = "robot-runners/robot_feed_touched_shadow.rs"
+required-features = ["robot-app"]
+
+[[example]]
 name = "robot_double_click"
 path = "robot-runners/robot_double_click.rs"
 required-features = ["robot-app"]

--- a/apps/desktop-demo/robot-runners/liquid_page.rs
+++ b/apps/desktop-demo/robot-runners/liquid_page.rs
@@ -8,17 +8,27 @@ use desktop_app::app::{DemoTab, TEST_ACTIVE_TAB_STATE, TEST_LIQUID_SCROLL_STATE}
 const SETTLE_ROUNDS: usize = 6;
 const SETTLE_FRAMES: u32 = 12;
 const SETTLE_MS: u64 = 250;
+const HOLD_ROUNDS: usize = 14;
+const HOLD_FRAMES: u32 = 4;
+const HOLD_MS: u64 = 350;
 
-/// The Liquid UI page's robot hooks: select the tab, and drive the page's own
-/// scroll state so a runner places content exactly instead of flinging a drag
-/// at it and landing wherever the settle policy snaps.
+type Bounds = (f32, f32, f32, f32);
+
+/// The liquid pages' robot hooks: select a tab by name, and drive the Liquid
+/// UI page's own scroll state so a runner places content exactly instead of
+/// flinging a drag at it and landing wherever the settle policy snaps.
 pub(crate) fn app_hook(name: String, argument: String) -> Result<Option<String>, String> {
     match name.as_str() {
         "set-tab" => {
+            let tab = match argument.as_str() {
+                "liquid" => DemoTab::Liquid,
+                "receipts" => DemoTab::GlassFeed,
+                other => return Err(format!("unknown tab {other}")),
+            };
             TEST_ACTIVE_TAB_STATE
                 .with(|cell| cell.borrow().as_ref().copied())
                 .ok_or_else(|| "active tab state was not installed".to_string())?
-                .set(DemoTab::Liquid);
+                .set(tab);
             Ok(None)
         }
         "scroll-liquid-to" => {
@@ -43,12 +53,36 @@ pub(crate) fn open(robot: &Robot) {
     settle(robot);
 }
 
+/// Opens the receipts feed and waits for it to come to rest.
+pub(crate) fn open_receipts(robot: &Robot) {
+    robot
+        .invoke_app_hook("set-tab", "receipts")
+        .expect("select the receipts tab");
+    settle(robot);
+}
+
 /// Scrolls the page to an absolute offset and waits for it to come to rest.
 pub(crate) fn scroll_to(robot: &Robot, offset: f32) {
     robot
         .invoke_app_hook("scroll-liquid-to", &offset.to_string())
         .expect("scroll the liquid page");
     settle(robot);
+}
+
+/// Presses at a point and holds until the press feedback has settled; the
+/// caller releases with `touch_up`.
+pub(crate) fn hold(robot: &Robot, x: f32, y: f32) {
+    robot.touch_down(x, y).expect("touch down");
+    for _ in 0..HOLD_ROUNDS {
+        robot.pump_frames(HOLD_FRAMES).expect("pump frames");
+    }
+    std::thread::sleep(Duration::from_millis(HOLD_MS));
+    robot.pump_frames(SETTLE_FRAMES).expect("pump frames");
+}
+
+/// The centre of a semantics box.
+pub(crate) fn centre(bounds: Bounds) -> (f32, f32) {
+    (bounds.0 + bounds.2 * 0.5, bounds.1 + bounds.3 * 0.5)
 }
 
 /// Pumps until animations and scrolling have stopped.

--- a/apps/desktop-demo/robot-runners/robot_feed_touched_shadow.rs
+++ b/apps/desktop-demo/robot-runners/robot_feed_touched_shadow.rs
@@ -1,0 +1,176 @@
+mod liquid_page;
+mod robot_exit;
+mod robot_shot;
+
+use std::{path::PathBuf, process::ExitCode, time::Duration};
+
+use cranpose::{AppLauncher, RobotScreenshot, SemanticElement};
+use cranpose_testing::{find_in_semantics, find_text_exact};
+use desktop_app::app;
+
+const WINDOW_WIDTH: u32 = 900;
+const WINDOW_HEIGHT: u32 = 700;
+const SHOT_SCALE: f32 = 2.0;
+/// The card whose star this runner holds: its neighbours' stars sit under the
+/// feed's chrome.
+const CARD: &str = "Receipt #0004 — 12 items";
+const STAR: &str = "★";
+/// How far left of the star's box the walk toward it starts, in dp: plain
+/// card there, well past the shadow's reach.
+const FAR: f32 = 32.0;
+/// Rows the walk samples, in dp from the star's vertical centre.
+const ROWS: [f32; 3] = [-10.0, 0.0, 10.0];
+/// The most a shadow that fades may darken from one dp to the next.
+const STEP_TOLERANCE: f32 = 3.0;
+/// A brightening this large is the glass rim: the walk has reached the control.
+const RIM_STEP: f32 = 20.0;
+
+type Bounds = (f32, f32, f32, f32);
+
+fn main() -> ExitCode {
+    let _ = env_logger::try_init();
+    let shot_dir = PathBuf::from(
+        std::env::var("ROBOT_SHOT_DIR").unwrap_or_else(|_| "target/feed-touched-shadow".into()),
+    );
+    std::fs::create_dir_all(&shot_dir).expect("create shot dir");
+    AppLauncher::new()
+        .with_title("Feed Touched Shadow")
+        .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
+        .with_fonts(desktop_app::fonts::DEMO_FONTS)
+        .with_headless(std::env::var("CRANPOSE_HEADLESS").as_deref() != Ok("0"))
+        .with_robot_app_hook(liquid_page::app_hook)
+        .with_test_driver(move |robot| {
+            robot_exit::arm_timeout(180);
+            std::thread::sleep(Duration::from_millis(700));
+            liquid_page::open_receipts(&robot);
+
+            let card = find_in_semantics(&robot, |element| find_text_exact(element, CARD))
+                .unwrap_or_else(|| {
+                    robot_exit::fail(&robot, &format!("{CARD} must be on the page"))
+                });
+            let star = find_in_semantics(&robot, |element| {
+                star_beside(element, card.1 + card.3 * 0.5)
+            })
+            .unwrap_or_else(|| robot_exit::fail(&robot, &format!("{CARD} must carry a {STAR}")));
+            println!("[touched] {CARD} {card:?} star {star:?}");
+
+            let rest = robot
+                .screenshot_with_scale(SHOT_SCALE)
+                .expect("resting screenshot");
+            robot_shot::save(&rest, &shot_dir, "rest.png");
+            let resting = walks(&rest, star);
+            let depth = resting
+                .iter()
+                .map(|walk| walk[0] - walk.iter().copied().fold(f32::INFINITY, f32::min))
+                .fold(0.0f32, f32::max);
+            if depth < STEP_TOLERANCE * 2.0 {
+                robot_exit::fail(
+                    &robot,
+                    &format!(
+                        "the star must cast a shadow on the card beside it for this to test \
+                         anything: the card darkens by only {depth:.1} toward the star"
+                    ),
+                );
+            }
+            if let Some(cut) = first_cut(&resting) {
+                robot_exit::fail(
+                    &robot,
+                    &format!("the resting page already steps beside the star: {cut}"),
+                );
+            }
+
+            let (cx, cy) = liquid_page::centre(star);
+            liquid_page::hold(&robot, cx, cy);
+            let held = robot
+                .screenshot_with_scale(SHOT_SCALE)
+                .expect("held screenshot");
+            robot_shot::save(&held, &shot_dir, "held.png");
+            let pressed = walks(&held, star);
+            robot.touch_up(cx, cy).expect("touch up");
+            liquid_page::settle(&robot);
+            let released = robot
+                .screenshot_with_scale(SHOT_SCALE)
+                .expect("released screenshot");
+            robot_shot::save(&released, &shot_dir, "released.png");
+
+            println!(
+                "[touched] centre row rest {:?}\n[touched] centre row held {:?}",
+                resting[1], pressed[1]
+            );
+            if let Some(cut) = first_cut(&pressed) {
+                robot_exit::fail(
+                    &robot,
+                    &format!(
+                        "holding the star cut its shadow into a rectangle: {cut}. A held \
+                         control's shadow must fade like the resting one."
+                    ),
+                );
+            }
+            println!("✓ PASS: holding the star keeps its shadow fading into the card");
+            robot.exit().expect("exit");
+        })
+        .try_run(app::combined_app)
+        .expect("launch feed touched shadow runner");
+    ExitCode::SUCCESS
+}
+
+/// The clickable element holding a star whose box spans `y`.
+fn star_beside(element: &SemanticElement, y: f32) -> Option<Bounds> {
+    let bounds = element.bounds;
+    if element.clickable
+        && (bounds.y..bounds.y + bounds.height).contains(&y)
+        && find_text_exact(element, STAR).is_some()
+    {
+        return Some((bounds.x, bounds.y, bounds.width, bounds.height));
+    }
+    element
+        .children
+        .iter()
+        .find_map(|child| star_beside(child, y))
+}
+
+/// The page's luma along each of [`ROWS`], walking from `FAR` dp left of the
+/// star's box toward its edge one dp at a time.
+fn walks(shot: &RobotScreenshot, star: Bounds) -> Vec<Vec<f32>> {
+    let sample = robot_shot::logical_sampler(shot);
+    let luma = |x: f32, y: f32| {
+        let (r, g, b) = sample(x, y);
+        0.299 * f32::from(r) + 0.587 * f32::from(g) + 0.114 * f32::from(b)
+    };
+    let centre = star.1 + star.3 * 0.5;
+    ROWS.iter()
+        .map(|row| {
+            let y = centre + row;
+            (0..FAR as usize)
+                .map(|step| luma(star.0 - FAR + step as f32, y))
+                .collect()
+        })
+        .collect()
+}
+
+/// Where a walk toward the star darkens by more than a fading shadow can in
+/// one dp before it reaches the glass rim: the edge of a cut shadow.
+fn first_cut(walks: &[Vec<f32>]) -> Option<String> {
+    walks.iter().zip(ROWS).find_map(|(walk, row)| {
+        walk.windows(2)
+            .enumerate()
+            .find_map(|(step, pair)| {
+                let inward = pair[1] - pair[0];
+                if inward > RIM_STEP {
+                    return Some(None);
+                }
+                (-inward > STEP_TOLERANCE).then(|| {
+                    Some(format!(
+                        "{:.1} dp below the centre row, the card goes from {:.1} to {:.1} between \
+                     {:.0} and {:.0} dp left of the star's box",
+                        row,
+                        pair[0],
+                        pair[1],
+                        FAR - step as f32,
+                        FAR - step as f32 - 1.0
+                    ))
+                })
+            })
+            .flatten()
+    })
+}

--- a/apps/desktop-demo/robot-runners/robot_liquid_touched_shadow.rs
+++ b/apps/desktop-demo/robot-runners/robot_liquid_touched_shadow.rs
@@ -62,13 +62,8 @@ fn main() -> ExitCode {
                 );
             }
 
-            let (cx, cy) = (first.0 + first.2 * 0.5, first.1 + first.3 * 0.5);
-            robot.touch_down(cx, cy).expect("touch down");
-            for _ in 0..14 {
-                robot.pump_frames(4).expect("pump frames");
-            }
-            std::thread::sleep(Duration::from_millis(350));
-            robot.pump_frames(12).expect("pump frames");
+            let (cx, cy) = liquid_page::centre(first);
+            liquid_page::hold(&robot, cx, cy);
             let held = robot
                 .screenshot_with_scale(SHOT_SCALE)
                 .expect("held screenshot");

--- a/crates/cranpose-render/wgpu/src/frame.rs
+++ b/crates/cranpose-render/wgpu/src/frame.rs
@@ -1009,14 +1009,14 @@ fn child_device_placement(
     (dest, clipped.and_then(|rect| rect.intersect(target_rect)))
 }
 
-/// What bounds a child's rendered surface on the page: the child's clip
+/// What the page shows of a child's rendered surface: the child's clip
 /// within the target, and nothing narrower.
 ///
 /// Not the child's own box. A surface holds what the child draws outside
 /// itself as well -- the shadow it casts -- and [`child_surface_rect`] sizes
-/// it to cover that. Scissoring the composite to the box instead drops the
-/// ring of shadow around the child, which is a rectangle of missing shadow
-/// exactly where the child sits.
+/// it to cover that. Rendering or compositing only the box's part of it
+/// instead drops the ring of shadow around the child, which is a rectangle
+/// of missing shadow exactly where the child sits.
 fn child_surface_bound(
     child: &ChildLayer,
     snap: Point,
@@ -1029,6 +1029,22 @@ fn child_surface_bound(
         }
         None => Some(target_rect),
     }
+}
+
+/// The part of a backdrop-reading child's surface `whole` worth rendering:
+/// what the page shows of it, `shown`, grown by `reach`, the pixels its
+/// glasses read past what they cover.
+///
+/// `shown` is the child's clip within the target, never its box. The shadow
+/// a child casts lies outside its box and inside its surface, and a press
+/// that promotes the child to a surface must render that shadow whole:
+/// trimmed to the box and the glass reach, it ends in a straight edge a few
+/// pixels out from every side of the control.
+fn rendered_surface(whole: DeviceRect, shown: DeviceRect, reach: f32) -> DeviceRect {
+    shown
+        .expand(reach)
+        .intersect(whole)
+        .map_or(whole, DeviceRect::snap_out)
 }
 
 /// Whether a child's runtime shader can draw in the final pass over the
@@ -3194,7 +3210,8 @@ impl<'r, 'c, C: FrameCommandRecorder> FrameExecutor<'r, 'c, C> {
             pass.pending.push(composite);
             return Ok(());
         }
-        let Some(surface) = self.render_child_surface(pass, child, z, grid, visible)? else {
+        let shown = child_surface_bound(child, snap, scale, pass.target_rect()).unwrap_or(visible);
+        let Some(surface) = self.render_child_surface(pass, child, z, grid, shown)? else {
             return Ok(());
         };
         if let Some(composite) =
@@ -3219,15 +3236,14 @@ impl<'r, 'c, C: FrameCommandRecorder> FrameExecutor<'r, 'c, C> {
             }
             None => surface.source.clone(),
         };
-        let bound = child_surface_bound(child, snap, scale, pass.target_rect()).unwrap_or(visible);
         let composite = match surface.grid_dest {
             Some(dest) => {
-                let visible = dest.intersect(bound).unwrap_or(visible);
+                let visible = dest.intersect(shown).unwrap_or(visible);
                 grid_child_composite(child, z, source, dest, snap, scale, visible)
             }
             None => {
                 let Some(composite) =
-                    projected_child_composite(child, z, source, &surface, snap, scale, bound)
+                    projected_child_composite(child, z, source, &surface, snap, scale, shown)
                 else {
                     return Ok(());
                 };
@@ -3302,9 +3318,10 @@ impl<'r, 'c, C: FrameCommandRecorder> FrameExecutor<'r, 'c, C> {
     /// its backdrop is never cached and renders every frame, so when it sits
     /// on the parent's pixel grid (a translation, or a uniform scale it
     /// renders at) and carries no effect of its own it renders the part of
-    /// its surface `visible` shows, grown by what its glasses read past it
-    /// (`backdrop_reach`): a card wider than the screen costs the screen,
-    /// and every capture inside it follows.
+    /// its surface the page shows (`shown`, its clip within the target),
+    /// grown by what its glasses read past it (`backdrop_reach`): a card
+    /// wider than the screen costs the screen, and every capture inside it
+    /// follows.
     #[allow(clippy::too_many_arguments)]
     fn render_child_surface(
         &mut self,
@@ -3312,7 +3329,7 @@ impl<'r, 'c, C: FrameCommandRecorder> FrameExecutor<'r, 'c, C> {
         child: &ChildLayer,
         z: usize,
         grid: Option<Point>,
-        visible: DeviceRect,
+        shown: DeviceRect,
     ) -> Result<Option<SurfaceRender>, String> {
         let scale = pass.scale;
         let surface_scale = scale * child.surface_scale;
@@ -3335,10 +3352,7 @@ impl<'r, 'c, C: FrameCommandRecorder> FrameExecutor<'r, 'c, C> {
                 let whole = child_rect.translated(offset).snap_out();
                 let dest = if reads_backdrop && child.effect.is_none() {
                     let reach = (backdrop_reach(&child.content) * surface_scale).ceil() + 1.0;
-                    visible
-                        .expand(reach)
-                        .intersect(whole)
-                        .map_or(whole, DeviceRect::snap_out)
+                    rendered_surface(whole, shown, reach)
                 } else {
                     whole
                 };
@@ -3844,7 +3858,10 @@ pub(crate) fn scene_bounds(layer: &LayerScene, scale: f32) -> Option<Rect> {
 
 #[cfg(test)]
 mod tests {
-    use super::{MAX_SURFACE_PIXELS, Rect, surface_pixels, surface_within_budget};
+    use super::{
+        DeviceRect, MAX_SURFACE_PIXELS, Rect, rendered_surface, surface_pixels,
+        surface_within_budget,
+    };
 
     fn rect(width: f32, height: f32) -> Rect {
         Rect {
@@ -3853,6 +3870,34 @@ mod tests {
             width,
             height,
         }
+    }
+
+    fn device(x: f32, y: f32, width: f32, height: f32) -> DeviceRect {
+        DeviceRect {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    #[test]
+    fn a_promoted_control_renders_the_shadow_past_its_box() {
+        // The receipts feed's star while held: a 76x52 dp box at 2.36 px per
+        // dp whose shadow reaches 20 dp out, on a page that shows all of it.
+        let page = device(0.0, 0.0, 1800.0, 1400.0);
+        let whole = device(1812.0, 1183.0, 368.0, 312.0);
+        assert_eq!(rendered_surface(whole, page, 9.0), whole);
+    }
+
+    #[test]
+    fn a_card_wider_than_the_page_costs_the_page_and_the_glass_reach() {
+        let page = device(0.0, 0.0, 1800.0, 1400.0);
+        let card = device(-400.0, 100.0, 3000.0, 400.0);
+        assert_eq!(
+            rendered_surface(card, page, 9.0),
+            device(-9.0, 100.0, 1818.0, 400.0)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Holding a glass control cut its shadow into a rectangle a few pixels out from every side of it: the receipts feed's star, and every other control the press promotes to its own surface.

## Cause

A press scales the control (`liquid_press_scale`), which isolates it and renders it as a child surface. A child that reads its backdrop and carries no effect renders only the part of its surface the page needs, grown by the reach of its glass; `render_child_surface` took that part from `visible`, which `child_device_placement` builds from the child's *box*. The box plus a few pixels of glass reach is smaller than the shadow the child draws around itself, so the surface was rendered with the shadow trimmed to a rectangle. #654 fixed the same mistake one step later, in the composite's scissor; this is the render side of it.

## Fix

`render_child_surface` now takes `shown`, the child's clip within the target (`child_surface_bound`), which `resolve_child` already computed for the composite. `rendered_surface(whole, shown, reach)` is the pure rule with unit tests: a promoted control keeps everything it draws on a page that shows it, and a card wider than the page still costs the page plus the glass reach.

## Proof

`robot_feed_touched_shadow` holds the star on the fourth receipt and walks the card's luma from 32 dp left of the star's box toward it, on three rows. A fading shadow never darkens by more than 3 luma units per dp; a cut steps by the shadow's full density there. The walk on the resting page must be clean and dark enough to test anything, then the held page must be clean too.

- macm3 (Metal), before: FATAL. Held, the walk sits at 53.9 from 32 dp out to 11 dp and drops to 49.3 in the next dp; at rest it fades by at most 1.0 per dp over the same span.
- macm3 (Metal), after: PASS. Held, the walk fades 54.8 → 46.1 over 25 dp with no step above 1.1, up to the glass rim.
- samarch-1 (Vulkan): this PR's robot suite, which discovers the runner by name.
- `robot_liquid_touched_shadow` (the bottom bar, #654) stays green on both.

The shared `liquid_page` hook now selects a tab by name and holds a point for both runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
