### PR TITLE
Run the skip-recomposition benchmark

### DIFF
--- a/crates/cranpose-ui/Cargo.toml
+++ b/crates/cranpose-ui/Cargo.toml
@@ -48,6 +48,10 @@ name = "pipeline"
 harness = false
 
 [[bench]]
+name = "skip_recomposition"
+harness = false
+
+[[bench]]
 name = "slot_table_v2"
 harness = false
 

--- a/crates/cranpose-ui/benches/skip_recomposition.rs
+++ b/crates/cranpose-ui/benches/skip_recomposition.rs
@@ -1,5 +1,7 @@
+use std::rc::Rc;
+
 use cranpose_core::{MemoryApplier, location_key};
-use cranpose_ui::{Composition, Modifier, Text, TextStyle, composable};
+use cranpose_ui::{AppContext, Composition, Modifier, Text, TextStyle, composable};
 use criterion::{Criterion, criterion_group, criterion_main};
 
 #[composable]
@@ -8,18 +10,23 @@ fn static_label(label: &'static str) {
 }
 
 fn skip_recomposition_static_label(c: &mut Criterion) {
-    let mut composition = Composition::new(MemoryApplier::new());
-    let key = location_key(file!(), line!(), column!());
+    // Composing touches render state, which is reachable only inside an app
+    // context; without this the bench panics before it measures anything.
+    let app_context: Rc<AppContext> = AppContext::new();
+    app_context.enter(|| {
+        let mut composition = Composition::new(MemoryApplier::new());
+        let key = location_key(file!(), line!(), column!());
 
-    composition
-        .render(key, || static_label("Hello"))
-        .expect("initial render");
+        composition
+            .render(key, || static_label("Hello"))
+            .expect("initial render");
 
-    c.bench_function("skip_recomposition_static_label", |b| {
-        b.iter(|| {
-            composition
-                .render(key, || static_label("Hello"))
-                .expect("render");
+        c.bench_function("skip_recomposition_static_label", |b| {
+            b.iter(|| {
+                composition
+                    .render(key, || static_label("Hello"))
+                    .expect("render");
+            });
         });
     });
 }


### PR DESCRIPTION
`crates/cranpose-ui/benches/skip_recomposition.rs` has never measured anything.

It has no `[[bench]]` entry — unlike `pipeline` and `slot_table_v2`, both of which carry `harness = false` — so cargo builds it with the default libtest harness, `criterion_main!` never runs, and `cargo bench -p cranpose-ui --bench skip_recomposition` prints `running 0 tests` and exits 0. A silent instrument reporting success.

Wiring the harness up surfaced the second half: composing touches render state, which is reachable only inside an app context, so the bench panicked with `render state access requires an active AppContext` on its first real run. It now enters one the way `pipeline` already does.

## What it measures

~1.0 µs per skipped recomposition of a static label on an M-series Mac.

It is also the instrument that settled a real question tonight: whether `CRANPOSE_DEBUG_SCOPE_LABELS` could be made to work in release builds, which would have made recomposition diagnosis far easier. A/B/A/B with the labels compiled in:

| leg | time |
|---|---|
| A (labels off) | 1059 ns |
| B (labels on) | 1262 ns |
| A (labels off) | 961 ns |
| B (labels on) | 1058 ns |

Both pairs agree, so roughly 15% on the recomposition path. Today `debug_scope_tracking_enabled()` is a literal `false` in release and the optimiser deletes every call site; a cached `OnceLock` turns them into real branches on a hot path. Not worth it for a debug feature, so the labels stay behind `debug_assertions` — and that conclusion now rests on a measurement rather than an opinion.

(A first, unpaired comparison read +38%. That was machine noise, and the ABAB is why it is not the number quoted here.)

## Checks

`just fmt` and `just precommit` green; the bench itself runs and reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)