### PR TITLE
Play remote audio on every native target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,6 +1059,7 @@ dependencies = [
  "cranpose-services",
  "log",
  "parking_lot",
+ "pollster",
  "symphonia",
 ]
 

--- a/crates/cranpose-media/Cargo.toml
+++ b/crates/cranpose-media/Cargo.toml
@@ -32,7 +32,12 @@ cranpose-audio = { workspace = true, features = ["aaudio"] }
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android", target_os = "ios")))'.dependencies]
 cranpose-audio = { workspace = true, features = ["cpal-backend"] }
 
+# A remote item is read over HTTP byte ranges rather than downloaded first, so
+# the decoder needs the platform's HTTP transfer and a way to block the decode
+# thread on it. Both are excluded from the targets whose modules compile away.
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "ios")))'.dependencies]
+cranpose-services = { workspace = true, features = ["http-native"] }
+pollster = "0.4"
 symphonia = { version = "0.6.1", default-features = false, features = ["all", "opt-simd"] }
 
 [dev-dependencies]

--- a/crates/cranpose-media/src/decode.rs
+++ b/crates/cranpose-media/src/decode.rs
@@ -13,8 +13,9 @@ use symphonia::core::{
 };
 
 use crate::{
-    source::{ChannelCount, Sample, SampleRate, SampleSource, SeekError},
-    spool::{Spool, SpoolCancel},
+    http::{self, HttpSource},
+    source::{ChannelCount, Sample, SampleRate, SampleSource, SeekError, SourceCancel},
+    spool::Spool,
 };
 
 const SPOOL_DIRECTORY: &str = "cranpose-media-spool";
