### PR TITLE
Add the Glass Tiles demo: neon lens glass on a tilting smoked slab

### DIFF
--- a/apps/desktop-demo/Cargo.toml
+++ b/apps/desktop-demo/Cargo.toml
@@ -309,6 +309,11 @@ path = "robot-runners/robot_feed_touched_shadow.rs"
 required-features = ["robot-app"]
 
 [[example]]
+name = "robot_glass_tiles"
+path = "robot-runners/robot_glass_tiles.rs"
+required-features = ["robot-app"]
+
+[[example]]
 name = "robot_double_click"
 path = "robot-runners/robot_double_click.rs"
 required-features = ["robot-app"]

--- a/apps/desktop-demo/robot-runners/liquid_page.rs
+++ b/apps/desktop-demo/robot-runners/liquid_page.rs
@@ -23,6 +23,7 @@ pub(crate) fn app_hook(name: String, argument: String) -> Result<Option<String>,
             let tab = match argument.as_str() {
                 "liquid" => DemoTab::Liquid,
                 "receipts" => DemoTab::GlassFeed,
+                "tiles" => DemoTab::GlassTiles,
                 other => return Err(format!("unknown tab {other}")),
             };
             TEST_ACTIVE_TAB_STATE
@@ -53,11 +54,12 @@ pub(crate) fn open(robot: &Robot) {
     settle(robot);
 }
 
