### PR TITLE
Stop a text field's position from recomposing its handle consumers

### DIFF
--- a/crates/cranpose-ui/src/tests/selection_handle_tests.rs
+++ b/crates/cranpose-ui/src/tests/selection_handle_tests.rs
@@ -469,3 +469,87 @@ mod kind_restart {
         );
     }
 }
+
+/// The metrics a field publishes while it sits unfocused on a scrolling page.
+fn resting_metrics(origin_y: f32) -> crate::text_field_modifier_node::TextFieldHandleMetrics {
+    crate::text_field_modifier_node::TextFieldHandleMetrics {
+        focused: false,
+        direct_manipulation: false,
+        node_origin: Point {
+            x: 20.0,
+            y: origin_y,
+        },
+        padding_left: 0.0,
+        padding_top: 0.0,
+        scroll_offset: 0.0,
+        line_height: 18.0,
+        glyph_box: (8.0, 18.0),
+        wrap_width: None,
+    }
+}
+
+thread_local! {
+    static HANDLE_READS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cranpose_macros::composable]
+#[allow(non_snake_case)]
+fn HandleConsumer(
+    controller: crate::text_field_modifier_node::TextFieldHandleController,
+    follow_position: bool,
+) {
+    HANDLE_READS.with(|reads| reads.set(reads.get() + 1));
+    let _ = if follow_position {
+        controller.live_metrics()
+    } else {
+        controller.metrics()
+    };
+}
+
+fn compositions_while_field_creeps(follow_position: bool) -> usize {
+    let mut composition = Composition::new(MemoryApplier::new());
+    let controller = crate::text_field_modifier_node::TextFieldHandleController::new();
+    controller.publish(resting_metrics(109.256_15));
+
+    HANDLE_READS.with(|reads| reads.set(0));
+    let controller_for_content = controller.clone();
+    composition
+        .render(location_key(file!(), line!(), column!()), move || {
+            HandleConsumer(controller_for_content.clone(), follow_position);
+        })
+        .expect("initial render");
+    let before = HANDLE_READS.with(std::cell::Cell::get);
+
+    // A list settling under the field nudges its origin by a fraction of a
+    // pixel a frame. Nothing about the handles changed.
+    for step in 1..=4 {
+        controller.publish(resting_metrics(109.256_15 - step as f32 * 0.000_2));
+        while composition
+            .process_invalid_scopes()
+            .expect("process the published metrics")
+        {}
+    }
+
+    HANDLE_READS.with(std::cell::Cell::get) - before
+}
+
+#[test]
+fn a_field_that_only_moves_does_not_recompose_its_handle_consumers() {
+    let _app_context = crate::render_state::app_context_test_scope();
+    assert_eq!(
+        compositions_while_field_creeps(false),
+        0,
+        "a scope that only asks whether the handles are live must not recompose when the field \
+         moves under a settling list"
+    );
+}
+
+#[test]
+fn a_live_handle_consumer_still_follows_the_field() {
+    let _app_context = crate::render_state::app_context_test_scope();
+    assert!(
+        compositions_while_field_creeps(true) >= 4,
+        "a scope placing handles at the caret must keep following the field, or this test cannot \
+         tell a fixed subscription from a severed one"
+    );
+}