@@ -33,7 +34,7 @@ pub(crate) struct Decoder {
 }
 
 impl Decoder {
-    pub(crate) fn open(uri: &str) -> Result<(Decoder, SpoolCancel), MediaError> {
+    pub(crate) fn open(uri: &str) -> Result<(Decoder, SourceCancel), MediaError> {
         let (media, cancel) = open_media(uri)?;
         Ok((Decoder::from_media(media, uri)?, cancel))
     }
@@ -42,12 +43,8 @@ impl Decoder {
         let stream = MediaSourceStream::new(media, Default::default());
 
         let mut hint = Hint::new();
-        if let Some(extension) = cranpose_services::path_from_uri(uri)
-            .as_deref()
-            .and_then(Path::extension)
-            .and_then(|extension| extension.to_str())
-        {
-            hint.with_extension(extension);
+        if let Some(extension) = extension_of(uri) {
+            hint.with_extension(&extension);
         }
 
         let format = symphonia::default::get_probe()
@@ -108,11 +105,12 @@ impl Decoder {
     }
 
     pub(crate) fn probe_duration(uri: &str) -> Option<Duration> {
-        let path = cranpose_services::path_from_uri(uri)?;
-        let file = std::fs::File::open(path).ok()?;
-        Decoder::from_media(Box::new(file), uri)
-            .ok()?
-            .total_duration()
+        let media: Box<dyn MediaSource> = if http::is_http_uri(uri) {
+            Box::new(HttpSource::open(uri).ok()?.0)
+        } else {
+            Box::new(std::fs::File::open(cranpose_services::path_from_uri(uri)?).ok()?)
+        };
+        Decoder::from_media(media, uri).ok()?.total_duration()
     }
 
     fn fill(&mut self) -> bool {
@@ -243,7 +241,26 @@ impl SampleSource for Decoder {
     }
 }
 
-fn open_media(uri: &str) -> Result<(Box<dyn MediaSource>, SpoolCancel), MediaError> {
+fn extension_of(uri: &str) -> Option<String> {
+    if http::is_http_uri(uri) {
+        let (_, rest) = uri.split_once("://")?;
+        let path = rest.split(['?', '#']).next()?;
+        let (_, name) = path.rsplit_once('/')?;
+        let (_, extension) = name.rsplit_once('.')?;
+        return (!extension.is_empty()).then(|| extension.to_ascii_lowercase());
+    }
+    cranpose_services::path_from_uri(uri)
+        .as_deref()
+        .and_then(Path::extension)
+        .and_then(|extension| extension.to_str())
+        .map(str::to_owned)
+}
+
+fn open_media(uri: &str) -> Result<(Box<dyn MediaSource>, SourceCancel), MediaError> {
+    if http::is_http_uri(uri) {
+        let (source, cancel) = HttpSource::open(uri)?;
+        return Ok((Box::new(source), cancel));
+    }
     let handle = cranpose_services::open_media_source(uri).map_err(|error| {
         if error.kind() == std::io::ErrorKind::Unsupported {
             MediaError::UnsupportedSource(uri.to_owned())
@@ -253,7 +270,7 @@ fn open_media(uri: &str) -> Result<(Box<dyn MediaSource>, SpoolCancel), MediaErr
     })?;
     let mut file = handle.stream;
     if seeks(&mut file) {
-        return Ok((Box::new(file), SpoolCancel::default()));
+        return Ok((Box::new(file), SourceCancel::default()));
     }
     log::debug!(
         "cranpose-media: {uri} does not seek; spooling {} bytes",

--- a/crates/cranpose-media/src/decode.rs
+++ b/crates/cranpose-media/src/decode.rs
@@ -452,6 +452,34 @@ mod tests {
     }
 
     #[test]
+    fn a_remote_uri_hints_the_extension_from_its_path() {
+        assert_eq!(
+            extension_of("https://host/music/track.MP3"),
+            Some("mp3".to_owned())
+        );
+        assert_eq!(
+            extension_of("https://host/track.flac?token=1&x=2"),
+            Some("flac".to_owned())
+        );
+        assert_eq!(
+            extension_of("https://host/track.ogg#start"),
+            Some("ogg".to_owned())
+        );
+        assert_eq!(extension_of("https://host/stream"), None);
+        assert_eq!(extension_of("https://host/v1.2/stream"), None);
+    }
+
+    #[test]
+    fn a_local_uri_still_hints_the_extension_from_its_path() {
+        assert_eq!(
+            extension_of("file:///music/track.wav"),
+            Some("wav".to_owned())
+        );
+        assert_eq!(extension_of("/music/track.wav"), Some("wav".to_owned()));
+        assert_eq!(extension_of("file:///music/track"), None);
+    }
+
+    #[test]
     fn a_document_uri_reports_no_duration_without_being_opened() {
         assert_eq!(Decoder::probe_duration("content://example/track"), None);
     }

--- a/crates/cranpose-media/src/http.rs
+++ b/crates/cranpose-media/src/http.rs
@@ -1,0 +1,517 @@
+use std::{
+    io::{self, Read, Seek, SeekFrom},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use cranpose_services::{
+    HttpClientRef, HttpControl, HttpRequest, HttpResponse, MediaError, default_http_client,
+};
+use parking_lot::Mutex;
+use symphonia::core::io::MediaSource;
+
+use crate::source::SourceCancel;
+
+const FORWARD_SKIP_LIMIT: u64 = 1 << 20;
+
+pub(crate) fn is_http_uri(uri: &str) -> bool {
+    matches!(
+        uri.split_once("://"),
+        Some((scheme, rest))
+            if !rest.is_empty()
+                && (scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https"))
+    )
+}
+
+#[derive(Clone, Default)]
+struct Abort {
+    stopped: Arc<AtomicBool>,
+    live: Arc<Mutex<Option<HttpControl>>>,
+}
+
+impl Abort {
+    fn stop(&self) {
+        self.stopped.store(true, Ordering::Release);
+        if let Some(control) = self.live.lock().take() {
+            control.cancel();
+        }
+    }
+
+    fn is_stopped(&self) -> bool {
+        self.stopped.load(Ordering::Acquire)
+    }
+
+    fn arm(&self, control: HttpControl) {
+        *self.live.lock() = Some(control);
+    }
+
+    fn disarm(&self) {
+        if let Some(control) = self.live.lock().take() {
+            control.cancel();
+        }
+    }
+}
+
+struct Stream {
+    response: HttpResponse,
+    next: u64,
+    pending: Vec<u8>,
+    taken: usize,
+    ended: bool,
+}
+
+impl Stream {
+    fn ready(&mut self) -> io::Result<usize> {
+        while self.taken >= self.pending.len() {
+            if self.ended {
+                return Ok(0);
+            }
+            match pollster::block_on(self.response.read_chunk()) {
+                Ok(Some(chunk)) => {
+                    self.pending = chunk;
+                    self.taken = 0;
+                }
+                Ok(None) => {
+                    self.ended = true;
+                    return Ok(0);
+                }
+                Err(error) => return Err(io::Error::other(error)),
+            }
+        }
+        Ok(self.pending.len() - self.taken)
+    }
+
+    fn take(&mut self, count: usize) -> &[u8] {
+        let from = self.taken;
+        self.taken += count;
+        self.next += count as u64;
+        &self.pending[from..from + count]
+    }
+}
+
+pub(crate) struct HttpSource {
+    client: HttpClientRef,
+    url: String,
+    len: Option<u64>,
+    ranged: bool,
+    position: u64,
+    stream: Option<Stream>,
+    abort: Abort,
+}
+
+impl HttpSource {
+    pub(crate) fn open(url: &str) -> Result<(HttpSource, SourceCancel), MediaError> {
+        HttpSource::open_with(url, default_http_client())
+    }
+
+    pub(crate) fn open_with(
+        url: &str,
+        client: HttpClientRef,
+    ) -> Result<(HttpSource, SourceCancel), MediaError> {
+        let abort = Abort::default();
+        let opened = Opened::request(&client, url, 0, &abort)
+            .map_err(|error| MediaError::Failed(format!("{url}: {error}")))?;
+        let stopping = abort.clone();
+        Ok((
+            HttpSource {
+                client,
+                url: url.to_owned(),
+                len: opened.len,
+                ranged: opened.ranged,
+                position: 0,
+                stream: Some(opened.stream),
+                abort,
+            },
+            SourceCancel::new(move || stopping.stop()),
+        ))
+    }
+
+    fn aligned(&mut self) -> io::Result<()> {
+        let target = self.position;
+        if let Some(stream) = self.stream.as_mut() {
+            if stream.next == target {
+                return Ok(());
+            }
+            if target > stream.next && target - stream.next <= FORWARD_SKIP_LIMIT {
+                while stream.next < target {
+                    let available = stream.ready()?;
+                    if available == 0 {
+                        break;
+                    }
+                    let step = ((target - stream.next) as usize).min(available);
+                    stream.take(step);
+                }
+                if stream.next == target {
+                    return Ok(());
+                }
+            }
+        }
+        self.reopen()
+    }
+
+    fn reopen(&mut self) -> io::Result<()> {
+        self.stream = None;
+        self.abort.disarm();
+        if self.position != 0 && !self.ranged {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!("{} does not serve byte ranges", self.url),
+            ));
+        }
+        let opened = Opened::request(&self.client, &self.url, self.position, &self.abort)?;
+        if self.len.is_none() {
+            self.len = opened.len;
+        }
+        self.stream = Some(opened.stream);
+        Ok(())
+    }
+}
+
+struct Opened {
+    stream: Stream,
+    len: Option<u64>,
+    ranged: bool,
+}
+
+impl Opened {
+    fn request(
+        client: &HttpClientRef,
+        url: &str,
+        offset: u64,
+        abort: &Abort,
+    ) -> Result<Opened, io::Error> {
+        let request = HttpRequest::get(url).resume_from(offset);
+        let control = HttpControl::new();
+        abort.arm(control.clone());
+        let response = pollster::block_on(client.send(&request, control))
+            .and_then(HttpResponse::error_for_status)
+            .map_err(io::Error::other)?;
+        if offset > 0 && !response.resumed {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!("the server answered {url} without the byte range it was asked for"),
+            ));
+        }
+        let len = response.content_length.map(|remaining| offset + remaining);
+        let ranged = response.resumed || serves_ranges(&response);
+        Ok(Opened {
+            stream: Stream {
+                response,
+                next: offset,
+                pending: Vec::new(),
+                taken: 0,
+                ended: false,
+            },
+            len,
+            ranged,
+        })
+    }
+}
+
+fn serves_ranges(response: &HttpResponse) -> bool {
+    response
+        .header("accept-ranges")
+        .is_some_and(|value| value.split(',').any(|unit| unit.trim() == "bytes"))
+}
+
+fn offset_from(base: u64, delta: i64) -> io::Result<u64> {
+    base.checked_add_signed(delta).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "attempted to seek before the start of the stream",
+        )
+    })
+}
+
+impl Read for HttpSource {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if buffer.is_empty() || self.abort.is_stopped() {
+            return Ok(0);
+        }
+        if self.len.is_some_and(|len| self.position >= len) {
+            return Ok(0);
+        }
+        self.aligned()?;
+        let Some(stream) = self.stream.as_mut() else {
+            return Ok(0);
+        };
+        let available = stream.ready()?;
+        if available == 0 {
+            return Ok(0);
+        }
+        let count = available.min(buffer.len());
+        buffer[..count].copy_from_slice(stream.take(count));
+        self.position += count as u64;
+        Ok(count)
+    }
+}
+
+impl Seek for HttpSource {
+    fn seek(&mut self, from: SeekFrom) -> io::Result<u64> {
+        let target = match from {
+            SeekFrom::Start(offset) => offset,
+            SeekFrom::Current(delta) => offset_from(self.position, delta)?,
+            SeekFrom::End(delta) => {
+                let len = self.len.ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        format!("{} states no length to seek from the end of", self.url),
+                    )
+                })?;
+                offset_from(len, delta)?
+            }
+        };
+        self.position = target;
+        Ok(target)
+    }
+}
+
+impl MediaSource for HttpSource {
+    fn is_seekable(&self) -> bool {
+        self.ranged
+    }
+
+    fn byte_len(&self) -> Option<u64> {
+        self.len
+    }
+}
+
+impl Drop for HttpSource {
+    fn drop(&mut self) {
+        self.stream = None;
+        self.abort.disarm();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cranpose_services::{BytesBody, HttpError, HttpResponse, StubHttpClient, http_body_ref};
+
+    use super::*;
+
+    fn payload(len: usize) -> Vec<u8> {
+        (0..=255u8).cycle().take(len).collect()
+    }
+
+    fn range_of(request: &HttpRequest) -> u64 {
+        request.resume_from.unwrap_or(0)
+    }
+
+    fn ranged_server(body: Vec<u8>) -> HttpClientRef {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        served(body, requests)
+    }
+
+    fn served(body: Vec<u8>, requests: Arc<Mutex<Vec<u64>>>) -> HttpClientRef {
+        Arc::new(StubHttpClient::new(move |request| {
+            let offset = range_of(request);
+            requests.lock().push(offset);
+            if offset as usize > body.len() {
+                return Err(HttpError::HttpStatus {
+                    url: request.url.clone(),
+                    status: 416,
+                });
+            }
+            let rest = body[offset as usize..].to_vec();
+            let length = rest.len() as u64;
+            Ok(
+                HttpResponse::new(request.url.clone(), if offset > 0 { 206 } else { 200 }, {
+                    http_body_ref(BytesBody::chunked(rest, 64))
+                })
+                .with_headers(vec![("accept-ranges".to_owned(), "bytes".to_owned())])
+                .with_content_length(Some(length))
+                .with_resumed(offset > 0),
+            )
+        }))
+    }
+
+    fn unranged_server(body: Vec<u8>) -> HttpClientRef {
+        Arc::new(StubHttpClient::new(move |request| {
+            let length = body.len() as u64;
+            Ok(HttpResponse::new(
+                request.url.clone(),
+                200,
+                http_body_ref(BytesBody::chunked(body.clone(), 64)),
+            )
+            .with_content_length(Some(length)))
+        }))
+    }
+
+    fn source(client: HttpClientRef) -> HttpSource {
+        HttpSource::open_with("https://host/track.mp3", client)
+            .expect("the stub answers")
+            .0
+    }
+
+    #[test]
+    fn only_http_and_https_uris_are_claimed() {
+        assert!(is_http_uri("https://host/track.mp3"));
+        assert!(is_http_uri("HTTP://host/track.mp3"));
+        assert!(!is_http_uri("file:///music/track.mp3"));
+        assert!(!is_http_uri("content://media/audio/1"));
+        assert!(!is_http_uri("/music/track.mp3"));
+        assert!(!is_http_uri("https://"));
+    }
+
+    #[test]
+    fn the_whole_body_comes_back_in_order() {
+        let body = payload(4096);
+        let mut source = source(ranged_server(body.clone()));
+
+        let mut read = Vec::new();
+        source.read_to_end(&mut read).expect("read to end");
+
+        assert_eq!(read, body);
+    }
+
+    #[test]
+    fn the_stated_length_is_reported_before_anything_is_read() {
+        let source = source(ranged_server(payload(9001)));
+
+        assert_eq!(source.byte_len(), Some(9001));
+        assert!(source.is_seekable());
+    }
+
+    #[test]
+    fn a_seek_forward_asks_the_server_for_that_offset() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let body = payload(1 << 22);
+        let mut source = source(served(body.clone(), Arc::clone(&requests)));
+
+        source.seek(SeekFrom::Start(3_000_000)).expect("seek");
+        let mut head = [0u8; 8];
+        source.read_exact(&mut head).expect("read after the seek");
+
+        assert_eq!(head, body[3_000_000..3_000_008]);
+        assert_eq!(*requests.lock(), vec![0, 3_000_000]);
+    }
+
+    #[test]
+    fn a_seek_backwards_asks_the_server_again() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let body = payload(4096);
+        let mut source = source(served(body.clone(), Arc::clone(&requests)));
+
+        let mut head = [0u8; 2048];
+        source.read_exact(&mut head).expect("read the head");
+        source.seek(SeekFrom::Start(16)).expect("seek back");
+        let mut again = [0u8; 8];
+        source.read_exact(&mut again).expect("read the head again");
+
+        assert_eq!(again, body[16..24]);
+        assert_eq!(*requests.lock(), vec![0, 16]);
+    }
+
+    #[test]
+    fn a_short_hop_forward_stays_on_the_open_response() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let body = payload(8192);
+        let mut source = source(served(body.clone(), Arc::clone(&requests)));
+
+        source.seek(SeekFrom::Start(4096)).expect("seek");
+        let mut tail = [0u8; 8];
+        source.read_exact(&mut tail).expect("read after the hop");
+
+        assert_eq!(tail, body[4096..4104]);
+        assert_eq!(
+            *requests.lock(),
+            vec![0],
+            "a hop inside the skip limit re-requested the body"
+        );
+    }
+
+    #[test]
+    fn seeking_from_the_end_uses_the_stated_length() {
+        let body = payload(2048);
+        let mut source = source(ranged_server(body.clone()));
+
+        assert_eq!(source.seek(SeekFrom::End(-4)).expect("seek"), 2044);
+        let mut tail = [0u8; 4];
+        source.read_exact(&mut tail).expect("read the tail");
+
+        assert_eq!(tail, body[2044..]);
+    }
+
+    #[test]
+    fn reading_past_the_stated_end_reports_the_end_of_the_stream() {
+        let mut source = source(ranged_server(payload(512)));
+
+        source.seek(SeekFrom::Start(512)).expect("seek");
+
+        assert_eq!(source.read(&mut [0u8; 16]).expect("read"), 0);
+    }
+
+    #[test]
+    fn seeking_before_the_start_is_an_error_rather_than_a_wrap() {
+        let mut source = source(ranged_server(payload(64)));
+
+        assert!(source.seek(SeekFrom::Current(-1)).is_err());
+    }
+
+    #[test]
+    fn a_server_without_ranges_plays_forward_and_refuses_to_seek() {
+        let body = payload(4096);
+        let mut source = source(unranged_server(body.clone()));
+
+        assert!(!source.is_seekable());
+        let mut head = [0u8; 2048];
+        source.read_exact(&mut head).expect("read the head");
+        assert_eq!(head.as_slice(), &body[..2048]);
+        source.seek(SeekFrom::Start(16)).expect("seek is recorded");
+
+        let error = source.read(&mut [0u8; 16]).expect_err("no ranges, no seek");
+        assert_eq!(error.kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[test]
+    fn a_server_that_ignores_the_range_it_was_asked_for_is_refused() {
+        let client: HttpClientRef = Arc::new(StubHttpClient::new(|request| {
+            let body = payload(4096);
+            Ok(HttpResponse::new(
+                request.url.clone(),
+                200,
+                http_body_ref(BytesBody::new(body)),
+            )
+            .with_headers(vec![("accept-ranges".to_owned(), "bytes".to_owned())])
+            .with_content_length(Some(4096)))
+        }));
+        let mut source = source(client);
+
+        source
+            .read_exact(&mut [0u8; 2048])
+            .expect("read past the offset to come back to");
+        source.seek(SeekFrom::Start(16)).expect("seek back");
+
+        let error = source.read(&mut [0u8; 16]).expect_err("the range was lost");
+        assert_eq!(error.kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[test]
+    fn a_refusing_server_fails_the_open_rather_than_the_first_read() {
+        let client: HttpClientRef = Arc::new(StubHttpClient::new(|request| {
+            Ok(HttpResponse::empty(request.url.clone(), 404))
+        }));
+
+        let error = HttpSource::open_with("https://host/gone.mp3", client)
+            .map(drop)
+            .expect_err("a 404 is not a stream");
+
+        assert!(
+            matches!(&error, MediaError::Failed(message) if message.contains("gone.mp3")),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn cancelling_ends_the_reads_that_follow() {
+        let (mut source, cancel) =
+            HttpSource::open_with("https://host/track.mp3", ranged_server(payload(4096)))
+                .expect("the stub answers");
+
+        cancel.cancel();
+
+        assert_eq!(source.read(&mut [0u8; 16]).expect("cancelled"), 0);
+    }
+}

--- a/crates/cranpose-media/src/lib.rs
+++ b/crates/cranpose-media/src/lib.rs
@@ -17,6 +17,15 @@
 //!
 //! Local files, addressed as `file:` URIs — see [`uri_for_path`] — in every
 //! container `symphonia` reads: MP3, AAC/MP4, FLAC, Vorbis, WAV, AIFF, ALAC.
+//!
+//! Remote items, addressed as `http:` or `https:` URIs, in those same
+//! containers. The decoder reads them over HTTP byte ranges: playback starts
+//! from the front while the rest is still on the wire, a seek asks the server
+//! for the offset it needs instead of waiting for the bytes in between, and
+//! nothing is written to disk. A server that answers `Accept-Ranges: bytes`
+//! seeks; one that does not plays forward and refuses to seek, which is what
+//! [`SoftwareMediaPlayer`] reports rather than pretending otherwise.
+//!
 //! Anything else is opened by the platform through
 //! [`open_media_source`](cranpose_services::open_media_source): on Android that
 //! is a `content://` document, which a provider backed by a network share hands
@@ -51,6 +60,8 @@ mod analysis;
 mod decode;
 #[cfg(not(any(target_arch = "wasm32", target_os = "ios")))]
 mod equalizer;
+#[cfg(not(any(target_arch = "wasm32", target_os = "ios")))]
+mod http;
 #[cfg(not(any(target_arch = "wasm32", target_os = "ios")))]
 mod player;
 #[cfg(not(any(target_arch = "wasm32", target_os = "ios")))]

--- a/crates/cranpose-media/src/player.rs
+++ b/crates/cranpose-media/src/player.rs
@@ -71,12 +71,12 @@ impl Default for SoftwareMediaPlayer {
 
 impl Shared {
     fn open(self: &Arc<Self>, item: &MediaItem) -> Result<Option<Duration>, MediaError> {
-        let (decoder, spool) = Decoder::open(&item.uri)?;
+        let (decoder, cancel) = Decoder::open(&item.uri)?;
         let duration = decoder.total_duration().or(item.metadata.duration);
         let source: Box<dyn SampleSource> =
             Box::new(self.analysis.wrap(self.equalizer.wrap(decoder)));
 
-        let sink = Sink::open(source, spool, *self.volume.lock(), *self.speed.lock())?;
+        let sink = Sink::open(source, cancel, *self.volume.lock(), *self.speed.lock())?;
 
         *self.active.lock() = Some(Active { sink, duration });
         self.start_progress_thread();
@@ -312,15 +312,9 @@ mod tests {
     }
 
     #[test]
-    fn a_uri_this_backend_cannot_read_is_refused_before_a_device_is_opened() {
+    fn a_uri_no_platform_claims_is_refused_before_a_device_is_opened() {
         let player = SoftwareMediaPlayer::new();
 
-        assert_eq!(
-            player.prepare(&MediaItem::new("https://host/stream.mp3")),
-            Err(MediaError::UnsupportedSource(
-                "https://host/stream.mp3".to_string()
-            ))
-        );
         assert_eq!(
             player.prepare(&MediaItem::new("content://media/audio/1")),
             Err(MediaError::UnsupportedSource(

--- a/crates/cranpose-media/src/sink.rs
+++ b/crates/cranpose-media/src/sink.rs
@@ -15,10 +15,7 @@ use cranpose_audio::{
 };
 use cranpose_services::MediaError;
 
-use crate::{
-    source::{SampleSource, SeekError},
-    spool::SpoolCancel,
-};
+use crate::source::{SampleSource, SeekError, SourceCancel};
 
 const BUFFER_SECONDS: f32 = 0.2;
 
@@ -121,13 +118,13 @@ pub(crate) struct Sink {
     commands: Sender<Command>,
     decoder: Option<std::thread::JoinHandle<()>>,
     seekable: Arc<AtomicBool>,
-    spool: SpoolCancel,
+    cancel: SourceCancel,
 }
 
 impl Sink {
     pub(crate) fn open(
         source: Box<dyn SampleSource>,
-        spool: SpoolCancel,
+        cancel: SourceCancel,
         volume: f32,
         speed: f32,
     ) -> Result<Sink, MediaError> {
@@ -158,7 +155,7 @@ impl Sink {
             commands,
             decoder: Some(decoder),
             seekable,
-            spool,
+            cancel,
         })
     }
 
@@ -203,7 +200,7 @@ impl Sink {
 impl Drop for Sink {
     fn drop(&mut self) {
         let _ = self.commands.send(Command::Stop);
-        self.spool.cancel();
+        self.cancel.cancel();
         if let Some(decoder) = self.decoder.take() {
             let _ = decoder.join();
         }

--- a/crates/cranpose-media/src/source.rs
+++ b/crates/cranpose-media/src/source.rs
@@ -1,5 +1,6 @@
 use std::{
     num::{NonZeroU16, NonZeroU32},
+    sync::Arc,
     time::Duration,
 };
 
@@ -25,6 +26,25 @@ impl std::fmt::Display for SeekError {
 }
 
 impl std::error::Error for SeekError {}
+
+#[derive(Clone, Default)]
+pub(crate) struct SourceCancel {
+    stop: Option<Arc<dyn Fn() + Send + Sync>>,
+}
+
+impl SourceCancel {
+    pub(crate) fn new(stop: impl Fn() + Send + Sync + 'static) -> SourceCancel {
+        SourceCancel {
+            stop: Some(Arc::new(stop)),
+        }
+    }
+
+    pub(crate) fn cancel(&self) {
+        if let Some(stop) = self.stop.as_ref() {
+            stop();
+        }
+    }
+}
 
 pub(crate) trait SampleSource: Iterator<Item = Sample> + Send {
     fn channels(&self) -> ChannelCount;
@@ -107,6 +127,25 @@ mod tests {
     fn a_buffer_yields_every_sample_once() {
         let buffer = SamplesBuffer::new(1, 8_000, vec![0.25, -0.5, 1.0]);
         assert_eq!(buffer.collect::<Vec<_>>(), vec![0.25, -0.5, 1.0]);
+    }
+
+    #[test]
+    fn cancelling_calls_the_stop_the_source_supplied() {
+        let stopped = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = Arc::clone(&stopped);
+        let cancel = SourceCancel::new(move || {
+            counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        });
+
+        cancel.cancel();
+        cancel.clone().cancel();
+
+        assert_eq!(stopped.load(std::sync::atomic::Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn cancelling_a_source_that_needs_no_stop_does_nothing() {
+        SourceCancel::default().cancel();
     }
 
     #[test]

--- a/crates/cranpose-media/src/spool.rs
+++ b/crates/cranpose-media/src/spool.rs
@@ -9,6 +9,8 @@ use std::{
     time::Duration,
 };
 
+use crate::source::SourceCancel;
+
 const CHUNK_BYTES: usize = 64 * 1024;
 
 const STALL_TIMEOUT: Duration = Duration::from_secs(20);
@@ -26,21 +28,6 @@ struct Shared {
     cancel: AtomicBool,
     path: PathBuf,
     stall: Duration,
-}
-
-#[derive(Clone, Default)]
-pub(crate) struct SpoolCancel {
-    shared: Option<Arc<Shared>>,
-}
-
-impl SpoolCancel {
-    pub(crate) fn cancel(&self) {
-        let Some(shared) = self.shared.as_ref() else {
-            return;
-        };
-        shared.cancel.store(true, Ordering::Relaxed);
-        shared.ready.notify_all();
-    }
 }
 
 impl Shared {
@@ -114,7 +101,7 @@ impl Spool {
         source: Box<dyn Read + Send>,
         directory: &Path,
         len: Option<u64>,
-    ) -> io::Result<(Spool, SpoolCancel)> {
+    ) -> io::Result<(Spool, SourceCancel)> {
         Spool::start_with(source, directory, len, STALL_TIMEOUT)
     }
 
@@ -123,7 +110,7 @@ impl Spool {
         directory: &Path,
         len: Option<u64>,
         stall: Duration,
-    ) -> io::Result<(Spool, SpoolCancel)> {
+    ) -> io::Result<(Spool, SourceCancel)> {
         std::fs::create_dir_all(directory)?;
         sweep_stale_spools(directory);
         let path = directory.join(next_spool_name());
@@ -148,9 +135,11 @@ impl Spool {
         std::thread::Builder::new()
             .name("cranpose-media-spool".to_owned())
             .spawn(move || run_download(source, writer, download))?;
-        let cancel = SpoolCancel {
-            shared: Some(Arc::clone(&shared)),
-        };
+        let stopping = Arc::clone(&shared);
+        let cancel = SourceCancel::new(move || {
+            stopping.cancel.store(true, Ordering::Relaxed);
+            stopping.ready.notify_all();
+        });
         Ok((
             Spool {
                 shared,
@@ -327,7 +316,7 @@ mod tests {
         (0..=255u8).cycle().take(len).collect()
     }
 
-    fn spool(bytes: &[u8], tag: &str) -> (Spool, SpoolCancel) {
+    fn spool(bytes: &[u8], tag: &str) -> (Spool, SourceCancel) {
         Spool::start(
             trickle(bytes.to_vec()),
             &directory(tag),

--- a/crates/cranpose-media/tests/remote_stream.rs
+++ b/crates/cranpose-media/tests/remote_stream.rs
@@ -1,0 +1,70 @@
+use std::{thread::sleep, time::Duration};
+
+use cranpose_media::SoftwareMediaPlayer;
+use cranpose_services::{MediaItem, MediaPlayer, PlaybackState, playback_progress, playback_state};
+
+const URL: &str = "CRANPOSE_REMOTE_AUDIO_URL";
+
+fn url() -> String {
+    std::env::var(URL).unwrap_or_else(|_| panic!("set {URL} to an audio URL to run this"))
+}
+
+#[test]
+#[ignore = "network and an output device: run with CRANPOSE_REMOTE_AUDIO_URL set"]
+fn a_remote_track_plays_and_its_position_advances() {
+    let item = MediaItem::new(url());
+    let player = SoftwareMediaPlayer::new();
+
+    let probed = player.probe_duration(&item);
+    player.prepare(&item).expect("the remote item opens");
+    player.play().expect("the remote item plays");
+
+    sleep(Duration::from_secs(3));
+    let early = playback_progress();
+    sleep(Duration::from_secs(3));
+    let later = playback_progress();
+    let state = playback_state();
+    player.stop();
+
+    assert_eq!(state, PlaybackState::Playing, "{early:?} then {later:?}");
+    assert!(
+        probed.is_some_and(|duration| duration > Duration::from_secs(1)),
+        "the probe read no duration from the stream: {probed:?}"
+    );
+    assert_eq!(later.duration, probed, "the duration changed mid-item");
+    assert!(
+        early.position > Duration::ZERO,
+        "nothing had played after three seconds"
+    );
+    assert!(
+        later.position > early.position + Duration::from_secs(2),
+        "the position went from {:?} to {:?} over three seconds",
+        early.position,
+        later.position
+    );
+}
+
+#[test]
+#[ignore = "network and an output device: run with CRANPOSE_REMOTE_AUDIO_URL set"]
+fn a_remote_track_seeks_without_reading_what_it_skipped() {
+    let item = MediaItem::new(url());
+    let player = SoftwareMediaPlayer::new();
+
+    player.prepare(&item).expect("the remote item opens");
+    player.play().expect("the remote item plays");
+    sleep(Duration::from_secs(1));
+    player
+        .seek_to(Duration::from_secs(120))
+        .expect("a ranged server seeks");
+    sleep(Duration::from_secs(3));
+    let after = playback_progress();
+    let state = playback_state();
+    player.stop();
+
+    assert_eq!(state, PlaybackState::Playing);
+    assert!(
+        after.position >= Duration::from_secs(121),
+        "the seek left the position at {:?}",
+        after.position
+    );
+}

--- a/crates/cranpose-services/src/lib.rs
+++ b/crates/cranpose-services/src/lib.rs
@@ -127,7 +127,7 @@ pub use host_surface::{
 pub use http::{
     BytesBody, HttpBody, HttpBodyRef, HttpClient, HttpClientRef, HttpControl, HttpError,
     HttpFuture, HttpMethod, HttpProgress, HttpRequest, HttpResponse, ProgressHandler, StubAnswer,
-    StubHttpClient, default_http_client, local_http_client, map_ordered_concurrent,
+    StubHttpClient, default_http_client, http_body_ref, local_http_client, map_ordered_concurrent,
 };
 pub use image_picker::{
     IMAGE_EXTENSIONS, ImagePicker, ImagePickerError, ImagePickerRef, ImageSource,

--- a/crates/cranpose/Cargo.toml
+++ b/crates/cranpose/Cargo.toml
@@ -453,11 +453,17 @@ objc2-av-foundation = { version = "0.3", default-features = false, optional = tr
     "AVCapturePhotoOutput",
     "AVMediaFormat",
     "AVVideoSettings",
+    # Media playback (`ios_media`): AVPlayer streams a remote item as well as a
+    # local one, and the asset is what answers a duration probe.
+    "AVAsset",
+    "AVPlayer",
+    "AVPlayerItem",
 ] }
 objc2-core-media = { version = "0.3", default-features = false, optional = true, features = [
     "std",
     "objc2-core-video",
     "CMSampleBuffer",
+    "CMTime",
 ] }
 objc2-core-video = { version = "0.3", default-features = false, optional = true, features = [
     "std",
@@ -479,11 +485,10 @@ objc2-user-notifications = { version = "0.3", default-features = false, optional
     "UNNotificationTrigger",
     "UNError",
 ] }
-# Media playback (`ios_media`): AVAudioPlayer for the item, AVAudioSession for
+# Media playback (`ios_media`): AVAudioSession for the category and the
 # interruptions, and MediaPlayer for the lock screen and the remote commands.
 objc2-avf-audio = { version = "0.3.2", default-features = false, optional = true, features = [
     "std",
-    "AVAudioPlayer",
     "AVAudioSession",
     "AVAudioSessionRoute",
     "AVAudioSessionTypes",

--- a/crates/cranpose/src/ios_media.rs
+++ b/crates/cranpose/src/ios_media.rs
@@ -14,21 +14,25 @@ use cranpose_services::{
     PlaybackProgress, PlaybackState, publish_audio_focus, publish_media_command,
     publish_playback_progress, publish_playback_state, set_platform_media_player,
 };
+use dispatch2::DispatchQueue;
 use objc2::{
-    AllocAnyThread, define_class, msg_send,
+    AllocAnyThread, MainThreadMarker, MainThreadOnly, define_class, msg_send,
     rc::Retained,
-    runtime::{AnyObject, ProtocolObject},
+    runtime::{AnyObject, NSObject},
     sel,
 };
-use objc2_avf_audio::{
-    AVAudioPlayer, AVAudioPlayerDelegate, AVAudioSession, AVAudioSessionCategoryPlayback,
-    AVAudioSessionInterruptionNotification, AVAudioSessionInterruptionOptionKey,
-    AVAudioSessionInterruptionOptions, AVAudioSessionInterruptionType,
-    AVAudioSessionInterruptionTypeKey,
+use objc2_av_foundation::{
+    AVPlayer, AVPlayerItem, AVPlayerItemDidPlayToEndTimeNotification,
+    AVPlayerItemFailedToPlayToEndTimeNotification, AVPlayerItemStatus, AVURLAsset,
 };
+use objc2_avf_audio::{
+    AVAudioSession, AVAudioSessionCategoryPlayback, AVAudioSessionInterruptionNotification,
+    AVAudioSessionInterruptionOptionKey, AVAudioSessionInterruptionOptions,
+    AVAudioSessionInterruptionType, AVAudioSessionInterruptionTypeKey,
+};
+use objc2_core_media::CMTime;
 use objc2_foundation::{
-    NSDictionary, NSNotification, NSNotificationCenter, NSNumber, NSObject, NSObjectProtocol,
-    NSString, NSURL,
+    NSDictionary, NSNotification, NSNotificationCenter, NSNumber, NSObjectProtocol, NSString, NSURL,
 };
 use objc2_media_player::{
     MPChangePlaybackPositionCommandEvent, MPMediaItemPropertyAlbumTitle, MPMediaItemPropertyArtist,
@@ -39,10 +43,13 @@ use objc2_media_player::{
 
 const PROGRESS_INTERVAL: Duration = Duration::from_millis(250);
 
+const SEEK_TIMESCALE: i32 = 1_000_000;
+
 struct PlayerHolder {
-    player: Retained<AVAudioPlayer>,
-    _delegate: Retained<EndDelegate>,
-    duration: Option<Duration>,
+    player: Retained<AVPlayer>,
+    item: Retained<AVPlayerItem>,
+    observer: Retained<ItemObserver>,
+    stated_duration: Option<Duration>,
 }
 
 unsafe impl Send for PlayerHolder {}
@@ -65,6 +72,26 @@ pub(crate) fn register() {
 }
 
 struct IosMediaPlayer;
+
+fn on_main<R: Send>(action: impl FnOnce(MainThreadMarker) -> R + Send) -> R {
+    if let Some(mtm) = MainThreadMarker::new() {
+        return action(mtm);
+    }
+    let mut landed = None;
+    DispatchQueue::main().exec_sync(|| {
+        let mtm = MainThreadMarker::new().expect("the main queue runs on the main thread");
+        landed = Some(action(mtm));
+    });
+    landed.expect("the main queue ran the action")
+}
+
+fn volume() -> f32 {
+    *VOLUME.lock().unwrap_or_else(|error| error.into_inner())
+}
+
+fn speed() -> f32 {
+    *SPEED.lock().unwrap_or_else(|error| error.into_inner())
+}
 
 fn configure_audio_session() {
     unsafe {
@@ -242,34 +269,36 @@ fn publish_now_playing(metadata: &MediaMetadata, position: Duration, rate: f32) 
 
 define_class!(
     #[unsafe(super(NSObject))]
-    #[name = "CranposeMediaEndDelegate"]
+    #[name = "CranposeMediaItemObserver"]
     #[ivars = ()]
-    struct EndDelegate;
+    struct ItemObserver;
 
-    unsafe impl NSObjectProtocol for EndDelegate {}
+    unsafe impl NSObjectProtocol for ItemObserver {}
 
-    unsafe impl AVAudioPlayerDelegate for EndDelegate {
-        #[unsafe(method(audioPlayerDidFinishPlaying:successfully:))]
-        unsafe fn did_finish(&self, _player: &AVAudioPlayer, successfully: bool) {
-            if successfully {
-                publish_end_of_item();
-            } else {
-                publish_playback_state(PlaybackState::Failed(MediaError::Failed(
-                    "playback stopped part way through the item".to_string(),
-                )));
-            }
+    impl ItemObserver {
+        #[unsafe(method(cranposeItemDidPlayToEnd:))]
+        fn did_play_to_end(&self, _notification: &NSNotification) {
+            end_of_item();
+        }
+
+        #[unsafe(method(cranposeItemFailedToPlayToEnd:))]
+        fn failed_to_play_to_end(&self, _notification: &NSNotification) {
+            fail_open_item("playback stopped part way through the item".to_string());
         }
     }
 );
 
-impl EndDelegate {
+impl ItemObserver {
     fn new() -> Retained<Self> {
         let this = Self::alloc().set_ivars(());
         unsafe { msg_send![super(this), init] }
     }
 }
 
-fn publish_end_of_item() {
+fn end_of_item() {
+    if LOOPING.load(Ordering::Acquire) && restart_open_item() {
+        return;
+    }
     if let Some(duration) = duration_of_open_item() {
         publish_playback_progress(PlaybackProgress::new(duration, duration));
     }
@@ -277,17 +306,67 @@ fn publish_end_of_item() {
     publish_playback_state(PlaybackState::Ended);
 }
 
+fn fail_open_item(reason: String) {
+    GENERATION.fetch_add(1, Ordering::AcqRel);
+    publish_playback_state(PlaybackState::Failed(MediaError::Failed(reason)));
+}
+
+fn restart_open_item() -> bool {
+    with_holder(|holder| unsafe {
+        holder.player.seekToTime(cm_time(Duration::ZERO));
+        start_playing(&holder.player);
+    })
+    .is_some()
+}
+
 fn duration_of_open_item() -> Option<Duration> {
-    player_slot()
-        .lock()
-        .ok()
-        .and_then(|holder| holder.as_ref().and_then(|holder| holder.duration))
+    with_holder(duration_of).flatten()
+}
+
+fn duration_of(holder: &PlayerHolder) -> Option<Duration> {
+    positive_seconds(unsafe { holder.item.duration() })
+        .map(Duration::from_secs_f64)
+        .or(holder.stated_duration)
+}
+
+fn positive_seconds(time: CMTime) -> Option<f64> {
+    let seconds = unsafe { time.seconds() };
+    (seconds.is_finite() && seconds > 0.0).then_some(seconds)
+}
+
+fn cm_time(position: Duration) -> CMTime {
+    unsafe { CMTime::with_seconds(position.as_secs_f64(), SEEK_TIMESCALE) }
+}
+
+fn start_playing(player: &AVPlayer) {
+    let speed = speed();
+    unsafe {
+        if speed == 1.0 {
+            player.play();
+        } else {
+            player.setRate(speed);
+        }
+    }
 }
 
 fn url_for(uri: &str) -> Option<Retained<NSURL>> {
-    let path = cranpose_services::media::path_from_uri(uri)?;
-    let path = path.to_str()?;
-    Some(NSURL::fileURLWithPath(&NSString::from_str(path)))
+    if let Some(path) = cranpose_services::media::path_from_uri(uri) {
+        let path = path.to_str()?;
+        return Some(NSURL::fileURLWithPath(&NSString::from_str(path)));
+    }
+    if !is_streamable_uri(uri) {
+        return None;
+    }
+    NSURL::URLWithString(&NSString::from_str(uri))
+}
+
+fn is_streamable_uri(uri: &str) -> bool {
+    matches!(
+        uri.split_once("://"),
+        Some((scheme, rest))
+            if !rest.is_empty()
+                && (scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https"))
+    )
 }
 
 fn progress_at(position: Duration, duration: Option<Duration>) -> PlaybackProgress {
@@ -308,10 +387,16 @@ fn start_progress_thread() {
                 if GENERATION.load(Ordering::Acquire) != generation {
                     return;
                 }
-                let Some((position, duration)) = observe_position() else {
-                    return;
-                };
-                publish_playback_progress(progress_at(position, duration));
+                match observe() {
+                    Some(Observed::Playing(position, duration)) => {
+                        publish_playback_progress(progress_at(position, duration));
+                    }
+                    Some(Observed::Failed(reason)) => {
+                        fail_open_item(reason);
+                        return;
+                    }
+                    None => return,
+                }
             }
         });
     if let Err(error) = spawned {
@@ -319,19 +404,105 @@ fn start_progress_thread() {
     }
 }
 
-fn observe_position() -> Option<(Duration, Option<Duration>)> {
-    let holder = player_slot().lock().ok()?;
-    let holder = holder.as_ref()?;
-    Some((
-        Duration::from_secs_f64(unsafe { holder.player.currentTime() }.max(0.0)),
-        holder.duration,
-    ))
+enum Observed {
+    Playing(Duration, Option<Duration>),
+    Failed(String),
 }
 
-fn with_player<R>(action: impl FnOnce(&AVAudioPlayer) -> R) -> Option<R> {
-    let holder = player_slot().lock().ok()?;
-    let holder = holder.as_ref()?;
-    Some(action(&holder.player))
+fn observe() -> Option<Observed> {
+    with_holder(|holder| {
+        if let Some(reason) = item_failure(holder) {
+            return Observed::Failed(reason);
+        }
+        Observed::Playing(position_of(holder), duration_of(holder))
+    })
+}
+
+fn item_failure(holder: &PlayerHolder) -> Option<String> {
+    if unsafe { holder.item.status() } != AVPlayerItemStatus::Failed {
+        return None;
+    }
+    Some(
+        unsafe { holder.item.error() }
+            .map(|error| error.localizedDescription().to_string())
+            .unwrap_or_else(|| "the item could not be played".to_string()),
+    )
+}
+
+fn position_of(holder: &PlayerHolder) -> Duration {
+    let seconds = unsafe { holder.player.currentTime().seconds() };
+    if seconds.is_finite() && seconds > 0.0 {
+        Duration::from_secs_f64(seconds)
+    } else {
+        Duration::ZERO
+    }
+}
+
+fn with_holder<R: Send>(action: impl FnOnce(&PlayerHolder) -> R + Send) -> Option<R> {
+    on_main(move |_mtm| {
+        let slot = player_slot()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        slot.as_ref().map(action)
+    })
+}
+
+fn open_item(
+    uri: &str,
+    stated: Option<Duration>,
+    mtm: MainThreadMarker,
+) -> Result<Option<Duration>, MediaError> {
+    let url = url_for(uri).ok_or_else(|| MediaError::UnsupportedSource(uri.to_owned()))?;
+    let observer = ItemObserver::new();
+    let holder = unsafe {
+        let item = AVPlayerItem::initWithURL(AVPlayerItem::alloc(mtm), &url);
+        let player = AVPlayer::initWithPlayerItem(AVPlayer::alloc(mtm), Some(&item));
+        player.setVolume(volume());
+        let center = NSNotificationCenter::defaultCenter();
+        let scope: &AnyObject = item.as_ref();
+        center.addObserver_selector_name_object(
+            &observer,
+            sel!(cranposeItemDidPlayToEnd:),
+            Some(AVPlayerItemDidPlayToEndTimeNotification),
+            Some(scope),
+        );
+        center.addObserver_selector_name_object(
+            &observer,
+            sel!(cranposeItemFailedToPlayToEnd:),
+            Some(AVPlayerItemFailedToPlayToEndTimeNotification),
+            Some(scope),
+        );
+        PlayerHolder {
+            player,
+            item,
+            observer,
+            stated_duration: stated,
+        }
+    };
+    let duration = duration_of(&holder);
+    *player_slot()
+        .lock()
+        .unwrap_or_else(|error| error.into_inner()) = Some(holder);
+    Ok(duration)
+}
+
+fn close_item() {
+    on_main(|_mtm| {
+        let taken = player_slot()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .take();
+        if let Some(holder) = taken {
+            unsafe {
+                holder.player.pause();
+                holder.player.replaceCurrentItemWithPlayerItem(None);
+                NSNotificationCenter::defaultCenter().removeObserver(&holder.observer);
+            }
+        }
+        unsafe {
+            MPNowPlayingInfoCenter::defaultCenter().setNowPlayingInfo(None);
+        }
+    });
 }
 
 const IOS_AUDIO_EXTENSIONS: &[&str] = &[
@@ -353,11 +524,8 @@ impl MediaPlayer for IosMediaPlayer {
 
     fn probe_duration(&self, item: &MediaItem) -> Option<Duration> {
         let url = url_for(&item.uri)?;
-        let player =
-            unsafe { AVAudioPlayer::initWithContentsOfURL_error(AVAudioPlayer::alloc(), &url) }
-                .ok()?;
-        let duration = unsafe { player.duration() };
-        (duration.is_finite() && duration > 0.0).then(|| Duration::from_secs_f64(duration))
+        let asset = unsafe { AVURLAsset::URLAssetWithURL_options(&url, None) };
+        positive_seconds(unsafe { asset.duration() }).map(Duration::from_secs_f64)
     }
 
     fn audio_extensions(&self) -> Vec<&'static str> {
@@ -365,35 +533,9 @@ impl MediaPlayer for IosMediaPlayer {
     }
     fn prepare(&self, item: &MediaItem) -> Result<(), MediaError> {
         self.stop();
-        let url =
-            url_for(&item.uri).ok_or_else(|| MediaError::UnsupportedSource(item.uri.clone()))?;
-        let player =
-            unsafe { AVAudioPlayer::initWithContentsOfURL_error(AVAudioPlayer::alloc(), &url) }
-                .map_err(|error| MediaError::Failed(format!("{error:?}")))?;
-        let delegate = EndDelegate::new();
-        let duration = unsafe { player.duration() };
-        let duration = (duration.is_finite() && duration > 0.0)
-            .then(|| Duration::from_secs_f64(duration))
-            .or(item.metadata.duration);
-        unsafe {
-            player.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
-            player.setEnableRate(true);
-            player.setVolume(*VOLUME.lock().unwrap_or_else(|error| error.into_inner()));
-            player.setRate(*SPEED.lock().unwrap_or_else(|error| error.into_inner()));
-            player.setNumberOfLoops(if LOOPING.load(Ordering::Acquire) {
-                -1
-            } else {
-                0
-            });
-            player.prepareToPlay();
-        }
-        if let Ok(mut slot) = player_slot().lock() {
-            *slot = Some(PlayerHolder {
-                player,
-                _delegate: delegate,
-                duration,
-            });
-        }
+        let uri = item.uri.clone();
+        let stated = item.metadata.duration;
+        let duration = on_main(move |mtm| open_item(&uri, stated, mtm))?;
         publish_playback_progress(progress_at(Duration::ZERO, duration));
         publish_playback_state(PlaybackState::Paused);
         publish_now_playing(&item.metadata, Duration::ZERO, 0.0);
@@ -401,45 +543,41 @@ impl MediaPlayer for IosMediaPlayer {
     }
 
     fn play(&self) -> Result<(), MediaError> {
-        let started =
-            with_player(|player| unsafe { player.play() }).ok_or(MediaError::NothingLoaded)?;
-        if !started {
-            return Err(MediaError::Failed(
-                "the audio session refused to start the item".to_string(),
-            ));
-        }
         activate_audio_session(true);
+        let failure = with_holder(|holder| {
+            let failure = item_failure(holder);
+            if failure.is_none() {
+                start_playing(&holder.player);
+            }
+            failure
+        })
+        .ok_or(MediaError::NothingLoaded)?;
+        if let Some(reason) = failure {
+            return Err(MediaError::Failed(reason));
+        }
         start_progress_thread();
         publish_playback_state(PlaybackState::Playing);
         Ok(())
     }
 
     fn pause(&self) {
-        with_player(|player| unsafe { player.pause() });
+        with_holder(|holder| unsafe { holder.player.pause() });
         GENERATION.fetch_add(1, Ordering::AcqRel);
         publish_playback_state(PlaybackState::Paused);
     }
 
     fn stop(&self) {
         GENERATION.fetch_add(1, Ordering::AcqRel);
-        if let Ok(mut slot) = player_slot().lock()
-            && let Some(holder) = slot.take()
-        {
-            unsafe {
-                holder.player.stop();
-                holder.player.setDelegate(None);
-            }
-        }
-        unsafe {
-            MPNowPlayingInfoCenter::defaultCenter().setNowPlayingInfo(None);
-        }
+        close_item();
         activate_audio_session(false);
     }
 
     fn seek_to(&self, position: Duration) -> Result<(), MediaError> {
-        let duration = duration_of_open_item();
-        with_player(|player| unsafe { player.setCurrentTime(position.as_secs_f64()) })
-            .ok_or(MediaError::NothingLoaded)?;
+        let duration = with_holder(|holder| {
+            unsafe { holder.player.seekToTime(cm_time(position)) };
+            duration_of(holder)
+        })
+        .ok_or(MediaError::NothingLoaded)?;
         publish_playback_progress(progress_at(position, duration));
         Ok(())
     }
@@ -447,38 +585,33 @@ impl MediaPlayer for IosMediaPlayer {
     fn set_volume(&self, volume: f32) {
         let volume = volume.clamp(0.0, 1.0);
         *VOLUME.lock().unwrap_or_else(|error| error.into_inner()) = volume;
-        with_player(|player| unsafe { player.setVolume(volume) });
+        with_holder(|holder| unsafe { holder.player.setVolume(volume) });
     }
 
     fn set_speed(&self, speed: f32) -> bool {
         let speed = speed.clamp(0.25, 4.0);
         *SPEED.lock().unwrap_or_else(|error| error.into_inner()) = speed;
-        with_player(|player| unsafe { player.setRate(speed) });
+        with_holder(|holder| unsafe {
+            if holder.player.rate() != 0.0 {
+                holder.player.setRate(speed);
+            }
+        });
         true
     }
 
     fn set_looping(&self, looping: bool) {
         LOOPING.store(looping, Ordering::Release);
-        with_player(|player| unsafe {
-            player.setNumberOfLoops(if looping { -1 } else { 0 });
-        });
     }
 
     fn set_session_metadata(&self, metadata: &MediaMetadata) {
-        let position =
-            with_player(|player| Duration::from_secs_f64(unsafe { player.currentTime() }.max(0.0)))
-                .unwrap_or_default();
-        let rate = with_player(|player| {
-            if unsafe { player.isPlaying() } {
-                unsafe { player.rate() }
-            } else {
-                0.0
-            }
-        })
-        .unwrap_or(0.0);
+        let observed = with_holder(|holder| {
+            let rate = unsafe { holder.player.rate() };
+            (position_of(holder), rate, duration_of(holder))
+        });
+        let (position, rate, duration) = observed.unwrap_or((Duration::ZERO, 0.0, None));
         let mut metadata = metadata.clone();
         if metadata.duration.is_none() {
-            metadata.duration = duration_of_open_item();
+            metadata.duration = duration;
         }
         publish_now_playing(&metadata, position, rate);
     }


### PR DESCRIPTION
## What this changes

Every native media backend resolved a URI to a filesystem path and gave up when
that failed, so an `https:` track was refused before a single byte was fetched.
Only the web build, which hands the URL to an `<audio>` element, could play one.
The two places that decided it:

- `crates/cranpose/src/ios_media.rs` built an `NSURL` with
  `fileURLWithPath` from `path_from_uri` and played it with `AVAudioPlayer`,
  which reads a file or a memory buffer and cannot stream a network URL at all.
- `crates/cranpose-media/src/decode.rs` opened `std::fs::File` on
  `path_from_uri`, which is `None` for a remote URI by design.

### iOS

`ios_media` now plays through `AVPlayer` — one path for a local file and a
remote URL, which is what `AVPlayer` is for. `AVPlayer` and `AVPlayerItem` are
main-thread types, so every touch goes through one hop to the main queue
(inline when the caller is already there, a `dispatch_sync` from the progress
thread otherwise) and the player mutex is only ever taken on that thread.

- End of item is `AVPlayerItemDidPlayToEndTimeNotification` rather than the
  `AVAudioPlayer` delegate; looping re-seeks to zero on that notification
  instead of `numberOfLoops`.
- The progress thread now also reads `AVPlayerItem.status`, so a stream that
  fails mid-flight reports `PlaybackState::Failed` instead of sitting at zero.
- A duration probe reads `AVURLAsset.duration`, for a local file and a remote
  one alike. Measured on the simulator, a remote MP3's length comes back from
  the probe (`3:49` for a 229-second track), so a playlist shows it without
  playing it; where an asset answers `kCMTimeIndefinite` the probe reports
  `None` rather than guessing, and the length arrives with the progress updates
  once the item is open. The probe loads the asset, so it belongs on a
  background thread — which is where `probe_media_duration` is documented to be
  called from.
- `objc2-avf-audio` loses the `AVAudioPlayer` feature; `AVAudioSession` and the
  `MediaPlayer` lock-screen integration are unchanged.

### Desktop and Android

`HttpSource` gives the in-process decoder `Read + Seek` over HTTP byte ranges:
playback starts from the front while the rest is still on the wire, a seek asks
the server for the offset it needs, a forward hop of up to a megabyte is taken
out of the response already open rather than by reconnecting, and nothing is
written to disk. `Accept-Ranges: bytes` decides whether the source reports
itself seekable; a server without ranges plays forward and says so rather than
pretending. Cancelling reaches the in-flight transfer through the same
`SourceCancel` the spool now uses (it replaces `SpoolCancel`), so the decode
thread is never left blocked on a socket that no longer matters.

`cranpose-media` therefore takes `cranpose-services/http-native` on the targets
whose modules it compiles. Not behind a feature: a media backend that cannot
open the most common URI scheme there is is the bug this fixes, and a flag would
leave it unfixed for anyone who does not know to set it.

`path_from_uri` is untouched — `None` for a remote URI is what it means, and the
media layer branches on the scheme instead.

## Verified

- `crates/cranpose-media/src/http.rs`: 13 unit tests over a `StubHttpClient`
  covering ordering, the stated length, forward and backward seeks, the
  in-response hop, seeking from the end, reading past the end, a server with no
  ranges, a server that ignores the range it was given, a refused open, and
  cancellation.
- `crates/cranpose-media/tests/remote_stream.rs`: two `#[ignore]`d tests that
  play a real URL through the real output device. Run against
  `https://fm.dmitrysamoylenko.in/afterglow.mp3` on macOS:
  probe `247.478s`; position `2.869s` → `5.962s` over three seconds; after
  `seek_to(120s)` and three more seconds, `122.741s`. State `Playing` throughout.
- iOS simulator (iPhone 17 Pro, iOS 26.5), Cranamp built against this branch:
  the remote `https://fm.dmitrysamoylenko.in/abyssal.mp3` played (`00:32` →
  `00:38` over six seconds), a drag on the seek bar jumped to `02:24` and kept
  advancing to `02:29`, a local file in the app container still played
  (`00:11` → `00:17`) and reported end of item at its full `01:40`, and a
  playlist entry with no stated duration had `3:49` filled in by the probe.
- `just clippy`, `just clippy-optional-backends`, `just clippy-ios`, the same
  clippy run against `aarch64-apple-ios`, `just doc`, `just fmt-check`,
  `just typos`, `just versions`, `just dep-budget`, `cargo test --workspace`,
  complexity and duplication gates: all clean.

Not run here: Android and web builds, and playback on a physical iPhone.

## Checklist

- [ ] `just ci` passes in full. Everything listed above ran clean on macOS; the
      Android, web and robot legs did not run here.
- [x] A bug fix starts with a test that fails without the fix.
- [x] New public API carries a `///` doc comment with an example. Internal code
      does not: good names beat narration.
- [x] No half-migrated state, deprecation shim, or "legacy" path left behind.
- [x] I used AI assistance (Claude, Copilot, etc.) to write this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


