### PR TITLE
Pin the shader tests' glass lookup to an exact label

### DIFF
--- a/apps/desktop-demo/robot-runners/robot_regression_shader_visual_contract.rs
+++ b/apps/desktop-demo/robot-runners/robot_regression_shader_visual_contract.rs
@@ -8,7 +8,7 @@ use std::{path::Path, time::Duration};
 use cranpose::AppLauncher;
 use cranpose_testing::{
     crop_screenshot_logical, find_button_in_semantics, find_text_in_semantics,
-    scroll_text_into_view, set_slider_fraction, ScrollConfig,
+    find_text_in_semantics_exact, scroll_text_into_view, set_slider_fraction, ScrollConfig,
 };
 use desktop_app::app::{self, DemoTab, ShaderSection, StartupSelection};
 use image::RgbaImage;
@@ -83,7 +83,7 @@ fn run_interactive_overlap() {
 
             let blur = find_text_in_semantics(&robot, "Blur")
                 .unwrap_or_else(|| robot_exit::fail_without_shutdown( "Blur label missing"));
-            let glass = find_text_in_semantics(&robot, "Glass")
+            let glass = find_text_in_semantics_exact(&robot, "Glass")
                 .unwrap_or_else(|| robot_exit::fail_without_shutdown( "Glass label missing"));
             let (blur_cx, blur_cy) = center(blur);
             let (glass_cx, glass_cy) = center(glass);

--- a/apps/desktop-demo/robot-runners/robot_shader_backdrop_drag.rs
+++ b/apps/desktop-demo/robot-runners/robot_shader_backdrop_drag.rs
@@ -7,7 +7,8 @@ use cranpose::AppLauncher;
 use cranpose_testing::{
     capture_screenshot, changed_pixel_count, changed_pixel_count_in_region,
     find_button_in_semantics, find_text, find_text_by_prefix, find_text_by_prefix_in_semantics,
-    find_text_in_semantics, parse_slider_value, root_bounds, screenshot_logical_size, y_is_visible,
+    find_text_in_semantics, find_text_in_semantics_exact, parse_slider_value, root_bounds,
+    screenshot_logical_size, y_is_visible,
 };
 use desktop_app::app;
 use image::{ImageBuffer, RgbaImage};
@@ -552,7 +553,7 @@ fn main() {
                 println!("✗ Could not find 'Blur' label");
                 std::process::exit(1);
             };
-            let Some(glass_before) = find_text_in_semantics(&robot, "Glass") else {
+            let Some(glass_before) = find_text_in_semantics_exact(&robot, "Glass") else {
                 println!("✗ Could not find 'Glass' label");
                 std::process::exit(1);
             };
@@ -629,7 +630,7 @@ fn main() {
             std::thread::sleep(Duration::from_millis(200));
             let _ = robot.wait_for_idle();
 
-            let Some(glass_after) = find_text_in_semantics(&robot, "Glass") else {
+            let Some(glass_after) = find_text_in_semantics_exact(&robot, "Glass") else {
                 println!("✗ Lost 'Glass' label after drag");
                 std::process::exit(1);
             };

--- a/apps/desktop-demo/robot-runners/robot_shader_full_demo_external_perf.rs
+++ b/apps/desktop-demo/robot-runners/robot_shader_full_demo_external_perf.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use cranpose::{AppLauncher, Robot};
-use cranpose_testing::{find_button_exact_in_semantics, find_text_in_semantics};
+use cranpose_testing::{find_button_exact_in_semantics, find_text_in_semantics_exact};
 use desktop_app::app::{self, DemoTab, ShaderSection, StartupSelection};
 use external_x11_frame_telemetry::{
     clear_records, install_primary_frame_telemetry_logger, summarize_records, FrameTelemetryRecord,
@@ -218,7 +218,7 @@ fn print_render_stats(
 }
 
 fn glass_drag_points(robot: &Robot) -> (f32, f32, f32, f32) {
-    let Some((x, y, w, h)) = find_text_in_semantics(robot, "Glass") else {
+    let Some((x, y, w, h)) = find_text_in_semantics_exact(robot, "Glass") else {
         panic!("Glass overlay text not found");
     };
     let start_x = x + w * 0.5;

--- a/crates/cranpose-testing/src/robot_helpers.rs
+++ b/crates/cranpose-testing/src/robot_helpers.rs
@@ -157,6 +157,24 @@ pub fn find_text_in_semantics(robot: &cranpose::Robot, text: &str) -> Option<(f3
     }
 }
 
+/// Find element by exact text in semantics tree (Robot wrapper).
+///
+/// Returns bounds (x, y, width, height). Unlike [`find_text_in_semantics`],
+/// a label that merely contains the query does not match, so a query stays
+/// pinned to its element when a longer label sharing its prefix appears.
+pub fn find_text_in_semantics_exact(
+    robot: &cranpose::Robot,
+    text: &str,
+) -> Option<(f32, f32, f32, f32)> {
+    match robot.find_text_bounds_exact(text) {
+        Ok(bounds) => bounds,
+        Err(e) => {
+            eprintln!("  ✗ Failed to query exact text semantics: {}", e);
+            None
+        }
+    }
+}
+
 /// Find an element whose text starts with the given prefix.
 /// Returns bounds (x, y, width, height) and the full text.
 pub fn find_text_by_prefix(

--- a/crates/cranpose/src/robot.rs
+++ b/crates/cranpose/src/robot.rs
@@ -782,6 +782,22 @@ impl Robot {
         })
     }
 
+    /// Find the first semantic node whose text is exactly the provided string.
+    ///
+    /// Prefer this to [`Robot::find_text_bounds`] whenever the target's label
+    /// is also a prefix of some other label on screen: a substring match
+    /// returns whichever node the tree reaches first, so adding a control
+    /// named "Glass Tiles" silently redirects a search for "Glass".
+    pub fn find_text_bounds_exact(
+        &self,
+        text: &str,
+    ) -> Result<Option<(f32, f32, f32, f32)>, String> {
+        self.semantic_query_bounds(RobotCommand::FindText {
+            text: text.to_string(),
+            match_kind: SemanticTextMatchKind::Exact,
+        })
+    }
+
     /// Find the first semantic node whose text starts with the provided prefix.
     pub fn find_text_by_prefix(&self, prefix: &str) -> Result<Option<TextMatchBounds>, String> {
         Ok(self


### PR DESCRIPTION
Fixes the `robot e2e (self-hosted GPU)` failure on main at `56de5e17`.

## What broke

The Glass Tiles demo (#663) added a tab labelled **"Glass Tiles"**. Three shader robot tests find their target with a *substring* search for `"Glass"`, and the tab label — always on screen, and earlier in the semantics tree than the page content — started winning that match. The tests then measured and dragged the tab strip instead of the glass rect:

```
robot_shader_backdrop_drag
  Glass=(2121.9,38.0) before and after
  ✗ Glass did not produce visible movement after drag (pixels=0)

robot_shader_full_demo_external_perf
  glass_drag_points: start=(2045.5,51.8)
  FAIL: glass drag did not visibly change: changed_pixels=0;
        produced no presented frames; app FPS counter reported no frames

robot_regression_shader_visual_contract
  crop=(3105, 61, 150, 110) bright_label_pixels=0
  FATAL: glass/blur overlap lost backdrop detail in the right half
```

Those `y` values — 38, 52, 61 — are the tab strip, not the content area. That is the whole failure: nothing is wrong with the glass rendering.

It reached main because #663's own `robot e2e` run was **cancelled**, not executed, so the suite never ran against it on any branch.

## The fix

The Shaders page's label is exactly `"Glass"` ([shaders.rs:499](apps/desktop-demo/src/app/shaders.rs#L499)), so an exact match resolves it unambiguously and cannot be captured by a longer label again.

This is the rule [docs/render_verification.md](docs/render_verification.md) already states — *"substring presence matches can select unrelated offscreen text"* — applied to text lookups, which had no exact variant: `find_button_bounds_exact` existed, `find_text_bounds_exact` did not. This adds it and the `find_text_in_semantics_exact` helper beside their `Contains` counterparts, and moves the four `"Glass"` call sites onto them.

Swept for other collisions with the new label: `robot_measure_shaders` already uses `find_text_exact`, and no other query is a substring of `"Glass Tiles"`.

## Verification

`robot_shader_backdrop_drag` is **measured**, both ways, on this commit. These runners do run on macOS; what made them look unrunnable is the 120 Hz frame-budget assertion, which a 60 Hz Mac cannot meet, so the run aborts before reaching the glass drag. `perf_contract::hardware_performance_contracts_enabled()` already carries the switch CI uses:

```bash
CRANPOSE_ROBOT_SOFTWARE_RENDERER=1 CRANPOSE_ROBOT_HEADLESS=1 \
  cargo run --release --example robot_shader_backdrop_drag \
  --features robot-app,desktop,renderer-wgpu
```

With this fix — exit 0:

```
Initial semantic label positions: Blur=(120.4,474.6) Glass=(116.5,474.6)
After glass drag: semantic Glass=(116.5,474.6) changed_pixels=24952
✓ PASS: Blur/Glass drag and tab-row clipping checks passed
```

With the two `Glass` lookups reverted to the substring form — CI's failure, byte for byte — exit 1:

```
Initial semantic label positions: Blur=(120.4,474.6) Glass=(2121.9,38.0)
After glass drag: semantic Glass=(2121.9,38.0) changed_pixels=0
✗ Glass did not produce visible movement after drag (pixels=0)
```

Run independently from two sessions with identical output. The revert was applied from a backup copy and restored from it, so the working tree carries only the fix.

`robot_shader_full_demo_external_perf` and `robot_regression_shader_visual_contract` are **inference, not measurement**. They shell out to `xdotool` (`text_showcase_external_helpers.rs:211`), which is X11-only, so they cannot run here. Their call sites are identical to the verified one and the sweep found no other collision, but only the Linux GPU board can confirm them.

`just clippy-robot` green — the gate that actually covers these `required-features` examples; `--all-targets` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