--- a/crates/cranpose-ui/src/text_field_modifier_node.rs
+++ b/crates/cranpose-ui/src/text_field_modifier_node.rs
@@ -40,7 +40,8 @@ impl PartialEq for TextFieldHandleController {
 
 struct TextFieldHandleControllerInner {
     metrics: Cell<Option<TextFieldHandleMetrics>>,
-    revision: MutableState<u64>,
+    activation: MutableState<u64>,
+    geometry: MutableState<u64>,
     gesture_claim: RefCell<Option<Rc<Cell<bool>>>>,
     press_track: Cell<Option<MutableState<Option<PointerPressTrack>>>>,
 }
@@ -50,7 +51,8 @@ impl TextFieldHandleController {
         Self {
             inner: Rc::new(TextFieldHandleControllerInner {
                 metrics: Cell::new(None),
-                revision: mutableStateOf(0u64),
+                activation: mutableStateOf(0u64),
+                geometry: mutableStateOf(0u64),
                 gesture_claim: RefCell::new(None),
                 press_track: Cell::new(None),
             }),
@@ -58,16 +60,56 @@ impl TextFieldHandleController {
     }
 
     pub(crate) fn publish(&self, metrics: TextFieldHandleMetrics) {
-        if self.inner.metrics.get() != Some(metrics) {
-            self.inner.metrics.set(Some(metrics));
-            self.inner
-                .revision
-                .update(|value| *value = value.wrapping_add(1));
+        let previous = self.inner.metrics.replace(Some(metrics));
+        if previous == Some(metrics) {
+            return;
         }
+        let was_live = previous.map(|metrics| (metrics.focused, metrics.direct_manipulation));
+        if was_live != Some((metrics.focused, metrics.direct_manipulation)) {
+            self.bump(&self.inner.activation);
+        }
+        self.bump(&self.inner.geometry);
     }
 
+    fn bump(&self, revision: &MutableState<u64>) {
+        revision.update(|value| *value = value.wrapping_add(1));
+    }
+
+    /// The field's current handle metrics, subscribing the caller to whether
+    /// the handles are live -- to [`TextFieldHandleMetrics::focused`] and
+    /// [`TextFieldHandleMetrics::direct_manipulation`], and to nothing else.
+    ///
+    /// The rest of the metrics describe where the field sits, and a field
+    /// moves for reasons that have nothing to do with its handles: a list
+    /// scrolling under it, a bounce settling, a layout shifting by a
+    /// fraction of a pixel. A caller that only wants to know whether to emit
+    /// handles must not be recomposed by any of that, so geometry is not part
+    /// of this subscription. Use [`Self::live_metrics`] once the handles are
+    /// live and their position has to follow the field, and
+    /// [`Self::metrics_now`] outside composition.
     pub fn metrics(&self) -> Option<TextFieldHandleMetrics> {
-        let _ = self.inner.revision.value();
+        let _ = self.inner.activation.value();
+        self.inner.metrics.get()
+    }
+
+    /// The field's current handle metrics, subscribing the caller to the
+    /// field's position as well.
+    ///
+    /// For a caller that places something at the caret and has to keep it
+    /// there while the field moves. Reach for it only past a
+    /// [`TextFieldHandleMetrics::focused`] check, because every caller that
+    /// holds this subscription recomposes whenever the field moves at all.
+    pub fn live_metrics(&self) -> Option<TextFieldHandleMetrics> {
+        let _ = self.inner.geometry.value();
+        self.inner.metrics.get()
+    }
+
+    /// The field's current handle metrics, subscribing the caller to nothing.
+    ///
+    /// For gesture callbacks and effects, which run after composition and want
+    /// the position as it is now rather than as it was when their scope last
+    /// composed.
+    pub fn metrics_now(&self) -> Option<TextFieldHandleMetrics> {
         self.inner.metrics.get()
     }
 
@@ -82,9 +124,7 @@ impl TextFieldHandleController {
     pub(crate) fn adopt_press_track(&self, press_track: MutableState<Option<PointerPressTrack>>) {
         if self.inner.press_track.get() != Some(press_track) {
             self.inner.press_track.set(Some(press_track));
-            self.inner
-                .revision
-                .update(|value| *value = value.wrapping_add(1));
+            self.bump(&self.inner.activation);
         }
     }
 

--- a/crates/cranpose-ui/src/widgets/basic_text_field.rs
+++ b/crates/cranpose-ui/src/widgets/basic_text_field.rs
@@ -382,7 +382,6 @@ fn BringCaretIntoView(
 
     let text = state.text();
     let selection = state.selection();
-    let caret = caret_window_rect(&text, &style, &metrics, selection.start);
 
     let key = (
         selection.start,
@@ -390,10 +389,15 @@ fn BringCaretIntoView(
         (ime_bottom * 4.0).round() as i64,
     );
     SideEffect(move || {
-        if previous.get() != Some(key) {
-            previous.set(Some(key));
-            responder.bring_into_view(caret, ime_bottom);
+        if previous.get() == Some(key) {
+            return;
         }
+        previous.set(Some(key));
+        let Some(metrics) = controller.metrics_now() else {
+            return;
+        };
+        let caret = caret_window_rect(&text, &style, &metrics, selection.start);
+        responder.bring_into_view(caret, ime_bottom);
     });
 }
 
@@ -445,6 +449,11 @@ fn SelectionHandles(
     if !metrics.focused || !metrics.direct_manipulation {
         return;
     }
+    // Past the gate the handles are on screen and have to travel with the
+    // field, so from here the scope follows its position too.
+    let Some(metrics) = controller.live_metrics() else {
+        return;
+    };
 
     let text = state.text();
 


### PR DESCRIPTION
An unfocused search field in cranpose-showcase recomposed two scopes on every frame of any scroll that carried it — 3000 recompositions over 3000 frames in one headless measurement, both tracing to a single `u64`.

## Cause

`TextFieldHandleController` kept one revision for the whole of `TextFieldHandleMetrics`, and `metrics()` read it before returning the value. That folded two unrelated signals into one subscription: whether the handles are live (`focused`, `direct_manipulation`), and where the field sits (`node_origin`, padding, scroll offset, glyph box). A field moves for reasons that have nothing to do with its handles, so `BringCaretIntoView` and `SelectionHandles` recomposed on every publish and then immediately returned, having found the field unfocused. In the showcase an overscroll bounce settling under the list moved the field's origin by about 2e-4 px a frame, and every one of those was a composition pass.

## Fix

The two signals are separate states now, and the accessor a caller reaches for says what it subscribes to:

| accessor | subscribes to |
|---|---|
| `metrics()` | activation only — `focused`, `direct_manipulation` |
| `live_metrics()` | activation **and** the field's position |
| `metrics_now()` | nothing |

`SelectionHandles` takes the position subscription only past its `focused && direct_manipulation` gate, where the handles are on screen and genuinely have to travel with the field. `BringCaretIntoView` builds its caret rect inside its `SideEffect` from the current metrics instead of capturing one at composition — which is what its documentation already promised ("always recomputed from the live metrics").

## Regression tests

In `crates/cranpose-ui/src/tests/selection_handle_tests.rs`:

- `a_field_that_only_moves_does_not_recompose_its_handle_consumers` — red with the old coupling restored (`left: 4`, `right: 0`).
- `a_live_handle_consumer_still_follows_the_field` — the control, so severing the subscription instead of narrowing it fails too. It earned its place immediately: the first harness used `with_group` rather than a `#[composable]`, created no recompose scope, and made the regression test pass vacuously.

## Scope of the claim

This is a bounded defect, not a runaway. The settle that moves the field finishes normally; the large frame counts above come from a headless loop that free-runs at thousands of frames a second. What this costs on device is two scopes recomposing per frame for the duration of any scroll that carries a text field.

It is also **not** sufficient to make the showcase's `robot-app-screens` pass: measured with this cause ablated, that runner still reports `left: 3259`, tripped by an unrelated defect in the liquid tab bar's lens (published inside a `BoxWithConstraints` subcomposition and read by the enclosing scope), and its "ambient motion" assertion was itself measuring a transition — both are being handled separately.

Ablation behind the fix: a drag that runs the list back to its top edge, measured on Explore, goes from 1927 recompositions to 0.

## Checks

`just fmt`, `just precommit`, `just clippy` and `just test` (190 binaries, exit 0) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)