-/// Opens the receipts feed and waits for it to come to rest.
-pub(crate) fn open_receipts(robot: &Robot) {
+/// Opens a tab by its hook name (`receipts`, `tiles`) and waits for it to
+/// come to rest.
+pub(crate) fn open_tab(robot: &Robot, tab: &str) {
     robot
-        .invoke_app_hook("set-tab", "receipts")
-        .expect("select the receipts tab");
+        .invoke_app_hook("set-tab", tab)
+        .expect("select the tab");
     settle(robot);
 }
 

--- a/apps/desktop-demo/robot-runners/robot_feed_touched_shadow.rs
+++ b/apps/desktop-demo/robot-runners/robot_feed_touched_shadow.rs
@@ -42,7 +42,7 @@ fn main() -> ExitCode {
         .with_test_driver(move |robot| {
             robot_exit::arm_timeout(180);
             std::thread::sleep(Duration::from_millis(700));
-            liquid_page::open_receipts(&robot);
+            liquid_page::open_tab(&robot, "receipts");
 
             let card = find_in_semantics(&robot, |element| find_text_exact(element, CARD))
                 .unwrap_or_else(|| {

--- a/apps/desktop-demo/robot-runners/robot_glass_tiles.rs
+++ b/apps/desktop-demo/robot-runners/robot_glass_tiles.rs
@@ -1,0 +1,149 @@
+mod liquid_page;
+mod robot_exit;
+mod robot_shot;
+
+use std::{path::PathBuf, process::ExitCode, time::Duration};
+
+use cranpose::{AppLauncher, Color, Robot, RobotScreenshot};
+use cranpose_testing::{find_in_semantics, find_text_exact};
+use desktop_app::app::{self, glass_tile_description, GLASS_TILES};
+
+const WINDOW_WIDTH: u32 = 1100;
+const WINDOW_HEIGHT: u32 = 800;
+const SHOT_SCALE: f32 = 2.0;
+/// The tile the runner hovers: top right, the reference's lit one.
+const SUBJECT: usize = 1;
+/// Where a tile's interior is read, in dp from its top-left corner: inside
+/// the glass, clear of the label and of the rim's bloom.
+const SAMPLE_INSET: (f32, f32) = (40.0, 164.0);
+/// Half the side of the patch averaged around the sample point, in dp.
+const SAMPLE_REACH: f32 = 3.0;
+/// How much more of its own colour a hovered tile's interior must carry than
+/// at rest, in 8-bit channel units along the colour's chroma.
+const FLOOD: f32 = 25.0;
+/// How far from rest the interior may sit once the pointer has left the tile:
+/// the stage lights keep drifting behind it.
+const REST_TOLERANCE: f32 = 15.0;
+
+type Bounds = (f32, f32, f32, f32);
+
+fn main() -> ExitCode {
+    let _ = env_logger::try_init();
+    let shot_dir = PathBuf::from(
+        std::env::var("ROBOT_SHOT_DIR").unwrap_or_else(|_| "target/glass-tiles".into()),
+    );
+    std::fs::create_dir_all(&shot_dir).expect("create shot dir");
+    AppLauncher::new()
+        .with_title("Glass Tiles")
+        .with_size(WINDOW_WIDTH, WINDOW_HEIGHT)
+        .with_fonts(desktop_app::fonts::DEMO_FONTS)
+        .with_headless(std::env::var("CRANPOSE_HEADLESS").as_deref() != Ok("0"))
+        .with_robot_app_hook(liquid_page::app_hook)
+        .with_test_driver(move |robot| {
+            robot_exit::arm_timeout(180);
+            std::thread::sleep(Duration::from_millis(700));
+            liquid_page::open_tab(&robot, "tiles");
+
+            let tiles: Vec<Bounds> = GLASS_TILES
+                .iter()
+                .map(|spec| tile_bounds(&robot, &glass_tile_description(spec)))
+                .collect();
+            let subject = tiles[SUBJECT];
+            let colour = GLASS_TILES[SUBJECT].color;
+            let first = tiles[0];
+            let last = tiles[tiles.len() - 1];
+            let slab_centre = (
+                (first.0 + last.0 + last.2) * 0.5,
+                (first.1 + last.1 + last.3) * 0.5,
+            );
+            println!("[tiles] tiles {tiles:?} slab centre {slab_centre:?}");
+
+            let rest = robot
+                .screenshot_with_scale(SHOT_SCALE)
+                .expect("resting screenshot");
+            robot_shot::save(&rest, &shot_dir, "rest.png");
+            let resting = interior(&rest, subject, colour);
+
+            let (cx, cy) = liquid_page::centre(subject);
+            robot.mouse_move(cx, cy).expect("hover the tile");
+            liquid_page::settle(&robot);
+            let hovered_shot = robot
+                .screenshot_with_scale(SHOT_SCALE)
+                .expect("hovered screenshot");
+            robot_shot::save(&hovered_shot, &shot_dir, "hovered.png");
+            let hovered = interior(&hovered_shot, subject, colour);
+
+            robot
+                .mouse_move(slab_centre.0, slab_centre.1)
+                .expect("leave the tile");
+            liquid_page::settle(&robot);
+            let left_shot = robot
+                .screenshot_with_scale(SHOT_SCALE)
+                .expect("left screenshot");
+            robot_shot::save(&left_shot, &shot_dir, "left.png");
+            let left = interior(&left_shot, subject, colour);
+
+            println!("[tiles] interior rest {resting:.1} hovered {hovered:.1} left {left:.1}");
+            if hovered - resting < FLOOD {
+                robot_exit::fail(
+                    &robot,
+                    &format!(
+                        "hovering a tile must flood it with its colour: its interior carried \
+                         {resting:.1} of it at rest and {hovered:.1} under the pointer"
+                    ),
+                );
+            }
+            if (left - resting).abs() > REST_TOLERANCE {
+                robot_exit::fail(
+                    &robot,
+                    &format!(
+                        "a tile must settle back once the pointer leaves it: its interior carried \
+                         {resting:.1} of its colour at rest and {left:.1} afterwards"
+                    ),
+                );
+            }
+            println!(
+                "✓ PASS: every tile is on the page, and hovering one floods it and lets it go"
+            );
+            robot.exit().expect("exit");
+        })
+        .try_run(app::combined_app)
+        .expect("launch glass tiles runner");
+    ExitCode::SUCCESS
+}
+
+fn tile_bounds(robot: &Robot, description: &str) -> Bounds {
+    find_in_semantics(robot, |element| find_text_exact(element, description))
+        .unwrap_or_else(|| robot_exit::fail(robot, &format!("{description} must be on the page")))
+}
+
+/// How much of `colour` the patch around a tile's sample point carries: the
+/// mean projection of each pixel's chroma onto the colour's chroma, so a white
+/// beam crossing behind the glass changes it little and a flood of the tile's
+/// own colour changes it a lot.
+fn interior(shot: &RobotScreenshot, tile: Bounds, colour: Color) -> f32 {
+    let sample = robot_shot::logical_sampler(shot);
+    let (x, y) = (tile.0 + SAMPLE_INSET.0, tile.1 + SAMPLE_INSET.1);
+    let axis = chroma([colour.r() * 255.0, colour.g() * 255.0, colour.b() * 255.0]);
+    let length = axis.iter().map(|c| c * c).sum::<f32>().sqrt().max(1.0);
+    let mut total = 0.0;
+    let mut count = 0.0;
+    let mut dy = -SAMPLE_REACH;
+    while dy <= SAMPLE_REACH {
+        let mut dx = -SAMPLE_REACH;
+        while dx <= SAMPLE_REACH {
+            let (r, g, b) = sample(x + dx, y + dy);
+            let pixel = chroma([f32::from(r), f32::from(g), f32::from(b)]);
+            total += pixel.iter().zip(axis).map(|(p, a)| p * a).sum::<f32>() / length;
+            count += 1.0;
+            dx += 1.0;
+        }
+        dy += 1.0;
+    }
+    total / count
+}
+
+fn chroma(channels: [f32; 3]) -> [f32; 3] {
+    let mean = (channels[0] + channels[1] + channels[2]) / 3.0;
+    channels.map(|channel| channel - mean)
+}

--- a/apps/desktop-demo/src/app.rs
+++ b/apps/desktop-demo/src/app.rs
@@ -24,6 +24,7 @@ use cranpose_ui::{
 mod animations;
 mod controls_ui;
 mod glass_feed;
+mod glass_tiles;
 mod hacker_news;
 mod images;
 mod interactive_anim;
@@ -47,6 +48,10 @@ use animations::AnimationsTab;
 use controls_ui::ControlsUiTab;
 use glass_feed::GlassFeedTab;
 pub use glass_feed::GLASS_FEED_LIST_TAG;
+use glass_tiles::GlassTilesTab;
+pub use glass_tiles::{
+    tile_description as glass_tile_description, TileSpec as GlassTileSpec, TILES as GLASS_TILES,
+};
 pub use hacker_news::HACKER_NEWS_SCROLL_STABILITY_TARGET_TITLE;
 use hacker_news::{HackerNewsScrollStabilityFixtureTab, HackerNewsTab};
 use images::images_tab;
@@ -114,6 +119,7 @@ pub enum DemoTab {
     Controls,
     Liquid,
     GlassFeed,
+    GlassTiles,
     MarkdownViewer,
     FilePicker,
     Rotary,
@@ -133,7 +139,7 @@ pub struct DemoTabInfo {
     pub startup_aliases: &'static [&'static str],
 }
 
-pub const DEMO_TAB_INFO: [DemoTabInfo; 26] = [
+pub const DEMO_TAB_INFO: [DemoTabInfo; 27] = [
     DemoTabInfo {
         tab: DemoTab::Counter,
         label: "Counter App",
@@ -293,6 +299,13 @@ pub const DEMO_TAB_INFO: [DemoTabInfo; 26] = [
         startup_aliases: &["glassfeed", "receipts"],
     },
     DemoTabInfo {
+        tab: DemoTab::GlassTiles,
+        label: "Glass Tiles",
+        slug: "glass-tiles",
+        source_path: "apps/desktop-demo/src/app/glass_tiles.rs",
+        startup_aliases: &["glasstiles", "tiles"],
+    },
+    DemoTabInfo {
         tab: DemoTab::MarkdownViewer,
         label: "Markdown",
         slug: "markdown-viewer",
@@ -359,7 +372,7 @@ impl DemoTab {
     }
 }
 
-pub const DEMO_TABS: [DemoTab; 26] = [
+pub const DEMO_TABS: [DemoTab; 27] = [
     DemoTab::Counter,
     DemoTab::Liquid,
     DemoTab::CompositionLocal,
@@ -386,6 +399,7 @@ pub const DEMO_TABS: [DemoTab; 26] = [
     DemoTab::Rotary,
     DemoTab::Wear,
     DemoTab::GlassFeed,
+    DemoTab::GlassTiles,
 ];
 
 pub fn demo_tab_labels() -> Vec<&'static str> {
@@ -865,6 +879,7 @@ fn tab_requires_scroll(tab: DemoTab) -> bool {
             | DemoTab::MarkdownViewer
             | DemoTab::Liquid
             | DemoTab::GlassFeed
+            | DemoTab::GlassTiles
     )
 }
 
@@ -896,7 +911,8 @@ fn render_active_tab(active: DemoTab, startup: StartupSelection, winamp_tab_stat
         | DemoTab::Controls
         | DemoTab::MarkdownViewer
         | DemoTab::Liquid
-        | DemoTab::GlassFeed => render_showcase_tab(active, startup, winamp_tab_state),
+        | DemoTab::GlassFeed
+        | DemoTab::GlassTiles => render_showcase_tab(active, startup, winamp_tab_state),
     }
 }
 
@@ -918,6 +934,7 @@ fn render_showcase_tab(
         DemoTab::MarkdownViewer => markdown_viewer_tab(),
         DemoTab::Liquid => LiquidUiTab(),
         DemoTab::GlassFeed => GlassFeedTab(),
+        DemoTab::GlassTiles => GlassTilesTab(),
         DemoTab::Counter
         | DemoTab::CompositionLocal
         | DemoTab::Async

--- a/apps/desktop-demo/src/app/glass_tiles.rs
+++ b/apps/desktop-demo/src/app/glass_tiles.rs
@@ -18,7 +18,7 @@ use cranpose_animation::{
 use cranpose_core::State;
 use cranpose_foundation::SemanticsConfiguration;
 use cranpose_ui::{Alignment, HorizontalAlignment, LinearArrangement, PointerEvent};
-use cranpose_ui_graphics::{BlendMode, DrawScope, Rect, Stroke};
+use cranpose_ui_graphics::{BlendMode, DrawScope, Rect, Stroke, TileMode};
 
 const SLAB_WIDTH: f32 = 640.0;
 const SLAB_HEIGHT: f32 = 560.0;
@@ -43,8 +43,19 @@ const SLAB_SWEEP_HALF_WIDTH: f32 = 130.0;
 const TILE_BEAM_HALF_WIDTH: f32 = 22.0;
 const TILE_STREAK_HALF_WIDTH: f32 = 3.5;
 const TILE_BEVEL_INSET: f32 = 8.0;
-const TILE_BLOOM_BANDS: usize = 8;
+const TILE_BLOOM_BANDS: usize = 12;
 const TILE_BLOOM_BAND_DP: f32 = 6.0;
+const STAGE_BOKEH_SCALE: f32 = 1.6;
+const TILE_RAY_HALF_WIDTH: f32 = 16.0;
+const TILE_POOL_RADIUS: f32 = 72.0;
+const TILE_SPILL_REACH: f32 = 0.7;
+
+const TILE_SCATTER: [(f32, f32, f32); 4] = [
+    (-4.0, 3.0, -0.8),
+    (5.0, -3.0, 0.6),
+    (-6.0, 4.0, 0.9),
+    (4.0, 5.0, -0.5),
+];
 const TILE_GLINT_RADIUS: f32 = 22.0;
 const TILE_SMOKE_ALPHA: f32 = 0.5;
 const SLAB_BEVEL_INSET: f32 = 6.0;
@@ -113,7 +124,7 @@ const STAGE_GLOWS: [(Color, f32, f32, f32); 3] = [
 fn slab_glass() -> Glass {
     Glass::clear()
         .shape(LiquidShape::RoundedRect(SLAB_RADIUS))
-        .tint(Color::rgba(0.02, 0.03, 0.06, 0.32))
+        .tint(Color::rgba(0.02, 0.03, 0.06, 0.24))
         .blur_radius(0.0)
         .adaptive_frost(Color::WHITE, 0.0)
         .lift(0.0)
@@ -143,7 +154,7 @@ fn tile_glass(color: Color) -> Glass {
         .saturation(1.3)
         .highlight(0.9)
         .contrast(1.1)
-        .shadow_style(GlassShadow::new(color.with_alpha(0.85), 34.0, 0.0, 4.0))
+        .shadow_style(GlassShadow::new(color.with_alpha(0.6), 34.0, 8.0, 4.0))
 }
 
 /// The semantics description of a tile, which robot runners find it by.
@@ -232,7 +243,7 @@ fn draw_stage(scope: &mut dyn DrawScope, t: f32) {
         );
         scope.draw_circle_blend(
             Brush::radial_gradient(
-                vec![color.with_alpha(0.16), color.with_alpha(0.0)],
+                vec![color.with_alpha(0.22), color.with_alpha(0.0)],
                 center,
                 reach,
             ),
@@ -254,12 +265,12 @@ fn draw_stage(scope: &mut dyn DrawScope, t: f32) {
         );
         scope.draw_circle_blend(
             Brush::radial_gradient(
-                vec![color.with_alpha(0.9), color.with_alpha(0.0)],
+                vec![color.with_alpha(1.0), color.with_alpha(0.0)],
                 center,
-                radius,
+                radius * STAGE_BOKEH_SCALE,
             ),
             center,
-            radius,
+            radius * STAGE_BOKEH_SCALE,
             BlendMode::Plus,
         );
     }
@@ -322,13 +333,25 @@ fn draw_tile_light(
         TILE_BEAM_HALF_WIDTH,
         -0.6,
     );
+    let ray_colour = mix(color, Color::WHITE, 0.25);
+    for (ray, slope) in [0.9, 1.35].into_iter().enumerate() {
+        let cycle = (t * (2.0 + ray as f32) + phase + ray as f32 * 0.45).fract();
+        draw_beam(
+            scope,
+            ray_colour,
+            0.3 * glow,
+            sweep(cycle),
+            TILE_RAY_HALF_WIDTH,
+            slope,
+        );
+    }
     let streak_colour = mix(color, Color::WHITE, 0.7);
-    for (streak, slope) in [0.9, 1.15, 0.7].into_iter().enumerate() {
-        let cycle = (t * (2.0 + streak as f32) + phase + streak as f32 * 0.37).fract();
+    for (streak, slope) in [0.95, 0.75].into_iter().enumerate() {
+        let cycle = (t * (3.0 + streak as f32) + phase + streak as f32 * 0.37).fract();
         draw_beam(
             scope,
             streak_colour,
-            0.9 * glow,
+            0.8 * glow,
             sweep(cycle),
             TILE_STREAK_HALF_WIDTH,
             slope,
@@ -338,7 +361,7 @@ fn draw_tile_light(
         let falloff = 1.0 - band as f32 / TILE_BLOOM_BANDS as f32;
         draw_rim(
             scope,
-            Brush::solid(color.with_alpha(0.22 * falloff * falloff * glow)),
+            Brush::solid(color.with_alpha(0.26 * falloff * falloff * glow)),
             TILE_BLOOM_BAND_DP,
             TILE_BLOOM_BAND_DP * (band as f32 + 0.5),
             TILE_RADIUS,
@@ -384,18 +407,65 @@ fn draw_tile_light(
         TILE_RADIUS,
         BlendMode::Plus,
     );
+    let pool = Point::new(
+        if index.is_multiple_of(2) {
+            0.0
+        } else {
+            size.width
+        },
+        if index < 2 { 0.0 } else { size.height },
+    );
+    scope.draw_circle_blend(
+        Brush::radial_gradient(
+            vec![
+                mix(color, Color::WHITE, 0.35).with_alpha(0.55 * glow),
+                color.with_alpha(0.0),
+            ],
+            pool,
+            TILE_POOL_RADIUS,
+        ),
+        pool,
+        TILE_POOL_RADIUS,
+        BlendMode::Plus,
+    );
     let glint = Point::new(
         size.width - TILE_GLINT_RADIUS - 8.0,
         TILE_GLINT_RADIUS + 8.0,
     );
     scope.draw_circle_blend(
         Brush::radial_gradient(
-            vec![Color::WHITE.with_alpha(glow), Color::WHITE.with_alpha(0.0)],
+            vec![
+                Color::WHITE.with_alpha(0.6 * glow),
+                Color::WHITE.with_alpha(0.0),
+            ],
             glint,
             TILE_GLINT_RADIUS,
         ),
         glint,
         TILE_GLINT_RADIUS,
+        BlendMode::Plus,
+    );
+}
+
+fn draw_tile_spill(scope: &mut dyn DrawScope, color: Color, hover: f32) {
+    let size = scope.size();
+    let centre = Point::new(size.width * 0.5, size.height + 12.0);
+    let reach = size.width * TILE_SPILL_REACH;
+    let alpha = 0.14 + 0.36 * hover;
+    scope.draw_circle_blend(
+        Brush::radial_gradient_stops(
+            vec![
+                (0.0, color.with_alpha(alpha)),
+                (0.3, color.with_alpha(alpha * 0.45)),
+                (0.65, color.with_alpha(alpha * 0.12)),
+                (1.0, color.with_alpha(0.0)),
+            ],
+            centre,
+            reach,
+            TileMode::Clamp,
+        ),
+        centre,
+        reach,
         BlendMode::Plus,
     );
 }
@@ -427,15 +497,23 @@ fn breath(t: f32, index: usize) -> f32 {
     0.5 + 0.5 * (t * TAU * BREATHE_CYCLES + index as f32 * 0.25 * TAU).sin()
 }
 
-fn tile_layer(hover: f32, press: f32, rotation_x: f32, rotation_y: f32) -> GraphicsLayer {
+fn tile_layer(
+    index: usize,
+    hover: f32,
+    press: f32,
+    rotation_x: f32,
+    rotation_y: f32,
+) -> GraphicsLayer {
     let scale = 1.0 + 0.05 * hover - 0.03 * press;
+    let (scatter_x, scatter_y, scatter_degrees) = TILE_SCATTER[index];
     GraphicsLayer {
         scale_x: scale,
         scale_y: scale,
         rotation_x: -rotation_x * TILE_PARALLAX,
         rotation_y: -rotation_y * TILE_PARALLAX,
-        translation_x: rotation_y * TILE_SHIFT_DP_PER_DEGREE,
-        translation_y: -rotation_x * TILE_SHIFT_DP_PER_DEGREE,
+        rotation_z: scatter_degrees,
+        translation_x: scatter_x + rotation_y * TILE_SHIFT_DP_PER_DEGREE,
+        translation_y: scatter_y - rotation_x * TILE_SHIFT_DP_PER_DEGREE,
         camera_distance: CAMERA_DISTANCE,
         ..Default::default()
     }
@@ -551,7 +629,7 @@ fn Slab(
         } else {
             -PRESS_TILT_DEGREES
         };
-        target_y += if index % 2 == 0 {
+        target_y += if index.is_multiple_of(2) {
             -PRESS_TILT_DEGREES
         } else {
             PRESS_TILT_DEGREES
@@ -664,8 +742,15 @@ fn Tile(
             .semantics(move |config: &mut SemanticsConfiguration| {
                 config.content_description = Some(description.clone());
             })
+            .draw_behind(move |scope| draw_tile_spill(scope, color, hover.get()))
             .graphics_layer(move || {
-                tile_layer(hover.get(), press.get(), rotation_x.get(), rotation_y.get())
+                tile_layer(
+                    index,
+                    hover.get(),
+                    press.get(),
+                    rotation_x.get(),
+                    rotation_y.get(),
+                )
             })
             .pointer_input(index, move |scope| {
                 let touch = touch.clone();
@@ -713,10 +798,10 @@ fn TileLabel(spec: &'static TileSpec) {
         Modifier::empty(),
         ColumnSpec::default().horizontal_alignment(HorizontalAlignment::CenterHorizontally),
         move || {
-            Text(spec.from, Modifier::empty(), label_style(26.0, Some(600)));
+            Text(spec.from, Modifier::empty(), label_style(22.0, Some(600)));
             Row(Modifier::empty(), RowSpec::default(), move || {
-                Text("→ ", Modifier::empty(), label_style(26.0, None));
-                Text(spec.to, Modifier::empty(), label_style(26.0, Some(600)));
+                Text("→ ", Modifier::empty(), label_style(22.0, None));
+                Text(spec.to, Modifier::empty(), label_style(22.0, Some(600)));
             });
         },
     );

--- a/apps/desktop-demo/src/app/glass_tiles.rs
+++ b/apps/desktop-demo/src/app/glass_tiles.rs
@@ -1,0 +1,616 @@
+#![allow(non_snake_case)]
+
+use std::{cell::Cell, rc::Rc};
+
+use cranpose::{
+    composable,
+    liquid::prelude::*,
+    mutableStateOf, remember,
+    text::{FontWeight, SpanStyle, TextStyle, TextUnit},
+    widgets::{Box, BoxSpec, Column, ColumnSpec, Row, RowSpec, Text},
+    Brush, Color, CornerRadii, GraphicsLayer, Modifier, MutableState, Point, PointerEventKind,
+    Size,
+};
+use cranpose_animation::{
+    animateFloatAsState, infiniteRepeatable, rememberInfiniteTransition, AnimationSpec, RepeatMode,
+    StartOffset,
+};
+use cranpose_core::State;
+use cranpose_foundation::SemanticsConfiguration;
+use cranpose_ui::{Alignment, HorizontalAlignment, LinearArrangement, PointerEvent};
+use cranpose_ui_graphics::{BlendMode, DrawScope, Rect, Stroke};
+
+const SLAB_WIDTH: f32 = 640.0;
+const SLAB_HEIGHT: f32 = 560.0;
+const SLAB_RADIUS: f32 = 36.0;
+const TILE_WIDTH: f32 = 236.0;
+const TILE_HEIGHT: f32 = 204.0;
+const TILE_RADIUS: f32 = 24.0;
+const TILE_GAP: f32 = 30.0;
+const CAMERA_DISTANCE: f32 = 12.0;
+const TILT_DEGREES: f32 = 13.0;
+const PRESS_TILT_DEGREES: f32 = 4.0;
+const SWAY_DEGREES: f32 = 3.0;
+const TILE_PARALLAX: f32 = 0.35;
+const TILE_SHIFT_DP_PER_DEGREE: f32 = 0.9;
+const CLOCK_PERIOD_MS: u64 = 48_000;
+const SWAY_CYCLES: f32 = 9.0;
+const BREATHE_CYCLES: f32 = 16.0;
+const SWEEP_CYCLES: f32 = 7.0;
+const STAGE_GRID_DP: f32 = 56.0;
+const STAGE_BEAM_HALF_WIDTH: f32 = 70.0;
+const TILE_BEAM_HALF_WIDTH: f32 = 22.0;
+const TAU: f32 = std::f32::consts::TAU;
+
+/// One tile: a language pair and the colour of its glass.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TileSpec {
+    /// The source language code.
+    pub from: &'static str,
+    /// The target language code.
+    pub to: &'static str,
+    /// The tile's glass colour.
+    pub color: Color,
+}
+
+/// The four tiles, top-left to bottom-right.
+pub const TILES: [TileSpec; 4] = [
+    TileSpec {
+        from: "EN",
+        to: "UA",
+        color: Color::from_rgb_u8(64, 186, 255),
+    },
+    TileSpec {
+        from: "UA",
+        to: "EN",
+        color: Color::from_rgb_u8(92, 255, 118),
+    },
+    TileSpec {
+        from: "EN",
+        to: "RU",
+        color: Color::from_rgb_u8(255, 138, 48),
+    },
+    TileSpec {
+        from: "RU",
+        to: "EN",
+        color: Color::from_rgb_u8(232, 78, 255),
+    },
+];
+
+const STAGE_BEAMS: [(Color, f32, f32, f32); 6] = [
+    (Color::from_rgb_u8(255, 70, 110), 3.0, 0.05, 0.9),
+    (Color::from_rgb_u8(60, 130, 255), 5.0, 0.4, -0.7),
+    (Color::from_rgb_u8(40, 230, 210), 4.0, 0.7, 1.4),
+    (Color::from_rgb_u8(255, 180, 60), 6.0, 0.2, -1.1),
+    (Color::from_rgb_u8(190, 90, 255), 2.0, 0.55, 0.5),
+    (Color::from_rgb_u8(220, 235, 255), 7.0, 0.85, -0.4),
+];
+
+const STAGE_GLOWS: [(Color, f32, f32, f32); 3] = [
+    (Color::from_rgb_u8(255, 60, 120), 1.0, 0.0, 1.9),
+    (Color::from_rgb_u8(50, 110, 255), 1.0, 2.1, 0.4),
+    (Color::from_rgb_u8(255, 160, 50), 2.0, 4.0, 3.1),
+];
+
+fn slab_glass() -> Glass {
+    Glass::clear()
+        .shape(LiquidShape::RoundedRect(SLAB_RADIUS))
+        .tint(Color::rgba(0.02, 0.03, 0.06, 0.32))
+        .blur_radius(0.0)
+        .adaptive_frost(Color::WHITE, 0.0)
+        .lift(0.0)
+        .refraction_depth(0.2)
+        .refraction_curve(0.6)
+        .dispersion(0.3)
+        .transmission_refraction(1.0)
+        .highlight(1.3)
+        .shadow_style(GlassShadow::new(
+            Color::BLACK.with_alpha(0.7),
+            50.0,
+            26.0,
+            0.0,
+        ))
+}
+
+fn tile_glass(color: Color) -> Glass {
+    Glass::lens()
+        .shape(LiquidShape::RoundedRect(TILE_RADIUS))
+        .tint(color.with_alpha(0.11))
+        .ink_recolor(color, 0.28)
+        .lift(0.0)
+        .refraction_depth(0.4)
+        .refraction_curve(0.8)
+        .dispersion(0.55)
+        .transmission_refraction(1.0)
+        .saturation(1.5)
+        .highlight(1.35)
+        .contrast(1.1)
+        .shadow_style(GlassShadow::new(color.with_alpha(0.85), 34.0, 0.0, 4.0))
+}
+
+/// The semantics description of a tile, which robot runners find it by.
+pub fn tile_description(spec: &TileSpec) -> String {
+    format!("Glass tile {} → {}", spec.from, spec.to)
+}
+
+fn label_style(size_sp: f32, weight: Option<u16>) -> TextStyle {
+    TextStyle {
+        span_style: SpanStyle {
+            color: Some(Color::WHITE),
+            font_size: TextUnit::Sp(size_sp),
+            font_weight: weight.map(FontWeight::new),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn mix(color: Color, toward: Color, amount: f32) -> Color {
+    Color::rgba(
+        color.r() + (toward.r() - color.r()) * amount,
+        color.g() + (toward.g() - color.g()) * amount,
+        color.b() + (toward.b() - color.b()) * amount,
+        color.a(),
+    )
+}
+
+fn draw_beam(
+    scope: &mut dyn DrawScope,
+    color: Color,
+    alpha: f32,
+    x: f32,
+    half_width: f32,
+    slope: f32,
+    reach: f32,
+) {
+    let clear = color.with_alpha(0.0);
+    scope.draw_rect_blend(
+        Brush::linear_gradient_range(
+            vec![clear, color.with_alpha(alpha), clear],
+            Point::new(x - half_width, 0.0),
+            Point::new(x + half_width, reach * slope),
+        ),
+        BlendMode::Plus,
+    );
+}
+
+fn draw_stage(scope: &mut dyn DrawScope, t: f32) {
+    let size = scope.size();
+    scope.draw_rect(Brush::solid(Color::from_rgb_u8(6, 7, 11)));
+    let line = Brush::solid(Color::WHITE.with_alpha(0.035));
+    let mut x = STAGE_GRID_DP;
+    while x < size.width {
+        scope.draw_rect_at(
+            Rect {
+                x,
+                y: 0.0,
+                width: 1.0,
+                height: size.height,
+            },
+            line.clone(),
+        );
+        x += STAGE_GRID_DP;
+    }
+    let mut y = STAGE_GRID_DP;
+    while y < size.height {
+        scope.draw_rect_at(
+            Rect {
+                x: 0.0,
+                y,
+                width: size.width,
+                height: 1.0,
+            },
+            line.clone(),
+        );
+        y += STAGE_GRID_DP;
+    }
+    let reach = size.width.max(size.height) * 0.42;
+    for (color, cycles, phase_x, phase_y) in STAGE_GLOWS {
+        let angle = t * TAU * cycles;
+        let center = Point::new(
+            size.width * (0.5 + 0.42 * (angle + phase_x).sin()),
+            size.height * (0.5 + 0.42 * (angle * 0.8 + phase_y).cos()),
+        );
+        scope.draw_circle_blend(
+            Brush::radial_gradient(
+                vec![color.with_alpha(0.28), color.with_alpha(0.0)],
+                center,
+                reach,
+            ),
+            center,
+            reach,
+            BlendMode::Plus,
+        );
+    }
+    for (color, cycles, phase, slope) in STAGE_BEAMS {
+        let cycle = (t * cycles + phase).fract();
+        let x = -size.width * 0.6 + size.width * 2.2 * cycle;
+        draw_beam(
+            scope,
+            color,
+            0.3,
+            x,
+            STAGE_BEAM_HALF_WIDTH,
+            slope,
+            size.height * 0.5,
+        );
+    }
+}
+
+fn draw_slab_light(scope: &mut dyn DrawScope, t: f32) {
+    let size = scope.size();
+    let cycle = (t * SWEEP_CYCLES).fract();
+    let x = -size.width * 0.5 + size.width * 2.0 * cycle;
+    draw_beam(scope, Color::WHITE, 0.07, x, 130.0, 0.6, size.height);
+    let radii = CornerRadii::uniform(SLAB_RADIUS);
+    scope.draw_round_rect_stroked_blend(
+        Brush::solid(Color::WHITE.with_alpha(0.05)),
+        radii,
+        Stroke::new(16.0),
+        BlendMode::Plus,
+    );
+    scope.draw_round_rect_stroked(
+        Brush::solid(Color::WHITE.with_alpha(0.5)),
+        radii,
+        Stroke::new(1.5),
+    );
+}
+
+fn draw_tile_light(
+    scope: &mut dyn DrawScope,
+    color: Color,
+    glow: f32,
+    flood: f32,
+    t: f32,
+    index: usize,
+) {
+    let size = scope.size();
+    scope.draw_rect_blend(
+        Brush::solid(color.with_alpha(0.32 * flood)),
+        BlendMode::Plus,
+    );
+    for beam in 0..2 {
+        let cycles = 3.0 + beam as f32;
+        let cycle = (t * cycles + index as f32 * 0.31 + beam as f32 * 0.5).fract();
+        let x = -size.width * 0.4 + size.width * 1.8 * cycle;
+        draw_beam(
+            scope,
+            color,
+            0.4 * glow,
+            x,
+            TILE_BEAM_HALF_WIDTH,
+            if beam == 0 { 0.8 } else { -0.6 },
+            size.height,
+        );
+    }
+    for (width, alpha) in [(44.0, 0.14), (16.0, 0.3), (5.0, 0.7)] {
+        draw_inset_rim(
+            scope,
+            color.with_alpha(alpha * glow),
+            width,
+            BlendMode::Plus,
+        );
+    }
+    draw_inset_rim(
+        scope,
+        mix(color, Color::WHITE, 0.55).with_alpha(0.5 + 0.5 * glow),
+        1.5,
+        BlendMode::SrcOver,
+    );
+}
+
+fn draw_inset_rim(scope: &mut dyn DrawScope, color: Color, width: f32, blend_mode: BlendMode) {
+    let size = scope.size();
+    let inset = width * 0.5;
+    scope.draw_round_rect_at_stroked_blend(
+        Rect {
+            x: inset,
+            y: inset,
+            width: size.width - width,
+            height: size.height - width,
+        },
+        Brush::solid(color),
+        CornerRadii::uniform((TILE_RADIUS - inset).max(1.0)),
+        Stroke::new(width),
+        blend_mode,
+    );
+}
+
+fn breath(t: f32, index: usize) -> f32 {
+    0.5 + 0.5 * (t * TAU * BREATHE_CYCLES + index as f32 * 0.25 * TAU).sin()
+}
+
+fn tile_layer(hover: f32, press: f32, rotation_x: f32, rotation_y: f32) -> GraphicsLayer {
+    let scale = 1.0 + 0.05 * hover - 0.03 * press;
+    GraphicsLayer {
+        scale_x: scale,
+        scale_y: scale,
+        rotation_x: -rotation_x * TILE_PARALLAX,
+        rotation_y: -rotation_y * TILE_PARALLAX,
+        translation_x: rotation_y * TILE_SHIFT_DP_PER_DEGREE,
+        translation_y: -rotation_x * TILE_SHIFT_DP_PER_DEGREE,
+        camera_distance: CAMERA_DISTANCE,
+        ..Default::default()
+    }
+}
+
+fn tile_dynamics(hover: f32, glow: f32, press: f32, finger: (f32, f32)) -> GlassDynamics {
+    GlassDynamics {
+        highlight_boost: 0.6 * hover + 0.15 * glow,
+        saturation_boost: 0.5 * hover + 0.1 * glow,
+        tint_alpha_multiplier: Some(1.0 + 3.2 * hover + 0.25 * glow),
+        ..Default::default()
+    }
+    .touched_up(press, Some(finger), (TILE_WIDTH * 0.5, TILE_HEIGHT * 0.5))
+}
+
+#[derive(Clone)]
+struct TileTouch {
+    index: usize,
+    hovered: MutableState<bool>,
+    pressed: MutableState<bool>,
+    finger: Rc<Cell<(f32, f32)>>,
+    pressed_tile: MutableState<Option<usize>>,
+}
+
+impl TileTouch {
+    fn on_event(&self, event: &PointerEvent) {
+        match event.kind {
+            PointerEventKind::Enter => self.hovered.set(true),
+            PointerEventKind::Exit => {
+                self.hovered.set(false);
+                self.release();
+            }
+            PointerEventKind::Move => self.finger.set((event.position.x, event.position.y)),
+            PointerEventKind::Down => {
+                self.finger.set((event.position.x, event.position.y));
+                self.pressed.set(true);
+                self.pressed_tile.set(Some(self.index));
+            }
+            PointerEventKind::Up | PointerEventKind::Cancel => self.release(),
+            _ => {}
+        }
+    }
+
+    fn release(&self) {
+        self.pressed.set(false);
+        self.pressed_tile.set(None);
+    }
+}
+
+#[composable]
+pub fn GlassTilesTab() {
+    let clock = rememberInfiniteTransition("glass_tiles_clock").animateFloat(
+        0.0,
+        1.0,
+        infiniteRepeatable(
+            AnimationSpec::linear(CLOCK_PERIOD_MS),
+            RepeatMode::Restart,
+            StartOffset::default(),
+        ),
+        "glass_tiles_time",
+    );
+    let pointer = remember(|| mutableStateOf(None::<(f32, f32)>)).with(|state| *state);
+    let pressed_tile = remember(|| mutableStateOf(None::<usize>)).with(|state| *state);
+    Box(
+        Modifier::empty()
+            .fill_max_size()
+            .draw_behind(move |scope| draw_stage(scope, clock.get()))
+            .pointer_input((), move |scope| async move {
+                scope
+                    .await_pointer_event_scope(|events| async move {
+                        loop {
+                            let event = events.await_pointer_event().await;
+                            match event.kind {
+                                PointerEventKind::Exit => pointer.set(None),
+                                PointerEventKind::Enter
+                                | PointerEventKind::Move
+                                | PointerEventKind::Down
+                                | PointerEventKind::Up => {
+                                    let size = events.size();
+                                    pointer.set(Some((
+                                        event.position.x / size.width.max(1.0),
+                                        event.position.y / size.height.max(1.0),
+                                    )));
+                                }
+                                _ => {}
+                            }
+                        }
+                    })
+                    .await
+            }),
+        BoxSpec::default().content_alignment(Alignment::CENTER),
+        move || Slab(clock, pointer, pressed_tile),
+    );
+}
+
+#[composable]
+fn Slab(
+    clock: State<f32>,
+    pointer: MutableState<Option<(f32, f32)>>,
+    pressed_tile: MutableState<Option<usize>>,
+) {
+    let (mut target_x, mut target_y, presence_target) = match pointer.get() {
+        Some((fx, fy)) => (
+            -(fy * 2.0 - 1.0) * TILT_DEGREES,
+            (fx * 2.0 - 1.0) * TILT_DEGREES,
+            1.0,
+        ),
+        None => (0.0, 0.0, 0.0),
+    };
+    if let Some(index) = pressed_tile.get() {
+        target_x += if index < 2 {
+            PRESS_TILT_DEGREES
+        } else {
+            -PRESS_TILT_DEGREES
+        };
+        target_y += if index % 2 == 0 {
+            -PRESS_TILT_DEGREES
+        } else {
+            PRESS_TILT_DEGREES
+        };
+    }
+    let rotation_x = animateFloatAsState(target_x, LiquidMotion::smooth(), "slab_rotation_x");
+    let rotation_y = animateFloatAsState(target_y, LiquidMotion::smooth(), "slab_rotation_y");
+    let presence = animateFloatAsState(presence_target, LiquidMotion::smooth(), "slab_presence");
+    Box(
+        Modifier::empty()
+            .size(Size::new(SLAB_WIDTH, SLAB_HEIGHT))
+            .graphics_layer(move || {
+                let t = clock.get();
+                let sway = 1.0 - presence.get();
+                let scale = 1.0 + 0.02 * presence.get();
+                GraphicsLayer {
+                    rotation_x: rotation_x.get()
+                        + sway * SWAY_DEGREES * (t * TAU * SWAY_CYCLES).sin(),
+                    rotation_y: rotation_y.get()
+                        + sway * SWAY_DEGREES * 1.3 * (t * TAU * SWAY_CYCLES * 0.7 + 1.0).cos(),
+                    camera_distance: CAMERA_DISTANCE,
+                    scale_x: scale,
+                    scale_y: scale,
+                    ..Default::default()
+                }
+            }),
+        BoxSpec::default(),
+        move || {
+            Box(
+                Modifier::empty()
+                    .fill_max_size()
+                    .glass_effect_with(slab_glass(), GlassDynamics::default)
+                    .draw_with_content(move |scope| {
+                        scope.draw_content();
+                        draw_slab_light(scope, clock.get());
+                    }),
+                BoxSpec::default().content_alignment(Alignment::CENTER),
+                move || SlabGrid(clock, rotation_x, rotation_y, pressed_tile),
+            );
+        },
+    );
+}
+
+#[composable]
+fn SlabGrid(
+    clock: State<f32>,
+    rotation_x: State<f32>,
+    rotation_y: State<f32>,
+    pressed_tile: MutableState<Option<usize>>,
+) {
+    Column(
+        Modifier::empty(),
+        ColumnSpec::default().vertical_arrangement(LinearArrangement::SpacedBy(TILE_GAP)),
+        move || {
+            Row(
+                Modifier::empty(),
+                RowSpec::default().horizontal_arrangement(LinearArrangement::SpacedBy(TILE_GAP)),
+                move || {
+                    Tile(0, clock, rotation_x, rotation_y, pressed_tile);
+                    Tile(1, clock, rotation_x, rotation_y, pressed_tile);
+                },
+            );
+            Row(
+                Modifier::empty(),
+                RowSpec::default().horizontal_arrangement(LinearArrangement::SpacedBy(TILE_GAP)),
+                move || {
+                    Tile(2, clock, rotation_x, rotation_y, pressed_tile);
+                    Tile(3, clock, rotation_x, rotation_y, pressed_tile);
+                },
+            );
+        },
+    );
+}
+
+#[composable]
+fn Tile(
+    index: usize,
+    clock: State<f32>,
+    rotation_x: State<f32>,
+    rotation_y: State<f32>,
+    pressed_tile: MutableState<Option<usize>>,
+) {
+    let spec = &TILES[index];
+    let color = spec.color;
+    let hovered = remember(|| mutableStateOf(false)).with(|state| *state);
+    let pressed = remember(|| mutableStateOf(false)).with(|state| *state);
+    let finger =
+        remember(|| Rc::new(Cell::new((TILE_WIDTH * 0.5, TILE_HEIGHT * 0.5)))).with(Rc::clone);
+    let hover = animateFloatAsState(
+        if hovered.get() { 1.0 } else { 0.0 },
+        LiquidMotion::smooth(),
+        "tile_hover",
+    );
+    let press = animateFloatAsState(
+        if pressed.get() { 1.0 } else { 0.0 },
+        LiquidMotion::snappy(),
+        "tile_press",
+    );
+    let touch = TileTouch {
+        index,
+        hovered,
+        pressed,
+        finger: Rc::clone(&finger),
+        pressed_tile,
+    };
+    let description = tile_description(spec);
+    Box(
+        Modifier::empty()
+            .size(Size::new(TILE_WIDTH, TILE_HEIGHT))
+            .semantics(move |config: &mut SemanticsConfiguration| {
+                config.content_description = Some(description.clone());
+            })
+            .graphics_layer(move || {
+                tile_layer(hover.get(), press.get(), rotation_x.get(), rotation_y.get())
+            })
+            .pointer_input(index, move |scope| {
+                let touch = touch.clone();
+                async move {
+                    scope
+                        .await_pointer_event_scope(|events| async move {
+                            loop {
+                                touch.on_event(&events.await_pointer_event().await);
+                            }
+                        })
+                        .await
+                }
+            }),
+        BoxSpec::default(),
+        move || {
+            let finger = Rc::clone(&finger);
+            Box(
+                Modifier::empty()
+                    .fill_max_size()
+                    .glass_effect_with(tile_glass(color), move || {
+                        tile_dynamics(
+                            hover.get(),
+                            breath(clock.get(), index),
+                            press.get(),
+                            finger.get(),
+                        )
+                    })
+                    .draw_with_content(move |scope| {
+                        let t = clock.get();
+                        let flood = hover.get();
+                        let glow = 0.5 + 0.5 * flood + 0.12 * breath(t, index);
+                        draw_tile_light(scope, color, glow, flood, t, index);
+                        scope.draw_content();
+                    }),
+                BoxSpec::default().content_alignment(Alignment::CENTER),
+                move || TileLabel(spec),
+            );
+        },
+    );
+}
+
+#[composable]
+fn TileLabel(spec: &'static TileSpec) {
+    Column(
+        Modifier::empty(),
+        ColumnSpec::default().horizontal_alignment(HorizontalAlignment::CenterHorizontally),
+        move || {
+            Text(spec.from, Modifier::empty(), label_style(26.0, Some(600)));
+            Row(Modifier::empty(), RowSpec::default(), move || {
+                Text("→ ", Modifier::empty(), label_style(26.0, None));
+                Text(spec.to, Modifier::empty(), label_style(26.0, Some(600)));
+            });
+        },
+    );
+}

--- a/apps/desktop-demo/src/app/glass_tiles.rs
+++ b/apps/desktop-demo/src/app/glass_tiles.rs
@@ -38,8 +38,16 @@ const SWAY_CYCLES: f32 = 9.0;
 const BREATHE_CYCLES: f32 = 16.0;
 const SWEEP_CYCLES: f32 = 7.0;
 const STAGE_GRID_DP: f32 = 56.0;
-const STAGE_BEAM_HALF_WIDTH: f32 = 70.0;
+const STAGE_BEAM_HALF_WIDTH: f32 = 90.0;
+const SLAB_SWEEP_HALF_WIDTH: f32 = 130.0;
 const TILE_BEAM_HALF_WIDTH: f32 = 22.0;
+const TILE_STREAK_HALF_WIDTH: f32 = 3.5;
+const TILE_BEVEL_INSET: f32 = 8.0;
+const TILE_BLOOM_BANDS: usize = 8;
+const TILE_BLOOM_BAND_DP: f32 = 6.0;
+const TILE_GLINT_RADIUS: f32 = 22.0;
+const TILE_SMOKE_ALPHA: f32 = 0.5;
+const SLAB_BEVEL_INSET: f32 = 6.0;
 const TAU: f32 = std::f32::consts::TAU;
 
 /// One tile: a language pair and the colour of its glass.
@@ -56,23 +64,23 @@ pub struct TileSpec {
 /// The four tiles, top-left to bottom-right.
 pub const TILES: [TileSpec; 4] = [
     TileSpec {
-        from: "EN",
-        to: "UA",
+        from: "AU",
+        to: "FR",
         color: Color::from_rgb_u8(64, 186, 255),
     },
     TileSpec {
-        from: "UA",
-        to: "EN",
+        from: "FR",
+        to: "AU",
         color: Color::from_rgb_u8(92, 255, 118),
     },
     TileSpec {
-        from: "EN",
-        to: "RU",
+        from: "AU",
+        to: "DE",
         color: Color::from_rgb_u8(255, 138, 48),
     },
     TileSpec {
-        from: "RU",
-        to: "EN",
+        from: "DE",
+        to: "AU",
         color: Color::from_rgb_u8(232, 78, 255),
     },
 ];
@@ -84,6 +92,16 @@ const STAGE_BEAMS: [(Color, f32, f32, f32); 6] = [
     (Color::from_rgb_u8(255, 180, 60), 6.0, 0.2, -1.1),
     (Color::from_rgb_u8(190, 90, 255), 2.0, 0.55, 0.5),
     (Color::from_rgb_u8(220, 235, 255), 7.0, 0.85, -0.4),
+];
+
+const STAGE_BOKEH: [(Color, f32, f32, f32, f32); 7] = [
+    (Color::from_rgb_u8(255, 90, 140), 1.0, 0.1, 0.2, 26.0),
+    (Color::from_rgb_u8(80, 150, 255), 1.0, 0.8, 0.5, 34.0),
+    (Color::from_rgb_u8(255, 200, 90), 2.0, 0.35, 0.85, 20.0),
+    (Color::from_rgb_u8(120, 255, 200), 1.0, 0.6, 0.15, 24.0),
+    (Color::from_rgb_u8(255, 120, 60), 2.0, 0.9, 0.7, 30.0),
+    (Color::from_rgb_u8(200, 120, 255), 1.0, 0.25, 0.6, 22.0),
+    (Color::from_rgb_u8(255, 255, 255), 3.0, 0.5, 0.35, 14.0),
 ];
 
 const STAGE_GLOWS: [(Color, f32, f32, f32); 3] = [
@@ -115,15 +133,15 @@ fn slab_glass() -> Glass {
 fn tile_glass(color: Color) -> Glass {
     Glass::lens()
         .shape(LiquidShape::RoundedRect(TILE_RADIUS))
-        .tint(color.with_alpha(0.11))
-        .ink_recolor(color, 0.28)
+        .tint(color.with_alpha(0.05))
+        .ink_recolor(color, 0.12)
         .lift(0.0)
-        .refraction_depth(0.4)
-        .refraction_curve(0.8)
+        .refraction_depth(0.9)
+        .refraction_curve(0.5)
         .dispersion(0.55)
         .transmission_refraction(1.0)
-        .saturation(1.5)
-        .highlight(1.35)
+        .saturation(1.3)
+        .highlight(0.9)
         .contrast(1.1)
         .shadow_style(GlassShadow::new(color.with_alpha(0.85), 34.0, 0.0, 4.0))
 }
@@ -159,16 +177,17 @@ fn draw_beam(
     color: Color,
     alpha: f32,
     x: f32,
-    half_width: f32,
+    half_thickness: f32,
     slope: f32,
-    reach: f32,
 ) {
+    let length = (1.0 + slope * slope).sqrt();
+    let normal = Point::new(-slope / length * half_thickness, half_thickness / length);
     let clear = color.with_alpha(0.0);
     scope.draw_rect_blend(
         Brush::linear_gradient_range(
             vec![clear, color.with_alpha(alpha), clear],
-            Point::new(x - half_width, 0.0),
-            Point::new(x + half_width, reach * slope),
+            Point::new(x - normal.x, -normal.y),
+            Point::new(x + normal.x, normal.y),
         ),
         BlendMode::Plus,
     );
@@ -213,7 +232,7 @@ fn draw_stage(scope: &mut dyn DrawScope, t: f32) {
         );
         scope.draw_circle_blend(
             Brush::radial_gradient(
-                vec![color.with_alpha(0.28), color.with_alpha(0.0)],
+                vec![color.with_alpha(0.16), color.with_alpha(0.0)],
                 center,
                 reach,
             ),
@@ -224,15 +243,24 @@ fn draw_stage(scope: &mut dyn DrawScope, t: f32) {
     }
     for (color, cycles, phase, slope) in STAGE_BEAMS {
         let cycle = (t * cycles + phase).fract();
-        let x = -size.width * 0.6 + size.width * 2.2 * cycle;
-        draw_beam(
-            scope,
-            color,
-            0.3,
-            x,
-            STAGE_BEAM_HALF_WIDTH,
-            slope,
-            size.height * 0.5,
+        let x = -size.width * 0.8 + size.width * 2.6 * cycle;
+        draw_beam(scope, color, 0.2, x, STAGE_BEAM_HALF_WIDTH, slope);
+    }
+    for (color, cycles, phase_x, phase_y, radius) in STAGE_BOKEH {
+        let angle = t * TAU * cycles;
+        let center = Point::new(
+            size.width * (phase_x + 0.06 * angle.sin()),
+            size.height * (phase_y + 0.05 * (angle * 1.3).cos()),
+        );
+        scope.draw_circle_blend(
+            Brush::radial_gradient(
+                vec![color.with_alpha(0.9), color.with_alpha(0.0)],
+                center,
+                radius,
+            ),
+            center,
+            radius,
+            BlendMode::Plus,
         );
     }
 }
@@ -240,8 +268,8 @@ fn draw_stage(scope: &mut dyn DrawScope, t: f32) {
 fn draw_slab_light(scope: &mut dyn DrawScope, t: f32) {
     let size = scope.size();
     let cycle = (t * SWEEP_CYCLES).fract();
-    let x = -size.width * 0.5 + size.width * 2.0 * cycle;
-    draw_beam(scope, Color::WHITE, 0.07, x, 130.0, 0.6, size.height);
+    let x = -size.width * 0.6 + size.width * 2.2 * cycle;
+    draw_beam(scope, Color::WHITE, 0.07, x, SLAB_SWEEP_HALF_WIDTH, 0.6);
     let radii = CornerRadii::uniform(SLAB_RADIUS);
     scope.draw_round_rect_stroked_blend(
         Brush::solid(Color::WHITE.with_alpha(0.05)),
@@ -249,8 +277,20 @@ fn draw_slab_light(scope: &mut dyn DrawScope, t: f32) {
         Stroke::new(16.0),
         BlendMode::Plus,
     );
+    draw_rim(
+        scope,
+        Brush::solid(Color::WHITE.with_alpha(0.12)),
+        1.0,
+        SLAB_BEVEL_INSET,
+        SLAB_RADIUS,
+        BlendMode::SrcOver,
+    );
     scope.draw_round_rect_stroked(
-        Brush::solid(Color::WHITE.with_alpha(0.5)),
+        Brush::vertical_gradient(
+            vec![Color::WHITE.with_alpha(0.85), Color::WHITE.with_alpha(0.25)],
+            0.0,
+            size.height,
+        ),
         radii,
         Stroke::new(1.5),
     );
@@ -265,52 +305,119 @@ fn draw_tile_light(
     index: usize,
 ) {
     let size = scope.size();
+    scope.draw_rect(Brush::solid(
+        Color::BLACK.with_alpha(TILE_SMOKE_ALPHA * (1.0 - 0.6 * flood)),
+    ));
     scope.draw_rect_blend(
         Brush::solid(color.with_alpha(0.32 * flood)),
         BlendMode::Plus,
     );
-    for beam in 0..2 {
-        let cycles = 3.0 + beam as f32;
-        let cycle = (t * cycles + index as f32 * 0.31 + beam as f32 * 0.5).fract();
-        let x = -size.width * 0.4 + size.width * 1.8 * cycle;
+    let phase = index as f32 * 0.31;
+    let sweep = |cycle: f32| -size.width * 1.2 + size.width * 2.8 * cycle;
+    draw_beam(
+        scope,
+        color,
+        0.3 * glow,
+        sweep((t * 3.0 + phase).fract()),
+        TILE_BEAM_HALF_WIDTH,
+        -0.6,
+    );
+    let streak_colour = mix(color, Color::WHITE, 0.7);
+    for (streak, slope) in [0.9, 1.15, 0.7].into_iter().enumerate() {
+        let cycle = (t * (2.0 + streak as f32) + phase + streak as f32 * 0.37).fract();
         draw_beam(
             scope,
-            color,
-            0.4 * glow,
-            x,
-            TILE_BEAM_HALF_WIDTH,
-            if beam == 0 { 0.8 } else { -0.6 },
-            size.height,
+            streak_colour,
+            0.9 * glow,
+            sweep(cycle),
+            TILE_STREAK_HALF_WIDTH,
+            slope,
         );
     }
-    for (width, alpha) in [(44.0, 0.14), (16.0, 0.3), (5.0, 0.7)] {
-        draw_inset_rim(
+    for band in 0..TILE_BLOOM_BANDS {
+        let falloff = 1.0 - band as f32 / TILE_BLOOM_BANDS as f32;
+        draw_rim(
             scope,
-            color.with_alpha(alpha * glow),
-            width,
+            Brush::solid(color.with_alpha(0.22 * falloff * falloff * glow)),
+            TILE_BLOOM_BAND_DP,
+            TILE_BLOOM_BAND_DP * (band as f32 + 0.5),
+            TILE_RADIUS,
             BlendMode::Plus,
         );
     }
-    draw_inset_rim(
+    draw_rim(
         scope,
-        mix(color, Color::WHITE, 0.55).with_alpha(0.5 + 0.5 * glow),
+        Brush::solid(color.with_alpha(0.7 * glow)),
+        5.0,
+        2.5,
+        TILE_RADIUS,
+        BlendMode::Plus,
+    );
+    draw_rim(
+        scope,
+        Brush::solid(mix(color, Color::WHITE, 0.3).with_alpha(0.35 * glow)),
+        1.0,
+        TILE_BEVEL_INSET,
+        TILE_RADIUS,
+        BlendMode::Plus,
+    );
+    draw_rim(
+        scope,
+        Brush::solid(mix(color, Color::WHITE, 0.55).with_alpha(0.5 + 0.5 * glow)),
         1.5,
+        0.75,
+        TILE_RADIUS,
         BlendMode::SrcOver,
+    );
+    draw_rim(
+        scope,
+        Brush::linear_gradient_range(
+            vec![
+                Color::WHITE.with_alpha(0.8 * glow),
+                Color::WHITE.with_alpha(0.0),
+            ],
+            Point::new(0.0, 0.0),
+            Point::new(size.width * 0.6, size.height * 0.8),
+        ),
+        2.0,
+        1.0,
+        TILE_RADIUS,
+        BlendMode::Plus,
+    );
+    let glint = Point::new(
+        size.width - TILE_GLINT_RADIUS - 8.0,
+        TILE_GLINT_RADIUS + 8.0,
+    );
+    scope.draw_circle_blend(
+        Brush::radial_gradient(
+            vec![Color::WHITE.with_alpha(glow), Color::WHITE.with_alpha(0.0)],
+            glint,
+            TILE_GLINT_RADIUS,
+        ),
+        glint,
+        TILE_GLINT_RADIUS,
+        BlendMode::Plus,
     );
 }
 
-fn draw_inset_rim(scope: &mut dyn DrawScope, color: Color, width: f32, blend_mode: BlendMode) {
+fn draw_rim(
+    scope: &mut dyn DrawScope,
+    brush: Brush,
+    width: f32,
+    inset: f32,
+    radius: f32,
+    blend_mode: BlendMode,
+) {
     let size = scope.size();
-    let inset = width * 0.5;
     scope.draw_round_rect_at_stroked_blend(
         Rect {
             x: inset,
             y: inset,
-            width: size.width - width,
-            height: size.height - width,
+            width: size.width - inset * 2.0,
+            height: size.height - inset * 2.0,
         },
-        Brush::solid(color),
-        CornerRadii::uniform((TILE_RADIUS - inset).max(1.0)),
+        brush,
+        CornerRadii::uniform((radius - inset).max(1.0)),
         Stroke::new(width),
         blend_mode,
     );
@@ -336,7 +443,7 @@ fn tile_layer(hover: f32, press: f32, rotation_x: f32, rotation_y: f32) -> Graph
 
 fn tile_dynamics(hover: f32, glow: f32, press: f32, finger: (f32, f32)) -> GlassDynamics {
     GlassDynamics {
-        highlight_boost: 0.6 * hover + 0.15 * glow,
+        highlight_boost: 0.3 * hover + 0.15 * glow,
         saturation_boost: 0.5 * hover + 0.1 * glow,
         tint_alpha_multiplier: Some(1.0 + 3.2 * hover + 0.25 * glow),
         ..Default::default()

--- a/apps/desktop-demo/src/tests/main_tests.rs
+++ b/apps/desktop-demo/src/tests/main_tests.rs
@@ -427,6 +427,10 @@ fn startup_tab_parser_accepts_variant_and_label_aliases() {
         DemoTab::from_startup_name("markdown-viewer"),
         Some(DemoTab::MarkdownViewer)
     );
+    assert_eq!(
+        DemoTab::from_startup_name("glass-tiles"),
+        Some(DemoTab::GlassTiles)
+    );
 }
 
 #[test]

--- a/crates/cranpose/src/desktop.rs
+++ b/crates/cranpose/src/desktop.rs
@@ -614,6 +614,7 @@ struct App {
     primary_surface_dirty: bool,
     primary_initial_present_pending: bool,
     vsync_interval: Duration,
+    exiting: bool,
     #[cfg(feature = "robot")]
     presented_frame_generation: u64,
     #[cfg(feature = "robot")]
@@ -680,6 +681,7 @@ impl App {
             primary_surface_dirty: false,
             primary_initial_present_pending: false,
             vsync_interval: default_vsync_interval(),
+            exiting: false,
             #[cfg(feature = "robot")]
             presented_frame_generation: 0,
             #[cfg(feature = "robot")]
@@ -4171,6 +4173,9 @@ impl cranpose_app_shell::PlatformTextInputHandler for DesktopTextInput {
 
 impl ApplicationHandler for App {
     fn proxy_wake_up(&mut self, event_loop: &dyn ActiveEventLoop) {
+        if self.exiting {
+            return;
+        }
         #[cfg(feature = "robot")]
         if self
             .robot_controller
@@ -4429,6 +4434,7 @@ impl ApplicationHandler for App {
                 {
                     eprintln!("[Recorder] Error saving recording: {}", e);
                 }
+                self.exiting = true;
                 event_loop.exit();
             }
             WindowEvent::DragDropped { ref paths, .. } => {
@@ -4793,6 +4799,7 @@ impl ApplicationHandler for App {
 
     fn about_to_wait(&mut self, event_loop: &dyn ActiveEventLoop) {
         if cranpose_services::take_exit_request() {
+            self.exiting = true;
             event_loop.exit();
             return;
         }
@@ -5363,6 +5370,7 @@ impl ApplicationHandler for App {
                     }
                     RobotCommand::Exit => {
                         let _ = controller.tx.send(RobotResponse::Ok);
+                        self.exiting = true;
                         event_loop.exit();
                         return;
                     }


### PR DESCRIPTION
A new demo tab, **Glass Tiles**: the neon-glass translator grid, rebuilt in Cranpose's liquid material with everything moving in 3D.

## What it is

- A dark smoked slab of clear glass (`Glass::clear()` with no frost or lift, a black tint, refraction and dispersion) with a rim brightest at the top and its own bevel, floating over a dark stage of drifting light beams, glows and bokeh that the glass refracts.
- Four tiles of lens glass in their own colours, after the photo: smoked interiors that the hover lifts, an inner bloom graded over eight bands so it fades instead of ending in a box, a bevel line, a top-left edge light, a corner glint, crisp caustic streaks crossing the interior, and a coloured halo cast on the slab (a coloured `GlassShadow`). The pairs are AU with FR and DE.
- 3D: the slab tilts toward the pointer in perspective (`rotation_x`/`rotation_y` with `camera_distance`), sways on its own when nothing hovers, and tips toward a pressed tile; the tiles counter-tilt and shift for parallax and lift on hover.
- Dynamic: hovering floods a tile with its colour, pressing runs the material's touched-up law with the glow under the finger, the rims breathe with phase offsets, a light sweep crosses the slab, and the stage lights never stop.

## Notes

- Found on the way and fixed here: a page that animates forever could keep the desktop loop alive after `robot.exit()` -- the frame waker's proxy wakes starved macOS's stop, and the process spun until the watchdog. The loop now remembers it is exiting and serves no more wakes; three fresh release launches in a row exit within seconds.

- The rotation lives on a wrapper node and the glass on its child. With both on one node the tile's promoted surface leaks a rectangle around the rounded shape — filed as #662.
- The bold Noto face has no `→`, so the arrow is a regular-weight span.
- The tab is `glass-tiles` (aliases `glasstiles`, `tiles`), reachable through the shared `liquid_page` hook.

## Proof

`robot_glass_tiles` finds all four tiles by their semantics, reads a tile's interior at rest, under the pointer and after the pointer moves to the slab's centre: it must carry 25 more of its colour under the pointer and settle back within 15 once the pointer leaves: 13.7 → 70.1 → 16.8, identical in debug and release on Metal across every run. Local: `just precommit`, `just clippy`, `just clippy-robot`, `cargo test -p desktop-app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
