### PR TITLE
Record what a quiet robot measurement window actually proves

### DIFF
--- a/docs/render_verification.md
+++ b/docs/render_verification.md
@@ -22,6 +22,9 @@
 - Lock GPU tests before changing process-global debug toggles and restore them before releasing `support::gpu_test_lock`.
 - Headless GPU tests must request supported adapter limits. On Huawei, eight default color attachments exceed the GLES adapter's four; match the application's enabled backends when building Android library tests. [Device evidence](huawei_showcase_frame_budget.md).
 - Treat GPU-driver failures as hypotheses until the same binary, adapter and host conditions are checked; a clean-main failure alone proves no cause.
+- A measurement window that rendered no frames proves nothing about settling; an armed animation is not sampled until something draws, so require rendered frames before calling a window quiet.
+- Wait for the composition to go quiet before measuring ambient recomposition; a fixed sleep after an interaction charges that transition's recompositions to the animation under test.
+- `CRANPOSE_DEBUG_SCOPE_LABELS` compiles only under `debug_assertions`, where skip verification re-runs skipped groups and inflates every configuration alike; those counts cannot be compared with the release `fps_stats().recompositions` a robot assertion reads.
 
 ## Pixels and renderer contracts
 


### PR DESCRIPTION
Three lessons from chasing a recomposition that the instruments could not see, added to [render verification](docs/render_verification.md) as one-liners.

**A window that rendered no frames says nothing about whether an animation has settled.** An armed animation is not sampled until something draws. In cranpose-showcase a tab glide sat armed and invisible for ~500 ms — the `Animatable` was armed 3 ms before the first measurement window, the frame clock did not stall across the gap (124,157 frame callbacks over 1015 ms of wall clock, no wall gap over 40 ms), and the composition simply never observed it until something else recomposed. Any settling check has to require rendered frames before it calls a window quiet.

**A fixed sleep after an interaction does not separate a transition from the ambient motion that follows it.** Transitions in the showcase take 1.25–1.75 s; a 700 ms sleep measured them and reported them as ambient animation. That is what made `robot-app-screens` fail in three runs out of four.

**`CRANPOSE_DEBUG_SCOPE_LABELS` compiles only under `debug_assertions`.** It is the instrument for "which scope is recomposing", and in that build the composer's skip verification re-runs skipped groups, so every configuration reports a large count — including an unmodified one. Those numbers cannot be compared with the release counter `fps_stats()` exposes, which is the counter robot assertions actually read. Anyone reaching for the instrument in a release-only investigation needs to know that before they measure, not after.

Docs only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)